### PR TITLE
Factor common multivariate MACSYMA terms

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added MACSYMA `factor` parity for a first multivariate case with a common
+  symbolic factor, so `factor(x^2*y - y)` now extracts `y` and factors the
+  residual through the canonical symbolic VM handler.
 - Added a small MACSYMA help catalog plus `?` query parsing helpers for REPL
   and session frontends.
 - Added MACSYMA session-property operations: `declare(sym, property, ...)`,

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/cas_handlers.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/cas_handlers.py
@@ -10,7 +10,7 @@ Organised in sections that mirror the substrate packages:
 
 - **simplify / expand** — :mod:`cas_simplify`
 - **substitution** — :mod:`cas_substitution`
-- **factor** — :mod:`cas_factor`
+- **factor** — canonical :mod:`symbolic_vm.cas_handlers`
 - **solve** — :mod:`cas_solve`
 - **list operations** — :mod:`cas_list_operations`
 - **matrix** — :mod:`cas_matrix`
@@ -36,7 +36,6 @@ import math
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
-from cas_factor import factor_integer_polynomial
 from cas_laplace import build_laplace_handler_table as _build_laplace_handlers
 from cas_limit_series import PolynomialError, limit_direct, taylor_polynomial
 from cas_list_operations import (
@@ -70,10 +69,6 @@ from cas_solve import (
 )
 from cas_substitution import subst
 from symbolic_ir import (
-    ADD,
-    MUL,
-    NEG,
-    POW,
     IRApply,
     IRInteger,
     IRNode,
@@ -92,6 +87,7 @@ from symbolic_vm.cas_handlers import erfc_handler as _erfc_handler
 from symbolic_vm.cas_handlers import erfi_handler as _erfi_handler
 from symbolic_vm.cas_handlers import fresnel_c_handler as _fresnel_c_handler
 from symbolic_vm.cas_handlers import fresnel_s_handler as _fresnel_s_handler
+from symbolic_vm.cas_handlers import factor_handler as _factor_handler_full
 from symbolic_vm.cas_handlers import gamma_handler as _gamma_handler
 from symbolic_vm.cas_handlers import li2_handler as _li2_handler
 from symbolic_vm.cas_handlers import (
@@ -180,54 +176,8 @@ def subst_handler(vm: VM, expr: IRApply) -> IRNode:
 
 
 def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
-    """``Factor(poly_expr)`` — factor a univariate integer polynomial.
-
-    Identifies the single free variable in ``poly_expr``, converts to
-    an integer coefficient list, calls :func:`cas_factor.factor_integer_polynomial`,
-    and reassembles the IR as ``Mul(content, Pow(factor_1, mult_1), …)``.
-
-    Returns the expression unevaluated if:
-
-    - the expression has more than one free variable,
-    - it cannot be represented as an integer polynomial over the free variable,
-    - the polynomial is constant (degree 0).
-    """
-    if len(expr.args) != 1:
-        return expr
-    inner = expr.args[0]
-
-    # Pick the single free variable.
-    x = _find_variable(inner)
-    if x is None:
-        return expr  # no variable — constant already
-
-    # Convert to integer coefficient list via the polynomial bridge.
-    coeffs = _ir_to_integer_poly(inner, x)
-    if coeffs is None:
-        return expr
-
-    # Factor.
-    content_val, factors = factor_integer_polynomial(coeffs)
-
-    if not factors:
-        # The polynomial was just the content (constant).
-        return inner
-
-    # Degree-1 polynomials (linear: [b, a]) are already in "factored form"
-    # by definition — return the polynomial directly rather than unevaluated.
-    # Only for degree ≥ 2 do we distinguish "irreducible" from "factored".
-    if len(coeffs) <= 2:
-        return _factor_result_to_ir(content_val, factors, x)
-
-    # For degree ≥ 2: if there is exactly one factor with multiplicity 1
-    # and the content is ±1, the polynomial is irreducible over Z — no
-    # non-trivial factoring was possible.  Return the expression
-    # *unevaluated* (head stays ``Factor``) so the user can see that it
-    # cannot be simplified further.
-    if len(factors) == 1 and factors[0][1] == 1 and abs(content_val) == 1:
-        return expr
-
-    return _factor_result_to_ir(content_val, factors, x)
+    """``Factor(poly_expr)`` — use the canonical symbolic VM factor handler."""
+    return _factor_handler_full(_vm, expr)
 
 
 def _find_variable(node: IRNode) -> IRSymbol | None:
@@ -251,133 +201,6 @@ def _collect_variables(node: IRNode, found: set[str]) -> None:
     elif isinstance(node, IRApply):
         for arg in node.args:
             _collect_variables(arg, found)
-
-
-def _ir_to_integer_poly(inner: IRNode, x: IRSymbol) -> list[int] | None:
-    """Convert IR to ``list[int]`` coefficient list (low-degree first).
-
-    Returns ``None`` if ``inner`` is not a pure polynomial in ``x`` with
-    rational coefficients, or if the denominators don't clear to integers.
-    """
-    result = to_rational(inner, x)
-    if result is None:
-        return None
-    num, den = result
-    # Must be a polynomial, not a genuine rational function.
-    if den != (Fraction(1),):
-        return None
-
-    # Clear denominators: find LCM of all coefficient denominators,
-    # then scale up to get integer coefficients.
-    denom_lcm = 1
-    for c in num:
-        denom_lcm = _lcm(denom_lcm, c.denominator)
-
-    int_coeffs = [int(c * denom_lcm) for c in num]
-
-    # Only include denom_lcm in the content if it's > 1 and we'd lose
-    # info. For integer polynomials this is a no-op; for rational inputs
-    # we scale up — that changes the polynomial, so bail out instead.
-    if denom_lcm != 1:
-        return None  # rational polynomial, not integer — leave unevaluated
-
-    return int_coeffs
-
-
-def _gcd(a: int, b: int) -> int:
-    while b:
-        a, b = b, a % b
-    return abs(a)
-
-
-def _lcm(a: int, b: int) -> int:
-    return abs(a * b) // _gcd(a, b) if a and b else 0
-
-
-def _factor_result_to_ir(
-    content_val: int,
-    factors: list[tuple[list[int], int]],
-    x: IRSymbol,
-) -> IRNode:
-    """Assemble ``Mul(content, Pow(f1, m1), Pow(f2, m2), …)`` as IR."""
-    parts: list[IRNode] = []
-
-    if content_val != 1:
-        parts.append(IRInteger(content_val))
-
-    for poly_coeffs, mult in factors:
-        factor_ir = _linear_poly_to_ir(poly_coeffs, x)
-        if mult == 1:
-            parts.append(factor_ir)
-        else:
-            parts.append(IRApply(POW, (factor_ir, IRInteger(mult))))
-
-    if not parts:
-        return IRInteger(content_val)
-    if len(parts) == 1:
-        return parts[0]
-    # Fold into left-associative binary Mul chain.
-    acc: IRNode = parts[0]
-    for p in parts[1:]:
-        acc = IRApply(MUL, (acc, p))
-    return acc
-
-
-def _linear_poly_to_ir(coeffs: list[int], x: IRSymbol) -> IRNode:
-    """Convert a small coefficient list to IR.
-
-    Covers the linear case ``[b, a]`` → ``a*x + b``.  Higher degrees
-    fall through to a generic builder.
-    """
-    if len(coeffs) == 1:
-        return IRInteger(coeffs[0])
-    if len(coeffs) == 2:
-        b, a = coeffs
-        # Build ``a*x``
-        if a == 1:
-            ax: IRNode = x
-        elif a == -1:
-            ax = IRApply(NEG, (x,))
-        else:
-            ax = IRApply(MUL, (IRInteger(a), x))
-        if b == 0:
-            return ax
-        if b > 0:
-            return IRApply(ADD, (ax, IRInteger(b)))
-        # b < 0: emit Sub(a*x, |b|)
-        from symbolic_ir import SUB
-
-        return IRApply(SUB, (ax, IRInteger(-b)))
-    # Generic: build Add chain for each term.
-    terms: list[IRNode] = []
-    for i, c in enumerate(coeffs):
-        if c == 0:
-            continue
-        if i == 0:
-            terms.append(IRInteger(c))
-        elif i == 1:
-            if c == 1:
-                terms.append(x)
-            elif c == -1:
-                terms.append(IRApply(NEG, (x,)))
-            else:
-                terms.append(IRApply(MUL, (IRInteger(c), x)))
-        else:
-            power: IRNode = IRApply(POW, (x, IRInteger(i)))
-            if c == 1:
-                terms.append(power)
-            elif c == -1:
-                terms.append(IRApply(NEG, (power,)))
-            else:
-                terms.append(IRApply(MUL, (IRInteger(c), power)))
-    if not terms:
-        return IRInteger(0)
-    from symbolic_ir import ADD as _ADD
-
-    acc2: IRNode = terms[0]
-    for t in terms[1:]:
-        acc2 = IRApply(_ADD, (acc2, t))
-    return acc2
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/macsyma-runtime/tests/test_cas_handlers.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_handlers.py
@@ -619,6 +619,19 @@ def test_factor_multivariate_returns_unevaluated() -> None:
     assert result.head == _sym("Factor")  # type: ignore[union-attr]
 
 
+def test_factor_common_multivariate_symbolic_factor() -> None:
+    """Factor(x^2*y - y) extracts y, then factors the univariate residual."""
+    vm = _vm()
+    x = _sym("x")
+    y = _sym("y")
+    x2_y = IRApply(MUL, (IRApply(POW, (x, _int(2))), y))
+    expr = _apply("Factor", IRApply(SUB, (x2_y, y)))
+    result = vm.eval(expr)
+    assert isinstance(result, IRApply)
+    assert result.head == _sym("Mul")  # type: ignore[union-attr]
+    assert result != expr
+
+
 def test_solve_no_variable_returns_unevaluated() -> None:
     """Solve(5, 3) — second arg is not a symbol → unevaluated."""
     vm = _vm()

--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -717,6 +717,15 @@ def test_pipeline_factor_irreducible_x2_plus_1_unchanged() -> None:
     assert result.head.name == "Factor"
 
 
+def test_pipeline_factor_common_multivariate_factor() -> None:
+    """factor(x^2*y - y) extracts the common y factor."""
+    result = _eval("factor(x^2*y - y)")
+    assert isinstance(result, IRApply)
+    assert result.head.name == "Mul"
+    assert "Factor" not in str(result)
+    assert "y" in str(result)
+
+
 # ---------------------------------------------------------------------------
 # Section S — Calculus: diff and integrate (already wired, no pipeline tests)
 # ---------------------------------------------------------------------------

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Added a small multivariate factoring foothold to `Factor`: additive
+  expressions with a common symbolic factor, such as `x^2*y - y`, now extract
+  that common factor and then reuse the existing univariate integer factorizer
+  on the residual.
+
 ## 0.53.0 — 2026-05-05
 
 **Phase 33 — Trig special values at rational multiples of π.**

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -965,6 +965,133 @@ def _factor_result_to_ir(
     return acc
 
 
+def _flatten_factor_terms(node: IRNode) -> list[IRNode]:
+    if isinstance(node, IRApply) and node.head == MUL:
+        terms: list[IRNode] = []
+        for arg in node.args:
+            terms.extend(_flatten_factor_terms(arg))
+        return terms
+    return [node]
+
+
+def _flatten_add_terms(node: IRNode) -> list[IRNode]:
+    if isinstance(node, IRApply) and node.head == ADD:
+        terms: list[IRNode] = []
+        for arg in node.args:
+            terms.extend(_flatten_add_terms(arg))
+        return terms
+    if isinstance(node, IRApply) and node.head == SUB and len(node.args) == 2:
+        return [*_flatten_add_terms(node.args[0]), _negate_ir(node.args[1])]
+    return [node]
+
+
+def _negate_ir(node: IRNode) -> IRNode:
+    if isinstance(node, IRInteger):
+        return IRInteger(-node.value)
+    if isinstance(node, IRApply) and node.head == NEG and len(node.args) == 1:
+        return node.args[0]
+    return IRApply(MUL, (IRInteger(-1), node))
+
+
+def _pow_node(base: IRNode, exponent: int) -> IRNode:
+    if exponent == 1:
+        return base
+    return IRApply(POW, (base, IRInteger(exponent)))
+
+
+def _mul_nodes(terms: list[IRNode]) -> IRNode:
+    if not terms:
+        return IRInteger(1)
+    acc = terms[0]
+    for term in terms[1:]:
+        acc = IRApply(MUL, (acc, term))
+    return acc
+
+
+def _add_nodes(terms: list[IRNode]) -> IRNode:
+    if not terms:
+        return IRInteger(0)
+    acc = terms[0]
+    for term in terms[1:]:
+        acc = IRApply(ADD, (acc, term))
+    return acc
+
+
+def _split_common_factor_term(node: IRNode) -> dict[IRNode, int] | None:
+    powers: dict[IRNode, int] = {}
+    for factor in _flatten_factor_terms(node):
+        if isinstance(factor, IRInteger):
+            continue
+        if isinstance(factor, IRApply) and factor.head == POW and len(factor.args) == 2:
+            base, exponent = factor.args
+            if isinstance(exponent, IRInteger) and exponent.value > 0:
+                powers[base] = powers.get(base, 0) + exponent.value
+                continue
+        if isinstance(factor, IRSymbol) and factor.name in _CONSTANT_NAMES:
+            continue
+        powers[factor] = powers.get(factor, 0) + 1
+    return powers
+
+
+def _remove_common_factor(node: IRNode, common: dict[IRNode, int]) -> IRNode:
+    remaining = dict(common)
+    rebuilt: list[IRNode] = []
+    for factor in _flatten_factor_terms(node):
+        if isinstance(factor, IRApply) and factor.head == POW and len(factor.args) == 2:
+            base, exponent = factor.args
+            if isinstance(exponent, IRInteger) and exponent.value > 0:
+                take = min(exponent.value, remaining.get(base, 0))
+                if take:
+                    remaining[base] -= take
+                    leftover_exp = exponent.value - take
+                    if leftover_exp:
+                        rebuilt.append(_pow_node(base, leftover_exp))
+                    continue
+        take = remaining.get(factor, 0)
+        if take:
+            remaining[factor] = take - 1
+        else:
+            rebuilt.append(factor)
+    return _mul_nodes(rebuilt)
+
+
+def _extract_common_symbolic_factor(inner: IRNode) -> IRNode | None:
+    """Pull a common symbolic factor from an additive expression.
+
+    This is a deliberately small multivariate factoring foothold. It handles
+    cases like ``x^2*y - y`` by extracting ``y`` and leaving ``x^2 - 1`` for
+    the existing univariate integer factorizer.
+    """
+    terms = _flatten_add_terms(inner)
+    if len(terms) < 2:
+        return None
+
+    per_term = [_split_common_factor_term(term) for term in terms]
+    if any(powers is None for powers in per_term):
+        return None
+    common = dict(per_term[0] or {})
+    for powers in per_term[1:]:
+        assert powers is not None
+        for base in list(common):
+            shared = min(common[base], powers.get(base, 0))
+            if shared:
+                common[base] = shared
+            else:
+                del common[base]
+
+    if not common:
+        return None
+
+    common_terms = [
+        _pow_node(base, exponent)
+        for base, exponent in sorted(common.items(), key=lambda item: str(item[0]))
+    ]
+    common_ir = _mul_nodes(common_terms)
+    residual_terms = [_remove_common_factor(term, common) for term in terms]
+    residual = _add_nodes(residual_terms)
+    return IRApply(MUL, (common_ir, IRApply(IRSymbol("Factor"), (residual,))))
+
+
 def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     """``Factor(expr)`` — factor a univariate integer polynomial over Z.
 
@@ -994,7 +1121,10 @@ def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     # Try to lift to rational function.
     rational = to_rational(inner, x)
     if rational is None:
-        return expr  # transcendental or multi-variable
+        common_factored = _extract_common_symbolic_factor(inner)
+        if common_factored is not None:
+            return _vm.eval(common_factored)
+        return expr  # transcendental or unsupported multi-variable
     num_frac, den_frac = rational
 
     # We only factor pure polynomials, not rational functions.
@@ -1008,6 +1138,11 @@ def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
         return expr
 
     content, factors = factor_integer_polynomial(int_coeffs)
+
+    # Linear polynomials are already factored by definition; return them in
+    # normalized linear form rather than wrapping bare ``x`` as unevaluated.
+    if len(int_coeffs) <= 2:
+        return _factor_result_to_ir(content, factors, x)
 
     # If factoring was a no-op — content 1, single factor, same
     # coefficients as the input — the polynomial is irreducible over Z.

--- a/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
+++ b/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
@@ -206,6 +206,18 @@ def test_factor_irreducible_passthrough() -> None:
     assert result == expr
 
 
+def test_factor_common_multivariate_symbolic_factor() -> None:
+    """Factor(x^2*y - y) extracts y, then factors the residual."""
+    vm, _ = make_vm()
+    x2_y = IRApply(MUL, (IRApply(POW, (x, IRInteger(2))), y))
+    target = IRApply(SUB, (x2_y, y))
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert isinstance(result, IRApply)
+    assert result.head == MUL
+    assert result != expr
+
+
 def test_factor_linear() -> None:
     """Factor(x - 3) → x - 3 (already irreducible linear, content 1)."""
     vm, _ = make_vm()


### PR DESCRIPTION
## Summary
- add a symbolic VM factor foothold that extracts common symbolic factors from additive multivariate expressions before reusing the existing univariate integer factorizer
- delegate MACSYMA runtime `factor` to the canonical symbolic VM handler and remove the stale local factor implementation
- cover `factor(x^2*y - y)` in symbolic VM unit tests and the MACSYMA parser-to-VM pipeline

## Validation
- `zsh BUILD` in `code/packages/python/symbolic-vm` (`1609 passed, 85 skipped`)
- `zsh BUILD` in `code/packages/python/macsyma-runtime` (`444 passed`)
- `git diff --check`
