### PR TITLE
Rust factor multivariate cubic identities

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Added Rust MACSYMA parity for bivariate difference-of-squares factoring, so
   `factor(x^2 - y^2)` returns `(x - y) * (x + y)` through the shared symbolic
   VM handler.
+- Added Rust MACSYMA parity for bivariate cubic-identity factoring, so
+  `factor(x^3 - y^3)` and `factor(x^3 + y^3)` return their linear/quadratic
+  products through the shared symbolic VM handler.
 - Added `?` / `? topic` help-query handling for Rust MACSYMA sessions.
 - Wired `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
   Rust MACSYMA session assumption context so declared properties feed property

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -159,6 +159,67 @@ fn factors_multivariate_difference_of_squares_through_runtime() {
 }
 
 #[test]
+fn factors_multivariate_difference_of_cubes_through_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x^3 - y^3);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(SUB), vec![sym("x"), sym("y")]),
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(
+                            sym(ADD),
+                            vec![
+                                apply(sym(POW), vec![sym("x"), int(2)]),
+                                apply(sym(MUL), vec![sym("x"), sym("y")]),
+                            ],
+                        ),
+                        apply(sym(POW), vec![sym("y"), int(2)]),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
+fn factors_multivariate_sum_of_cubes_through_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x^3 + y^3);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![sym("x"), sym("y")]),
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(
+                            sym(ADD),
+                            vec![
+                                apply(sym(POW), vec![sym("x"), int(2)]),
+                                apply(
+                                    sym(MUL),
+                                    vec![int(-1), apply(sym(MUL), vec![sym("x"), sym("y")]),],
+                                ),
+                            ],
+                        ),
+                        apply(sym(POW), vec![sym("y"), int(2)]),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
 fn question_mark_without_topic_lists_help_topics() {
     let mut session = MacsymaSession::new();
     let results = session.eval_source("?").unwrap();

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -11,6 +11,8 @@
   `x^2 + 2*x*y + y^2` and rewrites them as `(x + y)^2`.
 - `Factor` recognises bivariate difference-of-squares expressions such as
   `x^2 - y^2` and rewrites them as `(x - y) * (x + y)`.
+- `Factor` recognises bivariate cubic identities such as `x^3 - y^3` and
+  `x^3 + y^3`, rewriting them to their canonical linear/quadratic products.
 - `SymbolicBackend` installs a `D` derivative handler for symbolic-only
   differentiation of arithmetic, elementary, hyperbolic, and inverse
   hyperbolic expressions; `StrictBackend` continues to reject `D` as an

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1374,6 +1374,10 @@ fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
         }
     }
 
+    if let Some(rewritten) = factor_multivariate_cubic_identity(input) {
+        return rewritten;
+    }
+
     if let Some(rewritten) = factor_multivariate_difference_of_squares(input) {
         return rewritten;
     }
@@ -1468,6 +1472,101 @@ fn factor_multivariate_perfect_square(node: &IRNode) -> Option<IRNode> {
         apply_node(SUB, vec![squares[0].clone(), squares[1].clone()])
     };
     Some(apply_node(POW, vec![base, IRNode::Integer(2)]))
+}
+
+fn factor_multivariate_cubic_identity(node: &IRNode) -> Option<IRNode> {
+    let terms = additive_terms(node)?;
+    if terms.len() != 2 {
+        return None;
+    }
+
+    let mut positive_cube = None;
+    let mut negative_cube = None;
+    for term in &terms {
+        let (coefficient, powers) = term_integer_coefficient_and_powers(term)?;
+        if powers.len() != 1 {
+            return None;
+        }
+
+        let (base, exponent) = powers.iter().next()?;
+        if *exponent != 3 {
+            return None;
+        }
+
+        match coefficient {
+            1 => positive_cube = Some(base.clone()),
+            -1 => negative_cube = Some(base.clone()),
+            _ => return None,
+        }
+    }
+
+    if let Some(negative_cube) = negative_cube {
+        let positive_cube = positive_cube?;
+        return Some(apply_node(
+            MUL,
+            vec![
+                apply_node(SUB, vec![positive_cube.clone(), negative_cube.clone()]),
+                apply_node(
+                    ADD,
+                    vec![
+                        apply_node(
+                            ADD,
+                            vec![
+                                apply_node(POW, vec![positive_cube.clone(), IRNode::Integer(2)]),
+                                apply_node(MUL, vec![positive_cube, negative_cube.clone()]),
+                            ],
+                        ),
+                        apply_node(POW, vec![negative_cube, IRNode::Integer(2)]),
+                    ],
+                ),
+            ],
+        ));
+    }
+
+    let terms = additive_terms(node)?;
+    let mut cubes = Vec::new();
+    for term in &terms {
+        let (coefficient, powers) = term_integer_coefficient_and_powers(term)?;
+        if coefficient != 1 || powers.len() != 1 {
+            return None;
+        }
+        let (base, exponent) = powers.iter().next()?;
+        if *exponent != 3 {
+            return None;
+        }
+        cubes.push(base.clone());
+    }
+
+    if cubes.len() != 2 {
+        return None;
+    }
+    let first = cubes[0].clone();
+    let second = cubes[1].clone();
+    Some(apply_node(
+        MUL,
+        vec![
+            apply_node(ADD, vec![first.clone(), second.clone()]),
+            apply_node(
+                ADD,
+                vec![
+                    apply_node(
+                        ADD,
+                        vec![
+                            apply_node(POW, vec![first.clone(), IRNode::Integer(2)]),
+                            apply_node(
+                                MUL,
+                                vec![
+                                    IRNode::Integer(-1),
+                                    apply_node(MUL, vec![first, second.clone()]),
+                                ],
+                            ),
+                        ],
+                    ),
+                    apply_node(POW, vec![second, IRNode::Integer(2)]),
+                ],
+            ),
+        ],
+    ))
 }
 
 fn factor_multivariate_difference_of_squares(node: &IRNode) -> Option<IRNode> {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -315,6 +315,83 @@ fn symbolic_factor_extracts_multivariate_difference_of_squares() {
     );
 }
 
+#[test]
+fn symbolic_factor_extracts_multivariate_difference_of_cubes() {
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(SUB),
+            vec![
+                apply(sym(POW), vec![sym("x"), int(3)]),
+                apply(sym(POW), vec![sym("y"), int(3)]),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(SUB), vec![sym("x"), sym("y")]),
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(
+                            sym(ADD),
+                            vec![
+                                apply(sym(POW), vec![sym("x"), int(2)]),
+                                apply(sym(MUL), vec![sym("x"), sym("y")]),
+                            ],
+                        ),
+                        apply(sym(POW), vec![sym("y"), int(2)]),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
+fn symbolic_factor_extracts_multivariate_sum_of_cubes() {
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(ADD),
+            vec![
+                apply(sym(POW), vec![sym("x"), int(3)]),
+                apply(sym(POW), vec![sym("y"), int(3)]),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![sym("x"), sym("y")]),
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(
+                            sym(ADD),
+                            vec![
+                                apply(sym(POW), vec![sym("x"), int(2)]),
+                                apply(
+                                    sym(MUL),
+                                    vec![int(-1), apply(sym(MUL), vec![sym("x"), sym("y")]),],
+                                ),
+                            ],
+                        ),
+                        apply(sym(POW), vec![sym("y"), int(2)]),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolution
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a Rust symbolic-vm Factor foothold for bivariate cubic identities such as x^3 - y^3 and x^3 + y^3
- route the same behavior through the Rust MACSYMA runtime via factor(...)
- cover the direct VM and MACSYMA source paths and update package changelogs

## Validation
- `cargo test -p symbolic-vm`
- `cargo test -p coding-adventures-macsyma-runtime`
- `git diff --check`
