### PR TITLE
feat(lang39): LANG39 — AOT global variable support (__DATA section + ARM64 relocations)

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog — `aarch64-backend`
 
+## 0.2.1 — 2026-05-13 (LANG39)
+
+**Global variable load / store lowering.**
+
+Wires the `global_load` and `global_store` CIR opcodes into the dispatch table.
+
+### New CIR opcodes handled
+
+| CIR opcode | ARM64 sequence | Notes |
+|------------|----------------|-------|
+| `global_load Var(name)` | `ADRP X1 + ADD X1 + LDR X0 + STR X0` | 4 instructions; reads from `_twig_globals[slot*8]` |
+| `global_store Var(name), val` | `LDR X0 + ADRP X1 + ADD X1 + STR X0` | 4 instructions; writes to `_twig_globals[slot*8]` |
+
+### New public API
+
+- `compile_with_globals(ctx, ir, global_slots) → (bytes, ExternalRelocs, GlobalWordRelocs)` —
+  like `compile_with_relocs` but also accepts a `HashMap<String, usize>` mapping global names
+  to slot indices and returns `Vec<GlobalWordReloc>` for Mach-O ARM64 relocation emission.
+
+- `GlobalWordReloc { adrp_word: usize, add_word: usize }` — word-index pair for one
+  `ARM64_RELOC_PAGE21` + `ARM64_RELOC_PAGEOFF12` relocation site.
+
+### Implementation notes
+
+- The ADRP and ADD are placeholder instructions (`ADRP Xd, #0` / `ADD X1, X1, #0`);
+  the system linker patches the immediates when producing the final executable.
+- The LDR/STR slot offset (`slot * 8`) is baked in at compile time.
+- 5 new unit tests cover the opcode handlers, slot offset encoding, error handling,
+  and multi-global reloc counting.
+
 ## 0.2.0 — 2026-05-13 (LANG38)
 
 **Division, modulo, bitwise logic, shifts, negate, and bitwise-NOT lowering.**

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -666,7 +666,25 @@ fn emit_instr(
         global_relocs.push(GlobalWordReloc { adrp_word, add_word });
 
         // LDR X0, [X1, #slot*8]
-        let byte_offset = (slot * 8) as u32;
+        //
+        // Guard against slot indices that would overflow the ARM64 12-bit
+        // unsigned offset field.  For 64-bit (8-byte) accesses the LDR
+        // immediate is encoded in units of 8, so the maximum representable
+        // offset is 0xFFF * 8 = 32,760 bytes → 4,095 slots.  Silently
+        // truncating a large slot to u32 would produce a machine instruction
+        // that reads from the wrong address at runtime.
+        const MAX_GLOBAL_SLOT: usize = 4_095;
+        if slot > MAX_GLOBAL_SLOT {
+            return Err(BackendError::MalformedInstr(format!(
+                "global_load: slot index {slot} exceeds ARM64 12-bit LDR offset limit \
+                 (max {MAX_GLOBAL_SLOT} slots)"
+            )));
+        }
+        let byte_offset: u32 = (slot * 8)
+            .try_into()
+            .map_err(|_| BackendError::MalformedInstr(
+                format!("global_load: slot byte offset overflows u32 (slot={slot})")
+            ))?;
         asm.ldr(Reg::X0, Reg::X1, byte_offset)?;
 
         // Spill to dest's stack slot
@@ -708,7 +726,20 @@ fn emit_instr(
         global_relocs.push(GlobalWordReloc { adrp_word, add_word });
 
         // STR X0, [X1, #slot*8]
-        let byte_offset = (slot * 8) as u32;
+        //
+        // Same 4,095-slot limit as global_load — ARM64 12-bit unsigned offset.
+        const MAX_GLOBAL_SLOT_STORE: usize = 4_095;
+        if slot > MAX_GLOBAL_SLOT_STORE {
+            return Err(BackendError::MalformedInstr(format!(
+                "global_store: slot index {slot} exceeds ARM64 12-bit STR offset limit \
+                 (max {MAX_GLOBAL_SLOT_STORE} slots)"
+            )));
+        }
+        let byte_offset: u32 = (slot * 8)
+            .try_into()
+            .map_err(|_| BackendError::MalformedInstr(
+                format!("global_store: slot byte offset overflows u32 (slot={slot})")
+            ))?;
         asm.str_(Reg::X0, Reg::X1, byte_offset)?;
         // global_store has no dest.
         return Ok(());

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -19,8 +19,9 @@
 //! | Returns | `ret_<ty>`, `ret_void` |
 //! | Type guards | `type_assert` (lowered to `udf` trap — AOT has no deopt) |
 //! | Calls | `call` (direct + cross-function BL via external relocs) |
+//! | Globals | `global_load`, `global_store` (LANG39 — ADRP+ADD+LDR/STR via `_twig_globals`) |
 //! | Float, send, properties | **NOT YET** |
-//! | Closures, globals | **NOT YET** (LANG39/LANG40) |
+//! | Closures | **NOT YET** (LANG40) |
 //!
 //! Anything outside this list causes the backend to return `None`, which
 //! `aot-core` reports as a compile failure for that function (it falls
@@ -184,12 +185,42 @@ impl From<EncodeError> for BackendError {
 // Top-level compile() — stitches the prologue, body, and epilogue together
 // ===========================================================================
 
+// ===========================================================================
+// Global-variable relocation type (LANG39)
+// ===========================================================================
+
+/// Word-index positions of an ADRP+ADD instruction pair that references
+/// `_twig_globals` and needs two Mach-O ARM64 relocations:
+///
+/// - `adrp_word` → `ARM64_RELOC_PAGE21` on the `ADRP X1, #0` instruction.
+/// - `add_word`  → `ARM64_RELOC_PAGEOFF12` on the `ADD X1, X1, #0` instruction.
+///
+/// Both word indices are relative to the **start of this function's** byte
+/// output.  `twig-aot` converts them to byte offsets in the fully-linked
+/// text section by adding the function's byte offset.
+///
+/// # Example
+///
+/// If `global_load` for slot 2 is the 7th instruction in a function, `adrp_word`
+/// will be 7 and `add_word` will be 8 (they are always adjacent).
+#[derive(Debug, Clone, Copy)]
+pub struct GlobalWordReloc {
+    /// Word index of the `ADRP X1, #0` placeholder.
+    pub adrp_word: usize,
+    /// Word index of the `ADD X1, X1, #0` placeholder.
+    pub add_word: usize,
+}
+
+// ===========================================================================
+// Public compile entry points
+// ===========================================================================
+
 /// Public-ish entry point used by tests.  Production callers go through
 /// the `Backend` trait.  Relocations are silently discarded; use
 /// [`compile_with_relocs`] when you need them for AOT cross-function linking.
 pub fn compile(ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Result<Vec<u8>, String> {
-    compile_inner(ctx, ir)
-        .map(|(bytes, _relocs)| bytes)
+    compile_inner(ctx, ir, &HashMap::new())
+        .map(|(bytes, _ext, _glob)| bytes)
         .map_err(|e| format!("aarch64-backend: {e:?}"))
 }
 
@@ -203,10 +234,36 @@ pub fn compile_with_relocs(
     ctx: &FunctionContext<'_>,
     ir: &[CIRInstr],
 ) -> Result<(Vec<u8>, Vec<ExternalReloc>), String> {
-    compile_inner(ctx, ir).map_err(|e| format!("aarch64-backend: {e:?}"))
+    compile_inner(ctx, ir, &HashMap::new())
+        .map(|(bytes, ext, _glob)| (bytes, ext))
+        .map_err(|e| format!("aarch64-backend: {e:?}"))
 }
 
-fn compile_inner(ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Result<(Vec<u8>, Vec<ExternalReloc>), BackendError> {
+/// Like [`compile_with_relocs`] but also handles `global_load`/`global_store`
+/// CIR instructions using the provided slot map.
+///
+/// `global_slots` maps each global name (as it appears in `srcs[0].as_var()`)
+/// to a zero-based slot index.  Slot `i` corresponds to bytes `[i*8, i*8+8)`
+/// in the `_twig_globals` data section.
+///
+/// Returns the function's machine code bytes, any cross-function `BL`
+/// relocation entries, and a list of [`GlobalWordReloc`] entries — one per
+/// `global_load` / `global_store` instruction — that the Mach-O packager uses
+/// to emit `ARM64_RELOC_PAGE21` / `ARM64_RELOC_PAGEOFF12` records.
+pub fn compile_with_globals(
+    ctx: &FunctionContext<'_>,
+    ir: &[CIRInstr],
+    global_slots: &HashMap<String, usize>,
+) -> Result<(Vec<u8>, Vec<ExternalReloc>, Vec<GlobalWordReloc>), String> {
+    compile_inner(ctx, ir, global_slots)
+        .map_err(|e| format!("aarch64-backend: {e:?}"))
+}
+
+fn compile_inner(
+    ctx: &FunctionContext<'_>,
+    ir: &[CIRInstr],
+    global_slots: &HashMap<String, usize>,
+) -> Result<(Vec<u8>, Vec<ExternalReloc>, Vec<GlobalWordReloc>), BackendError> {
     if ctx.params.len() > 8 {
         return Err(BackendError::TooManyParams(ctx.params.len()));
     }
@@ -295,8 +352,10 @@ fn compile_inner(ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Result<(Vec<u8>,
     }
 
     // ---- Body ------------------------------------------------------------
+    let mut global_relocs: Vec<GlobalWordReloc> = Vec::new();
     for instr in ir {
-        emit_instr(&mut asm, instr, &mut alloc, &labels, frame, ctx.name)?;
+        emit_instr(&mut asm, instr, &mut alloc, &labels, frame, ctx.name,
+                   global_slots, &mut global_relocs)?;
     }
 
     // ---- Final epilogue (only reached if the function falls off the end) -
@@ -307,7 +366,7 @@ fn compile_inner(ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Result<(Vec<u8>,
 
     let external_relocs = std::mem::take(&mut asm.external_relocs);
     let bytes = asm.finish().map_err(BackendError::from)?;
-    Ok((bytes, external_relocs))
+    Ok((bytes, external_relocs, global_relocs))
 }
 
 // ===========================================================================
@@ -321,6 +380,8 @@ fn emit_instr(
     labels: &HashMap<String, LabelId>,
     frame: u32,
     fn_name: &str,
+    global_slots: &HashMap<String, usize>,
+    global_relocs: &mut Vec<GlobalWordReloc>,
 ) -> Result<(), BackendError> {
     let op = instr.op.as_str();
 
@@ -572,6 +633,84 @@ fn emit_instr(
         asm.mvn(Reg::X0, Reg::X0);
         let slot = alloc.slot_of(dest);
         asm.str_(Reg::X0, Reg::Sp, slot)?;
+        return Ok(());
+    }
+
+    // ---- global_load Str("name") → dest  (LANG39) -------------------------
+    //
+    // Materialise the address of `_twig_globals` via ADRP+ADD (to be patched
+    // by the Mach-O linker), then load the 8-byte value at slot*8.
+    //
+    // CIR encoding after aot_specialise:
+    //   srcs[0] = Var("name")  (Str("name") was lifted to Var by CIROperand::From)
+    //   dest    = Some("%v")
+    //
+    // ARM64 sequence (4 instructions):
+    //   ADRP X1, _twig_globals@PAGE    ; placeholder, patched by ld
+    //   ADD  X1, X1, _twig_globals@PAGEOFF ; placeholder, patched by ld
+    //   LDR  X0, [X1, #slot*8]         ; load value from global slot
+    //   STR  X0, [SP, #dest_slot]      ; spill to stack frame
+    if op == "global_load" {
+        let name = instr.srcs.first().and_then(CIROperand::as_var)
+            .ok_or_else(|| BackendError::MalformedInstr("global_load: srcs[0] must be Var(name)".into()))?;
+        let slot = global_slots.get(name)
+            .copied()
+            .ok_or_else(|| BackendError::MalformedInstr(format!("global_load: unknown global '{name}'")))?;
+        let dest = require_dest(instr)?;
+
+        // ADRP X1, #0  (ARM64_RELOC_PAGE21 target)
+        let adrp_word = asm.adrp_placeholder(Reg::X1);
+        // ADD  X1, X1, #0  (ARM64_RELOC_PAGEOFF12 target)
+        let add_word = asm.len_words();
+        asm.add_imm(Reg::X1, Reg::X1, 0)?;
+        global_relocs.push(GlobalWordReloc { adrp_word, add_word });
+
+        // LDR X0, [X1, #slot*8]
+        let byte_offset = (slot * 8) as u32;
+        asm.ldr(Reg::X0, Reg::X1, byte_offset)?;
+
+        // Spill to dest's stack slot
+        let d = alloc.slot_of(dest);
+        asm.str_(Reg::X0, Reg::Sp, d)?;
+        return Ok(());
+    }
+
+    // ---- global_store Str("name"), src  (LANG39) --------------------------
+    //
+    // Load the value from the stack frame, then store it into the global slot.
+    //
+    // CIR encoding:
+    //   srcs[0] = Var("name")   (global name, lifted from Str)
+    //   srcs[1] = Var("%v")     (value to write)
+    //
+    // ARM64 sequence (4 instructions):
+    //   LDR  X0, [SP, #val_slot]        ; load value from stack frame
+    //   ADRP X1, _twig_globals@PAGE     ; placeholder, patched by ld
+    //   ADD  X1, X1, _twig_globals@PAGEOFF ; placeholder, patched by ld
+    //   STR  X0, [X1, #slot*8]          ; write to global slot
+    if op == "global_store" {
+        let name = instr.srcs.first().and_then(CIROperand::as_var)
+            .ok_or_else(|| BackendError::MalformedInstr("global_store: srcs[0] must be Var(name)".into()))?;
+        let slot = global_slots.get(name)
+            .copied()
+            .ok_or_else(|| BackendError::MalformedInstr(format!("global_store: unknown global '{name}'")))?;
+        let val_src = instr.srcs.get(1)
+            .ok_or_else(|| BackendError::MalformedInstr("global_store: needs srcs[1]=value".into()))?;
+
+        // Load value from caller's stack slot into X0.
+        load_operand(asm, alloc, Reg::X0, val_src)?;
+
+        // ADRP X1, #0  (ARM64_RELOC_PAGE21 target)
+        let adrp_word = asm.adrp_placeholder(Reg::X1);
+        // ADD  X1, X1, #0  (ARM64_RELOC_PAGEOFF12 target)
+        let add_word = asm.len_words();
+        asm.add_imm(Reg::X1, Reg::X1, 0)?;
+        global_relocs.push(GlobalWordReloc { adrp_word, add_word });
+
+        // STR X0, [X1, #slot*8]
+        let byte_offset = (slot * 8) as u32;
+        asm.str_(Reg::X0, Reg::X1, byte_offset)?;
+        // global_store has no dest.
         return Ok(());
     }
 
@@ -1068,6 +1207,122 @@ mod tests {
         ];
         let bytes = compile(&ctx("fnot", &params, "i64"), &cir).expect("not_i64");
         assert!(bytes.len() > 0 && bytes.len() % 4 == 0);
+    }
+
+    // ---- LANG39: global_load / global_store ----
+
+    #[test]
+    fn global_store_emits_four_instructions() {
+        // global_store Var("x"), Var("v0")
+        // Sequence: LDR X0, [SP, #val_slot]; ADRP X1; ADD X1, X1, #0; STR X0, [X1, #0]
+        let mut slots: HashMap<String, usize> = HashMap::new();
+        slots.insert("x".into(), 0);
+
+        let cir = vec![
+            CIRInstr { op: "const_i64".into(), dest: Some("v0".into()),
+                       srcs: vec![CIROperand::Int(42)], ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "global_store".into(), dest: None,
+                       srcs: vec![CIROperand::Var("x".into()), CIROperand::Var("v0".into())],
+                       ty: "void".into(), deopt_to: None },
+            CIRInstr { op: "ret_void".into(), dest: None, srcs: vec![],
+                       ty: "void".into(), deopt_to: None },
+        ];
+        let (bytes, _ext, g_relocs) = compile_with_globals(
+            &ctx("f_gs", &[], "void"), &cir, &slots
+        ).expect("global_store must compile");
+        assert!(bytes.len() > 0 && bytes.len() % 4 == 0, "byte-aligned output");
+        assert_eq!(g_relocs.len(), 1, "one global_store → one GlobalWordReloc");
+        let r = g_relocs[0];
+        assert_eq!(r.add_word, r.adrp_word + 1, "ADD immediately follows ADRP");
+    }
+
+    #[test]
+    fn global_load_emits_four_instructions() {
+        // global_load Var("x") → v1
+        // Sequence: ADRP X1; ADD X1, X1, #0; LDR X0, [X1, #0]; STR X0, [SP, #dest_slot]
+        let mut slots: HashMap<String, usize> = HashMap::new();
+        slots.insert("x".into(), 0);
+
+        let cir = vec![
+            CIRInstr { op: "global_load".into(), dest: Some("v1".into()),
+                       srcs: vec![CIROperand::Var("x".into())],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "ret_i64".into(), dest: None,
+                       srcs: vec![CIROperand::Var("v1".into())],
+                       ty: "i64".into(), deopt_to: None },
+        ];
+        let (bytes, _ext, g_relocs) = compile_with_globals(
+            &ctx("f_gl", &[], "i64"), &cir, &slots
+        ).expect("global_load must compile");
+        assert!(bytes.len() > 0 && bytes.len() % 4 == 0, "byte-aligned output");
+        assert_eq!(g_relocs.len(), 1, "one global_load → one GlobalWordReloc");
+        let r = g_relocs[0];
+        assert_eq!(r.add_word, r.adrp_word + 1, "ADD immediately follows ADRP");
+    }
+
+    #[test]
+    fn global_load_stores_slot_offset_in_ldr() {
+        // Slot 2 → offset 16 bytes.  The LDR instruction word should have
+        // imm12=2 (16/8=2) in the [21:10] field of an F9400000-class instruction.
+        let mut slots: HashMap<String, usize> = HashMap::new();
+        slots.insert("y".into(), 2);
+
+        let cir = vec![
+            CIRInstr { op: "global_load".into(), dest: Some("v0".into()),
+                       srcs: vec![CIROperand::Var("y".into())],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "ret_i64".into(), dest: None,
+                       srcs: vec![CIROperand::Var("v0".into())],
+                       ty: "i64".into(), deopt_to: None },
+        ];
+        let (bytes, _, g_relocs) = compile_with_globals(
+            &ctx("f_slot", &[], "i64"), &cir, &slots
+        ).expect("compile ok");
+
+        let r = g_relocs[0];
+        // The LDR instruction is immediately after the ADD (r.add_word + 1).
+        let ldr_byte = (r.add_word + 1) * 4;
+        let ldr_word = u32::from_le_bytes(bytes[ldr_byte..ldr_byte+4].try_into().unwrap());
+        // LDR X0, [X1, #16]: 0xF9400000 | (imm12=2 << 10) | (X1=1 << 5) | X0=0
+        //   = 0xF9400000 | 0x800 | 0x20 | 0 = 0xF9400820
+        assert_eq!(ldr_word, 0xF9400820, "LDR X0,[X1,#16] for slot 2");
+    }
+
+    #[test]
+    fn global_store_unknown_name_errors() {
+        let slots: HashMap<String, usize> = HashMap::new(); // empty!
+        let cir = vec![
+            CIRInstr { op: "global_store".into(), dest: None,
+                       srcs: vec![CIROperand::Var("z".into()), CIROperand::Int(0)],
+                       ty: "void".into(), deopt_to: None },
+        ];
+        let result = compile_with_globals(&ctx("f_err", &[], "void"), &cir, &slots);
+        assert!(result.is_err(), "unknown global should error");
+    }
+
+    #[test]
+    fn two_globals_produce_two_relocs() {
+        let mut slots: HashMap<String, usize> = HashMap::new();
+        slots.insert("a".into(), 0);
+        slots.insert("b".into(), 1);
+
+        let cir = vec![
+            CIRInstr { op: "const_i64".into(), dest: Some("v0".into()),
+                       srcs: vec![CIROperand::Int(1)], ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "global_store".into(), dest: None,
+                       srcs: vec![CIROperand::Var("a".into()), CIROperand::Var("v0".into())],
+                       ty: "void".into(), deopt_to: None },
+            CIRInstr { op: "global_load".into(), dest: Some("v1".into()),
+                       srcs: vec![CIROperand::Var("b".into())],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "ret_i64".into(), dest: None,
+                       srcs: vec![CIROperand::Var("v1".into())],
+                       ty: "i64".into(), deopt_to: None },
+        ];
+        let (_, _, g_relocs) = compile_with_globals(
+            &ctx("f_two", &[], "i64"), &cir, &slots
+        ).expect("compile ok");
+        assert_eq!(g_relocs.len(), 2, "one reloc per global access");
     }
 
     #[test]

--- a/code/packages/rust/aarch64-encoder/CHANGELOG.md
+++ b/code/packages/rust/aarch64-encoder/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — `aarch64-encoder`
 
+## 0.2.1 — 2026-05-13 (LANG39)
+
+**PC-relative ADRP placeholder for Mach-O data-section relocations.**
+
+### New method
+
+| Method | ARM64 mnemonic | Purpose |
+|--------|---------------|---------|
+| `adrp_placeholder(rd) → usize` | `ADRP Xd, #0` | Emit a zeroed-immediate ADRP; returns word index for `ARM64_RELOC_PAGE21` relocation |
+
+`adrp_placeholder` is the first half of the ADRP+ADD address-materialisation
+pair used by `aarch64-backend` to access `_twig_globals` in the `__data`
+section.  The system linker patches the 21-bit `immhi:immlo` field at final
+link time.
+
+2 new unit tests verify the encoding and the returned word-index contract.
+
 ## 0.2.0 — 2026-05-13 (LANG38)
 
 **Integer division, bitwise logic, variable shifts, unary negate/NOT.**

--- a/code/packages/rust/aarch64-encoder/Cargo.toml
+++ b/code/packages/rust/aarch64-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-encoder"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Pure-Rust ARM64 (AArch64) instruction encoder — covers the subset needed by jit-core / aot-core to lower CIR to native machine code."
 

--- a/code/packages/rust/aarch64-encoder/src/lib.rs
+++ b/code/packages/rust/aarch64-encoder/src/lib.rs
@@ -25,6 +25,7 @@
 //! | Logical (reg) | `and_`, `orr`, `eor`, `mvn` | AND / OR / XOR / NOT (LANG38) |
 //! | Shifts (reg) | `lsl_reg`, `lsr_reg`, `asr_reg` | variable-amount logical/arithmetic shifts (LANG38) |
 //! | Unary | `neg_` | two's-complement negate (LANG38) |
+//! | PC-relative | `adrp_placeholder` | zeroed ADRP for Mach-O `ARM64_RELOC_PAGE21` (LANG39) |
 //! | Memory | `ldr`, `str_` | unsigned-offset, 64-bit |
 //! | Pair | `stp_pre`, `ldp_post` | for prologue/epilogue framing |
 //! | Branch | `b`, `b_cond`, `bl` | PC-relative, label-resolved |
@@ -648,6 +649,48 @@ impl Assembler {
             | (0b11111 << 5) // XZR = 31
             | rd.idx();
         self.emit(word);
+    }
+
+    // -----------------------------------------------------------------------
+    // PC-relative addressing — ADRP placeholder for Mach-O relocation
+    // -----------------------------------------------------------------------
+
+    /// Emit `ADRP Xd, #0` with a **zeroed** 21-bit page offset.
+    ///
+    /// This is a placeholder instruction: the caller records the returned word
+    /// index and passes it to `code-packager` as an `ARM64_RELOC_PAGE21`
+    /// relocation site.  The system linker (`ld`) then patches the 21-bit
+    /// `immhi:immlo` field with the correct page-relative offset when
+    /// producing the final executable.
+    ///
+    /// Together with an immediately following `ADD Xd, Xd, #0` (issued via
+    /// [`add_imm`](Self::add_imm)) carrying an `ARM64_RELOC_PAGEOFF12`
+    /// relocation, this pair gives the runtime address of any `__data` symbol:
+    ///
+    /// ```text
+    /// ADRP X1, sym@PAGE       ; bits[31:12] of sym's VA → X1
+    /// ADD  X1, X1, sym@PAGEOFF ; low 12 bits of sym's VA → X1
+    /// LDR  X0, [X1, #offset]  ; access sym + offset
+    /// ```
+    ///
+    /// # Encoding (ARM ARM DDI 0487 §C3.3.5)
+    ///
+    /// ```text
+    /// │ 1 │ immlo[1:0] │ 10000 │ immhi[20:2] │ Rd[4:0] │
+    ///   31   30:29       28:24    23:5           4:0
+    /// ```
+    ///
+    /// With all immediate bits zero: `0x90000000 | Rd`.
+    ///
+    /// # Returns
+    ///
+    /// The word index (not byte offset) of the emitted instruction.  Pass
+    /// `word_index * 4 + fn_byte_offset` to the Mach-O packager.
+    pub fn adrp_placeholder(&mut self, rd: Reg) -> usize {
+        let word_idx = self.code.len();
+        // ADRP Xd, #0  =  sf:1, immlo:00, opcode:10000, immhi:all-zero, Rd
+        self.emit(0x90000000 | rd.idx());
+        word_idx
     }
 
     // -----------------------------------------------------------------------
@@ -1418,6 +1461,41 @@ mod tests {
         let bytes = a.finish().unwrap();
         let word = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
         assert_eq!(word, 0xCB0103E0, "neg x0,x1");
+    }
+
+    // ---- LANG39: adrp_placeholder ----
+
+    #[test]
+    fn adrp_placeholder_encoding() {
+        // ADRP X0, #0 = sf:1, immlo:00, opcode:10000, immhi:0*19, Rd:00000
+        //             = 0x90000000 | 0 = 0x90000000
+        //
+        // ADRP X1, #0 = 0x90000001
+        //
+        // These are the placeholder words emitted before the system linker
+        // patches in the real page offset via ARM64_RELOC_PAGE21.
+        let mut a = Assembler::new();
+        let idx0 = a.adrp_placeholder(Reg::X0);
+        let idx1 = a.adrp_placeholder(Reg::X1);
+        let bytes = a.finish().unwrap();
+
+        let w0 = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let w1 = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert_eq!(w0, 0x90000000, "ADRP X0, #0");
+        assert_eq!(w1, 0x90000001, "ADRP X1, #0");
+        assert_eq!(idx0, 0, "ADRP X0 is word 0");
+        assert_eq!(idx1, 1, "ADRP X1 is word 1");
+    }
+
+    #[test]
+    fn adrp_placeholder_returns_word_index() {
+        // After emitting some instructions, adrp_placeholder reports the
+        // correct word index (not byte offset).
+        let mut a = Assembler::new();
+        a.movz(Reg::X0, 42, 0);   // word 0
+        a.movz(Reg::X0, 43, 0);   // word 1
+        let idx = a.adrp_placeholder(Reg::X1); // word 2
+        assert_eq!(idx, 2);
     }
 
     // ---- LANG38: Composite — modulo via sdiv + msub ----

--- a/code/packages/rust/code-packager/CHANGELOG.md
+++ b/code/packages/rust/code-packager/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this crate will be documented here.
 
+## [0.2.1] — 2026-05-13 (LANG39)
+
+### Added
+
+- **`GlobalByteReloc`** struct — byte-offset pair (`adrp_byte_offset`, `add_byte_offset`)
+  for one `ADRP + ADD` instruction pair that references `_twig_globals`.
+- **`pack_object_with_globals`** — extends `pack_object` to emit:
+  - A `__DATA/__data` section (zero-initialised global variable slots)
+  - An exported `_twig_globals` symbol pointing to the start of that section
+  - `ARM64_RELOC_PAGE21` + `ARM64_RELOC_PAGEOFF12` relocation records per
+    `GlobalByteReloc` so the system linker can patch `ADRP + ADD` pairs
+
+  Header layout: `312` bytes (vs 232 in `pack_object`) due to the second `section_64`.
+  ARM64-only (x86_64 global relocations are deferred).
+
+9 new unit tests verify the Mach-O layout, relocation record encoding, and
+output size formula.
+
 ## [0.2.0] — 2026-05-05
 
 ### Added

--- a/code/packages/rust/code-packager/Cargo.toml
+++ b/code/packages/rust/code-packager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-packager"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Cross-platform binary packaging for compiled code (LANG10) — Mach-O on Apple Silicon ships ad-hoc code-signed."
 license = "MIT"

--- a/code/packages/rust/code-packager/src/macho_object.rs
+++ b/code/packages/rust/code-packager/src/macho_object.rs
@@ -234,6 +234,306 @@ pub fn pack_object(artifact: &CodeArtifact) -> Result<Vec<u8>, PackagerError> {
 /// Conventional file extension for object files written by [`pack_object`].
 pub fn file_extension() -> &'static str { ".o" }
 
+// ── Global-variable support (LANG39) ─────────────────────────────────────────
+
+/// ARM64 relocation type codes (subset of `<mach-o/arm64/reloc.h>`).
+const ARM64_RELOC_PAGE21:    u32 = 1;
+const ARM64_RELOC_PAGEOFF12: u32 = 2;
+
+/// Byte offsets within the `__text` section of one `ADRP + ADD` instruction
+/// pair that must be patched by the system linker to address `_twig_globals`.
+///
+/// These correspond directly to [`aarch64_backend::GlobalWordReloc`] after
+/// converting word indices to byte offsets.
+///
+/// The Mach-O packager emits two relocation records per [`GlobalByteReloc`]:
+///
+/// 1. `ARM64_RELOC_PAGE21` at `adrp_byte_offset` — patches the 21-bit page
+///    offset in the `ADRP X1, #0` instruction.
+/// 2. `ARM64_RELOC_PAGEOFF12` at `add_byte_offset` — patches the 12-bit
+///    page-relative offset in the `ADD X1, X1, #0` instruction.
+///
+/// Both records reference the `_twig_globals` symbol (symbol table index 1).
+#[derive(Debug, Clone, Copy)]
+pub struct GlobalByteReloc {
+    /// Byte offset in the linked `__text` section of the `ADRP` instruction.
+    pub adrp_byte_offset: u32,
+    /// Byte offset in the linked `__text` section of the `ADD` instruction.
+    pub add_byte_offset:  u32,
+}
+
+// Header constant with two sections (for pack_object_with_globals).
+//
+// LC_SEGMENT_64 command with 2 sections = 72 + 2*80 = 232
+const LC_SEGMENT_TWO_SECTS: usize = LC_SEGMENT_SIZE + 2 * SECTION_SIZE;
+const HEADER_TOTAL_WITH_DATA: usize = MACH_HEADER_SIZE
+    + LC_SEGMENT_TWO_SECTS
+    + LC_BUILD_VERSION_SIZE
+    + LC_SYMTAB_SIZE; // = 312
+
+/// Like [`pack_object`] but also emits a `__DATA/__data` section that holds
+/// the Twig program's global variable slots, plus `ARM64_RELOC_PAGE21` /
+/// `ARM64_RELOC_PAGEOFF12` relocation records so the system linker can patch
+/// the `ADRP + ADD` address-materialisation pairs in the code.
+///
+/// # Parameters
+///
+/// - `text_bytes` — ARM64 machine code for the `__text` section.
+/// - `entry_point` — byte offset of `_main` within `text_bytes`.
+/// - `globals_n_slots` — number of 8-byte global variable slots.  The
+///   `__data` section will be `globals_n_slots * 8` bytes of zeroes.
+///   Pass `0` if there are no global accesses (the function degenerates to
+///   [`pack_object`] but with two sections and two symbols).
+/// - `text_relocs` — one [`GlobalByteReloc`] per `global_load`/`global_store`
+///   instruction across all compiled functions.
+/// - `target` — must be `macos` + `arm64` (x86_64 global support is NYI).
+///
+/// # Object-file layout
+///
+/// ```text
+/// 0              │ 312     │ Headers (mach_header_64 + LC_SEGMENT_64×2 + LC_BUILD_VERSION + LC_SYMTAB)
+/// 312            │ N       │ __text bytes
+/// 312+N          │ M       │ __data bytes (zero-initialised globals, M = globals_n_slots * 8)
+/// 312+N+M        │ 2*R*8   │ text relocation records (2 per global access = 2 × R × 8 bytes)
+/// 312+N+M+2*R*8  │ 32      │ 2 nlist_64 entries: _main (sect 1) + _twig_globals (sect 2)
+/// …              │ S       │ string table: "\0_main\0_twig_globals\0"
+/// ```
+///
+/// where `R = text_relocs.len()`.
+pub fn pack_object_with_globals(
+    text_bytes: &[u8],
+    entry_point: usize,
+    globals_n_slots: usize,
+    text_relocs: &[GlobalByteReloc],
+    target: &Target,
+) -> Result<Vec<u8>, PackagerError> {
+    if target.os != "macos" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "pack_object_with_globals expects os=macos, got {:?}", target.os
+        )));
+    }
+    if target.arch != "arm64" {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "pack_object_with_globals: ARM64 global relocations only; got arch {:?}", target.arch
+        )));
+    }
+    let (cputype, cpusubtype) = cpu_type(target)?;
+
+    let code_len   = text_bytes.len() as u64;
+    let data_len   = (globals_n_slots * 8) as u64;
+    let n_relocs   = text_relocs.len() as u32;     // each becomes 2 reloc records
+    let reloc_bytes = (n_relocs as u64) * 2 * 8;   // 8 bytes per relocation_info
+    let entry_off  = entry_point as u64;
+
+    if entry_off > code_len {
+        return Err(PackagerError::UnsupportedTarget(format!(
+            "pack_object_with_globals: entry_point {entry_off} exceeds text length {code_len}"
+        )));
+    }
+
+    // ── String table ─────────────────────────────────────────────────────────
+    //
+    // Layout: "\0_main\0_twig_globals\0"
+    //                                 ^-- symbol 1 n_strx = 1 (_main)
+    //                                             ^-- symbol 2 n_strx = 7 (_twig_globals)
+    const GLOBALS_SYMBOL: &str = "_twig_globals";
+    let strtab: Vec<u8> = {
+        let mut s = Vec::new();
+        s.push(0u8);                                // leading NUL (reserved)
+        s.extend_from_slice(ENTRY_SYMBOL.as_bytes()); // "_main"
+        s.push(0u8);
+        s.extend_from_slice(GLOBALS_SYMBOL.as_bytes()); // "_twig_globals"
+        s.push(0u8);
+        s
+    };
+    // n_strx for _twig_globals = 1 (skip leading NUL) + len("_main") + 1 (NUL)
+    let twig_globals_strx: u32 = 1 + ENTRY_SYMBOL.len() as u32 + 1;
+
+    // ── File-offset calculations ──────────────────────────────────────────────
+    let text_file_off  = HEADER_TOTAL_WITH_DATA as u64;
+    let data_file_off  = text_file_off + code_len;
+    let reloc_file_off = data_file_off + data_len;
+    let symtab_off     = reloc_file_off + reloc_bytes;
+    let strtab_off     = symtab_off + 2 * NLIST_64_SIZE as u64; // 2 symbols
+
+    let total_size: usize = strtab_off as usize + strtab.len();
+
+    // ── sizeofcmds ───────────────────────────────────────────────────────────
+    let sizeofcmds: u32 = (LC_SEGMENT_TWO_SECTS + LC_BUILD_VERSION_SIZE + LC_SYMTAB_SIZE) as u32;
+
+    let mut out: Vec<u8> = Vec::with_capacity(total_size);
+
+    // ── mach_header_64 ───────────────────────────────────────────────────────
+    out.extend_from_slice(&MH_MAGIC_64.to_le_bytes());
+    out.extend_from_slice(&cputype.to_le_bytes());
+    out.extend_from_slice(&cpusubtype.to_le_bytes());
+    out.extend_from_slice(&MH_OBJECT.to_le_bytes());
+    out.extend_from_slice(&3u32.to_le_bytes());          // ncmds = 3
+    out.extend_from_slice(&sizeofcmds.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());          // flags
+    out.extend_from_slice(&0u32.to_le_bytes());          // reserved
+    debug_assert_eq!(out.len(), MACH_HEADER_SIZE);
+
+    // ── LC_SEGMENT_64 (two sections: __text + __data) ─────────────────────
+    //
+    // In MH_OBJECT files the segment command has an empty segname and covers
+    // all sections.  The vmsize spans both sections back-to-back.
+    let segment_vmsize = code_len + data_len;
+    out.extend_from_slice(&LC_SEGMENT_64.to_le_bytes());
+    out.extend_from_slice(&(LC_SEGMENT_TWO_SECTS as u32).to_le_bytes()); // cmdsize
+    write_name16(&mut out, b"");                  // segname = empty
+    out.extend_from_slice(&0u64.to_le_bytes());   // vmaddr = 0
+    out.extend_from_slice(&segment_vmsize.to_le_bytes()); // vmsize
+    out.extend_from_slice(&text_file_off.to_le_bytes());  // fileoff = first section offset
+    out.extend_from_slice(&segment_vmsize.to_le_bytes()); // filesize
+    out.extend_from_slice(&7u32.to_le_bytes());   // maxprot  = rwx
+    out.extend_from_slice(&7u32.to_le_bytes());   // initprot = rwx
+    out.extend_from_slice(&2u32.to_le_bytes());   // nsects = 2
+    out.extend_from_slice(&0u32.to_le_bytes());   // flags
+
+    // ── section_64: __text / __TEXT ─────────────────────────────────────────
+    //
+    // reloff points to the relocation records that follow the data section.
+    write_name16(&mut out, b"__text");
+    write_name16(&mut out, b"__TEXT");
+    out.extend_from_slice(&0u64.to_le_bytes());          // addr = 0 (relocatable)
+    out.extend_from_slice(&code_len.to_le_bytes());       // size
+    out.extend_from_slice(&(text_file_off as u32).to_le_bytes()); // offset
+    out.extend_from_slice(&4u32.to_le_bytes());           // align = 2^4 = 16
+    // reloff = file offset of our relocation records
+    out.extend_from_slice(&(reloc_file_off as u32).to_le_bytes());
+    // nreloc = 2 records per GlobalByteReloc (PAGE21 + PAGEOFF12)
+    out.extend_from_slice(&(n_relocs * 2).to_le_bytes());
+    out.extend_from_slice(&SECTION_FLAGS_CODE.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());           // reserved1
+    out.extend_from_slice(&0u32.to_le_bytes());           // reserved2
+    out.extend_from_slice(&0u32.to_le_bytes());           // reserved3
+
+    // ── section_64: __data / __DATA ─────────────────────────────────────────
+    //
+    // Zero-initialised mutable data holding global variable slots.
+    // No relocations in the data section itself.
+    write_name16(&mut out, b"__data");
+    write_name16(&mut out, b"__DATA");
+    out.extend_from_slice(&code_len.to_le_bytes());  // addr = immediately after __text
+    out.extend_from_slice(&data_len.to_le_bytes());  // size = n_slots * 8
+    out.extend_from_slice(&(data_file_off as u32).to_le_bytes()); // offset
+    out.extend_from_slice(&3u32.to_le_bytes());       // align = 2^3 = 8 (64-bit slots)
+    out.extend_from_slice(&0u32.to_le_bytes());       // reloff = 0 (no data relocs)
+    out.extend_from_slice(&0u32.to_le_bytes());       // nreloc = 0
+    out.extend_from_slice(&0u32.to_le_bytes());       // flags = S_REGULAR (plain data)
+    out.extend_from_slice(&0u32.to_le_bytes());       // reserved1
+    out.extend_from_slice(&0u32.to_le_bytes());       // reserved2
+    out.extend_from_slice(&0u32.to_le_bytes());       // reserved3
+
+    debug_assert_eq!(out.len(), MACH_HEADER_SIZE + LC_SEGMENT_TWO_SECTS);
+
+    // ── LC_BUILD_VERSION ─────────────────────────────────────────────────────
+    out.extend_from_slice(&LC_BUILD_VERSION.to_le_bytes());
+    out.extend_from_slice(&(LC_BUILD_VERSION_SIZE as u32).to_le_bytes());
+    out.extend_from_slice(&PLATFORM_MACOS.to_le_bytes());
+    out.extend_from_slice(&MIN_OS_VERSION.to_le_bytes());
+    out.extend_from_slice(&SDK_VERSION.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());       // ntools
+
+    // ── LC_SYMTAB ────────────────────────────────────────────────────────────
+    out.extend_from_slice(&LC_SYMTAB.to_le_bytes());
+    out.extend_from_slice(&(LC_SYMTAB_SIZE as u32).to_le_bytes());
+    out.extend_from_slice(&(symtab_off as u32).to_le_bytes());    // symoff
+    out.extend_from_slice(&2u32.to_le_bytes());                   // nsyms = 2
+    out.extend_from_slice(&(strtab_off as u32).to_le_bytes());    // stroff
+    out.extend_from_slice(&(strtab.len() as u32).to_le_bytes());  // strsize
+
+    debug_assert_eq!(out.len(), HEADER_TOTAL_WITH_DATA);
+
+    // ── __text bytes ─────────────────────────────────────────────────────────
+    out.extend_from_slice(text_bytes);
+
+    // ── __data bytes (zero-initialised) ──────────────────────────────────────
+    let data_start = out.len();
+    out.resize(data_start + data_len as usize, 0u8);
+
+    // ── ARM64 relocation records ──────────────────────────────────────────────
+    //
+    // Each GlobalByteReloc produces two relocation_info records (8 bytes each):
+    //
+    //   ARM64_RELOC_PAGE21 on the ADRP instruction:
+    //     r_address    = adrp_byte_offset
+    //     r_symbolnum  = 1 (index of _twig_globals in symtab)
+    //     r_pcrel      = 1
+    //     r_length     = 2  (log2(4) = 2 for 4-byte instruction)
+    //     r_extern     = 1  (symbol-relative, not section-relative)
+    //     r_type       = ARM64_RELOC_PAGE21 (1)
+    //
+    //   ARM64_RELOC_PAGEOFF12 on the ADD instruction:
+    //     r_address    = add_byte_offset
+    //     r_symbolnum  = 1
+    //     r_pcrel      = 0
+    //     r_length     = 2
+    //     r_extern     = 1
+    //     r_type       = ARM64_RELOC_PAGEOFF12 (2)
+    //
+    // The packed u32 (second field):
+    //   bits  0-23: r_symbolnum
+    //   bit     24: r_pcrel
+    //   bits 25-26: r_length
+    //   bit     27: r_extern
+    //   bits 28-31: r_type
+    //
+    // SYMBOL_IDX = 1 (_twig_globals is the second symbol in the symtab).
+    const SYMBOL_IDX: u32 = 1;
+
+    // PAGE21:    symbolnum=1, pcrel=1, length=2, extern=1, type=1
+    //   packed = 1 | (1<<24) | (2<<25) | (1<<27) | (1<<28) = 0x1D000001
+    let page21_info: u32 =
+        SYMBOL_IDX
+        | (1u32 << 24)                      // r_pcrel
+        | (2u32 << 25)                      // r_length = 2
+        | (1u32 << 27)                      // r_extern
+        | (ARM64_RELOC_PAGE21 << 28);       // r_type
+
+    // PAGEOFF12: symbolnum=1, pcrel=0, length=2, extern=1, type=2
+    //   packed = 1 | (0<<24) | (2<<25) | (1<<27) | (2<<28) = 0x2C000001
+    let pageoff12_info: u32 =
+        SYMBOL_IDX
+        | (0u32 << 24)                      // r_pcrel = 0
+        | (2u32 << 25)                      // r_length = 2
+        | (1u32 << 27)                      // r_extern
+        | (ARM64_RELOC_PAGEOFF12 << 28);    // r_type
+
+    for reloc in text_relocs {
+        // ARM64_RELOC_PAGE21 on ADRP
+        out.extend_from_slice(&(reloc.adrp_byte_offset as i32).to_le_bytes());
+        out.extend_from_slice(&page21_info.to_le_bytes());
+
+        // ARM64_RELOC_PAGEOFF12 on ADD
+        out.extend_from_slice(&(reloc.add_byte_offset as i32).to_le_bytes());
+        out.extend_from_slice(&pageoff12_info.to_le_bytes());
+    }
+
+    // ── Symbol table — _main (index 0) + _twig_globals (index 1) ─────────────
+    //
+    // _main: in __text (section 1), at entry_point offset.
+    out.extend_from_slice(&1u32.to_le_bytes());          // n_strx (skip leading NUL)
+    out.push(N_SECT | N_EXT);                            // n_type
+    out.push(1u8);                                       // n_sect = 1 (__text)
+    out.extend_from_slice(&0u16.to_le_bytes());          // n_desc
+    out.extend_from_slice(&entry_off.to_le_bytes());     // n_value (byte offset)
+
+    // _twig_globals: in __data (section 2), at offset 0 within that section.
+    out.extend_from_slice(&twig_globals_strx.to_le_bytes()); // n_strx
+    out.push(N_SECT | N_EXT);                           // n_type
+    out.push(2u8);                                       // n_sect = 2 (__data)
+    out.extend_from_slice(&0u16.to_le_bytes());          // n_desc
+    out.extend_from_slice(&code_len.to_le_bytes());      // n_value = VM addr of __data start
+
+    // ── String table ─────────────────────────────────────────────────────────
+    out.extend_from_slice(&strtab);
+
+    debug_assert_eq!(out.len(), total_size, "layout mismatch: expected {total_size} got {}", out.len());
+    Ok(out)
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -311,5 +611,111 @@ mod tests {
         // strtab is at the very end, length 7 ("\0_main\0").
         let strtab = &bytes[bytes.len() - 7 ..];
         assert_eq!(strtab, b"\0_main\0");
+    }
+
+    // ── pack_object_with_globals tests (LANG39) ───────────────────────────────
+
+    fn arm64_globals_bytes(code: Vec<u8>, n_slots: usize, relocs: &[GlobalByteReloc]) -> Vec<u8> {
+        pack_object_with_globals(&code, 0, n_slots, relocs, &Target::macos_arm64()).unwrap()
+    }
+
+    #[test]
+    fn globals_produces_macho_magic() {
+        let bytes = arm64_globals_bytes(vec![0x00; 4], 2, &[]);
+        assert_eq!(&bytes[0..4], &[0xCF, 0xFA, 0xED, 0xFE]);
+    }
+
+    #[test]
+    fn globals_filetype_is_mh_object() {
+        let bytes = arm64_globals_bytes(vec![0x00; 4], 1, &[]);
+        let filetype = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
+        assert_eq!(filetype, 1u32, "MH_OBJECT");
+    }
+
+    #[test]
+    fn globals_ncmds_is_three() {
+        let bytes = arm64_globals_bytes(vec![0x00; 4], 1, &[]);
+        let ncmds = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
+        assert_eq!(ncmds, 3);
+    }
+
+    #[test]
+    fn globals_header_is_312_bytes() {
+        // With 2 sections, HEADER_TOTAL_WITH_DATA = 312.
+        let code = vec![0x00u8; 8];
+        let bytes = arm64_globals_bytes(code, 3, &[]);
+        // text starts at byte 312.
+        assert_eq!(&bytes[312..320], &[0x00u8; 8]);
+    }
+
+    #[test]
+    fn globals_data_section_is_zeroed() {
+        let code = vec![0x42u8; 4];
+        let n_slots = 4;
+        let bytes = arm64_globals_bytes(code.clone(), n_slots, &[]);
+        // __data starts at 312 + code_len = 312 + 4 = 316
+        let data_start = 312 + 4;
+        let data = &bytes[data_start..data_start + n_slots * 8];
+        assert_eq!(data, &vec![0u8; n_slots * 8][..], "__data must be zero-init");
+    }
+
+    #[test]
+    fn globals_two_relocs_per_access() {
+        let code = vec![0x00u8; 16];
+        let relocs = vec![
+            GlobalByteReloc { adrp_byte_offset: 0, add_byte_offset: 4 },
+        ];
+        let n_slots = 1;
+        let bytes = arm64_globals_bytes(code, n_slots, &relocs);
+        // relocation records are at 312 + code + data
+        // = 312 + 16 + 8 = 336
+        let reloc_start = 312 + 16 + 8;
+        // Two records of 8 bytes each = 16 bytes.
+        let rec0 = &bytes[reloc_start..reloc_start + 8];
+        let rec1 = &bytes[reloc_start + 8..reloc_start + 16];
+
+        // rec0: r_address=0 (ADRP), r_info=0x1D000001 (PAGE21, extern, sym=1)
+        let r0_addr = i32::from_le_bytes(rec0[0..4].try_into().unwrap());
+        let r0_info = u32::from_le_bytes(rec0[4..8].try_into().unwrap());
+        assert_eq!(r0_addr, 0, "ADRP byte offset");
+        assert_eq!(r0_info, 0x1D000001, "PAGE21 packed info");
+
+        // rec1: r_address=4 (ADD), r_info=0x2C000001 (PAGEOFF12, extern, sym=1)
+        let r1_addr = i32::from_le_bytes(rec1[0..4].try_into().unwrap());
+        let r1_info = u32::from_le_bytes(rec1[4..8].try_into().unwrap());
+        assert_eq!(r1_addr, 4, "ADD byte offset");
+        assert_eq!(r1_info, 0x2C000001, "PAGEOFF12 packed info");
+    }
+
+    #[test]
+    fn globals_string_table_ends_with_twig_globals() {
+        let bytes = arm64_globals_bytes(vec![0x00; 4], 1, &[]);
+        // The string table always ends with "\0_twig_globals\0".
+        let tail = b"_twig_globals\0";
+        let end = &bytes[bytes.len() - tail.len()..];
+        assert_eq!(end, tail, "string table must end with _twig_globals");
+    }
+
+    #[test]
+    fn globals_rejects_non_arm64() {
+        let result = pack_object_with_globals(&[0x00; 4], 0, 0, &[], &Target::macos_x64());
+        assert!(result.is_err(), "x86_64 should be rejected");
+    }
+
+    #[test]
+    fn globals_output_size_matches_formula() {
+        // total = 312 + N + M + 2*R*8 + 2*16 + strtab_len
+        // strtab = "\0_main\0_twig_globals\0" = 21 bytes
+        let n = 12usize;   // code bytes
+        let m = 2 * 8;     // 2 global slots
+        let r = 2usize;    // 2 reloc entries → 4 records × 8 bytes
+        let strtab_len = 1 + 5 + 1 + 13 + 1; // "\0_main\0_twig_globals\0" = 21
+        let expected = 312 + n + m + 2 * r * 8 + 2 * 16 + strtab_len;
+        let relocs = vec![
+            GlobalByteReloc { adrp_byte_offset: 0, add_byte_offset: 4 },
+            GlobalByteReloc { adrp_byte_offset: 8, add_byte_offset: 12 },
+        ];
+        let bytes = arm64_globals_bytes(vec![0x00u8; n], 2, &relocs);
+        assert_eq!(bytes.len(), expected, "size formula");
     }
 }

--- a/code/packages/rust/code-packager/src/macho_object.rs
+++ b/code/packages/rust/code-packager/src/macho_object.rs
@@ -361,6 +361,30 @@ pub fn pack_object_with_globals(
     // ── sizeofcmds ───────────────────────────────────────────────────────────
     let sizeofcmds: u32 = (LC_SEGMENT_TWO_SECTS + LC_BUILD_VERSION_SIZE + LC_SYMTAB_SIZE) as u32;
 
+    // ── Checked u64 → u32 conversions for Mach-O 32-bit file-offset fields ──
+    //
+    // All Mach-O section and symtab file-offset fields are 32-bit.  For normal
+    // AOT object files these offsets will never approach 4 GiB, but we verify
+    // that explicitly so a pathological input (e.g. a module with >512 MB of
+    // machine code) produces a clear error rather than a silently malformed
+    // object file with truncated offsets.
+    //
+    // Helper closure: try_into() with a meaningful PackagerError on overflow.
+    macro_rules! off32 {
+        ($val:expr, $name:expr) => {
+            u32::try_from($val).map_err(|_| PackagerError::UnsupportedTarget(format!(
+                "pack_object_with_globals: {} file offset {} exceeds 4 GiB; \
+                 object files do not support this",
+                $name, $val
+            )))?
+        };
+    }
+    let text_file_off_u32  = off32!(text_file_off,  "text");
+    let reloc_file_off_u32 = off32!(reloc_file_off, "reloc");
+    let data_file_off_u32  = off32!(data_file_off,  "data");
+    let symtab_off_u32     = off32!(symtab_off,     "symtab");
+    let strtab_off_u32     = off32!(strtab_off,     "strtab");
+
     let mut out: Vec<u8> = Vec::with_capacity(total_size);
 
     // ── mach_header_64 ───────────────────────────────────────────────────────
@@ -398,10 +422,10 @@ pub fn pack_object_with_globals(
     write_name16(&mut out, b"__TEXT");
     out.extend_from_slice(&0u64.to_le_bytes());          // addr = 0 (relocatable)
     out.extend_from_slice(&code_len.to_le_bytes());       // size
-    out.extend_from_slice(&(text_file_off as u32).to_le_bytes()); // offset
+    out.extend_from_slice(&text_file_off_u32.to_le_bytes()); // offset
     out.extend_from_slice(&4u32.to_le_bytes());           // align = 2^4 = 16
     // reloff = file offset of our relocation records
-    out.extend_from_slice(&(reloc_file_off as u32).to_le_bytes());
+    out.extend_from_slice(&reloc_file_off_u32.to_le_bytes());
     // nreloc = 2 records per GlobalByteReloc (PAGE21 + PAGEOFF12)
     out.extend_from_slice(&(n_relocs * 2).to_le_bytes());
     out.extend_from_slice(&SECTION_FLAGS_CODE.to_le_bytes());
@@ -417,7 +441,7 @@ pub fn pack_object_with_globals(
     write_name16(&mut out, b"__DATA");
     out.extend_from_slice(&code_len.to_le_bytes());  // addr = immediately after __text
     out.extend_from_slice(&data_len.to_le_bytes());  // size = n_slots * 8
-    out.extend_from_slice(&(data_file_off as u32).to_le_bytes()); // offset
+    out.extend_from_slice(&data_file_off_u32.to_le_bytes()); // offset
     out.extend_from_slice(&3u32.to_le_bytes());       // align = 2^3 = 8 (64-bit slots)
     out.extend_from_slice(&0u32.to_le_bytes());       // reloff = 0 (no data relocs)
     out.extend_from_slice(&0u32.to_le_bytes());       // nreloc = 0
@@ -439,9 +463,9 @@ pub fn pack_object_with_globals(
     // ── LC_SYMTAB ────────────────────────────────────────────────────────────
     out.extend_from_slice(&LC_SYMTAB.to_le_bytes());
     out.extend_from_slice(&(LC_SYMTAB_SIZE as u32).to_le_bytes());
-    out.extend_from_slice(&(symtab_off as u32).to_le_bytes());    // symoff
+    out.extend_from_slice(&symtab_off_u32.to_le_bytes());          // symoff
     out.extend_from_slice(&2u32.to_le_bytes());                   // nsyms = 2
-    out.extend_from_slice(&(strtab_off as u32).to_le_bytes());    // stroff
+    out.extend_from_slice(&strtab_off_u32.to_le_bytes());          // stroff
     out.extend_from_slice(&(strtab.len() as u32).to_le_bytes());  // strsize
 
     debug_assert_eq!(out.len(), HEADER_TOTAL_WITH_DATA);

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,82 @@
 # Changelog — `twig-aot`
 
+## 0.1.6 — 2026-05-13 (LANG39)
+
+**First-class global variable support — `(define x 5) x` now compiles to native code.**
+
+Twig programs that use top-level value defines (`(define x 5)`, `(define counter 0)`)
+previously failed with `AotError::BackendRefused` because the V1 ARM64 backend didn't
+know how to handle `global_set` / `global_get` builtins.  LANG39 closes that gap
+end-to-end across all four affected crates.
+
+### New dependency
+
+- `iir-builtin-lowering` added to `Cargo.toml` (provides `lower_global_io`).
+
+### Pipeline changes
+
+#### `prepare_module_for_aot`
+
+Two new phases prepend the existing four-step AOT preparation pipeline:
+
+**Phase 0 — `lower_global_io(module)`**
+Converts `call_builtin "global_set"/%n/%v` → `global_store Str("name") Var(val_reg)` and
+`call_builtin "global_get"/%n` → `global_load Str("name")` (imported from `iir-builtin-lowering`).
+Must run before arithmetic pre-lowering so the const-string look-back can see the full instruction list.
+
+**Phase 0b — `strip_dead_string_consts(func)`**
+The twig-ir-compiler emits `const %n = Var("x")` (name-register) before each
+`global_set`/`global_get` call.  After Phase 0, those call_builtins are gone
+but the `const %n` instruction remains dead in the list.  `aot_specialise` would
+convert it to `const_str` which the ARM64 backend cannot lower.
+
+This new pass removes every `const` instruction whose source is `Operand::Var(_)`
+(the string-literal-as-Var encoding) **and** whose dest register is never referenced
+in any other instruction's `srcs`.  Registers that are still read (e.g. name args to
+un-lowered `call_builtin "make_closure"`) are retained.
+
+#### `compile_module_to_text` / `compile_module_to_text_raw`
+
+Return type extended from `(Vec<u8>, HashMap<String, usize>)` to
+`(Vec<u8>, HashMap<String, usize>, usize, Vec<GlobalByteReloc>)`.
+
+New fields:
+- `n_global_slots` — number of unique globals found by `collect_global_slots`.
+- `global_byte_relocs` — `Vec<GlobalByteReloc>` containing the byte offsets of
+  every `ADRP + ADD` instruction pair in the linked text section (for `ld`'s
+  ARM64 relocation records).
+
+#### `compile_module_macos_arm64_object`
+
+When `n_global_slots > 0`, now calls `pack_object_with_globals` (from
+`code-packager 0.2.1`) instead of `pack_object`.  This emits a two-section
+Mach-O object file (`__TEXT/__text` + `__DATA/__data`) with:
+- A zero-initialised `__data` section (8 bytes per global slot).
+- An exported `_twig_globals` symbol pointing to the start of that section.
+- `ARM64_RELOC_PAGE21` + `ARM64_RELOC_PAGEOFF12` relocation records per `GlobalByteReloc`.
+
+When `n_global_slots == 0`, the original single-section `pack_object` path is used unchanged.
+
+#### `collect_global_slots(module)`
+
+New internal helper.  Scans all `global_load`/`global_store` instructions in a
+post-`lower_global_io` module for `Operand::Str(name)` in `srcs[0]`.  Assigns each
+unique global name a consecutive 0-based slot index (slot `i` lives at `_twig_globals + i*8`).
+
+### Test changes
+
+- `untyped_twig_returns_backend_refused` → renamed to `global_define_compiles_ok`.
+  The old test expected `(define x 5) x` to fail.  With LANG39 it must now succeed
+  and produce a valid `MH_OBJECT` Mach-O.
+
+### Upstream dependency versions
+
+| Crate | Old | New |
+|-------|-----|-----|
+| `aarch64-encoder` | 0.2.0 | 0.2.1 (adds `adrp_placeholder`) |
+| `aarch64-backend` | 0.2.0 | 0.2.1 (adds `compile_with_globals`, `GlobalWordReloc`) |
+| `code-packager` | 0.2.0 | 0.2.1 (adds `pack_object_with_globals`, `GlobalByteReloc`) |
+
 ## 0.1.5 — 2026-05-13
 
 **Default integer type changed from `u64` to `i64` — all typing states now correct.**

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "twig-aot"
-version = "0.1.0"
+version = "0.1.6"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source."
 
 [dependencies]
-twig-ir-compiler = { path = "../twig-ir-compiler" }
-interpreter-ir   = { path = "../interpreter-ir" }
-aot-core         = { path = "../aot-core" }
-aarch64-backend  = { path = "../aarch64-backend" }
-jit-core         = { path = "../jit-core" }
-code-packager    = { path = "../code-packager" }
-cli-builder      = { path = "../cli-builder" }
+twig-ir-compiler     = { path = "../twig-ir-compiler" }
+interpreter-ir        = { path = "../interpreter-ir" }
+aot-core              = { path = "../aot-core" }
+aarch64-backend       = { path = "../aarch64-backend" }
+jit-core              = { path = "../jit-core" }
+code-packager         = { path = "../code-packager" }
+cli-builder           = { path = "../cli-builder" }
+iir-builtin-lowering  = { path = "../iir-builtin-lowering" }
 
 [[bin]]
 name = "twig-aot"

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -53,15 +53,16 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use aarch64_backend::{compile_with_relocs, Reloc};
+use aarch64_backend::{compile_with_globals, GlobalWordReloc, Reloc};
 use aot_core::infer::infer_types;
 use aot_core::link::{entry_point_offset, link};
 use aot_core::specialise::aot_specialise;
-use code_packager::macho_object::pack_object;
+use code_packager::macho_object::{pack_object, pack_object_with_globals, GlobalByteReloc};
 use code_packager::{CodeArtifact, Target};
 use interpreter_ir::function::IIRFunction;
 use interpreter_ir::instr::{IIRInstr, Operand};
 use interpreter_ir::module::IIRModule;
+use iir_builtin_lowering::lower_global_io;
 use jit_core::backend::FunctionContext;
 
 // ---------------------------------------------------------------------------
@@ -138,25 +139,44 @@ pub fn compile_macos_arm64_object(source: &str, module_name: &str) -> Result<Vec
 }
 
 /// Compile an already-built `IIRModule` to Mach-O object-file bytes.
+///
+/// When the module references global variables (LANG39), the object file
+/// is produced via [`pack_object_with_globals`] which adds a `__DATA/__data`
+/// section and emits `ARM64_RELOC_PAGE21` / `ARM64_RELOC_PAGEOFF12`
+/// relocation records so that the system linker (`ld`) can patch the
+/// `ADRP + ADD` instruction pairs that address `_twig_globals`.
 pub fn compile_module_macos_arm64_object(module: &IIRModule) -> Result<Vec<u8>, AotError> {
     let entry = module.entry_point.as_deref().ok_or(AotError::NoEntryPoint)?;
-    let (text, offsets) = compile_module_to_text(module)?;
+    let (text, offsets, n_global_slots, global_relocs) = compile_module_to_text(module)?;
     let entry_off = entry_point_offset(&offsets, Some(entry));
 
-    let artifact = CodeArtifact::new(text, entry_off, Target::macos_arm64());
-    pack_object(&artifact).map_err(|e| AotError::Packager(format!("{e}")))
+    if n_global_slots > 0 {
+        // Module uses globals: emit a two-section Mach-O (text + data) with
+        // ARM64 relocation records so the linker patches ADRP+ADD pairs.
+        pack_object_with_globals(&text, entry_off, n_global_slots, &global_relocs, &Target::macos_arm64())
+            .map_err(|e| AotError::Packager(format!("{e}")))
+    } else {
+        // No globals: use the simpler single-section object packager.
+        let artifact = CodeArtifact::new(text, entry_off, Target::macos_arm64());
+        pack_object(&artifact).map_err(|e| AotError::Packager(format!("{e}")))
+    }
 }
 
 /// Returns raw ARM64 machine code bytes and a function-name→byte-offset map.
 ///
-/// Uses the standard untyped prep pipeline (pre-lower + u64 normalization +
-/// type propagation + default-any-to-u64).  The resulting bytes are a flat
+/// Uses the standard untyped prep pipeline (pre-lower + i64 normalization +
+/// type propagation + default-any-to-i64).  The resulting bytes are a flat
 /// code section with no Mach-O wrapping — suitable for in-process execution
 /// via [`call_arm64_function_in_process`].
+///
+/// Global-variable relocation metadata (`n_global_slots`, `global_byte_relocs`)
+/// is intentionally discarded here; callers that need a full Mach-O object
+/// should use [`compile_module_macos_arm64_object`] instead.
 pub fn compile_module_to_arm64_bytes(
     module: &IIRModule,
 ) -> Result<(Vec<u8>, HashMap<String, usize>), AotError> {
-    compile_module_to_text(module)
+    let (text, offsets, _, _) = compile_module_to_text(module)?;
+    Ok((text, offsets))
 }
 
 /// Like [`compile_module_to_arm64_bytes`] but uses the caller-supplied type
@@ -203,7 +223,10 @@ pub fn compile_typed_module_to_arm64_bytes(
         // (Should be rare after propagation with typed params.)
         default_any_to_i64(func);
     }
-    compile_module_to_text_raw(&module)
+    // Discard global reloc metadata — typed callers obtain Mach-O objects via
+    // `compile_module_macos_arm64_object`, which preserves those fields.
+    let (text, offsets, _, _) = compile_module_to_text_raw(&module)?;
+    Ok((text, offsets))
 }
 
 /// Apply the AOT builtin pre-lowering pass to every function in `module`.
@@ -644,6 +667,51 @@ fn resolve_src_aot_type(src: Option<&Operand>, env: &HashMap<String, String>) ->
     }
 }
 
+/// Step 0b: remove dead string-literal `const` instructions.
+///
+/// The twig-ir-compiler emits a pattern like:
+/// ```text
+/// const  %n1 = Var("x")            -- name register (string literal)
+/// call_builtin "global_set" %n1 %v -- will be lowered by lower_global_io
+/// ```
+///
+/// After `lower_global_io` runs, `call_builtin "global_set"` becomes
+/// `global_store Str("x") Var("%v")` — the global name is now inline.
+/// The `const %n1` instruction becomes dead code (its register is never
+/// read again).  If left in place, `aot_specialise` converts it to
+/// `const_str`, which the ARM64 backend cannot lower.
+///
+/// This pass removes `const` instructions whose source is `Operand::Var(_)`
+/// (the string-literal-as-Var encoding) AND whose dest register never
+/// appears in any other instruction's `srcs`.  Instructions that are
+/// still referenced (e.g. as arg to an un-lowered `call_builtin`, or as
+/// a `make_closure` name register) are retained.
+fn strip_dead_string_consts(func: &mut IIRFunction) {
+    use std::collections::HashSet;
+
+    // Build a set of every Var-register name that is read in any src position.
+    let used: HashSet<String> = func.instructions
+        .iter()
+        .flat_map(|instr| instr.srcs.iter())
+        .filter_map(|op| {
+            if let Operand::Var(n) = op { Some(n.clone()) } else { None }
+        })
+        .collect();
+
+    // Remove const instructions of the form `%dest = Var("text")` whose
+    // dest is not in `used`.  These are dead name-register loads.
+    func.instructions.retain(|instr| {
+        if instr.op == "const" {
+            if let Some(Operand::Var(_)) = instr.srcs.first() {
+                if let Some(dest) = &instr.dest {
+                    return used.contains(dest);
+                }
+            }
+        }
+        true // keep everything else
+    });
+}
+
 /// Step 3b: default any remaining `"any"` hints on arithmetic / move
 /// instructions to `"i64"`.
 ///
@@ -667,9 +735,30 @@ fn default_any_to_i64(func: &mut IIRFunction) {
     }
 }
 
-/// Apply all three preparation steps to every function in `module`.
+/// Apply all preparation steps to every function in `module`.
+///
+/// Steps:
+///  0. `lower_global_io` — converts `call_builtin "global_set"` /
+///     `"global_get"` to `global_store` / `global_load` (LANG39).
+///     Must run first so the const-string look-back can see all instructions.
+///  0b. `strip_dead_string_consts` — removes `const %n = Var("name")`
+///     instructions that are now dead after step 0.  Without this pass,
+///     `aot_specialise` converts them to `const_str` which the ARM64 backend
+///     cannot lower (there is no stack-slot for a string pointer).
+///  1. `pre_lower_aot_builtins` — lowers `call_builtin "+"` → `add`, etc.
+///  2. `normalize_params_to_i64` — promotes untyped params to `i64`.
+///  3. `propagate_aot_types` — fixed-point type propagation.
+///  4. `default_any_to_i64` — defaults unresolved arithmetic types to `i64`.
 fn prepare_module_for_aot(module: &mut IIRModule) {
+    // Phase 0: lower global_set / global_get → global_store / global_load.
+    lower_global_io(module);
+
     for func in &mut module.functions {
+        // Phase 0b: remove dead name-register `const` instructions.
+        // `lower_global_io` leaves `const %n = Var("x")` in place even after
+        // the `global_set`/`global_get` that consumed it is rewritten.
+        // These become `const_str` in CIR which the ARM64 backend rejects.
+        strip_dead_string_consts(func);
         pre_lower_aot_builtins(func);
         normalize_params_to_i64(func);
         propagate_aot_types(func);
@@ -692,9 +781,10 @@ fn prepare_module_for_aot(module: &mut IIRModule) {
 /// `u64`.  For signed `i64` semantics use [`compile_typed_module_to_arm64_bytes`].
 fn compile_module_to_text(
     module: &IIRModule,
-) -> Result<(Vec<u8>, HashMap<String, usize>), AotError> {
+) -> Result<(Vec<u8>, HashMap<String, usize>, usize, Vec<GlobalByteReloc>), AotError> {
     // We work on a clone so the caller's `IIRModule` is never mutated.
-    // `prepare_module_for_aot` runs three passes:
+    // `prepare_module_for_aot` runs four passes (LANG39 adds step 0):
+    //   0. `lower_global_io` — `call_builtin "global_set/get"` → `global_store/load`
     //   1. `call_builtin "+"` → `add`, etc.   (see `pre_lower_aot_builtins`)
     //   2. param types "any" → "i64"           (see `normalize_params_to_i64`)
     //   3. propagate + default remaining "any" (see `propagate_aot_types` /
@@ -703,6 +793,35 @@ fn compile_module_to_text(
     prepare_module_for_aot(&mut module);
     compile_module_to_text_raw(&module)
 }
+
+// ---------------------------------------------------------------------------
+// Global-slot scanning (LANG39)
+// ---------------------------------------------------------------------------
+
+/// Scan all functions in a (post-`lower_global_io`) IIR module for
+/// `global_load` / `global_store` instructions and assign each unique global
+/// name a consecutive slot index (0, 1, 2, …).
+///
+/// Returns a map from global name → slot index.  If no globals are used the
+/// map is empty.
+fn collect_global_slots(module: &IIRModule) -> HashMap<String, usize> {
+    let mut map: HashMap<String, usize> = HashMap::new();
+    for fn_ in &module.functions {
+        for instr in &fn_.instructions {
+            if instr.op == "global_load" || instr.op == "global_store" {
+                if let Some(Operand::Str(name)) = instr.srcs.first() {
+                    let next = map.len();
+                    map.entry(name.clone()).or_insert(next);
+                }
+            }
+        }
+    }
+    map
+}
+
+// ---------------------------------------------------------------------------
+// Inner two-pass compile + link
+// ---------------------------------------------------------------------------
 
 /// Inner two-pass compile + link, operating on an already-prepared `IIRModule`.
 ///
@@ -716,38 +835,64 @@ fn compile_module_to_text(
 /// Pass 1 — compile each function independently.  Cross-function `call`
 ///   instructions emit `BL #0` placeholder instructions and record
 ///   [`Reloc`] entries (callee name + word index in the per-function binary).
+///   `global_load`/`global_store` instructions emit `ADRP + ADD` placeholder
+///   pairs and record [`GlobalWordReloc`] entries (word indices for Mach-O
+///   ARM64 relocations).
 ///
 /// Link — concatenate all function binaries into one flat code section and
 ///   record each function's byte offset.
 ///
 /// Pass 2 — patch every placeholder `BL` with the correct PC-relative
-///   offset using the now-known function offsets.
+///   offset using the now-known function offsets.  `GlobalWordReloc` entries
+///   are converted to [`GlobalByteReloc`] byte offsets (for `pack_object_with_globals`).
 ///
 /// ARM64 `BL` encoding: opcode `0x94000000`, 26-bit signed PC-relative
 /// offset in units of 4 bytes (instruction words).
+///
+/// Returns `(linked_text, fn_offsets, n_global_slots, global_byte_relocs)`.
 fn compile_module_to_text_raw(
     module: &IIRModule,
-) -> Result<(Vec<u8>, HashMap<String, usize>), AotError> {
-    // ── Pass 1: compile all functions, collecting cross-function relocations ──
-    // Each entry: (fn_name, per-function bytes, list of ExternalReloc for that fn)
-    let mut fn_results: Vec<(String, Vec<u8>, Vec<Reloc>)> =
+) -> Result<(Vec<u8>, HashMap<String, usize>, usize, Vec<GlobalByteReloc>), AotError> {
+    // ── Collect global names (LANG39) ─────────────────────────────────────────
+    let global_slots = collect_global_slots(module);
+    let n_global_slots = global_slots.len();
+
+    // ── Pass 1: compile all functions, collecting cross-function + global relocs ─
+    // Each entry: (fn_name, per-function bytes, ExternalRelocs, GlobalWordRelocs)
+    let mut fn_results: Vec<(String, Vec<u8>, Vec<Reloc>, Vec<GlobalWordReloc>)> =
         Vec::with_capacity(module.functions.len());
 
     for fn_ in &module.functions {
-        let (bytes, relocs) = compile_one_with_relocs(fn_)
+        let (bytes, ext_relocs, glob_relocs) = compile_one_with_globals(fn_, &global_slots)
             .ok_or_else(|| AotError::BackendRefused { function: fn_.name.clone() })?;
-        fn_results.push((fn_.name.clone(), bytes, relocs));
+        fn_results.push((fn_.name.clone(), bytes, ext_relocs, glob_relocs));
     }
 
     // ── Link: concatenate binaries and record byte offsets ──────────────────
     let plain_binaries: Vec<(String, Vec<u8>)> = fn_results
         .iter()
-        .map(|(name, bytes, _)| (name.clone(), bytes.clone()))
+        .map(|(name, bytes, _, _)| (name.clone(), bytes.clone()))
         .collect();
     let (mut linked, offsets) = link(&plain_binaries);
 
+    // ── Collect global byte relocs (LANG39) ───────────────────────────────
+    //
+    // Convert GlobalWordReloc (word indices relative to each function) to
+    // GlobalByteReloc (byte offsets relative to the linked text section) by
+    // adding the function's byte offset and multiplying word index by 4.
+    let mut global_byte_relocs: Vec<GlobalByteReloc> = Vec::new();
+    for (fn_name, _bytes, _, glob_relocs) in &fn_results {
+        let fn_byte_offset = *offsets.get(fn_name.as_str()).unwrap_or(&0);
+        for gr in glob_relocs {
+            global_byte_relocs.push(GlobalByteReloc {
+                adrp_byte_offset: (fn_byte_offset + gr.adrp_word * 4) as u32,
+                add_byte_offset:  (fn_byte_offset + gr.add_word  * 4) as u32,
+            });
+        }
+    }
+
     // ── Pass 2: patch cross-function BL placeholders ──────────────────────
-    for (fn_name, _bytes, relocs) in &fn_results {
+    for (fn_name, _bytes, relocs, _) in &fn_results {
         let fn_offset = *offsets.get(fn_name.as_str()).unwrap_or(&0);
 
         for reloc in relocs {
@@ -816,13 +961,16 @@ fn compile_module_to_text_raw(
         }
     }
 
-    Ok((linked, offsets))
+    Ok((linked, offsets, n_global_slots, global_byte_relocs))
 }
 
-/// Compile one `IIRFunction` to ARM64 machine code, returning the bytes and
-/// any cross-function call relocations.  Returns `None` if the function
-/// contains opcodes the backend doesn't support.
-fn compile_one_with_relocs(fn_: &IIRFunction) -> Option<(Vec<u8>, Vec<Reloc>)> {
+/// Compile one `IIRFunction` to ARM64 machine code, returning the bytes,
+/// any cross-function call relocations, and global-access relocations.
+/// Returns `None` if the function contains opcodes the backend doesn't support.
+fn compile_one_with_globals(
+    fn_: &IIRFunction,
+    global_slots: &HashMap<String, usize>,
+) -> Option<(Vec<u8>, Vec<Reloc>, Vec<GlobalWordReloc>)> {
     let inferred = infer_types(fn_);
     let cir = aot_specialise(fn_, Some(&inferred));
     let ctx = FunctionContext {
@@ -830,7 +978,7 @@ fn compile_one_with_relocs(fn_: &IIRFunction) -> Option<(Vec<u8>, Vec<Reloc>)> {
         params:      &fn_.params,
         return_type: &fn_.return_type,
     };
-    compile_with_relocs(&ctx, &cir).ok()
+    compile_with_globals(&ctx, &cir, global_slots).ok()
 }
 
 // ===========================================================================
@@ -852,13 +1000,20 @@ mod tests {
     }
 
     #[test]
-    fn untyped_twig_returns_backend_refused() {
-        // `(define x 5)` is a top-level value define — the ir compiler
-        // emits a `global_set` call_builtin which the V1 backend doesn't
-        // support → BackendRefused.
+    fn global_define_compiles_ok() {
+        // `(define x 5)` is a top-level value define — the ir compiler emits a
+        // `global_set` call_builtin.  LANG39 (lower_global_io + ARM64 global
+        // load/store + pack_object_with_globals) now handles this end-to-end,
+        // so the program must compile to a valid Mach-O object file.
         let src = "(define x 5) x";
-        let err = compile_macos_arm64_object(src, "untyped").unwrap_err();
-        assert!(matches!(err, AotError::BackendRefused { .. }), "got: {err:?}");
+        let result = compile_macos_arm64_object(src, "globals_test");
+        assert!(result.is_ok(), "global define should compile with LANG39; got: {:?}", result.err());
+
+        // The output must be a Mach-O MH_OBJECT (filetype == 1).
+        let bytes = result.unwrap();
+        assert_eq!(&bytes[0..4], &[0xCF, 0xFA, 0xED, 0xFE], "Mach-O magic");
+        let filetype = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
+        assert_eq!(filetype, 1, "MH_OBJECT");
     }
 
     #[test]

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -882,7 +882,19 @@ fn compile_module_to_text_raw(
     // adding the function's byte offset and multiplying word index by 4.
     let mut global_byte_relocs: Vec<GlobalByteReloc> = Vec::new();
     for (fn_name, _bytes, _, glob_relocs) in &fn_results {
-        let fn_byte_offset = *offsets.get(fn_name.as_str()).unwrap_or(&0);
+        // Use an explicit error rather than `unwrap_or(&0)`.  A missing entry
+        // in `offsets` here would mean a function was compiled but not linked,
+        // which indicates a linker bug — silently using offset 0 would produce
+        // relocation records pointing to the wrong instructions.
+        let fn_byte_offset = *offsets.get(fn_name.as_str())
+            .ok_or_else(|| AotError::Linker {
+                status: None,
+                stderr: format!(
+                    "twig-aot: internal error: function '{}' missing from link offsets \
+                     during global reloc collection",
+                    fn_name
+                ),
+            })?;
         for gr in glob_relocs {
             global_byte_relocs.push(GlobalByteReloc {
                 adrp_byte_offset: (fn_byte_offset + gr.adrp_word * 4) as u32,

--- a/code/specs/LANG39-aot-globals.md
+++ b/code/specs/LANG39-aot-globals.md
@@ -1,0 +1,157 @@
+# LANG39 — AOT Global Variables
+
+**Status**: Implementation  
+**Depends on**: LANG38 (merged), LANG32 (`global_load`/`global_store` IIR opcodes)
+
+---
+
+## Motivation
+
+Twig programs use `(define x <expr>)` at the top level to create named global
+values.  In the interpreter these are dispatched via `call_builtin "global_set"`
+and `call_builtin "global_get"`.  `iir-builtin-lowering` converts these to the
+`global_store Str(name), val` / `global_load Str(name) → dest` opcodes defined
+in LANG32.
+
+The AOT pipeline did not previously handle either form:
+
+- `pre_lower_aot_builtins` did not call `iir-builtin-lowering`
+- `aarch64-backend` had no handlers for `global_load` / `global_store`
+- `code-packager` emitted only a `__text` section (no `__data` for mutable globals)
+
+LANG39 closes all three gaps.  After this change, programs like
+
+```twig
+(define x 5)
+(define (f n) (+ n x))
+(f 3)   ; → 8
+```
+
+compile to a runnable ARM64 Mach-O binary.
+
+---
+
+## Design
+
+### Where globals live: `__DATA, __data` section
+
+Global variables are stored in a zero-initialised 8-byte-per-slot array in the
+Mach-O `__DATA` segment (`__data` section).  Each unique global name is assigned
+a consecutive slot index at module-compile time:
+
+```
+_twig_globals:   [0×8 bytes]    ; slot 0 = first global name
+                 [8×8 bytes]    ; slot 1 = second global name
+                 ...
+```
+
+The array is emitted in the Mach-O object file as a `__data` section and
+exported via the `_twig_globals` symbol.  The system linker (`ld`) places it in
+the final executable.
+
+### Instruction sequence per access
+
+**`global_store Str("x"), %v0`** (write):
+
+```
+LDR  X0, [SP, #slot_of_v0]       ; load value from stack frame
+ADRP X1, _twig_globals@PAGE      ; get globals base page (patched by ld)
+ADD  X1, X1, _twig_globals@PAGEOFF   ; add page offset (patched by ld)
+STR  X0, [X1, #slot_x * 8]       ; write to global slot
+```
+
+**`global_load Str("x") → %dest`** (read):
+
+```
+ADRP X1, _twig_globals@PAGE
+ADD  X1, X1, _twig_globals@PAGEOFF
+LDR  X0, [X1, #slot_x * 8]       ; read from global slot
+STR  X0, [SP, #slot_of_dest]     ; spill to stack frame
+```
+
+### ARM64 relocations in the Mach-O object file
+
+The ADRP and ADD instructions need two Mach-O ARM64 relocations per access so
+`ld` can patch the 21-bit page offset and 12-bit page-relative offset:
+
+| Instruction | Reloc type       | r_type | r_pcrel | Purpose |
+|-------------|------------------|--------|---------|---------|
+| ADRP        | ARM64_RELOC_PAGE21   | 1 | 1 | Page address of `_twig_globals` |
+| ADD         | ARM64_RELOC_PAGEOFF12 | 2 | 0 | Low-12-bit offset within page |
+
+Both records reference the `_twig_globals` symbol (symbol table index 1 in the
+generated object file; index 0 is reserved for `_main`).
+
+### Mach-O layout
+
+`pack_object_with_globals` produces:
+
+```
+Offset          │ Size   │ Content
+────────────────┼────────┼─────────────────────────────────────────
+0               │ 32     │ mach_header_64 (ncmds=3)
+32              │ 232    │ LC_SEGMENT_64 (header + 2 section_64s)
+264             │ 24     │ LC_BUILD_VERSION
+288             │ 24     │ LC_SYMTAB
+── HEADER = 312 ───────────────────────────────────────────────────
+312             │ N      │ __text bytes (machine code)
+312+N           │ M      │ __data bytes (zero-init globals, M = n_slots * 8)
+312+N+M         │ 2*R*8  │ text relocation records (2 per global access)
+312+N+M+2*R*8   │ 32     │ 2 nlist_64 entries: _main, _twig_globals
+…               │ S      │ string table: "\0_main\0_twig_globals\0"
+```
+
+Where `R` = number of global accesses (loads + stores across all functions).
+
+---
+
+## Files changed
+
+| File | Package | Change |
+|------|---------|--------|
+| `aarch64-encoder/src/lib.rs` | aarch64-encoder 0.2.1 | `+adrp_placeholder(rd)` |
+| `aarch64-backend/src/lib.rs` | aarch64-backend 0.2.1 | `GlobalWordReloc`, `compile_with_globals` |
+| `code-packager/src/macho_object.rs` | code-packager | `GlobalByteReloc`, `pack_object_with_globals` |
+| `twig-aot/Cargo.toml` | twig-aot | add `iir-builtin-lowering` dep |
+| `twig-aot/src/lib.rs` | twig-aot | run `lower_global_io`, scan globals, use new packager fn |
+
+---
+
+## Data-type pipeline
+
+```
+twig-ir-compiler output:
+  call_builtin "global_set" %name_reg %val_reg
+  call_builtin "global_get" %name_reg  →  %dest
+
+iir-builtin-lowering::lower_global_io (added to prepare_module_for_aot):
+  global_store Str("x"), Var("%val_reg")
+  global_load  Str("x")  →  %dest
+
+aot_specialise (fallback path):
+  global_store  srcs=[Var("x"), Var("%val_reg")]   (Str→Var lifting)
+  global_load   srcs=[Var("x")]  dest=%dest
+
+aarch64-backend emit_global_store / emit_global_load:
+  LDR X0, [SP, #val_slot]; ADRP X1; ADD X1; STR X0, [X1, #slot*8]
+  ADRP X1; ADD X1; LDR X0, [X1, #slot*8]; STR X0, [SP, #dest_slot]
+```
+
+---
+
+## Limitations (out of scope for LANG39)
+
+- **Float globals**: globals are always 64-bit integer slots; float support is deferred
+- **String/heap globals**: depend on LANG40 (heap allocation)
+- **Cross-module globals**: the current linker is single-module only
+- **Slot count cap**: slot index × 8 must fit in a 12-bit LDR/STR offset (≤ 4095 slots, i.e. 32760 bytes)
+- **Type propagation**: `global_load` produces a `"any"`-typed result in CIR; downstream arithmetic defaults to `i64` via `default_any_to_i64`
+
+---
+
+## Test plan
+
+- `aarch64-encoder`: `adrp_placeholder` encoding test
+- `aarch64-backend`: `global_load` / `global_store` CIR handler tests (round-trip via `compile_with_globals`)
+- `code-packager`: `pack_object_with_globals` produces correct Mach-O layout
+- `twig-aot`: `(define x 5) x` no longer returns `BackendRefused`; compiles to object bytes


### PR DESCRIPTION
## Summary

- **`aarch64-encoder 0.2.1`**: `adrp_placeholder(rd)` — emits `ADRP Xd, #0` and returns word index for relocation patching
- **`aarch64-backend 0.2.1`**: `GlobalWordReloc` + `compile_with_globals` — handles `global_load`/`global_store` CIR opcodes via 4-instruction ADRP+ADD+LDR/STR sequences; records relocation sites
- **`code-packager 0.2.1`**: `GlobalByteReloc` + `pack_object_with_globals` — two-section Mach-O (`__TEXT/__text` + `__DATA/__data`) with `ARM64_RELOC_PAGE21`/`ARM64_RELOC_PAGEOFF12` records for `ld` to patch
- **`twig-aot 0.1.6`**: wires `lower_global_io` + `strip_dead_string_consts` + `collect_global_slots` + conditional `pack_object_with_globals`; `(define x 5) x` now compiles end-to-end

Programs using `(define x 5)` or any top-level value defines previously failed with `AotError::BackendRefused`. With this PR they compile to a valid Mach-O object that `ld` links correctly.

Security fixes included: slot index bounds check (HIGH), u64→u32 offset overflow guard (MEDIUM), explicit linker-offset error (LOW).

## Test plan

- [x] `cargo test -p twig-aot -p aarch64-backend -p aarch64-encoder -p code-packager -p iir-builtin-lowering` → 348 tests, all green
- [x] End-to-end: `(define x 5) x` → valid Mach-O object bytes (new `global_define_compiles_ok` test)
- [x] Existing: `fib`, `empty_main`, `end_to_end_object_through_ld_returns_42` all still pass
- [x] Security review: 2 rounds, all findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)