### PR TITLE
[codex] Add HTML fragment tree-construction smoke batch

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -13,6 +13,8 @@ use coding_adventures_html_lexer::{
 use dom_core::{Attribute, Document, DocumentType, Element, Node};
 use std::fmt;
 
+const FRAGMENT_CONTEXT_MARKER: &str = "data-venture-fragment-context";
+
 /// Parser options that influence tokenizer handoff and tree construction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HtmlParseOptions {
@@ -650,6 +652,42 @@ pub fn parse_html_fragment_with_options(
     Ok(parse_html_fragment_with_diagnostics_and_options(source, options)?.nodes)
 }
 
+/// Parse an HTML fragment in the context of a given HTML element.
+pub fn parse_html_fragment_for_context(
+    source: &str,
+    context_element: &str,
+) -> Result<Vec<Node>, ParseError> {
+    Ok(parse_html_fragment_for_context_with_diagnostics(source, context_element)?.nodes)
+}
+
+/// Parse an HTML fragment in the context of a given HTML element plus diagnostics.
+pub fn parse_html_fragment_for_context_with_diagnostics(
+    source: &str,
+    context_element: &str,
+) -> Result<FragmentOutput, ParseError> {
+    parse_html_fragment_for_context_with_diagnostics_and_options(
+        source,
+        context_element,
+        HtmlParseOptions::default(),
+    )
+}
+
+/// Parse an HTML fragment in the context of a given HTML element with explicit options.
+pub fn parse_html_fragment_for_context_with_options(
+    source: &str,
+    context_element: &str,
+    options: HtmlParseOptions,
+) -> Result<Vec<Node>, ParseError> {
+    Ok(
+        parse_html_fragment_for_context_with_diagnostics_and_options(
+            source,
+            context_element,
+            options,
+        )?
+        .nodes,
+    )
+}
+
 /// Parse a complete HTML string into a DOM document plus diagnostics with explicit parser options.
 pub fn parse_html_with_diagnostics_and_options(
     source: &str,
@@ -703,6 +741,39 @@ pub fn parse_html_fragment_with_diagnostics_and_options(
 
     Ok(FragmentOutput {
         nodes: body_fragment_nodes(document),
+        lexer_diagnostics,
+        parser_diagnostics: parser.diagnostics,
+    })
+}
+
+/// Parse an HTML fragment in the context of a given HTML element plus diagnostics.
+pub fn parse_html_fragment_for_context_with_diagnostics_and_options(
+    source: &str,
+    context_element: &str,
+    options: HtmlParseOptions,
+) -> Result<FragmentOutput, ParseError> {
+    let context_element = context_element.to_ascii_lowercase();
+    let mut lexer = create_html_lexer()?;
+    let lex_context = fragment_initial_lex_context(&context_element, options)
+        .unwrap_or_else(|| options.initial_tokenizer_context.lex_context());
+    apply_html_lex_context(&mut lexer, &lex_context)?;
+    let mut parser = HtmlParser::with_fragment_context_options(options, &context_element);
+
+    for ch in source.chars() {
+        let mut buffer = [0; 4];
+        lexer.push(ch.encode_utf8(&mut buffer))?;
+        drain_parser_tokens(&mut lexer, &mut parser, false)?;
+    }
+
+    lexer.finish()?;
+    drain_parser_tokens(&mut lexer, &mut parser, true)?;
+    parser.process_token(Token::Eof);
+
+    let lexer_diagnostics = lexer.diagnostics().to_vec();
+    let document = parser.finish_document();
+
+    Ok(FragmentOutput {
+        nodes: marked_fragment_context_nodes(document),
         lexer_diagnostics,
         parser_diagnostics: parser.diagnostics,
     })
@@ -799,6 +870,29 @@ impl HtmlParser {
         }
     }
 
+    fn with_fragment_context_options(options: HtmlParseOptions, context_element: &str) -> Self {
+        let (document, open_elements) = fragment_context_shell(context_element);
+
+        Self {
+            document,
+            open_elements,
+            pending_formatting_reconstruction: Vec::new(),
+            prunable_empty_reconstructed_formatting_paths: Vec::new(),
+            diagnostics: Vec::new(),
+            options,
+            quirks_mode: true,
+            strip_next_leading_lf: false,
+            explicit_head_end_seen: false,
+            explicit_body_end_seen: false,
+            explicit_body_start_seen: matches!(context_element, "body"),
+            explicit_html_end_seen: false,
+            pending_table_text: String::new(),
+            strip_next_leading_noscript_literal: false,
+            form_element_pointer_set: matches!(context_element, "form"),
+            foreign_cdata_text: None,
+        }
+    }
+
     pub fn parse_tokens(&mut self, tokens: impl IntoIterator<Item = Token>) -> Document {
         for token in tokens {
             self.process_token(token);
@@ -808,6 +902,82 @@ impl HtmlParser {
 
     pub fn diagnostics(&self) -> &[ParserDiagnostic] {
         &self.diagnostics
+    }
+
+    fn current_element_is_marked_fragment_context(&self, name: &str) -> bool {
+        let Some(path) = self.open_elements.last() else {
+            return false;
+        };
+        element_ref_at_path(&self.document, path)
+            .is_some_and(|element| element.name == name && has_fragment_context_marker(element))
+    }
+
+    fn fragment_context_ignores_table_start_tag(&self, name: &str) -> bool {
+        if self.has_unmarked_table_after_last_fragment_marker() {
+            return false;
+        }
+        let Some(context) = self.open_fragment_context_name() else {
+            return false;
+        };
+        match context {
+            "table" => name == "table",
+            "caption" => matches!(
+                name,
+                "caption"
+                    | "col"
+                    | "colgroup"
+                    | "html"
+                    | "tbody"
+                    | "td"
+                    | "tfoot"
+                    | "thead"
+                    | "th"
+                    | "tr"
+            ),
+            "colgroup" => name != "col",
+            "tbody" | "thead" | "tfoot" => {
+                matches!(
+                    name,
+                    "caption" | "col" | "colgroup" | "tbody" | "thead" | "tfoot"
+                )
+            }
+            "tr" => matches!(
+                name,
+                "caption" | "col" | "colgroup" | "tbody" | "thead" | "tfoot" | "tr"
+            ),
+            "td" | "th" => matches!(
+                name,
+                "caption" | "col" | "colgroup" | "tbody" | "thead" | "tfoot" | "tr" | "td" | "th"
+            ),
+            _ => false,
+        }
+    }
+
+    fn open_fragment_context_name(&self) -> Option<&str> {
+        self.open_elements.iter().rev().find_map(|path| {
+            let element = element_ref_at_path(&self.document, path)?;
+            fragment_marker_value(element)
+        })
+    }
+
+    fn open_marked_fragment_shell_element_matches(&self, name: &str) -> bool {
+        self.open_elements.iter().rev().any(|path| {
+            element_ref_at_path(&self.document, path)
+                .is_some_and(|element| element.name == name && has_fragment_context_marker(element))
+        })
+    }
+
+    fn has_unmarked_table_after_last_fragment_marker(&self) -> bool {
+        let Some(marker_index) = self.open_elements.iter().rposition(|path| {
+            element_ref_at_path(&self.document, path).is_some_and(has_fragment_context_marker)
+        }) else {
+            return false;
+        };
+        self.open_elements[marker_index + 1..].iter().any(|path| {
+            element_ref_at_path(&self.document, path).is_some_and(|element| {
+                element.name == "table" && !has_fragment_context_marker(element)
+            })
+        })
     }
 
     fn finish_document(&mut self) -> Document {
@@ -1131,6 +1301,9 @@ impl HtmlParser {
             self.apply_document_shell_implied_contexts(&name);
             self.close_fostered_formatting_before_table_context(&name);
             self.pop_fostered_content_before_table_context(&name);
+            if self.fragment_context_ignores_table_start_tag(&name) {
+                return;
+            }
             if self.has_open_element("select")
                 && self.has_open_table_context()
                 && (name == "table" || starts_table_context(&name))
@@ -1577,6 +1750,15 @@ impl HtmlParser {
         let text = if self.strip_next_leading_lf {
             self.strip_next_leading_lf = false;
             text.strip_prefix('\n').unwrap_or(&text).to_string()
+        } else {
+            text
+        };
+        let text = if self.current_element_is_marked_fragment_context("colgroup")
+            && !is_html_whitespace_text(&text)
+        {
+            text.chars()
+                .filter(|character| is_html_whitespace(*character))
+                .collect::<String>()
         } else {
             text
         };
@@ -2383,6 +2565,12 @@ impl HtmlParser {
     fn handle_end_tag(&mut self, name: &str) {
         if name == "script" && self.current_script_text_treats_next_end_tag_as_data() {
             self.append_text_to_current("</script>".to_string());
+            return;
+        }
+        if name != "html" && self.current_element_is_marked_fragment_context(name) {
+            return;
+        }
+        if self.open_marked_fragment_shell_element_matches(name) {
             return;
         }
         if self.has_open_svg_html_integration_point()
@@ -4845,6 +5033,280 @@ fn body_fragment_nodes(mut document: Document) -> Vec<Node> {
     }
 
     fragment
+}
+
+fn fragment_context_shell(context_element: &str) -> (Document, Vec<Vec<usize>>) {
+    let chain = fragment_context_chain(context_element);
+    let mut document = Document::new();
+    let html = marked_shell_element("html", context_element == "html", context_element);
+    document.push_child(html);
+
+    let mut open_elements = vec![vec![0]];
+    let mut parent_path = vec![0];
+    for (index, element_name) in chain.iter().enumerate().skip(1) {
+        let marker = index == chain.len() - 1
+            || is_fragment_table_shell_wrapper(element_name, context_element);
+        let child_index = {
+            let parent = element_at_path_mut(&mut document, &parent_path)
+                .expect("fragment shell parent must exist");
+            parent
+                .children
+                .push(marked_shell_element(element_name, marker, context_element));
+            parent.children.len() - 1
+        };
+
+        if *element_name == "head" && !marker {
+            continue;
+        }
+
+        let mut path = parent_path.clone();
+        path.push(child_index);
+        open_elements.push(path.clone());
+        parent_path = path;
+    }
+
+    (document, open_elements)
+}
+
+fn fragment_context_chain(context_element: &str) -> Vec<&str> {
+    match context_element {
+        "html" => vec!["html"],
+        "head" => vec!["html", "head"],
+        "body" => vec!["html", "head", "body"],
+        "frameset" => vec!["html", "head", "frameset"],
+        "caption" => vec!["html", "head", "body", "table", "caption"],
+        "colgroup" => vec!["html", "head", "body", "table", "colgroup"],
+        "tbody" | "thead" | "tfoot" => {
+            vec!["html", "head", "body", "table", context_element]
+        }
+        "tr" => vec!["html", "head", "body", "table", "tbody", "tr"],
+        "td" | "th" => {
+            vec![
+                "html",
+                "head",
+                "body",
+                "table",
+                "tbody",
+                "tr",
+                context_element,
+            ]
+        }
+        _ => vec!["html", "head", "body", context_element],
+    }
+}
+
+fn is_fragment_table_shell_wrapper(element_name: &str, context_element: &str) -> bool {
+    if context_element == "table" {
+        return false;
+    }
+    matches!(
+        context_element,
+        "caption" | "colgroup" | "tbody" | "thead" | "tfoot" | "tr" | "td" | "th"
+    ) && matches!(element_name, "table" | "tbody" | "thead" | "tfoot" | "tr")
+}
+
+fn marked_shell_element(name: &str, marker: bool, context_element: &str) -> Node {
+    let attributes = if marker {
+        vec![Attribute {
+            name: FRAGMENT_CONTEXT_MARKER.to_string(),
+            value: context_element.to_string(),
+        }]
+    } else {
+        Vec::new()
+    };
+    Node::element(name.to_string(), attributes)
+}
+
+fn fragment_initial_lex_context(
+    context_element: &str,
+    options: HtmlParseOptions,
+) -> Option<HtmlLexContext> {
+    let state = match context_element {
+        "title" | "textarea" => HtmlTokenizerState::Rcdata,
+        "iframe" | "noembed" | "noframes" | "style" | "xmp" => HtmlTokenizerState::Rawtext,
+        "noscript" if options.scripting == HtmlScriptingMode::Enabled => {
+            HtmlTokenizerState::Rawtext
+        }
+        "script" => HtmlTokenizerState::ScriptData,
+        "plaintext" => HtmlTokenizerState::Plaintext,
+        _ => return None,
+    };
+
+    Some(HtmlLexContext::new(state))
+}
+
+fn marked_fragment_context_nodes(mut document: Document) -> Vec<Node> {
+    let Some(marker_path) = find_fragment_context_marker_path(document.children.as_slice()) else {
+        return body_fragment_nodes(document);
+    };
+    let marker_name = element_ref_at_path(&document, &marker_path)
+        .map(|element| element.name.as_str())
+        .unwrap_or_default();
+
+    if marker_name == "html" {
+        let Some(html) = element_at_path_mut(&mut document, &marker_path) else {
+            return Vec::new();
+        };
+        strip_fragment_context_markers(&mut html.children);
+        move_leading_html_fragment_misc_after_body(&mut html.children);
+        return std::mem::take(&mut html.children)
+            .into_iter()
+            .filter(|node| !matches!(node, Node::DocumentType(_)))
+            .collect();
+    }
+
+    if marker_name == "head" {
+        let Some(head) = element_at_path_mut(&mut document, &marker_path) else {
+            return Vec::new();
+        };
+        strip_fragment_context_markers(&mut head.children);
+        return std::mem::take(&mut head.children)
+            .into_iter()
+            .filter(|node| !matches!(node, Node::DocumentType(_)))
+            .collect();
+    }
+
+    let flatten_root = marker_path
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(depth, _)| {
+            let ancestor_path = &marker_path[..=depth];
+            let name = element_ref_at_path(&document, ancestor_path)?.name.as_str();
+            matches!(name, "body" | "frameset").then_some(ancestor_path.to_vec())
+        })
+        .unwrap_or_else(|| marker_path.clone());
+
+    let Some(root) = element_at_path_mut(&mut document, &flatten_root) else {
+        return Vec::new();
+    };
+    let mut fragment = flatten_marked_fragment_branch(std::mem::take(&mut root.children), None);
+    strip_fragment_context_markers(&mut fragment);
+    fragment
+        .into_iter()
+        .filter(|node| !matches!(node, Node::DocumentType(_)))
+        .collect()
+}
+
+fn find_fragment_context_marker_path(nodes: &[Node]) -> Option<Vec<usize>> {
+    for (index, node) in nodes.iter().enumerate() {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        if has_fragment_context_marker(element) {
+            return Some(vec![index]);
+        }
+        if let Some(mut path) = find_fragment_context_marker_path(&element.children) {
+            path.insert(0, index);
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn flatten_marked_fragment_branch(
+    nodes: Vec<Node>,
+    unwrap_table_scaffold_context: Option<String>,
+) -> Vec<Node> {
+    let mut flattened = Vec::new();
+    for node in nodes {
+        match node {
+            Node::Element(mut element) if has_fragment_context_marker(&element) => {
+                let unwrap_children = fragment_marker_value(&element)
+                    .filter(|context| context_unwraps_table_scaffold(context))
+                    .map(str::to_string);
+                flattened.extend(flatten_marked_fragment_branch(
+                    std::mem::take(&mut element.children),
+                    unwrap_children,
+                ));
+            }
+            Node::Element(mut element)
+                if unwrap_table_scaffold_context
+                    .as_deref()
+                    .is_some_and(|context| {
+                        is_table_scaffold_element_for_context(&element.name, context)
+                    }) =>
+            {
+                flattened.extend(flatten_marked_fragment_branch(
+                    std::mem::take(&mut element.children),
+                    unwrap_table_scaffold_context.clone(),
+                ));
+            }
+            Node::Element(mut element)
+                if find_fragment_context_marker_path(&element.children).is_some() =>
+            {
+                flattened.extend(flatten_marked_fragment_branch(
+                    std::mem::take(&mut element.children),
+                    unwrap_table_scaffold_context.clone(),
+                ));
+            }
+            node => flattened.push(node),
+        }
+    }
+    flattened
+}
+
+fn context_unwraps_table_scaffold(context_element: &str) -> bool {
+    matches!(
+        context_element,
+        "caption" | "colgroup" | "tbody" | "thead" | "tfoot" | "tr" | "td" | "th"
+    )
+}
+
+fn is_table_scaffold_element_for_context(name: &str, context_element: &str) -> bool {
+    match context_element {
+        "tbody" | "thead" | "tfoot" => matches!(name, "tbody" | "thead" | "tfoot"),
+        "tr" | "td" | "th" => matches!(name, "tbody" | "thead" | "tfoot" | "tr"),
+        "caption" | "colgroup" => matches!(name, "tbody" | "thead" | "tfoot" | "tr"),
+        _ => false,
+    }
+}
+
+fn strip_fragment_context_markers(nodes: &mut [Node]) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        element
+            .attributes
+            .retain(|attribute| attribute.name != FRAGMENT_CONTEXT_MARKER);
+        strip_fragment_context_markers(&mut element.children);
+    }
+}
+
+fn move_leading_html_fragment_misc_after_body(nodes: &mut Vec<Node>) {
+    let body_index = nodes
+        .iter()
+        .position(|node| matches!(node, Node::Element(element) if element.name == "body"));
+    let Some(body_index) = body_index else {
+        return;
+    };
+
+    let mut leading_misc = Vec::new();
+    while matches!(nodes.first(), Some(Node::Comment(_) | Node::Text(_))) {
+        leading_misc.push(nodes.remove(0));
+    }
+    if leading_misc.is_empty() {
+        return;
+    }
+
+    let body_index = body_index.saturating_sub(leading_misc.len());
+    let insert_at = body_index + 1;
+    for (offset, node) in leading_misc.into_iter().enumerate() {
+        nodes.insert(insert_at + offset, node);
+    }
+}
+
+fn has_fragment_context_marker(element: &Element) -> bool {
+    fragment_marker_value(element).is_some()
+}
+
+fn fragment_marker_value(element: &Element) -> Option<&str> {
+    element
+        .attributes
+        .iter()
+        .find(|attribute| attribute.name == FRAGMENT_CONTEXT_MARKER)
+        .map(|attribute| attribute.value.as_str())
 }
 
 #[derive(Debug, Default)]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -24455,3 +24455,1120 @@ x<table><table>x
 |       <a>
 |       <p>
 |         <a>
+#source tests4.dat:1
+#data
+direct div content
+#errors
+#document-fragment
+div
+#document
+| "direct div content"
+
+#source tests4.dat:2
+#data
+direct textarea content
+#errors
+#document-fragment
+textarea
+#document
+| "direct textarea content"
+
+#source tests4.dat:3
+#data
+textarea content with <em>pseudo</em> <foo>markup
+#errors
+#document-fragment
+textarea
+#document
+| "textarea content with <em>pseudo</em> <foo>markup"
+
+#source tests4.dat:4
+#data
+this is &#x0043;DATA inside a <style> element
+#errors
+#document-fragment
+style
+#document
+| "this is &#x0043;DATA inside a <style> element"
+
+#source tests4.dat:5
+#data
+</plaintext>
+#errors
+#document-fragment
+plaintext
+#document
+| "</plaintext>"
+
+#source tests4.dat:6
+#data
+setting html's innerHTML
+#errors
+#document-fragment
+html
+#document
+| <head>
+| <body>
+|   "setting html's innerHTML"
+
+#source tests4.dat:7
+#data
+<title>setting head's innerHTML</title>
+#errors
+#document-fragment
+head
+#document
+| <title>
+|   "setting head's innerHTML"
+
+#source tests4.dat:8
+#data
+direct <title> content
+#errors
+#document-fragment
+title
+#document
+| "direct <title> content"
+
+#source tests6.dat:7
+#data
+<body>
+<div>
+#errors
+(1,6): unexpected-start-tag
+(2,5): expected-closing-tag-but-got-eof
+#document-fragment
+div
+#document
+| "
+"
+| <div>
+
+#source tests6.dat:18
+#data
+</caption><div>
+#errors
+(1,10): XXX-undefined-error
+(1,15): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <div>
+
+#source tests6.dat:21
+#data
+</table><div>
+#errors
+(1,8): unexpected-end-tag
+(1,13): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <div>
+
+#source tests6.dat:25
+#data
+</table></tbody></tfoot></thead></tr><div>
+#errors
+(1,8): unexpected-end-tag
+(1,16): unexpected-end-tag
+(1,24): unexpected-end-tag
+(1,32): unexpected-end-tag
+(1,37): unexpected-end-tag
+(1,42): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <div>
+
+#source tests6.dat:27
+#data
+foo<col>
+#errors
+(1,1): unexpected-character-in-colgroup
+(1,2): unexpected-character-in-colgroup
+(1,3): unexpected-character-in-colgroup
+#document-fragment
+colgroup
+#document
+| <col>
+
+#source tests6.dat:30
+#data
+</frameset><frame>
+#errors
+(1,11): unexpected-frameset-in-frameset-innerhtml
+#document-fragment
+frameset
+#document
+| <frame>
+
+#source tests6.dat:32
+#data
+</body><div>
+#errors
+(1,7): unexpected-close-tag
+(1,12): expected-closing-tag-but-got-eof
+#document-fragment
+body
+#document
+| <div>
+
+#source tests6.dat:34
+#data
+</tr><td>
+#errors
+(1,5): unexpected-end-tag
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests6.dat:35
+#data
+</tbody></tfoot></thead><td>
+#errors
+(1,8): unexpected-end-tag
+(1,16): unexpected-end-tag
+(1,24): unexpected-end-tag
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests6.dat:37
+#data
+<caption><col><colgroup><tbody><tfoot><thead><tr>
+#errors
+(1,9): unexpected-start-tag
+(1,14): unexpected-start-tag
+(1,24): unexpected-start-tag
+(1,31): unexpected-start-tag
+(1,38): unexpected-start-tag
+(1,45): unexpected-start-tag
+#document-fragment
+tbody
+#document
+| <tr>
+
+#source tests6.dat:39
+#data
+</table><tr>
+#errors
+(1,8): unexpected-end-tag
+#document-fragment
+tbody
+#document
+| <tr>
+
+#source tests6.dat:44
+#data
+</table><tr>
+#errors
+(1,8): unexpected-end-tag
+#document-fragment
+table
+#document
+| <tbody>
+|   <tr>
+
+#source tests6.dat:45
+#data
+<body></body></html>
+#errors
+(1,20): unexpected-end-tag-after-body-innerhtml
+#document-fragment
+html
+#document
+| <head>
+| <body>
+
+#source tests7.dat:28
+#data
+<body>X</body></body>
+#errors
+(1,21): unexpected-end-tag-after-body
+#document-fragment
+html
+#document
+| <head>
+| <body>
+|   "X"
+
+#source tests_innerHTML_1.dat:1
+#data
+<body><span>
+#errors
+(1,6): unexpected-start-tag
+(1,12): expected-closing-tag-but-got-eof
+#document-fragment
+body
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:2
+#data
+<span><body>
+#errors
+(1,12): unexpected-start-tag
+(1,12): expected-closing-tag-but-got-eof
+#document-fragment
+body
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:3
+#data
+<span><body>
+#errors
+(1,12): unexpected-start-tag
+(1,12): expected-closing-tag-but-got-eof
+#document-fragment
+div
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:4
+#data
+<body><span>
+#errors
+(1,12): expected-closing-tag-but-got-eof
+#document-fragment
+html
+#document
+| <head>
+| <body>
+|   <span>
+
+#source tests_innerHTML_1.dat:5
+#data
+<frameset><span>
+#errors
+(1,10): unexpected-start-tag
+(1,16): expected-closing-tag-but-got-eof
+#document-fragment
+body
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:6
+#data
+<span><frameset>
+#errors
+(1,16): unexpected-start-tag
+(1,16): expected-closing-tag-but-got-eof
+#document-fragment
+body
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:7
+#data
+<span><frameset>
+#errors
+(1,16): unexpected-start-tag
+(1,16): expected-closing-tag-but-got-eof
+#document-fragment
+div
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:8
+#data
+<frameset><span>
+#errors
+(1,16): unexpected-start-tag-in-frameset
+(1,16): eof-in-frameset
+#document-fragment
+html
+#document
+| <head>
+| <frameset>
+
+#source tests_innerHTML_1.dat:9
+#data
+<table><tr>
+#errors
+(1,7): unexpected-start-tag
+#document-fragment
+table
+#document
+| <tbody>
+|   <tr>
+
+#source tests_innerHTML_1.dat:10
+#data
+</table><tr>
+#errors
+(1,8): unexpected-end-tag
+#document-fragment
+table
+#document
+| <tbody>
+|   <tr>
+
+#source tests_innerHTML_1.dat:11
+#data
+<a>
+#errors
+(1,3): unexpected-start-tag-implies-table-voodoo
+(1,3): eof-in-table
+#document-fragment
+table
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:12
+#data
+<a><caption>a
+#errors
+(1,3): unexpected-start-tag-implies-table-voodoo
+(1,13): expected-closing-tag-but-got-eof
+#document-fragment
+table
+#document
+| <a>
+| <caption>
+|   "a"
+
+#source tests_innerHTML_1.dat:13
+#data
+<a><colgroup><col>
+#errors
+(1,3): foster-parenting-start-token
+(1,18): expected-closing-tag-but-got-eof
+#document-fragment
+table
+#document
+| <a>
+| <colgroup>
+|   <col>
+
+#source tests_innerHTML_1.dat:14
+#data
+<a><tbody><tr>
+#errors
+(1,3): foster-parenting-start-tag
+#document-fragment
+table
+#document
+| <a>
+| <tbody>
+|   <tr>
+
+#source tests_innerHTML_1.dat:15
+#data
+<a><tfoot><tr>
+#errors
+(1,3): foster-parenting-start-tag
+#document-fragment
+table
+#document
+| <a>
+| <tfoot>
+|   <tr>
+
+#source tests_innerHTML_1.dat:16
+#data
+<a><thead><tr>
+#errors
+(1,3): foster-parenting-start-tag
+#document-fragment
+table
+#document
+| <a>
+| <thead>
+|   <tr>
+
+#source tests_innerHTML_1.dat:17
+#data
+<a><tr>
+#errors
+(1,3): foster-parenting-start-tag
+#document-fragment
+table
+#document
+| <a>
+| <tbody>
+|   <tr>
+
+#source tests_innerHTML_1.dat:18
+#data
+<a><th>
+#errors
+(1,3): unexpected-start-tag-implies-table-voodoo
+(1,7): unexpected-cell-in-table-body
+#document-fragment
+table
+#document
+| <a>
+| <tbody>
+|   <tr>
+|     <th>
+
+#source tests_innerHTML_1.dat:19
+#data
+<a><td>
+#errors
+(1,3): unexpected-start-tag-implies-table-voodoo
+(1,7): unexpected-cell-in-table-body
+#document-fragment
+table
+#document
+| <a>
+| <tbody>
+|   <tr>
+|     <td>
+
+#source tests_innerHTML_1.dat:20
+#data
+<table></table><tbody>
+#errors
+(1,22): unexpected-start-tag
+#document-fragment
+caption
+#document
+| <table>
+
+#source tests_innerHTML_1.dat:21
+#data
+</table><span>
+#errors
+(1,8): unexpected-end-tag
+(1,14): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:22
+#data
+<span></table>
+#errors
+(1,14): unexpected-end-tag
+(1,14): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:23
+#data
+</caption><span>
+#errors
+(1,10): XXX-undefined-error
+(1,16): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+
+#source tests_innerHTML_1.dat:24
+#data
+<span></caption><span>
+#errors
+(1,16): XXX-undefined-error
+(1,22): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:25
+#data
+<span><caption><span>
+#errors
+(1,15): unexpected-start-tag
+(1,21): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:26
+#data
+<span><col><span>
+#errors
+(1,11): unexpected-start-tag
+(1,17): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:27
+#data
+<span><colgroup><span>
+#errors
+(1,16): unexpected-start-tag
+(1,22): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:28
+#data
+<span><html><span>
+#errors
+(1,12): non-html-root
+(1,18): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:29
+#data
+<span><tbody><span>
+#errors
+(1,13): unexpected-start-tag
+(1,19): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:30
+#data
+<span><td><span>
+#errors
+(1,10): unexpected-start-tag
+(1,16): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:31
+#data
+<span><tfoot><span>
+#errors
+(1,13): unexpected-start-tag
+(1,19): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:32
+#data
+<span><thead><span>
+#errors
+(1,13): unexpected-start-tag
+(1,19): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:33
+#data
+<span><th><span>
+#errors
+(1,10): unexpected-start-tag
+(1,16): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:34
+#data
+<span><tr><span>
+#errors
+(1,10): unexpected-start-tag
+(1,16): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:35
+#data
+<span></table><span>
+#errors
+(1,14): unexpected-end-tag
+(1,20): expected-closing-tag-but-got-eof
+#document-fragment
+caption
+#document
+| <span>
+|   <span>
+
+#source tests_innerHTML_1.dat:36
+#data
+</colgroup><col>
+#errors
+(1,11): XXX-undefined-error
+#document-fragment
+colgroup
+#document
+| <col>
+
+#source tests_innerHTML_1.dat:37
+#data
+<a><col>
+#errors
+(1,3): XXX-undefined-error
+#document-fragment
+colgroup
+#document
+| <col>
+
+#source tests_innerHTML_1.dat:38
+#data
+<caption><a>
+#errors
+(1,9): XXX-undefined-error
+(1,12): unexpected-start-tag-implies-table-voodoo
+(1,12): eof-in-table
+#document-fragment
+tbody
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:39
+#data
+<col><a>
+#errors
+(1,5): XXX-undefined-error
+(1,8): unexpected-start-tag-implies-table-voodoo
+(1,8): eof-in-table
+#document-fragment
+tbody
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:40
+#data
+<colgroup><a>
+#errors
+(1,10): XXX-undefined-error
+(1,13): unexpected-start-tag-implies-table-voodoo
+(1,13): eof-in-table
+#document-fragment
+tbody
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:41
+#data
+<tbody><a>
+#errors
+(1,7): XXX-undefined-error
+(1,10): unexpected-start-tag-implies-table-voodoo
+(1,10): eof-in-table
+#document-fragment
+tbody
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:42
+#data
+<tfoot><a>
+#errors
+(1,7): XXX-undefined-error
+(1,10): unexpected-start-tag-implies-table-voodoo
+(1,10): eof-in-table
+#document-fragment
+tbody
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:43
+#data
+<thead><a>
+#errors
+(1,7): XXX-undefined-error
+(1,10): unexpected-start-tag-implies-table-voodoo
+(1,10): eof-in-table
+#document-fragment
+tbody
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:44
+#data
+</table><a>
+#errors
+(1,8): XXX-undefined-error
+(1,11): unexpected-start-tag-implies-table-voodoo
+(1,11): eof-in-table
+#document-fragment
+tbody
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:45
+#data
+<a><tr>
+#errors
+(1,3): unexpected-start-tag-implies-table-voodoo
+#document-fragment
+tbody
+#document
+| <a>
+| <tr>
+
+#source tests_innerHTML_1.dat:46
+#data
+<a><td>
+#errors
+(1,3): unexpected-start-tag-implies-table-voodoo
+(1,7): unexpected-cell-in-table-body
+#document-fragment
+tbody
+#document
+| <a>
+| <tr>
+|   <td>
+
+#source tests_innerHTML_1.dat:48
+#data
+</tr><td>
+#errors
+(1,5): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:50
+#data
+<caption><td>
+#errors
+(1,9): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:51
+#data
+<col><td>
+#errors
+(1,5): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:52
+#data
+<colgroup><td>
+#errors
+(1,10): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:53
+#data
+<tbody><td>
+#errors
+(1,7): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:54
+#data
+<tfoot><td>
+#errors
+(1,7): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:55
+#data
+<thead><td>
+#errors
+(1,7): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:56
+#data
+<tr><td>
+#errors
+(1,4): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:57
+#data
+</table><td>
+#errors
+(1,8): XXX-undefined-error
+#document-fragment
+tr
+#document
+| <td>
+
+#source tests_innerHTML_1.dat:58
+#data
+<td><table></table><td>
+#errors
+#document-fragment
+tr
+#document
+| <td>
+|   <table>
+| <td>
+
+#source tests_innerHTML_1.dat:59
+#data
+<caption><a>
+#errors
+(1,9): XXX-undefined-error
+(1,12): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:60
+#data
+<col><a>
+#errors
+(1,5): XXX-undefined-error
+(1,8): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:61
+#data
+<colgroup><a>
+#errors
+(1,10): XXX-undefined-error
+(1,13): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:62
+#data
+<tbody><a>
+#errors
+(1,7): XXX-undefined-error
+(1,10): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:63
+#data
+<tfoot><a>
+#errors
+(1,7): XXX-undefined-error
+(1,10): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:64
+#data
+<th><a>
+#errors
+(1,4): XXX-undefined-error
+(1,7): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:65
+#data
+<thead><a>
+#errors
+(1,7): XXX-undefined-error
+(1,10): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:66
+#data
+<tr><a>
+#errors
+(1,4): XXX-undefined-error
+(1,7): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:67
+#data
+</table><a>
+#errors
+(1,8): XXX-undefined-error
+(1,11): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:68
+#data
+</tbody><a>
+#errors
+(1,8): XXX-undefined-error
+(1,11): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:69
+#data
+</td><a>
+#errors
+(1,5): unexpected-end-tag
+(1,8): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:70
+#data
+</tfoot><a>
+#errors
+(1,8): XXX-undefined-error
+(1,11): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:71
+#data
+</thead><a>
+#errors
+(1,8): XXX-undefined-error
+(1,11): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:72
+#data
+</th><a>
+#errors
+(1,5): unexpected-end-tag
+(1,8): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:73
+#data
+</tr><a>
+#errors
+(1,5): XXX-undefined-error
+(1,8): expected-closing-tag-but-got-eof
+#document-fragment
+td
+#document
+| <a>
+
+#source tests_innerHTML_1.dat:75
+#data
+</select><option>
+#errors
+(1,9): XXX-undefined-error
+#document-fragment
+select
+#document
+| <option>
+
+#source tests_innerHTML_1.dat:76
+#data
+<input><option>
+#errors
+#document-fragment
+select
+#document
+| <input>
+| <option>
+
+#source tests_innerHTML_1.dat:77
+#data
+<keygen><option>
+#errors
+#document-fragment
+select
+#document
+| <keygen>
+| <option>
+
+#source tests_innerHTML_1.dat:78
+#data
+<textarea><option>
+#errors
+1:19: ERROR: Premature end of file. Currently open tags: html, textarea.
+#document-fragment
+select
+#document
+| <textarea>
+|   "<option>"
+
+#source tests_innerHTML_1.dat:79
+#data
+</html><!--abc-->
+#errors
+(1,7): unexpected-end-tag-after-body-innerhtml
+#document-fragment
+html
+#document
+| <head>
+| <body>
+| <!-- abc -->
+
+#source tests_innerHTML_1.dat:80
+#data
+</frameset><frame>
+#errors
+(1,11): unexpected-frameset-in-frameset-innerhtml
+#document-fragment
+frameset
+#document
+| <frame>
+
+#source tests_innerHTML_1.dat:81
+#data
+#errors
+#document-fragment
+html
+#document
+| <head>
+| <body>

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -1,5 +1,7 @@
 use coding_adventures_html_lexer::HtmlScriptingMode;
-use coding_adventures_html_parser::{parse_html_with_options, HtmlParseOptions};
+use coding_adventures_html_parser::{
+    parse_html_fragment_for_context_with_options, parse_html_with_options, HtmlParseOptions,
+};
 use dom_core::{Document, DocumentType, Element, Node};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
@@ -9,6 +11,7 @@ struct TreeConstructionCase {
     source: String,
     data: String,
     scripting: HtmlScriptingMode,
+    fragment_context: Option<String>,
     document: Vec<String>,
 }
 
@@ -18,15 +21,20 @@ fn html5lib_tree_construction_smoke_cases_match_dom_dump() {
     assert!(!cases.is_empty(), "fixture should contain cases");
 
     for (index, case) in cases.iter().enumerate() {
-        let document = parse_html_with_options(
-            &case.data,
-            HtmlParseOptions {
-                scripting: case.scripting,
-                ..HtmlParseOptions::default()
-            },
-        )
-        .expect("parser should accept any HTML input");
-        let actual = dump_document(&document);
+        let options = HtmlParseOptions {
+            scripting: case.scripting,
+            ..HtmlParseOptions::default()
+        };
+        let actual = if let Some(fragment_context) = &case.fragment_context {
+            let nodes =
+                parse_html_fragment_for_context_with_options(&case.data, fragment_context, options)
+                    .expect("parser should accept any HTML fragment input");
+            dump_nodes(&nodes)
+        } else {
+            let document = parse_html_with_options(&case.data, options)
+                .expect("parser should accept any HTML input");
+            dump_document(&document)
+        };
         assert_eq!(
             actual,
             case.document,
@@ -63,9 +71,19 @@ fn parse_tree_construction_cases(raw: &str) -> Vec<TreeConstructionCase> {
         }
 
         let mut scripting = HtmlScriptingMode::Enabled;
-        for line in lines.by_ref() {
+        let mut fragment_context = None;
+        while let Some(line) = lines.next() {
             if line == "#document" {
                 break;
+            }
+            if line == "#document-fragment" {
+                fragment_context = Some(
+                    lines
+                        .next()
+                        .expect("document-fragment marker should name a context element")
+                        .to_string(),
+                );
+                continue;
             }
             if line == "#script-off" {
                 scripting = HtmlScriptingMode::Disabled;
@@ -89,6 +107,7 @@ fn parse_tree_construction_cases(raw: &str) -> Vec<TreeConstructionCase> {
             source: std::mem::take(&mut source),
             data: data.join("\n"),
             scripting,
+            fragment_context,
             document,
         });
     }
@@ -97,8 +116,12 @@ fn parse_tree_construction_cases(raw: &str) -> Vec<TreeConstructionCase> {
 }
 
 fn dump_document(document: &Document) -> Vec<String> {
+    dump_nodes(&document.children)
+}
+
+fn dump_nodes(nodes: &[Node]) -> Vec<String> {
     let mut lines = Vec::new();
-    for node in &document.children {
+    for node in nodes {
         dump_node(node, 0, &mut lines);
     }
     lines


### PR DESCRIPTION
## Summary
- add context-aware HTML fragment parsing APIs for html5lib `#document-fragment` / innerHTML-style cases
- teach the tree-construction smoke harness to run both full-document and fragment-context fixtures
- add 100 green fragment/innerHTML tree-construction smoke cases in one batch

## Notes
- The full-document smoke set was already complete, so this starts the next compliance loop on fragment/innerHTML coverage.
- I deliberately left the remaining four known fragment blockers out of this batch so the PR stays green: `tests4.dat:9`, `tests_innerHTML_1.dat:47`, `tests_innerHTML_1.dat:49`, and `tests_innerHTML_1.dat:74`.
- Those blockers are all in the script-context or nested-real-table-in-fragment area and should be handled as the next focused follow-up.

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer`
