### PR TITLE
fix(twig-aot+demo): default integer type to i64; all typing states correct

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog — `twig-aot`
 
+## 0.1.5 — 2026-05-13
+
+**Default integer type changed from `u64` to `i64` — all typing states now correct.**
+
+Twig integers are semantically signed 64-bit values.  The previous default of
+`"u64"` for untyped params caused `(< x 0)` to emit an unsigned ARM64 `CMP`,
+which treated `-5` as a very large positive number and returned wrong results
+for programs that compared against negative numbers.
+
+### Changes
+
+- **`normalize_params_to_i64`** (was `normalize_params_to_u64`): promotes
+  `"any"` / `"polymorphic"` params to `"i64"` instead of `"u64"`.
+- **`default_any_to_i64`** (was `default_any_to_u64`): defaults remaining
+  `"any"` arithmetic/mov hints to `"i64"` instead of `"u64"`.
+- **`infer_aot_type`**: integer literal constants (`Operand::Int(_)`) now infer
+  `"i64"` instead of `"u64"`, so constant expressions propagate signed types.
+- **`compile_typed_module_to_arm64_bytes`**: now calls `normalize_params_to_i64`
+  before `propagate_aot_types`, ensuring that unannotated params (still `"any"`
+  after the caller has set annotation-derived types) also get `"i64"` semantics.
+  Previously this function relied entirely on the caller to set all param types,
+  which left unannotated functions with unsigned comparisons.
+
+### Effect
+
+All three optional-typing states (untyped / partially typed / fully typed) now
+produce correct results for programs that compare against negative numbers.
+Type annotations are purely additive: they document intent and may enable future
+optimisations, but are never required for correctness.
+
 ## 0.1.4 — 2026-05-13
 
 **In-process ARM64 execution + typed i64 pipeline.**
@@ -9,18 +39,18 @@
 #### `compile_module_to_arm64_bytes(module) → Result<(Vec<u8>, HashMap<String, usize>), AotError>`
 
 Returns raw ARM64 machine code bytes and a function-name→byte-offset map.
-Uses the standard untyped prep pipeline (builtin pre-lowering + u64
-normalization + type propagation + default-any-to-u64).  Suitable for
+Uses the full preparation pipeline (builtin pre-lowering + i64 param
+normalisation + type propagation + default-any-to-i64).  Suitable for
 in-process execution via `call_arm64_function_in_process`.
 
 #### `compile_typed_module_to_arm64_bytes(module) → Result<(Vec<u8>, HashMap<String, usize>), AotError>`
 
 Like `compile_module_to_arm64_bytes` but uses caller-supplied type
-annotations.  The caller pre-lowers builtins and sets params to `"i64"`;
-this function propagates types from those params (without running
-`normalize_params_to_u64`), so comparison instructions emit
-`cmp_lt_i64` (signed ARM64 condition code) rather than `cmp_lt_u64`
-(unsigned).  Correct for negative numbers.
+annotations.  The caller pre-lowers builtins and may set params to `"i64"`;
+this function first normalises any remaining `"any"` params to `"i64"`, then
+propagates types.  Comparison instructions emit `cmp_lt_i64` (signed ARM64
+condition code).  Correct for negative numbers whether or not the caller
+pre-annotated params.
 
 #### `pre_lower_aot_builtins_on_module(module: &mut IIRModule)`
 

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -187,13 +187,21 @@ pub fn compile_typed_module_to_arm64_bytes(
     let mut module = module.clone();
     for func in &mut module.functions {
         pre_lower_aot_builtins(func);
-        // Propagate types seeded from the (already-set) params.
+        // Promote any params still marked "any" or "polymorphic" to "i64".
+        //
+        // The caller may have already set some params to "i64" from source-level
+        // annotations (e.g. `(x : int)`).  `normalize_params_to_i64` only touches
+        // params that are STILL "any" — so caller-set types are never overwritten.
+        // This ensures that unannotated functions (no param_refinements) also get
+        // signed-integer semantics, matching Twig's semantic model.
+        normalize_params_to_i64(func);
+        // Propagate types seeded from the (now-concrete) params.
         // This fills in instructions like `sub dest, param, const` that
         // iir-type-checker missed because it doesn't seed from func.params.
         propagate_aot_types(func);
-        // Default any still-unresolvable arithmetic/mov hints to u64.
+        // Default any still-unresolvable arithmetic/mov hints to i64.
         // (Should be rare after propagation with typed params.)
-        default_any_to_u64(func);
+        default_any_to_i64(func);
     }
     compile_module_to_text_raw(&module)
 }
@@ -477,16 +485,18 @@ fn sdk_lib_path() -> PathBuf {
 //
 //  Step 2 — Normalise param types.
 //    The Twig IR compiler declares every param as `"any"`.  We promote them to
-//    `"u64"` — Twig's tagged-integer representation fits in a 64-bit register
-//    and all arithmetic on function arguments is 64-bit.  `infer_types` (from
-//    `aot-core`) seeds its environment from `func.params`, so this is the
-//    right place to override the "any" sentinel.
+//    `"i64"` — Twig integers are semantically signed 64-bit values, so using
+//    the signed default ensures that comparisons (e.g. `cmp_lt`) emit signed
+//    ARM64 condition codes (`B.LT`) rather than unsigned ones (`B.CC`), which
+//    matters for programs that test against negative numbers.  `infer_types`
+//    (from `aot-core`) seeds its environment from `func.params`, so this is
+//    the right place to override the "any" sentinel.
 //
 //  Step 3 — Propagate and default types.
 //    A lightweight fixed-point pass populates `type_hint` on every instruction
 //    whose type can be determined from its operands and the seeded param types.
 //    Any remaining `"any"` hints on arithmetic and `mov` instructions are
-//    then defaulted to `"u64"` so that `aot_specialise` never sees an
+//    then defaulted to `"i64"` so that `aot_specialise` never sees an
 //    untyped instruction and never emits `type_assert` guards (which the ARM64
 //    backend lowers to `udf` hard-traps).
 
@@ -515,11 +525,18 @@ fn pre_lower_aot_builtins(func: &mut IIRFunction) {
     }).collect();
 }
 
-/// Step 2: promote `"any"` / `"polymorphic"` param types to `"u64"`.
-fn normalize_params_to_u64(func: &mut IIRFunction) {
+/// Step 2: promote `"any"` / `"polymorphic"` param types to `"i64"`.
+///
+/// Twig integers are semantically signed 64-bit values.  Using `i64` as the
+/// default ensures that comparison instructions like `cmp_lt` emit signed ARM64
+/// condition codes (`B.LT` / `B.GE`) rather than unsigned ones (`B.CC` / `B.CS`).
+/// This matters for any program that compares against negative numbers — e.g.
+/// `(if (< x 0) …)` — where unsigned semantics would treat `-5` as a huge
+/// positive number and take the wrong branch.
+fn normalize_params_to_i64(func: &mut IIRFunction) {
     for (_, ty) in &mut func.params {
         if ty == "any" || ty == "polymorphic" {
-            *ty = "u64".to_string();
+            *ty = "i64".to_string();
         }
     }
 }
@@ -527,7 +544,7 @@ fn normalize_params_to_u64(func: &mut IIRFunction) {
 /// Step 3a: fixed-point type propagation seeded from params.
 ///
 /// Applies inference rules:
-/// - `const` with `Int` → `"u64"`, `Bool` → `"bool"`
+/// - `const` with `Int` → `"i64"`, `Bool` → `"bool"`
 /// - `cmp_*` → **operand type** (not `"bool"`)
 /// - `add`, `sub`, `mul`, `div`, `mov`, `neg`, `not` → type of first operand
 ///
@@ -543,7 +560,7 @@ fn normalize_params_to_u64(func: &mut IIRFunction) {
 /// selecting the right condition code in each case.  The boolean result value
 /// (0 or 1 stored to the dest register) is the same either way.
 ///
-/// Runs in a loop until stable.  Function params (already "u64" or "i64")
+/// Runs in a loop until stable.  Function params (already "i64" or a typed hint)
 /// seed the environment together with already-typed instructions.
 fn propagate_aot_types(func: &mut IIRFunction) {
     // Build initial env from params + any already-typed instructions.
@@ -589,7 +606,7 @@ fn propagate_aot_types(func: &mut IIRFunction) {
 fn infer_aot_type(instr: &IIRInstr, env: &HashMap<String, String>) -> Option<String> {
     match instr.op.as_str() {
         "const" => match instr.srcs.first() {
-            Some(Operand::Int(_))  => Some("u64".into()),
+            Some(Operand::Int(_))  => Some("i64".into()),
             Some(Operand::Bool(_)) => Some("bool".into()),
             _                       => None,
         },
@@ -621,27 +638,29 @@ fn resolve_src_aot_type(src: Option<&Operand>, env: &HashMap<String, String>) ->
                 None
             }
         }
-        Operand::Int(_)  => Some("u64".into()),
+        Operand::Int(_)  => Some("i64".into()),
         Operand::Bool(_) => Some("bool".into()),
         _                => None,
     }
 }
 
 /// Step 3b: default any remaining `"any"` hints on arithmetic / move
-/// instructions to `"u64"`.
+/// instructions to `"i64"`.
 ///
 /// This handles instructions whose sources are still `"any"` after the
 /// propagation pass — most commonly the results of `call` instructions whose
-/// return type is not tracked.  Defaulting to `"u64"` is safe for Twig:
-/// integer values fit in 64 bits and all arithmetic operates on them uniformly.
-/// The ARM64 backend generates correct code regardless of signed/unsigned
-/// flavour for the non-negative values produced by programs like fibonacci.
-fn default_any_to_u64(func: &mut IIRFunction) {
+/// return type is not tracked.  Defaulting to `"i64"` is correct for Twig:
+/// all Twig integer literals and arithmetic results are semantically signed
+/// 64-bit values.  Using `i64` here ensures that comparisons downstream
+/// (e.g. `cmp_lt`) emit signed ARM64 condition codes and produce correct
+/// results for negative numbers, regardless of whether the source was
+/// annotated or not.
+fn default_any_to_i64(func: &mut IIRFunction) {
     for instr in &mut func.instructions {
         if instr.type_hint != "any" { continue; }
         match instr.op.as_str() {
             "add" | "sub" | "mul" | "div" | "mod" | "mov" | "neg" | "not" => {
-                instr.type_hint = "u64".to_string();
+                instr.type_hint = "i64".to_string();
             }
             _ => {}
         }
@@ -652,9 +671,9 @@ fn default_any_to_u64(func: &mut IIRFunction) {
 fn prepare_module_for_aot(module: &mut IIRModule) {
     for func in &mut module.functions {
         pre_lower_aot_builtins(func);
-        normalize_params_to_u64(func);
+        normalize_params_to_i64(func);
         propagate_aot_types(func);
-        default_any_to_u64(func);
+        default_any_to_i64(func);
     }
 }
 
@@ -677,9 +696,9 @@ fn compile_module_to_text(
     // We work on a clone so the caller's `IIRModule` is never mutated.
     // `prepare_module_for_aot` runs three passes:
     //   1. `call_builtin "+"` → `add`, etc.   (see `pre_lower_aot_builtins`)
-    //   2. param types "any" → "u64"           (see `normalize_params_to_u64`)
+    //   2. param types "any" → "i64"           (see `normalize_params_to_i64`)
     //   3. propagate + default remaining "any" (see `propagate_aot_types` /
-    //                                            `default_any_to_u64`)
+    //                                            `default_any_to_i64`)
     let mut module = module.clone();
     prepare_module_for_aot(&mut module);
     compile_module_to_text_raw(&module)
@@ -860,12 +879,12 @@ mod tests {
         use interpreter_ir::instr::{IIRInstr, Operand};
 
         let main = IIRFunction::new(
-            "main", vec![], "u64",
+            "main", vec![], "i64",
             vec![
                 IIRInstr::new("const", Some("v0".into()),
-                              vec![Operand::Int(0)], "u64"),
+                              vec![Operand::Int(0)], "i64"),
                 IIRInstr::new("ret", None,
-                              vec![Operand::Var("v0".into())], "u64"),
+                              vec![Operand::Var("v0".into())], "i64"),
             ],
         );
         let mut m = IIRModule::new("hello", "twig");

--- a/code/packages/rust/twig-demo/CHANGELOG.md
+++ b/code/packages/rust/twig-demo/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — `twig-demo`
 
+## [0.1.4] — 2026-05-13
+
+**All typing states produce correct results; demo and commentary updated.**
+
+Following `twig-aot 0.1.5`'s change of the default integer type from `u64` to
+`i64`, all three type states (UNTYPED / PARTIAL / FULL) in `run_typing_demo()`
+now produce the correct result `0` for every backend including AOT.
+
+### Updated demos
+
+- **`run_typing_demo()`**: UNTYPED variant note changed from "AOT uses u64
+  throughout" to "AOT uses i64 default (signed, correct)".  Introductory text
+  updated to reflect that all three states are correct.  The "signed/unsigned
+  split" explanation was simplified.
+- **`aot_type_correctness_demo()`**: Retitled to "both paths use i64 (signed)".
+  Both the untyped (default i64) and typed (explicit i64) paths produce
+  `abs(-5) = 5 ✅ CORRECT`.
+- **`aot_in_process_demo()`**: Labels changed from "Untyped (u64 ops)" /
+  "Typed (i64 ops)" to "Untyped (default i64)" / "Typed (explicit i64)".
+- **`run_aot_annotated()`**: Docstring and inline comments updated to describe
+  the i64 default rather than the old u64 fallback.
+- All constant docstrings (`TYPING_UNTYPED`, `TYPING_PARTIAL`, `TYPING_FULL`,
+  `ABS_PROGRAM`) updated to describe the i64-default behaviour.
+
 ## [0.1.3] — 2026-05-13
 
 **Optional-typing demo: untyped / partially typed / fully typed.**

--- a/code/packages/rust/twig-demo/src/main.rs
+++ b/code/packages/rust/twig-demo/src/main.rs
@@ -1197,14 +1197,14 @@ fn exec_method(
 // AOT deep-dive: phase breakdown + type correctness demo (macOS/ARM64 only)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Abs-value Twig program: `(abs-val -5)` should return 5 for signed types.
+/// Abs-value Twig program: `(abs-val -5)` should return 5.
 ///
-/// With *unsigned* u64 comparison, the condition `(< x 0)` is always false
-/// because -5 is stored as a very large u64 — the branch is never taken and
-/// the result is -5 (wrong).
+/// Both the untyped (default i64) and explicitly-typed (i64) AOT paths produce
+/// the correct result 5, because the AOT backend defaults all unresolved params
+/// to `"i64"` — Twig integers are semantically signed 64-bit values.
 ///
 /// With *signed* i64 comparison, -5 < 0 is true, so `(- 0 x)` = `(- 0 -5)`
-/// = 5 is returned (correct).
+/// = 5 is returned.
 const ABS_PROGRAM: &str =
     "(define (abs-val x) (if (< x 0) (- 0 x) x)) (abs-val -5)";
 
@@ -1311,10 +1311,12 @@ fn invoke_xcrun_sdk_lib() -> std::path::PathBuf {
 /// call the function directly — no ld, no subprocess, no dyld overhead.
 ///
 /// Two variants:
-/// - **Untyped (u64 ops)**: uses `compile_module_to_arm64_bytes` — standard
-///   u64 pipeline; correct for non-negative integers like fib(10).
-/// - **Typed (i64 ops)**: uses `iir-type-checker` to produce i64-annotated
-///   IIR, then `compile_typed_module_to_arm64_bytes` — correct for all integers.
+/// - **Untyped (default i64)**: uses `compile_module_to_arm64_bytes` — the
+///   standard pipeline that defaults all untyped params to `"i64"`.  Correct
+///   for all integers including negative values.
+/// - **Typed (explicit i64)**: uses `iir-type-checker` to produce i64-annotated
+///   IIR, then `compile_typed_module_to_arm64_bytes`.  Same result — shown for
+///   comparison.
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn aot_in_process_demo() {
     println!("{}", "═".repeat(62));
@@ -1328,32 +1330,30 @@ fn aot_in_process_demo() {
         Err(e) => { println!("  compile_source failed: {e}"); return; }
     };
 
-    // ── Untyped (u64) ──
+    // ── Untyped (default i64) ──
     let t = Instant::now();
     let untyped_result = twig_aot::compile_module_to_arm64_bytes(&module)
         .and_then(|(bytes, offsets)| {
             twig_aot::call_arm64_function_in_process(&bytes, &offsets, "fib", 10)
         });
-    let ms_u64 = t.elapsed().as_millis();
+    let ms_i64_default = t.elapsed().as_millis();
 
     match &untyped_result {
-        Ok(v)  => println!("  {:<28} {:>8}  {:>8}  {}", "Untyped (u64 ops)", ms_u64, v,
+        Ok(v)  => println!("  {:<28} {:>8}  {:>8}  {}", "Untyped (default i64)", ms_i64_default, v,
                            if *v == EXPECTED { "correct" } else { "WRONG" }),
-        Err(e) => println!("  {:<28} {:>8}  {:>8}", "Untyped (u64 ops)", ms_u64, format!("ERR: {e:?}")),
+        Err(e) => println!("  {:<28} {:>8}  {:>8}", "Untyped (default i64)", ms_i64_default, format!("ERR: {e:?}")),
     }
 
-    // ── Typed (i64) — run iir-type-checker first ──
+    // ── Typed (explicit i64) — run iir-type-checker first ──
     let t = Instant::now();
     let typed_result = {
         let mut typed_module = module.clone();
         // Step 1: pre-lower builtins so named ops (`add`, `cmp_lt`, etc.) are
         // visible to the AOT type-propagation pass.
         twig_aot::pre_lower_aot_builtins_on_module(&mut typed_module);
-        // Step 2: set params to "i64".  The twig IR compiler marks all params
-        // "any"; by changing them to "i64" we tell the propagation pass (inside
-        // compile_typed_module_to_arm64_bytes) to seed the SSA env with i64,
-        // so comparison instructions get `cmp_lt_i64` (signed) instead of
-        // `cmp_lt_u64` (unsigned).
+        // Step 2: explicitly set params to "i64".  The twig IR compiler marks
+        // all params "any"; by changing them to "i64" we confirm the signed
+        // type to the propagation pass inside compile_typed_module_to_arm64_bytes.
         for func in &mut typed_module.functions {
             for (_, ty) in &mut func.params {
                 if ty == "any" { *ty = "i64".to_string(); }
@@ -1364,12 +1364,12 @@ fn aot_in_process_demo() {
                 twig_aot::call_arm64_function_in_process(&bytes, &offsets, "fib", 10)
             })
     };
-    let ms_i64 = t.elapsed().as_millis();
+    let ms_i64_explicit = t.elapsed().as_millis();
 
     match &typed_result {
-        Ok(v)  => println!("  {:<28} {:>8}  {:>8}  {}", "Typed (i64 ops)", ms_i64, v,
+        Ok(v)  => println!("  {:<28} {:>8}  {:>8}  {}", "Typed (explicit i64)", ms_i64_explicit, v,
                            if *v == EXPECTED { "correct" } else { "WRONG" }),
-        Err(e) => println!("  {:<28} {:>8}  {:>8}", "Typed (i64 ops)", ms_i64, format!("ERR: {e:?}")),
+        Err(e) => println!("  {:<28} {:>8}  {:>8}", "Typed (explicit i64)", ms_i64_explicit, format!("ERR: {e:?}")),
     }
 
     println!();
@@ -1377,23 +1377,26 @@ fn aot_in_process_demo() {
 
 // ── Section 3: Type correctness: abs(-5) ──────────────────────────────────────
 
-/// Demonstrate the signed/unsigned comparison correctness gap.
+/// Demonstrate that both the untyped and typed AOT paths produce correct
+/// results now that the AOT backend defaults unresolved params to `"i64"`.
 ///
-/// `(abs-val -5)` should return 5.
+/// `(abs-val -5)` should return 5.  Both the standard (no annotations) path
+/// via `compile_module_to_arm64_bytes` and the explicit typed path via
+/// `compile_typed_module_to_arm64_bytes` emit signed ARM64 comparisons and
+/// return 5.
 ///
-/// With the untyped u64 pipeline, `-5` is stored as `0xFFFF_FFFF_FFFF_FFFB`
-/// — a very large unsigned integer — so `(< x 0)` compares as unsigned and
-/// is always false.  The else branch returns -5 unchanged.
+/// ## Why the default is i64
 ///
-/// With the typed i64 pipeline, -5 is a proper signed 64-bit integer.
-/// `(< x 0)` uses a signed `CMP`, which correctly identifies -5 < 0, and
-/// `(- 0 x)` = `(- 0 -5)` = 5 is returned.
+/// Twig integers are semantically signed 64-bit values.  Using `"i64"` as the
+/// default ensures `(< x 0)` emits a signed `CMP` (`B.LT` ARM64 mnemonic)
+/// regardless of whether the source was annotated.  The untyped path and the
+/// explicitly-typed path are semantically identical for integer-only programs.
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn aot_type_correctness_demo() {
     println!("{}", "═".repeat(62));
-    println!("  Type correctness: abs(-5) — unsigned vs signed comparison");
+    println!("  Type correctness: abs(-5) — both paths use i64 (signed)");
     println!("{}", "═".repeat(62));
-    println!("  {:<22} {:>8}  {}", "Backend", "Result", "Correct?");
+    println!("  {:<26} {:>8}  {}", "Path", "Result", "Correct?");
     println!("  {}", "─".repeat(45));
 
     let module = match compile_source(ABS_PROGRAM, "abs_demo") {
@@ -1401,7 +1404,9 @@ fn aot_type_correctness_demo() {
         Err(e) => { println!("  compile_source failed: {e}"); return; }
     };
 
-    // Untyped (u64): wrong — unsigned comparison makes `< 0` always false.
+    // Untyped path: `compile_module_to_arm64_bytes` runs the full preparation
+    // pipeline (normalize_params_to_i64 + propagate + default_any_to_i64).
+    // All params default to i64, so `(< x 0)` emits a signed CMP.
     let untyped_result = twig_aot::compile_module_to_arm64_bytes(&module)
         .and_then(|(bytes, offsets)| {
             // The function is named "abs-val" (hyphens preserved by the IR compiler).
@@ -1411,22 +1416,16 @@ fn aot_type_correctness_demo() {
     match untyped_result {
         Ok(v)  => {
             let correct = v == 5;
-            println!("  {:<22} {:>8}  {}",
-                "Untyped (u64)", v,
-                if correct { "CORRECT" } else { "WRONG  (-5 stored as large u64, < 0 is false)" });
+            println!("  {:<26} {:>8}  {}",
+                "Untyped (default i64)", v,
+                if correct { "✅ CORRECT" } else { "❌ WRONG" });
         }
-        Err(e) => println!("  {:<22} {:>8}", "Untyped (u64)", format!("ERR: {e:?}")),
+        Err(e) => println!("  {:<26} {:>8}", "Untyped (default i64)", format!("ERR: {e:?}")),
     }
 
-    // Typed (i64): correct — signed comparison identifies -5 < 0.
-    //
-    // The key steps:
-    //   1. pre_lower_aot_builtins — converts `call_builtin "<"` → `cmp_lt`
-    //   2. Set params to "i64" — seeds propagation with signed type
-    //   3. compile_typed_module_to_arm64_bytes — propagates i64 to cmp_lt,
-    //      emitting `cmp_lt_i64` (signed ARM64 condition) instead of
-    //      `cmp_lt_u64` (unsigned).  With -5 as input, the signed path
-    //      correctly sees -5 < 0 and returns (0 - (-5)) = 5.
+    // Typed path: explicitly set params to "i64" before calling
+    // compile_typed_module_to_arm64_bytes.  The result is the same — both
+    // paths produce signed comparisons when the default is i64.
     let typed_result = {
         let mut typed_module = module.clone();
         twig_aot::pre_lower_aot_builtins_on_module(&mut typed_module);
@@ -1444,11 +1443,11 @@ fn aot_type_correctness_demo() {
     match typed_result {
         Ok(v)  => {
             let correct = v == 5;
-            println!("  {:<22} {:>8}  {}",
-                "Typed (i64)", v,
-                if correct { "CORRECT (signed comparison works)" } else { "WRONG" });
+            println!("  {:<26} {:>8}  {}",
+                "Typed (explicit i64)", v,
+                if correct { "✅ CORRECT" } else { "❌ WRONG" });
         }
-        Err(e) => println!("  {:<22} {:>8}", "Typed (i64)", format!("ERR: {e:?}")),
+        Err(e) => println!("  {:<26} {:>8}", "Typed (explicit i64)", format!("ERR: {e:?}")),
     }
 
     println!();
@@ -1465,11 +1464,11 @@ const TYPING_EXPECTED: i64 = 0;
 
 /// Untyped version — no annotations anywhere.
 ///
-/// Twig accepts this without complaint; every backend that uses a type-inference
-/// pass (interpreter, BEAM, WASM, JVM, CLR) produces the correct answer.
-/// The AOT backend must fall back to **unsigned (u64)** comparisons because
-/// it has no type information, so `(< −5 0)` reads as `large_u64 < 0` = false
-/// and `clamp_low` skips the branch — returning −5 instead of 0.
+/// Twig accepts this without complaint.  All six backends produce the correct
+/// answer: the interpreter, BEAM, WASM, JVM, and CLR backends use their own
+/// type-inference passes; the AOT backend defaults untyped params to `"i64"`
+/// (signed 64-bit), so `(< −5 0)` emits a signed ARM64 `CMP` and correctly
+/// takes the true branch — returning 0.
 const TYPING_UNTYPED: &str = "\
 (define (add-offset x offset) (+ x offset))
 (define (clamp-low x) (if (< x 0) 0 x))
@@ -1478,12 +1477,11 @@ const TYPING_UNTYPED: &str = "\
 
 /// Partially typed — only `clamp-low` carries type annotations.
 ///
-/// The annotation `(x : int)` tells the AOT pipeline that `x` is a signed
-/// 64-bit integer, so the compiler emits a signed `CMP` for `(< x 0)`.
-/// That is the only comparison in the hot path, so this is enough to fix
-/// the wrong result.  `add-offset` and `process` remain untyped (u64), which
-/// is fine for addition (two's-complement addition is the same for signed
-/// and unsigned).
+/// The annotation `(x : int)` explicitly tells the AOT pipeline that `x` is
+/// a signed 64-bit integer.  `add-offset` and `process` remain unannotated
+/// and use the `"i64"` default, which is also correct — two's-complement
+/// addition is the same for signed and unsigned, and the only comparison
+/// lives in `clamp-low` where it is now explicitly typed.
 const TYPING_PARTIAL: &str = "\
 (define (add-offset x offset) (+ x offset))
 (define (clamp-low (x : int) -> int) (if (< x 0) 0 x))
@@ -1493,7 +1491,9 @@ const TYPING_PARTIAL: &str = "\
 /// Fully typed — every parameter and return type is annotated.
 ///
 /// The AOT backend emits signed instructions for every arithmetic operation
-/// and comparison in the module.  No u64 fall-back is needed.
+/// and comparison in the module.  The result is identical to the untyped and
+/// partially-typed paths because the `"i64"` default already handles all
+/// unannotated params correctly.
 const TYPING_FULL: &str = "\
 (define (add-offset (x : int) (offset : int) -> int) (+ x offset))
 (define (clamp-low (x : int) -> int) (if (< x 0) 0 x))
@@ -1505,23 +1505,22 @@ const TYPING_FULL: &str = "\
 /// AOT path for the typing demo: reads `param_refinements` from the compiled
 /// `IIRModule` and seeds the ARM64 type-propagation pass from them.
 ///
-/// ## Why this matters
+/// ## How type annotations feed into AOT
 ///
 /// `twig_ir_compiler::compile_source` stores Twig type annotations in
 /// `func.param_refinements: Vec<Option<RefinedType>>`, but leaves
-/// `func.params` typed as `"any"` for all parameters.  The standard AOT
-/// preparation pipeline (`prepare_module_for_aot`) overwrites every param
-/// with `"u64"` — so annotations would otherwise be silently ignored.
+/// `func.params` typed as `"any"` for all parameters.  This function bridges
+/// the gap between source-level annotations and the AOT preparation pipeline:
 ///
-/// This function bridges the gap:
 /// 1. Pre-lower builtins (`call_builtin "+"` → `add`, etc.)
 /// 2. Walk `param_refinements` and, wherever a `Some(rt)` exists, set
 ///    `func.params[i].1 = rt.kind.as_type_hint()` (e.g. `"i64"` for `int`).
 /// 3. Hand the annotated module to `compile_typed_module_to_arm64_bytes`,
-///    which propagates those types and defaults anything still `"any"` to u64.
+///    which propagates those types and defaults anything still `"any"` to i64.
 ///
-/// Result: annotated params use signed i64 semantics; unannotated params
-/// use unsigned u64 semantics — exactly what "optional typing" promises.
+/// Because the AOT default is now `"i64"`, unannotated params are already
+/// signed — so all three typing variants (untyped / partial / full) produce
+/// the same correct results.
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn run_aot_annotated(source: &str) -> (u128, u128, Result<i64, String>) {
     let t_compile = Instant::now();
@@ -1546,7 +1545,7 @@ fn run_aot_annotated(source: &str) -> (u128, u128, Result<i64, String>) {
     //   Kind::Any  → "any"   (no-op — keeps the default)
     //   … etc.
     //
-    // Unannotated params remain "any" and are defaulted to "u64" downstream.
+    // Unannotated params remain "any" and are defaulted to "i64" downstream.
     for func in &mut module.functions {
         for (i, (_, param_ty)) in func.params.iter_mut().enumerate() {
             if let Some(Some(rt)) = func.param_refinements.get(i) {
@@ -1559,7 +1558,7 @@ fn run_aot_annotated(source: &str) -> (u128, u128, Result<i64, String>) {
     }
 
     // Step 4: propagate types seeded from annotated params, default remaining
-    // "any" to u64, and compile to flat ARM64 code bytes.
+    // "any" to i64, and compile to flat ARM64 code bytes.
     let (bytes, offsets) = match twig_aot::compile_typed_module_to_arm64_bytes(&module) {
         Ok(r)  => r,
         Err(e) => return (t_compile.elapsed().as_micros(), 0,
@@ -1595,14 +1594,17 @@ fn run_aot_annotated(_source: &str) -> (u128, u128, Result<i64, String>) {
 /// | Partial  | no ann.     | `(x:int) -> int`  | no ann.     |
 /// | Full     | `(x:int)(offset:int)->int` | `(x:int)->int` | `(val:int)->int` |
 ///
-/// The critical operation is `(< x 0)` inside `clamp-low`.
-/// - Without a type annotation, the AOT backend defaults `x` to **u64**
-///   and emits an unsigned `CMP` — so `(< −5 0)` is **false** (wrong).
-/// - With `(x : int)` on `clamp-low`, the AOT backend seeds `x` as **i64**
-///   and emits a signed `CMP` — so `(< −5 0)` is **true** (correct).
+/// All three type states produce the correct result (0) across all six
+/// backends:
+/// - The interpreter, BEAM, WASM, JVM, and CLR backends run their own
+///   type-inference passes and are always correct.
+/// - The AOT backend defaults untyped params to `"i64"` (signed 64-bit), so
+///   `(< −5 0)` emits a signed ARM64 `CMP` and takes the true branch in all
+///   three states — returning 0 correctly.
 ///
-/// The interpreter, BEAM, WASM, JVM, and CLR backends are correct in all
-/// three states because they run their own type-inference pass.
+/// Type annotations are now purely additive: they document intent, can expose
+/// type errors at compile time, and may enable future optimisations — but they
+/// are never required for correctness.
 fn run_typing_demo() {
     let sep = "═".repeat(74);
     println!("\n{sep}");
@@ -1611,16 +1613,15 @@ fn run_typing_demo() {
     println!("  Expected: {TYPING_EXPECTED}   (add-offset returns −5; clamp-low must see it as signed)");
     println!("{sep}");
     println!();
-    println!("  The signed/unsigned split lives in `(< x 0)` inside clamp-low:");
-    println!("    −5 as u64 = 0xFFFF_FFFF_FFFF_FFFB  →  u64 < 0  = false  →  returns −5 ❌");
-    println!("    −5 as i64 = −5                      →  i64 < 0  = true   →  returns  0 ✅");
+    println!("  The comparison `(< x 0)` inside clamp-low uses signed i64 semantics:");
+    println!("    −5 as i64 = −5  →  i64 < 0  = true  →  returns 0 ✅  (all three type states)");
     println!();
 
     let variants: &[(&str, &str, &str)] = &[
         (
             "UNTYPED",
             TYPING_UNTYPED,
-            "no annotations — AOT uses u64 throughout",
+            "no annotations — AOT uses i64 default (signed, correct)",
         ),
         (
             "PARTIALLY TYPED",
@@ -1644,8 +1645,8 @@ fn run_typing_demo() {
         results.push(BackendResult::new("Interpreter (twig-vm)", c, r, res));
 
         // AOT: annotation-aware in-process path.
-        // Unannotated params default to u64 (may give wrong answer);
-        // annotated params use their declared type (signed i64 for `int`).
+        // Unannotated params default to i64 (signed, correct for all cases);
+        // annotated params use their declared type (also i64 for `int`).
         let (c, r, res) = run_aot_annotated(source);
         results.push(BackendResult::new("AOT (in-process)", c, r, res));
 


### PR DESCRIPTION
## Summary

- **twig-aot 0.1.5**: Changed the AOT default integer type from `u64` to `i64`. Twig integers are semantically signed 64-bit values. The old `u64` default caused `(< x 0)` to emit an unsigned ARM64 CMP, which treated `-5` as `0xFFFFFFFFFFFFFFFB` and silently returned wrong results for programs comparing against negative numbers.
- **twig-demo 0.1.4**: Updated all three optional-typing demo variants (UNTYPED / PARTIAL / FULL) — they now all produce `0 ✅ PASS` across all 6 backends. Updated commentary, labels, and type-correctness demo to reflect the i64-default behaviour.

### Key changes in twig-aot

- `normalize_params_to_i64` (was `_to_u64`): promotes `"any"/"polymorphic"` params to `"i64"`
- `default_any_to_i64` (was `_to_u64`): defaults unresolved `"any"` arithmetic hints to `"i64"`
- `infer_aot_type` / `resolve_src_aot_type`: `Operand::Int(_)` → `"i64"` not `"u64"`
- `compile_typed_module_to_arm64_bytes`: now calls `normalize_params_to_i64` so unannotated params that remain `"any"` after the caller's annotation pass also get `"i64"` semantics

### Effect

All three optional-typing states produce correct results for programs that compare against negative numbers. Type annotations are purely additive — correctness no longer depends on them.

## Test plan

- [x] `cargo test -p twig-aot` — all 9 tests pass
- [x] `cargo run -p twig-demo` — UNTYPED / PARTIAL / FULL all show `0 ✅ PASS` for AOT
- [x] Security review passed (1 round)

🤖 Generated with [Claude Code](https://claude.com/claude-code)