### PR TITLE
TypeScript factor multivariate difference squares

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -7,6 +7,8 @@
   substrate.
 - Add TypeScript MACSYMA parity for the bivariate perfect-square factoring
   foothold, so `factor(x^2 + 2*x*y + y^2)` returns `(x+y)^2`.
+- Add TypeScript MACSYMA parity for the bivariate difference-of-squares
+  factoring foothold, so `factor(x^2 - y^2)` returns `(x-y)*(x+y)`.
 - Add `?` / `? topic` help-query handling for TypeScript MACSYMA sessions and
   JSON responses.
 - Wire `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -176,6 +176,16 @@ describe("macsyma-runtime", () => {
     ]));
   });
 
+  it("factors bivariate differences of squares through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x^2 - y^2);");
+
+    expect(result.output).toEqual(app(MUL, [
+      app(SUB, [sym("x"), sym("y")]),
+      app(ADD, [sym("x"), sym("y")]),
+    ]));
+  });
+
   it("tracks the showtime option flag through normal assignments", () => {
     const session = new MacsymaSession();
     const [enabled, timed, disabled, untimed] = session.evalSource(

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -9,6 +9,8 @@
   like `x^2*y - y`.
 - Added a bivariate perfect-square factoring foothold so `Factor` recognises
   expressions like `x^2 + 2*x*y + y^2` as `(x+y)^2`.
+- Added a bivariate difference-of-squares factoring foothold so `Factor`
+  recognises expressions like `x^2 - y^2` as `(x-y)*(x+y)`.
 - Added a symbolic-backend-only `D` handler for pure IR differentiation,
   including arithmetic, power, elementary, hyperbolic, and inverse hyperbolic
   chain rules.

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -373,6 +373,8 @@ function factorHandler(vm: VM, expr: IRApply): IRNode {
 
   const coeffs = irToIntegerPoly(inner, variable);
   if (coeffs === undefined) {
+    const difference = extractMultivariateDifferenceOfSquares(inner);
+    if (difference !== undefined) return difference;
     const perfectSquare = extractMultivariatePerfectSquare(inner);
     if (perfectSquare !== undefined) return perfectSquare;
     const commonFactored = extractCommonSymbolicFactor(inner);
@@ -660,6 +662,37 @@ function extractMultivariatePerfectSquare(inner: IRNode): IRNode | undefined {
     ? app(ADD, [first.base, second.base])
     : app(SUB, [first.base, second.base]);
   return app(POW, [base, int(2)]);
+}
+
+function extractMultivariateDifferenceOfSquares(inner: IRNode): IRNode | undefined {
+  const terms = flattenAddTerms(inner);
+  if (terms.length !== 2) return undefined;
+
+  const parsed = terms.map((term) => splitIntegerCoefficientAndPowers(term));
+  if (parsed.some((term) => term === undefined)) return undefined;
+
+  let positiveSquare: IRNode | undefined;
+  let negativeSquare: IRNode | undefined;
+  for (const parsedTerm of parsed) {
+    if (parsedTerm === undefined) return undefined;
+    const { coefficient, powers } = parsedTerm;
+    if (powers.size !== 1) return undefined;
+    const [power] = [...powers.values()];
+    if (power.exponent !== 2) return undefined;
+    if (coefficient === 1n) {
+      positiveSquare = power.base;
+    } else if (coefficient === -1n) {
+      negativeSquare = power.base;
+    } else {
+      return undefined;
+    }
+  }
+
+  if (positiveSquare === undefined || negativeSquare === undefined) return undefined;
+  return app(MUL, [
+    app(SUB, [positiveSquare, negativeSquare]),
+    app(ADD, [positiveSquare, negativeSquare]),
+  ]);
 }
 
 function polyAdd(a: readonly bigint[], b: readonly bigint[]): bigint[] {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -122,6 +122,23 @@ describe("symbolic-vm", () => {
     ]));
   });
 
+  it("factors bivariate differences of squares", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    const expr = app(FACTOR, [
+      app(SUB, [
+        app(POW, [x, int(2)]),
+        app(POW, [y, int(2)]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(MUL, [
+      app(SUB, [x, y]),
+      app(ADD, [x, y]),
+    ]));
+  });
+
   it("supports assignment and later lookup", () => {
     const vm = new VM(new SymbolicBackend());
     expect(vm.eval(app(ASSIGN, [sym("x"), app(ADD, [int(2), int(3)])]))).toEqual(int(5));


### PR DESCRIPTION
## Summary
- add a TypeScript symbolic-vm Factor foothold for bivariate difference-of-squares expressions such as x^2 - y^2
- route the same behavior through the TypeScript MACSYMA runtime via factor(...)
- cover the direct VM and MACSYMA source paths and update package changelogs

## Validation
- npm install (in code/packages/typescript/symbolic-vm and code/packages/typescript/macsyma-runtime, to hydrate fresh-worktree dev dependencies)
- npm test (in code/packages/typescript/symbolic-vm)
- npm test (in code/packages/typescript/macsyma-runtime)
- npm run build (in code/packages/typescript/symbolic-vm)
- npm run build (in code/packages/typescript/macsyma-runtime)
- git diff --check