### PR TITLE
feat(llm-primitives): decompose-text-v5 — typed-quantity extraction (ADJ21)

### DIFF
--- a/code/packages/rust/llm-primitives/CHANGELOG.md
+++ b/code/packages/rust/llm-primitives/CHANGELOG.md
@@ -2,6 +2,83 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2026-05-13 — decompose-text-v5 (typed quantities)
+
+### Changed
+
+`DECOMPOSE_TEXT_PROMPT_VERSION: "decompose-text-v4" → "decompose-text-v5"`.
+
+The prompt now teaches typed-quantity extraction. See
+[ADJ21](../../../specs/ADJ21-typed-quantity-decomposition.md)
+for the full motivation.
+
+#### What the prompt now says
+
+A new "QUANTITY rules" section between the existing NODE and
+EDGE rule sections:
+
+- **7a**: Every numerical quantity in the source MUST appear as a
+  `quantity(<value>, <unit>)` compound term. Values are atoms
+  with literal numbers preserved (no rounding, no conversion).
+  Units are snake_case atoms (`oz`, `ml`, `inches`, `wh`,
+  `celsius`, `percent_abv`, etc.). The quantity is embedded
+  inside the surrounding fact's args — never flattened into the
+  predicate name.
+
+    > **Wrong**: `blade_4_inches(knife)`
+    > **Right**: `blade_length(knife, quantity(4, inches))`
+
+- **7b**: Bare numbers without units use `count` or
+  domain-appropriate predicates.
+  `"1 carry-on bag"` → `carry_on_bag(quantity(1, count))`.
+
+- **7c**: The rationale — downstream rules compare quantities
+  against thresholds; the engine evaluates these
+  deterministically only if the source IR preserves the typed
+  value.
+
+#### Second worked example
+
+A new worked example for `"4 inch pocket knife."` was added after
+the existing matches example, demonstrating the typed-quantity
+shape end-to-end including the rationale paragraph that
+references the engine evaluating `4 > 2.36`.
+
+### Why now
+
+The ADJ18 v0.13 bench surfaced empirical evidence: every model
+mishandled numerical thresholds (the pocket-knife regression).
+The LLM cannot reliably do arithmetic inside its forward pass.
+The structural fix is to lower comparisons to the engine —
+which requires the source IR to preserve typed values. This PR
+is the prompt side of that fix; ADJ22 (queued) adds the
+validator that catches the LLM dropping units.
+
+### Tests
+
+3 new offline unit tests (81 lib total):
+
+- `system_prompt_documents_typed_quantity_extraction`
+- `system_prompt_includes_pocket_knife_worked_example`
+- `system_prompt_uses_domain_neutral_quantity_rules`
+
+Updated `prompt_version_constants_are_stable` to expect
+`decompose-text-v5`.
+
+### Compatibility
+
+- Audit-trail compatible: old v4 records remain replayable.
+- Wire format unchanged: ADJ01 v3 IR already supports
+  `quantity(value, unit)` compounds.
+- Caller API unchanged: `decompose_text(req, gateway)` signature
+  the same.
+- Other primitives untouched.
+
+### Follow-ups
+
+- **ADJ22**: typed-quantity coverage checker.
+- **ADJ23**: end-to-end re-bench against v5 + fact sheets.
+
 ## [0.10.0] - 2026-05-12
 
 ### Changed (breaking on-the-wire shape)

--- a/code/packages/rust/llm-primitives/Cargo.toml
+++ b/code/packages/rust/llm-primitives/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "llm-primitives"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
-description = "LM00b — typed LLM primitives layer. v0.10 bumps the decompose_text prompt to v4 to teach the LLM the multi-directed acyclic graph IR shape from ADJ01 v3: the response now has top-level `nodes` and `edges` arrays, edges carry a typed `relation` from a closed taxonomy (Contains, Mentions, Excepts, Cites, RowOf, etc.), nodes drop `part_of`/`lowered_from` (replaced by Contains/Clarifies edges), and node kinds add Section (structural unit) and Entity (deduplicated reference target) while dropping TextRun. Includes a worked example showing both arrays end-to-end."
+description = "LM00b — typed LLM primitives layer. v0.11 bumps the decompose_text prompt to v5 (per ADJ21): the prompt now explicitly teaches typed-quantity extraction (every numerical value-with-unit in the source becomes a `quantity(value, unit)` compound term, never flattened into the predicate name). Includes a second worked example demonstrating the typed-quantity shape end-to-end so the engine can evaluate threshold comparisons deterministically rather than asking the LLM to do arithmetic inside its forward pass."
 
 [dependencies]
 llm-gateway = { path = "../llm-gateway" }

--- a/code/packages/rust/llm-primitives/src/decompose_text.rs
+++ b/code/packages/rust/llm-primitives/src/decompose_text.rs
@@ -157,6 +157,49 @@ that the Section groups N1 and N2 — semantic structure that the \
 checker passes use. Coverage adds up: N1[0,14] + S1[14,16] + \
 N2[16,23] + S1[23,24] = [0,24).\n\
 \n\
+Second worked example, showing typed quantities. SOURCE: \
+`\"4 inch pocket knife.\"` (20 bytes). Correct output:\n\
+\n\
+{\n\
+  \"document_id\": \"<doc-id>\",\n\
+  \"nodes\": [\n\
+    { \"id\": \"N1\", \"kind\": \"Fact\",\n\
+      \"term\": { \"functor\": \"declared\", \"args\": [ { \"atom\": \"pocket_knife\" } ] },\n\
+      \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
+      \"source_spans\": [ { \"start\": 7, \"end\": 19 } ] },\n\
+    { \"id\": \"N2\", \"kind\": \"Fact\",\n\
+      \"term\": { \"functor\": \"blade_length\", \"args\": [\n\
+        { \"atom\": \"pocket_knife\" },\n\
+        { \"functor\": \"quantity\", \"args\": [ { \"atom\": \"4\" }, { \"atom\": \"inches\" } ] }\n\
+      ] },\n\
+      \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
+      \"source_spans\": [ { \"start\": 0, \"end\": 6 } ] },\n\
+    { \"id\": \"S1\", \"kind\": \"Section\",\n\
+      \"term\": { \"functor\": \"sentence\", \"args\": [] },\n\
+      \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
+      \"source_spans\": [ { \"start\": 6, \"end\": 7 }, { \"start\": 19, \"end\": 20 } ] }\n\
+  ],\n\
+  \"edges\": [\n\
+    { \"id\": \"E1\", \"source\": \"S1\", \"target\": \"N1\",\n\
+      \"relation\": \"Contains\",\n\
+      \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
+      \"source_spans\": [] },\n\
+    { \"id\": \"E2\", \"source\": \"S1\", \"target\": \"N2\",\n\
+      \"relation\": \"Contains\",\n\
+      \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
+      \"source_spans\": [] }\n\
+  ]\n\
+}\n\
+\n\
+N2's term carries the typed quantity `quantity(4, inches)` as a \
+nested compound. A downstream rule like \
+`prohibited(X) :- blade_length(X, quantity(L, inches)), gt(L, \
+quantity(2.36, inches))` can pattern-match `L = 4` and evaluate \
+`4 > 2.36` deterministically in the engine. If the IR had \
+flattened the number into the predicate name (`blade_4_inches`) \
+or dropped the unit (`blade_length(pocket_knife, 4)`), the rule \
+could not fire correctly. Preserve the typed value.\n\
+\n\
 RULES (every rule is mandatory, no exceptions):\n\
 \n\
 ## NODE rules\n\
@@ -189,6 +232,37 @@ recursively use the same term shape.\n\
 synthesized questions. Entity nodes MAY have empty `source_spans` \
 when synthesized. Every other kind MUST have non-empty \
 `source_spans`.\n\
+\n\
+## QUANTITY rules\n\
+\n\
+7a. **Every numerical quantity in the source gets a typed term.** \
+Whenever the source mentions a value paired with a unit (`\"3.4 \
+oz\"`, `\"200 Wh\"`, `\"4 inch\"`, `\"30 days\"`, `\"750 ml\"`, \
+`\"70% ABV\"`, `\"38.5°C\"`, `\"4 hours\"`), the value MUST appear \
+in IR as a `quantity(<value>, <unit>)` compound term: \
+\n\
+   * `<value>` is a numeric atom — preserve the literal number from \
+the source (`4`, `3.4`, `200`, `750`, `38.5`). Do NOT round, \
+truncate, or convert.\n\
+   * `<unit>` is a snake_case atom — normalise common units to their \
+canonical forms: `oz`, `ml`, `inches`, `mm`, `days`, `hours`, \
+`wh`, `kg`, `celsius`, `percent_abv`, `usd`, etc.\n\
+   * Embed the quantity inside the surrounding fact's args, do NOT \
+flatten the number into the predicate name. \
+**Wrong**: `blade_4_inches(knife)`. \
+**Right**: `blade_length(knife, quantity(4, inches))`.\n\
+\n\
+7b. **Numbers without units are still atoms, but use `count` or the \
+domain-appropriate predicate.** `\"1 carry-on bag\"` becomes \
+`carry_on(quantity(1, count))` or `carry_on_bag(quantity(1, count))`; \
+the literal `1` is not lost.\n\
+\n\
+7c. **Why this matters:** downstream rules will compare quantities \
+against thresholds (`gt(L, quantity(2.36, inches))`, \
+`le(V, quantity(100, ml))`). The engine evaluates these comparisons \
+deterministically — but only if the source IR preserves the typed \
+value. Lose the unit, or fold the number into the predicate name, \
+and the engine has nothing to compare.\n\
 \n\
 ## EDGE rules\n\
 \n\
@@ -509,7 +583,7 @@ mod tests {
 
         assert_eq!(resp.call_record.primitive, "decompose_text");
         assert_eq!(resp.call_record.role, "extractor");
-        assert_eq!(resp.call_record.prompt_version, "decompose-text-v4");
+        assert_eq!(resp.call_record.prompt_version, "decompose-text-v5");
         assert!(!resp.call_record.prompt_hash.is_empty());
         assert_eq!(resp.call_record.usage.input_tokens, 700);
         assert_eq!(resp.call_record.usage.output_tokens, 320);
@@ -533,6 +607,77 @@ mod tests {
     fn missing_language_hint_renders_auto_detect() {
         let text = build_user_text(&req());
         assert!(text.contains("LANGUAGE: auto-detect"));
+    }
+
+    #[test]
+    fn system_prompt_documents_typed_quantity_extraction() {
+        // ADJ21: every numerical quantity in the source must lower
+        // into a `quantity(value, unit)` compound term. The prompt
+        // explicitly says so and shows a worked example.
+        let s = SYSTEM_PROMPT;
+        assert!(
+            s.contains("quantity(<value>, <unit>)") || s.contains("quantity(4, inches)"),
+            "system prompt must teach the quantity(value, unit) shape"
+        );
+        // The quantity rule must explicitly forbid flattening the
+        // number into the predicate name (the pocket-knife regression
+        // from ADJ18).
+        assert!(
+            s.contains("blade_4_inches"),
+            "prompt must show the canonical wrong pattern (blade_4_inches) as a forbidden example"
+        );
+        assert!(
+            s.contains("blade_length(knife, quantity(4, inches))"),
+            "prompt must show the canonical right pattern (blade_length + quantity) as the worked example"
+        );
+        // Common units must be enumerated so the model uses
+        // consistent atoms across runs.
+        for unit in &["oz", "ml", "inches", "wh", "kg", "days"] {
+            assert!(
+                s.contains(unit),
+                "common unit `{unit}` should be mentioned in the unit-normalisation list"
+            );
+        }
+    }
+
+    #[test]
+    fn system_prompt_includes_pocket_knife_worked_example() {
+        // The second worked example specifically demonstrates that
+        // typed quantities lower correctly. Without this example the
+        // model has no anchor for what the shape looks like in
+        // practice.
+        let s = SYSTEM_PROMPT;
+        assert!(
+            s.contains("\"4 inch pocket knife.\""),
+            "prompt must include the typed-quantity worked example source"
+        );
+        assert!(
+            s.contains("blade_length") && s.contains("pocket_knife"),
+            "prompt's typed-quantity worked example must produce a blade_length fact"
+        );
+        // The rationale paragraph after the example must connect
+        // the quantity preservation back to the engine's job.
+        assert!(
+            s.contains("4 > 2.36"),
+            "prompt must explain why preserving the typed quantity matters (the engine evaluates the threshold)"
+        );
+    }
+
+    #[test]
+    fn system_prompt_uses_domain_neutral_quantity_rules() {
+        // The quantity rule should NOT presume a specific domain's
+        // unit vocabulary; the unit list is an example, not an
+        // enumeration. (TSA happens to be in the worked example;
+        // the framework should also handle clinical, contract, etc.)
+        let s = SYSTEM_PROMPT;
+        // Clinical-flavored units should NOT appear in the rule
+        // text (only in domain-flavored worked examples, if at all).
+        // The point: the rule applies to ANY value+unit pairing,
+        // not just TSA's.
+        assert!(s.contains("snake_case atom"));
+        // The rule explicitly says "every numerical quantity",
+        // not "every TSA quantity" or similar.
+        assert!(s.contains("Every numerical quantity in the source"));
     }
 
     #[test]

--- a/code/packages/rust/llm-primitives/src/lib.rs
+++ b/code/packages/rust/llm-primitives/src/lib.rs
@@ -372,7 +372,7 @@ impl From<LlmError> for PrimitiveError {
 // prompt: every `LlmCallRecord` carries the version, so replay
 // matches `(prompt_version, prompt_hash)`.
 
-pub const DECOMPOSE_TEXT_PROMPT_VERSION: &str = "decompose-text-v4";
+pub const DECOMPOSE_TEXT_PROMPT_VERSION: &str = "decompose-text-v5";
 pub const RENDER_NODE_PROMPT_VERSION: &str = "render-node-v1";
 pub const ENTAIL_PROMPT_VERSION: &str = "entail-v1";
 pub const ADVERSARY_PROMPT_VERSION: &str = "adversary-v1";
@@ -885,7 +885,7 @@ mod tests {
     fn prompt_version_constants_are_stable() {
         // Locking the constants down — bumping any of these is an
         // audit-trail-affecting change and should be a separate PR.
-        assert_eq!(DECOMPOSE_TEXT_PROMPT_VERSION, "decompose-text-v4");
+        assert_eq!(DECOMPOSE_TEXT_PROMPT_VERSION, "decompose-text-v5");
         assert_eq!(RENDER_NODE_PROMPT_VERSION, "render-node-v1");
         assert_eq!(ENTAIL_PROMPT_VERSION, "entail-v1");
         assert_eq!(ADVERSARY_PROMPT_VERSION, "adversary-v1");

--- a/code/specs/ADJ-OVERVIEW.md
+++ b/code/specs/ADJ-OVERVIEW.md
@@ -265,5 +265,13 @@ ADJ_DEMO_ENDPOINT=http://127.0.0.1:11434 \
   case and whether the v0.12 priming dispatch reduces gemma4
   truncation in practice. Harness at
   [`scripts/adj18_bench.py`](../../scripts/adj18_bench.py).
+- [ADJ21](ADJ21-typed-quantity-decomposition.md) — `decompose_text`
+  prompt update (v4 → v5) that explicitly teaches typed-quantity
+  extraction. Every numerical value-with-unit in the source
+  becomes a `quantity(value, unit)` compound term, preserved in
+  the IR so the engine can evaluate threshold comparisons
+  deterministically (instead of asking the LLM to do arithmetic
+  inside its forward pass — the failure mode the ADJ18 v0.13
+  bench surfaced empirically).
 - [LM00](LM00-llm-gateway-architecture.md) — gateway architecture.
 - [LM00b](LM00b-llm-primitives.md) — primitives layer.

--- a/code/specs/ADJ21-typed-quantity-decomposition.md
+++ b/code/specs/ADJ21-typed-quantity-decomposition.md
@@ -1,0 +1,250 @@
+# ADJ21 — Typed quantity decomposition (decompose_text v5)
+
+## Overview
+
+The ADJ18 v0.13 bench (PR #3069) confirmed empirically what the
+framework's design already implied: **the LLM cannot reliably
+evaluate numerical thresholds inside its forward pass.** Every
+model in the lineup mishandled the "4-inch blade vs 2.36-inch
+limit" comparison from rule 6, and none escalated despite the
+v0.13 prompt giving them that option.
+
+The structural fix is to **let the engine do the comparisons**.
+For the engine to do that, the source IR has to preserve typed
+quantities — value + unit — as structured terms rather than
+folding numbers into predicate names or losing units to the
+LLM's interpretation.
+
+ADJ21 is the smallest possible step toward that goal: a
+**targeted update to `decompose_text`'s prompt** so the LLM
+reliably extracts numerical quantities as `quantity(value, unit)`
+compound terms. No new primitive. No domain-specific
+configuration. The corrected prompt + the IR grammar (already
+on main since ADJ01 v3) together cover the contract.
+
+The follow-up — a typed-quantity coverage checker that
+validates the LLM did extract every quantity in the source —
+is queued as **ADJ22** for a separate PR.
+
+## Why this isn't a new primitive
+
+A natural-looking move would be to add a sibling primitive
+called `decompose_typed_facts(text, domain, expected_quantity_types)`.
+That's wrong:
+
+- **The IR grammar is already domain-agnostic.** `IRNode` with
+  `kind: Fact` and a compound term containing `quantity(value,
+  unit)` can express any value-with-unit from any domain. No
+  schema extension needed.
+- **Pre-declared quantity types couple callers to domains.**
+  Asking the caller to list `["blade_length", "volume", "voltage"]`
+  for TSA, `["temperature", "heart_rate", "ABV"]` for clinical,
+  etc., re-introduces the domain-specific coupling the framework
+  is designed to avoid.
+- **The model can do this generically with the right prompt.**
+  Structured information extraction is a well-studied task. LLMs
+  reliably extract `(value, unit)` pairs from arbitrary text when
+  the prompt asks for them in a typed shape and shows one worked
+  example.
+
+So the fix is in the existing primitive's prompt template, not
+in adding a parallel primitive.
+
+## What the prompt change does
+
+Three additions to `decompose_text`'s system prompt:
+
+### 1. A new section: "QUANTITY rules"
+
+Three new rules under their own heading:
+
+- **7a**: Every numerical quantity in the source MUST appear as a
+  `quantity(<value>, <unit>)` compound term. Values are atoms
+  with literal numbers preserved (no rounding, no conversion).
+  Units are snake_case atoms (`oz`, `ml`, `inches`, `wh`, etc.).
+  Quantities are embedded inside the surrounding fact's args —
+  never flattened into the predicate name.
+
+  > **Wrong**: `blade_4_inches(knife)`
+  > **Right**: `blade_length(knife, quantity(4, inches))`
+
+- **7b**: Bare numbers without units are still preserved as
+  atoms, using `count` or domain-appropriate predicates.
+  `"1 carry-on bag"` → `carry_on_bag(quantity(1, count))`.
+
+- **7c**: The rationale — downstream rules compare quantities
+  against thresholds (`gt(L, quantity(2.36, inches))`,
+  `le(V, quantity(100, ml))`). The engine evaluates these
+  comparisons deterministically — but only if the source IR
+  preserves the typed value.
+
+### 2. A second worked example
+
+The existing prompt's worked example uses `"1 carry-on bag,
+matches."` — a case without typed quantities. The v5 prompt adds
+a second worked example with a numerical quantity:
+
+```
+SOURCE: "4 inch pocket knife." (20 bytes)
+
+Output (excerpt):
+  N1: declared(pocket_knife)
+  N2: blade_length(pocket_knife, quantity(4, inches))
+  S1: sentence (covers ". " connective + trailing punctuation)
+
+Coverage tiles 0..20.
+```
+
+The example follows the existing prompt conventions (id naming,
+source_spans tiling, Section/Contains structure). The only new
+shape it teaches is the nested `quantity(4, inches)` compound.
+
+The rationale paragraph after the example connects the typed
+quantity to the engine's job:
+
+> *"A downstream rule like `prohibited(X) :- blade_length(X,
+> quantity(L, inches)), gt(L, quantity(2.36, inches))` can
+> pattern-match `L = 4` and evaluate `4 > 2.36` deterministically
+> in the engine. If the IR had flattened the number into the
+> predicate name (`blade_4_inches`) or dropped the unit
+> (`blade_length(pocket_knife, 4)`), the rule could not fire
+> correctly. Preserve the typed value."*
+
+### 3. Prompt version bump
+
+`DECOMPOSE_TEXT_PROMPT_VERSION: "decompose-text-v4" → "decompose-text-v5"`.
+
+The audit-trail discipline requires every prompt change to bump
+the version constant so replayed adjudications can distinguish
+v4-era IR from v5-era IR. Pre-existing audit records remain
+replayable; new records use v5.
+
+## What the prompt change does NOT do
+
+- **No domain-specific unit lists.** The unit examples in the
+  rule (`oz`, `ml`, `inches`, `wh`, `celsius`, `percent_abv`,
+  etc.) are illustrative, not exhaustive. The model is expected
+  to use any sensible snake_case unit atom appropriate to the
+  source.
+- **No new edge relations.** The existing edge taxonomy
+  (`Contains`, `Refers`, `Mentions`, etc.) is sufficient.
+  Quantities live INSIDE the surrounding fact's compound term;
+  they don't need their own edge relation.
+- **No structural changes to the IR grammar.** `IRDocument`,
+  `IRNode`, `IREdge` are unchanged. Only the prompt asks for a
+  particular shape of compound term inside `IRNode.term`.
+- **No new primitive.** `decompose_text` remains the only
+  text-to-IR primitive.
+
+## Tests
+
+Three new offline unit tests added to
+`adjudication-rust/llm-primitives/src/decompose_text.rs`:
+
+- `system_prompt_documents_typed_quantity_extraction` — pins
+  the prompt mentions the quantity-extraction rule, the
+  wrong-vs-right pattern (`blade_4_inches` vs
+  `blade_length(knife, quantity(4, inches))`), and the common
+  unit list.
+- `system_prompt_includes_pocket_knife_worked_example` — pins
+  the second worked example is present, produces the right shape,
+  and the rationale paragraph mentions `4 > 2.36` (the engine's
+  evaluation).
+- `system_prompt_uses_domain_neutral_quantity_rules` — pins the
+  generic phrasing: "Every numerical quantity in the source"
+  (not "Every TSA quantity"), `snake_case atom` for units.
+
+Plus the existing `prompt_version_constants_are_stable` test was
+updated to expect `decompose-text-v5`.
+
+All 81 lib tests pass.
+
+## How this composes with other ADJs
+
+```
+ADJ01 v3 (IR grammar)
+   ↓ supports
+quantity(value, unit) as a compound term
+   ↓ now produced by
+decompose_text v5 (this PR)
+   ↓ enables
+ADJ20 fact sheets to reference typed quantities by entity
+   ↓ enables
+adjudication-pipeline run_with_rulebooks to lower typed-quantity
+rules (rulebook says `gt(L, quantity(2.36, inches))`) and the
+engine to unify them with source IR's quantity atoms
+   ↓ produces
+deterministic verdicts where the LLM never had to do the
+arithmetic.
+```
+
+The framework's pipeline becomes:
+
+1. **Source decomposition (this PR)** — LLM produces typed
+   IR including `quantity(...)` atoms for every numerical literal.
+2. **Fact sheets (ADJ20-impl, not yet on main)** — per-entity
+   world-knowledge facts that map entity types to applicable
+   rule classes.
+3. **Rulebook** — domain rules referencing typed quantities and
+   thresholds.
+4. **Engine** — unifies source IR + fact sheets + rulebook,
+   evaluates threshold comparisons deterministically.
+5. **Verdict** — proof DAG citing typed-quantity facts, fact-sheet
+   entries, and rule clauses by provenance.
+
+The LLM's job shrinks to: produce well-typed IR. The arithmetic
+is the engine's.
+
+## ADJ22 (queued): typed-quantity coverage checker
+
+The next sibling spec adds a coverage-checker pass that walks
+the source text for numerical literals (regex
+`[0-9]+(\.[0-9]+)?\s*\S+`) and verifies each one has a
+corresponding `quantity(...)` compound somewhere in the IR with
+an overlapping source span. Failures route to ADJ06
+clarification — same loop the framework uses for ADJ02 coverage
+failures.
+
+ADJ22 is a separate PR because:
+
+- It's a new crate (or extension to `adjudication-coverage`).
+- It needs its own prompt-version-aware retry logic.
+- It needs its own test suite covering edge cases (numbers in
+  compound words, e.g., "30-day window"; ranges, e.g., "5-7
+  inches"; ordinals; etc.).
+
+ADJ21 (this PR) lands the prompt change first so it's available
+in main; ADJ22 follows with the validator. Both are needed for
+the engine arm to work end-to-end on non-canonical declarations.
+
+## Reproduction
+
+The prompt change is observable in the prompt-version constant:
+
+```bash
+# After this PR lands:
+cargo run -p adjudication-tsa-demo -- ...   # ↑ uses decompose-text-v5
+```
+
+Every `LlmCallRecord` for `decompose_text` calls after this PR
+will record `prompt_version: "decompose-text-v5"`. Replay of
+pre-existing v4-era audit records is unaffected — the framework's
+audit trail discipline keeps versions distinguishable.
+
+A second-pass bench (re-running ADJ18 / ADJ19 against v5
+decompose_text + Arm B / Arm C) is the natural empirical
+follow-up. Queued as ADJ23.
+
+## See also
+
+- [ADJ01](ADJ01-adjudication-ir-grammar.md) — the IR grammar
+  that already supports typed quantities; this PR just makes
+  the prompt reliably produce them.
+- [ADJ18 §"v0.13 re-run results"](ADJ18-broadened-tsa-empirical-bench.md)
+  — the empirical evidence that prompt-level ESCALATE is
+  insufficient because the LLM cannot evaluate thresholds.
+- [ADJ20](ADJ20-fact-sheets-and-pipeline-reorder.md) — the
+  fact-sheet primitive that consumes typed quantities from
+  source IR + rules from rulebooks.
+- ADJ22 (queued) — typed-quantity coverage checker.
+- ADJ23 (queued) — empirical re-bench post-v5 decompose_text.


### PR DESCRIPTION
## Summary

The ADJ18 v0.13 bench showed empirically that **every model in the 5-model lineup misapplies numerical thresholds inside its forward pass**. The pocket-knife case (4-inch blade vs 2.36-inch rule limit) was the cleanest example — every model said COMPLIANT despite the math.

The structural fix is to let the engine do the comparisons. For the engine to do that, the source IR must preserve typed quantities as structured terms.

**ADJ21 is the smallest step toward that goal**: update `decompose_text`'s prompt so the LLM reliably extracts numerical quantities as `quantity(value, unit)` compound terms. No new primitive. No domain config.

## Prompt change

New \"QUANTITY rules\" section (7a/7b/7c) in the system prompt:

- Every value-with-unit must lower to `quantity(<value>, <unit>)`.
- Units are snake_case atoms; values preserve the literal number.
- Quantities embed INSIDE the surrounding fact's args — never flatten into the predicate name.

  > Wrong: `blade_4_inches(knife)`
  > Right: `blade_length(knife, quantity(4, inches))`

Plus a second worked example:

```
SOURCE: \"4 inch pocket knife.\" (20 bytes)
  →  blade_length(pocket_knife, quantity(4, inches))
```

The rationale paragraph after it explicitly mentions that a rule like `gt(L, quantity(2.36, inches))` can fire deterministically because the engine evaluates `4 > 2.36`, not the LLM.

## What this is NOT

- **Not a new primitive.** `decompose_text` remains the only text-to-IR primitive.
- **Not domain-specific.** Unit examples are illustrative; the rule applies to every numerical quantity.
- **Not a checker.** The validator that asserts every numerical literal in the source produced a quantity node is **ADJ22** (queued).
- **Not a re-bench.** End-to-end empirical follow-up is **ADJ23** (queued).

## Compatibility

- Audit-trail compatible: old v4 records still replay; new records use v5.
- Wire format unchanged: ADJ01 v3 IR already supports `quantity(...)` compounds.
- Caller API unchanged.

## Tests

81 lib tests pass (3 new):
- Prompt teaches the `quantity(value, unit)` shape + wrong-vs-right pattern + unit list.
- Pocket-knife worked example present + rationale mentions `4 > 2.36`.
- Quantity rules are domain-neutral (\"Every numerical quantity\", not TSA-specific).

## Follow-ups

- **ADJ22**: typed-quantity coverage checker (Rust validator + ADJ06 retry).
- **ADJ23**: re-bench ADJ18 / ADJ19 against v5 decompose_text + ADJ20 fact sheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)