### PR TITLE
Python factor multivariate perfect squares

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added MACSYMA `factor` parity for the bivariate perfect-square factoring
+  foothold, so `factor(x^2 + 2*x*y + y^2)` now returns `(x+y)^2` through the
+  canonical symbolic VM handler.
 - Added MACSYMA `factor` parity for a first multivariate case with a common
   symbolic factor, so `factor(x^2*y - y)` now extracts `y` and factors the
   residual through the canonical symbolic VM handler.

--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -726,6 +726,18 @@ def test_pipeline_factor_common_multivariate_factor() -> None:
     assert "y" in str(result)
 
 
+def test_pipeline_factor_multivariate_perfect_square() -> None:
+    """factor(x^2 + 2*x*y + y^2) recognises (x+y)^2."""
+    result = _eval("factor(x^2 + 2*x*y + y^2)")
+    assert isinstance(result, IRApply)
+    assert result.head.name == "Pow"
+    base, exponent = result.args
+    assert exponent == IRInteger(2)
+    assert isinstance(base, IRApply)
+    assert base.head.name == "Add"
+    assert set(base.args) == {IRSymbol("x"), IRSymbol("y")}
+
+
 # ---------------------------------------------------------------------------
 # Section S — Calculus: diff and integrate (already wired, no pipeline tests)
 # ---------------------------------------------------------------------------

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added a second small multivariate factoring foothold to `Factor`:
+  bivariate perfect-square quadratics such as `x^2 + 2*x*y + y^2` now factor
+  to `(x+y)^2`.
 - Added a small multivariate factoring foothold to `Factor`: additive
   expressions with a common symbolic factor, such as `x^2*y - y`, now extract
   that common factor and then reuse the existing univariate integer factorizer

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -1033,6 +1033,26 @@ def _split_common_factor_term(node: IRNode) -> dict[IRNode, int] | None:
     return powers
 
 
+def _split_integer_coefficient_and_powers(
+    node: IRNode,
+) -> tuple[int, dict[IRNode, int]] | None:
+    coefficient = 1
+    powers: dict[IRNode, int] = {}
+    for factor in _flatten_factor_terms(node):
+        if isinstance(factor, IRInteger):
+            coefficient *= factor.value
+            continue
+        if isinstance(factor, IRApply) and factor.head == POW and len(factor.args) == 2:
+            base, exponent = factor.args
+            if isinstance(exponent, IRInteger) and exponent.value > 0:
+                powers[base] = powers.get(base, 0) + exponent.value
+                continue
+        if isinstance(factor, IRSymbol) and factor.name in _CONSTANT_NAMES:
+            return None
+        powers[factor] = powers.get(factor, 0) + 1
+    return coefficient, powers
+
+
 def _remove_common_factor(node: IRNode, common: dict[IRNode, int]) -> IRNode:
     remaining = dict(common)
     rebuilt: list[IRNode] = []
@@ -1092,6 +1112,47 @@ def _extract_common_symbolic_factor(inner: IRNode) -> IRNode | None:
     return IRApply(MUL, (common_ir, IRApply(IRSymbol("Factor"), (residual,))))
 
 
+def _extract_multivariate_perfect_square(inner: IRNode) -> IRNode | None:
+    """Recognise the small ``a^2 +/- 2ab + b^2`` multivariate factor case."""
+    terms = _flatten_add_terms(inner)
+    if len(terms) != 3:
+        return None
+
+    parsed = [_split_integer_coefficient_and_powers(term) for term in terms]
+    if any(term is None for term in parsed):
+        return None
+
+    squares: list[IRNode] = []
+    cross: tuple[int, IRNode, IRNode] | None = None
+    for parsed_term in parsed:
+        assert parsed_term is not None
+        coefficient, powers = parsed_term
+        if coefficient == 1 and len(powers) == 1:
+            base, exponent = next(iter(powers.items()))
+            if exponent == 2:
+                squares.append(base)
+                continue
+        if abs(coefficient) == 2 and len(powers) == 2:
+            items = list(powers.items())
+            if items[0][1] == 1 and items[1][1] == 1:
+                cross = (coefficient, items[0][0], items[1][0])
+                continue
+        return None
+
+    if len(squares) != 2 or cross is None:
+        return None
+    first, second = squares
+    cross_coefficient, cross_first, cross_second = cross
+    if {first, second} != {cross_first, cross_second}:
+        return None
+
+    if cross_coefficient > 0:
+        base = IRApply(ADD, (first, second))
+    else:
+        base = IRApply(SUB, (first, second))
+    return IRApply(POW, (base, IRInteger(2)))
+
+
 def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     """``Factor(expr)`` — factor a univariate integer polynomial over Z.
 
@@ -1121,6 +1182,9 @@ def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     # Try to lift to rational function.
     rational = to_rational(inner, x)
     if rational is None:
+        perfect_square = _extract_multivariate_perfect_square(inner)
+        if perfect_square is not None:
+            return perfect_square
         common_factored = _extract_common_symbolic_factor(inner)
         if common_factored is not None:
             return _vm.eval(common_factored)

--- a/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
+++ b/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
@@ -218,6 +218,18 @@ def test_factor_common_multivariate_symbolic_factor() -> None:
     assert result != expr
 
 
+def test_factor_multivariate_perfect_square() -> None:
+    """Factor(x^2 + 2*x*y + y^2) recognises a bivariate square."""
+    vm, _ = make_vm()
+    x2 = IRApply(POW, (x, IRInteger(2)))
+    two_xy = IRApply(MUL, (IRInteger(2), IRApply(MUL, (x, y))))
+    y2 = IRApply(POW, (y, IRInteger(2)))
+    target = IRApply(ADD, (IRApply(ADD, (x2, two_xy)), y2))
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert result == IRApply(POW, (IRApply(ADD, (x, y)), IRInteger(2)))
+
+
 def test_factor_linear() -> None:
     """Factor(x - 3) → x - 3 (already irreducible linear, content 1)."""
     vm, _ = make_vm()


### PR DESCRIPTION
## Summary
- add a Python symbolic-vm factoring foothold for bivariate perfect squares like `x^2 + 2*x*y + y^2`
- route MACSYMA `factor` through the canonical handler so `factor(x^2 + 2*x*y + y^2)` returns `(x+y)^2`
- cover the direct symbolic VM handler and MACSYMA pipeline paths

## Validation
- `python -m pytest tests/test_cas_handlers.py::test_factor_multivariate_perfect_square tests/test_cas_handlers.py::test_factor_common_multivariate_symbolic_factor -q --no-cov`
- `python -m pytest tests/test_cas_pipeline.py::test_pipeline_factor_multivariate_perfect_square tests/test_cas_pipeline.py::test_pipeline_factor_common_multivariate_factor -q --no-cov`
- `python -m ruff check src/symbolic_vm/cas_handlers.py`
- `python -m ruff check tests/test_cas_pipeline.py`
- `git diff --check`