### PR TITLE
Wire UNO R4 SerialUSB PWM backend

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -140,11 +140,11 @@ Arduino's `IRQManager.cpp` installs USBFS interrupt handlers dynamically during
 `src/arduino_usb_link.rs` records the Arduino Renesas/TinyUSB link contract for
 the built-in USB path: Arduino core version `1.5.3`, FQBN
 `arduino:renesas_uno:unor4wifi`, required TinyUSB C objects, `USB.cpp`,
-`IRQManager.cpp`, the Uno R4 WiFi `libfsp.a`, include directories, compile
-defines, and the Rust-provided C++ ABI hook symbols. The firmware build script
-uses the same manifest when `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, keeping CI
-independent from a local Arduino install while giving hardware builds an
-explicit link path.
+`IRQManager.cpp`, the Arduino GPT/AGT PWM objects, the Uno R4 WiFi `libfsp.a`,
+include directories, compile defines, and the Rust-provided C++ ABI hook
+symbols. The firmware build script uses the same manifest when
+`BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, keeping CI independent from a local
+Arduino install while giving hardware builds an explicit link path.
 
 Build the firmware library and host-tested server path now:
 
@@ -166,10 +166,12 @@ rustup run stable cargo build \
   --release
 ```
 
-The build script compiles the manifest's Arduino/TinyUSB C/C++ sources into a
-small archive under Cargo's `OUT_DIR`, links it with the Uno R4 WiFi `libfsp.a`
-for `uno-r4-wifi-serialusb-server`, and leaves the other firmware binaries on
-the pure-Rust link path. Override `BOARD_VM_UNO_R4_ARM_GCC`,
+The build script compiles the manifest's Arduino/TinyUSB/PWM C/C++ sources into
+a small archive under Cargo's `OUT_DIR`, links it with the Uno R4 WiFi
+`libfsp.a` for `uno-r4-wifi-serialusb-server`, and leaves the other firmware
+binaries on the pure-Rust link path. With that link enabled, the SerialUSB
+server swaps in the PWM-capable firmware backend and advertises `pwm.write` for
+the board's PWM-capable digital pins. Override `BOARD_VM_UNO_R4_ARM_GCC`,
 `BOARD_VM_UNO_R4_ARM_GXX`, or `BOARD_VM_UNO_R4_ARM_AR` if the Arduino-packaged
 toolchain cannot run on the host. When using a native ARM compiler that does
 not carry Newlib/libstdc++ headers, point `BOARD_VM_UNO_R4_ARM_COMPAT_ROOT` at

--- a/code/packages/rust/board-vm-uno-r4-firmware/build.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/build.rs
@@ -13,7 +13,7 @@ use arduino_usb_link::{
     ARDUINO_ARM_GCC_ENV_VAR, ARDUINO_ARM_GXX_ENV_VAR, ARDUINO_CORE_ENV_VAR,
     ARDUINO_USB_LINK_CFLAGS, ARDUINO_USB_LINK_CXXFLAGS, ARDUINO_USB_LINK_DEFINES,
     ARDUINO_USB_LINK_ENV_VAR, ARDUINO_USB_LINK_INCLUDE_DIRS, ARDUINO_USB_LINK_SOURCES,
-    UNO_R4_WIFI_FSP_ARCHIVE,
+    BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE, UNO_R4_WIFI_FSP_ARCHIVE,
 };
 
 const UNO_R4_SKETCH_FLASH_ORIGIN: u32 = 0x0000_4000;
@@ -33,6 +33,7 @@ const FIRMWARE_BINS: [&str; 6] = [
 
 fn main() {
     emit_rerun_hints();
+    println!("cargo:rustc-check-cfg=cfg(board_vm_uno_r4_arduino_usb_link)");
 
     if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("arm") {
         let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by Cargo"));
@@ -44,6 +45,7 @@ fn main() {
         }
 
         if env_enabled(ARDUINO_USB_LINK_ENV_VAR) {
+            println!("cargo:rustc-cfg=board_vm_uno_r4_arduino_usb_link");
             compile_and_link_arduino_usb(&out_dir);
         }
     }
@@ -118,6 +120,20 @@ fn compile_and_link_arduino_usb(out_dir: &Path) {
             }
         }
     }
+
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    let bridge_source = manifest_dir.join(BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE);
+    println!("cargo:rerun-if-changed={}", bridge_source.display());
+    let bridge_object = object_dir.join(object_name(BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE));
+    compile_source(
+        &gxx,
+        &core_dir,
+        &bridge_source,
+        &bridge_object,
+        ARDUINO_USB_LINK_CXXFLAGS,
+        &cxx_compat_args(&compat_root, &compat_header),
+    );
+    objects.push(bridge_object);
 
     let archive_path = out_dir.join(format!("lib{ARDUINO_USB_ARCHIVE}.a"));
     if archive_path.exists() {

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -2,7 +2,8 @@
 //
 // The Rust firmware owns the VM, protocol, device state, and CDC byte stream.
 // Arduino's Renesas core still owns the RA4M1 TinyUSB descriptors, IRQ
-// plumbing, and FSP USB driver objects needed by `__USBStart`.
+// plumbing, FSP USB driver objects needed by `__USBStart`, and the low-level
+// GPT/AGT timer setup behind the SerialUSB firmware's PWM backend.
 
 pub const ARDUINO_RENESAS_UNO_CORE_VERSION: &str = "1.5.3";
 pub const UNO_R4_WIFI_FQBN: &str = "arduino:renesas_uno:unor4wifi";
@@ -25,6 +26,7 @@ pub const ARDUINO_ARM_AR_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_AR";
 pub const ARDUINO_ARM_COMPAT_ROOT_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_COMPAT_ROOT";
 
 pub const ARDUINO_USB_START_SYMBOL: &str = "_Z10__USBStartv";
+pub const BOARD_VM_UNO_R4_PWM_WRITE_SYMBOL: &str = "board_vm_uno_r4_pwm_write";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
@@ -33,6 +35,7 @@ pub const RUST_USB_CDC_LINE_CODING_CALLBACK_SYMBOL: &str = "tud_cdc_line_coding_
 
 pub const UNO_R4_WIFI_FSP_ARCHIVE: &str = "variants/UNOWIFIR4/libs/libfsp.a";
 pub const UNO_R4_WIFI_FSP_LINKER_SCRIPT: &str = "variants/UNOWIFIR4/fsp.ld";
+pub const BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE: &str = "src/uno_r4_wifi_pwm_bridge.cpp";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArduinoSourceLanguage {
@@ -80,6 +83,8 @@ pub const ARDUINO_USB_LINK_SOURCES: &[ArduinoLinkSource] = &[
     ArduinoLinkSource::c("cores/arduino/tinyusb/rusb2/dcd_rusb2.c"),
     ArduinoLinkSource::c("cores/arduino/tinyusb/rusb2/rusb2_common.c"),
     ArduinoLinkSource::cxx("cores/arduino/IRQManager.cpp"),
+    ArduinoLinkSource::cxx("cores/arduino/FspTimer.cpp"),
+    ArduinoLinkSource::cxx("cores/arduino/pwm.cpp"),
     ArduinoLinkSource::cxx("cores/arduino/usb/USB.cpp"),
     ArduinoLinkSource::static_archive(UNO_R4_WIFI_FSP_ARCHIVE),
 ];
@@ -172,6 +177,9 @@ pub const ARDUINO_PROVIDED_USB_SYMBOLS: &[&str] = &[
     ARDUINO_USB_START_SYMBOL,
     "R_IOPORT_PinCfg",
     "R_IOPORT_PinWrite",
+    "R_GPT_Open",
+    "R_GPT_Start",
+    "R_GPT_DutyCycleSet",
     "tud_task_ext",
     "tud_cdc_n_connected",
     "tud_cdc_n_get_line_state",
@@ -214,9 +222,11 @@ mod tests {
     }
 
     #[test]
-    fn link_manifest_includes_usb_start_tinyusb_and_fsp_objects() {
+    fn link_manifest_includes_usb_start_tinyusb_pwm_and_fsp_objects() {
         assert!(contains_source("cores/arduino/usb/USB.cpp"));
         assert!(contains_source("cores/arduino/IRQManager.cpp"));
+        assert!(contains_source("cores/arduino/FspTimer.cpp"));
+        assert!(contains_source("cores/arduino/pwm.cpp"));
         assert!(contains_source("cores/arduino/tinyusb/tusb.c"));
         assert!(contains_source(
             "cores/arduino/tinyusb/class/cdc/cdc_device.c"
@@ -251,7 +261,16 @@ mod tests {
         assert!(RUST_PROVIDED_USB_SYMBOLS.contains(&"tud_cdc_line_coding_cb"));
         assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"R_IOPORT_PinCfg"));
         assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"R_IOPORT_PinWrite"));
+        assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"R_GPT_DutyCycleSet"));
         assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"tud_cdc_n_read"));
         assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"tud_cdc_n_write_flush"));
+        assert_eq!(
+            BOARD_VM_UNO_R4_PWM_WRITE_SYMBOL,
+            "board_vm_uno_r4_pwm_write"
+        );
+        assert_eq!(
+            BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE,
+            "src/uno_r4_wifi_pwm_bridge.cpp"
+        );
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_server.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_server.rs
@@ -9,7 +9,10 @@ mod firmware {
     use board_vm_uno_r4_firmware::serial_usb_server::{
         serial_usb_endpoint, serve_serial_usb_available,
     };
+    #[cfg(not(board_vm_uno_r4_arduino_usb_link))]
     use board_vm_uno_r4_firmware::uno_r4_wifi_backend::UnoR4WifiLedBackend;
+    #[cfg(board_vm_uno_r4_arduino_usb_link)]
+    use board_vm_uno_r4_firmware::uno_r4_wifi_backend::UnoR4WifiPwmBackend as UnoR4WifiLedBackend;
     use board_vm_uno_r4_usb_cdc::UnoR4WifiSerialUsb;
     use panic_halt as _;
 

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -95,3 +95,86 @@ impl UnoR4Backend for UnoR4WifiLedBackend {
         Ok(())
     }
 }
+
+#[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
+pub struct UnoR4WifiPwmBackend {
+    inner: UnoR4WifiLedBackend,
+}
+
+#[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
+impl UnoR4WifiPwmBackend {
+    pub fn new() -> Self {
+        Self {
+            inner: UnoR4WifiLedBackend::new(),
+        }
+    }
+
+    pub fn set_led(&mut self, level: Level) {
+        self.inner.set_led(level);
+    }
+
+    pub fn pause_ms(&mut self, duration_ms: u32) {
+        self.inner.pause_ms(duration_ms);
+    }
+
+    pub fn blink_pattern(&mut self, pulses: u8, on_ms: u32, off_ms: u32) {
+        self.inner.blink_pattern(pulses, on_ms, off_ms);
+    }
+
+    pub fn refresh_led_matrix_once(&mut self) {
+        self.inner.refresh_led_matrix_once();
+    }
+}
+
+#[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
+impl Default for UnoR4WifiPwmBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
+impl UnoR4Backend for UnoR4WifiPwmBackend {
+    fn configure_gpio(&mut self, pin: u8, mode: GpioMode) -> Result<(), HalError> {
+        self.inner.configure_gpio(pin, mode)
+    }
+
+    fn write_gpio(&mut self, pin: u8, level: Level) -> Result<(), HalError> {
+        self.inner.write_gpio(pin, level)
+    }
+
+    fn read_gpio(&mut self, pin: u8) -> Result<Level, HalError> {
+        self.inner.read_gpio(pin)
+    }
+
+    fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError> {
+        self.inner.sleep_ms(duration_ms)
+    }
+
+    fn now_ms(&self) -> u32 {
+        self.inner.now_ms()
+    }
+
+    fn supports_pwm(&self) -> bool {
+        true
+    }
+
+    fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
+        self.inner.led_matrix_frame(frame)
+    }
+
+    fn write_pwm(&mut self, pin: u8, duty: u16) -> Result<(), HalError> {
+        if unsafe { pwm_ffi::board_vm_uno_r4_pwm_write(pin, duty) } {
+            Ok(())
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+}
+
+#[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
+mod pwm_ffi {
+    unsafe extern "C" {
+        pub fn board_vm_uno_r4_pwm_write(pin: u8, duty: u16) -> bool;
+    }
+}

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -1,0 +1,192 @@
+#include <array>
+#include <stddef.h>
+#include <stdint.h>
+#include <new>
+
+#include "Arduino.h"
+#include "pwm.h"
+#include "pinmux.inc"
+
+namespace {
+
+constexpr uint8_t kPwmPins[] = {3, 5, 6, 9, 10, 11};
+constexpr size_t kOperatorNewHeapBytes = 2048;
+
+struct PwmSlot {
+  uint8_t pin;
+  alignas(PwmOut) uint8_t storage[sizeof(PwmOut)];
+  PwmOut *pwm;
+  bool started;
+};
+
+alignas(max_align_t) uint8_t g_operator_new_heap[kOperatorNewHeapBytes];
+size_t g_operator_new_next = 0;
+PwmSlot g_pwm_slots[] = {
+  {3, {}, nullptr, false},
+  {5, {}, nullptr, false},
+  {6, {}, nullptr, false},
+  {9, {}, nullptr, false},
+  {10, {}, nullptr, false},
+  {11, {}, nullptr, false},
+};
+bool g_pwm_channels_reserved = false;
+
+PwmSlot *find_slot(uint8_t pin) {
+  for (auto &slot : g_pwm_slots) {
+    if (slot.pin == pin) {
+      return &slot;
+    }
+  }
+  return nullptr;
+}
+
+size_t align_up(size_t value, size_t align) {
+  return (value + align - 1) & ~(align - 1);
+}
+
+void *allocate_operator_new(size_t size) {
+  if (size == 0) {
+    size = 1;
+  }
+
+  size_t aligned = align_up(g_operator_new_next, alignof(max_align_t));
+  size_t next = aligned + size;
+  if (next > kOperatorNewHeapBytes) {
+    while (true) {
+    }
+  }
+
+  g_operator_new_next = next;
+  return &g_operator_new_heap[aligned];
+}
+
+void reserve_pwm_timer_channels() {
+  if (g_pwm_channels_reserved) {
+    return;
+  }
+
+  for (uint8_t pin : kPwmPins) {
+    auto cfg = getPinCfgs(pin, PIN_CFG_REQ_PWM);
+    if (cfg[0] != 0) {
+      FspTimer::set_initial_timer_channel_as_pwm(GPT_TIMER, GET_CHANNEL(cfg[0]));
+    }
+  }
+
+  g_pwm_channels_reserved = true;
+}
+
+PwmOut *slot_pwm(PwmSlot &slot) {
+  if (slot.pwm == nullptr) {
+    slot.pwm = new (slot.storage) PwmOut(slot.pin);
+  }
+  return slot.pwm;
+}
+
+bool pin_cfg_matches(uint16_t cfg, PinCfgReq_t req) {
+  switch (req) {
+    case PIN_CFG_REQ_PWM:
+      return IS_PIN_PWM(cfg);
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
+void *operator new(size_t size) {
+  return allocate_operator_new(size);
+}
+
+void *operator new[](size_t size) {
+  return allocate_operator_new(size);
+}
+
+void operator delete(void *) noexcept {}
+
+void operator delete[](void *) noexcept {}
+
+void operator delete(void *, size_t) noexcept {}
+
+void operator delete[](void *, size_t) noexcept {}
+
+extern "C" const PinMuxCfg_t g_pin_cfg[] = {
+  {BSP_IO_PORT_03_PIN_01, P301}, /* (0) D0 */
+  {BSP_IO_PORT_03_PIN_02, P302}, /* (1) D1 */
+  {BSP_IO_PORT_01_PIN_04, P104}, /* (2) D2 */
+  {BSP_IO_PORT_01_PIN_05, P105}, /* (3) D3~ */
+  {BSP_IO_PORT_01_PIN_06, P106}, /* (4) D4 */
+  {BSP_IO_PORT_01_PIN_07, P107}, /* (5) D5~ */
+  {BSP_IO_PORT_01_PIN_11, P111}, /* (6) D6~ */
+  {BSP_IO_PORT_01_PIN_12, P112}, /* (7) D7 */
+  {BSP_IO_PORT_03_PIN_04, P304}, /* (8) D8 */
+  {BSP_IO_PORT_03_PIN_03, P303}, /* (9) D9~ */
+  {BSP_IO_PORT_01_PIN_03, P103}, /* (10) D10~ */
+  {BSP_IO_PORT_04_PIN_11, P411}, /* (11) D11~ */
+  {BSP_IO_PORT_04_PIN_10, P410}, /* (12) D12 */
+  {BSP_IO_PORT_01_PIN_02, P102}, /* (13) D13 */
+};
+
+extern "C" ioport_instance_ctrl_t g_ioport_ctrl = {};
+
+extern "C" unsigned int PINCOUNT_fn() {
+  return sizeof(g_pin_cfg) / sizeof(g_pin_cfg[0]);
+}
+
+int32_t getPinIndex(bsp_io_port_pin_t pin) {
+  for (unsigned int index = 0; index < PINCOUNT_fn(); index++) {
+    if (g_pin_cfg[index].pin == pin) {
+      return static_cast<int32_t>(index);
+    }
+  }
+  return -1;
+}
+
+std::array<uint16_t, 3> getPinCfgs(const pin_size_t pin, PinCfgReq_t req) {
+  std::array<uint16_t, 3> ret = {0, 0, 0};
+  if (pin >= PINCOUNT_fn()) {
+    return ret;
+  }
+
+  const uint16_t *cfg = g_pin_cfg[pin].list;
+  uint8_t out = 0;
+  for (uint8_t index = 0; out < ret.size(); index++) {
+    uint16_t item = *(cfg + index);
+    if (pin_cfg_matches(item, req)) {
+      ret[out++] = item;
+    }
+    if (IS_LAST_ITEM(item)) {
+      break;
+    }
+  }
+
+  return ret;
+}
+
+FspTimer *__get_timer_for_channel(int channel) {
+  for (auto &slot : g_pwm_slots) {
+    if (slot.started && slot.pwm != nullptr &&
+        slot.pwm->get_timer()->get_channel() == static_cast<uint32_t>(channel)) {
+      return slot.pwm->get_timer();
+    }
+  }
+  return nullptr;
+}
+
+extern "C" bool board_vm_uno_r4_pwm_write(uint8_t pin, uint16_t duty) {
+  PwmSlot *slot = find_slot(pin);
+  if (slot == nullptr) {
+    return false;
+  }
+
+  reserve_pwm_timer_channels();
+  PwmOut *pwm = slot_pwm(*slot);
+  if (!slot->started) {
+    if (!pwm->begin()) {
+      return false;
+    }
+    slot->started = true;
+  }
+
+  float duty_percent = (static_cast<float>(duty) * 100.0f) / 65535.0f;
+  return pwm->pulse_perc(duty_percent);
+}


### PR DESCRIPTION
## Summary
- link Arduino Renesas FspTimer/PwmOut sources into the UNO R4 SerialUSB firmware artifact
- add a SerialUSB-only PWM backend that advertises `pwm.write` when the Arduino USB link path is enabled
- bridge Board VM normalized u16 PWM writes to the UNO R4 WiFi PWM-capable digital pins (3, 5, 6, 9, 10, 11)

## Hardware status
- The ARM SerialUSB firmware artifact builds and links with the PWM backend.
- Physical flashing is currently blocked by the board staying on runtime USB PID `0x006D` after 1200-baud bootloader touch; BOSSA reports `No device found on cu.usbmodem1101`. This requires a manual double-tap/reset into bootloader before the new firmware can be uploaded and smoke-tested on the board.

## Validation
- `cargo test -p board-vm-uno-r4-firmware`
- `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1 BOARD_VM_UNO_R4_ARDUINO_CORE="$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" BOARD_VM_UNO_R4_ARM_GCC=/opt/homebrew/bin/arm-none-eabi-gcc BOARD_VM_UNO_R4_ARM_GXX=/opt/homebrew/bin/arm-none-eabi-g++ BOARD_VM_UNO_R4_ARM_AR=/opt/homebrew/bin/arm-none-eabi-ar BOARD_VM_UNO_R4_ARM_COMPAT_ROOT="$HOME/Library/Arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4" RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-server --release`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
