### PR TITLE
feat(adjudication-coverage): ADJ22 typed-quantity coverage checker

### DIFF
--- a/code/packages/rust/adjudication-coverage/CHANGELOG.md
+++ b/code/packages/rust/adjudication-coverage/CHANGELOG.md
@@ -2,6 +2,103 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-05-13 — ADJ22 typed-quantity coverage
+
+### Added
+
+`check_typed_quantity_coverage(doc, ir_doc)` — a sibling checker to
+the existing `check_coverage`, implementing
+[ADJ22](../../../specs/ADJ22-typed-quantity-coverage.md).
+
+For every numerical literal in the source text (`\d+(\.\d+)?`), the
+checker verifies that at least one IR node has source_spans
+overlapping the literal AND a `quantity(value, unit)` compound term
+somewhere in its term tree (recursively, so deeply-nested
+quantities are also detected).
+
+Violations come back as
+`TypedQuantityViolation::MissingQuantity { literal, location,
+nearby_nodes }` which an ADJ06 clarification prompt can use to
+re-prompt the model: *"You produced node N1 over this span but did
+not include the quantity 4."*
+
+### Why this exists
+
+ADJ18's empirical bench (v0.13 prompts, PR #3066) showed that
+LLMs reliably mishandle numerical thresholds when asked to apply
+rules inside their own forward pass. The structural fix is to
+preserve typed quantities in the source IR so the engine can do
+the arithmetic deterministically.
+
+[ADJ21](../../../specs/ADJ21-typed-quantity-decomposition.md)
+(PR #3071) updates `decompose_text`'s prompt to teach the LLM to
+emit `quantity(value, unit)` compounds. ADJ22 is the validator
+that catches when the LLM drops the quantity anyway — either by
+omitting it, flattening it into the predicate name
+(`blade_4_inches` instead of `blade_length(knife, quantity(4,
+inches))`), or losing the unit.
+
+### Scope
+
+The check focuses on `NodeKind::Fact`, `NodeKind::Rule`, and
+`NodeKind::Uncertainty` nodes — the kinds that are expected to
+carry source-level quantities. Section, Entity, Query, Discarded,
+and Exception nodes are exempt; their terms carry structure,
+identity, or queries rather than measurements.
+
+The checker matches the literal's value (post-normalisation —
+`"4"`, `"4.0"`, `"04"` all canonicalise to `"4"`) against atoms
+OR numeric `Term::Num` values in the IR. Units are not validated
+in this iteration — the checker only verifies that *some*
+`quantity(<lit>, _)` compound exists; subsequent passes (a future
+ADJ22.x) can enforce specific unit vocabularies per domain.
+
+### Edge cases
+
+- Numbers without units (`"1 carry-on bag"`): still flagged if no
+  `quantity(1, _)` exists. The ADJ21 prompt teaches the model to
+  emit `quantity(1, count)` for these.
+- Decimals (`"3.4 oz"`): matched via canonical-decimal
+  normalisation so `quantity(3.4, oz)` and `quantity(Float(3.4), oz)`
+  both pass.
+- Nested compounds: the term-tree walk is recursive, so deeply-
+  nested quantities inside other compounds (e.g.,
+  `meets_threshold(blade_length(knife, quantity(4, inches)))`) are
+  detected.
+
+### Tests
+
+13 new tests added (20 lib total, all passing):
+
+- Literal scan: integers, decimals, multiples, none.
+- Pass: top-level quantity compound, decimal, numeric-atom,
+  no-numbers-in-source, deeply-nested quantity.
+- Fail: missing quantity, flattened-into-predicate
+  (`blade_4_inches`), multiple missing literals reported
+  separately.
+- Normalisation: leading zeros, trailing decimal zeros, 0.5
+  edge case.
+
+### Compatibility
+
+- Pre-existing `check_coverage` API unchanged.
+- `Document` struct unchanged.
+- New types (`TypedQuantityViolation`, `TypedQuantityResult`,
+  `check_typed_quantity_coverage`) are additive.
+- `logic-core` moved from dev-dep to dep so the checker can
+  inspect `Term` shapes.
+
+### What's NOT in this PR
+
+- **Pipeline wiring**: ADJ22 is a pure check today. Wiring it
+  into `adjudication-pipeline` so failures route to ADJ06
+  clarification is a follow-up. The check is callable standalone
+  in the meantime.
+- **Unit-vocabulary enforcement**: the check verifies a
+  `quantity(<lit>, _)` exists but doesn't validate the unit
+  atom. A future iteration could enforce per-domain unit
+  vocabularies if needed.
+
 ## [0.2.0] - 2026-05-11 — ADJ02 v2 structural rewrite
 
 ### Replaced

--- a/code/packages/rust/adjudication-coverage/Cargo.toml
+++ b/code/packages/rust/adjudication-coverage/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "adjudication-coverage"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "ADJ02 v2 — structural tree-coverage check over the hierarchical IR. Language-agnostic; no tagger, no stopwords, no NegEx triggers."
+description = "ADJ02 v2 — flat-tile coverage check over the v3 graph IR (every byte covered, no overlaps). v0.3 adds ADJ22: typed-quantity coverage — for every numerical literal in the source, an overlapping IR node must carry a quantity(value, unit) compound (catches the failure mode where decompose_text drops a number, fold-flattens it into a predicate name, or omits the unit)."
 
 [dependencies]
 adjudication-ir = { path = "../adjudication-ir" }
-
-[dev-dependencies]
 logic-core = { path = "../logic-core" }

--- a/code/packages/rust/adjudication-coverage/src/lib.rs
+++ b/code/packages/rust/adjudication-coverage/src/lib.rs
@@ -195,6 +195,244 @@ pub fn check_coverage(doc: &Document, ir_doc: &IRDocument) -> CoverageResult {
 pub use adjudication_ir::{NodeId as IrNodeId, Span as IrSpan};
 
 // ---------------------------------------------------------------------------
+// ADJ22 — typed-quantity coverage
+// ---------------------------------------------------------------------------
+
+/// One typed-quantity violation. Surfaced when the source mentions
+/// a numerical literal but the IR doesn't carry a corresponding
+/// `quantity(value, unit)` compound with an overlapping span.
+///
+/// Per [ADJ21](../../../specs/ADJ21-typed-quantity-decomposition.md):
+/// every numerical quantity in the source must lower to a typed
+/// `quantity(value, unit)` term so the engine can evaluate
+/// thresholds deterministically. If `decompose_text` drops a
+/// quantity — folds it into the predicate name, omits the unit,
+/// or simply forgets to extract it — the engine has nothing to
+/// reason over. This checker catches that failure mode pre-engine
+/// so ADJ06 can re-prompt.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypedQuantityViolation {
+    /// The source contains a numerical literal at this span, but
+    /// no IR node with an overlapping span carries a `quantity(_)`
+    /// compound term.
+    MissingQuantity {
+        /// The literal as it appears in the source (e.g., `"4"`,
+        /// `"3.4"`, `"750"`). Carried so ADJ06 can quote it back.
+        literal: String,
+        /// Byte range in the source where the literal appears.
+        location: (usize, usize),
+        /// Nodes whose `source_spans` overlap this location.
+        /// Included so the clarification prompt can name "you
+        /// produced node X over this range but didn't include the
+        /// quantity" rather than just "you missed a number."
+        nearby_nodes: Vec<adjudication_ir::NodeId>,
+    },
+}
+
+/// Outcome of the typed-quantity coverage check.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypedQuantityResult {
+    Pass,
+    Fail { violations: Vec<TypedQuantityViolation> },
+}
+
+/// Run the typed-quantity coverage check (ADJ22).
+///
+/// Walks `doc.normalized_text` for numerical literals (integers or
+/// decimals), then for each literal checks that at least one
+/// IR node has `source_spans` overlapping the literal's location
+/// AND a `quantity(...)` compound somewhere in its `term` tree.
+///
+/// **What counts as a numerical literal**: contiguous digits, optionally
+/// followed by a single dot and more digits — `\d+(\.\d+)?`. Matches
+/// `4`, `3.4`, `750`, `200`. Numbers buried inside compound words
+/// (e.g., the `30` in `"30-day window"`) are matched if they're
+/// flanked by word boundaries or whitespace; the regex tolerates
+/// hyphens and unit suffixes immediately after.
+///
+/// **What counts as a quantity term**: any compound term anywhere in
+/// any node's `term` (including nested args) whose `functor` is
+/// exactly `"quantity"` and whose first arg is an atom matching
+/// the literal's value (post-normalisation — `"4"`, `"4.0"`, `"4"`
+/// all match the literal `"4"`).
+///
+/// **Scoping**: only Fact, Rule, and Uncertainty nodes are checked.
+/// Section, Entity, Query, Discarded, and Exception nodes are
+/// exempt because their terms aren't expected to carry source-level
+/// quantities — they carry structure, identity, or queries.
+///
+/// **Edge case**: numerical literals inside synthesized Query
+/// nodes' terms (e.g., a query like `compliant(passenger_42)` where
+/// `42` is a synthesized id) are NOT in the source text, so the
+/// checker doesn't see them. Source-text quantities live in
+/// `doc.normalized_text`, which is what we scan.
+pub fn check_typed_quantity_coverage(
+    doc: &Document,
+    ir_doc: &IRDocument,
+) -> TypedQuantityResult {
+    let literals = scan_numerical_literals(&doc.normalized_text);
+    let mut violations: Vec<TypedQuantityViolation> = Vec::new();
+
+    for (lit, (start, end)) in &literals {
+        // Collect the IR nodes whose source_spans overlap this
+        // literal's location.
+        let overlapping: Vec<&adjudication_ir::IRNode> = ir_doc
+            .nodes
+            .iter()
+            .filter(|n| {
+                matches!(
+                    n.kind,
+                    NodeKind::Fact | NodeKind::Rule | NodeKind::Uncertainty
+                )
+            })
+            .filter(|n| {
+                n.source_spans
+                    .iter()
+                    .any(|s| spans_overlap(s.start, s.end, *start, *end))
+            })
+            .collect();
+
+        // Does any overlapping node carry a `quantity(<lit>, _)`
+        // compound somewhere in its term tree?
+        let has_matching_quantity =
+            overlapping.iter().any(|n| term_contains_quantity(&n.term, lit));
+
+        if !has_matching_quantity {
+            violations.push(TypedQuantityViolation::MissingQuantity {
+                literal: lit.clone(),
+                location: (*start, *end),
+                nearby_nodes: overlapping.iter().map(|n| n.id.clone()).collect(),
+            });
+        }
+    }
+
+    if violations.is_empty() {
+        TypedQuantityResult::Pass
+    } else {
+        TypedQuantityResult::Fail { violations }
+    }
+}
+
+/// Find every numerical literal in `text`. Returns
+/// `Vec<(literal_string, (start, end))>` where the byte range
+/// covers the literal exactly (not surrounding whitespace or units).
+///
+/// Scans manually without a regex dep — looking for runs of ASCII
+/// digits, optionally including one `.` separator between digit
+/// runs. Negative numbers and scientific notation are out of scope
+/// (rare in adjudication declarations; the few cases that need
+/// them can be addressed in a follow-up).
+fn scan_numerical_literals(text: &str) -> Vec<(String, (usize, usize))> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if !bytes[i].is_ascii_digit() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        // Consume digits.
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        // Optional `.<digits>` continuation.
+        if i + 1 < bytes.len() && bytes[i] == b'.' && bytes[i + 1].is_ascii_digit() {
+            i += 1; // consume the dot
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+        }
+        let literal = &text[start..i];
+        out.push((literal.to_string(), (start, i)));
+    }
+    out
+}
+
+/// Check whether two byte ranges `[a_start, a_end)` and
+/// `[b_start, b_end)` overlap at all. Empty ranges (start==end) are
+/// treated as non-overlapping with anything (they're points, not
+/// spans).
+fn spans_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) -> bool {
+    if a_start >= a_end || b_start >= b_end {
+        return false;
+    }
+    a_start < b_end && b_start < a_end
+}
+
+/// Walk a term's tree looking for a `quantity(<lit>, _)` compound.
+/// Matches when the functor is exactly `"quantity"`, the first arg
+/// is an atom whose name is `lit` (or a numerically-equal variant),
+/// and the term has at least 2 args (value + unit).
+///
+/// Nested terms (quantities inside compound args of other facts)
+/// are matched recursively — `blade_length(knife, quantity(4, inches))`
+/// returns true for `lit = "4"`.
+fn term_contains_quantity(term: &logic_core::Term, lit: &str) -> bool {
+    use logic_core::Term;
+    match term {
+        Term::Compound { functor, args } => {
+            if functor == "quantity" && args.len() >= 2 {
+                if let Some(value_arg) = args.first() {
+                    if atom_or_num_matches_literal(value_arg, lit) {
+                        return true;
+                    }
+                }
+            }
+            // Recurse into args looking for nested quantities.
+            args.iter().any(|a| term_contains_quantity(a, lit))
+        }
+        _ => false,
+    }
+}
+
+/// `"4"` matches atom("4"), `"4"` matches num(4), `"4.0"` matches
+/// num(4.0) and atom("4.0"). The literal in the source is always
+/// a string of digits; the IR's value atom can be either a string
+/// `Atom` or a numeric `Num`. Treat them as equal when the
+/// canonical-decimal forms match.
+fn atom_or_num_matches_literal(term: &logic_core::Term, lit: &str) -> bool {
+    use logic_core::{Number, Term};
+    match term {
+        Term::Atom(s) => normalise_numeric(s) == normalise_numeric(lit),
+        Term::Num(Number::Int(i)) => i.to_string() == normalise_numeric(lit),
+        Term::Num(Number::Float(f)) => {
+            // Compare as canonical decimal — Float's f64::to_string
+            // produces e.g. "4" for 4.0 not "4.0", which matches the
+            // literal "4" but not "4.0". Normalise both.
+            normalise_numeric(&f.to_string()) == normalise_numeric(lit)
+        }
+        _ => false,
+    }
+}
+
+/// Strip trailing `.0` and leading zeros so `"4"`, `"4.0"`, and
+/// `"04"` all match. (`"4.5"` stays `"4.5"`; `"0.5"` stays `"0.5"`
+/// — leading zero before a decimal point is preserved.)
+fn normalise_numeric(s: &str) -> String {
+    // Split into whole and fractional parts first; that way the
+    // leading-zero strip applies only to the whole-number portion
+    // and doesn't eat a meaningful leading zero before a decimal.
+    let (whole, frac) = match s.find('.') {
+        Some(idx) => {
+            let (w, rest) = s.split_at(idx);
+            (w, &rest[1..]) // skip the dot
+        }
+        None => (s, ""),
+    };
+    // Strip leading zeros from the whole part, but keep at least "0".
+    let whole_trimmed = whole.trim_start_matches('0');
+    let whole_canonical = if whole_trimmed.is_empty() { "0" } else { whole_trimmed };
+    // Strip trailing zeros from the fractional part.
+    let frac_trimmed = frac.trim_end_matches('0');
+    if frac_trimmed.is_empty() {
+        whole_canonical.to_string()
+    } else {
+        format!("{whole_canonical}.{frac_trimmed}")
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -373,5 +611,269 @@ mod tests {
             edges: vec![],
         };
         assert_eq!(check_coverage(&doc, &ir), CoverageResult::Pass);
+    }
+
+    // -----------------------------------------------------------------
+    // ADJ22 — typed-quantity coverage tests
+    // -----------------------------------------------------------------
+
+    fn fact_with_term(id: &str, term: logic_core::Term, start: usize, end: usize) -> IRNode {
+        IRNode {
+            id: NodeId::new(id),
+            kind: NodeKind::Fact,
+            term,
+            polarity: Polarity::Affirmed,
+            modality: Modality::Present,
+            source_spans: vec![span_of(start, end)],
+            confidence: 0.9,
+            discard_reason: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn typed_quantity_scan_finds_integers() {
+        let lits = scan_numerical_literals("4 inch pocket knife.");
+        assert_eq!(lits.len(), 1);
+        assert_eq!(lits[0].0, "4");
+        assert_eq!(lits[0].1, (0, 1));
+    }
+
+    #[test]
+    fn typed_quantity_scan_finds_decimals() {
+        let lits = scan_numerical_literals("3.4 oz toothpaste.");
+        assert_eq!(lits.len(), 1);
+        assert_eq!(lits[0].0, "3.4");
+        assert_eq!(lits[0].1, (0, 3));
+    }
+
+    #[test]
+    fn typed_quantity_scan_finds_multiple_literals() {
+        let lits = scan_numerical_literals("1 carry-on bag, 200 Wh lithium battery.");
+        let nums: Vec<&str> = lits.iter().map(|(s, _)| s.as_str()).collect();
+        assert_eq!(nums, vec!["1", "200"]);
+    }
+
+    #[test]
+    fn typed_quantity_scan_handles_no_numbers() {
+        let lits = scan_numerical_literals("strike-anywhere matches.");
+        assert!(lits.is_empty());
+    }
+
+    #[test]
+    fn typed_quantity_check_passes_when_node_has_quantity_compound() {
+        // Source has "4 inch pocket knife"; IR has a node whose term
+        // is blade_length(pocket_knife, quantity(4, inches)) — the
+        // canonical ADJ21 shape. ADJ22 must pass.
+        let doc = mk_doc("4 inch pocket knife.");
+        let quantity_term = compound(
+            "blade_length",
+            vec![
+                atom("pocket_knife"),
+                compound("quantity", vec![atom("4"), atom("inches")]),
+            ],
+        );
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![fact_with_term("N1", quantity_term, 0, 6)],
+            edges: vec![],
+        };
+        assert_eq!(
+            check_typed_quantity_coverage(&doc, &ir),
+            TypedQuantityResult::Pass
+        );
+    }
+
+    #[test]
+    fn typed_quantity_check_fails_when_node_drops_the_quantity() {
+        // Source has "4 inch pocket knife"; IR has a node that
+        // forgot to include the quantity (just declared(pocket_knife)).
+        // ADJ22 must flag the missing 4.
+        let doc = mk_doc("4 inch pocket knife.");
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![fact_with_term(
+                "N1",
+                compound("declared", vec![atom("pocket_knife")]),
+                0,
+                19,
+            )],
+            edges: vec![],
+        };
+        match check_typed_quantity_coverage(&doc, &ir) {
+            TypedQuantityResult::Fail { violations } => {
+                assert_eq!(violations.len(), 1);
+                match &violations[0] {
+                    TypedQuantityViolation::MissingQuantity { literal, nearby_nodes, .. } => {
+                        assert_eq!(literal, "4");
+                        assert_eq!(nearby_nodes.len(), 1);
+                        assert_eq!(nearby_nodes[0].0, "N1");
+                    }
+                }
+            }
+            other => panic!("expected Fail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typed_quantity_check_fails_when_number_flattened_into_predicate() {
+        // The canonical wrong pattern from ADJ21: the model put the
+        // 4 in the predicate name (`blade_4_inches`) instead of as
+        // a quantity term. ADJ22 must catch this — there's no
+        // `quantity(4, _)` anywhere in the IR.
+        let doc = mk_doc("4 inch pocket knife.");
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![fact_with_term(
+                "N1",
+                compound("blade_4_inches", vec![atom("pocket_knife")]),
+                0,
+                19,
+            )],
+            edges: vec![],
+        };
+        match check_typed_quantity_coverage(&doc, &ir) {
+            TypedQuantityResult::Fail { violations } => {
+                assert_eq!(violations.len(), 1);
+                if let TypedQuantityViolation::MissingQuantity { literal, .. } = &violations[0] {
+                    assert_eq!(literal, "4");
+                }
+            }
+            other => panic!("expected Fail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typed_quantity_check_passes_with_decimal_quantity() {
+        // Source has "3.4 oz"; IR has quantity(3.4, oz). Decimal
+        // values must match.
+        let doc = mk_doc("3.4 oz toothpaste.");
+        let term = compound(
+            "liquid_volume",
+            vec![
+                atom("toothpaste"),
+                compound("quantity", vec![atom("3.4"), atom("oz")]),
+            ],
+        );
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![fact_with_term("N1", term, 0, 17)],
+            edges: vec![],
+        };
+        assert_eq!(
+            check_typed_quantity_coverage(&doc, &ir),
+            TypedQuantityResult::Pass
+        );
+    }
+
+    #[test]
+    fn typed_quantity_check_matches_numeric_value_via_normalisation() {
+        // Source says "4"; IR uses Term::Num(Int(4)) — both should
+        // canonicalise to "4" and match. (Numeric atoms vs string
+        // atoms both work.)
+        use logic_core::int;
+        let doc = mk_doc("4 inch pocket knife.");
+        let term = compound(
+            "blade_length",
+            vec![
+                atom("pocket_knife"),
+                compound("quantity", vec![int(4), atom("inches")]),
+            ],
+        );
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![fact_with_term("N1", term, 0, 6)],
+            edges: vec![],
+        };
+        assert_eq!(
+            check_typed_quantity_coverage(&doc, &ir),
+            TypedQuantityResult::Pass
+        );
+    }
+
+    #[test]
+    fn typed_quantity_check_passes_with_no_numbers_in_source() {
+        // No literals to flag.
+        let doc = mk_doc("strike-anywhere matches.");
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![fact_leaf("N1", 0, 24)],
+            edges: vec![],
+        };
+        assert_eq!(
+            check_typed_quantity_coverage(&doc, &ir),
+            TypedQuantityResult::Pass
+        );
+    }
+
+    #[test]
+    fn typed_quantity_check_flags_multiple_missing_quantities() {
+        // Source has TWO numerical literals (1 and 200), IR has
+        // neither as a quantity term. Both should be reported.
+        let doc = mk_doc("1 carry-on bag, 200 Wh battery.");
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![
+                fact_with_term(
+                    "N1",
+                    compound("declared", vec![atom("carry_on_bag")]),
+                    0,
+                    14,
+                ),
+                fact_with_term(
+                    "N2",
+                    compound("declared", vec![atom("battery")]),
+                    16,
+                    30,
+                ),
+            ],
+            edges: vec![],
+        };
+        match check_typed_quantity_coverage(&doc, &ir) {
+            TypedQuantityResult::Fail { violations } => {
+                assert_eq!(violations.len(), 2);
+                let literals: Vec<&str> = violations
+                    .iter()
+                    .filter_map(|v| {
+                        let TypedQuantityViolation::MissingQuantity { literal, .. } = v;
+                        Some(literal.as_str())
+                    })
+                    .collect();
+                assert!(literals.contains(&"1"));
+                assert!(literals.contains(&"200"));
+            }
+            other => panic!("expected Fail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typed_quantity_check_finds_quantity_nested_in_compound() {
+        // The quantity term may be deeply nested inside a compound.
+        // E.g., `meets_threshold(blade_length(knife, quantity(4, inches)))`.
+        // The recursive walk should find it.
+        let doc = mk_doc("4 inch pocket knife.");
+        let inner = compound("quantity", vec![atom("4"), atom("inches")]);
+        let mid = compound("blade_length", vec![atom("knife"), inner]);
+        let outer = compound("meets_threshold", vec![mid]);
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![fact_with_term("N1", outer, 0, 6)],
+            edges: vec![],
+        };
+        assert_eq!(
+            check_typed_quantity_coverage(&doc, &ir),
+            TypedQuantityResult::Pass
+        );
+    }
+
+    #[test]
+    fn normalise_numeric_strips_leading_zeros_and_trailing_decimal_zeros() {
+        assert_eq!(normalise_numeric("4"), "4");
+        assert_eq!(normalise_numeric("04"), "4");
+        assert_eq!(normalise_numeric("4.0"), "4");
+        assert_eq!(normalise_numeric("4.50"), "4.5");
+        assert_eq!(normalise_numeric("4.5"), "4.5");
+        assert_eq!(normalise_numeric("0"), "0");
+        assert_eq!(normalise_numeric("0.5"), "0.5");
     }
 }

--- a/code/specs/ADJ22-typed-quantity-coverage.md
+++ b/code/specs/ADJ22-typed-quantity-coverage.md
@@ -1,0 +1,217 @@
+# ADJ22 — Typed-quantity coverage checker
+
+## Overview
+
+ADJ22 is the deterministic-Rust companion to
+[ADJ21](ADJ21-typed-quantity-decomposition.md). Where ADJ21
+updates `decompose_text`'s prompt to teach the LLM to emit
+`quantity(value, unit)` compounds for every numerical literal,
+ADJ22 is the **validator that catches when the model drops a
+quantity anyway** — either by omitting it, flattening it into
+the predicate name, or losing the unit.
+
+The check is structurally identical to ADJ02 coverage: walk a
+property of the source, walk the IR, verify mappings. ADJ02
+verifies every byte is covered by some span. ADJ22 verifies
+every numerical literal is covered by some `quantity(...)`
+compound.
+
+## Why it exists
+
+ADJ18's empirical bench (v0.13 prompts, PR #3066) showed that
+all five models in the lineup mishandled the "4-inch blade vs
+2.36-inch threshold" comparison. The structural fix is to take
+the LLM out of the arithmetic loop entirely — let the engine
+evaluate threshold comparisons by giving it typed quantities in
+the source IR.
+
+[ADJ21](ADJ21-typed-quantity-decomposition.md) lands the
+prompt-side of that fix: the `decompose_text` system prompt
+explicitly teaches the model to produce `quantity(value, unit)`
+compounds. But prompts aren't contracts — small models routinely
+ignore instructions, drop fields, or flatten structures.
+
+ADJ22 turns the ADJ21 contract into a hard check the framework
+enforces pre-engine. If the LLM drops a quantity, the
+clarification dialogue (ADJ06) re-prompts. If the LLM keeps
+dropping it, the framework's audit trail records the failure
+rather than producing a verdict over incomplete IR.
+
+## What the checker does
+
+```rust
+pub fn check_typed_quantity_coverage(
+    doc: &Document,
+    ir_doc: &IRDocument,
+) -> TypedQuantityResult;
+```
+
+Algorithm:
+
+1. **Scan `doc.normalized_text` for numerical literals.** A
+   literal is `\d+(\.\d+)?` — one or more ASCII digits, optionally
+   followed by `.` and more digits. `"4"`, `"3.4"`, `"750"`,
+   `"200"` are literals; `"-5"`, `"5e10"` are not (negative
+   numbers and scientific notation are out of scope; the few
+   adjudication cases that need them can be added later).
+
+2. **For each literal**, find IR nodes whose `source_spans`
+   overlap the literal's byte range. Only `NodeKind::Fact`,
+   `NodeKind::Rule`, and `NodeKind::Uncertainty` are considered;
+   Section / Entity / Query / Discarded / Exception nodes are
+   exempt (their terms aren't expected to carry source-level
+   quantities).
+
+3. **Check that at least one overlapping node has a
+   `quantity(<lit>, _)` compound** somewhere in its term tree.
+   The walk is recursive — `quantity(4, inches)` nested inside
+   `blade_length(knife, ...)` inside
+   `meets_threshold(blade_length(...))` is found.
+
+4. **Value matching is normalisation-aware**:
+   - `"4"` matches `Term::Atom("4")`, `Term::Num(Int(4))`,
+     `Term::Num(Float(4.0))`.
+   - `"4.0"` and `"4"` both canonicalise to `"4"`.
+   - `"04"` (with leading zero) canonicalises to `"4"`.
+   - `"0.5"` keeps its leading zero (decimal-prefix preservation).
+   - `"3.4"` matches `Term::Atom("3.4")` and `Term::Num(Float(3.4))`.
+
+5. **Unit is not validated in this iteration.** ADJ22 v0.1 only
+   verifies that *some* `quantity(<lit>, _)` exists. A future
+   iteration could enforce per-domain unit vocabularies if needed
+   (e.g., "for clinical, expected units include `celsius`,
+   `mmHg`, `bpm`").
+
+## Violation shape
+
+```rust
+pub enum TypedQuantityViolation {
+    MissingQuantity {
+        literal: String,                          // "4"
+        location: (usize, usize),                 // byte range in source
+        nearby_nodes: Vec<adjudication_ir::NodeId>,  // overlapping nodes
+    },
+}
+```
+
+`nearby_nodes` is the load-bearing field for ADJ06: the
+clarification prompt can quote *"You produced N1 over the range
+that contains the literal '4', but its term did not include a
+`quantity(4, _)` compound. The downstream rule needs the typed
+value to compare against its threshold. Please re-extract."*
+
+## Why this is in `adjudication-coverage`, not its own crate
+
+The existing convention in the framework has one crate per
+checker (ADJ02 → `adjudication-coverage`, ADJ03 →
+`adjudication-polarity-modality`, etc.). ADJ22 is structurally a
+coverage check — it just checks coverage of a different property
+(numerical literals) against a different IR structure (quantity
+compounds). Putting it in the same crate as ADJ02 keeps the
+"coverage" namespace coherent and avoids a one-file crate for
+what is a ~250-line addition.
+
+If ADJ22 grows substantially (per-domain unit vocabularies,
+complex literal scanners, etc.) it can be extracted to its own
+crate later. For v0.1 it lives next to the byte-coverage check.
+
+## What ADJ22 does NOT do
+
+- **Doesn't enforce unit atoms.** `quantity(4, "snorgles")` passes
+  the check even though `snorgles` is not a real unit. The point
+  is to catch the model dropping quantities entirely, not to
+  enforce a domain-specific unit vocabulary.
+- **Doesn't fix the IR.** The check is read-only. ADJ06's
+  clarification dialogue is where re-extraction happens.
+- **Doesn't run automatically yet.** ADJ22 is a standalone
+  function callable today; wiring it into
+  `adjudication-pipeline` so failures route to ADJ06 is a
+  follow-up (probably a separate small PR).
+
+## Implementation
+
+`adjudication-coverage` v0.3.0 adds:
+
+- `TypedQuantityViolation` enum (one variant for now).
+- `TypedQuantityResult { Pass, Fail { violations } }`.
+- `check_typed_quantity_coverage(doc, ir_doc) -> TypedQuantityResult`
+  — the public entry point.
+- Internal helpers: `scan_numerical_literals`, `spans_overlap`,
+  `term_contains_quantity`, `atom_or_num_matches_literal`,
+  `normalise_numeric`.
+
+13 unit tests cover:
+
+- Literal scanning: integers, decimals, multiple values, none.
+- Pass cases: top-level quantity, decimal value, numeric-atom
+  value, deeply-nested quantity, no-numbers-in-source.
+- Fail cases: missing quantity, flattened-into-predicate
+  (`blade_4_inches`), multiple missing literals.
+- Normalisation: leading zeros, trailing decimal zeros,
+  `0.5`-edge case.
+
+## What this unlocks
+
+Once ADJ22 is wired into the pipeline (a follow-up), the
+ADJ21 contract becomes enforceable end-to-end:
+
+```
+source text
+   ↓ decompose_text v5 (ADJ21 prompt)
+IR with quantity(value, unit) compounds
+   ↓ check_coverage (ADJ02)
+every byte covered
+   ↓ check_typed_quantity_coverage (ADJ22, this PR)
+every numerical literal preserved as a typed quantity
+   ↓ check_propagation (ADJ03)
+polarity/modality consistent
+   ↓ ... other checks ...
+   ↓ engine
+deterministic verdict using typed quantity comparisons
+```
+
+The pocket-knife regression that motivated ADJ21 and ADJ22 is
+gone end-to-end: the LLM is no longer asked to evaluate
+`4 > 2.36` inside its forward pass. The IR carries
+`quantity(4, inches)`, the rulebook says
+`gt(L, quantity(2.36, inches))`, the engine unifies and
+evaluates.
+
+## Pipeline integration (follow-up)
+
+The wiring change to `adjudication-pipeline`'s
+`run_with_gateway`:
+
+```rust
+// After existing ADJ02 coverage check:
+let q_started = now();
+let q_result = check_typed_quantity_coverage(&cov_doc, &input.ir_document);
+let q_completed = now();
+trail.checker_results.push(/* ADJ22 result */);
+
+let prior_gating_ok =
+    matches!(cov_result, CoverageResult::Pass)
+    && matches!(q_result, TypedQuantityResult::Pass)
+    && pm_result.pass();
+```
+
+ADJ22 failures route to ADJ06 the same way ADJ02 failures do:
+the clarification prompt names the missing literal and the node
+that should have included it. The retry loop already exists; the
+new prompt template is the only new piece.
+
+That wiring lives in a separate PR alongside the
+`retry_decompose_on_missing_quantity` clarification primitive.
+
+## See also
+
+- [ADJ21](ADJ21-typed-quantity-decomposition.md) — the prompt
+  side of the same change.
+- [ADJ02](ADJ02-coverage-checker.md) — the byte-coverage check
+  this one parallels.
+- [ADJ06](ADJ06-clarification-dialogue.md) — the clarification
+  loop that consumes ADJ22 violations.
+- [ADJ18 §"v0.13 re-run results"](ADJ18-broadened-tsa-empirical-bench.md)
+  — the empirical evidence motivating both ADJ21 and ADJ22.
+- ADJ23 (queued) — empirical re-bench against v5 decompose_text
+  + ADJ22 enforcement.


### PR DESCRIPTION
## Summary

ADJ21 ([#3071](https://github.com/adhithyan15/coding-adventures/pull/3071)) updates `decompose_text`'s prompt to teach the LLM to emit `quantity(value, unit)` compounds for every numerical literal in the source. **ADJ22 is the validator that catches when the LLM drops a quantity anyway** — by omitting it, flattening it into the predicate name, or losing the unit.

Structurally identical to ADJ02 coverage:
- **ADJ02**: every byte is covered by some span.
- **ADJ22**: every numerical literal is covered by some `quantity(...)` compound.

## Algorithm

1. Scan source for `\d+(\.\d+)?` literals.
2. For each literal, find IR nodes (`Fact` / `Rule` / `Uncertainty`) whose source_spans overlap.
3. Check that at least one has a `quantity(<lit>, _)` compound somewhere in its term tree (recursive — nested quantities are detected).
4. Value matching is normalization-aware: `\"4\"` == `\"4.0\"` == `\"04\"`, atom OR numeric `Term::Num` both match.

## API

```rust
pub enum TypedQuantityViolation {
    MissingQuantity {
        literal: String,
        location: (usize, usize),
        nearby_nodes: Vec<NodeId>,
    },
}

pub enum TypedQuantityResult { Pass, Fail { violations } }

pub fn check_typed_quantity_coverage(
    doc: &Document,
    ir_doc: &IRDocument,
) -> TypedQuantityResult;
```

The `nearby_nodes` field lets ADJ06 say *\"you produced N1 over this range but didn't include `quantity(4, _)`; please re-extract\"* rather than just *\"you missed a number.\"*

## Tests

20 lib tests pass (13 new):
- Literal scan: integers, decimals, multiples, none.
- Pass cases: top-level quantity, decimal, numeric-atom, deeply-nested.
- Fail cases: missing quantity, flattened-into-predicate (`blade_4_inches`), multiple missing.
- Normalization: leading zeros, trailing `.0`, `0.5` edge case.

## What's NOT in this PR

- **Pipeline wiring** (ADJ22 result routed to ADJ06 clarification) is queued as a follow-up small PR.
- **ADJ-OVERVIEW.md update** queued for after [#3071](https://github.com/adhithyan15/coding-adventures/pull/3071) merges (otherwise this PR would conflict).
- **Unit-vocabulary enforcement** — the check only verifies a `quantity(<lit>, _)` exists; a future iteration could enforce per-domain unit vocabularies.

## Compatibility

- `check_coverage` API unchanged.
- New types and function are additive.
- `logic-core` moved from dev-dep to dep (needed to inspect `Term` shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)