### PR TITLE
Rust factor grouped multivariate terms

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Added Rust MACSYMA parity for bivariate cubic-identity factoring, so
   `factor(x^3 - y^3)` and `factor(x^3 + y^3)` return their linear/quadratic
   products through the shared symbolic VM handler.
+- Added Rust MACSYMA parity for four-term bilinear grouping, so
+  `factor(x*y + x*z + y + z)` returns `(x + 1) * (y + z)` through the shared
+  symbolic VM handler.
 - Added `?` / `? topic` help-query handling for Rust MACSYMA sessions.
 - Wired `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
   Rust MACSYMA session assumption context so declared properties feed property

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -220,6 +220,43 @@ fn factors_multivariate_sum_of_cubes_through_runtime() {
 }
 
 #[test]
+fn factors_grouped_multivariate_terms_through_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x*y + x*z + y + z);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![sym("x"), int(1)]),
+                apply(sym(ADD), vec![sym("y"), sym("z")]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn factors_grouped_multivariate_terms_with_signed_residuals_through_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("factor(x*y - x*z + y - z);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![sym("x"), int(1)]),
+                apply(
+                    sym(ADD),
+                    vec![sym("y"), apply(sym(MUL), vec![int(-1), sym("z")]),],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
 fn question_mark_without_topic_lists_help_topics() {
     let mut session = MacsymaSession::new();
     let results = session.eval_source("?").unwrap();

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -13,6 +13,8 @@
   `x^2 - y^2` and rewrites them as `(x - y) * (x + y)`.
 - `Factor` recognises bivariate cubic identities such as `x^3 - y^3` and
   `x^3 + y^3`, rewriting them to their canonical linear/quadratic products.
+- `Factor` recognises four-term bilinear grouping such as
+  `x*y + x*z + y + z` and rewrites it as `(x + 1) * (y + z)`.
 - `SymbolicBackend` installs a `D` derivative handler for symbolic-only
   differentiation of arithmetic, elementary, hyperbolic, and inverse
   hyperbolic expressions; `StrictBackend` continues to reject `D` as an

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1386,6 +1386,10 @@ fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
         return rewritten;
     }
 
+    if let Some(rewritten) = factor_multivariate_grouping(input) {
+        return rewritten;
+    }
+
     if let Some(rewritten) = factor_common_symbolic_term(input) {
         return vm.eval(rewritten);
     }
@@ -1604,6 +1608,90 @@ fn factor_multivariate_difference_of_squares(node: &IRNode) -> Option<IRNode> {
             apply_node(ADD, vec![positive_square, negative_square]),
         ],
     ))
+}
+
+fn factor_multivariate_grouping(node: &IRNode) -> Option<IRNode> {
+    let terms = additive_terms(node)?;
+    if terms.len() != 4 {
+        return None;
+    }
+
+    for first_index in 0..terms.len() - 1 {
+        for second_index in first_index + 1..terms.len() {
+            let grouped = vec![terms[first_index].clone(), terms[second_index].clone()];
+            let first_common = common_symbolic_powers(&grouped);
+            if first_common.is_empty() {
+                continue;
+            }
+
+            let rest: Vec<IRNode> = terms
+                .iter()
+                .enumerate()
+                .filter_map(|(index, term)| {
+                    if index == first_index || index == second_index {
+                        None
+                    } else {
+                        Some(term.clone())
+                    }
+                })
+                .collect();
+            let first_residual: Vec<IRNode> = grouped
+                .iter()
+                .map(|term| remove_common_factor(term, &first_common))
+                .collect();
+            let second_common = common_symbolic_powers(&rest);
+            let second_residual: Vec<IRNode> = rest
+                .iter()
+                .map(|term| remove_common_factor(term, &second_common))
+                .collect();
+            if !same_two_terms(&first_residual, &second_residual) {
+                continue;
+            }
+
+            let first_factor = powers_to_ir(&first_common);
+            let second_factor = if second_common.is_empty() {
+                IRNode::Integer(1)
+            } else {
+                powers_to_ir(&second_common)
+            };
+            return Some(apply_node(
+                MUL,
+                vec![
+                    apply_node(ADD, vec![first_factor, second_factor]),
+                    add_nodes(first_residual),
+                ],
+            ));
+        }
+    }
+
+    None
+}
+
+fn common_symbolic_powers(terms: &[IRNode]) -> HashMap<IRNode, usize> {
+    let Some((first, rest)) = terms.split_first() else {
+        return HashMap::new();
+    };
+
+    let mut common = term_factor_powers(first);
+    for term in rest {
+        let powers = term_factor_powers(term);
+        common.retain(|base, exponent| {
+            if let Some(other) = powers.get(base) {
+                *exponent = (*exponent).min(*other);
+                *exponent > 0
+            } else {
+                false
+            }
+        });
+    }
+    common
+}
+
+fn same_two_terms(left: &[IRNode], right: &[IRNode]) -> bool {
+    left.len() == 2
+        && right.len() == 2
+        && ((left[0] == right[0] && left[1] == right[1])
+            || (left[0] == right[1] && left[1] == right[0]))
 }
 
 fn additive_terms(node: &IRNode) -> Option<Vec<IRNode>> {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -392,6 +392,71 @@ fn symbolic_factor_extracts_multivariate_sum_of_cubes() {
     );
 }
 
+#[test]
+fn symbolic_factor_extracts_grouped_multivariate_terms() {
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(sym(MUL), vec![sym("x"), sym("y")]),
+                        apply(sym(MUL), vec![sym("x"), sym("z")]),
+                    ],
+                ),
+                apply(sym(ADD), vec![sym("y"), sym("z")]),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![sym("x"), int(1)]),
+                apply(sym(ADD), vec![sym("y"), sym("z")]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn symbolic_factor_extracts_grouped_multivariate_terms_with_signed_residuals() {
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(SUB),
+                    vec![
+                        apply(sym(MUL), vec![sym("x"), sym("y")]),
+                        apply(sym(MUL), vec![sym("x"), sym("z")]),
+                    ],
+                ),
+                apply(sym(SUB), vec![sym("y"), sym("z")]),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![sym("x"), int(1)]),
+                apply(
+                    sym(ADD),
+                    vec![sym("y"), apply(sym(MUL), vec![int(-1), sym("z")]),],
+                ),
+            ],
+        )
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolution
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a Rust symbolic-vm factor-by-grouping foothold for four-term bilinear expressions like x*y + x*z + y + z
- route the same behavior through the Rust MACSYMA runtime via factor(...)
- cover unsigned and signed residual grouping cases and update package changelogs

## Validation
- `cargo test -p symbolic-vm`
- `cargo test -p coding-adventures-macsyma-runtime`
- `git diff --check`
