### PR TITLE
TypeScript factor grouped multivariate terms

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Add TypeScript MACSYMA parity for bivariate cubic identities, so
   `factor(x^3 - y^3)` and `factor(x^3 + y^3)` return the textbook two-factor
   decompositions through the shared symbolic VM handler.
+- Add TypeScript MACSYMA parity for four-term bilinear grouping, so
+  `factor(x*y + x*z + y + z)` returns `(x+1)*(y+z)` through the shared
+  symbolic VM handler.
 - Add `?` / `? topic` help-query handling for TypeScript MACSYMA sessions and
   JSON responses.
 - Wire `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -218,6 +218,26 @@ describe("macsyma-runtime", () => {
     ]));
   });
 
+  it("factors grouped multivariate terms through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x*y + x*z + y + z);");
+
+    expect(result.output).toEqual(app(MUL, [
+      app(ADD, [sym("x"), int(1)]),
+      app(ADD, [sym("y"), sym("z")]),
+    ]));
+  });
+
+  it("factors grouped multivariate terms with signed residuals through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x*y - x*z + y - z);");
+
+    expect(result.output).toEqual(app(MUL, [
+      app(ADD, [sym("x"), int(1)]),
+      app(ADD, [sym("y"), app(MUL, [int(-1), sym("z")])]),
+    ]));
+  });
+
   it("tracks the showtime option flag through normal assignments", () => {
     const session = new MacsymaSession();
     const [enabled, timed, disabled, untimed] = session.evalSource(

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Added a bivariate cubic-identity factoring foothold so `Factor` recognises
   expressions like `x^3 - y^3` and `x^3 + y^3` as their textbook two-factor
   decompositions.
+- Added a four-term bilinear grouping factoring foothold so `Factor`
+  recognises expressions like `x*y + x*z + y + z` as `(x+1)*(y+z)`.
 - Added a symbolic-backend-only `D` handler for pure IR differentiation,
   including arithmetic, power, elementary, hyperbolic, and inverse hyperbolic
   chain rules.

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -379,6 +379,8 @@ function factorHandler(vm: VM, expr: IRApply): IRNode {
     if (difference !== undefined) return difference;
     const perfectSquare = extractMultivariatePerfectSquare(inner);
     if (perfectSquare !== undefined) return perfectSquare;
+    const grouping = extractMultivariateGrouping(inner);
+    if (grouping !== undefined) return grouping;
     const commonFactored = extractCommonSymbolicFactor(inner);
     return commonFactored === undefined ? expr : vm.eval(commonFactored);
   }
@@ -743,6 +745,69 @@ function extractMultivariateCubicIdentity(inner: IRNode): IRNode | undefined {
       app(POW, [second, int(2)]),
     ]),
   ]);
+}
+
+function commonSymbolicPowers(terms: readonly IRNode[]): Map<string, FactorPower> {
+  if (terms.length === 0) return new Map();
+
+  const common = new Map(splitCommonFactorTerm(terms[0]));
+  for (const term of terms.slice(1)) {
+    const powers = splitCommonFactorTerm(term);
+    for (const [key, power] of [...common.entries()]) {
+      const shared = Math.min(power.exponent, powers.get(key)?.exponent ?? 0);
+      if (shared > 0) {
+        common.set(key, { base: power.base, exponent: shared });
+      } else {
+        common.delete(key);
+      }
+    }
+  }
+  return common;
+}
+
+function sameTwoTerms(left: readonly IRNode[], right: readonly IRNode[]): boolean {
+  if (left.length !== 2 || right.length !== 2) return false;
+  const leftKeys = left.map(nodeKey);
+  const rightKeys = right.map(nodeKey);
+  return (
+    (leftKeys[0] === rightKeys[0] && leftKeys[1] === rightKeys[1])
+    || (leftKeys[0] === rightKeys[1] && leftKeys[1] === rightKeys[0])
+  );
+}
+
+function extractMultivariateGrouping(inner: IRNode): IRNode | undefined {
+  const terms = flattenAddTerms(inner);
+  if (terms.length !== 4) return undefined;
+
+  for (let firstIndex = 0; firstIndex < terms.length - 1; firstIndex += 1) {
+    for (let secondIndex = firstIndex + 1; secondIndex < terms.length; secondIndex += 1) {
+      const grouped = [terms[firstIndex], terms[secondIndex]];
+      const firstCommon = commonSymbolicPowers(grouped);
+      if (firstCommon.size === 0) continue;
+
+      const rest = terms.filter((_term, index) => index !== firstIndex && index !== secondIndex);
+      const firstResidual = grouped.map((term) => removeCommonFactor(term, firstCommon));
+      const secondCommon = commonSymbolicPowers(rest);
+      const secondResidual = rest.map((term) => removeCommonFactor(term, secondCommon));
+      if (!sameTwoTerms(firstResidual, secondResidual)) continue;
+
+      const firstFactor = multiplyNodes([...firstCommon.values()]
+        .sort((a, b) => nodeKey(a.base).localeCompare(nodeKey(b.base)))
+        .map((power) => powNode(power.base, power.exponent)));
+      const secondFactor = secondCommon.size === 0
+        ? int(1)
+        : multiplyNodes([...secondCommon.values()]
+          .sort((a, b) => nodeKey(a.base).localeCompare(nodeKey(b.base)))
+          .map((power) => powNode(power.base, power.exponent)));
+
+      return app(MUL, [
+        app(ADD, [firstFactor, secondFactor]),
+        addNodes(firstResidual),
+      ]);
+    }
+  }
+
+  return undefined;
 }
 
 function polyAdd(a: readonly bigint[], b: readonly bigint[]): bigint[] {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -185,6 +185,42 @@ describe("symbolic-vm", () => {
     ]));
   });
 
+  it("factors grouped multivariate terms", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    const z = sym("z");
+    const expr = app(FACTOR, [
+      app(ADD, [
+        app(ADD, [app(MUL, [x, y]), app(MUL, [x, z])]),
+        app(ADD, [y, z]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(MUL, [
+      app(ADD, [x, int(1)]),
+      app(ADD, [y, z]),
+    ]));
+  });
+
+  it("factors grouped multivariate terms with signed residuals", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    const z = sym("z");
+    const expr = app(FACTOR, [
+      app(ADD, [
+        app(SUB, [app(MUL, [x, y]), app(MUL, [x, z])]),
+        app(SUB, [y, z]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(MUL, [
+      app(ADD, [x, int(1)]),
+      app(ADD, [y, app(MUL, [int(-1), z])]),
+    ]));
+  });
+
   it("supports assignment and later lookup", () => {
     const vm = new VM(new SymbolicBackend());
     expect(vm.eval(app(ASSIGN, [sym("x"), app(ADD, [int(2), int(3)])]))).toEqual(int(5));


### PR DESCRIPTION
## Summary
- add a TypeScript symbolic-vm factor-by-grouping foothold for four-term bilinear expressions like x*y + x*z + y + z
- route the same behavior through the TypeScript MACSYMA runtime via factor(...)
- cover unsigned and signed residual grouping cases and update package changelogs

## Validation
- `npm test` in `code/packages/typescript/symbolic-vm`
- `npm test` in `code/packages/typescript/macsyma-runtime`
- `npm run build` in `code/packages/typescript/symbolic-vm`
- `npm run build` in `code/packages/typescript/macsyma-runtime`
- `git diff --check`
