### PR TITLE
TypeScript factor multivariate perfect squares

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Delegate `factor` to the canonical TypeScript symbolic VM handler so common
   multivariate terms such as `factor(x^2*y - y)` reduce through the shared CAS
   substrate.
+- Add TypeScript MACSYMA parity for the bivariate perfect-square factoring
+  foothold, so `factor(x^2 + 2*x*y + y^2)` returns `(x+y)^2`.
 - Add `?` / `? topic` help-query handling for TypeScript MACSYMA sessions and
   JSON responses.
 - Wire `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -166,6 +166,16 @@ describe("macsyma-runtime", () => {
     ]));
   });
 
+  it("factors bivariate perfect squares through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x^2 + 2*x*y + y^2);");
+
+    expect(result.output).toEqual(app(POW, [
+      app(ADD, [sym("x"), sym("y")]),
+      int(2),
+    ]));
+  });
+
   it("tracks the showtime option flag through normal assignments", () => {
     const session = new MacsymaSession();
     const [enabled, timed, disabled, untimed] = session.evalSource(

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added a canonical symbolic `Factor` handler backed by `cas-factor`, including
   a small common-symbolic-factor extraction pass for multivariate expressions
   like `x^2*y - y`.
+- Added a bivariate perfect-square factoring foothold so `Factor` recognises
+  expressions like `x^2 + 2*x*y + y^2` as `(x+y)^2`.
 - Added a symbolic-backend-only `D` handler for pure IR differentiation,
   including arithmetic, power, elementary, hyperbolic, and inverse hyperbolic
   chain rules.

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -373,6 +373,8 @@ function factorHandler(vm: VM, expr: IRApply): IRNode {
 
   const coeffs = irToIntegerPoly(inner, variable);
   if (coeffs === undefined) {
+    const perfectSquare = extractMultivariatePerfectSquare(inner);
+    if (perfectSquare !== undefined) return perfectSquare;
     const commonFactored = extractCommonSymbolicFactor(inner);
     return commonFactored === undefined ? expr : vm.eval(commonFactored);
   }
@@ -507,6 +509,11 @@ function multiplyNodes(nodes: readonly IRNode[]): IRNode {
 
 type FactorPower = { readonly base: IRNode; exponent: number };
 
+type CoefficientPowers = {
+  readonly coefficient: bigint;
+  readonly powers: Map<string, FactorPower>;
+};
+
 function splitCommonFactorTerm(node: IRNode): Map<string, FactorPower> {
   const powers = new Map<string, FactorPower>();
   for (const factor of flattenFactorTerms(node)) {
@@ -523,6 +530,28 @@ function splitCommonFactorTerm(node: IRNode): Map<string, FactorPower> {
     addPower(powers, factor, 1);
   }
   return powers;
+}
+
+function splitIntegerCoefficientAndPowers(node: IRNode): CoefficientPowers | undefined {
+  let coefficient = 1n;
+  const powers = new Map<string, FactorPower>();
+  for (const factor of flattenFactorTerms(node)) {
+    if (factor.kind === "integer") {
+      coefficient *= factor.value;
+      continue;
+    }
+    if (factor.kind === "symbol" && factor.name.startsWith("%")) return undefined;
+
+    if (factor.kind === "apply" && equals(factor.head, POW) && factor.args.length === 2) {
+      const [base, exponent] = factor.args;
+      if (exponent.kind === "integer" && exponent.value > 0n) {
+        addPower(powers, base, Number(exponent.value));
+        continue;
+      }
+    }
+    addPower(powers, factor, 1);
+  }
+  return { coefficient, powers };
 }
 
 function addPower(powers: Map<string, FactorPower>, base: IRNode, exponent: number): void {
@@ -584,6 +613,53 @@ function extractCommonSymbolicFactor(inner: IRNode): IRNode | undefined {
     .map((power) => powNode(power.base, power.exponent));
   const residualTerms = terms.map((term) => removeCommonFactor(term, common));
   return app(MUL, [multiplyNodes(commonTerms), app(FACTOR, [addNodes(residualTerms)])]);
+}
+
+function extractMultivariatePerfectSquare(inner: IRNode): IRNode | undefined {
+  const terms = flattenAddTerms(inner);
+  if (terms.length !== 3) return undefined;
+
+  const parsed = terms.map((term) => splitIntegerCoefficientAndPowers(term));
+  if (parsed.some((term) => term === undefined)) return undefined;
+
+  const squares: FactorPower[] = [];
+  let cross: { readonly coefficient: bigint; readonly factors: readonly [FactorPower, FactorPower] } | undefined;
+  for (const parsedTerm of parsed) {
+    if (parsedTerm === undefined) return undefined;
+    const { coefficient, powers } = parsedTerm;
+    if (coefficient === 1n && powers.size === 1) {
+      const [power] = [...powers.values()];
+      if (power.exponent === 2) {
+        squares.push(power);
+        continue;
+      }
+    }
+    if ((coefficient === 2n || coefficient === -2n) && powers.size === 2) {
+      const factors = [...powers.values()];
+      if (factors[0].exponent === 1 && factors[1].exponent === 1) {
+        cross = { coefficient, factors: [factors[0], factors[1]] };
+        continue;
+      }
+    }
+    return undefined;
+  }
+
+  if (squares.length !== 2 || cross === undefined) return undefined;
+  const squareKeys = new Set(squares.map((power) => nodeKey(power.base)));
+  const crossKeys = new Set(cross.factors.map((power) => nodeKey(power.base)));
+  if (
+    squareKeys.size !== 2
+    || crossKeys.size !== 2
+    || [...squareKeys].some((key) => !crossKeys.has(key))
+  ) {
+    return undefined;
+  }
+
+  const [first, second] = squares;
+  const base = cross.coefficient > 0n
+    ? app(ADD, [first.base, second.base])
+    : app(SUB, [first.base, second.base]);
+  return app(POW, [base, int(2)]);
 }
 
 function polyAdd(a: readonly bigint[], b: readonly bigint[]): bigint[] {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -102,6 +102,26 @@ describe("symbolic-vm", () => {
     ]));
   });
 
+  it("factors bivariate perfect squares", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    const expr = app(FACTOR, [
+      app(ADD, [
+        app(ADD, [
+          app(POW, [x, int(2)]),
+          app(MUL, [int(2), app(MUL, [x, y])]),
+        ]),
+        app(POW, [y, int(2)]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(POW, [
+      app(ADD, [x, y]),
+      int(2),
+    ]));
+  });
+
   it("supports assignment and later lookup", () => {
     const vm = new VM(new SymbolicBackend());
     expect(vm.eval(app(ASSIGN, [sym("x"), app(ADD, [int(2), int(3)])]))).toEqual(int(5));


### PR DESCRIPTION
## Summary
- add a TypeScript symbolic-vm factoring foothold for bivariate perfect squares like `x^2 + 2*x*y + y^2`
- route TypeScript MACSYMA `factor` through the canonical handler so `factor(x^2 + 2*x*y + y^2)` returns `(x+y)^2`
- cover the direct symbolic VM handler and MACSYMA runtime paths

## Validation
- `npm test` in `code/packages/typescript/symbolic-vm`
- `npm run build` in `code/packages/typescript/symbolic-vm`
- `npm test` in `code/packages/typescript/macsyma-runtime`
- `npm run build` in `code/packages/typescript/macsyma-runtime`
- `git diff --check`