### PR TITLE
Rust factor common multivariate MACSYMA terms

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Delegated Rust MACSYMA `factor` evaluation to the shared `symbolic-vm`
+  canonical handler, including coverage for common multivariate factors.
 - Added `?` / `? topic` help-query handling for Rust MACSYMA sessions.
 - Wired `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
   Rust MACSYMA session assumption context so declared properties feed property

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT"
 
 [dependencies]
 cas-list-operations = { path = "../cas-list-operations" }
-cas-factor = { path = "../cas-factor" }
 cas-pretty-printer = { path = "../cas-pretty-printer" }
 cas-solve = { path = "../cas-solve" }
 cas-simplify = { path = "../cas-simplify" }

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -8,7 +8,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use cas_factor::factor_integer_polynomial;
 use cas_list_operations::{
     append, apply_ as list_apply, first, flatten, join, last, length, map_ as list_map, part,
     range_ as list_range, rest, reverse, sort_, ListOperationError, ListResult,
@@ -23,8 +22,8 @@ use coding_adventures_macsyma_compiler::{
     SUPPRESS as COMPILER_SUPPRESS,
 };
 use symbolic_ir::{
-    apply, str_node, sym, IRApply, IRNode, ADD, ASSIGN, DEFINE, GREATER, GREATER_EQUAL, IF, LESS,
-    LESS_EQUAL, LIST, MUL, POW, SUB,
+    apply, str_node, sym, IRApply, IRNode, ASSIGN, DEFINE, GREATER, GREATER_EQUAL, IF, LESS,
+    LESS_EQUAL, LIST, POW,
 };
 use symbolic_vm::backend::{handler_fn, Backend, Handler};
 use symbolic_vm::handlers::build_handler_table;
@@ -512,7 +511,6 @@ impl MacsymaBackend {
         handlers.insert(SOLVE.to_string(), handler_fn(solve_handler));
         handlers.insert(SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(SUBST.to_string(), handler_fn(subst_handler));
-        handlers.insert(FACTOR.to_string(), handler_fn(factor_handler));
         handlers.insert(RAT_SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(TRIG_SIMPLIFY.to_string(), handler_fn(trig_simplify_handler));
         handlers.insert(TRIG_EXPAND.to_string(), handler_fn(trig_expand_handler));
@@ -1029,28 +1027,6 @@ fn subst_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     subst(expr.args[0].clone(), &expr.args[1], expr.args[2].clone())
 }
 
-fn factor_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
-    let fallback = IRNode::Apply(Box::new(expr.clone()));
-    if expr.args.len() != 1 {
-        return fallback;
-    }
-    let Some(variable) = find_single_variable(&expr.args[0]) else {
-        return fallback;
-    };
-    let Some(coeffs) = ir_to_integer_poly(&expr.args[0], &variable) else {
-        return fallback;
-    };
-
-    let (content, factors) = factor_integer_polynomial(&coeffs);
-    if factors.is_empty() {
-        return expr.args[0].clone();
-    }
-    if coeffs.len() > 2 && factors.len() == 1 && factors[0].1 == 1 && content.abs() == 1 {
-        return fallback;
-    }
-    factor_result_to_ir(content, factors, &variable)
-}
-
 fn list_handler<F>(arity: Option<usize>, body: F) -> Handler
 where
     F: Fn(&[IRNode]) -> ListResult<IRNode> + Send + Sync + 'static,
@@ -1062,181 +1038,6 @@ where
         }
         body(&expr.args).unwrap_or(fallback)
     })
-}
-
-fn find_single_variable(node: &IRNode) -> Option<String> {
-    let mut variables = HashSet::new();
-    collect_variables(node, &mut variables);
-    if variables.len() == 1 {
-        variables.into_iter().next()
-    } else {
-        None
-    }
-}
-
-fn collect_variables(node: &IRNode, variables: &mut HashSet<String>) {
-    match node {
-        IRNode::Symbol(name) if !name.starts_with('%') => {
-            variables.insert(name.clone());
-        }
-        IRNode::Apply(apply) => {
-            for arg in &apply.args {
-                collect_variables(arg, variables);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn ir_to_integer_poly(node: &IRNode, variable: &str) -> Option<Vec<i64>> {
-    match node {
-        IRNode::Integer(value) => Some(vec![*value]),
-        IRNode::Symbol(name) if name == variable => Some(vec![0, 1]),
-        IRNode::Apply(apply) if is_head_name(&apply.head, ADD) => {
-            apply.args.iter().try_fold(vec![0], |acc, arg| {
-                Some(poly_add(&acc, &ir_to_integer_poly(arg, variable)?))
-            })
-        }
-        IRNode::Apply(apply) if is_head_name(&apply.head, SUB) && apply.args.len() == 2 => {
-            let a = ir_to_integer_poly(&apply.args[0], variable)?;
-            let b = ir_to_integer_poly(&apply.args[1], variable)?;
-            Some(poly_sub(&a, &b))
-        }
-        IRNode::Apply(apply) if is_head_name(&apply.head, MUL) => {
-            apply.args.iter().try_fold(vec![1], |acc, arg| {
-                Some(poly_mul(&acc, &ir_to_integer_poly(arg, variable)?))
-            })
-        }
-        IRNode::Apply(apply) if is_head_name(&apply.head, POW) && apply.args.len() == 2 => {
-            let IRNode::Integer(exp) = apply.args[1] else {
-                return None;
-            };
-            if !(0..=32).contains(&exp) {
-                return None;
-            }
-            let base = ir_to_integer_poly(&apply.args[0], variable)?;
-            Some(poly_pow(&base, exp as usize))
-        }
-        _ => None,
-    }
-}
-
-fn factor_result_to_ir(content: i64, factors: Vec<(Vec<i64>, usize)>, variable: &str) -> IRNode {
-    let mut pieces = Vec::new();
-    if content != 1 {
-        pieces.push(IRNode::Integer(content));
-    }
-    for (coeffs, multiplicity) in factors {
-        let factor = poly_to_ir(&coeffs, variable);
-        if multiplicity == 1 {
-            pieces.push(factor);
-        } else {
-            pieces.push(apply(
-                sym(POW),
-                vec![factor, IRNode::Integer(multiplicity as i64)],
-            ));
-        }
-    }
-    multiply_nodes(pieces)
-}
-
-fn poly_to_ir(coeffs: &[i64], variable: &str) -> IRNode {
-    let terms: Vec<IRNode> = coeffs
-        .iter()
-        .enumerate()
-        .filter_map(|(degree, coeff)| {
-            if *coeff == 0 {
-                None
-            } else {
-                Some(monomial_to_ir(*coeff, degree, variable))
-            }
-        })
-        .collect();
-    if terms.is_empty() {
-        IRNode::Integer(0)
-    } else {
-        add_nodes(terms)
-    }
-}
-
-fn monomial_to_ir(coeff: i64, degree: usize, variable: &str) -> IRNode {
-    if degree == 0 {
-        return IRNode::Integer(coeff);
-    }
-    let power = if degree == 1 {
-        sym(variable)
-    } else {
-        apply(
-            sym(POW),
-            vec![sym(variable), IRNode::Integer(degree as i64)],
-        )
-    };
-    match coeff {
-        1 => power,
-        -1 => apply(sym(MUL), vec![IRNode::Integer(-1), power]),
-        _ => apply(sym(MUL), vec![IRNode::Integer(coeff), power]),
-    }
-}
-
-fn add_nodes(nodes: Vec<IRNode>) -> IRNode {
-    if nodes.len() == 1 {
-        nodes.into_iter().next().unwrap()
-    } else {
-        apply(sym(ADD), nodes)
-    }
-}
-
-fn multiply_nodes(nodes: Vec<IRNode>) -> IRNode {
-    if nodes.is_empty() {
-        IRNode::Integer(1)
-    } else if nodes.len() == 1 {
-        nodes.into_iter().next().unwrap()
-    } else {
-        apply(sym(MUL), nodes)
-    }
-}
-
-fn poly_add(a: &[i64], b: &[i64]) -> Vec<i64> {
-    let len = a.len().max(b.len());
-    let mut out = vec![0; len];
-    for i in 0..len {
-        out[i] = a.get(i).copied().unwrap_or(0) + b.get(i).copied().unwrap_or(0);
-    }
-    trim_poly(out)
-}
-
-fn poly_sub(a: &[i64], b: &[i64]) -> Vec<i64> {
-    let len = a.len().max(b.len());
-    let mut out = vec![0; len];
-    for i in 0..len {
-        out[i] = a.get(i).copied().unwrap_or(0) - b.get(i).copied().unwrap_or(0);
-    }
-    trim_poly(out)
-}
-
-fn poly_mul(a: &[i64], b: &[i64]) -> Vec<i64> {
-    let mut out = vec![0; a.len() + b.len() - 1];
-    for (i, ca) in a.iter().enumerate() {
-        for (j, cb) in b.iter().enumerate() {
-            out[i + j] += ca * cb;
-        }
-    }
-    trim_poly(out)
-}
-
-fn poly_pow(base: &[i64], exp: usize) -> Vec<i64> {
-    let mut out = vec![1];
-    for _ in 0..exp {
-        out = poly_mul(&out, base);
-    }
-    out
-}
-
-fn trim_poly(mut poly: Vec<i64>) -> Vec<i64> {
-    while poly.len() > 1 && poly.last() == Some(&0) {
-        poly.pop();
-    }
-    poly
 }
 
 fn range_handler(args: &[IRNode]) -> ListResult<IRNode> {

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -105,6 +105,29 @@ fn keeps_multivariate_factor_calls_unevaluated() {
 }
 
 #[test]
+fn factors_common_multivariate_terms_through_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x^2*y - y);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![
+                sym("y"),
+                apply(
+                    sym(MUL),
+                    vec![
+                        apply(sym(ADD), vec![int(1), sym("x")]),
+                        apply(sym(ADD), vec![int(-1), sym("x")]),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
 fn question_mark_without_topic_lists_help_topics() {
     let mut session = MacsymaSession::new();
     let results = session.eval_source("?").unwrap();

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- `SymbolicBackend` now installs canonical `Factor` handling backed by
+  `cas-factor`, including common-symbolic-factor extraction for additive
+  multivariate expressions before univariate integer factorization.
 - `SymbolicBackend` installs a `D` derivative handler for symbolic-only
   differentiation of arithmetic, elementary, hyperbolic, and inverse
   hyperbolic expressions; `StrictBackend` continues to reject `D` as an

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -6,4 +6,5 @@ description = "Generic symbolic expression evaluator over the symbolic-ir tree r
 license = "MIT"
 
 [dependencies]
+cas-factor = { path = "../cas-factor" }
 symbolic-ir = { path = "../symbolic-ir" }

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -21,16 +21,19 @@
 //! non-numeric nodes); [`from_numeric`] converts back to `IRNode`,
 //! collapsing `Rat(n, 1)` to `Int(n)`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use cas_factor::factor_integer_polynomial;
 use symbolic_ir::{
     IRApply, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ASSIGN, ATAN, ATANH, COS, COSH, COTH,
     CSCH, D, DEFINE, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INTEGRATE, INV, LESS, LESS_EQUAL,
     LOG, MUL, NEG, NOT, NOT_EQUAL, OR, POW, SECH, SIN, SINH, SQRT, SUB, TAN, TANH,
 };
 
-use crate::backend::Handler;
+use crate::backend::{handler_fn, Handler};
 use crate::vm::VM;
+
+const FACTOR: &str = "Factor";
 
 // ---------------------------------------------------------------------------
 // Numeric intermediate value
@@ -1348,6 +1351,384 @@ fn apply_node(head: &str, args: Vec<IRNode>) -> IRNode {
 }
 
 // ---------------------------------------------------------------------------
+// Factor
+// ---------------------------------------------------------------------------
+
+fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    let fallback = IRNode::Apply(Box::new(expr.clone()));
+    if expr.args.len() != 1 {
+        return fallback;
+    }
+
+    let input = &expr.args[0];
+    if let Some(variable) = find_single_variable(input) {
+        if let Some(coeffs) = ir_to_integer_poly(input, &variable) {
+            let (content, factors) = factor_integer_polynomial(&coeffs);
+            if factors.is_empty() {
+                return input.clone();
+            }
+            if factors.len() == 1 && factors[0].1 == 1 && content == 1 && factors[0].0 == coeffs {
+                return fallback;
+            }
+            return factor_result_to_ir(content, factors, &variable);
+        }
+    }
+
+    if let Some(rewritten) = factor_common_symbolic_term(input) {
+        return vm.eval(rewritten);
+    }
+
+    fallback
+}
+
+fn factor_common_symbolic_term(node: &IRNode) -> Option<IRNode> {
+    let terms = additive_terms(node)?;
+    if terms.len() < 2 {
+        return None;
+    }
+
+    let mut common = term_factor_powers(&terms[0]);
+    for term in &terms[1..] {
+        let powers = term_factor_powers(term);
+        common.retain(|base, exponent| {
+            if let Some(other) = powers.get(base) {
+                *exponent = (*exponent).min(*other);
+                *exponent > 0
+            } else {
+                false
+            }
+        });
+        if common.is_empty() {
+            return None;
+        }
+    }
+
+    let common_factor = powers_to_ir(&common);
+    let residual_terms: Vec<IRNode> = terms
+        .iter()
+        .map(|term| remove_common_factor(term, &common))
+        .collect();
+    let residual = add_nodes(residual_terms);
+    Some(apply_node(
+        MUL,
+        vec![common_factor, apply_node(FACTOR, vec![residual])],
+    ))
+}
+
+fn additive_terms(node: &IRNode) -> Option<Vec<IRNode>> {
+    match node {
+        IRNode::Apply(apply) if is_head_name(&apply.head, ADD) => {
+            let mut terms = Vec::new();
+            for arg in &apply.args {
+                collect_additive_terms(arg, &mut terms);
+            }
+            Some(terms)
+        }
+        IRNode::Apply(apply) if is_head_name(&apply.head, SUB) && apply.args.len() == 2 => {
+            let mut terms = Vec::new();
+            collect_additive_terms(&apply.args[0], &mut terms);
+            terms.push(negate_node(apply.args[1].clone()));
+            Some(terms)
+        }
+        _ => None,
+    }
+}
+
+fn collect_additive_terms(node: &IRNode, terms: &mut Vec<IRNode>) {
+    match node {
+        IRNode::Apply(apply) if is_head_name(&apply.head, ADD) => {
+            for arg in &apply.args {
+                collect_additive_terms(arg, terms);
+            }
+        }
+        IRNode::Apply(apply) if is_head_name(&apply.head, SUB) && apply.args.len() == 2 => {
+            collect_additive_terms(&apply.args[0], terms);
+            terms.push(negate_node(apply.args[1].clone()));
+        }
+        other => terms.push(other.clone()),
+    }
+}
+
+fn negate_node(node: IRNode) -> IRNode {
+    match node {
+        IRNode::Integer(value) => IRNode::Integer(-value),
+        IRNode::Apply(apply) if is_head_name(&apply.head, MUL) => {
+            let mut args = Vec::with_capacity(apply.args.len() + 1);
+            args.push(IRNode::Integer(-1));
+            args.extend(apply.args);
+            apply_node(MUL, args)
+        }
+        other => apply_node(MUL, vec![IRNode::Integer(-1), other]),
+    }
+}
+
+fn term_factor_powers(term: &IRNode) -> HashMap<IRNode, usize> {
+    let mut powers = HashMap::new();
+    for factor in multiplicative_factors(term) {
+        if let Some((base, exponent)) = factor_base_power(factor) {
+            *powers.entry(base).or_insert(0) += exponent;
+        }
+    }
+    powers
+}
+
+fn multiplicative_factors(node: &IRNode) -> Vec<IRNode> {
+    match node {
+        IRNode::Apply(apply) if is_head_name(&apply.head, MUL) => {
+            apply.args.iter().flat_map(multiplicative_factors).collect()
+        }
+        other => vec![other.clone()],
+    }
+}
+
+fn factor_base_power(factor: IRNode) -> Option<(IRNode, usize)> {
+    match factor {
+        IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_) => None,
+        IRNode::Symbol(name) if name.starts_with('%') => None,
+        IRNode::Apply(apply) if is_head_name(&apply.head, POW) && apply.args.len() == 2 => {
+            if let IRNode::Integer(exponent) = apply.args[1] {
+                if exponent > 0 && !is_numeric_or_protected(&apply.args[0]) {
+                    return Some((apply.args[0].clone(), exponent as usize));
+                }
+            }
+            Some((IRNode::Apply(apply), 1))
+        }
+        other if is_numeric_or_protected(&other) => None,
+        other => Some((other, 1)),
+    }
+}
+
+fn is_numeric_or_protected(node: &IRNode) -> bool {
+    match node {
+        IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_) => true,
+        IRNode::Symbol(name) => name.starts_with('%'),
+        _ => false,
+    }
+}
+
+fn remove_common_factor(term: &IRNode, common: &HashMap<IRNode, usize>) -> IRNode {
+    let mut remaining = common.clone();
+    let mut pieces = Vec::new();
+    for factor in multiplicative_factors(term) {
+        let Some((base, exponent)) = factor_base_power(factor.clone()) else {
+            pieces.push(factor);
+            continue;
+        };
+        let Some(common_exponent) = remaining.get_mut(&base) else {
+            pieces.push(factor);
+            continue;
+        };
+
+        if exponent > *common_exponent {
+            pieces.push(power_to_ir(base.clone(), exponent - *common_exponent));
+            *common_exponent = 0;
+        } else {
+            *common_exponent -= exponent;
+        }
+    }
+    multiply_nodes(pieces)
+}
+
+fn powers_to_ir(powers: &HashMap<IRNode, usize>) -> IRNode {
+    let mut pieces: Vec<IRNode> = powers
+        .iter()
+        .map(|(base, exponent)| power_to_ir(base.clone(), *exponent))
+        .collect();
+    pieces.sort_by_key(|piece| piece.to_string());
+    multiply_nodes(pieces)
+}
+
+fn power_to_ir(base: IRNode, exponent: usize) -> IRNode {
+    if exponent == 1 {
+        base
+    } else {
+        apply_node(POW, vec![base, IRNode::Integer(exponent as i64)])
+    }
+}
+
+fn find_single_variable(node: &IRNode) -> Option<String> {
+    let mut variables = HashSet::new();
+    collect_variables(node, &mut variables);
+    if variables.len() == 1 {
+        variables.into_iter().next()
+    } else {
+        None
+    }
+}
+
+fn collect_variables(node: &IRNode, variables: &mut HashSet<String>) {
+    match node {
+        IRNode::Symbol(name) if !name.starts_with('%') => {
+            variables.insert(name.clone());
+        }
+        IRNode::Apply(apply) => {
+            for arg in &apply.args {
+                collect_variables(arg, variables);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn ir_to_integer_poly(node: &IRNode, variable: &str) -> Option<Vec<i64>> {
+    match node {
+        IRNode::Integer(value) => Some(vec![*value]),
+        IRNode::Symbol(name) if name == variable => Some(vec![0, 1]),
+        IRNode::Apply(apply) if is_head_name(&apply.head, ADD) => {
+            apply.args.iter().try_fold(vec![0], |acc, arg| {
+                Some(poly_add(&acc, &ir_to_integer_poly(arg, variable)?))
+            })
+        }
+        IRNode::Apply(apply) if is_head_name(&apply.head, SUB) && apply.args.len() == 2 => {
+            let a = ir_to_integer_poly(&apply.args[0], variable)?;
+            let b = ir_to_integer_poly(&apply.args[1], variable)?;
+            Some(poly_sub(&a, &b))
+        }
+        IRNode::Apply(apply) if is_head_name(&apply.head, MUL) => {
+            apply.args.iter().try_fold(vec![1], |acc, arg| {
+                Some(poly_mul(&acc, &ir_to_integer_poly(arg, variable)?))
+            })
+        }
+        IRNode::Apply(apply) if is_head_name(&apply.head, POW) && apply.args.len() == 2 => {
+            let IRNode::Integer(exp) = apply.args[1] else {
+                return None;
+            };
+            if !(0..=32).contains(&exp) {
+                return None;
+            }
+            let base = ir_to_integer_poly(&apply.args[0], variable)?;
+            Some(poly_pow(&base, exp as usize))
+        }
+        _ => None,
+    }
+}
+
+fn factor_result_to_ir(content: i64, factors: Vec<(Vec<i64>, usize)>, variable: &str) -> IRNode {
+    let mut pieces = Vec::new();
+    if content != 1 {
+        pieces.push(IRNode::Integer(content));
+    }
+    for (coeffs, multiplicity) in factors {
+        let factor = poly_to_ir(&coeffs, variable);
+        if multiplicity == 1 {
+            pieces.push(factor);
+        } else {
+            pieces.push(apply_node(
+                POW,
+                vec![factor, IRNode::Integer(multiplicity as i64)],
+            ));
+        }
+    }
+    multiply_nodes(pieces)
+}
+
+fn poly_to_ir(coeffs: &[i64], variable: &str) -> IRNode {
+    let terms: Vec<IRNode> = coeffs
+        .iter()
+        .enumerate()
+        .filter_map(|(degree, coeff)| {
+            if *coeff == 0 {
+                None
+            } else {
+                Some(monomial_to_ir(*coeff, degree, variable))
+            }
+        })
+        .collect();
+    if terms.is_empty() {
+        IRNode::Integer(0)
+    } else {
+        add_nodes(terms)
+    }
+}
+
+fn monomial_to_ir(coeff: i64, degree: usize, variable: &str) -> IRNode {
+    if degree == 0 {
+        return IRNode::Integer(coeff);
+    }
+    let power = if degree == 1 {
+        IRNode::Symbol(variable.to_string())
+    } else {
+        apply_node(
+            POW,
+            vec![
+                IRNode::Symbol(variable.to_string()),
+                IRNode::Integer(degree as i64),
+            ],
+        )
+    };
+    match coeff {
+        1 => power,
+        -1 => apply_node(MUL, vec![IRNode::Integer(-1), power]),
+        _ => apply_node(MUL, vec![IRNode::Integer(coeff), power]),
+    }
+}
+
+fn add_nodes(nodes: Vec<IRNode>) -> IRNode {
+    if nodes.len() == 1 {
+        nodes.into_iter().next().unwrap()
+    } else {
+        apply_node(ADD, nodes)
+    }
+}
+
+fn multiply_nodes(nodes: Vec<IRNode>) -> IRNode {
+    if nodes.is_empty() {
+        IRNode::Integer(1)
+    } else if nodes.len() == 1 {
+        nodes.into_iter().next().unwrap()
+    } else {
+        apply_node(MUL, nodes)
+    }
+}
+
+fn poly_add(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let len = a.len().max(b.len());
+    let mut out = vec![0; len];
+    for i in 0..len {
+        out[i] = a.get(i).copied().unwrap_or(0) + b.get(i).copied().unwrap_or(0);
+    }
+    trim_poly(out)
+}
+
+fn poly_sub(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let len = a.len().max(b.len());
+    let mut out = vec![0; len];
+    for i in 0..len {
+        out[i] = a.get(i).copied().unwrap_or(0) - b.get(i).copied().unwrap_or(0);
+    }
+    trim_poly(out)
+}
+
+fn poly_mul(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let mut out = vec![0; a.len() + b.len() - 1];
+    for (i, ca) in a.iter().enumerate() {
+        for (j, cb) in b.iter().enumerate() {
+            out[i + j] += ca * cb;
+        }
+    }
+    trim_poly(out)
+}
+
+fn poly_pow(base: &[i64], exp: usize) -> Vec<i64> {
+    let mut out = vec![1];
+    for _ in 0..exp {
+        out = poly_mul(&out, base);
+    }
+    out
+}
+
+fn trim_poly(mut poly: Vec<i64>) -> Vec<i64> {
+    while poly.len() > 1 && poly.last() == Some(&0) {
+        poly.pop();
+    }
+    poly
+}
+
+fn is_head_name(head: &IRNode, expected: &str) -> bool {
+    matches!(head, IRNode::Symbol(name) if name == expected)
+}
+
+// ---------------------------------------------------------------------------
 // Build handler table
 // ---------------------------------------------------------------------------
 
@@ -1416,6 +1797,7 @@ pub fn build_handler_table(simplify: bool) -> HashMap<String, Handler> {
     if simplify {
         m.insert(D.to_string(), derivative_handler());
         m.insert(INTEGRATE.to_string(), integrate_handler());
+        m.insert(FACTOR.to_string(), handler_fn(factor_handler));
     }
     m
 }

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -203,6 +203,62 @@ fn symbolic_unknown_head_passes_through() {
     assert_eq!(symbolic().eval(expr.clone()), expr);
 }
 
+#[test]
+fn symbolic_factor_univariate_integer_polynomial() {
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(SUB),
+            vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![int(1), sym("x")]),
+                apply(sym(ADD), vec![int(-1), sym("x")]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn symbolic_factor_extracts_common_multivariate_term() {
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(SUB),
+            vec![
+                apply(
+                    sym(MUL),
+                    vec![apply(sym(POW), vec![sym("x"), int(2)]), sym("y")],
+                ),
+                sym("y"),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(
+            sym(MUL),
+            vec![
+                sym("y"),
+                apply(
+                    sym(MUL),
+                    vec![
+                        apply(sym(ADD), vec![int(1), sym("x")]),
+                        apply(sym(ADD), vec![int(-1), sym("x")]),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolution
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- move Rust `Factor` handling into `symbolic-vm` backed by `cas-factor` so MACSYMA shares the canonical handler
- extract common symbolic factors from additive multivariate expressions before reusing the univariate integer factorizer
- delegate Rust MACSYMA `factor` to the shared symbolic VM handler and cover `factor(x^2*y - y)` at VM/runtime layers

## Validation
- `cargo test -p symbolic-vm`
- `cargo test -p coding-adventures-macsyma-runtime`
- `git diff --check`