### PR TITLE
TypeScript factor multivariate cubic identities

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -9,6 +9,9 @@
   foothold, so `factor(x^2 + 2*x*y + y^2)` returns `(x+y)^2`.
 - Add TypeScript MACSYMA parity for the bivariate difference-of-squares
   factoring foothold, so `factor(x^2 - y^2)` returns `(x-y)*(x+y)`.
+- Add TypeScript MACSYMA parity for bivariate cubic identities, so
+  `factor(x^3 - y^3)` and `factor(x^3 + y^3)` return the textbook two-factor
+  decompositions through the shared symbolic VM handler.
 - Add `?` / `? topic` help-query handling for TypeScript MACSYMA sessions and
   JSON responses.
 - Wire `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -186,6 +186,38 @@ describe("macsyma-runtime", () => {
     ]));
   });
 
+  it("factors bivariate differences of cubes through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x^3 - y^3);");
+
+    expect(result.output).toEqual(app(MUL, [
+      app(SUB, [sym("x"), sym("y")]),
+      app(ADD, [
+        app(ADD, [
+          app(POW, [sym("x"), int(2)]),
+          app(MUL, [sym("x"), sym("y")]),
+        ]),
+        app(POW, [sym("y"), int(2)]),
+      ]),
+    ]));
+  });
+
+  it("factors bivariate sums of cubes through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x^3 + y^3);");
+
+    expect(result.output).toEqual(app(MUL, [
+      app(ADD, [sym("x"), sym("y")]),
+      app(ADD, [
+        app(ADD, [
+          app(POW, [sym("x"), int(2)]),
+          app(MUL, [int(-1), app(MUL, [sym("x"), sym("y")])]),
+        ]),
+        app(POW, [sym("y"), int(2)]),
+      ]),
+    ]));
+  });
+
   it("tracks the showtime option flag through normal assignments", () => {
     const session = new MacsymaSession();
     const [enabled, timed, disabled, untimed] = session.evalSource(

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -11,6 +11,9 @@
   expressions like `x^2 + 2*x*y + y^2` as `(x+y)^2`.
 - Added a bivariate difference-of-squares factoring foothold so `Factor`
   recognises expressions like `x^2 - y^2` as `(x-y)*(x+y)`.
+- Added a bivariate cubic-identity factoring foothold so `Factor` recognises
+  expressions like `x^3 - y^3` and `x^3 + y^3` as their textbook two-factor
+  decompositions.
 - Added a symbolic-backend-only `D` handler for pure IR differentiation,
   including arithmetic, power, elementary, hyperbolic, and inverse hyperbolic
   chain rules.

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -373,6 +373,8 @@ function factorHandler(vm: VM, expr: IRApply): IRNode {
 
   const coeffs = irToIntegerPoly(inner, variable);
   if (coeffs === undefined) {
+    const cubicIdentity = extractMultivariateCubicIdentity(inner);
+    if (cubicIdentity !== undefined) return cubicIdentity;
     const difference = extractMultivariateDifferenceOfSquares(inner);
     if (difference !== undefined) return difference;
     const perfectSquare = extractMultivariatePerfectSquare(inner);
@@ -692,6 +694,54 @@ function extractMultivariateDifferenceOfSquares(inner: IRNode): IRNode | undefin
   return app(MUL, [
     app(SUB, [positiveSquare, negativeSquare]),
     app(ADD, [positiveSquare, negativeSquare]),
+  ]);
+}
+
+function extractMultivariateCubicIdentity(inner: IRNode): IRNode | undefined {
+  const terms = flattenAddTerms(inner);
+  if (terms.length !== 2) return undefined;
+
+  const parsed = terms.map((term) => splitIntegerCoefficientAndPowers(term));
+  if (parsed.some((term) => term === undefined)) return undefined;
+
+  const cubes: Array<{ readonly coefficient: bigint; readonly base: IRNode }> = [];
+  for (const parsedTerm of parsed) {
+    if (parsedTerm === undefined) return undefined;
+    const { coefficient, powers } = parsedTerm;
+    if ((coefficient !== 1n && coefficient !== -1n) || powers.size !== 1) return undefined;
+    const [power] = [...powers.values()];
+    if (power.exponent !== 3) return undefined;
+    cubes.push({ coefficient, base: power.base });
+  }
+
+  const signs = cubes.map((cube) => cube.coefficient).join(",");
+  let first: IRNode;
+  let second: IRNode;
+  let linear: IRNode;
+  let middle: IRNode;
+  if (signs === "1,1") {
+    first = cubes[0].base;
+    second = cubes[1].base;
+    linear = app(ADD, [first, second]);
+    middle = app(MUL, [int(-1), app(MUL, [first, second])]);
+  } else if (cubes.some((cube) => cube.coefficient === 1n) && cubes.some((cube) => cube.coefficient === -1n)) {
+    const positive = cubes.find((cube) => cube.coefficient === 1n);
+    const negative = cubes.find((cube) => cube.coefficient === -1n);
+    if (positive === undefined || negative === undefined) return undefined;
+    first = positive.base;
+    second = negative.base;
+    linear = app(SUB, [first, second]);
+    middle = app(MUL, [first, second]);
+  } else {
+    return undefined;
+  }
+
+  return app(MUL, [
+    linear,
+    app(ADD, [
+      app(ADD, [app(POW, [first, int(2)]), middle]),
+      app(POW, [second, int(2)]),
+    ]),
   ]);
 }
 

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -139,6 +139,52 @@ describe("symbolic-vm", () => {
     ]));
   });
 
+  it("factors bivariate differences of cubes", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    const expr = app(FACTOR, [
+      app(SUB, [
+        app(POW, [x, int(3)]),
+        app(POW, [y, int(3)]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(MUL, [
+      app(SUB, [x, y]),
+      app(ADD, [
+        app(ADD, [
+          app(POW, [x, int(2)]),
+          app(MUL, [x, y]),
+        ]),
+        app(POW, [y, int(2)]),
+      ]),
+    ]));
+  });
+
+  it("factors bivariate sums of cubes", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    const expr = app(FACTOR, [
+      app(ADD, [
+        app(POW, [x, int(3)]),
+        app(POW, [y, int(3)]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(MUL, [
+      app(ADD, [x, y]),
+      app(ADD, [
+        app(ADD, [
+          app(POW, [x, int(2)]),
+          app(MUL, [int(-1), app(MUL, [x, y])]),
+        ]),
+        app(POW, [y, int(2)]),
+      ]),
+    ]));
+  });
+
   it("supports assignment and later lookup", () => {
     const vm = new VM(new SymbolicBackend());
     expect(vm.eval(app(ASSIGN, [sym("x"), app(ADD, [int(2), int(3)])]))).toEqual(int(5));


### PR DESCRIPTION
## Summary
- add a TypeScript symbolic-vm Factor foothold for bivariate cubic identities such as x^3 - y^3 and x^3 + y^3
- route the same behavior through the TypeScript MACSYMA runtime via factor(...)
- cover the direct VM and MACSYMA source paths and update package changelogs

## Validation
- `npm install` (in `code/packages/typescript/symbolic-vm` and `code/packages/typescript/macsyma-runtime`, to hydrate fresh-worktree dev dependencies)
- `npm test` (in `code/packages/typescript/symbolic-vm`)
- `npm test` (in `code/packages/typescript/macsyma-runtime`)
- `npm run build` (in `code/packages/typescript/symbolic-vm`)
- `npm run build` (in `code/packages/typescript/macsyma-runtime`)
- `git diff --check`
