### PR TITLE
Python factor multivariate difference squares

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added MACSYMA `factor` parity for the bivariate difference-of-squares
+  factoring foothold, so `factor(x^2 - y^2)` now returns `(x-y)*(x+y)`
+  through the canonical symbolic VM handler.
 - Added MACSYMA `factor` parity for the bivariate perfect-square factoring
   foothold, so `factor(x^2 + 2*x*y + y^2)` now returns `(x+y)^2` through the
   canonical symbolic VM handler.

--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -738,6 +738,17 @@ def test_pipeline_factor_multivariate_perfect_square() -> None:
     assert set(base.args) == {IRSymbol("x"), IRSymbol("y")}
 
 
+def test_pipeline_factor_multivariate_difference_of_squares() -> None:
+    """factor(x^2 - y^2) recognises (x-y)*(x+y)."""
+    result = _eval("factor(x^2 - y^2)")
+    assert isinstance(result, IRApply)
+    assert result.head.name == "Mul"
+    assert result.args == (
+        IRApply(IRSymbol("Sub"), (IRSymbol("x"), IRSymbol("y"))),
+        IRApply(IRSymbol("Add"), (IRSymbol("x"), IRSymbol("y"))),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Section S — Calculus: diff and integrate (already wired, no pipeline tests)
 # ---------------------------------------------------------------------------

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added another small multivariate factoring foothold to `Factor`: bivariate
+  differences of squares such as `x^2 - y^2` now factor to `(x-y)*(x+y)`.
 - Added a second small multivariate factoring foothold to `Factor`:
   bivariate perfect-square quadratics such as `x^2 + 2*x*y + y^2` now factor
   to `(x+y)^2`.

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -1153,6 +1153,45 @@ def _extract_multivariate_perfect_square(inner: IRNode) -> IRNode | None:
     return IRApply(POW, (base, IRInteger(2)))
 
 
+def _extract_multivariate_difference_of_squares(inner: IRNode) -> IRNode | None:
+    """Recognise the small ``a^2 - b^2`` multivariate factor case."""
+    terms = _flatten_add_terms(inner)
+    if len(terms) != 2:
+        return None
+
+    parsed = [_split_integer_coefficient_and_powers(term) for term in terms]
+    if any(term is None for term in parsed):
+        return None
+
+    positive_square: IRNode | None = None
+    negative_square: IRNode | None = None
+    for parsed_term in parsed:
+        assert parsed_term is not None
+        coefficient, powers = parsed_term
+        if len(powers) != 1:
+            return None
+        base, exponent = next(iter(powers.items()))
+        if exponent != 2:
+            return None
+        if coefficient == 1:
+            positive_square = base
+        elif coefficient == -1:
+            negative_square = base
+        else:
+            return None
+
+    if positive_square is None or negative_square is None:
+        return None
+
+    return IRApply(
+        MUL,
+        (
+            IRApply(SUB, (positive_square, negative_square)),
+            IRApply(ADD, (positive_square, negative_square)),
+        ),
+    )
+
+
 def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     """``Factor(expr)`` — factor a univariate integer polynomial over Z.
 
@@ -1182,6 +1221,9 @@ def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     # Try to lift to rational function.
     rational = to_rational(inner, x)
     if rational is None:
+        difference = _extract_multivariate_difference_of_squares(inner)
+        if difference is not None:
+            return difference
         perfect_square = _extract_multivariate_perfect_square(inner)
         if perfect_square is not None:
             return perfect_square

--- a/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
+++ b/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
@@ -230,6 +230,27 @@ def test_factor_multivariate_perfect_square() -> None:
     assert result == IRApply(POW, (IRApply(ADD, (x, y)), IRInteger(2)))
 
 
+def test_factor_multivariate_difference_of_squares() -> None:
+    """Factor(x^2 - y^2) recognises a bivariate difference of squares."""
+    vm, _ = make_vm()
+    target = IRApply(
+        SUB,
+        (
+            IRApply(POW, (x, IRInteger(2))),
+            IRApply(POW, (y, IRInteger(2))),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert result == IRApply(
+        MUL,
+        (
+            IRApply(SUB, (x, y)),
+            IRApply(ADD, (x, y)),
+        ),
+    )
+
+
 def test_factor_linear() -> None:
     """Factor(x - 3) → x - 3 (already irreducible linear, content 1)."""
     vm, _ = make_vm()


### PR DESCRIPTION
## Summary
- add a Python symbolic-vm Factor foothold for bivariate difference-of-squares expressions such as x^2 - y^2
- route the same behavior through the Python MACSYMA runtime via factor(...)
- cover the direct VM and MACSYMA source paths and update package changelogs

## Validation
- PYTHONPATH="$(printf '%s:' code/packages/python/*/src)" MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-difference-square python -m pytest code/packages/python/symbolic-vm/tests/test_cas_handlers.py::test_factor_multivariate_difference_of_squares code/packages/python/symbolic-vm/tests/test_cas_handlers.py::test_factor_multivariate_perfect_square code/packages/python/symbolic-vm/tests/test_cas_handlers.py::test_factor_common_multivariate_symbolic_factor -q --no-cov
- PYTHONPATH="$(printf '%s:' code/packages/python/*/src)" MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-difference-square python -m pytest code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py::test_pipeline_factor_multivariate_difference_of_squares code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py::test_pipeline_factor_multivariate_perfect_square code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py::test_pipeline_factor_common_multivariate_factor -q --no-cov
- PYTHONPATH="$(printf '%s:' code/packages/python/*/src)" MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-difference-square python -m pytest code/packages/python/symbolic-vm/tests/test_cas_handlers.py -q --no-cov
- PYTHONPATH="$(printf '%s:' code/packages/python/*/src)" MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-difference-square python -m pytest code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py -q --no-cov
- PYTHONPATH="$(printf '%s:' code/packages/python/*/src)" MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-difference-square python -m ruff check code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
- git diff --check

## Note
A broader ruff run over code/packages/python/symbolic-vm/tests/test_cas_handlers.py still reports pre-existing line-length and IRNode annotation issues outside this patch; the focused new tests and touched source/runtime pipeline files are clean.