### PR TITLE
Rust factor multivariate perfect squares

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Delegated Rust MACSYMA `factor` evaluation to the shared `symbolic-vm`
   canonical handler, including coverage for common multivariate factors.
+- Added Rust MACSYMA parity for bivariate perfect-square factoring, so
+  `factor(x^2 + 2*x*y + y^2)` returns `(x + y)^2` through the shared symbolic
+  VM handler.
 - Added `?` / `? topic` help-query handling for Rust MACSYMA sessions.
 - Wired `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
   Rust MACSYMA session assumption context so declared properties feed property

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -128,6 +128,20 @@ fn factors_common_multivariate_terms_through_runtime() {
 }
 
 #[test]
+fn factors_multivariate_perfect_squares_through_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x^2 + 2*x*y + y^2);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(POW),
+            vec![apply(sym(ADD), vec![sym("x"), sym("y")]), int(2)]
+        )
+    );
+}
+
+#[test]
 fn question_mark_without_topic_lists_help_topics() {
     let mut session = MacsymaSession::new();
     let results = session.eval_source("?").unwrap();

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `SymbolicBackend` now installs canonical `Factor` handling backed by
   `cas-factor`, including common-symbolic-factor extraction for additive
   multivariate expressions before univariate integer factorization.
+- `Factor` recognises bivariate perfect-square trinomials such as
+  `x^2 + 2*x*y + y^2` and rewrites them as `(x + y)^2`.
 - `SymbolicBackend` installs a `D` derivative handler for symbolic-only
   differentiation of arithmetic, elementary, hyperbolic, and inverse
   hyperbolic expressions; `StrictBackend` continues to reject `D` as an

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1374,6 +1374,10 @@ fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
         }
     }
 
+    if let Some(rewritten) = factor_multivariate_perfect_square(input) {
+        return rewritten;
+    }
+
     if let Some(rewritten) = factor_common_symbolic_term(input) {
         return vm.eval(rewritten);
     }
@@ -1413,6 +1417,53 @@ fn factor_common_symbolic_term(node: &IRNode) -> Option<IRNode> {
         MUL,
         vec![common_factor, apply_node(FACTOR, vec![residual])],
     ))
+}
+
+fn factor_multivariate_perfect_square(node: &IRNode) -> Option<IRNode> {
+    let terms = additive_terms(node)?;
+    if terms.len() != 3 {
+        return None;
+    }
+
+    let mut squares = Vec::new();
+    let mut cross = None;
+    for term in &terms {
+        let (coefficient, powers) = term_integer_coefficient_and_powers(term)?;
+        if coefficient == 1 && powers.len() == 1 {
+            let (base, exponent) = powers.iter().next()?;
+            if *exponent == 2 {
+                squares.push(base.clone());
+                continue;
+            }
+        }
+        if (coefficient == 2 || coefficient == -2) && powers.len() == 2 {
+            let mut items = powers.iter();
+            let (first, first_exponent) = items.next()?;
+            let (second, second_exponent) = items.next()?;
+            if *first_exponent == 1 && *second_exponent == 1 {
+                cross = Some((coefficient, first.clone(), second.clone()));
+                continue;
+            }
+        }
+        return None;
+    }
+
+    if squares.len() != 2 {
+        return None;
+    }
+    let (coefficient, cross_first, cross_second) = cross?;
+    let square_keys: HashSet<IRNode> = squares.iter().cloned().collect();
+    let cross_keys: HashSet<IRNode> = [cross_first, cross_second].into_iter().collect();
+    if square_keys != cross_keys {
+        return None;
+    }
+
+    let base = if coefficient > 0 {
+        apply_node(ADD, vec![squares[0].clone(), squares[1].clone()])
+    } else {
+        apply_node(SUB, vec![squares[0].clone(), squares[1].clone()])
+    };
+    Some(apply_node(POW, vec![base, IRNode::Integer(2)]))
 }
 
 fn additive_terms(node: &IRNode) -> Option<Vec<IRNode>> {
@@ -1470,6 +1521,20 @@ fn term_factor_powers(term: &IRNode) -> HashMap<IRNode, usize> {
         }
     }
     powers
+}
+
+fn term_integer_coefficient_and_powers(term: &IRNode) -> Option<(i64, HashMap<IRNode, usize>)> {
+    let mut coefficient: i64 = 1;
+    let mut powers = HashMap::new();
+    for factor in multiplicative_factors(term) {
+        if let IRNode::Integer(value) = factor {
+            coefficient *= value;
+            continue;
+        }
+        let (base, exponent) = factor_base_power(factor)?;
+        *powers.entry(base).or_insert(0) += exponent;
+    }
+    Some((coefficient, powers))
 }
 
 fn multiplicative_factors(node: &IRNode) -> Vec<IRNode> {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -259,6 +259,37 @@ fn symbolic_factor_extracts_common_multivariate_term() {
     );
 }
 
+#[test]
+fn symbolic_factor_extracts_multivariate_perfect_square() {
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(sym(POW), vec![sym("x"), int(2)]),
+                        apply(
+                            sym(MUL),
+                            vec![int(2), apply(sym(MUL), vec![sym("x"), sym("y")])],
+                        ),
+                    ],
+                ),
+                apply(sym(POW), vec![sym("y"), int(2)]),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(
+            sym(POW),
+            vec![apply(sym(ADD), vec![sym("x"), sym("y")]), int(2)]
+        )
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolution
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a Rust symbolic-vm Factor foothold for bivariate perfect-square trinomials such as x^2 + 2*x*y + y^2
- route the same behavior through the Rust MACSYMA runtime via factor(...)
- cover the direct VM and MACSYMA source paths and update package changelogs

## Validation
- cargo fmt -p symbolic-vm -p coding-adventures-macsyma-runtime
- cargo test -p symbolic-vm symbolic_factor_extracts_multivariate_perfect_square
- cargo test -p coding-adventures-macsyma-runtime factors_multivariate_perfect_squares_through_runtime
- cargo test -p symbolic-vm
- cargo test -p coding-adventures-macsyma-runtime
- git diff --check