### PR TITLE
Expose Board VM digital pin metadata

### DIFF
--- a/code/packages/lua/board_vm_native/src/lib.rs
+++ b/code/packages/lua/board_vm_native/src/lib.rs
@@ -19,8 +19,9 @@ use board_vm_language_core::{
     pico_uf2_upload_options_for_target, wireless_transport_name, BoardVmLanguageSession,
     BuiltWireFrame, LanguageBluetoothBackendOpenPlan, LanguageBluetoothDiscoveredDevice,
     LanguageBluetoothEndpoint, LanguageBluetoothEndpointCandidate, LanguageConnectionOption,
-    LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed,
-    LanguagePicoUf2UploadOptions, LanguageTargetInfo, LanguageWirelessInterface,
+    LanguageCoreError, LanguageDigitalPin, LanguageEspUploadOptions, LanguageHostDevice,
+    LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageTargetInfo,
+    LanguageWirelessInterface,
 };
 use lua_bridge::{
     get_str, luaL_Reg, luaL_checkinteger, lua_Integer, lua_State, lua_createtable, lua_getfield,
@@ -449,6 +450,10 @@ unsafe fn push_target(L: *mut lua_State, target: &LanguageTargetInfo) {
     );
     set_int(L, "digital_pin_count", target.digital_pin_count as u64);
 
+    let key = CString::new("digital_pins").unwrap();
+    push_digital_pins(L, &target.digital_pins);
+    lua_setfield(L, -2, key.as_ptr());
+
     let key = CString::new("onboard_led").unwrap();
     push_onboard_led(L, target.onboard_led);
     lua_setfield(L, -2, key.as_ptr());
@@ -468,6 +473,26 @@ unsafe fn push_target(L: *mut lua_State, target: &LanguageTargetInfo) {
     let key = CString::new("capabilities").unwrap();
     push_string_array(L, &target.capabilities);
     lua_setfield(L, -2, key.as_ptr());
+}
+
+unsafe fn push_digital_pins(L: *mut lua_State, pins: &[LanguageDigitalPin]) {
+    lua_createtable(L, pins.len() as c_int, 0);
+    for (index, pin) in pins.iter().enumerate() {
+        lua_bridge::lua_newtable(L);
+        set_int(L, "pin", pin.pin as u64);
+        set_str(L, "label", &pin.label);
+        set_bool(L, "supports_input", pin.supports_input);
+        set_bool(L, "supports_output", pin.supports_output);
+        set_bool(L, "supports_pullup", pin.supports_pullup);
+        set_bool(L, "supports_pulldown", pin.supports_pulldown);
+        set_bool(L, "supports_adc", pin.supports_adc);
+        set_bool(L, "supports_pwm", pin.supports_pwm);
+        set_bool(L, "supports_touch", pin.supports_touch);
+        set_bool(L, "supports_interrupt", pin.supports_interrupt);
+        set_bool(L, "boot_strap", pin.boot_strap);
+        set_str(L, "notes", &pin.notes);
+        lua_rawseti(L, -2, (index + 1) as lua_Integer);
+    }
 }
 
 unsafe fn push_led_matrix(

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -22,6 +22,21 @@ describe("coding_adventures.board_vm_native", function()
         assert.is_true(uno.connection_options[2].ota_update)
         assert.are.equal(8, uno.led_matrix.rows)
         assert.are.equal(12, uno.led_matrix.columns)
+        assert.are.equal(uno.digital_pin_count, #uno.digital_pins)
+        local d3 = nil
+        for _, pin in ipairs(uno.digital_pins) do
+            if pin.pin == 3 then
+                d3 = pin
+            end
+        end
+        assert.are.equal("D3", d3.label)
+        assert.is_true(d3.supports_input)
+        assert.is_true(d3.supports_output)
+        assert.is_true(d3.supports_pullup)
+        assert.is_false(d3.supports_pulldown)
+        assert.is_true(d3.supports_pwm)
+        assert.is_true(d3.supports_interrupt)
+        assert.is_false(d3.supports_adc)
         assert.are.equal("esp32-devkit-v1", esp.board_id)
         assert.are.equal("xtensa-esp32-none-elf", esp.rust_target)
         assert.are.equal("gpio", esp.onboard_led.kind)

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -212,6 +212,16 @@ class BoardTarget:
         return int(self.raw["digital_pin_count"])
 
     @property
+    def digital_pins(self) -> list[dict[str, Any]]:
+        return [dict(item) for item in self.raw.get("digital_pins", [])]
+
+    def digital_pin(self, pin: int) -> dict[str, Any] | None:
+        for item in self.digital_pins:
+            if int(item["pin"]) == int(pin):
+                return item
+        return None
+
+    @property
     def wireless(self) -> list[dict[str, Any]]:
         return [dict(item) for item in self.raw.get("wireless", [])]
 

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -30,8 +30,8 @@ use board_vm_language_core::{
     BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
     LanguageBluetoothBackendOpenPlan, LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
     LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
-    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
-    LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
+    LanguageDigitalPin, LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed,
+    LanguagePicoUf2UploadOptions, LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
 };
 use python_bridge::*;
 
@@ -886,6 +886,11 @@ unsafe fn language_target_to_py(target: &LanguageTargetInfo) -> PyObjectPtr {
         "digital_pin_count",
         usize_to_py(target.digital_pin_count),
     );
+    dict_set(
+        dict,
+        "digital_pins",
+        language_digital_pins_to_py(&target.digital_pins),
+    );
     dict_set(dict, "wireless", language_wireless_to_py(&target.wireless));
     dict_set(
         dict,
@@ -898,6 +903,31 @@ unsafe fn language_target_to_py(target: &LanguageTargetInfo) -> PyObjectPtr {
     }
     dict_set(dict, "capabilities", capabilities);
     dict
+}
+
+unsafe fn language_digital_pins_to_py(pins: &[LanguageDigitalPin]) -> PyObjectPtr {
+    let array = PyList_New(pins.len() as isize);
+    for (index, pin) in pins.iter().enumerate() {
+        let dict = PyDict_New();
+        dict_set(dict, "pin", usize_to_py(pin.pin as usize));
+        dict_set(dict, "label", str_to_py(&pin.label));
+        dict_set(dict, "supports_input", bool_to_py(pin.supports_input));
+        dict_set(dict, "supports_output", bool_to_py(pin.supports_output));
+        dict_set(dict, "supports_pullup", bool_to_py(pin.supports_pullup));
+        dict_set(dict, "supports_pulldown", bool_to_py(pin.supports_pulldown));
+        dict_set(dict, "supports_adc", bool_to_py(pin.supports_adc));
+        dict_set(dict, "supports_pwm", bool_to_py(pin.supports_pwm));
+        dict_set(dict, "supports_touch", bool_to_py(pin.supports_touch));
+        dict_set(
+            dict,
+            "supports_interrupt",
+            bool_to_py(pin.supports_interrupt),
+        );
+        dict_set(dict, "boot_strap", bool_to_py(pin.boot_strap));
+        dict_set(dict, "notes", str_to_py(&pin.notes));
+        PyList_SetItem(array, index as isize, dict);
+    }
+    array
 }
 
 unsafe fn language_led_matrix_to_py(

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -140,6 +140,17 @@ def test_known_targets_are_exposed_from_rust_registry():
     assert uno_r4_wifi.ota_transports == ["wifi"]
     assert uno_r4_wifi.supports_command_transport("serial") is True
     assert uno_r4_wifi.led_matrix == {"rows": 8, "columns": 12}
+    assert uno_r4_wifi.digital_pin_count == len(uno_r4_wifi.digital_pins)
+    d3 = uno_r4_wifi.digital_pin(3)
+    assert d3 is not None
+    assert d3["label"] == "D3"
+    assert d3["supports_input"] is True
+    assert d3["supports_output"] is True
+    assert d3["supports_pullup"] is True
+    assert d3["supports_pulldown"] is False
+    assert d3["supports_pwm"] is True
+    assert d3["supports_interrupt"] is True
+    assert d3["supports_adc"] is False
     assert esp32 is not None
     assert esp32.family == "esp32"
     assert esp32.runtime_id == "board-vm-esp32"

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -33,8 +33,8 @@ use board_vm_language_core::{
     BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
     LanguageBluetoothBackendOpenPlan, LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
     LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
-    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
-    LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
+    LanguageDigitalPin, LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed,
+    LanguagePicoUf2UploadOptions, LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
 };
 use ruby_bridge::VALUE;
 
@@ -746,6 +746,11 @@ fn language_target_to_rb(target: &LanguageTargetInfo) -> VALUE {
         "digital_pin_count",
         rb_usize(target.digital_pin_count),
     );
+    hash_set(
+        hash,
+        "digital_pins",
+        language_digital_pins_to_rb(&target.digital_pins),
+    );
     hash_set(hash, "wireless", language_wireless_to_rb(&target.wireless));
     hash_set(
         hash,
@@ -758,6 +763,51 @@ fn language_target_to_rb(target: &LanguageTargetInfo) -> VALUE {
     }
     hash_set(hash, "capabilities", capabilities);
     hash
+}
+
+fn language_digital_pins_to_rb(pins: &[LanguageDigitalPin]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for pin in pins {
+        let hash = ruby_bridge::hash_new();
+        hash_set(hash, "pin", rb_usize(pin.pin));
+        hash_set(hash, "label", ruby_bridge::str_to_rb(&pin.label));
+        hash_set(
+            hash,
+            "supports_input",
+            ruby_bridge::bool_to_rb(pin.supports_input),
+        );
+        hash_set(
+            hash,
+            "supports_output",
+            ruby_bridge::bool_to_rb(pin.supports_output),
+        );
+        hash_set(
+            hash,
+            "supports_pullup",
+            ruby_bridge::bool_to_rb(pin.supports_pullup),
+        );
+        hash_set(
+            hash,
+            "supports_pulldown",
+            ruby_bridge::bool_to_rb(pin.supports_pulldown),
+        );
+        hash_set(hash, "supports_adc", ruby_bridge::bool_to_rb(pin.supports_adc));
+        hash_set(hash, "supports_pwm", ruby_bridge::bool_to_rb(pin.supports_pwm));
+        hash_set(
+            hash,
+            "supports_touch",
+            ruby_bridge::bool_to_rb(pin.supports_touch),
+        );
+        hash_set(
+            hash,
+            "supports_interrupt",
+            ruby_bridge::bool_to_rb(pin.supports_interrupt),
+        );
+        hash_set(hash, "boot_strap", ruby_bridge::bool_to_rb(pin.boot_strap));
+        hash_set(hash, "notes", ruby_bridge::str_to_rb(&pin.notes));
+        ruby_bridge::array_push(array, hash);
+    }
+    array
 }
 
 fn language_led_matrix_to_rb(matrix: Option<board_vm_language_core::LanguageLedMatrix>) -> VALUE {

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -40,6 +40,16 @@ module CodingAdventures
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
         assert_equal ["wifi"], uno_r4_wifi["connection_options"].select { |item| item["ota_update"] }.map { |item| item["transport"] }
         assert_equal({ "rows" => 8, "columns" => 12 }, uno_r4_wifi["led_matrix"])
+        assert_equal uno_r4_wifi["digital_pin_count"], uno_r4_wifi["digital_pins"].length
+        d3 = uno_r4_wifi["digital_pins"].find { |pin| pin["pin"] == 3 }
+        assert_equal "D3", d3["label"]
+        assert d3["supports_input"]
+        assert d3["supports_output"]
+        assert d3["supports_pullup"]
+        refute d3["supports_pulldown"]
+        assert d3["supports_pwm"]
+        assert d3["supports_interrupt"]
+        refute d3["supports_adc"]
         assert_equal "esp32", esp32["family"]
         assert_equal "board-vm-esp32", esp32["runtime_id"]
         assert_equal({ "kind" => "gpio", "pin" => 2 }, esp32["onboard_led"])

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -54,8 +54,9 @@ use board_vm_protocol::{
     CAP_FLAG_PROTOCOL_FEATURE, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
 };
 use board_vm_targets::{
-    all_targets, BoardFamily, BoardTargetInfo, OnboardLed as TargetOnboardLed,
-    WirelessInterfaceInfo as TargetWirelessInterface, WirelessTransport as TargetWirelessTransport,
+    all_targets, BoardFamily, BoardTargetInfo, DigitalPinInfo as TargetDigitalPin,
+    OnboardLed as TargetOnboardLed, WirelessInterfaceInfo as TargetWirelessInterface,
+    WirelessTransport as TargetWirelessTransport,
 };
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
@@ -380,9 +381,26 @@ pub struct LanguageTargetInfo {
     pub onboard_led: Option<LanguageOnboardLed>,
     pub led_matrix: Option<LanguageLedMatrix>,
     pub digital_pin_count: usize,
+    pub digital_pins: Vec<LanguageDigitalPin>,
     pub wireless: Vec<LanguageWirelessInterface>,
     pub connection_options: Vec<LanguageConnectionOption>,
     pub capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageDigitalPin {
+    pub pin: u8,
+    pub label: String,
+    pub supports_input: bool,
+    pub supports_output: bool,
+    pub supports_pullup: bool,
+    pub supports_pulldown: bool,
+    pub supports_adc: bool,
+    pub supports_pwm: bool,
+    pub supports_touch: bool,
+    pub supports_interrupt: bool,
+    pub boot_strap: bool,
+    pub notes: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1036,6 +1054,11 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
             columns: matrix.columns,
         }),
         digital_pin_count: target.digital_pin_count,
+        digital_pins: target
+            .digital_pins
+            .iter()
+            .map(language_digital_pin)
+            .collect(),
         wireless: target
             .wireless
             .iter()
@@ -1047,6 +1070,23 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
             .iter()
             .map(|capability| (*capability).to_owned())
             .collect(),
+    }
+}
+
+fn language_digital_pin(pin: &TargetDigitalPin) -> LanguageDigitalPin {
+    LanguageDigitalPin {
+        pin: pin.pin,
+        label: pin.label.to_owned(),
+        supports_input: pin.supports_input,
+        supports_output: pin.supports_output,
+        supports_pullup: pin.supports_pullup,
+        supports_pulldown: pin.supports_pulldown,
+        supports_adc: pin.supports_adc,
+        supports_pwm: pin.supports_pwm,
+        supports_touch: pin.supports_touch,
+        supports_interrupt: pin.supports_interrupt,
+        boot_strap: pin.boot_strap,
+        notes: pin.notes.to_owned(),
     }
 }
 
@@ -2684,6 +2724,7 @@ mod tests {
     fn known_targets_are_owned_by_rust_language_core() {
         let targets = known_targets();
         let esp32 = known_target("esp32-devkit-v1").unwrap();
+        let uno = known_target("arduino-uno-r4-wifi").unwrap();
         let pico_w = known_target("raspberry-pi-pico-w").unwrap();
 
         assert!(targets
@@ -2694,12 +2735,18 @@ mod tests {
         assert_eq!(esp32.runtime_id, "board-vm-esp32");
         assert_eq!(esp32.onboard_led, Some(LanguageOnboardLed::Gpio(2)));
         assert_eq!(
-            known_target("arduino-uno-r4-wifi").unwrap().led_matrix,
+            uno.led_matrix,
             Some(LanguageLedMatrix {
                 rows: 8,
                 columns: 12
             })
         );
+        assert_eq!(uno.digital_pin_count, uno.digital_pins.len());
+        let uno_d3 = uno.digital_pins.iter().find(|pin| pin.pin == 3).unwrap();
+        assert_eq!(uno_d3.label, "D3");
+        assert!(uno_d3.supports_pwm);
+        assert!(uno_d3.supports_interrupt);
+        assert!(!uno_d3.supports_adc);
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -35,6 +35,41 @@ pub struct LedMatrixInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DigitalPinInfo {
+    pub pin: u8,
+    pub label: &'static str,
+    pub supports_input: bool,
+    pub supports_output: bool,
+    pub supports_pullup: bool,
+    pub supports_pulldown: bool,
+    pub supports_adc: bool,
+    pub supports_pwm: bool,
+    pub supports_touch: bool,
+    pub supports_interrupt: bool,
+    pub boot_strap: bool,
+    pub notes: &'static str,
+}
+
+impl DigitalPinInfo {
+    const fn placeholder() -> Self {
+        Self {
+            pin: 0,
+            label: "",
+            supports_input: false,
+            supports_output: false,
+            supports_pullup: false,
+            supports_pulldown: false,
+            supports_adc: false,
+            supports_pwm: false,
+            supports_touch: false,
+            supports_interrupt: false,
+            boot_strap: false,
+            notes: "",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoardTargetInfo {
     pub board_id: &'static str,
     pub display_name: &'static str,
@@ -48,6 +83,7 @@ pub struct BoardTargetInfo {
     pub onboard_led: Option<OnboardLed>,
     pub led_matrix: Option<LedMatrixInfo>,
     pub digital_pin_count: usize,
+    pub digital_pins: &'static [DigitalPinInfo],
     pub wireless: &'static [WirelessInterfaceInfo],
     pub capabilities: &'static [&'static str],
 }
@@ -170,6 +206,102 @@ pub const PICO_W_WIRELESS: [WirelessInterfaceInfo; 3] = [
     },
 ];
 
+pub const UNO_R4_DIGITAL_PINS: [DigitalPinInfo; 14] =
+    map_uno_r4_digital_pins(board_vm_uno_r4::UNO_R4_DIGITAL_PINS);
+
+pub const ESP32_DIGITAL_PINS: [DigitalPinInfo; 30] =
+    map_esp32_digital_pins(board_vm_esp32::ESP32_DEVKIT_V1_DIGITAL_PINS);
+
+pub const PICO_DIGITAL_PINS: [DigitalPinInfo; 29] =
+    map_pico_digital_pins(board_vm_pico::PICO_DIGITAL_PINS);
+
+const fn map_uno_r4_digital_pins<const N: usize>(
+    source: [board_vm_uno_r4::DigitalPinDescriptor; N],
+) -> [DigitalPinInfo; N] {
+    let mut pins = [DigitalPinInfo::placeholder(); N];
+    let mut index = 0;
+    while index < N {
+        pins[index] = uno_r4_digital_pin(source[index]);
+        index += 1;
+    }
+    pins
+}
+
+const fn uno_r4_digital_pin(pin: board_vm_uno_r4::DigitalPinDescriptor) -> DigitalPinInfo {
+    DigitalPinInfo {
+        pin: pin.arduino_pin,
+        label: pin.label,
+        supports_input: true,
+        supports_output: true,
+        supports_pullup: true,
+        supports_pulldown: false,
+        supports_adc: false,
+        supports_pwm: pin.supports_pwm,
+        supports_touch: false,
+        supports_interrupt: pin.supports_interrupt,
+        boot_strap: false,
+        notes: pin.notes,
+    }
+}
+
+const fn map_esp32_digital_pins<const N: usize>(
+    source: [board_vm_esp32::DigitalPinDescriptor; N],
+) -> [DigitalPinInfo; N] {
+    let mut pins = [DigitalPinInfo::placeholder(); N];
+    let mut index = 0;
+    while index < N {
+        pins[index] = esp32_digital_pin(source[index]);
+        index += 1;
+    }
+    pins
+}
+
+const fn esp32_digital_pin(pin: board_vm_esp32::DigitalPinDescriptor) -> DigitalPinInfo {
+    DigitalPinInfo {
+        pin: pin.gpio,
+        label: pin.label,
+        supports_input: pin.supports_input,
+        supports_output: pin.supports_output,
+        supports_pullup: pin.supports_pullup,
+        supports_pulldown: pin.supports_pulldown,
+        supports_adc: pin.supports_adc,
+        supports_pwm: pin.supports_output,
+        supports_touch: pin.supports_touch,
+        supports_interrupt: pin.supports_input,
+        boot_strap: pin.boot_strap,
+        notes: pin.notes,
+    }
+}
+
+const fn map_pico_digital_pins<const N: usize>(
+    source: [board_vm_pico::DigitalPinDescriptor; N],
+) -> [DigitalPinInfo; N] {
+    let mut pins = [DigitalPinInfo::placeholder(); N];
+    let mut index = 0;
+    while index < N {
+        pins[index] = pico_digital_pin(source[index]);
+        index += 1;
+    }
+    pins
+}
+
+const fn pico_digital_pin(pin: board_vm_pico::DigitalPinDescriptor) -> DigitalPinInfo {
+    DigitalPinInfo {
+        pin: pin.gpio,
+        label: pin.label,
+        supports_input: pin.supports_input,
+        supports_output: pin.supports_output,
+        supports_pullup: pin.supports_pullup,
+        supports_pulldown: pin.supports_pulldown,
+        supports_adc: pin.supports_adc,
+        supports_pwm: pin.supports_pwm,
+        supports_touch: false,
+        supports_interrupt: pin.supports_input,
+        boot_strap: false,
+        notes: pin.notes,
+    }
+}
+
 pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
     BoardTargetInfo {
         board_id: board_vm_uno_r4::UNO_R4_MINIMA.board_id,
@@ -185,7 +317,8 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             board_vm_uno_r4::UNO_R4_MINIMA.onboard_led_pin,
         )),
         led_matrix: None,
-        digital_pin_count: board_vm_uno_r4::UNO_R4_MINIMA.digital_pins.len(),
+        digital_pin_count: UNO_R4_DIGITAL_PINS.len(),
+        digital_pins: &UNO_R4_DIGITAL_PINS,
         wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
@@ -207,7 +340,8 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         } else {
             None
         },
-        digital_pin_count: board_vm_uno_r4::UNO_R4_WIFI.digital_pins.len(),
+        digital_pin_count: UNO_R4_DIGITAL_PINS.len(),
+        digital_pins: &UNO_R4_DIGITAL_PINS,
         wireless: &UNO_R4_WIFI_WIRELESS,
         capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
@@ -226,7 +360,8 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             None => None,
         },
         led_matrix: None,
-        digital_pin_count: board_vm_esp32::ESP32_DEVKIT_V1.digital_pins.len(),
+        digital_pin_count: ESP32_DIGITAL_PINS.len(),
+        digital_pins: &ESP32_DIGITAL_PINS,
         wireless: &ESP32_WIRELESS,
         capabilities: &ESP32_CAPABILITIES,
     },
@@ -248,7 +383,8 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             None => None,
         },
         led_matrix: None,
-        digital_pin_count: board_vm_pico::PICO.digital_pins.len(),
+        digital_pin_count: PICO_DIGITAL_PINS.len(),
+        digital_pins: &PICO_DIGITAL_PINS,
         wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
@@ -270,7 +406,8 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             None => None,
         },
         led_matrix: None,
-        digital_pin_count: board_vm_pico::PICO_W.digital_pins.len(),
+        digital_pin_count: PICO_DIGITAL_PINS.len(),
+        digital_pins: &PICO_DIGITAL_PINS,
         wireless: &PICO_W_WIRELESS,
         capabilities: &PICO_W_CAPABILITIES,
     },
@@ -328,6 +465,36 @@ mod tests {
             None
         );
         assert_eq!(find_target("raspberry-pi-pico-w").unwrap().led_matrix, None);
+    }
+
+    #[test]
+    fn registry_exposes_digital_pin_capability_metadata() {
+        let uno = find_target("arduino-uno-r4-wifi").unwrap();
+        assert_eq!(uno.digital_pin_count, uno.digital_pins.len());
+
+        let d3 = uno.digital_pins.iter().find(|pin| pin.pin == 3).unwrap();
+        assert_eq!(d3.label, "D3");
+        assert!(d3.supports_input);
+        assert!(d3.supports_output);
+        assert!(d3.supports_pullup);
+        assert!(!d3.supports_pulldown);
+        assert!(d3.supports_pwm);
+        assert!(d3.supports_interrupt);
+        assert!(!d3.supports_adc);
+
+        let d13 = uno.digital_pins.iter().find(|pin| pin.pin == 13).unwrap();
+        assert!(d13.notes.contains("onboard LED"));
+        assert!(!d13.supports_pwm);
+
+        let pico = find_target("raspberry-pi-pico").unwrap();
+        let adc0 = pico.digital_pins.iter().find(|pin| pin.pin == 26).unwrap();
+        assert!(adc0.supports_adc);
+        assert!(adc0.supports_pwm);
+
+        let esp32 = find_target("esp32-devkit-v1").unwrap();
+        let boot = esp32.digital_pins.iter().find(|pin| pin.pin == 0).unwrap();
+        assert!(boot.boot_strap);
+        assert!(boot.supports_touch);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Rust-owned digital pin capability metadata to the Board VM target registry.
- Carry that metadata through board-vm-language-core for language frontends.
- Expose `digital_pins` in Ruby, Python, and Lua target dictionaries with coverage for UNO R4 PWM/interrupt/pullup facts.

## Validation
- `cargo fmt -p board-vm-targets -p board-vm-language-core`
- `cargo test -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `bundle exec rake test` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
