### PR TITLE
Discover UNO R4 BOSSA uploader from Arduino core

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -189,7 +189,6 @@ cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- \
   --print-only \
   --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" \
   --arm-toolchain-bin /opt/homebrew/bin \
-  --bossac-path /tmp/arduino-bossa/bin \
   --port /dev/cu.usbmodem... \
   --upload \
   --smoke
@@ -204,20 +203,23 @@ it, follow the post-upload runtime port, and run the host smoke path:
 cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- \
   --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" \
   --arm-toolchain-bin /opt/homebrew/bin \
-  --bossac-path /tmp/arduino-bossa/bin \
   --port /dev/cu.usbmodem... \
   --upload \
   --smoke
 ```
 
 The helper discovers Rust's bundled `llvm-objcopy`, the stable rustup `rustc`,
-and `arm-none-eabi-*` tools on `PATH` when available. Override `--rustc`,
-`--arm-gcc`, `--arm-gxx`, `--arm-ar`, `--arm-compat-root`, `--objcopy`,
-`--arduino-cli`, `--bossac-path`, `--target-dir`, `--baud`, or `--timeout-ms`
-for local tooling differences. Before upload, the helper now performs the
-Arduino-compatible 1200-baud bootloader touch on the requested port and polls
-for the bootloader port before invoking Arduino CLI. Pass `--no-bootloader-touch`
-when the board is already in bootloader mode, or tune
+and `arm-none-eabi-*` tools on `PATH` when available. When `--core` points at an
+installed Arduino Renesas UNO core, it also discovers Arduino's packaged
+`bossac` root and passes it to Arduino CLI as the upload tool path. On Apple
+Silicon this keeps the upload path on Arduino's patched BOSSA build; install
+Rosetta if that packaged uploader is x86-only. Override `--rustc`, `--arm-gcc`,
+`--arm-gxx`, `--arm-ar`, `--arm-compat-root`, `--objcopy`, `--arduino-cli`,
+`--bossac-path`, `--target-dir`, `--baud`, or `--timeout-ms` for local tooling
+differences. Before upload, the helper now performs the Arduino-compatible
+1200-baud bootloader touch on the requested port and polls for the bootloader
+port before invoking Arduino CLI. Pass `--no-bootloader-touch` when the board is
+already in bootloader mode, or tune
 `--bootloader-touch-timeout-ms`, `--bootloader-touch-settle-ms`, and
 `--bootloader-port-wait-ms` for local USB timing.
 
@@ -242,8 +244,9 @@ arduino-cli upload \
 ```
 
 On Apple Silicon systems without Rosetta, Arduino's packaged macOS `bossac`
-may be x86-only. Build Arduino's patched BOSSA uploader locally and override the
-tool path when uploading:
+may be x86-only. Prefer installing Rosetta so the helper can keep using
+Arduino's packaged patched uploader. If a native uploader is still required,
+build Arduino's patched BOSSA locally and override the tool path when uploading:
 
 ```sh
 git clone --depth 1 https://github.com/arduino/BOSSA.git /tmp/arduino-bossa

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
@@ -164,6 +164,13 @@ impl SerialUsbArtifactOptions {
                 .as_deref()
                 .and_then(arduino_arm_compat_root_from_core);
         }
+
+        if self.bossac_path.is_none() {
+            self.bossac_path = self
+                .arduino_core
+                .as_deref()
+                .and_then(arduino_bossac_root_from_core);
+        }
     }
 
     pub fn profile_dir(&self) -> &'static str {
@@ -265,6 +272,7 @@ impl SerialUsbArtifactOptions {
             .arg_path(&self.bin_path());
 
         if let Some(path) = &self.bossac_path {
+            let path = bossac_upload_property_path(path);
             command = command.arg("--upload-property").arg(format!(
                 "runtime.tools.bossac-1.9.1-arduino5.path={}",
                 path.display()
@@ -580,6 +588,21 @@ pub fn arduino_arm_compat_root_from_core(core_dir: &Path) -> Option<PathBuf> {
     root.exists().then_some(root)
 }
 
+pub fn arduino_bossac_root_from_core(core_dir: &Path) -> Option<PathBuf> {
+    let packages_dir = core_dir.ancestors().nth(4)?;
+    let root = packages_dir
+        .join("arduino/tools/bossac")
+        .join("1.9.1-arduino5");
+    root.exists().then_some(root)
+}
+
+pub fn bossac_upload_property_path(path: &Path) -> PathBuf {
+    match path.file_name().and_then(OsStr::to_str) {
+        Some("bossac") | Some("bossac.exe") => path.parent().unwrap_or(path).to_path_buf(),
+        _ => path.to_path_buf(),
+    }
+}
+
 pub fn detect_host_triple(rustc_verbose_version: &str) -> Option<String> {
     rustc_verbose_version
         .lines()
@@ -638,6 +661,8 @@ fn shell_escape(value: &OsStr) -> String {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
     use std::vec;
 
     fn options() -> SerialUsbArtifactOptions {
@@ -671,6 +696,19 @@ mod tests {
             .iter()
             .map(|arg| arg.to_string_lossy().to_string())
             .collect()
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = env::temp_dir().join(format!(
+            "board-vm-uno-r4-firmware-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        dir
     }
 
     #[test]
@@ -781,6 +819,48 @@ mod tests {
                 "115200",
                 "--timeout-ms",
                 "1000",
+            ]
+        );
+    }
+
+    #[test]
+    fn fill_host_defaults_discovers_arduino_packaged_bossac_from_core() {
+        let root = unique_temp_dir("bossac");
+        let core = root.join("packages/arduino/hardware/renesas_uno/1.5.3");
+        let bossac = root.join("packages/arduino/tools/bossac/1.9.1-arduino5");
+        fs::create_dir_all(&core).unwrap();
+        fs::create_dir_all(&bossac).unwrap();
+
+        let mut options = options();
+        options.arduino_core = Some(core);
+        options.bossac_path = None;
+        options.fill_host_defaults();
+
+        assert_eq!(options.bossac_path, Some(bossac));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn upload_command_accepts_a_bossac_binary_path() {
+        let mut options = options();
+        options.bossac_path = Some(PathBuf::from(
+            "/Arduino15/packages/arduino/tools/bossac/1.9.1-arduino5/bossac",
+        ));
+
+        let command = options.upload_command_for_port("/dev/cu.usbmodem-test");
+
+        assert_eq!(
+            args(&command),
+            [
+                "upload",
+                "-p",
+                "/dev/cu.usbmodem-test",
+                "-b",
+                UNO_R4_WIFI_FQBN,
+                "-i",
+                "target/thumbv7em-none-eabihf/release/uno-r4-wifi-serialusb-server.bin",
+                "--upload-property",
+                "runtime.tools.bossac-1.9.1-arduino5.path=/Arduino15/packages/arduino/tools/bossac/1.9.1-arduino5",
             ]
         );
     }


### PR DESCRIPTION
## Summary
- discover Arduino packaged bossac from the UNO R4 core path during artifact helper host-default filling
- normalize --bossac-path when callers pass the bossac binary instead of its tool root
- update the UNO R4 firmware runbook so --core is enough for the normal patched BOSSA path

## Validation
- cargo fmt -p board-vm-uno-r4-firmware
- cargo test -p board-vm-uno-r4-firmware
- RUSTC="$(rustup which --toolchain stable rustc)" cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --print-only --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" --arm-toolchain-bin /opt/homebrew/bin --port /dev/cu.usbmodem1101 --upload --smoke, with MISE_TRUSTED_CONFIG_PATHS set for this worktree; output included runtime.tools.bossac-1.9.1-arduino5.path=$HOME/Library/Arduino15/packages/arduino/tools/bossac/1.9.1-arduino5
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check