### PR TITLE
Python factor multivariate cubic identities

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added MACSYMA `factor` parity for bivariate cubic identities, so
+  `factor(x^3 - y^3)` and `factor(x^3 + y^3)` now return the textbook
+  two-factor decompositions through the canonical symbolic VM handler.
 - Added MACSYMA `factor` parity for the bivariate difference-of-squares
   factoring foothold, so `factor(x^2 - y^2)` now returns `(x-y)*(x+y)`
   through the canonical symbolic VM handler.

--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -749,6 +749,60 @@ def test_pipeline_factor_multivariate_difference_of_squares() -> None:
     )
 
 
+def test_pipeline_factor_multivariate_difference_of_cubes() -> None:
+    """factor(x^3 - y^3) recognises (x-y)*(x^2+x*y+y^2)."""
+    result = _eval("factor(x^3 - y^3)")
+    assert isinstance(result, IRApply)
+    assert result.head.name == "Mul"
+    assert result.args == (
+        IRApply(IRSymbol("Sub"), (IRSymbol("x"), IRSymbol("y"))),
+        IRApply(
+            IRSymbol("Add"),
+            (
+                IRApply(
+                    IRSymbol("Add"),
+                    (
+                        IRApply(IRSymbol("Pow"), (IRSymbol("x"), IRInteger(2))),
+                        IRApply(IRSymbol("Mul"), (IRSymbol("x"), IRSymbol("y"))),
+                    ),
+                ),
+                IRApply(IRSymbol("Pow"), (IRSymbol("y"), IRInteger(2))),
+            ),
+        ),
+    )
+
+
+def test_pipeline_factor_multivariate_sum_of_cubes() -> None:
+    """factor(x^3 + y^3) recognises (x+y)*(x^2-x*y+y^2)."""
+    result = _eval("factor(x^3 + y^3)")
+    assert isinstance(result, IRApply)
+    assert result.head.name == "Mul"
+    assert result.args == (
+        IRApply(IRSymbol("Add"), (IRSymbol("x"), IRSymbol("y"))),
+        IRApply(
+            IRSymbol("Add"),
+            (
+                IRApply(
+                    IRSymbol("Add"),
+                    (
+                        IRApply(IRSymbol("Pow"), (IRSymbol("x"), IRInteger(2))),
+                        IRApply(
+                            IRSymbol("Mul"),
+                            (
+                                IRInteger(-1),
+                                IRApply(
+                                    IRSymbol("Mul"), (IRSymbol("x"), IRSymbol("y"))
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                IRApply(IRSymbol("Pow"), (IRSymbol("y"), IRInteger(2))),
+            ),
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Section S — Calculus: diff and integrate (already wired, no pipeline tests)
 # ---------------------------------------------------------------------------

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Added another small multivariate factoring foothold to `Factor`: bivariate
+  cubic identities such as `x^3 - y^3` and `x^3 + y^3` now factor to their
+  textbook two-factor decompositions.
+- Added another small multivariate factoring foothold to `Factor`: bivariate
   differences of squares such as `x^2 - y^2` now factor to `(x-y)*(x+y)`.
 - Added a second small multivariate factoring foothold to `Factor`:
   bivariate perfect-square quadratics such as `x^2 + 2*x*y + y^2` now factor

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -1192,6 +1192,51 @@ def _extract_multivariate_difference_of_squares(inner: IRNode) -> IRNode | None:
     )
 
 
+def _extract_multivariate_cubic_identity(inner: IRNode) -> IRNode | None:
+    """Recognise the small ``a^3 +/- b^3`` multivariate factor cases."""
+    terms = _flatten_add_terms(inner)
+    if len(terms) != 2:
+        return None
+
+    parsed = [_split_integer_coefficient_and_powers(term) for term in terms]
+    if any(term is None for term in parsed):
+        return None
+
+    cubes: list[tuple[int, IRNode]] = []
+    for parsed_term in parsed:
+        assert parsed_term is not None
+        coefficient, powers = parsed_term
+        if coefficient not in (-1, 1) or len(powers) != 1:
+            return None
+        base, exponent = next(iter(powers.items()))
+        if exponent != 3:
+            return None
+        cubes.append((coefficient, base))
+
+    signs = [coefficient for coefficient, _base in cubes]
+    if signs == [1, 1]:
+        first, second = cubes[0][1], cubes[1][1]
+        linear = IRApply(ADD, (first, second))
+        middle = IRApply(MUL, (IRInteger(-1), IRApply(MUL, (first, second))))
+    elif sorted(signs) == [-1, 1]:
+        positive = next(base for coefficient, base in cubes if coefficient == 1)
+        negative = next(base for coefficient, base in cubes if coefficient == -1)
+        first, second = positive, negative
+        linear = IRApply(SUB, (first, second))
+        middle = IRApply(MUL, (first, second))
+    else:
+        return None
+
+    quadratic = IRApply(
+        ADD,
+        (
+            IRApply(ADD, (IRApply(POW, (first, IRInteger(2))), middle)),
+            IRApply(POW, (second, IRInteger(2))),
+        ),
+    )
+    return IRApply(MUL, (linear, quadratic))
+
+
 def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     """``Factor(expr)`` — factor a univariate integer polynomial over Z.
 
@@ -1221,6 +1266,9 @@ def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     # Try to lift to rational function.
     rational = to_rational(inner, x)
     if rational is None:
+        cubic_identity = _extract_multivariate_cubic_identity(inner)
+        if cubic_identity is not None:
+            return cubic_identity
         difference = _extract_multivariate_difference_of_squares(inner)
         if difference is not None:
             return difference

--- a/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
+++ b/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
@@ -251,6 +251,69 @@ def test_factor_multivariate_difference_of_squares() -> None:
     )
 
 
+def test_factor_multivariate_difference_of_cubes() -> None:
+    """Factor(x^3 - y^3) recognises the cubic identity."""
+    vm, _ = make_vm()
+    target = IRApply(
+        SUB,
+        (
+            IRApply(POW, (x, IRInteger(3))),
+            IRApply(POW, (y, IRInteger(3))),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert result == IRApply(
+        MUL,
+        (
+            IRApply(SUB, (x, y)),
+            IRApply(
+                ADD,
+                (
+                    IRApply(
+                        ADD,
+                        (IRApply(POW, (x, IRInteger(2))), IRApply(MUL, (x, y))),
+                    ),
+                    IRApply(POW, (y, IRInteger(2))),
+                ),
+            ),
+        ),
+    )
+
+
+def test_factor_multivariate_sum_of_cubes() -> None:
+    """Factor(x^3 + y^3) recognises the cubic identity."""
+    vm, _ = make_vm()
+    target = IRApply(
+        ADD,
+        (
+            IRApply(POW, (x, IRInteger(3))),
+            IRApply(POW, (y, IRInteger(3))),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert result == IRApply(
+        MUL,
+        (
+            IRApply(ADD, (x, y)),
+            IRApply(
+                ADD,
+                (
+                    IRApply(
+                        ADD,
+                        (
+                            IRApply(POW, (x, IRInteger(2))),
+                            IRApply(MUL, (IRInteger(-1), IRApply(MUL, (x, y)))),
+                        ),
+                    ),
+                    IRApply(POW, (y, IRInteger(2))),
+                ),
+            ),
+        ),
+    )
+
+
 def test_factor_linear() -> None:
     """Factor(x - 3) → x - 3 (already irreducible linear, content 1)."""
     vm, _ = make_vm()


### PR DESCRIPTION
## Summary
- add a Python symbolic-vm Factor foothold for bivariate cubic identities such as x^3 - y^3 and x^3 + y^3
- route the same behavior through the Python MACSYMA runtime via factor(...)
- cover the direct VM and MACSYMA source paths and update package changelogs

## Validation
- `PYTHONPATH=$(printf '%s:' code/packages/python/*/src) MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-cubic-identities python -m pytest tests/test_cas_handlers.py --no-cov` (in `code/packages/python/symbolic-vm`)
- `PYTHONPATH=$(printf '%s:' code/packages/python/*/src) MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-cubic-identities python -m pytest tests/test_cas_pipeline.py --no-cov` (in `code/packages/python/macsyma-runtime`)
- `git diff --check`
