### PR TITLE
Python factor grouped multivariate terms

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added MACSYMA `factor` parity for four-term bilinear grouping, so
+  `factor(x*y + x*z + y + z)` now returns `(x+1)*(y+z)` through the canonical
+  symbolic VM handler.
 - Added MACSYMA `factor` parity for bivariate cubic identities, so
   `factor(x^3 - y^3)` and `factor(x^3 + y^3)` now return the textbook
   two-factor decompositions through the canonical symbolic VM handler.

--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -803,6 +803,32 @@ def test_pipeline_factor_multivariate_sum_of_cubes() -> None:
     )
 
 
+def test_pipeline_factor_multivariate_grouping() -> None:
+    """factor(x*y + x*z + y + z) recognises (x+1)*(y+z)."""
+    result = _eval("factor(x*y + x*z + y + z)")
+    assert isinstance(result, IRApply)
+    assert result.args == (
+        IRApply(IRSymbol("Add"), (IRSymbol("x"), IRInteger(1))),
+        IRApply(IRSymbol("Add"), (IRSymbol("y"), IRSymbol("z"))),
+    )
+
+
+def test_pipeline_factor_multivariate_grouping_with_signed_residual() -> None:
+    """factor(x*y - x*z + y - z) recognises (x+1)*(y-z)."""
+    result = _eval("factor(x*y - x*z + y - z)")
+    assert isinstance(result, IRApply)
+    assert result.args == (
+        IRApply(IRSymbol("Add"), (IRSymbol("x"), IRInteger(1))),
+        IRApply(
+            IRSymbol("Add"),
+            (
+                IRSymbol("y"),
+                IRApply(IRSymbol("Mul"), (IRInteger(-1), IRSymbol("z"))),
+            ),
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Section S — Calculus: diff and integrate (already wired, no pipeline tests)
 # ---------------------------------------------------------------------------

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added another small multivariate factoring foothold to `Factor`: four-term
+  bilinear grouping such as `x*y + x*z + y + z` now factors to
+  `(x+1)*(y+z)`.
 - Added another small multivariate factoring foothold to `Factor`: bivariate
   cubic identities such as `x^3 - y^3` and `x^3 + y^3` now factor to their
   textbook two-factor decompositions.

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -1237,6 +1237,95 @@ def _extract_multivariate_cubic_identity(inner: IRNode) -> IRNode | None:
     return IRApply(MUL, (linear, quadratic))
 
 
+def _common_symbolic_powers(terms: list[IRNode]) -> dict[IRNode, int]:
+    """Return symbolic factors shared by every term."""
+    if not terms:
+        return {}
+
+    common = dict(_split_common_factor_term(terms[0]))
+    for term in terms[1:]:
+        powers = _split_common_factor_term(term)
+        for base in list(common):
+            shared = min(common[base], powers.get(base, 0))
+            if shared:
+                common[base] = shared
+            else:
+                del common[base]
+    return common
+
+
+def _same_two_terms(left: list[IRNode], right: list[IRNode]) -> bool:
+    if len(left) != 2 or len(right) != 2:
+        return False
+    return (left[0] == right[0] and left[1] == right[1]) or (
+        left[0] == right[1] and left[1] == right[0]
+    )
+
+
+def _extract_multivariate_grouping(inner: IRNode) -> IRNode | None:
+    """Recognise a four-term factor-by-grouping case.
+
+    This intentionally small foothold covers bilinear groupings such as
+    ``x*y + x*z + y + z -> (x + 1)*(y + z)`` without pretending to be a full
+    multivariate factorization algorithm.
+    """
+    terms = _flatten_add_terms(inner)
+    if len(terms) != 4:
+        return None
+
+    for first_index in range(3):
+        for second_index in range(first_index + 1, 4):
+            grouped = [terms[first_index], terms[second_index]]
+            first_common = _common_symbolic_powers(grouped)
+            if not first_common:
+                continue
+
+            rest = [
+                term
+                for index, term in enumerate(terms)
+                if index not in (first_index, second_index)
+            ]
+            first_residual = [
+                _remove_common_factor(term, first_common) for term in grouped
+            ]
+            second_common = _common_symbolic_powers(rest)
+            second_residual = [
+                _remove_common_factor(term, second_common) for term in rest
+            ]
+            if not _same_two_terms(first_residual, second_residual):
+                continue
+
+            first_factor = _mul_nodes(
+                [
+                    _pow_node(base, exponent)
+                    for base, exponent in sorted(
+                        first_common.items(), key=lambda item: str(item[0])
+                    )
+                ]
+            )
+            second_factor = (
+                _mul_nodes(
+                    [
+                        _pow_node(base, exponent)
+                        for base, exponent in sorted(
+                            second_common.items(), key=lambda item: str(item[0])
+                        )
+                    ]
+                )
+                if second_common
+                else IRInteger(1)
+            )
+            return IRApply(
+                MUL,
+                (
+                    IRApply(ADD, (first_factor, second_factor)),
+                    _add_nodes(first_residual),
+                ),
+            )
+
+    return None
+
+
 def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
     """``Factor(expr)`` — factor a univariate integer polynomial over Z.
 
@@ -1275,6 +1364,9 @@ def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
         perfect_square = _extract_multivariate_perfect_square(inner)
         if perfect_square is not None:
             return perfect_square
+        grouping = _extract_multivariate_grouping(inner)
+        if grouping is not None:
+            return grouping
         common_factored = _extract_common_symbolic_factor(inner)
         if common_factored is not None:
             return _vm.eval(common_factored)

--- a/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
+++ b/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
@@ -77,6 +77,7 @@ _EQUAL = IRSymbol("Equal")
 
 x = IRSymbol("x")
 y = IRSymbol("y")
+z = IRSymbol("z")
 
 
 def ilist(*args: object) -> IRApply:
@@ -310,6 +311,48 @@ def test_factor_multivariate_sum_of_cubes() -> None:
                     IRApply(POW, (y, IRInteger(2))),
                 ),
             ),
+        ),
+    )
+
+
+def test_factor_multivariate_grouping() -> None:
+    """Factor(x*y + x*z + y + z) recognises grouped bilinear factors."""
+    vm, _ = make_vm()
+    target = IRApply(
+        ADD,
+        (
+            IRApply(ADD, (IRApply(MUL, (x, y)), IRApply(MUL, (x, z)))),
+            IRApply(ADD, (y, z)),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert result == IRApply(
+        MUL,
+        (
+            IRApply(ADD, (x, IRInteger(1))),
+            IRApply(ADD, (y, z)),
+        ),
+    )
+
+
+def test_factor_multivariate_grouping_with_signed_residual() -> None:
+    """Factor(x*y - x*z + y - z) preserves the grouped residual sign."""
+    vm, _ = make_vm()
+    target = IRApply(
+        ADD,
+        (
+            IRApply(SUB, (IRApply(MUL, (x, y)), IRApply(MUL, (x, z)))),
+            IRApply(SUB, (y, z)),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert result == IRApply(
+        MUL,
+        (
+            IRApply(ADD, (x, IRInteger(1))),
+            IRApply(ADD, (y, IRApply(MUL, (IRInteger(-1), z)))),
         ),
     )
 


### PR DESCRIPTION
## Summary
- add a Python symbolic-vm factor-by-grouping foothold for four-term bilinear expressions like x*y + x*z + y + z
- route the same behavior through the MACSYMA pipeline via factor(...)
- cover unsigned and signed residual grouping cases and update package changelogs

## Validation
- `PYTHONPATH=$(printf '%s:' /Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-grouping/code/packages/python/*/src) MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-grouping pytest -q code/packages/python/symbolic-vm/tests/test_cas_handlers.py -k 'factor' --no-cov`
- `PYTHONPATH=$(printf '%s:' /Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-grouping/code/packages/python/*/src) MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-cas-factor-grouping pytest -q code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py -k 'factor' --no-cov`
- `git diff --check`
