### PR TITLE
feat(adjudication): ADJ25 PR-6 — foundation bench (methodology + harness)

### DIFF
--- a/code/packages/rust/adjudication-pipeline/CHANGELOG.md
+++ b/code/packages/rust/adjudication-pipeline/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2026-05-13 — ADJ25 PR-6: foundation bench harness
+
+### Added
+
+- `src/bin/adj_pr6_bench.rs` — small CLI binary that wraps
+  `decompose_hierarchical` and reports per-level coverage as
+  structured JSON. Reads source / model / endpoint / timeout /
+  retries from env vars (`ADJ_PR6_*`) and emits one JSON record to
+  stdout per invocation. Errors always exit 0 so the harness can
+  capture diagnostics.
+- 3 unit tests for the binary's helpers: epoch conversion (1970-01-01
+  / one-day round-trip) and `summarise_coverage` shape.
+
+### Spec
+
+- `code/specs/ADJ26-foundation-bench.md` — methodology for the 8 ×
+  5 matrix bench, reproduction instructions, hypotheses, gating
+  condition for unblocking the other workstreams (ADJ14 / 15 / 16
+  / 17 / 18 / 19 / 20).
+
+### Harness
+
+- `scripts/adj_pr6_foundation_bench.py` — Python driver that iterates
+  the 8 ADJ18 declarations × 5 ADJ12 models matrix, shells out to
+  the bench binary per cell, captures JSON output, writes to
+  `code/specs/data/adj25-pr6-foundation-bench-YYYY-MM-DD.json`.
+  Persists after every cell so a crash loses at most the in-flight
+  cell.
+
+### Dependency change
+
+- `llm-gateway` promoted from `[dev-dependencies]` to a regular
+  dependency — needed by the new bench binary.
+- `llm-provider-ollama` added as a regular dependency — same.
+
+### Scope
+
+This PR is **methodology + harness only**. The empirical-results
+section of `ADJ26` is marked `TBD`; a follow-up data PR runs the
+bench against a live Ollama instance and adds the empirical
+results + a proposed threshold for unblocking the paused
+workstreams.
+
+### Notes
+
+- Version: 0.10.0 → 0.11.0 (new bin + new deps).
+
 ## [0.10.0] - 2026-05-13 — ADJ25 PR-5: orchestrator emits correlation IDs
 
 ### Added

--- a/code/packages/rust/adjudication-pipeline/Cargo.toml
+++ b/code/packages/rust/adjudication-pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adjudication-pipeline"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Orchestrator for the adjudication framework. Composes ADJ02 + ADJ22 + ADJ03 + ADJ04 + ADJ05 + engine into a single end-to-end pipeline and writes results into an ADJ07 AuditTrail. v0.8 wires ADJ22 typed-quantity coverage into both `run_with_gateway` and `run_with_rulebooks` between ADJ02 and ADJ03; ADJ22 joins the engine-gating set so the engine only runs when every numerical literal in source was preserved as a `quantity(value, unit)` compound. v0.5 added ADJ16 step 2; v0.6 added ADJ16 step 3; v0.7 added ADJ16 step 4 (agreement-weighted rulebook merger)."
 
@@ -13,10 +13,9 @@ adjudication-coverage = { path = "../adjudication-coverage" }
 adjudication-ir = { path = "../adjudication-ir" }
 adjudication-polarity-modality = { path = "../adjudication-polarity-modality" }
 adjudication-round-trip = { path = "../adjudication-round-trip" }
+llm-gateway = { path = "../llm-gateway" }
 llm-primitives = { path = "../llm-primitives" }
+llm-provider-ollama = { path = "../llm-provider-ollama" }
 logic-core = { path = "../logic-core" }
 logic-engine = { path = "../logic-engine" }
 serde_json = "1"
-
-[dev-dependencies]
-llm-gateway = { path = "../llm-gateway" }

--- a/code/packages/rust/adjudication-pipeline/src/bin/adj_pr6_bench.rs
+++ b/code/packages/rust/adjudication-pipeline/src/bin/adj_pr6_bench.rs
@@ -1,0 +1,290 @@
+//! adj_pr6_bench — single-cell driver for the ADJ25 / ADJ26 foundation
+//! bench.
+//!
+//! The Python harness `scripts/adj_pr6_foundation_bench.py` iterates
+//! the 8-declaration × 5-model matrix and shells out to this binary
+//! per cell. Each cell receives source text + a model name + an
+//! endpoint via env vars, runs `decompose_hierarchical` against a
+//! real Ollama gateway, runs the per-level coverage check on the
+//! produced IR, and emits one JSON record to stdout.
+//!
+//! Env-var contract (all required unless marked):
+//!
+//!   ADJ_PR6_SOURCE          — source text to decompose
+//!   ADJ_PR6_MODEL           — ollama model id (e.g. "gemma4:latest")
+//!   ADJ_PR6_ENDPOINT        — ollama endpoint (e.g. "http://127.0.0.1:11434")
+//!   ADJ_PR6_TIMEOUT_SECS    — per-call timeout, defaults to 300
+//!   ADJ_PR6_MAX_RETRIES     — per-parent retry budget, defaults to 3
+//!   ADJ_PR6_DOCUMENT_ID     — stable doc id, defaults to "doc-bench"
+//!
+//! Output: one JSON object on stdout. Schema:
+//!
+//! ```json
+//! {
+//!   "model": "gemma4:latest",
+//!   "source": "1 carry-on bag, matches.",
+//!   "wallclock_secs": 42.3,
+//!   "total_llm_calls": 7,
+//!   "retry_calls": 1,
+//!   "ir_summary": {
+//!     "node_count": 14,
+//!     "edge_count": 13,
+//!     "kinds_present": ["Document", "Sentence", "Phrase", ...]
+//!   },
+//!   "per_level_coverage": [
+//!     { "level": "DocumentToSentence", "passed": true, "gap_count": 0 },
+//!     ...
+//!   ],
+//!   "correlation_completeness": "pass" | { "missing": "..." },
+//!   "error": null
+//! }
+//! ```
+//!
+//! Errors are reported in the `error` field; the binary always
+//! exits 0 so the harness can capture the JSON even on failure.
+
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
+
+use adjudication_coverage::{
+    check_hierarchical_coverage, DecompLevel, Document as CovDocument,
+    HierarchicalCoverageResult,
+};
+use adjudication_ir::check_correlation_completeness;
+use adjudication_pipeline::{
+    decompose_hierarchical, HierarchicalDecomposeError, HierarchicalDecomposeRequest,
+    DEFAULT_MAX_RETRIES_PER_PARENT,
+};
+use llm_primitives::{GatewayConfig, Role};
+use llm_provider_ollama::OllamaClient;
+use serde_json::json;
+
+fn main() {
+    let source = match std::env::var("ADJ_PR6_SOURCE") {
+        Ok(s) if !s.is_empty() => s,
+        _ => {
+            emit_error("missing ADJ_PR6_SOURCE env var");
+            return;
+        }
+    };
+    let model = match std::env::var("ADJ_PR6_MODEL") {
+        Ok(s) if !s.is_empty() => s,
+        _ => {
+            emit_error("missing ADJ_PR6_MODEL env var");
+            return;
+        }
+    };
+    let endpoint = match std::env::var("ADJ_PR6_ENDPOINT") {
+        Ok(s) if !s.is_empty() => s,
+        _ => "http://127.0.0.1:11434".to_string(),
+    };
+    let timeout_secs: u64 = std::env::var("ADJ_PR6_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(300);
+    let max_retries: usize = std::env::var("ADJ_PR6_MAX_RETRIES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_MAX_RETRIES_PER_PARENT);
+    let document_id = std::env::var("ADJ_PR6_DOCUMENT_ID")
+        .unwrap_or_else(|_| "doc-bench".to_string());
+
+    let client = OllamaClient::new(model.clone())
+        .with_endpoint(endpoint.clone())
+        .with_timeout(Duration::from_secs(timeout_secs));
+    let gateway = GatewayConfig::new().with_client(Role::Extractor, Box::new(client));
+
+    let req = HierarchicalDecomposeRequest {
+        document_id,
+        source_text: source.clone(),
+        max_retries_per_parent: max_retries,
+    };
+
+    let start = Instant::now();
+    let now_clock = || chrono_iso_now();
+    let outcome = decompose_hierarchical(&req, &gateway, now_clock);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    match outcome {
+        Ok(out) => {
+            let cov_doc = CovDocument {
+                id: out.ir_document.document_id.clone(),
+                normalized_text: source.clone(),
+            };
+            let cov = check_hierarchical_coverage(&cov_doc, &out.ir_document);
+            let cov_summary = summarise_coverage(&cov);
+            let kinds_present = collect_kinds(&out.ir_document);
+            let correlation = match check_correlation_completeness(&out.ir_document) {
+                Ok(_) => json!("pass"),
+                Err(e) => json!({ "missing": e.to_string() }),
+            };
+            let record = json!({
+                "model": model,
+                "source": source,
+                "wallclock_secs": elapsed,
+                "total_llm_calls": out.total_llm_calls,
+                "retry_calls": out.retry_calls,
+                "ir_summary": {
+                    "node_count": out.ir_document.nodes.len(),
+                    "edge_count": out.ir_document.edges.len(),
+                    "kinds_present": kinds_present,
+                },
+                "per_level_coverage": cov_summary,
+                "correlation_completeness": correlation,
+                "error": serde_json::Value::Null,
+            });
+            println!("{}", record);
+        }
+        Err(e) => {
+            let kind = match &e {
+                HierarchicalDecomposeError::Primitive { level, .. } => {
+                    format!("primitive_at_{:?}", level)
+                }
+                HierarchicalDecomposeError::UnparseableResponse { level, .. } => {
+                    format!("unparseable_at_{:?}", level)
+                }
+                HierarchicalDecomposeError::CoverageUnresolved { gaps } => {
+                    format!("coverage_unresolved({} gap(s))", gaps.len())
+                }
+            };
+            let record = json!({
+                "model": model,
+                "source": source,
+                "wallclock_secs": elapsed,
+                "error": {
+                    "kind": kind,
+                    "message": e.to_string(),
+                }
+            });
+            println!("{}", record);
+        }
+    }
+}
+
+fn emit_error(msg: &str) {
+    let record = json!({ "error": { "kind": "harness_error", "message": msg } });
+    println!("{}", record);
+}
+
+/// ISO-8601 timestamp without bringing in chrono — uses
+/// `std::time::SystemTime` and a hand-rolled formatter so the
+/// audit-trail discipline (every dialogue turn timestamped) is
+/// honoured without adding a heavy dep. Format:
+/// `YYYY-MM-DDTHH:MM:SSZ` (seconds resolution is enough for replay).
+fn chrono_iso_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (year, month, day, hour, minute, second) = epoch_secs_to_utc(secs);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hour, minute, second
+    )
+}
+
+/// Convert Unix epoch seconds → broken-down UTC. Uses the standard
+/// civil-from-days algorithm (Howard Hinnant's date library). Bounded
+/// to a 64-bit input; no overflow on any realistic timestamp.
+fn epoch_secs_to_utc(secs: u64) -> (i64, u32, u32, u32, u32, u32) {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let hour = (rem / 3600) as u32;
+    let minute = ((rem % 3600) / 60) as u32;
+    let second = (rem % 60) as u32;
+    // 719_468 = days from 0000-03-01 to 1970-01-01. We shift to a
+    // calendar starting March so leap-day fits at the end of the year.
+    let z = days + 719_468;
+    let era = if z >= 0 { z / 146_097 } else { (z - 146_096) / 146_097 };
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe.wrapping_sub(doe / 1_460).wrapping_add(doe / 36_524).wrapping_sub(doe / 146_096)) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d, hour, minute, second)
+}
+
+fn summarise_coverage(result: &HierarchicalCoverageResult) -> serde_json::Value {
+    let mut per_level: Vec<(DecompLevel, usize)> = vec![
+        (DecompLevel::DocumentToSentence, 0),
+        (DecompLevel::SentenceToPhrase, 0),
+        (DecompLevel::PhraseToClaim, 0),
+        (DecompLevel::FactToTypedComponent, 0),
+    ];
+    let mut flatten_count = 0usize;
+    match result {
+        HierarchicalCoverageResult::Pass => {}
+        HierarchicalCoverageResult::Fail { gaps } => {
+            for gap in gaps {
+                // Flattening violations are reported under the
+                // FactToTypedComponent level by check_hierarchical_coverage;
+                // count them separately for clarity.
+                if matches!(
+                    gap.kind,
+                    adjudication_coverage::HierarchicalGapKind::FlattenedAtom { .. }
+                ) {
+                    flatten_count += 1;
+                    continue;
+                }
+                for (lvl, count) in per_level.iter_mut() {
+                    if *lvl == gap.level {
+                        *count += 1;
+                    }
+                }
+            }
+        }
+    }
+    let entries: Vec<serde_json::Value> = per_level
+        .iter()
+        .map(|(lvl, count)| {
+            json!({
+                "level": format!("{:?}", lvl),
+                "passed": *count == 0,
+                "gap_count": *count,
+            })
+        })
+        .collect();
+    json!({
+        "by_level": entries,
+        "flattening_gaps": flatten_count,
+        "overall_pass": matches!(result, HierarchicalCoverageResult::Pass),
+    })
+}
+
+fn collect_kinds(doc: &adjudication_ir::IRDocument) -> Vec<String> {
+    let mut s: BTreeSet<String> = BTreeSet::new();
+    for n in &doc.nodes {
+        s.insert(format!("{:?}", n.kind));
+    }
+    s.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epoch_zero_is_1970_01_01() {
+        let (y, m, d, h, mi, s) = epoch_secs_to_utc(0);
+        assert_eq!((y, m, d, h, mi, s), (1970, 1, 1, 0, 0, 0));
+    }
+
+    #[test]
+    fn epoch_one_day_is_1970_01_02() {
+        let (y, m, d, _, _, _) = epoch_secs_to_utc(86_400);
+        assert_eq!((y, m, d), (1970, 1, 2));
+    }
+
+    #[test]
+    fn summarise_coverage_counts_per_level() {
+        let result = HierarchicalCoverageResult::Pass;
+        let v = summarise_coverage(&result);
+        assert_eq!(v["overall_pass"], serde_json::Value::Bool(true));
+        assert_eq!(v["flattening_gaps"], serde_json::Value::Number(0.into()));
+        assert_eq!(v["by_level"].as_array().unwrap().len(), 4);
+    }
+}

--- a/code/specs/ADJ26-foundation-bench.md
+++ b/code/specs/ADJ26-foundation-bench.md
@@ -1,0 +1,279 @@
+# ADJ26 — Foundation Bench: Hierarchical Decomposition × Per-Level Coverage
+
+> **Methodology PR. Empirical results follow in a data PR.**
+>
+> ADJ25's migration plan calls this PR-6, the foundation bench. It is
+> the first empirical measurement of whether the hierarchical
+> decomposition flow (Document → Sentence → Phrase → Claim →
+> TypedComponent) works against real LLMs.
+>
+> The bench is the gate that unblocks the rest of the framework:
+> until it shows reliable per-level coverage across the 8-declaration
+> × 5-model matrix, the paused workstreams (ADJ14/15/17 rulebook
+> elicitation, ADJ16 engine adjudication, ADJ18/19 verdict benches)
+> stay paused.
+
+## What this bench measures
+
+For each `(declaration, model)` cell:
+
+1. Run `decompose_hierarchical` against the source text via a real
+   Ollama gateway. The orchestrator walks the four level boundaries
+   in order, dispatching one LLM call per parent at each level, then
+   runs `check_hierarchical_coverage` and retries on every failing
+   parent up to `max_retries_per_parent`.
+2. Capture per-level coverage pass/fail. Each boundary produces an
+   `passed: bool` + `gap_count: usize`.
+3. Capture flattening violations separately so we can see how often
+   the LLM tries to smuggle source content into atom names
+   (`50_wh`, `4_inch_blade`, etc.).
+4. Capture `check_correlation_completeness` outcome on the
+   orchestrator's final IR — should be `pass` by construction (PR-5
+   guarantees this), so any failure here is a wiring bug.
+5. Wallclock latency.
+6. Total LLM calls dispatched (initial + retries).
+
+The headline metric is **per-level coverage pass rate**:
+
+```
+% cells where ADJ02-style coverage held at every parent → child
+boundary across the four levels.
+```
+
+A cell counts as "passing" only when:
+- `Document → Sentence` tiled exactly,
+- AND `Sentence → Phrase` tiled exactly at every sentence,
+- AND `Phrase → Claim` tiled exactly at every phrase,
+- AND `Fact → TypedComponent` tiled exactly at every fact,
+- AND no atom in the IR violated the no-flattening rule.
+
+This is the "every byte accounted for" hypothesis from
+[project_total_coverage_forces_reasoning](../../memory/project_total_coverage_forces_reasoning.md),
+operationalised. ADJ12 measured the flat-tile version on a single
+fixture; ADJ26 measures the hierarchical version across the
+8-declaration set ADJ18 established.
+
+## What this bench deliberately does NOT measure
+
+- **Verdict accuracy.** ADJ18 measured Arm A (raw LLM verdict).
+  ADJ26 measures *Arm B*'s decomposition step only. A cell that
+  produces a perfectly-tiled hierarchical IR but the verdict
+  downstream is wrong still counts as "passing" for ADJ26.
+  Verdict accuracy returns to scope after the foundation gate
+  holds.
+- **Real adversarial cross-checks** (ADJ05) — paused, advisory
+  only.
+- **Real rulebook injection** (ADJ15/17) — paused.
+- **Cross-domain breadth** — clinical / contract benches are
+  paused until TSA is stable.
+
+## Methodology
+
+### The matrix
+
+- **8 declarations** mirroring ADJ18, single-item shapes isolating
+  one verdict per item:
+
+  | id | text |
+  |---|---|
+  | `matches` | `1 carry-on bag, matches.` |
+  | `large-lithium` | `1 carry-on bag, lithium battery, 200 Wh.` |
+  | `large-toothpaste` | `1 carry-on bag, 4 oz toothpaste.` |
+  | `pocket-knife` | `1 carry-on bag, 4 inch pocket knife.` |
+  | `wine-bottle` | `1 carry-on bag, 1 bottle of wine, 750 ml.` |
+  | `small-lithium` | `1 carry-on bag, lithium battery, 50 Wh.` |
+  | `small-perfume` | `1 carry-on bag, 3 oz perfume.` |
+  | `lighter-disposable` | `1 carry-on bag, disposable lighter.` |
+
+- **5 models** mirroring ADJ12: `gemma4:latest` (8B),
+  `llama3.1:8b` (8B), `qwen2.5:3b` (3B), `qwen2.5:1.5b` (1.5B),
+  `qwen2.5:0.5b` (0.5B). Different vendors, different family
+  scales, all locally-pullable via Ollama.
+
+- Total: **40 cells**.
+
+### Per-cell settings
+
+- `temperature = 0.0`, deterministic.
+- `max_retries_per_parent = 3` (the ADJ25 default).
+- Per-call timeout: 300 s.
+- Per-cell hard cap: 900 s.
+- Endpoint: localhost Ollama (`http://127.0.0.1:11434`).
+
+### The driver
+
+A small Rust binary `adj_pr6_bench` (in `adjudication-pipeline`)
+reads source / model / endpoint / timeout / retries from env vars,
+runs `decompose_hierarchical` against a real Ollama gateway, runs
+`check_hierarchical_coverage` on the result, and emits one JSON
+record to stdout.
+
+Schema (per cell):
+
+```json
+{
+  "model": "gemma4:latest",
+  "source": "1 carry-on bag, matches.",
+  "wallclock_secs": 42.3,
+  "total_llm_calls": 7,
+  "retry_calls": 1,
+  "ir_summary": {
+    "node_count": 14,
+    "edge_count": 13,
+    "kinds_present": ["Document", "Sentence", "Phrase", "Fact", "Entity"]
+  },
+  "per_level_coverage": {
+    "overall_pass": true,
+    "flattening_gaps": 0,
+    "by_level": [
+      { "level": "DocumentToSentence", "passed": true, "gap_count": 0 },
+      ...
+    ]
+  },
+  "correlation_completeness": "pass",
+  "error": null
+}
+```
+
+### The harness
+
+A Python script `scripts/adj_pr6_foundation_bench.py` iterates the
+matrix, shells out to the binary per cell, captures JSON output,
+and writes the aggregated result to
+`code/specs/data/adj25-pr6-foundation-bench-YYYY-MM-DD.json`. The
+harness persists after every cell so a crash loses at most the
+in-flight cell.
+
+## Reproduction
+
+```bash
+# Build the bench binary (release for realistic latency).
+cargo build -p adjudication-pipeline --bin adj_pr6_bench --release
+
+# Pull the 5 models if not already.
+ollama pull gemma4:latest
+ollama pull llama3.1:8b
+ollama pull qwen2.5:3b
+ollama pull qwen2.5:1.5b
+ollama pull qwen2.5:0.5b
+
+# Run the full matrix (~30 min – 2 h depending on hardware).
+python3 scripts/adj_pr6_foundation_bench.py \
+    --endpoint http://127.0.0.1:11434 \
+    --binary code/packages/rust/target/release/adj_pr6_bench
+```
+
+Subset runs (e.g., for debugging):
+
+```bash
+python3 scripts/adj_pr6_foundation_bench.py \
+    --models gemma4:latest \
+    --declarations matches,large-lithium
+```
+
+## Hypotheses
+
+The framework's headline claim — "shrink the model down, push
+intelligence into the framework" — is the hypothesis the bench
+tests. Specifically:
+
+- **H1 (the big one).** The hierarchical orchestrator + per-level
+  retry primitive will drive *some* coverage pass even on the 8B
+  reference models. We do not require 100%; we require *any*
+  consistent ratio strictly above the empirically-known baseline
+  of `~10%` (PR's first-pass typed-quantity recall on the v5 prompt
+  in ADJ24).
+- **H2 (the small-model claim).** Per-parent fresh-agent retries
+  with parent-scoped prompts work for the 1.5B and 0.5B models in
+  ways that the prior whole-document retries did not. ADJ24's
+  retry loop got llama3.1:8b from 0% → 12% on typed-quantity; the
+  hierarchical orchestrator should do meaningfully better than that
+  on the same scales because each call is smaller.
+- **H3 (the failure-mode claim).** Where the orchestrator fails,
+  it fails *loudly* and *structurally* — typed `Primitive`,
+  `UnparseableResponse`, or `CoverageUnresolved` error. No silent
+  bad output. The audit trail captures the gap that drove the
+  failure.
+
+A pass on H3 is necessary for the framework's auditability story
+even if H1/H2 only partially hold.
+
+## Known limitations of this bench
+
+1. **No new `decompose-text-vN` prompt yet.** The orchestrator
+   relies on whatever prompt `decompose_text` is shipping with
+   (currently `v5`, which teaches the v3 flat IR). A model asked to
+   decompose a source chunk via this prompt will produce flat-IR
+   shaped output; the orchestrator's `parse_child_node` filters
+   to the allowed kinds at each level. The hierarchy contract is
+   *implicit* — the model is asked for a chunk-of-source
+   decomposition without being told "produce a Sentence node".
+   Expected consequence: low first-pass pass rate; the retry prompt
+   (which IS hierarchy-aware) does most of the lifting. A
+   follow-up that lands `decompose-text-v6` should improve
+   numbers meaningfully.
+2. **The orchestrator's retry budget is fixed at 3 per parent.**
+   PR-5 made it `max_retries.min(64)`; the bench uses the default.
+3. **Real LLMs only.** The harness does not run against scripted
+   clients — those are unit-test territory.
+4. **No fact-sheet world knowledge.** ADJ23 surfaced that bag-count
+   "1" is a learned-prior-against-typing problem the retry primitive
+   doesn't move. ADJ20 (fact sheets) is the structural answer but
+   is paused; this bench will likely show the same residual failure
+   pattern on the bag-count literal.
+
+## Empirical results
+
+**TBD — populated by a follow-up data PR after the bench has been
+run end-to-end against a live Ollama instance with the 5 models
+pulled.** The data PR adds a new section here summarising:
+
+- Aggregate per-level pass rates (one number per level).
+- Per-model breakdown (overall pass, per-level pass, average
+  wallclock, average LLM calls).
+- Notable failure patterns (which declarations break which models
+  at which level).
+- Comparison to the ADJ23 / ADJ24 baseline (10% / 20% ADJ22 pass).
+- Whether the gate condition (the threshold required to unblock
+  ADJ14/15/17/16/18/19) is met.
+
+## Gating condition for unblocking other workstreams
+
+Per ADJ25's spec, ADJ14 / ADJ15 / ADJ16 / ADJ17 / ADJ18 / ADJ19 /
+ADJ20 stay paused until this bench shows reliable per-level
+coverage. "Reliable" is not yet operationalised — the empirical
+results PR will propose a threshold based on the actual numbers.
+Reasonable candidates:
+
+- **Strict**: every cell passes every level (`40/40 cells fully
+  green`). Very aggressive; probably unmeetable without
+  `decompose-text-v6`.
+- **Per-model**: every model passes at least 50% of cells fully.
+  Demonstrates the orchestrator works across the size range.
+- **Per-level**: every level passes at least 70% across the
+  matrix. Identifies the weakest boundary for targeted work.
+
+The PR that lands empirical results picks a threshold and
+documents whether it was met. If it isn't, that PR also proposes
+which paused workstream to unblock first based on what the bench
+revealed (e.g., if ADJ20 fact-sheet handling is the obvious
+unblocker for bag-count failures, that becomes the next active
+piece).
+
+## See also
+
+- [ADJ25](ADJ25-hierarchical-decomposition.md) — the spec this
+  bench validates.
+- [ADJ12](ADJ12-small-model-benchmarks.md) — the 5-model lineup.
+- [ADJ18](ADJ18-broadened-tsa-empirical-bench.md) — the
+  8-declaration set.
+- [ADJ23](ADJ23-decomposition-bench.md),
+  [ADJ24](ADJ24-typed-quantity-pipeline-wiring.md) — prior
+  decomposition benches showing the 10% / 20% ADJ22 baseline this
+  bench is designed to beat.
+
+## Status
+
+- v1 — methodology + harness landed (this PR).
+- Empirical results — follow-up data PR after the bench has run
+  end-to-end.

--- a/scripts/adj_pr6_foundation_bench.py
+++ b/scripts/adj_pr6_foundation_bench.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""ADJ25 PR-6 foundation bench: hierarchical decomposition × per-level coverage.
+
+Iterates 8 declarations × 5 models = 40 cells. For each cell it
+invokes the compiled `adj_pr6_bench` binary with the source text +
+model + Ollama endpoint, captures the JSON output, and aggregates
+results.
+
+The eight declarations mirror ADJ18 — same single-item shapes
+isolating one verdict per item. The five models mirror ADJ12 — the
+gemma4 / llama3.1 8B reference pair plus the qwen2.5 3B / 1.5B /
+0.5B small-model tier.
+
+For each cell the bench captures:
+
+  * Per-level coverage pass/fail across the four boundaries
+    (Document→Sentence, Sentence→Phrase, Phrase→Claim,
+    Fact→TypedComponent).
+  * Flattening violations (separate from coverage gaps so we can
+    see how often the LLM tries the `50_wh` flatten-into-atom
+    trick).
+  * Correlation completeness on the orchestrator's output.
+  * Wallclock latency.
+  * Total LLM calls dispatched (initial + retries).
+
+The bench expects the binary to be built:
+
+    cargo build -p adjudication-pipeline --bin adj_pr6_bench --release
+
+And Ollama to be running locally with all 5 models pulled. The
+harness handles cell-level timeouts and writes per-cell results to
+the output JSON file incrementally so a crash loses at most the
+in-flight cell.
+
+Output: `code/specs/data/adj25-pr6-foundation-bench-YYYY-MM-DD.json`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+from typing import List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Declaration set (mirrors ADJ18)
+# ---------------------------------------------------------------------------
+
+DECLARATIONS: List[dict] = [
+    {
+        "id": "matches",
+        "text": "1 carry-on bag, matches.",
+        "expected_verdict": "NON-COMPLIANT",
+    },
+    {
+        "id": "large-lithium",
+        "text": "1 carry-on bag, lithium battery, 200 Wh.",
+        "expected_verdict": "NON-COMPLIANT",
+    },
+    {
+        "id": "large-toothpaste",
+        "text": "1 carry-on bag, 4 oz toothpaste.",
+        "expected_verdict": "NON-COMPLIANT",
+    },
+    {
+        "id": "pocket-knife",
+        "text": "1 carry-on bag, 4 inch pocket knife.",
+        "expected_verdict": "NON-COMPLIANT",
+    },
+    {
+        "id": "wine-bottle",
+        "text": "1 carry-on bag, 1 bottle of wine, 750 ml.",
+        "expected_verdict": "NON-COMPLIANT",
+    },
+    {
+        "id": "small-lithium",
+        "text": "1 carry-on bag, lithium battery, 50 Wh.",
+        "expected_verdict": "COMPLIANT",
+    },
+    {
+        "id": "small-perfume",
+        "text": "1 carry-on bag, 3 oz perfume.",
+        "expected_verdict": "COMPLIANT",
+    },
+    {
+        "id": "lighter-disposable",
+        "text": "1 carry-on bag, disposable lighter.",
+        "expected_verdict": "COMPLIANT",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Model set (mirrors ADJ12)
+# ---------------------------------------------------------------------------
+
+MODELS: List[str] = [
+    "gemma4:latest",
+    "llama3.1:8b",
+    "qwen2.5:3b",
+    "qwen2.5:1.5b",
+    "qwen2.5:0.5b",
+]
+
+
+# ---------------------------------------------------------------------------
+# Cell driver
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class CellResult:
+    """Per-cell record written to the output JSON file."""
+
+    declaration_id: str
+    declaration_text: str
+    expected_verdict: str
+    model: str
+    wallclock_secs: float
+    raw_output: dict
+    exit_code: int
+    stderr_excerpt: str
+
+
+def run_cell(
+    *,
+    binary: pathlib.Path,
+    declaration: dict,
+    model: str,
+    endpoint: str,
+    timeout_secs: int,
+    max_retries: int,
+    cell_timeout: int,
+) -> CellResult:
+    env = os.environ.copy()
+    env["ADJ_PR6_SOURCE"] = declaration["text"]
+    env["ADJ_PR6_MODEL"] = model
+    env["ADJ_PR6_ENDPOINT"] = endpoint
+    env["ADJ_PR6_TIMEOUT_SECS"] = str(timeout_secs)
+    env["ADJ_PR6_MAX_RETRIES"] = str(max_retries)
+    env["ADJ_PR6_DOCUMENT_ID"] = f"pr6-{declaration['id']}-{model.replace(':', '_').replace('/', '_')}"
+
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            [str(binary)],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=cell_timeout,
+        )
+        elapsed = time.monotonic() - started
+        try:
+            parsed = json.loads(proc.stdout.decode("utf-8", errors="replace") or "{}")
+        except json.JSONDecodeError as e:
+            parsed = {
+                "error": {
+                    "kind": "json_decode_error",
+                    "message": str(e),
+                    "stdout_excerpt": proc.stdout[:512].decode("utf-8", errors="replace"),
+                }
+            }
+        return CellResult(
+            declaration_id=declaration["id"],
+            declaration_text=declaration["text"],
+            expected_verdict=declaration["expected_verdict"],
+            model=model,
+            wallclock_secs=elapsed,
+            raw_output=parsed,
+            exit_code=proc.returncode,
+            stderr_excerpt=proc.stderr[:512].decode("utf-8", errors="replace"),
+        )
+    except subprocess.TimeoutExpired:
+        return CellResult(
+            declaration_id=declaration["id"],
+            declaration_text=declaration["text"],
+            expected_verdict=declaration["expected_verdict"],
+            model=model,
+            wallclock_secs=time.monotonic() - started,
+            raw_output={"error": {"kind": "cell_timeout", "message": f"cell exceeded {cell_timeout}s"}},
+            exit_code=-1,
+            stderr_excerpt="",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def summarise(cells: List[CellResult]) -> dict:
+    """Compute headline metrics across all cells.
+
+    Reported metrics:
+
+      * Per-model: % cells that produced any IR at all (no error),
+        % cells whose IR passed the full hierarchical coverage check,
+        average wallclock.
+      * Per-level: across all cells that produced IR, % that passed
+        each of the four boundaries.
+      * Correlation completeness: % of IR-producing cells where the
+        check passed.
+    """
+    by_model: dict = {}
+    by_level: dict = {
+        "DocumentToSentence": {"passed": 0, "total": 0},
+        "SentenceToPhrase": {"passed": 0, "total": 0},
+        "PhraseToClaim": {"passed": 0, "total": 0},
+        "FactToTypedComponent": {"passed": 0, "total": 0},
+    }
+    correlation_pass = 0
+    correlation_total = 0
+    overall_pass = 0
+    overall_total = 0
+
+    for cell in cells:
+        model = cell.model
+        slot = by_model.setdefault(
+            model,
+            {"cells": 0, "ir_produced": 0, "overall_pass": 0, "wallclock_sum": 0.0},
+        )
+        slot["cells"] += 1
+        slot["wallclock_sum"] += cell.wallclock_secs
+        raw = cell.raw_output
+        if "error" in raw and raw["error"] is not None:
+            continue
+        slot["ir_produced"] += 1
+        overall_total += 1
+        per_level = raw.get("per_level_coverage", {})
+        if per_level.get("overall_pass"):
+            slot["overall_pass"] += 1
+            overall_pass += 1
+        for entry in per_level.get("by_level", []):
+            lvl_name = entry.get("level", "")
+            if lvl_name not in by_level:
+                continue
+            by_level[lvl_name]["total"] += 1
+            if entry.get("passed"):
+                by_level[lvl_name]["passed"] += 1
+        correlation_total += 1
+        if raw.get("correlation_completeness") == "pass":
+            correlation_pass += 1
+
+    return {
+        "totals": {
+            "cells_run": len(cells),
+            "ir_produced": overall_total,
+            "fully_passing": overall_pass,
+            "correlation_complete": correlation_pass,
+            "correlation_total": correlation_total,
+        },
+        "by_model": by_model,
+        "by_level": by_level,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--endpoint", default="http://127.0.0.1:11434")
+    p.add_argument(
+        "--binary",
+        default="code/packages/rust/target/release/adj_pr6_bench",
+        help="path to the built adj_pr6_bench binary",
+    )
+    p.add_argument("--timeout-secs", type=int, default=300, help="per-call LLM timeout")
+    p.add_argument("--max-retries", type=int, default=3)
+    p.add_argument("--cell-timeout", type=int, default=900, help="hard cap per cell")
+    p.add_argument(
+        "--out",
+        default=None,
+        help="output JSON file; defaults to "
+        "code/specs/data/adj25-pr6-foundation-bench-YYYY-MM-DD.json",
+    )
+    p.add_argument(
+        "--models",
+        default=",".join(MODELS),
+        help="comma-separated subset of models (for incremental runs)",
+    )
+    p.add_argument(
+        "--declarations",
+        default=",".join(d["id"] for d in DECLARATIONS),
+        help="comma-separated subset of declaration ids",
+    )
+    args = p.parse_args(argv)
+
+    binary = pathlib.Path(args.binary)
+    if not binary.exists():
+        print(f"binary not found at {binary}", file=sys.stderr)
+        print(
+            "build it with: cargo build -p adjudication-pipeline --bin adj_pr6_bench --release",
+            file=sys.stderr,
+        )
+        return 2
+
+    out_path = pathlib.Path(
+        args.out
+        if args.out
+        else f"code/specs/data/adj25-pr6-foundation-bench-{time.strftime('%Y-%m-%d')}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    selected_models = [m.strip() for m in args.models.split(",") if m.strip()]
+    selected_ids = set(d.strip() for d in args.declarations.split(",") if d.strip())
+    selected_decls = [d for d in DECLARATIONS if d["id"] in selected_ids]
+
+    cells: List[CellResult] = []
+    total_cells = len(selected_decls) * len(selected_models)
+    print(
+        f"running {total_cells} cells "
+        f"({len(selected_decls)} declarations × {len(selected_models)} models)",
+        file=sys.stderr,
+    )
+    cell_index = 0
+    for decl in selected_decls:
+        for model in selected_models:
+            cell_index += 1
+            print(
+                f"  [{cell_index}/{total_cells}] {decl['id']} × {model}", file=sys.stderr
+            )
+            result = run_cell(
+                binary=binary,
+                declaration=decl,
+                model=model,
+                endpoint=args.endpoint,
+                timeout_secs=args.timeout_secs,
+                max_retries=args.max_retries,
+                cell_timeout=args.cell_timeout,
+            )
+            cells.append(result)
+            # Persist after every cell so a crash loses at most the
+            # in-flight cell.
+            with open(out_path, "w") as fh:
+                json.dump(
+                    {
+                        "harness_version": "adj25-pr6-v1",
+                        "endpoint": args.endpoint,
+                        "binary": str(binary),
+                        "models": selected_models,
+                        "declarations": [d["id"] for d in selected_decls],
+                        "cells": [dataclasses.asdict(c) for c in cells],
+                        "summary": summarise(cells),
+                    },
+                    fh,
+                    indent=2,
+                )
+    print(f"wrote {out_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **ADJ25 PR-6, methodology + harness only.** Empirical results land in a follow-up data PR after the bench runs end-to-end against a live Ollama instance.
- Adds **3 artefacts**:
  - `code/packages/rust/adjudication-pipeline/src/bin/adj_pr6_bench.rs` — single-cell Rust driver. Env-var input → JSON-record output.
  - `scripts/adj_pr6_foundation_bench.py` — Python harness for the 8 declarations × 5 models = 40 cells matrix.
  - `code/specs/ADJ26-foundation-bench.md` — methodology spec.
- **This bench is the gate.** Per ADJ25, until per-level coverage holds reliably across the matrix, the paused workstreams (ADJ14/15/17 rulebook elicitation, ADJ16 engine adjudication, ADJ18/19 verdict benches, ADJ20 fact sheets) stay paused.

## What the bench captures per cell

- Per-level coverage pass/fail across `Document→Sentence`, `Sentence→Phrase`, `Phrase→Claim`, `Fact→TypedComponent`.
- Flattening violations separately (so we see how often the LLM smuggles `50_wh`-style atoms).
- Correlation completeness (passes by construction per PR-5; any failure is a wiring bug).
- Wallclock latency.
- Total LLM calls dispatched (initial + retries).

## Why empirical results aren't in this PR

Running the bench needs a live Ollama instance with all 5 models pulled (gemma4 / llama3.1:8b / qwen2.5:3b/1.5b/0.5b) and 30 min – 2 h of wallclock per full run. The harness is built and dry-tested; the actual run + numbers come in a follow-up data PR. This matches the ADJ18 pattern (methodology first, data PR second).

## Reproduction

```bash
cargo build -p adjudication-pipeline --bin adj_pr6_bench --release
ollama pull gemma4:latest llama3.1:8b qwen2.5:3b qwen2.5:1.5b qwen2.5:0.5b
python3 scripts/adj_pr6_foundation_bench.py
```

## Known limitations (documented in the spec)

- **No `decompose-text-v6` yet.** The orchestrator relies on the existing `v5` prompt, which teaches the flat IR, not the hierarchy. The bench will measure how well the orchestrator's per-parent retry prompts make up for that. A follow-up PR landing `v6` is expected to improve numbers.
- Real LLMs only — scripted clients are for unit tests.
- No fact-sheet world knowledge (ADJ20 paused); the bag-count "1" failure pattern from ADJ23/ADJ24 likely persists.

## Test plan

- [x] `cargo build -p adjudication-pipeline --bin adj_pr6_bench --release` clean
- [x] `cargo test -p adjudication-pipeline` — 47 lib tests + 3 new bin tests, all passing
- [x] Python script syntax-validates (`ast.parse` clean)
- [x] Security review (sub-agent) passed clean: no `shell=True`, no `eval`/`pickle`, no unsafe Rust, no panicking unwraps
- [ ] CI green
- [ ] No merge conflicts

## Migration plan position

- ✅ PR-1..5 (IR kinds, coverage, retry primitive, orchestrator, correlation vector)
- **PR-6 (this)** — foundation bench
- PR-7 — cutover (retire `decompose_text` v5 path, demoted kinds, ADJ22 standalone check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)