### PR TITLE
Wire factor in TypeScript and Rust MACSYMA runtimes

### DIFF
--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [dependencies]
 cas-list-operations = { path = "../cas-list-operations" }
+cas-factor = { path = "../cas-factor" }
 cas-pretty-printer = { path = "../cas-pretty-printer" }
 cas-solve = { path = "../cas-solve" }
 cas-simplify = { path = "../cas-simplify" }

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use cas_factor::factor_integer_polynomial;
 use cas_list_operations::{
     append, apply_ as list_apply, first, flatten, join, last, length, map_ as list_map, part,
     range_ as list_range, rest, reverse, sort_, ListOperationError, ListResult,
@@ -22,8 +23,8 @@ use coding_adventures_macsyma_compiler::{
     SUPPRESS as COMPILER_SUPPRESS,
 };
 use symbolic_ir::{
-    apply, str_node, sym, IRApply, IRNode, ASSIGN, DEFINE, GREATER, GREATER_EQUAL, IF, LESS,
-    LESS_EQUAL, LIST, POW,
+    apply, str_node, sym, IRApply, IRNode, ADD, ASSIGN, DEFINE, GREATER, GREATER_EQUAL, IF, LESS,
+    LESS_EQUAL, LIST, MUL, POW, SUB,
 };
 use symbolic_vm::backend::{handler_fn, Backend, Handler};
 use symbolic_vm::handlers::build_handler_table;
@@ -511,6 +512,7 @@ impl MacsymaBackend {
         handlers.insert(SOLVE.to_string(), handler_fn(solve_handler));
         handlers.insert(SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(SUBST.to_string(), handler_fn(subst_handler));
+        handlers.insert(FACTOR.to_string(), handler_fn(factor_handler));
         handlers.insert(RAT_SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(TRIG_SIMPLIFY.to_string(), handler_fn(trig_simplify_handler));
         handlers.insert(TRIG_EXPAND.to_string(), handler_fn(trig_expand_handler));
@@ -1027,6 +1029,28 @@ fn subst_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     subst(expr.args[0].clone(), &expr.args[1], expr.args[2].clone())
 }
 
+fn factor_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
+    let fallback = IRNode::Apply(Box::new(expr.clone()));
+    if expr.args.len() != 1 {
+        return fallback;
+    }
+    let Some(variable) = find_single_variable(&expr.args[0]) else {
+        return fallback;
+    };
+    let Some(coeffs) = ir_to_integer_poly(&expr.args[0], &variable) else {
+        return fallback;
+    };
+
+    let (content, factors) = factor_integer_polynomial(&coeffs);
+    if factors.is_empty() {
+        return expr.args[0].clone();
+    }
+    if coeffs.len() > 2 && factors.len() == 1 && factors[0].1 == 1 && content.abs() == 1 {
+        return fallback;
+    }
+    factor_result_to_ir(content, factors, &variable)
+}
+
 fn list_handler<F>(arity: Option<usize>, body: F) -> Handler
 where
     F: Fn(&[IRNode]) -> ListResult<IRNode> + Send + Sync + 'static,
@@ -1038,6 +1062,181 @@ where
         }
         body(&expr.args).unwrap_or(fallback)
     })
+}
+
+fn find_single_variable(node: &IRNode) -> Option<String> {
+    let mut variables = HashSet::new();
+    collect_variables(node, &mut variables);
+    if variables.len() == 1 {
+        variables.into_iter().next()
+    } else {
+        None
+    }
+}
+
+fn collect_variables(node: &IRNode, variables: &mut HashSet<String>) {
+    match node {
+        IRNode::Symbol(name) if !name.starts_with('%') => {
+            variables.insert(name.clone());
+        }
+        IRNode::Apply(apply) => {
+            for arg in &apply.args {
+                collect_variables(arg, variables);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn ir_to_integer_poly(node: &IRNode, variable: &str) -> Option<Vec<i64>> {
+    match node {
+        IRNode::Integer(value) => Some(vec![*value]),
+        IRNode::Symbol(name) if name == variable => Some(vec![0, 1]),
+        IRNode::Apply(apply) if is_head_name(&apply.head, ADD) => {
+            apply.args.iter().try_fold(vec![0], |acc, arg| {
+                Some(poly_add(&acc, &ir_to_integer_poly(arg, variable)?))
+            })
+        }
+        IRNode::Apply(apply) if is_head_name(&apply.head, SUB) && apply.args.len() == 2 => {
+            let a = ir_to_integer_poly(&apply.args[0], variable)?;
+            let b = ir_to_integer_poly(&apply.args[1], variable)?;
+            Some(poly_sub(&a, &b))
+        }
+        IRNode::Apply(apply) if is_head_name(&apply.head, MUL) => {
+            apply.args.iter().try_fold(vec![1], |acc, arg| {
+                Some(poly_mul(&acc, &ir_to_integer_poly(arg, variable)?))
+            })
+        }
+        IRNode::Apply(apply) if is_head_name(&apply.head, POW) && apply.args.len() == 2 => {
+            let IRNode::Integer(exp) = apply.args[1] else {
+                return None;
+            };
+            if !(0..=32).contains(&exp) {
+                return None;
+            }
+            let base = ir_to_integer_poly(&apply.args[0], variable)?;
+            Some(poly_pow(&base, exp as usize))
+        }
+        _ => None,
+    }
+}
+
+fn factor_result_to_ir(content: i64, factors: Vec<(Vec<i64>, usize)>, variable: &str) -> IRNode {
+    let mut pieces = Vec::new();
+    if content != 1 {
+        pieces.push(IRNode::Integer(content));
+    }
+    for (coeffs, multiplicity) in factors {
+        let factor = poly_to_ir(&coeffs, variable);
+        if multiplicity == 1 {
+            pieces.push(factor);
+        } else {
+            pieces.push(apply(
+                sym(POW),
+                vec![factor, IRNode::Integer(multiplicity as i64)],
+            ));
+        }
+    }
+    multiply_nodes(pieces)
+}
+
+fn poly_to_ir(coeffs: &[i64], variable: &str) -> IRNode {
+    let terms: Vec<IRNode> = coeffs
+        .iter()
+        .enumerate()
+        .filter_map(|(degree, coeff)| {
+            if *coeff == 0 {
+                None
+            } else {
+                Some(monomial_to_ir(*coeff, degree, variable))
+            }
+        })
+        .collect();
+    if terms.is_empty() {
+        IRNode::Integer(0)
+    } else {
+        add_nodes(terms)
+    }
+}
+
+fn monomial_to_ir(coeff: i64, degree: usize, variable: &str) -> IRNode {
+    if degree == 0 {
+        return IRNode::Integer(coeff);
+    }
+    let power = if degree == 1 {
+        sym(variable)
+    } else {
+        apply(
+            sym(POW),
+            vec![sym(variable), IRNode::Integer(degree as i64)],
+        )
+    };
+    match coeff {
+        1 => power,
+        -1 => apply(sym(MUL), vec![IRNode::Integer(-1), power]),
+        _ => apply(sym(MUL), vec![IRNode::Integer(coeff), power]),
+    }
+}
+
+fn add_nodes(nodes: Vec<IRNode>) -> IRNode {
+    if nodes.len() == 1 {
+        nodes.into_iter().next().unwrap()
+    } else {
+        apply(sym(ADD), nodes)
+    }
+}
+
+fn multiply_nodes(nodes: Vec<IRNode>) -> IRNode {
+    if nodes.is_empty() {
+        IRNode::Integer(1)
+    } else if nodes.len() == 1 {
+        nodes.into_iter().next().unwrap()
+    } else {
+        apply(sym(MUL), nodes)
+    }
+}
+
+fn poly_add(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let len = a.len().max(b.len());
+    let mut out = vec![0; len];
+    for i in 0..len {
+        out[i] = a.get(i).copied().unwrap_or(0) + b.get(i).copied().unwrap_or(0);
+    }
+    trim_poly(out)
+}
+
+fn poly_sub(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let len = a.len().max(b.len());
+    let mut out = vec![0; len];
+    for i in 0..len {
+        out[i] = a.get(i).copied().unwrap_or(0) - b.get(i).copied().unwrap_or(0);
+    }
+    trim_poly(out)
+}
+
+fn poly_mul(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let mut out = vec![0; a.len() + b.len() - 1];
+    for (i, ca) in a.iter().enumerate() {
+        for (j, cb) in b.iter().enumerate() {
+            out[i + j] += ca * cb;
+        }
+    }
+    trim_poly(out)
+}
+
+fn poly_pow(base: &[i64], exp: usize) -> Vec<i64> {
+    let mut out = vec![1];
+    for _ in 0..exp {
+        out = poly_mul(&out, base);
+    }
+    out
+}
+
+fn trim_poly(mut poly: Vec<i64>) -> Vec<i64> {
+    while poly.len() > 1 && poly.last() == Some(&0) {
+        poly.pop();
+    }
+    poly
 }
 
 fn range_handler(args: &[IRNode]) -> ListResult<IRNode> {

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -74,6 +74,37 @@ fn parses_and_renders_question_mark_help() {
 }
 
 #[test]
+fn factors_univariate_integer_polynomials_through_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x^2 - 1);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![int(1), sym("x")]),
+                apply(sym(ADD), vec![int(-1), sym("x")]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn keeps_multivariate_factor_calls_unevaluated() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x + y);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym("Factor"),
+            vec![apply(sym(ADD), vec![sym("x"), sym("y")])]
+        )
+    );
+}
+
+#[test]
 fn question_mark_without_topic_lists_help_topics() {
     let mut session = MacsymaSession::new();
     let results = session.eval_source("?").unwrap();

--- a/code/packages/typescript/macsyma-runtime/BUILD
+++ b/code/packages/typescript/macsyma-runtime/BUILD
@@ -12,6 +12,7 @@ cd ../macsyma-compiler && npm ci --quiet
 cd ../cas-list-operations && npm ci --quiet
 cd ../cas-pattern-matching && npm ci --quiet
 cd ../cas-pretty-printer && npm ci --quiet
+cd ../cas-factor && npm ci --quiet
 cd ../cas-simplify && npm ci --quiet
 cd ../cas-solve && npm ci --quiet
 cd ../cas-substitution && npm ci --quiet

--- a/code/packages/typescript/macsyma-runtime/package-lock.json
+++ b/code/packages/typescript/macsyma-runtime/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@coding-adventures/cas-factor": "file:../cas-factor",
         "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
         "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
         "@coding-adventures/cas-pretty-printer": "file:../cas-pretty-printer",
@@ -29,6 +30,17 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-factor": {
+      "name": "@coding-adventures/cas-factor",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.19.18",
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
@@ -351,6 +363,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/cas-factor": {
+      "resolved": "../cas-factor",
+      "link": true
     },
     "node_modules/@coding-adventures/cas-list-operations": {
       "resolved": "../cas-list-operations",

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -22,6 +22,7 @@
     "@coding-adventures/parser": "file:../parser",
     "@coding-adventures/state-machine": "file:../state-machine",
     "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
+    "@coding-adventures/cas-factor": "file:../cas-factor",
     "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
     "@coding-adventures/cas-pretty-printer": "file:../cas-pretty-printer",
     "@coding-adventures/cas-simplify": "file:../cas-simplify",

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -1,4 +1,5 @@
 import { compileMacsyma } from "@coding-adventures/macsyma-compiler";
+import { factorIntegerPolynomial } from "@coding-adventures/cas-factor";
 import {
   append,
   applyList,
@@ -21,6 +22,7 @@ import { expandTrig, trigReduce, trigSimplify } from "@coding-adventures/cas-tri
 import {
   ACOS,
   ACOSH,
+  ADD,
   ASSUME,
   ASIN,
   ASINH,
@@ -41,10 +43,13 @@ import {
   LESS_EQUAL,
   LIST,
   LOG,
+  MUL,
+  POW,
   SIN,
   SINH,
   SOLVE,
   SQRT,
+  SUB,
   SUBST,
   SUM,
   TAN,
@@ -52,6 +57,7 @@ import {
   TRUE,
   app,
   equals,
+  int,
   numberNode,
   stringNode,
   sym,
@@ -388,6 +394,7 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(PROP_VARS.name, propvarsHandler);
     table.set(SOLVE.name, solveHandler);
     table.set(SUBST.name, substHandler);
+    table.set(FACTOR.name, factorHandler);
     table.set(SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
     table.set(RAT_SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
     table.set(TRIG_SIMPLIFY.name, unaryHandler((value) => simplifyCas(trigSimplify(value))));
@@ -419,6 +426,7 @@ export class MacsymaBackend extends SymbolicBackend {
       PROP_VARS.name,
       SOLVE.name,
       SUBST.name,
+      FACTOR.name,
     ]);
   }
 
@@ -820,6 +828,21 @@ function substHandler(_vm: VM, expr: IRApply): IRNode {
   return subst(value, variable, target);
 }
 
+function factorHandler(_vm: VM, expr: IRApply): IRNode {
+  if (expr.args.length !== 1) return expr;
+  const variable = findSingleVariable(expr.args[0]);
+  if (variable === undefined) return expr;
+  const coeffs = irToIntegerPoly(expr.args[0], variable);
+  if (coeffs === undefined) return expr;
+
+  const [content, factors] = factorIntegerPolynomial(coeffs);
+  if (factors.length === 0) return expr.args[0];
+  if (coeffs.length > 2 && factors.length === 1 && factors[0][1] === 1 && absBigint(content) === 1n) {
+    return expr;
+  }
+  return factorResultToIr(content, factors, variable);
+}
+
 function unaryHandler(body: (value: IRNode) => IRNode): Handler {
   return (_vm, expr) => {
     if (expr.args.length !== 1) return expr;
@@ -829,6 +852,129 @@ function unaryHandler(body: (value: IRNode) => IRNode): Handler {
       return expr;
     }
   };
+}
+
+function findSingleVariable(node: IRNode): IRSymbol | undefined {
+  const variables = new Set<string>();
+  collectVariables(node, variables);
+  if (variables.size !== 1) return undefined;
+  return sym([...variables][0]);
+}
+
+function collectVariables(node: IRNode, variables: Set<string>): void {
+  if (node.kind === "symbol" && !node.name.startsWith("%")) {
+    variables.add(node.name);
+    return;
+  }
+  if (node.kind === "apply") {
+    for (const arg of node.args) collectVariables(arg, variables);
+  }
+}
+
+function irToIntegerPoly(node: IRNode, variable: IRSymbol): bigint[] | undefined {
+  if (node.kind === "integer") return [node.value];
+  if (equals(node, variable)) return [0n, 1n];
+  if (node.kind !== "apply" || node.head.kind !== "symbol") return undefined;
+
+  if (node.head.name === ADD.name) {
+    return node.args.reduce<bigint[] | undefined>((acc, arg) => {
+      const p = irToIntegerPoly(arg, variable);
+      return acc === undefined || p === undefined ? undefined : polyAdd(acc, p);
+    }, [0n]);
+  }
+  if (node.head.name === SUB.name && node.args.length === 2) {
+    const a = irToIntegerPoly(node.args[0], variable);
+    const b = irToIntegerPoly(node.args[1], variable);
+    return a === undefined || b === undefined ? undefined : polySub(a, b);
+  }
+  if (node.head.name === MUL.name) {
+    return node.args.reduce<bigint[] | undefined>((acc, arg) => {
+      const p = irToIntegerPoly(arg, variable);
+      return acc === undefined || p === undefined ? undefined : polyMul(acc, p);
+    }, [1n]);
+  }
+  if (node.head.name === POW.name && node.args.length === 2 && node.args[1].kind === "integer" && node.args[1].value >= 0n) {
+    const base = irToIntegerPoly(node.args[0], variable);
+    return base === undefined ? undefined : polyPow(base, node.args[1].value);
+  }
+  return undefined;
+}
+
+function factorResultToIr(content: bigint, factors: Array<[bigint[], number]>, variable: IRSymbol): IRNode {
+  const pieces: IRNode[] = [];
+  if (content !== 1n) pieces.push(int(content));
+  for (const [coeffs, multiplicity] of factors) {
+    const factor = polyToIr(coeffs, variable);
+    pieces.push(multiplicity === 1 ? factor : app(POW, [factor, int(multiplicity)]));
+  }
+  return multiplyNodes(pieces);
+}
+
+function polyToIr(coeffs: readonly bigint[], variable: IRSymbol): IRNode {
+  const terms: IRNode[] = [];
+  for (let degree = 0; degree < coeffs.length; degree += 1) {
+    const coeff = coeffs[degree];
+    if (coeff === 0n) continue;
+    terms.push(monomialToIr(coeff, degree, variable));
+  }
+  return terms.length === 0 ? int(0) : addNodes(terms);
+}
+
+function monomialToIr(coeff: bigint, degree: number, variable: IRSymbol): IRNode {
+  if (degree === 0) return int(coeff);
+  const power = degree === 1 ? variable : app(POW, [variable, int(degree)]);
+  if (coeff === 1n) return power;
+  if (coeff === -1n) return app(MUL, [int(-1), power]);
+  return app(MUL, [int(coeff), power]);
+}
+
+function addNodes(nodes: readonly IRNode[]): IRNode {
+  if (nodes.length === 1) return nodes[0];
+  return app(ADD, nodes);
+}
+
+function multiplyNodes(nodes: readonly IRNode[]): IRNode {
+  if (nodes.length === 0) return int(1);
+  if (nodes.length === 1) return nodes[0];
+  return app(MUL, nodes);
+}
+
+function polyAdd(a: readonly bigint[], b: readonly bigint[]): bigint[] {
+  const len = Math.max(a.length, b.length);
+  const out = Array<bigint>(len).fill(0n);
+  for (let i = 0; i < len; i += 1) out[i] = (a[i] ?? 0n) + (b[i] ?? 0n);
+  return trimPoly(out);
+}
+
+function polySub(a: readonly bigint[], b: readonly bigint[]): bigint[] {
+  const len = Math.max(a.length, b.length);
+  const out = Array<bigint>(len).fill(0n);
+  for (let i = 0; i < len; i += 1) out[i] = (a[i] ?? 0n) - (b[i] ?? 0n);
+  return trimPoly(out);
+}
+
+function polyMul(a: readonly bigint[], b: readonly bigint[]): bigint[] {
+  const out = Array<bigint>(a.length + b.length - 1).fill(0n);
+  for (let i = 0; i < a.length; i += 1) {
+    for (let j = 0; j < b.length; j += 1) out[i + j] += a[i] * b[j];
+  }
+  return trimPoly(out);
+}
+
+function polyPow(base: readonly bigint[], exp: bigint): bigint[] | undefined {
+  if (exp > 32n) return undefined;
+  let out = [1n];
+  for (let i = 0n; i < exp; i += 1n) out = polyMul(out, base);
+  return out;
+}
+
+function trimPoly(poly: bigint[]): bigint[] {
+  while (poly.length > 1 && poly[poly.length - 1] === 0n) poly.pop();
+  return poly;
+}
+
+function absBigint(value: bigint): bigint {
+  return value < 0n ? -value : value;
 }
 
 function listHandler(

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -4,6 +4,7 @@ import {
   ASSUME,
   EQUAL,
   EXP,
+  FACTOR,
   FALSE,
   FORGET,
   GREATER,
@@ -133,6 +134,23 @@ describe("macsyma-runtime", () => {
     expect(killResult.input).toEqual(app(KILL, [sym("x")]));
     expect(evResult.input).toEqual(app(EV, [app(ADD, [int(1), int(2)]), sym("numer")]));
     expect(evResult.output).toEqual(numberNode(3));
+  });
+
+  it("factors univariate integer polynomials through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x^2 - 1);");
+
+    expect(result.output).toEqual(app(MUL, [
+      app(ADD, [int(1), sym("x")]),
+      app(ADD, [int(-1), sym("x")]),
+    ]));
+  });
+
+  it("leaves multivariate factor calls unevaluated", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x + y);");
+
+    expect(result.output).toEqual(app(FACTOR, [app(ADD, [sym("x"), sym("y")])]));
   });
 
   it("tracks the showtime option flag through normal assignments", () => {

--- a/code/programs/typescript/macsyma-browser-repl/BUILD
+++ b/code/programs/typescript/macsyma-browser-repl/BUILD
@@ -12,6 +12,7 @@ cd ../../../packages/typescript/macsyma-compiler && npm ci --quiet
 cd ../../../packages/typescript/cas-list-operations && npm ci --quiet
 cd ../../../packages/typescript/cas-pattern-matching && npm ci --quiet
 cd ../../../packages/typescript/cas-pretty-printer && npm ci --quiet
+cd ../../../packages/typescript/cas-factor && npm ci --quiet
 cd ../../../packages/typescript/cas-simplify && npm ci --quiet
 cd ../../../packages/typescript/cas-solve && npm ci --quiet
 cd ../../../packages/typescript/cas-substitution && npm ci --quiet


### PR DESCRIPTION
## Summary
- add TypeScript MACSYMA runtime wiring for the existing cas-factor package
- add Rust MACSYMA runtime wiring for the existing cas-factor crate
- cover univariate factor evaluation and multivariate unevaluated fallback in both runtimes

## Validation
- `npm test && npm run build` from `code/packages/typescript/macsyma-runtime`
- `cargo fmt -p coding-adventures-macsyma-runtime` from `code/packages/rust`
- `cargo test -p coding-adventures-macsyma-runtime` from `code/packages/rust`
- `git diff --check`