### PR TITLE
Add Board VM PWM write capability slice

### DIFF
--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -132,6 +132,7 @@ def test_known_targets_are_exposed_from_rust_registry():
     assert uno_r4_wifi is not None
     assert "transport.wifi" in uno_r4_wifi.capabilities
     assert "transport.bluetooth_le" in uno_r4_wifi.capabilities
+    assert "pwm.write" in uno_r4_wifi.capabilities
     assert uno_r4_wifi.wireless_transports == ["wifi", "bluetooth_le"]
     assert uno_r4_wifi.supports_wifi is True
     assert uno_r4_wifi.supports_bluetooth is True

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -2,12 +2,13 @@ use std::ffi::{c_char, c_int, c_long, c_void};
 use std::ptr;
 use std::slice;
 
+use board_vm_host::PwmWriteProgram;
 use board_vm_host::{
     BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
     GpioOpenProgram, GpioReadProgram, GpioWriteProgram, LedMatrixFrameProgram, TimeNowProgram,
     TimeSleepMsProgram, BLINK_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN,
     GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
-    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
+    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
     TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
@@ -17,10 +18,10 @@ use board_vm_language_core::{
     build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
     build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
     build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
-    build_program_end_wire_frame, build_raw_module, build_run_background_wire_frame,
-    build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
-    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
-    capability_bytecode_callable, capability_flag_names,
+    build_program_end_wire_frame, build_pwm_write_module, build_raw_module,
+    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
+    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, connection_transport_name, decode_wire_response,
     detect_target as core_detect_target,
     discover_bluetooth_devices as core_discover_bluetooth_devices,
@@ -211,6 +212,21 @@ extern "C" fn session_led_matrix_frame_module(
 
     let module = build_led_matrix_frame_module_value([word0, word1, word2], max_stack)
         .unwrap_or_else(|error| raise_core_error("led_matrix_frame_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_pwm_write_module(
+    _self_val: VALUE,
+    pin_val: VALUE,
+    duty_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let pin = rb_u8(pin_val, "pin");
+    let duty = rb_u16(duty_val, "duty");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_pwm_write_module_value(pin, duty, max_stack)
+        .unwrap_or_else(|error| raise_core_error("pwm_write_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -791,8 +807,16 @@ fn language_digital_pins_to_rb(pins: &[LanguageDigitalPin]) -> VALUE {
             "supports_pulldown",
             ruby_bridge::bool_to_rb(pin.supports_pulldown),
         );
-        hash_set(hash, "supports_adc", ruby_bridge::bool_to_rb(pin.supports_adc));
-        hash_set(hash, "supports_pwm", ruby_bridge::bool_to_rb(pin.supports_pwm));
+        hash_set(
+            hash,
+            "supports_adc",
+            ruby_bridge::bool_to_rb(pin.supports_adc),
+        );
+        hash_set(
+            hash,
+            "supports_pwm",
+            ruby_bridge::bool_to_rb(pin.supports_pwm),
+        );
         hash_set(
             hash,
             "supports_touch",
@@ -1342,8 +1366,24 @@ fn build_led_matrix_frame_module_value(
     max_stack: u8,
 ) -> Result<Vec<u8>, LanguageCoreError> {
     let mut module = vec![0; LED_MATRIX_FRAME_MODULE_LEN];
-    let len = build_led_matrix_frame_module(
-        LedMatrixFrameProgram { words, max_stack },
+    let len =
+        build_led_matrix_frame_module(LedMatrixFrameProgram { words, max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_pwm_write_module_value(
+    pin: u8,
+    duty: u16,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; PWM_WRITE_MODULE_LEN];
+    let len = build_pwm_write_module(
+        PwmWriteProgram {
+            pin,
+            duty,
+            max_stack,
+        },
         &mut module,
     )?;
     module.truncate(len);
@@ -1646,6 +1686,12 @@ pub extern "C" fn Init_board_vm_native() {
         "led_matrix_frame_module",
         session_led_matrix_frame_module as *const c_void,
         4,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "pwm_write_module",
+        session_pwm_write_module as *const c_void,
+        3,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -98,6 +98,10 @@ module CodingAdventures
         Gpio.new(self)
       end
 
+      def pwm
+        Pwm.new(self)
+      end
+
       def eject
         Ejector.new(self)
       end
@@ -213,6 +217,28 @@ module CodingAdventures
           budget: budget,
           pin: pin,
           value: value,
+          max_stack: max_stack,
+          handshake: true,
+          query_caps: true,
+          host_nonce: host_nonce
+        )
+      end
+
+      def pwm_write!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        pin:,
+        duty:,
+        max_stack: 2
+      )
+        ensure_uno_r4_wifi!
+
+        session.pwm_write(
+          program_id: program_id,
+          budget: budget,
+          pin: pin,
+          duty: duty,
           max_stack: max_stack,
           handshake: true,
           query_caps: true,
@@ -872,6 +898,38 @@ module CodingAdventures
           budget: budget,
           max_stack: max_stack
         )
+      end
+    end
+
+    class Pwm
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def write(
+        pin:,
+        duty:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        max_stack: 2
+      )
+        @connection.pwm_write!(
+          program_id: program_id,
+          budget: budget,
+          host_nonce: host_nonce,
+          pin: pin,
+          duty: duty,
+          max_stack: max_stack
+        )
+      end
+
+      def off(pin:, **options)
+        write(pin: pin, duty: 0, **options)
+      end
+
+      def full(pin:, **options)
+        write(pin: pin, duty: 0xFFFF, **options)
       end
     end
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -197,6 +197,10 @@ module CodingAdventures
         native_session.gpio_write_module(pin, gpio_write_value(value) ? 1 : 0, max_stack)
       end
 
+      def pwm_write_module(pin:, duty:, max_stack: 2)
+        native_session.pwm_write_module(pin, pwm_duty_value(duty), max_stack)
+      end
+
       def gpio_open_module(pin:, mode: :output, max_stack: 2)
         native_session.gpio_open_module(pin, gpio_mode(mode), max_stack)
       end
@@ -234,6 +238,18 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: gpio_write_module(pin: pin, value: value, max_stack: max_stack)
+        )
+      end
+
+      def upload_pwm_write(
+        program_id: @program_id,
+        pin:,
+        duty:,
+        max_stack: 2
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: pwm_write_module(pin: pin, duty: duty, max_stack: max_stack)
         )
       end
 
@@ -470,6 +486,36 @@ module CodingAdventures
         gpio_write(pin: pin, value: false, **options)
       end
 
+      def pwm_write(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        pin:,
+        duty:,
+        max_stack: 2,
+        handshake: false,
+        query_caps: false,
+        host_name: @host_name,
+        host_nonce: @host_nonce
+      )
+        results = []
+        results << hello(host_name: host_name, host_nonce: host_nonce) if handshake
+        results << capabilities if query_caps
+        results.concat(
+          upload_pwm_write(
+            program_id: program_id,
+            pin: pin,
+            duty: duty,
+            max_stack: max_stack
+          ).results
+        )
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget
+        )
+        SessionResult.new(results: results)
+      end
+
       def gpio_open(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -663,6 +709,8 @@ module CodingAdventures
           upload_gpio_read(**gpio_read_command_options(words, command, options, require_budget: false))
         when "upload-gpio-write", "upload-gpio.write"
           upload_gpio_write(**gpio_write_command_options(words, command, options, require_budget: false))
+        when "upload-pwm-write", "upload-pwm.write"
+          upload_pwm_write(**pwm_write_command_options(words, command, options, require_budget: false))
         when "upload-gpio-open", "upload-gpio.open"
           upload_gpio_open(**gpio_open_command_options(words, command, options, require_budget: false))
         when "upload-gpio-handle-read", "upload-gpio.handle-read"
@@ -693,6 +741,8 @@ module CodingAdventures
           gpio_read(**gpio_read_command_options(words, command, options))
         when "gpio-write", "gpio.write"
           gpio_write(**gpio_write_command_options(words, command, options))
+        when "pwm-write", "pwm.write"
+          pwm_write(**pwm_write_command_options(words, command, options))
         when "gpio-high", "gpio.high"
           gpio_write(**gpio_level_command_options(words, command, options, value: true))
         when "gpio-low", "gpio.low"
@@ -879,6 +929,22 @@ module CodingAdventures
         merged
       end
 
+      def pwm_write_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:pin] = integer_argument(words.shift, "#{command} pin") unless words.empty?
+        merged[:duty] = pwm_duty_value(words.shift) unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires pin" unless merged.key?(:pin)
+        raise ArgumentError, "#{command} requires duty" unless merged.key?(:duty)
+
+        merged
+      end
+
       def gpio_open_command_options(words, command, options, require_budget: true)
         merged = options.dup
         merged[:pin] = integer_argument(words.shift, "#{command} pin") unless words.empty?
@@ -940,6 +1006,21 @@ module CodingAdventures
         GPIO_WRITE_VALUES.fetch(text.to_sym) do
           raise ArgumentError, "unsupported GPIO write value: #{value.inspect}"
         end
+      end
+
+      def pwm_duty_value(value)
+        duty = if value.is_a?(Integer)
+          value
+        else
+          begin
+            Integer(value, 0)
+          rescue ArgumentError
+            raise ArgumentError, "PWM duty must be an integer: #{value.inspect}"
+          end
+        end
+        raise ArgumentError, "PWM duty must fit in u16" if duty.negative? || duty > 0xFFFF
+
+        duty
       end
 
       def boot_policy_value(value)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -35,6 +35,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "transport.wifi"
         assert_includes uno_r4_wifi["capabilities"], "transport.bluetooth_le"
         assert_includes uno_r4_wifi["capabilities"], "led_matrix.frame"
+        assert_includes uno_r4_wifi["capabilities"], "pwm.write"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -1196,6 +1197,28 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_pwm_write_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          result = board.pwm.write(pin: 3, duty: 0x8000, program_id: 10, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 6, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal transport.frames, result.frames
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          result.results.map(&:command)
+      end
+
       def test_store_program_dispatches_native_protocol_frame_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1530,6 +1553,26 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_pwm_write
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("pwm-write 3 0x8000 24", program_id: 9)
+          upload = board.session.run_command("upload-pwm-write 3 32768", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
       def test_board_descriptor_wraps_rust_decoded_capability_report
         decoded = {
           "kind" => "caps_report",
@@ -1638,6 +1681,10 @@ module CodingAdventures
         )
         assert_instance_of String, led_matrix_module_bytes
         assert_operator led_matrix_module_bytes.bytesize, :>, 0
+
+        pwm_module_bytes = session.pwm_write_module(3, 0x8000, 2)
+        assert_instance_of String, pwm_module_bytes
+        assert_operator pwm_module_bytes.bytesize, :>, 0
 
         gpio_module_bytes = session.gpio_read_module(13, 2, 2)
         assert_instance_of String, gpio_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -2,7 +2,7 @@
 
 use board_vm_ir::{
     parse_module, validate, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE,
-    CAP_LED_MATRIX_FRAME, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -113,6 +113,114 @@ pub const BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>
         version: 1,
         flags: CAP_FLAG_BYTECODE_CALLABLE,
         name: "time.now_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_LED_MATRIX_FRAME,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "led_matrix.frame",
+    },
+    CapabilityDescriptor {
+        id: CAP_PROGRAM_RAM_EXEC,
+        version: 1,
+        flags: CAP_FLAG_PROTOCOL_FEATURE,
+        name: "program.ram_exec",
+    },
+];
+
+pub const BLINK_MVP_WITH_PWM_CAPABILITIES: [CapabilityDescriptor<'static>; 8] = [
+    CapabilityDescriptor {
+        id: CAP_GPIO_OPEN,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.open",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_CLOSE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.close",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_SLEEP_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.sleep_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_NOW_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.now_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_PWM_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "pwm.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_PROGRAM_RAM_EXEC,
+        version: 1,
+        flags: CAP_FLAG_PROTOCOL_FEATURE,
+        name: "program.ram_exec",
+    },
+];
+
+pub const BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>; 9] = [
+    CapabilityDescriptor {
+        id: CAP_GPIO_OPEN,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.open",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_CLOSE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.close",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_SLEEP_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.sleep_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_NOW_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.now_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_PWM_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "pwm.write",
     },
     CapabilityDescriptor {
         id: CAP_LED_MATRIX_FRAME,

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,8 +1,8 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_GPIO_CLOSE,
-    CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_TIME_NOW_MS,
-    CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
-    MODULE_MAGIC, MODULE_VERSION,
+    CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+    CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
+    FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -34,6 +34,8 @@ pub const TIME_NOW_CODE_LEN: usize = 3;
 pub const TIME_NOW_MODULE_LEN: usize = 13;
 pub const TIME_SLEEP_MS_CODE_LEN: usize = 5;
 pub const TIME_SLEEP_MS_MODULE_LEN: usize = 15;
+pub const PWM_WRITE_CODE_LEN: usize = 8;
+pub const PWM_WRITE_MODULE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -149,6 +151,13 @@ pub struct GpioOpenProgram {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PwmWriteProgram {
+    pub pin: u8,
+    pub duty: u16,
+    pub max_stack: u8,
+}
+
 impl GpioOpenProgram {
     pub const fn output(pin: u8) -> Self {
         Self {
@@ -236,6 +245,24 @@ impl GpioHandleCloseProgram {
 impl Default for GpioHandleCloseProgram {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl PwmWriteProgram {
+    pub const fn new(pin: u8, duty: u16) -> Self {
+        Self {
+            pin,
+            duty,
+            max_stack: 2,
+        }
+    }
+
+    pub const fn off(pin: u8) -> Self {
+        Self::new(pin, 0)
+    }
+
+    pub const fn full(pin: u8) -> Self {
+        Self::new(pin, u16::MAX)
     }
 }
 
@@ -954,6 +981,43 @@ pub fn write_time_sleep_ms_module(
     Ok(offset)
 }
 
+pub fn write_pwm_write_code(program: PwmWriteProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if out.len() < PWM_WRITE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.pin)?;
+    write_push_u16(out, &mut offset, program.duty)?;
+    write_call_u8(out, &mut offset, CAP_PWM_WRITE)?;
+    write_u8(out, &mut offset, OP_HALT)?;
+    Ok(offset)
+}
+
+pub fn write_pwm_write_module(
+    program: PwmWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < PWM_WRITE_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; PWM_WRITE_CODE_LEN];
+    let code_len = write_pwm_write_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(0, program.max_stack, &code[..code_len]),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_pwm(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_led_matrix_frame_code(
     program: LedMatrixFrameProgram,
     out: &mut [u8],
@@ -1103,7 +1167,7 @@ mod tests {
     use super::*;
     use board_vm_ir::{
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
-        CAP_LED_MATRIX_FRAME,
+        CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -1142,6 +1206,10 @@ mod tests {
     ];
     const TIME_SLEEP_MS_MODULE_HEX: [u8; TIME_SLEEP_MS_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x05, 0x13, 0xFA, 0x00, 0x40, 0x10, 0x00,
+    ];
+    const PWM_WRITE_HALF_MODULE_HEX: [u8; PWM_WRITE_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x02, 0x00, 0x08, 0x12, 0x03, 0x13, 0x00, 0x80, 0x40,
+        0x20, 0x00, 0x00,
     ];
     const LED_MATRIX_HEART_MODULE_HEX: [u8; LED_MATRIX_FRAME_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x12, 0x14, 0x44, 0xA4, 0x84, 0x31, 0x14,
@@ -1287,6 +1355,20 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_LED_MATRIX_FRAME]);
+    }
+
+    #[test]
+    fn builds_pwm_write_module() {
+        let mut module = [0u8; PWM_WRITE_MODULE_LEN];
+        let len = write_pwm_write_module(PwmWriteProgram::new(3, 0x8000), &mut module).unwrap();
+        assert_eq!(len, PWM_WRITE_MODULE_LEN);
+        assert_eq!(module, PWM_WRITE_HALF_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_pwm(), 2).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_PWM_WRITE]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -16,6 +16,7 @@ pub const CAP_GPIO_READ: u16 = 0x03;
 pub const CAP_GPIO_CLOSE: u16 = 0x04;
 pub const CAP_TIME_SLEEP_MS: u16 = 0x10;
 pub const CAP_TIME_NOW_MS: u16 = 0x11;
+pub const CAP_PWM_WRITE: u16 = 0x20;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -24,6 +25,7 @@ const CAP_GPIO_READ_U8: u8 = CAP_GPIO_READ as u8;
 const CAP_GPIO_CLOSE_U8: u8 = CAP_GPIO_CLOSE as u8;
 const CAP_TIME_SLEEP_MS_U8: u8 = CAP_TIME_SLEEP_MS as u8;
 const CAP_TIME_NOW_MS_U8: u8 = CAP_TIME_NOW_MS as u8;
+const CAP_PWM_WRITE_U8: u8 = CAP_PWM_WRITE as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,6 +98,7 @@ pub struct Module<'a> {
 pub struct CapabilitySet {
     pub gpio_digital: bool,
     pub time: bool,
+    pub pwm: bool,
     pub led_matrix: bool,
 }
 
@@ -104,6 +107,7 @@ impl CapabilitySet {
         Self {
             gpio_digital: false,
             time: false,
+            pwm: false,
             led_matrix: false,
         }
     }
@@ -112,8 +116,13 @@ impl CapabilitySet {
         Self {
             gpio_digital: true,
             time: true,
+            pwm: false,
             led_matrix: false,
         }
+    }
+
+    pub const fn with_pwm(self) -> Self {
+        Self { pwm: true, ..self }
     }
 
     pub const fn with_led_matrix(self) -> Self {
@@ -127,6 +136,7 @@ impl CapabilitySet {
         match capability_id {
             CAP_GPIO_OPEN | CAP_GPIO_WRITE | CAP_GPIO_READ | CAP_GPIO_CLOSE => self.gpio_digital,
             CAP_TIME_SLEEP_MS | CAP_TIME_NOW_MS => self.time,
+            CAP_PWM_WRITE => self.pwm,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -359,6 +369,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_GPIO_CLOSE_U8) | Op::CallU16(CAP_GPIO_CLOSE) => (1, 0),
         Op::CallU8(CAP_TIME_SLEEP_MS_U8) | Op::CallU16(CAP_TIME_SLEEP_MS) => (1, 0),
         Op::CallU8(CAP_TIME_NOW_MS_U8) | Op::CallU16(CAP_TIME_NOW_MS) => (0, 1),
+        Op::CallU8(CAP_PWM_WRITE_U8) | Op::CallU16(CAP_PWM_WRITE) => (2, 0),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -511,6 +522,36 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_LED_MATRIX_FRAME]);
+    }
+
+    #[test]
+    fn validates_pwm_write_capability() {
+        let module = Module {
+            flags: 0,
+            max_stack: 2,
+            code: &[0x12, 3, 0x13, 0x00, 0x80, 0x40, CAP_PWM_WRITE as u8],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_pwm(), 2).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_PWM_WRITE]);
+    }
+
+    #[test]
+    fn rejects_pwm_write_without_capability() {
+        let module = Module {
+            flags: 0,
+            max_stack: 2,
+            code: &[0x12, 3, 0x13, 0x00, 0x80, 0x40, CAP_PWM_WRITE as u8],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 2),
+            Err(ValidateError::UnsupportedCapability(CAP_PWM_WRITE))
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -37,13 +37,14 @@ use board_vm_esp_rom::{
 use board_vm_host::{
     write_blink_module, write_gpio_handle_close_module, write_gpio_handle_read_module,
     write_gpio_handle_write_module, write_gpio_open_module, write_gpio_read_module,
-    write_gpio_write_module, write_led_matrix_frame_module, write_module, write_time_now_module,
-    write_time_sleep_ms_module, BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram,
-    GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError,
-    HostSession, LedMatrixFrameProgram, ModuleSpec, TimeNowProgram, TimeSleepMsProgram,
-    BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
-    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
-    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
+    write_gpio_write_module, write_led_matrix_frame_module, write_module, write_pwm_write_module,
+    write_time_now_module, write_time_sleep_ms_module, BlinkProgram, GpioHandleCloseProgram,
+    GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
+    GpioWriteProgram, HostError, HostSession, LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram,
+    TimeNowProgram, TimeSleepMsProgram, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
+    DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN,
+    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
+    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
     TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
@@ -1579,6 +1580,13 @@ pub fn build_led_matrix_frame_module(
     Ok(write_led_matrix_frame_module(program, out)?)
 }
 
+pub fn build_pwm_write_module(
+    program: PwmWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_pwm_write_module(program, out)?)
+}
+
 pub fn build_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2219,6 +2227,31 @@ pub unsafe extern "C" fn board_vm_language_led_matrix_frame_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_pwm_write_module(
+    pin: u8,
+    duty: u16,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_pwm_write_module(
+            PwmWriteProgram {
+                pin,
+                duty,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2524,6 +2557,11 @@ pub extern "C" fn board_vm_language_time_sleep_ms_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_pwm_write_module_len() -> u64 {
+    PWM_WRITE_MODULE_LEN as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_led_matrix_frame_module_len() -> u64 {
     LED_MATRIX_FRAME_MODULE_LEN as u64
 }
@@ -2747,6 +2785,7 @@ mod tests {
         assert!(uno_d3.supports_pwm);
         assert!(uno_d3.supports_interrupt);
         assert!(!uno_d3.supports_adc);
+        assert!(uno.capabilities.contains(&"pwm.write".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -3513,6 +3552,19 @@ mod tests {
         };
         assert_eq!(led_matrix_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(led_matrix_status.len, LED_MATRIX_FRAME_MODULE_LEN as u64);
+
+        let mut pwm_module = [0u8; PWM_WRITE_MODULE_LEN];
+        let pwm_status = unsafe {
+            board_vm_language_pwm_write_module(
+                3,
+                0x8000,
+                2,
+                pwm_module.as_mut_ptr(),
+                pwm_module.len() as u64,
+            )
+        };
+        assert_eq!(pwm_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(pwm_status.len, PWM_WRITE_MODULE_LEN as u64);
 
         let mut gpio_read_module = [0u8; GPIO_READ_MODULE_LEN];
         let gpio_read_status = unsafe {

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -2,7 +2,7 @@
 
 use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ,
-    CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,6 +60,10 @@ pub trait BoardHal {
 
     fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError>;
     fn now_ms(&self) -> u32;
+
+    fn pwm_write(&mut self, _pin: u16, _duty: u16) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
 
     fn led_matrix_frame(&mut self, _frame: [u32; 3]) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
@@ -392,6 +396,14 @@ where
                 let now = self.hal.now_ms();
                 self.push(Value::U32(now), ip)
             }
+            CAP_PWM_WRITE => {
+                let duty = self.pop_u16(ip)?;
+                let pin = self.pop_u16(ip)?;
+                self.hal.pwm_write(pin, duty).map_err(|err| RuntimeError {
+                    ip,
+                    kind: hal_error_kind(err),
+                })
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -622,6 +634,7 @@ mod tests {
         Open(u16, GpioMode),
         Write(u32, Level),
         Sleep(u16),
+        PwmWrite(u16, u16),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -641,7 +654,7 @@ mod tests {
 
     impl BoardHal for FakeHal {
         fn capabilities(&self) -> CapabilitySet {
-            CapabilitySet::blink_mvp().with_led_matrix()
+            CapabilitySet::blink_mvp().with_pwm().with_led_matrix()
         }
 
         fn gpio_open(&mut self, pin: u16, mode: GpioMode) -> Result<u32, HalError> {
@@ -670,6 +683,11 @@ mod tests {
 
         fn now_ms(&self) -> u32 {
             self.now_ms
+        }
+
+        fn pwm_write(&mut self, pin: u16, duty: u16) -> Result<(), HalError> {
+            self.events.push(Event::PwmWrite(pin, duty));
+            Ok(())
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -772,5 +790,16 @@ mod tests {
                 0x100A_0040,
             ])]
         );
+    }
+
+    #[test]
+    fn pwm_write_dispatches_pin_and_normalized_duty() {
+        let mut runtime: Runtime<FakeHal, 4, 1> = Runtime::new(FakeHal::new());
+        let code = [0x12, 3, 0x13, 0x00, 0x80, 0x40, CAP_PWM_WRITE as u8, 0x00];
+
+        let report = runtime.run_code(&code, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(runtime.hal().events, vec![Event::PwmWrite(3, 0x8000)]);
     }
 }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -99,7 +99,19 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 12] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 9] = [
+    "transport.serial",
+    "gpio.open",
+    "gpio.write",
+    "gpio.read",
+    "gpio.close",
+    "time.sleep_ms",
+    "time.now_ms",
+    "pwm.write",
+    "program.ram_exec",
+];
+
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 13] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -110,6 +122,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 12] = [
     "gpio.close",
     "time.sleep_ms",
     "time.now_ms",
+    "pwm.write",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -320,7 +333,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         digital_pin_count: UNO_R4_DIGITAL_PINS.len(),
         digital_pins: &UNO_R4_DIGITAL_PINS,
         wireless: &[],
-        capabilities: &BLINK_MVP_CAPABILITIES,
+        capabilities: &UNO_R4_MINIMA_CAPABILITIES,
     },
     BoardTargetInfo {
         board_id: board_vm_uno_r4::UNO_R4_WIFI.board_id,
@@ -504,6 +517,10 @@ mod tests {
         assert!(pico.capabilities.contains(&"transport.serial"));
         assert!(pico.capabilities.contains(&"gpio.open"));
         assert!(pico.capabilities.contains(&"program.ram_exec"));
+        assert!(!pico.capabilities.contains(&"pwm.write"));
+
+        let uno = find_target("arduino-uno-r4-wifi").unwrap();
+        assert!(uno.capabilities.contains(&"pwm.write"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -2,7 +2,8 @@
 
 use board_vm_device::{
     BoardVmDevice, DeviceDescriptor, BLINK_MVP_CAPABILITIES,
-    BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES, DEFAULT_MAX_FRAME_PAYLOAD,
+    BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_CAPABILITIES, DEFAULT_MAX_FRAME_PAYLOAD,
 };
 use board_vm_ir::CapabilitySet;
 use board_vm_runtime::{BoardHal, GpioMode, HalError, Level};
@@ -178,7 +179,7 @@ pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     onboard_led_pin: UNO_R4_ONBOARD_LED_PIN,
     supports_wifi_module: false,
     supports_led_matrix: false,
-    capabilities: CapabilitySet::blink_mvp(),
+    capabilities: CapabilitySet::blink_mvp().with_pwm(),
     digital_pins: &UNO_R4_DIGITAL_PINS,
 };
 
@@ -198,7 +199,7 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
     onboard_led_pin: UNO_R4_ONBOARD_LED_PIN,
     supports_wifi_module: true,
     supports_led_matrix: true,
-    capabilities: CapabilitySet::blink_mvp().with_led_matrix(),
+    capabilities: CapabilitySet::blink_mvp().with_pwm().with_led_matrix(),
     digital_pins: &UNO_R4_DIGITAL_PINS,
 };
 
@@ -209,7 +210,15 @@ pub trait UnoR4Backend {
     fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError>;
     fn now_ms(&self) -> u32;
 
+    fn supports_pwm(&self) -> bool {
+        false
+    }
+
     fn led_matrix_frame(&mut self, _frame: [u32; 3]) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn write_pwm(&mut self, _pin: u8, _duty: u16) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
 }
@@ -251,8 +260,16 @@ where
     }
 
     pub fn into_device(self, board_nonce: u32) -> UnoR4Device<B> {
-        let descriptor = uno_r4_device_descriptor(self.target, board_nonce);
+        let capabilities = self.resolved_capabilities();
+        let descriptor =
+            uno_r4_device_descriptor_for_capabilities(self.target, board_nonce, capabilities);
         BoardVmDevice::new(descriptor, self)
+    }
+
+    fn resolved_capabilities(&self) -> CapabilitySet {
+        let mut capabilities = self.target.capabilities;
+        capabilities.pwm = self.backend.supports_pwm();
+        capabilities
     }
 }
 
@@ -261,7 +278,7 @@ where
     B: UnoR4Backend,
 {
     fn capabilities(&self) -> CapabilitySet {
-        self.target.capabilities
+        self.resolved_capabilities()
     }
 
     fn gpio_open(&mut self, pin: u16, mode: GpioMode) -> Result<u32, HalError> {
@@ -292,6 +309,11 @@ where
         self.backend.now_ms()
     }
 
+    fn pwm_write(&mut self, pin: u16, duty: u16) -> Result<(), HalError> {
+        let pin = normalize_pwm_pin(pin)?;
+        self.backend.write_pwm(pin, duty)
+    }
+
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
         if !self.target.supports_led_matrix {
             return Err(HalError::UnsupportedMode);
@@ -310,9 +332,26 @@ pub fn is_valid_digital_pin(pin: u16) -> bool {
     pin <= 13
 }
 
+fn normalize_pwm_pin(pin: u16) -> Result<u8, HalError> {
+    let pin = normalize_digital_pin(pin)?;
+    match digital_pin(pin) {
+        Some(descriptor) if descriptor.supports_pwm => Ok(pin),
+        Some(_) => Err(HalError::UnsupportedMode),
+        None => Err(HalError::InvalidPin),
+    }
+}
+
 pub fn uno_r4_device_descriptor(
     target: &'static TargetDescriptor,
     board_nonce: u32,
+) -> DeviceDescriptor<'static> {
+    uno_r4_device_descriptor_for_capabilities(target, board_nonce, target.capabilities)
+}
+
+fn uno_r4_device_descriptor_for_capabilities(
+    target: &'static TargetDescriptor,
+    board_nonce: u32,
+    capabilities: CapabilitySet,
 ) -> DeviceDescriptor<'static> {
     DeviceDescriptor {
         board_id: target.board_id,
@@ -320,8 +359,12 @@ pub fn uno_r4_device_descriptor(
         board_nonce,
         max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
         supports_store_program: false,
-        capabilities: if target.supports_led_matrix {
+        capabilities: if target.supports_led_matrix && capabilities.pwm {
+            &BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_led_matrix {
             &BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES
+        } else if capabilities.pwm {
+            &BLINK_MVP_WITH_PWM_CAPABILITIES
         } else {
             &BLINK_MVP_CAPABILITIES
         },
@@ -375,6 +418,7 @@ mod tests {
         Configure(u8, GpioMode),
         Write(u8, Level),
         Sleep(u16),
+        PwmWrite(u8, u16),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -415,6 +459,15 @@ mod tests {
 
         fn now_ms(&self) -> u32 {
             self.now_ms
+        }
+
+        fn supports_pwm(&self) -> bool {
+            true
+        }
+
+        fn write_pwm(&mut self, pin: u8, duty: u16) -> Result<(), HalError> {
+            self.events.push(Event::PwmWrite(pin, duty));
+            Ok(())
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -478,8 +531,14 @@ mod tests {
         assert_eq!(descriptor.max_frame_payload, DEFAULT_MAX_FRAME_PAYLOAD);
         assert_eq!(
             descriptor.capabilities.len(),
-            BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES.len()
+            BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES.len()
         );
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_PWM_WRITE));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_PWM_WRITE));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -503,6 +562,22 @@ mod tests {
                 0x100A_0040,
             ])]
         );
+    }
+
+    #[test]
+    fn pwm_write_runs_through_pwm_pin_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+        board.pwm_write(3, 0x8000).unwrap();
+
+        assert_eq!(board.backend().events, vec![Event::PwmWrite(3, 0x8000)]);
+    }
+
+    #[test]
+    fn pwm_write_rejects_non_pwm_pin() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(board.pwm_write(2, 0x8000), Err(HalError::UnsupportedMode));
+        assert_eq!(board.pwm_write(99, 0x8000), Err(HalError::InvalidPin));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds the first Board VM PWM execution slice.

- Adds a new bytecode capability, `pwm.write`, with stack validation, required-capability collection, runtime dispatch, and a host-side module builder.
- Models PWM duty as a normalized `u16` value, so language frontends and future board backends share one VM-level contract.
- Extends UNO R4 target metadata so PWM-capable digital pins are visible from the Rust-owned target registry.
- Adds thin Ruby helpers for building, uploading, and running `pwm.write` modules from the session/connection APIs.
- Keeps live device capability reports honest: the UNO R4 WiFi firmware backend does not advertise `pwm.write` until the physical PWM backend is actually wired.

## Important Hardware Status

This PR does not yet drive a physical PWM pin on the UNO R4 WiFi.

The VM instruction, protocol-facing capability, host builder, target metadata, and Ruby API are in place. The current physical UNO R4 WiFi firmware backend still supports D13 GPIO and the LED matrix; it intentionally reports `pwm.write` only if a backend implementation claims PWM support. That keeps Ruby/host code from believing hardware PWM is available before the firmware backend can execute it.

The follow-up slice should wire the actual UNO R4 WiFi PWM backend, likely by using the Arduino Renesas core's PWM/`analogWrite` path or an equivalent Rust-owned RA4M1 timer implementation.

## Validation

- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware` in `code/packages/rust`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `cargo test -p board-vm-uno-r4-firmware` in `code/packages/rust`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `bundle exec rake test` in `code/packages/ruby/board_vm`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
