### PR TITLE
Rust factor multivariate difference squares

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added Rust MACSYMA parity for bivariate perfect-square factoring, so
   `factor(x^2 + 2*x*y + y^2)` returns `(x + y)^2` through the shared symbolic
   VM handler.
+- Added Rust MACSYMA parity for bivariate difference-of-squares factoring, so
+  `factor(x^2 - y^2)` returns `(x - y) * (x + y)` through the shared symbolic
+  VM handler.
 - Added `?` / `? topic` help-query handling for Rust MACSYMA sessions.
 - Wired `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
   Rust MACSYMA session assumption context so declared properties feed property

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -142,6 +142,23 @@ fn factors_multivariate_perfect_squares_through_runtime() {
 }
 
 #[test]
+fn factors_multivariate_difference_of_squares_through_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x^2 - y^2);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(SUB), vec![sym("x"), sym("y")]),
+                apply(sym(ADD), vec![sym("x"), sym("y")]),
+            ],
+        )
+    );
+}
+
+#[test]
 fn question_mark_without_topic_lists_help_topics() {
     let mut session = MacsymaSession::new();
     let results = session.eval_source("?").unwrap();

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -9,6 +9,8 @@
   multivariate expressions before univariate integer factorization.
 - `Factor` recognises bivariate perfect-square trinomials such as
   `x^2 + 2*x*y + y^2` and rewrites them as `(x + y)^2`.
+- `Factor` recognises bivariate difference-of-squares expressions such as
+  `x^2 - y^2` and rewrites them as `(x - y) * (x + y)`.
 - `SymbolicBackend` installs a `D` derivative handler for symbolic-only
   differentiation of arithmetic, elementary, hyperbolic, and inverse
   hyperbolic expressions; `StrictBackend` continues to reject `D` as an

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1374,6 +1374,10 @@ fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
         }
     }
 
+    if let Some(rewritten) = factor_multivariate_difference_of_squares(input) {
+        return rewritten;
+    }
+
     if let Some(rewritten) = factor_multivariate_perfect_square(input) {
         return rewritten;
     }
@@ -1464,6 +1468,43 @@ fn factor_multivariate_perfect_square(node: &IRNode) -> Option<IRNode> {
         apply_node(SUB, vec![squares[0].clone(), squares[1].clone()])
     };
     Some(apply_node(POW, vec![base, IRNode::Integer(2)]))
+}
+
+fn factor_multivariate_difference_of_squares(node: &IRNode) -> Option<IRNode> {
+    let terms = additive_terms(node)?;
+    if terms.len() != 2 {
+        return None;
+    }
+
+    let mut positive_square = None;
+    let mut negative_square = None;
+    for term in &terms {
+        let (coefficient, powers) = term_integer_coefficient_and_powers(term)?;
+        if powers.len() != 1 {
+            return None;
+        }
+
+        let (base, exponent) = powers.iter().next()?;
+        if *exponent != 2 {
+            return None;
+        }
+
+        match coefficient {
+            1 => positive_square = Some(base.clone()),
+            -1 => negative_square = Some(base.clone()),
+            _ => return None,
+        }
+    }
+
+    let positive_square = positive_square?;
+    let negative_square = negative_square?;
+    Some(apply_node(
+        MUL,
+        vec![
+            apply_node(SUB, vec![positive_square.clone(), negative_square.clone()]),
+            apply_node(ADD, vec![positive_square, negative_square]),
+        ],
+    ))
 }
 
 fn additive_terms(node: &IRNode) -> Option<Vec<IRNode>> {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -290,6 +290,31 @@ fn symbolic_factor_extracts_multivariate_perfect_square() {
     );
 }
 
+#[test]
+fn symbolic_factor_extracts_multivariate_difference_of_squares() {
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(SUB),
+            vec![
+                apply(sym(POW), vec![sym("x"), int(2)]),
+                apply(sym(POW), vec![sym("y"), int(2)]),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(SUB), vec![sym("x"), sym("y")]),
+                apply(sym(ADD), vec![sym("x"), sym("y")]),
+            ],
+        )
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolution
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a Rust symbolic-vm Factor foothold for bivariate difference-of-squares expressions such as x^2 - y^2
- route the same behavior through the Rust MACSYMA runtime via factor(...)
- cover the direct VM and MACSYMA source paths and update package changelogs

## Validation
- cargo test -p symbolic-vm
- cargo test -p coding-adventures-macsyma-runtime
- git diff --check HEAD~1 HEAD