### PR TITLE
feat: MX05 Phase 4.7 — unary ops with folded input collapse to memset

### DIFF
--- a/code/packages/rust/image-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/image-gpu-core/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog — image-gpu-core
 
+## 0.10.0 — 2026-05-13
+
+### Added — MX05 Phase 4.7 end-to-end (unary memset path through DispatchSpecialised)
+
+matrix-metal v0.9.0 added an emitter shape where a unary op's
+input is folded into the kernel source — the kernel becomes a
+memset of `f(K)` with zero input buffers.  This release verifies
+the full chain end-to-end: image-gpu-core's `dispatch_specialised_via`
+handles `n_in == 0` correctly (passes an empty `inputs: vec![]`
+to `DispatchSpecialised`), and the metal executor's install
+closure binds only the output buffer.
+
+#### Test
+
+`dispatch_specialised_via_routes_unary_folded_input` (Apple-only):
+
+Builds `Op::Sqrt(input = [16, 16, 16, 16]) → C`, installs the
+`sqrt_input_const_f32` specialised kernel (K=16), and asserts
+the output is `[4.0, 4.0, 4.0, 4.0]` — `√16 = 4` written by the
+memset kernel.
+
+Test count: 31 → 32.
+
+#### Dispatcher change
+
+No source change needed — the Phase 4.6 trimming logic
+`ir_inputs.iter().take(n_in)` naturally yields an empty Vec when
+`n_in == 0`, and the slot-shuffle guard only fires when
+`ir_inputs.len() == 2 && n_in == 1`.  The unary-memset path
+"just works" through existing code.
+
 ## 0.9.0 — 2026-05-13
 
 ### Added — MX05 Phase 4.6 (dispatch routes the unfolded slot)

--- a/code/packages/rust/image-gpu-core/Cargo.toml
+++ b/code/packages/rust/image-gpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image-gpu-core"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). v0.3 wires the optional matrix-metal GPU backend. v0.4 wires the MX05 specialisation pipeline. v0.5 installs CpuSpecialiser. v0.6 adds tensor-byte sampling. v0.7 (MX05 Phase 4.3) adds the runtime-side auto-installer with a specialised_install_count() counter. v0.8 (MX05 Phase 4.4) closes the dispatch half: when a single-Compute-op graph has an installed specialised kernel on metal, image-gpu-core now routes the dispatch through ExecutorRequest::DispatchSpecialised (a prep Dispatch sets up buffers, then DispatchSpecialised invokes the installed kernel by handle). Counter specialised_dispatch_count() tracks how many invocations went specialised."
 

--- a/code/packages/rust/image-gpu-core/src/pipeline.rs
+++ b/code/packages/rust/image-gpu-core/src/pipeline.rs
@@ -1729,5 +1729,141 @@ mod tests {
             result
         );
     }
+
+    /// **MX05 Phase 4.7 end-to-end test.**  Unary op with folded
+    /// input constant — the kernel takes **zero** input buffers and
+    /// writes the precomputed `f(K)` to every output element.
+    ///
+    /// Graph: `Op::Sqrt(input = [16, 16, 16, 16]) → C`.  The input
+    /// is observed as the constant `K = 16.0`, so the specialised
+    /// kernel is `sqrt_input_const_f32` which writes `√16 = 4.0`
+    /// everywhere.  Expected output: `[4.0, 4.0, 4.0, 4.0]`.
+    ///
+    /// This exercises the `n_in == 0` path in
+    /// `dispatch_specialised_via`: the `DispatchSpecialised` request
+    /// carries an empty `inputs: vec![]`, and the metal kernel only
+    /// binds the output buffer at `buffer(0)`.
+    #[cfg(all(feature = "metal-backend", target_vendor = "apple"))]
+    #[test]
+    fn dispatch_specialised_via_routes_unary_folded_input() {
+        use crate::specialised_dispatch_count;
+        use compute_ir::{
+            BufferId, ComputeGraph, ExecutorId as ComputeExecutorId, OpTiming as PlanOpTiming,
+            PlacedConstant, PlacedOp, PlacedTensor, Residency, WIRE_FORMAT_VERSION,
+        };
+        use matrix_ir::{DType, Op, Shape, TensorId};
+
+        let backend = match metal_backend() {
+            Some(b) => b,
+            None => return,
+        };
+
+        // Install a Sqrt-with-input=16.0 kernel.  folded_slot = 0
+        // (unary ops have only one input slot).
+        let constant: f32 = 16.0;
+        let spec_key = matrix_runtime::SpecKey {
+            op_kind: 0x02, // Op::Sqrt
+            dtype: DType::F32,
+            shape_class: matrix_runtime::ShapeClass::Dynamic,
+            range_class: matrix_runtime::RangeClass::Constant {
+                bytes: constant.to_le_bytes().to_vec(),
+            },
+            backend_id: 1,
+            folded_slot: Some(0),
+        };
+        const TEST_HANDLE: u64 = 0x1717_1717_1717_1717;
+        let emitted = matrix_metal::emit_specialised_kernel(&spec_key, TEST_HANDLE)
+            .expect("Phase 4.7 emitter must support Sqrt with folded input");
+        assert_eq!(emitted.input_buffer_count, 0, "unary kernel must take 0 inputs");
+        let n_in = emitted.input_buffer_count;
+        let n_out = emitted.output_buffer_count;
+        backend
+            .executor
+            .install_specialised_from_emitted(TEST_HANDLE, emitted)
+            .expect("install must succeed on a real Metal device");
+        record_test_kernel_metadata(TEST_HANDLE, n_in, n_out, Some(0));
+
+        // Build the placed graph:
+        //   Op::Const → tensor A ([16, 16, 16, 16])
+        //   PlacedOp::Alloc → output buffer
+        //   Op::Sqrt(A) → tensor B
+        //
+        // The Sqrt op's input is A; the prep dispatch will still
+        // run the Const op (writes 16.0 four times into a buffer
+        // that the specialised kernel never reads).  The specialised
+        // kernel writes 4.0 to every element of B.  Wasted work for
+        // the Const but correct.
+        let metal_exec_id = ComputeExecutorId(1);
+        let a_residency = Residency { executor: metal_exec_id, buffer: BufferId(30) };
+        let b_residency = Residency { executor: metal_exec_id, buffer: BufferId(31) };
+        let a_bytes: Vec<u8> = [constant; 4].iter().flat_map(|v| v.to_le_bytes()).collect();
+        let f32_shape4 = Shape::from(&[4u32]);
+
+        let tensor_a = PlacedTensor {
+            id: TensorId(0),
+            dtype: DType::F32,
+            shape: f32_shape4.clone(),
+            residency: a_residency,
+        };
+        let tensor_b = PlacedTensor {
+            id: TensorId(1),
+            dtype: DType::F32,
+            shape: f32_shape4.clone(),
+            residency: b_residency,
+        };
+
+        let placed = ComputeGraph {
+            format_version: WIRE_FORMAT_VERSION,
+            inputs: vec![],
+            outputs: vec![tensor_b.clone()],
+            constants: vec![PlacedConstant {
+                tensor: TensorId(0),
+                residency: a_residency,
+                bytes: a_bytes,
+            }],
+            ops: vec![
+                PlacedOp::Compute {
+                    op: Op::Const { constant: 0, output: TensorId(0) },
+                    executor: metal_exec_id,
+                    timing: PlanOpTiming { estimated_ns: 0 },
+                },
+                PlacedOp::Alloc {
+                    residency: b_residency,
+                    bytes: 16,
+                },
+                PlacedOp::Compute {
+                    op: Op::Sqrt { input: TensorId(0), output: TensorId(1) },
+                    executor: metal_exec_id,
+                    timing: PlanOpTiming { estimated_ns: 0 },
+                },
+            ],
+            tensors: vec![tensor_a, tensor_b.clone()],
+        };
+
+        let before = specialised_dispatch_count();
+        let bytes = dispatch_specialised_via(
+            &backend.transport,
+            &placed,
+            2, // Sqrt op is at index 2
+            TEST_HANDLE,
+            b_residency,
+            16,
+        )
+        .expect("specialised unary dispatch must succeed");
+        let after = specialised_dispatch_count();
+
+        assert!(after > before, "specialised_dispatch_count must rise");
+
+        // Expected: [√16, √16, √16, √16] = [4.0, 4.0, 4.0, 4.0].
+        let result: Vec<f32> = bytes
+            .chunks(4)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect();
+        assert_eq!(
+            result,
+            vec![4.0, 4.0, 4.0, 4.0],
+            "Phase 4.7 Sqrt with folded input=16: kernel must memset √16=4.0"
+        );
+    }
 }
 

--- a/code/packages/rust/matrix-metal/CHANGELOG.md
+++ b/code/packages/rust/matrix-metal/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog — matrix-metal
 
+## 0.9.0 — 2026-05-13
+
+### Added — MX05 Phase 4.7 (unary ops with folded input constant)
+
+The MSL emitter now supports **unary f32 ops** when their single
+input is itself observed as a stable constant `K`.  In that case
+every output element equals `f(K)`, so the kernel collapses to a
+**memset of the precomputed value** — zero input buffers, just
+the output.
+
+| `op_kind`     | `f(K)` baked in | Example                       |
+|---------------|-----------------|-------------------------------|
+| `0x00` Neg    | `-K`            | `K = 3.0`  → output `-3.0`    |
+| `0x01` Abs    | `\|K\|`           | `K = -7.5` → output `7.5`     |
+| `0x02` Sqrt   | `√K`            | `K = 16.0` → output `4.0`     |
+| `0x03` Exp    | `e^K`           | `K = 0.0`  → output `1.0`     |
+| `0x04` Log    | `ln K`          | `K = 1.0`  → output `0.0`     |
+| `0x05` Tanh   | `tanh K`        | `K = 0.0`  → output `0.0`     |
+| `0x06` Recip  | `1/K`           | `K = 4.0`  → output `0.25`    |
+
+#### Kernel signature
+
+The unary-folded-input kernel has **zero input buffers** — `K` is
+baked into the source as a literal.  Binding order:
+
+  - `out [[buffer(0)]]`
+  - `n   [[buffer(1)]]`
+
+(vs the binary-folded-constant kernel's `(a, out, n)` at slots
+0/1/2.)
+
+Entry points embed `_input_const_` to distinguish from the binary
+`_const_` / `_lhs_const_` / `_rhs_const_` naming:
+
+```
+specialised_sqrt_input_const_f32_0xHHHHHHHHHHHHHHHH
+```
+
+#### Runtime install path
+
+`MetalExecutor::install_specialised_from_emitted` now branches on
+`emitted.input_buffer_count`:
+
+  - `n_in == 0` → bind `(out, n)` to slots `(0, 1)` — memset kernel
+  - `n_in == 1` → bind `(a, out, n)` to slots `(0, 1, 2)` — existing
+    binary path
+
+The branch is internal to the closure stored in `SpecialisedTable`;
+no protocol or public API changes.
+
+#### Tests
+
+9 new emitter tests (31 → 40 in matrix-metal; the `lib` test count
+went 35 → 40, +5 op-specific + +4 structural):
+
+- `neg_f32_with_folded_input_emits_memset_kernel`
+- `abs_f32_with_folded_input_emits_memset_kernel`
+- `sqrt_f32_with_folded_input_emits_memset_kernel`
+- `exp_f32_with_folded_input_emits_memset_kernel`
+- `log_f32_with_folded_input_emits_memset_kernel`
+- `tanh_f32_with_folded_input_emits_memset_kernel`
+- `recip_f32_with_folded_input_emits_memset_kernel`
+- `unary_input_const_entry_names_distinct_from_binary_const` —
+  proves namespace separation
+- `unary_ops_return_none_without_folded_slot` — pins the
+  "no folded_slot → no kernel" guard
+
+Plus `returns_none_for_unsupported_op_kind` was retargeted: Op::Neg
+is now supported, so the test now uses `Op::ReduceSum` (0x0E) as
+the "not yet" exemplar — reductions are future phase work.
+
 ## 0.8.0 — 2026-05-13
 
 ### Added — MX05 Phase 4.6 (Sub/Div/Pow with folded constant unlock)

--- a/code/packages/rust/matrix-metal/Cargo.toml
+++ b/code/packages/rust/matrix-metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-metal"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "First real GPU executor for the matrix execution layer. Lowers a subset of MatrixIR ops to MSL kernels and dispatches via the metal-compute crate. Falls back to CPU automatically (via the planner's capability filter) for ops it doesn't yet support. v0.6 (MX05 Phase 4.2) ships the MSL emitter — given a SpecKey it generates an MSL kernel string with observed constants folded in as literal values — plus the per-handle specialised pipeline table and live DispatchSpecialised handler that runs on Apple targets."
 license = "MIT"

--- a/code/packages/rust/matrix-metal/src/lib.rs
+++ b/code/packages/rust/matrix-metal/src/lib.rs
@@ -372,24 +372,45 @@ impl MetalExecutor {
             // (see binary_dispatch in dispatch.rs).  The buffers
             // outlive the dispatch call because the BufferStore
             // owns them and we hold the executor mutex.
-            let a_ptr = ctx
-                .buffers
-                .get(inputs[0])
-                .map_err(|e| format!("input[0] buffer not found: {}", e))? as *const _;
             let out_ptr = ctx
                 .buffers
                 .get(outputs[0])
                 .map_err(|e| format!("output[0] buffer not found: {}", e))? as *const _;
-            let a_buf = unsafe { &*a_ptr };
             let out_buf = unsafe { &*out_ptr };
 
-            ctx.queue.dispatch(|enc| {
-                enc.set_pipeline(&pipeline);
-                enc.set_buffer(a_buf, 0);
-                enc.set_buffer(out_buf, 1);
-                enc.set_bytes(&n_bytes, 2);
-                enc.dispatch_threads_1d(n, tg);
-            });
+            // **MX05 Phase 4.7.**  Two kernel signatures depending
+            // on `n_in`:
+            //
+            // - `n_in == 0` → memset kernel (unary with folded
+            //   input).  Signature: `(out [buffer(0)], n [buffer(1)])`.
+            //   No input buffer to bind.
+            // - `n_in == 1` → binary-with-folded-constant kernel.
+            //   Signature: `(a [buffer(0)], out [buffer(1)], n [buffer(2)])`.
+            //
+            // Higher arities (n_in >= 2) aren't emitted today; the
+            // length-check above already rejects them at runtime.
+            if n_in == 0 {
+                ctx.queue.dispatch(|enc| {
+                    enc.set_pipeline(&pipeline);
+                    enc.set_buffer(out_buf, 0);
+                    enc.set_bytes(&n_bytes, 1);
+                    enc.dispatch_threads_1d(n, tg);
+                });
+            } else {
+                let a_ptr = ctx
+                    .buffers
+                    .get(inputs[0])
+                    .map_err(|e| format!("input[0] buffer not found: {}", e))?
+                    as *const _;
+                let a_buf = unsafe { &*a_ptr };
+                ctx.queue.dispatch(|enc| {
+                    enc.set_pipeline(&pipeline);
+                    enc.set_buffer(a_buf, 0);
+                    enc.set_buffer(out_buf, 1);
+                    enc.set_bytes(&n_bytes, 2);
+                    enc.dispatch_threads_1d(n, tg);
+                });
+            }
 
             Ok(vec![OpTiming { op_index: 0, ns: 0 }])
         });

--- a/code/packages/rust/matrix-metal/src/msl_emitter.rs
+++ b/code/packages/rust/matrix-metal/src/msl_emitter.rs
@@ -144,15 +144,31 @@ pub struct EmittedKernel {
 ///
 /// # Currently supported shapes
 ///
-/// | `op_kind`  | `dtype` | `shape_class` | `range_class`              | Notes                                            |
-/// |------------|---------|---------------|----------------------------|--------------------------------------------------|
-/// | `0x07` Add | `F32`   | any           | `Constant { bytes: 4 B }`  | Commutative; slot irrelevant                     |
-/// | `0x08` Sub | `F32`   | any           | `Constant { bytes: 4 B }`  | Non-commutative; LHS- and RHS-folded variants    |
-/// | `0x09` Mul | `F32`   | any           | `Constant { bytes: 4 B }`  | Commutative; slot irrelevant                     |
-/// | `0x0A` Div | `F32`   | any           | `Constant { bytes: 4 B }`  | Non-commutative; LHS- and RHS-folded variants    |
-/// | `0x0B` Max | `F32`   | any           | `Constant { bytes: 4 B }`  | Commutative; slot irrelevant                     |
-/// | `0x0C` Min | `F32`   | any           | `Constant { bytes: 4 B }`  | Commutative; slot irrelevant                     |
-/// | `0x0D` Pow | `F32`   | any           | `Constant { bytes: 4 B }`  | Non-commutative; LHS- and RHS-folded variants    |
+/// | `op_kind`    | `dtype` | `shape_class` | `range_class`              | Notes                                            |
+/// |--------------|---------|---------------|----------------------------|--------------------------------------------------|
+/// | `0x00` Neg   | `F32`   | any           | `Constant { bytes: 4 B }`  | Unary; output precomputed (memset of `-K`)       |
+/// | `0x01` Abs   | `F32`   | any           | `Constant { bytes: 4 B }`  | Unary; output precomputed (memset of `\|K\|`)      |
+/// | `0x02` Sqrt  | `F32`   | any           | `Constant { bytes: 4 B }`  | Unary; output precomputed (memset of `√K`)       |
+/// | `0x03` Exp   | `F32`   | any           | `Constant { bytes: 4 B }`  | Unary; output precomputed (memset of `e^K`)      |
+/// | `0x04` Log   | `F32`   | any           | `Constant { bytes: 4 B }`  | Unary; output precomputed (memset of `ln K`)     |
+/// | `0x05` Tanh  | `F32`   | any           | `Constant { bytes: 4 B }`  | Unary; output precomputed (memset of `tanh K`)   |
+/// | `0x06` Recip | `F32`   | any           | `Constant { bytes: 4 B }`  | Unary; output precomputed (memset of `1/K`)      |
+/// | `0x07` Add   | `F32`   | any           | `Constant { bytes: 4 B }`  | Commutative; slot irrelevant                     |
+/// | `0x08` Sub   | `F32`   | any           | `Constant { bytes: 4 B }`  | Non-commutative; LHS- and RHS-folded variants    |
+/// | `0x09` Mul   | `F32`   | any           | `Constant { bytes: 4 B }`  | Commutative; slot irrelevant                     |
+/// | `0x0A` Div   | `F32`   | any           | `Constant { bytes: 4 B }`  | Non-commutative; LHS- and RHS-folded variants    |
+/// | `0x0B` Max   | `F32`   | any           | `Constant { bytes: 4 B }`  | Commutative; slot irrelevant                     |
+/// | `0x0C` Min   | `F32`   | any           | `Constant { bytes: 4 B }`  | Commutative; slot irrelevant                     |
+/// | `0x0D` Pow   | `F32`   | any           | `Constant { bytes: 4 B }`  | Non-commutative; LHS- and RHS-folded variants    |
+///
+/// ## Unary ops with folded input constant (Phase 4.7)
+///
+/// When a unary op's single input is itself observed as a stable
+/// constant `K`, the entire output is precomputed at emit time:
+/// every element is `f(K)`.  The kernel collapses to a memset —
+/// `input_buffer_count = 0`, only the output buffer is bound.
+/// The dispatcher passes an empty `inputs` vector to
+/// `DispatchSpecialised`.
 ///
 /// All other combinations return `None` for now.  Adding a shape is
 /// a small change — add a match arm and a unit test.
@@ -209,16 +225,33 @@ pub fn emit_specialised_kernel(key: &SpecKey, handle: u64) -> Option<EmittedKern
     // folded, otherwise we'd guess wrong half the time.  No
     // `folded_slot` → fall back to generic dispatch.
     let folded_slot = key.folded_slot?;
-    // Each non-commutative op has two variants: one where the
-    // constant is on the LHS (`K op b[gid]`) and one where it's
-    // on the RHS (`a[gid] op K`).  We pass two MSL expression
-    // templates and let `emit_binary_f32_with_const_at_slot`
-    // pick based on the slot.
+
+    // **MX05 Phase 4.7.**  Unary f32 ops with a folded input constant.
     //
-    // The template uses `{a}` for the kernel's single variable
-    // input load (always `a[gid]` in the emitted code — the
-    // dispatcher feeds the correct buffer into slot 0) and
-    // `{k}` for the constant literal.
+    // When the single input of a unary op is itself observed as a
+    // stable constant `K`, the entire output tensor is precomputed:
+    // every element is `f(K)`.  The kernel collapses to a memset.
+    // The kernel takes **zero** input buffers — the value is baked
+    // into the source as a literal.  Output buffer count is still 1.
+    //
+    // For `folded_slot` we require `Some(0)` since unary ops have
+    // exactly one input slot.
+    let unary_eval: Option<(&str, f32)> = match key.op_kind {
+        0x00 if folded_slot == 0 => Some(("neg", -constant)),
+        0x01 if folded_slot == 0 => Some(("abs", constant.abs())),
+        0x02 if folded_slot == 0 => Some(("sqrt", constant.sqrt())),
+        0x03 if folded_slot == 0 => Some(("exp", constant.exp())),
+        0x04 if folded_slot == 0 => Some(("log", constant.ln())),
+        0x05 if folded_slot == 0 => Some(("tanh", constant.tanh())),
+        0x06 if folded_slot == 0 => Some(("recip", 1.0_f32 / constant)),
+        _ => None,
+    };
+    if let Some((op_name, precomputed)) = unary_eval {
+        return Some(emit_unary_f32_folded_constant(handle, op_name, precomputed));
+    }
+
+    // Non-commutative binary ops: we **must** know which slot the
+    // policy folded, otherwise we'd guess wrong half the time.
     let (op_name, lhs_template, rhs_template) = match key.op_kind {
         0x08 => ("sub", "{k} - {a}", "{a} - {k}"),
         0x0A => ("div", "{k} / {a}", "{a} / {k}"),
@@ -390,6 +423,59 @@ fn emit_binary_f32_with_const_at_slot(
         source,
         entry_point: entry,
         input_buffer_count: 1,
+        output_buffer_count: 1,
+    }
+}
+
+/// **MX05 Phase 4.7.**  Emit a unary-f32 kernel whose input is a
+/// known constant, producing a memset of the precomputed value.
+///
+/// The output is `f(K)` for every element, where `f` is the unary
+/// op (Neg / Abs / Sqrt / Exp / Log / Tanh / Recip) and `K` is the
+/// observed constant input.  Since every output element is the same
+/// value, the kernel is a one-line write of the precomputed literal.
+///
+/// Kernel signature:
+/// - **0 inputs** (input was folded away)
+/// - 1 output buffer at `buffer(0)`
+/// - `n` element count at `buffer(1)`
+///
+/// Entry-point name: `specialised_<op_name>_input_const_f32_0xHHHHHHHHHHHHHHHH`.
+/// The `_input_const_` fragment distinguishes these from the binary
+/// `_const_` and `_lhs_const_`/`_rhs_const_` kernels in the same
+/// library.
+///
+/// The dispatcher in image-gpu-core consults `KernelMetadata.n_in`
+/// and passes an empty `inputs: vec![]` when `n_in == 0`.
+fn emit_unary_f32_folded_constant(handle: u64, op_name: &str, precomputed: f32) -> EmittedKernel {
+    let entry = format!("specialised_{op_name}_input_const_f32_0x{handle:016X}");
+    let literal = format_f32_literal(precomputed);
+
+    let source = format!(
+        "#include <metal_stdlib>\n\
+         using namespace metal;\n\
+         \n\
+         // MX05 Phase 4.7 — specialised {op_name}_f32 with folded input.\n\
+         // handle = 0x{handle:016X}\n\
+         // precomputed = {literal}\n\
+         kernel void {entry}(\n\
+         \x20   device float*       out [[buffer(0)]],\n\
+         \x20   constant uint&      n   [[buffer(1)]],\n\
+         \x20   uint gid [[thread_position_in_grid]]\n\
+         ) {{\n\
+         \x20   if (gid >= n) return;\n\
+         \x20   out[gid] = {literal};\n\
+         }}\n",
+        handle = handle,
+        entry = entry,
+        op_name = op_name,
+        literal = literal,
+    );
+
+    EmittedKernel {
+        source,
+        entry_point: entry,
+        input_buffer_count: 0,
         output_buffer_count: 1,
     }
 }
@@ -708,13 +794,144 @@ mod tests {
 
     #[test]
     fn returns_none_for_unsupported_op_kind() {
-        // Op::Neg (0x00) — unary, no binary-with-folded-constant
-        // emitter shape applies.  Future phase work could add unary
-        // ops with their input folded (the kernel becomes a memset
-        // of a precomputed value), but until then this returns None.
+        // Op::ReduceSum (0x0E) — reductions aren't yet in the
+        // emitter's shape catalogue.  Future phase work could add
+        // them (with the reduction axis encoded in the SpecKey),
+        // but until then this returns None.
         let mut key = add_const_key(7.0);
-        key.op_kind = 0x00;
+        key.op_kind = 0x0E;
         assert!(emit_specialised_kernel(&key, 0).is_none());
+    }
+
+    // ───────────── MX05 Phase 4.7 — unary with folded input ─────────────
+
+    /// Build a SpecKey for a unary op with its single input folded
+    /// as a constant.
+    fn unary_input_const_key(op_kind: u8, constant: f32) -> SpecKey {
+        SpecKey {
+            op_kind,
+            dtype: DType::F32,
+            shape_class: ShapeClass::Dynamic,
+            range_class: RangeClass::Constant {
+                bytes: constant.to_le_bytes().to_vec(),
+            },
+            backend_id: 1,
+            folded_slot: Some(0), // Unary ops have only one input slot.
+        }
+    }
+
+    /// **MX05 Phase 4.7.**  `Op::Neg` (0x00) with folded input
+    /// constant `K` collapses to a memset of `-K`.  The emitted
+    /// kernel takes **zero** input buffers — the value is baked in.
+    #[test]
+    fn neg_f32_with_folded_input_emits_memset_kernel() {
+        let k = emit_specialised_kernel(&unary_input_const_key(0x00, 3.0), 0xA1).unwrap();
+        assert_eq!(
+            k.entry_point,
+            "specialised_neg_input_const_f32_0x00000000000000A1"
+        );
+        assert_eq!(k.input_buffer_count, 0);
+        assert_eq!(k.output_buffer_count, 1);
+        // -3.0 formats as `-3.0f` after Ryu + suffix.
+        assert!(
+            k.source.contains("out[gid] = -3.0f"),
+            "expected 'out[gid] = -3.0f' in body:\n{}",
+            k.source
+        );
+        // No input buffer in the signature.
+        assert!(
+            !k.source.contains("device const float* a"),
+            "specialised unary kernel must NOT take an input buffer"
+        );
+    }
+
+    /// **MX05 Phase 4.7.**  `Op::Sqrt` (0x02) with `K = 16.0` is the
+    /// canonical example: the kernel writes `4.0` everywhere.
+    #[test]
+    fn sqrt_f32_with_folded_input_emits_memset_kernel() {
+        let k = emit_specialised_kernel(&unary_input_const_key(0x02, 16.0), 0xA2).unwrap();
+        assert_eq!(
+            k.entry_point,
+            "specialised_sqrt_input_const_f32_0x00000000000000A2"
+        );
+        assert_eq!(k.input_buffer_count, 0);
+        assert!(k.source.contains("out[gid] = 4.0f"));
+    }
+
+    /// **MX05 Phase 4.7.**  `Op::Abs` (0x01) with `K = -7.5` writes
+    /// `7.5` everywhere.
+    #[test]
+    fn abs_f32_with_folded_input_emits_memset_kernel() {
+        let k = emit_specialised_kernel(&unary_input_const_key(0x01, -7.5), 0xA3).unwrap();
+        assert_eq!(k.input_buffer_count, 0);
+        assert!(k.source.contains("out[gid] = 7.5f"));
+    }
+
+    /// **MX05 Phase 4.7.**  `Op::Exp` (0x03) with `K = 0.0` writes
+    /// `1.0` (since `exp(0) = 1`).
+    #[test]
+    fn exp_f32_with_folded_input_emits_memset_kernel() {
+        let k = emit_specialised_kernel(&unary_input_const_key(0x03, 0.0), 0xA4).unwrap();
+        assert_eq!(k.input_buffer_count, 0);
+        assert!(k.source.contains("out[gid] = 1.0f"));
+    }
+
+    /// **MX05 Phase 4.7.**  `Op::Log` (0x04) with `K = 1.0` writes
+    /// `0.0` (since `ln(1) = 0`).
+    #[test]
+    fn log_f32_with_folded_input_emits_memset_kernel() {
+        let k = emit_specialised_kernel(&unary_input_const_key(0x04, 1.0), 0xA5).unwrap();
+        assert_eq!(k.input_buffer_count, 0);
+        assert!(k.source.contains("out[gid] = 0.0f"));
+    }
+
+    /// **MX05 Phase 4.7.**  `Op::Tanh` (0x05) with `K = 0.0` writes
+    /// `0.0` (since `tanh(0) = 0`).
+    #[test]
+    fn tanh_f32_with_folded_input_emits_memset_kernel() {
+        let k = emit_specialised_kernel(&unary_input_const_key(0x05, 0.0), 0xA6).unwrap();
+        assert_eq!(k.input_buffer_count, 0);
+        assert!(k.source.contains("out[gid] = 0.0f"));
+    }
+
+    /// **MX05 Phase 4.7.**  `Op::Recip` (0x06) with `K = 4.0` writes
+    /// `0.25` everywhere.
+    #[test]
+    fn recip_f32_with_folded_input_emits_memset_kernel() {
+        let k = emit_specialised_kernel(&unary_input_const_key(0x06, 4.0), 0xA7).unwrap();
+        assert_eq!(k.input_buffer_count, 0);
+        assert!(k.source.contains("out[gid] = 0.25f"));
+    }
+
+    /// **MX05 Phase 4.7.**  Unary kernels' entry-point names embed
+    /// the `_input_const_` fragment so they don't collide with the
+    /// binary-with-folded-constant kernels (`_const_`,
+    /// `_lhs_const_`, `_rhs_const_`).
+    #[test]
+    fn unary_input_const_entry_names_distinct_from_binary_const() {
+        let neg = emit_specialised_kernel(&unary_input_const_key(0x00, 3.0), 0xBB).unwrap();
+        let add = emit_specialised_kernel(&binary_const_key(0x07, 3.0), 0xBB).unwrap();
+        assert_ne!(neg.entry_point, add.entry_point);
+        assert!(neg.entry_point.contains("_input_const_"));
+        assert!(add.entry_point.contains("_const_"));
+        assert!(!add.entry_point.contains("_input_const_"));
+    }
+
+    /// **MX05 Phase 4.7.**  Unary ops still return `None` if the
+    /// policy didn't fold the input — the emitter has no other
+    /// useful unary specialisation to offer until later phases
+    /// (e.g. range narrowing) land.
+    #[test]
+    fn unary_ops_return_none_without_folded_slot() {
+        for op_kind in [0x00u8, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06] {
+            let mut key = unary_input_const_key(op_kind, 1.0);
+            key.folded_slot = None;
+            assert!(
+                emit_specialised_kernel(&key, 0).is_none(),
+                "expected None for unary op_kind 0x{:02X} with folded_slot=None",
+                op_kind
+            );
+        }
     }
 
     #[test]

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -242,6 +242,28 @@ The compile happens in a background worker thread so live dispatches
 aren't blocked.  Once ready, the specialised pipeline is inserted
 into the cache.
 
+> **Implementation status (Phase 4.7 landed — unary ops with folded input collapse to memset)**:
+> matrix-metal v0.9.0 extends `msl_emitter` to support **unary
+> f32 ops** (Neg, Abs, Sqrt, Exp, Log, Tanh, Recip) when their
+> single input is itself observed as a stable constant `K`.  In
+> that case every output element is `f(K)`, so the kernel collapses
+> to a memset of the precomputed value — `input_buffer_count = 0`,
+> only the output buffer is bound.  Entry-point names embed
+> `_input_const_` to distinguish from the binary `_const_` /
+> `_lhs_const_` / `_rhs_const_` namespace.
+> `MetalExecutor::install_specialised_from_emitted` branches its
+> install closure on `n_in`: 0-input kernels bind `(out, n)` at
+> slots `(0, 1)`; 1-input kernels keep the existing
+> `(a, out, n)` at `(0, 1, 2)` layout.  image-gpu-core v0.10.0
+> needed no dispatcher changes — Phase 4.6's
+> `ir_inputs.iter().take(n_in)` naturally yields an empty Vec when
+> `n_in == 0`.  End-to-end test
+> `dispatch_specialised_via_routes_unary_folded_input` runs
+> `Op::Sqrt(input=[16,16,16,16])` through the full chain and
+> asserts the output is `[4, 4, 4, 4]` — the memset kernel wrote
+> `√16 = 4` to every element.  Test counts:
+> matrix-metal 40 emitter (+9), image-gpu-core 32 (+1).
+
 > **Implementation status (Phase 4.6 landed — `folded_slot` unlocks non-commutative ops)**:
 > `SpecKey` gains a `folded_slot: Option<u8>` field
 > (matrix-profile v0.2.0) recording which input slot the policy


### PR DESCRIPTION
## Summary

When a unary op's single input is itself observed as a stable constant \`K\`, the entire output is precomputed: every element is \`f(K)\`. The kernel collapses to a **memset of the precomputed value** — zero input buffers, only the output is bound.

## Supported ops (matrix-metal v0.9.0)

| \`op_kind\`     | \`f(K)\` baked in | Example                       |
|---------------|-----------------|-------------------------------|
| \`0x00\` Neg    | \`-K\`            | K = 3.0  → -3.0               |
| \`0x01\` Abs    | \`\|K\|\`           | K = -7.5 →  7.5               |
| \`0x02\` Sqrt   | \`√K\`            | K = 16.0 →  4.0               |
| \`0x03\` Exp    | \`e^K\`           | K = 0.0  →  1.0               |
| \`0x04\` Log    | \`ln K\`          | K = 1.0  →  0.0               |
| \`0x05\` Tanh   | \`tanh K\`        | K = 0.0  →  0.0               |
| \`0x06\` Recip  | \`1/K\`           | K = 4.0  →  0.25              |

Entry points: \`specialised_<op>_input_const_f32_0xH…H\` (distinct from the binary \`_const_\` namespace).

## Runtime install path

\`MetalExecutor::install_specialised_from_emitted\` branches its closure on \`n_in\`:

- \`n_in == 0\` → bind \`(out, n)\` at slots \`(0, 1)\` — memset path
- \`n_in == 1\` → bind \`(a, out, n)\` at slots \`(0, 1, 2)\` — existing binary path

No protocol changes.

## image-gpu-core v0.10.0

\`dispatch_specialised_via\` needed **no source change** — Phase 4.6's \`ir_inputs.iter().take(n_in)\` yields an empty Vec when \`n_in == 0\`. The unary-memset path falls through existing code.

## Tests

- **matrix-metal**: 31 → 40 emitter tests (+9 Phase 4.7), 25 integration still green
- **image-gpu-core**: 31 → 32 tests (+1 E2E: Sqrt(input=16) → output [4, 4, 4, 4])

## Security review (passed)

- f(K) math at emit time uses Rust's f32 ops; non-finite results format via existing NAN/INFINITY branch.
- The \`unsafe { &*out_ptr }\` deref is sound; n_in==0 path drops the input pointer entirely.
- \`op_name\` is from a closed match on op_kind — no source injection.

## Test plan

- [x] All affected crates green
- [x] Linux cross-compile clean
- [x] Security review passed (1 round)
- [x] Spec MX05 updated with \"Phase 4.7 landed\" status block

🤖 Generated with [Claude Code](https://claude.com/claude-code)