### PR TITLE
feat(adjudication-ir): ADJ25 PR-1 — hierarchical-decomposition node kinds

### DIFF
--- a/code/packages/rust/adjudication-connector/src/lib.rs
+++ b/code/packages/rust/adjudication-connector/src/lib.rs
@@ -253,7 +253,22 @@ pub fn lower_to_kb_with_provenance(
             | NodeKind::Exception
             | NodeKind::Discarded
             | NodeKind::Section
-            | NodeKind::Entity => {}
+            | NodeKind::Entity
+            // ADJ25 PR-1: hierarchical-decomposition kinds are
+            // source-structural. They do not produce engine clauses
+            // directly; their contents are reached by walking
+            // Contains edges to descendant Facts/Rules (which lower
+            // here) and via Mentions edges to Entities.
+            | NodeKind::Document
+            | NodeKind::Sentence
+            | NodeKind::Phrase
+            | NodeKind::Question
+            | NodeKind::Quantity
+            | NodeKind::Polarity
+            | NodeKind::Predicate
+            | NodeKind::Comparator
+            | NodeKind::TimeRef
+            | NodeKind::Modifier => {}
         }
     }
     for edge in &ir_doc.edges {
@@ -305,7 +320,22 @@ pub fn lower_to_kb(ir_doc: &IRDocument) -> Result<KnowledgeBase, LoweringError> 
             | NodeKind::Exception
             | NodeKind::Discarded
             | NodeKind::Section
-            | NodeKind::Entity => {
+            | NodeKind::Entity
+            // ADJ25 PR-1: hierarchical-decomposition kinds are
+            // source-structural. Same rationale as the
+            // provenance-tracked branch above — none produce
+            // independent engine clauses; their content reaches the
+            // engine via descendant Fact/Rule lowering.
+            | NodeKind::Document
+            | NodeKind::Sentence
+            | NodeKind::Phrase
+            | NodeKind::Question
+            | NodeKind::Quantity
+            | NodeKind::Polarity
+            | NodeKind::Predicate
+            | NodeKind::Comparator
+            | NodeKind::TimeRef
+            | NodeKind::Modifier => {
                 // Query nodes are returned by extract_queries;
                 // Uncertainty / Exception / Discarded participate in
                 // clarification, audit, and rule priority. Section is

--- a/code/packages/rust/adjudication-ir/CHANGELOG.md
+++ b/code/packages/rust/adjudication-ir/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-05-13 — ADJ25 PR-1: hierarchical-decomposition node kinds
+
+### Added
+
+New `NodeKind` variants per
+[ADJ25](../../specs/ADJ25-hierarchical-decomposition.md), the
+foundational reset to per-level coverage for source decomposition.
+This PR is **additive only** — existing v3 kinds remain valid; the
+PR-2/PR-7 sequence retires `Section` in favour of the explicit
+level kinds once the foundation bench (PR-6) passes.
+
+**Level-0 → level-3 skeleton kinds:**
+
+- `NodeKind::Document` — the root of the hierarchical decomposition.
+  Exactly one per IR document, span `[0, N)`.
+- `NodeKind::Sentence` — a natural-language sentence in the source
+  (level 1; children of `Document`).
+- `NodeKind::Phrase` — a sub-sentence chunk that commits to one claim
+  / uncertainty / question / discardable (level 2; children of
+  `Sentence`).
+- `NodeKind::Question` — an interrogative present in the source text,
+  distinct from the engine-facing `Query` kind (level 3; children of
+  `Phrase`).
+
+**Level-4 typed-component slots (children of `Fact`):**
+
+- `NodeKind::Quantity` — typed numerical literal `quantity(value,
+  unit)`. Every numerical literal in a `Fact`'s span must surface as
+  one of these (PR-2 will enforce; PR-1 only introduces the kind).
+- `NodeKind::Polarity` — typed polarity slot, present when a `Fact`
+  contains negation cues. The variant name shadows the lattice enum
+  `Polarity`; disambiguate with `NodeKind::Polarity`.
+- `NodeKind::Predicate` — the relation / verb of a `Fact`.
+- `NodeKind::Comparator` — relational operator (`Eq`, `Lt`, `Le`,
+  `Gt`, `Ge`, `Ne`).
+- `NodeKind::TimeRef` — date, duration, or temporal phrase.
+- `NodeKind::Modifier` — adjective / adverb refinement.
+
+`NodeKind::Entity` is reused as the level-4 entity component
+unchanged.
+
+### Tests
+
+Eight new test cases in the `tests` module covering construction +
+validation of every new kind, plus a regression-guard on the
+`discard_reason` rule for typed components. Total tests: 26 → 34.
+
+### Notes
+
+- Adding variants to a non-`#[non_exhaustive]` enum is a SemVer
+  breaking change for downstream exhaustive matches. The workspace
+  consumers (`adjudication-connector`) have been updated in the same
+  PR. External consumers may need updates; this is consistent with
+  the 0.x convention of minor-bumps for breaking changes.
+- No coverage or per-level invariants are enforced yet — those land
+  in PR-2 (per-level coverage check). PR-1 deliberately ships only
+  the type-level additions so each subsequent PR has a tight scope.
+
 ## [0.3.0] - 2026-05-12 — ADJ01 v3 multi-directed acyclic graph
 
 ### Changed (breaking)

--- a/code/packages/rust/adjudication-ir/Cargo.toml
+++ b/code/packages/rust/adjudication-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adjudication-ir"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "The typed intermediate representation for rule-based adjudication (ADJ01 v3): multi-directed acyclic graph IR with typed edges, replacing v2's hierarchical decomposition tree. Adds IREdge alongside IRNode with a closed eleven-group edge-relation taxonomy (structural, identity, rule-modification, application, provenance, tabular, temporal, cross-source, discourse, refinement, and a DomainSpecific escape hatch), drops TextRun + part_of + lowered_from, adds Section and Entity node kinds, and switches coverage to a flat tile of (nodes ∪ edges).source_spans with a uniform DAG acyclicity check."
 

--- a/code/packages/rust/adjudication-ir/src/lib.rs
+++ b/code/packages/rust/adjudication-ir/src/lib.rs
@@ -193,14 +193,32 @@ pub enum Modality {
 
 /// The role a node plays in the IR.
 ///
-/// **v3** drops `TextRun` (replaced by [`Section`](NodeKind::Section)
-/// which carries meaningful structural metadata) and adds
+/// **v3** dropped `TextRun` (replaced by [`Section`](NodeKind::Section)
+/// which carries meaningful structural metadata) and added
 /// [`Entity`](NodeKind::Entity) for deduplicated reference targets.
+///
+/// **ADJ25 (PR-1, additive)** adds the hierarchical decomposition
+/// kinds required by `code/specs/ADJ25-hierarchical-decomposition.md`:
+/// [`Document`](NodeKind::Document), [`Sentence`](NodeKind::Sentence),
+/// [`Phrase`](NodeKind::Phrase), and [`Question`](NodeKind::Question)
+/// form the level-0 → level-3 skeleton; the level-4 typed-component
+/// kinds [`Quantity`](NodeKind::Quantity),
+/// [`Polarity`](NodeKind::Polarity),
+/// [`Predicate`](NodeKind::Predicate),
+/// [`Comparator`](NodeKind::Comparator),
+/// [`TimeRef`](NodeKind::TimeRef), and
+/// [`Modifier`](NodeKind::Modifier) decompose a `Fact`'s content into
+/// structured slots. [`Entity`](NodeKind::Entity) doubles as the
+/// level-4 entity component. PR-1 is additive only — the v3 kinds
+/// remain valid; PR-7 retires `Section` and the demoted kinds after
+/// the foundation bench passes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NodeKind {
     /// A claim about the world.
     Fact,
-    /// A question the adjudication is asked.
+    /// A question the adjudication is asked. Engine-facing — distinct
+    /// from [`Question`](NodeKind::Question), which is an interrogative
+    /// present in the source text (per ADJ25 level 3).
     Query,
     /// The source explicitly raised a question without answering it.
     Uncertainty,
@@ -216,11 +234,83 @@ pub enum NodeKind {
     /// kind (e.g., `paragraph(_)`, `row(3)`); its source_spans cover
     /// the *meta-text* (heading, numbering, delimiters), not the
     /// content. Content is reached via `Contains` edges.
+    ///
+    /// **ADJ25**: retiring in favour of the explicit level kinds
+    /// [`Sentence`](NodeKind::Sentence) and
+    /// [`Phrase`](NodeKind::Phrase). Deprecation lands with PR-7
+    /// (cutover) once the foundation bench (PR-6) passes.
     Section,
     /// A deduplicated reference target for an atom or compound term
     /// mentioned at multiple sites. Mentioning nodes connect via
     /// `Mentions` edges. May have empty source_spans if synthesized.
+    ///
+    /// **ADJ25**: also serves as the level-4 entity component when
+    /// it is a child of a `Fact` via `Contains` (a non-synthesized
+    /// Entity with non-empty spans inside a Fact's bytes).
     Entity,
+
+    // -----------------------------------------------------------------
+    // ADJ25 — hierarchical decomposition skeleton (levels 0 → 3)
+    // -----------------------------------------------------------------
+    /// **ADJ25 level 0.** The root of the hierarchical decomposition.
+    /// Exactly one per IR document. Its span covers `[0, N)` where
+    /// `N = len(normalized_text)`. Its children are `Sentence` (and
+    /// document-scope `Discarded`) nodes that tile the full range.
+    Document,
+    /// **ADJ25 level 1.** A natural-language sentence in the source.
+    /// Decomposition granularity is model-determined subject to the
+    /// per-level coverage check. Tiles part of a [`Document`]'s span;
+    /// children are [`Phrase`] and (sentence-scope) [`Discarded`] nodes
+    /// that tile the Sentence's span.
+    Sentence,
+    /// **ADJ25 level 2.** A sub-sentence chunk — a coherent unit of
+    /// meaning the model commits to as *"this stretch contributes one
+    /// claim (or one uncertainty / question / discardable)."* Tiles
+    /// part of a [`Sentence`]'s span; children are level-3 claim
+    /// nodes ([`Fact`], [`Uncertainty`], [`Question`],
+    /// phrase-scope [`Discarded`]) tiling the Phrase's span.
+    Phrase,
+    /// **ADJ25 level 3.** An interrogative present in the source text
+    /// ("Is this allowed?", "How many batteries can I bring?").
+    /// Distinct from [`Query`](NodeKind::Query), which is an
+    /// engine-facing posed question synthesized downstream of the
+    /// source decomposition.
+    Question,
+
+    // -----------------------------------------------------------------
+    // ADJ25 — level-4 typed-component slots (children of `Fact`)
+    // -----------------------------------------------------------------
+    /// **ADJ25 level 4.** A typed numerical literal — `Quantity(value,
+    /// unit)`. Every numerical literal in the source within a
+    /// [`Fact`]'s span MUST surface as a `Quantity` child of that
+    /// Fact. Flattening the literal into an atom name (e.g.,
+    /// `battery_50_wh`) is rejected by the no-flattening rule.
+    Quantity,
+    /// **ADJ25 level 4.** A typed polarity slot — `Polarity(Affirmed |
+    /// Denied)`. Exists when a [`Fact`]'s span contains negation cues
+    /// ("no", "not", "denies", "without"). The structural slot is
+    /// gated; the *value* the model assigns is not (per
+    /// `feedback_adjudication_no_interpretive_gating`).
+    ///
+    /// Note: the variant name shadows the lattice enum
+    /// [`Polarity`](crate::Polarity); use `NodeKind::Polarity` to
+    /// disambiguate.
+    Polarity,
+    /// **ADJ25 level 4.** The relation / verb of a [`Fact`]. Often a
+    /// single source word ("carry", "deliver", "exceeds"). Decomposes
+    /// the Fact's predicate from its arguments.
+    Predicate,
+    /// **ADJ25 level 4.** A relational operator — `Eq`, `Lt`, `Le`,
+    /// `Gt`, `Ge`, `Ne`. Used in threshold conditions ("blade length
+    /// > 2.36 inches", "battery capacity ≤ 100 Wh").
+    Comparator,
+    /// **ADJ25 level 4.** A date, duration, or temporal phrase
+    /// ("by 2026-12-01", "within 30 days", "Q3 2024").
+    TimeRef,
+    /// **ADJ25 level 4.** An adjective or adverb refinement that
+    /// doesn't fit the other level-4 slots ("strike-anywhere",
+    /// "disposable", "carry-on", "promptly").
+    Modifier,
 }
 
 /// Controlled vocabulary for [`NodeKind::Discarded`] nodes'
@@ -838,7 +928,25 @@ fn validate_per_node(n: &IRNode, doc: &IRDocument) -> Result<(), ValidationError
                 });
             }
         }
-        NodeKind::Section | NodeKind::Entity | NodeKind::Discarded => {
+        NodeKind::Section
+        | NodeKind::Entity
+        | NodeKind::Discarded
+        // ADJ25 PR-1: hierarchical-decomposition skeleton kinds. These
+        // are structural slots — no polarity constraint at the kind
+        // level. Per-level coverage rules (PR-2) will enforce structural
+        // invariants. The model-assigned polarity *value* lives in a
+        // dedicated `Polarity` child node, not on these structural
+        // ancestors.
+        | NodeKind::Document
+        | NodeKind::Sentence
+        | NodeKind::Phrase
+        | NodeKind::Question
+        | NodeKind::Quantity
+        | NodeKind::Polarity
+        | NodeKind::Predicate
+        | NodeKind::Comparator
+        | NodeKind::TimeRef
+        | NodeKind::Modifier => {
             // No polarity constraint beyond "set to something legal";
             // the lattice itself is the legal set.
         }
@@ -2081,5 +2189,150 @@ mod tests {
             edges: vec![excepts_edge_marker, mention_passenger],
         };
         assert_eq!(validate(&doc), Ok(()));
+    }
+
+    // -----------------------------------------------------------------
+    // ADJ25 PR-1 — additive node-kind smoke tests
+    //
+    // PR-1 only introduces the new variants; the per-level coverage
+    // invariants and Contains-edge tiling are PR-2's responsibility.
+    // These tests confirm the additive change is sound: each new kind
+    // can be constructed, validates as a stand-alone node tiling a
+    // document, and respects the discard_reason rules.
+    // -----------------------------------------------------------------
+
+    fn typed_node(id: &str, kind: NodeKind, did: &DocumentId, start: usize, end: usize) -> IRNode {
+        IRNode {
+            id: NodeId::new(id),
+            kind,
+            term: atom("placeholder"),
+            polarity: Polarity::Affirmed,
+            modality: Modality::Present,
+            source_spans: vec![span(did, start, end)],
+            confidence: 1.0,
+            discard_reason: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn assert_validates_as_root_node(node: IRNode) {
+        let did = node.source_spans[0].document_id.clone();
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![node],
+            edges: vec![],
+        };
+        assert_eq!(validate(&doc), Ok(()));
+    }
+
+    #[test]
+    fn adj25_document_node_validates() {
+        let did = DocumentId::new("d");
+        let n = typed_node("Doc", NodeKind::Document, &did, 0, 24);
+        assert_validates_as_root_node(n);
+    }
+
+    #[test]
+    fn adj25_sentence_node_validates() {
+        let did = DocumentId::new("d");
+        let n = typed_node("S1", NodeKind::Sentence, &did, 0, 24);
+        assert_validates_as_root_node(n);
+    }
+
+    #[test]
+    fn adj25_phrase_node_validates() {
+        let did = DocumentId::new("d");
+        let n = typed_node("P1", NodeKind::Phrase, &did, 0, 16);
+        assert_validates_as_root_node(n);
+    }
+
+    #[test]
+    fn adj25_question_node_validates() {
+        let did = DocumentId::new("d");
+        let n = typed_node("Q1", NodeKind::Question, &did, 0, 17);
+        assert_validates_as_root_node(n);
+    }
+
+    #[test]
+    fn adj25_quantity_component_validates() {
+        let did = DocumentId::new("d");
+        let n = IRNode {
+            id: NodeId::new("Q200wh"),
+            kind: NodeKind::Quantity,
+            term: compound("quantity", vec![atom("200"), atom("wh")]),
+            polarity: Polarity::Affirmed,
+            modality: Modality::Present,
+            source_spans: vec![span(&did, 0, 6)],
+            confidence: 1.0,
+            discard_reason: None,
+            metadata: HashMap::new(),
+        };
+        assert_validates_as_root_node(n);
+    }
+
+    #[test]
+    fn adj25_polarity_component_validates() {
+        let did = DocumentId::new("d");
+        let n = IRNode {
+            id: NodeId::new("PolDenied"),
+            kind: NodeKind::Polarity,
+            term: atom("denied"),
+            polarity: Polarity::Affirmed,
+            modality: Modality::Present,
+            source_spans: vec![span(&did, 0, 2)],
+            confidence: 1.0,
+            discard_reason: None,
+            metadata: HashMap::new(),
+        };
+        assert_validates_as_root_node(n);
+    }
+
+    #[test]
+    fn adj25_typed_components_reject_discard_reason() {
+        let did = DocumentId::new("d");
+        let mut n = typed_node("Pred", NodeKind::Predicate, &did, 0, 5);
+        n.discard_reason = Some(DiscardReason::NonDomainContent);
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![n],
+            edges: vec![],
+        };
+        match validate(&doc) {
+            Err(ValidationError::NonDiscardedWithReason { node_id, kind }) => {
+                assert_eq!(node_id.0, "Pred");
+                assert_eq!(kind, NodeKind::Predicate);
+            }
+            other => panic!("expected NonDiscardedWithReason, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn adj25_all_new_kinds_round_trip_through_match() {
+        // Sanity that the exhaustive match in validate_per_node was
+        // updated for every new variant. If a new kind is added later
+        // without updating the match, this test still passes (compile
+        // error would catch it earlier); the test documents the
+        // expected per-kind validation behaviour.
+        let did = DocumentId::new("d");
+        for (kind, end) in [
+            (NodeKind::Document, 10usize),
+            (NodeKind::Sentence, 10),
+            (NodeKind::Phrase, 10),
+            (NodeKind::Question, 10),
+            (NodeKind::Quantity, 10),
+            (NodeKind::Polarity, 10),
+            (NodeKind::Predicate, 10),
+            (NodeKind::Comparator, 10),
+            (NodeKind::TimeRef, 10),
+            (NodeKind::Modifier, 10),
+        ] {
+            let n = typed_node("X", kind, &did, 0, end);
+            let doc = IRDocument {
+                document_id: did.clone(),
+                nodes: vec![n],
+                edges: vec![],
+            };
+            assert_eq!(validate(&doc), Ok(()), "kind {:?} failed validation", kind);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **ADJ25 PR-1, additive only.** Introduces the new `NodeKind` variants the upcoming per-level coverage check will gate on. Type-level additions only; no behavioral changes yet.
- **Level 0 → level 3 skeleton kinds**: `Document`, `Sentence`, `Phrase`, `Question` (distinct from engine-facing `Query`).
- **Level 4 typed-component slots** (children of `Fact`): `Quantity`, `Polarity` (shadows the lattice enum; disambiguate as `NodeKind::Polarity`), `Predicate`, `Comparator`, `TimeRef`, `Modifier`. `Entity` is reused as the level-4 entity component.
- **Exhaustive-match updates** in `adjudication_ir::validate_per_node` (new kinds get the no-polarity-constraint arm) and `adjudication_connector::lower_to_kb` / `lower_to_kb_with_provenance` (new kinds are no-ops — they don't produce engine clauses directly).
- **Version bump 0.3.0 → 0.4.0** since adding variants to a non-`#[non_exhaustive]` enum is a SemVer breaking change for exhaustive downstream matches.
- **No coverage / no flattening rule yet** — those land in PR-2 per the spec's migration plan.

Spec: [ADJ25](https://github.com/adhithyan15/coding-adventures/blob/claude/naughty-varahamihira-949835/code/specs/ADJ25-hierarchical-decomposition.md) (separate PR [#3087](https://github.com/adhithyan15/coding-adventures/pull/3087)).

## Why this is small

The ADJ25 migration plan deliberately splits the work into 7 sequenced PRs so each one has a tight, testable scope:

- **PR-1 (this PR)** — new IR types only.
- **PR-2** — per-level coverage check + no-flattening rule.
- **PR-3** — fresh-agent retry primitive.
- **PR-4** — orchestrator (`decompose_text_hierarchical`).
- **PR-5** — correlation vector through connector + audit trail.
- **PR-6** — foundation bench (the gate that unblocks other workstreams).
- **PR-7** — cutover (retire Section, demoted kinds, old decompose_text).

PR-1 is intentionally minimal so the structural additions can land cleanly and the next PRs can build on a stable enum surface.

## Test plan

- [x] `cargo build -p adjudication-ir -p adjudication-connector` clean
- [x] `cargo test -p adjudication-ir` — 26 existing tests + 8 new ADJ25 tests, all 34 passing
- [x] `cargo test -p adjudication-connector` — 25 tests passing (workspace consumers unbroken)
- [x] Security review (sub-agent) passed: additive type-system changes only, no I/O, no unsafe, no parsing
- [ ] CI green
- [ ] No merge conflicts with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)