### PR TITLE
Python factor multivariate integer content

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added MACSYMA `factor` parity for shared integer content in multivariate
+  common-factor expressions, so `factor(2*x*y + 2*x*z)` now returns
+  `2*x*(y+z)` through the canonical symbolic VM handler.
 - Added MACSYMA `factor` parity for perfect-cube expansions, so
   `factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3)` returns `(x+y)^3` and
   `factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3)` returns `(x-y)^3` through the

--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -726,6 +726,32 @@ def test_pipeline_factor_common_multivariate_factor() -> None:
     assert "y" in str(result)
 
 
+def test_pipeline_factor_common_multivariate_integer_content() -> None:
+    """factor(2*x*y + 2*x*z) extracts the shared integer and symbolic factors."""
+    result = _eval("factor(2*x*y + 2*x*z)")
+    assert isinstance(result, IRApply)
+    assert result == IRApply(
+        IRSymbol("Mul"),
+        (
+            IRApply(IRSymbol("Mul"), (IRInteger(2), IRSymbol("x"))),
+            IRApply(IRSymbol("Add"), (IRSymbol("y"), IRSymbol("z"))),
+        ),
+    )
+
+
+def test_pipeline_factor_common_multivariate_negative_integer_content() -> None:
+    """factor(-2*x*y - 2*x*z) keeps the shared sign with the content."""
+    result = _eval("factor(-2*x*y - 2*x*z)")
+    assert isinstance(result, IRApply)
+    assert result == IRApply(
+        IRSymbol("Mul"),
+        (
+            IRApply(IRSymbol("Mul"), (IRInteger(-2), IRSymbol("x"))),
+            IRApply(IRSymbol("Add"), (IRSymbol("y"), IRSymbol("z"))),
+        ),
+    )
+
+
 def test_pipeline_factor_multivariate_perfect_square() -> None:
     """factor(x^2 + 2*x*y + y^2) recognises (x+y)^2."""
     result = _eval("factor(x^2 + 2*x*y + y^2)")

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Extended the common multivariate factoring foothold to extract shared
+  integer content as well as symbolic powers, so expressions like
+  `2*x*y + 2*x*z` now factor to `2*x*(y+z)`.
 - Added another small multivariate factoring foothold to `Factor`: four-term
   perfect-cube expansions such as `x^3 + 3*x^2*y + 3*x*y^2 + y^3` now factor
   to `(x+y)^3`, and `x^3 - 3*x^2*y + 3*x*y^2 - y^3` to `(x-y)^3`.

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -1053,6 +1053,20 @@ def _split_integer_coefficient_and_powers(
     return coefficient, powers
 
 
+def _term_from_integer_coefficient_and_powers(
+    coefficient: int,
+    powers: dict[IRNode, int],
+) -> IRNode:
+    terms: list[IRNode] = []
+    if coefficient != 1 or not powers:
+        terms.append(IRInteger(coefficient))
+    terms.extend(
+        _pow_node(base, exponent)
+        for base, exponent in sorted(powers.items(), key=lambda item: str(item[0]))
+    )
+    return _mul_nodes(terms)
+
+
 def _remove_common_factor(node: IRNode, common: dict[IRNode, int]) -> IRNode:
     remaining = dict(common)
     rebuilt: list[IRNode] = []
@@ -1075,23 +1089,44 @@ def _remove_common_factor(node: IRNode, common: dict[IRNode, int]) -> IRNode:
     return _mul_nodes(rebuilt)
 
 
+def _maybe_factor_residual(residual: IRNode) -> IRNode:
+    x = _find_variable(residual)
+    if x is not None and to_rational(residual, x) is not None:
+        return IRApply(IRSymbol("Factor"), (residual,))
+    return residual
+
+
 def _extract_common_symbolic_factor(inner: IRNode) -> IRNode | None:
     """Pull a common symbolic factor from an additive expression.
 
     This is a deliberately small multivariate factoring foothold. It handles
-    cases like ``x^2*y - y`` by extracting ``y`` and leaving ``x^2 - 1`` for
-    the existing univariate integer factorizer.
+    cases like ``x^2*y - y`` and ``2*x*y + 2*x*z`` by extracting the common
+    symbolic powers and integer content shared by every term.
     """
     terms = _flatten_add_terms(inner)
     if len(terms) < 2:
         return None
 
-    per_term = [_split_common_factor_term(term) for term in terms]
-    if any(powers is None for powers in per_term):
+    parsed = [_split_integer_coefficient_and_powers(term) for term in terms]
+    if any(term is None for term in parsed):
         return None
-    common = dict(per_term[0] or {})
-    for powers in per_term[1:]:
-        assert powers is not None
+
+    parsed_terms: list[tuple[int, dict[IRNode, int]]] = []
+    for parsed_term in parsed:
+        assert parsed_term is not None
+        parsed_terms.append(parsed_term)
+
+    coefficients = [coefficient for coefficient, _powers in parsed_terms]
+    common_coefficient = 0
+    for coefficient in coefficients:
+        common_coefficient = math.gcd(common_coefficient, abs(coefficient))
+    if common_coefficient and all(coefficient < 0 for coefficient in coefficients):
+        common_coefficient = -common_coefficient
+    if common_coefficient == 0:
+        common_coefficient = 1
+
+    common = dict(parsed_terms[0][1])
+    for _coefficient, powers in parsed_terms[1:]:
         for base in list(common):
             shared = min(common[base], powers.get(base, 0))
             if shared:
@@ -1099,17 +1134,23 @@ def _extract_common_symbolic_factor(inner: IRNode) -> IRNode | None:
             else:
                 del common[base]
 
-    if not common:
+    if common_coefficient == 1 and not common:
         return None
 
-    common_terms = [
-        _pow_node(base, exponent)
-        for base, exponent in sorted(common.items(), key=lambda item: str(item[0]))
+    common_ir = _term_from_integer_coefficient_and_powers(common_coefficient, common)
+    residual_terms = [
+        _term_from_integer_coefficient_and_powers(
+            coefficient // common_coefficient,
+            {
+                base: exponent - common.get(base, 0)
+                for base, exponent in powers.items()
+                if exponent - common.get(base, 0) > 0
+            },
+        )
+        for coefficient, powers in parsed_terms
     ]
-    common_ir = _mul_nodes(common_terms)
-    residual_terms = [_remove_common_factor(term, common) for term in terms]
     residual = _add_nodes(residual_terms)
-    return IRApply(MUL, (common_ir, IRApply(IRSymbol("Factor"), (residual,))))
+    return IRApply(MUL, (common_ir, _maybe_factor_residual(residual)))
 
 
 def _extract_multivariate_perfect_square(inner: IRNode) -> IRNode | None:

--- a/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
+++ b/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
@@ -219,6 +219,52 @@ def test_factor_common_multivariate_symbolic_factor() -> None:
     assert result != expr
 
 
+def test_factor_common_multivariate_integer_content() -> None:
+    """Factor(2*x*y + 2*x*z) extracts both 2 and x."""
+    vm, _ = make_vm()
+    xy = IRApply(MUL, (x, y))
+    xz = IRApply(MUL, (x, z))
+    target = IRApply(
+        ADD,
+        (
+            IRApply(MUL, (IRInteger(2), xy)),
+            IRApply(MUL, (IRInteger(2), xz)),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert result == IRApply(
+        MUL,
+        (
+            IRApply(MUL, (IRInteger(2), x)),
+            IRApply(ADD, (y, z)),
+        ),
+    )
+
+
+def test_factor_common_multivariate_negative_integer_content() -> None:
+    """Factor(-2*x*y - 2*x*z) extracts a negative common coefficient."""
+    vm, _ = make_vm()
+    xy = IRApply(MUL, (x, y))
+    xz = IRApply(MUL, (x, z))
+    target = IRApply(
+        ADD,
+        (
+            IRApply(MUL, (IRInteger(-2), xy)),
+            IRApply(MUL, (IRInteger(-2), xz)),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    assert result == IRApply(
+        MUL,
+        (
+            IRApply(MUL, (IRInteger(-2), x)),
+            IRApply(ADD, (y, z)),
+        ),
+    )
+
+
 def test_factor_multivariate_perfect_square() -> None:
     """Factor(x^2 + 2*x*y + y^2) recognises a bivariate square."""
     vm, _ = make_vm()


### PR DESCRIPTION
## Summary
- extend the Python symbolic-vm common multivariate factor foothold to extract shared integer content as well as symbolic powers
- make factor(2*x*y + 2*x*z) produce 2*x*(y+z), with all-negative content keeping the shared sign
- cover the behavior through direct symbolic-vm handler tests and the MACSYMA runtime pipeline

## Validation
- `pytest -q code/packages/python/symbolic-vm/tests/test_cas_handlers.py -k factor --no-cov`
- `pytest -q code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py -k factor --no-cov`
- `git diff --check`
