### PR TITLE
feat: MX05 Phase 4.9 — matrix-cpu auto-install + dispatch routing

### DIFF
--- a/code/packages/rust/image-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/image-gpu-core/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog — image-gpu-core
 
+## 0.12.0 — 2026-05-13
+
+### Added — MX05 Phase 4.9 (matrix-cpu auto-install + dispatch routing)
+
+Closes the gap that's been open since Phase 4.3: the auto-installer
+now installs on the **CPU executor** too, not just metal.  Combined
+with matrix-cpu v0.5.0's new `build_specialised_kernel`, this
+finally exercises specialised dispatch on every platform — Linux
+and Windows CI included, where metal is unavailable.
+
+#### Per-thread `CpuBackend`
+
+Promotes the CPU executor from a per-dispatch construction
+(`matrix_cpu::local_transport()` per call) to a **thread-local**
+singleton.  Persistence within a thread means a real workload's
+1000+ repeat dispatches see the auto-installer's installs.
+Per-thread isolation means cargo's parallel unit-test runner
+doesn't cross-contaminate `BufferStore` state.
+
+```rust
+thread_local! {
+    static CPU_BACKEND: CpuBackend = { /* Arc<CpuExecutor> + LocalTransport */ };
+}
+```
+
+Callers use `with_cpu_backend(|b| ...)` to access the
+thread-local instance.
+
+#### `try_auto_install_specialised` dispatches on `backend_id`
+
+The auto-installer now branches on `specialised.key.backend_id`:
+
+  - `0` → CPU: `matrix_cpu::build_specialised_kernel` →
+    `CpuExecutor::install_specialised`.  Always available.
+  - `1` → metal: `matrix_metal::emit_specialised_kernel` →
+    `MetalExecutor::install_specialised_from_emitted`.
+    Apple-only.
+
+Both paths share `INSTALLED_HANDLES` (handles are unique because
+the SpecKey hash feeds on `backend_id` since Phase 4.6) and
+`INSTALLED_KERNEL_METADATA`.
+
+#### Updated `specialised_install_count`
+
+Was Apple-only via `#[cfg(feature = "metal-backend")]` returning
+the metal executor's count.  Now sums **both** backends' counts —
+matrix-cpu's `specialised_count()` plus matrix-metal's (when
+available).  Returns the total installs in this thread, across
+backends.
+
+#### Test (33 → 34)
+
+`cpu_auto_installer_registers_kernel_after_threshold` — the CPU
+counterpart of Phase 4.3's metal-only `auto_installer_registers_kernel_after_threshold`.
+
+Drives an Add-with-constant graph 1100 times, asserts
+`specialised_install_count` rises.  **Runs on every platform**
+because the planner picks CPU for tiny graphs unconditionally
+(no metal-vs-CPU cost-model gymnastics required).
+
+#### Side-table cfg cleanup
+
+`installed_handles`, `installed_kernel_metadata`,
+`record_test_kernel_metadata`, `KernelMetadata`, and
+`handle_is_installed` lost their `#[cfg(feature = "metal-backend")]`
+gates — they're now always-on because the CPU install path also
+exercises them.
+
 ## 0.11.0 — 2026-05-13
 
 ### Added — MX05 Phase 4.8 (multi-op specialised dispatch)

--- a/code/packages/rust/image-gpu-core/Cargo.toml
+++ b/code/packages/rust/image-gpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image-gpu-core"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). v0.3 wires the optional matrix-metal GPU backend. v0.4 wires the MX05 specialisation pipeline. v0.5 installs CpuSpecialiser. v0.6 adds tensor-byte sampling. v0.7 (MX05 Phase 4.3) adds the runtime-side auto-installer with a specialised_install_count() counter. v0.8 (MX05 Phase 4.4) closes the dispatch half: when a single-Compute-op graph has an installed specialised kernel on metal, image-gpu-core now routes the dispatch through ExecutorRequest::DispatchSpecialised (a prep Dispatch sets up buffers, then DispatchSpecialised invokes the installed kernel by handle). Counter specialised_dispatch_count() tracks how many invocations went specialised."
 

--- a/code/packages/rust/image-gpu-core/src/pipeline.rs
+++ b/code/packages/rust/image-gpu-core/src/pipeline.rs
@@ -63,16 +63,11 @@ use matrix_ir::{Graph, Op, TensorId};
 use matrix_runtime::{DefaultPolicy, Profiler, Runtime, SpecCache, SpecRouter};
 use std::cell::Cell;
 use std::collections::HashMap;
-#[cfg(feature = "metal-backend")]
 use std::collections::HashSet;
-#[cfg(feature = "metal-backend")]
 use std::sync::{Arc, Mutex, OnceLock};
-#[cfg(not(feature = "metal-backend"))]
-use std::sync::OnceLock;
 // matrix_profile re-exports SpecialisedKernel via matrix_runtime; we
 // take it directly so the auto-installer can pattern-match on its
 // `key` field.
-#[cfg(feature = "metal-backend")]
 use matrix_runtime::SpecialisedKernel;
 
 // ─────────────────────────── Last-executor reporting ───────────────────────────
@@ -149,6 +144,49 @@ fn metal_backend() -> Option<&'static MetalBackend> {
     .as_ref()
 }
 
+// ─────────────────────────── CPU backend singleton (Phase 4.9) ───────────────────────────
+//
+// Up to Phase 4.8 the CPU dispatch path called `matrix_cpu::local_transport()`
+// per invocation, which created a fresh `CpuExecutor` each time.
+// That was fine when specialised kernels only ever lived on the
+// metal executor, but Phase 4.9 wants the auto-installer to install
+// closures on the CPU executor too — and those installs need to
+// persist across invocations.  So we promote the CPU executor to
+// a process-wide singleton, exactly parallel to `MetalBackend`.
+
+struct CpuBackend {
+    /// Direct reference to the CPU executor so the auto-installer
+    /// can call `install_specialised(handle, kernel)` on it.
+    executor: Arc<matrix_cpu::CpuExecutor>,
+    /// The standard wire-format transport used by the dispatcher.
+    transport: LocalTransport,
+}
+
+// **Per-thread** so concurrent unit tests don't contaminate each
+// other's BufferStore.  Within one thread (real workloads, or one
+// test's sequence of dispatches) the backend is persistent — so
+// specialised kernels installed by the auto-installer survive
+// across the 1000+ invocations that real workflows need.  Each
+// production dispatch path lives on its own thread (or runs
+// serially within image-gpu-core's caller), so per-thread
+// persistence matches the actual sharing model.
+thread_local! {
+    static CPU_BACKEND: CpuBackend = {
+        let exec = Arc::new(matrix_cpu::CpuExecutor::new());
+        let exec2 = exec.clone();
+        let transport = LocalTransport::new(move |req| exec2.handle(req));
+        CpuBackend { executor: exec, transport }
+    };
+}
+
+/// Run a closure with access to the thread-local `CpuBackend`.
+/// Used by every caller that needs to interact with the CPU
+/// executor — the dispatcher, the auto-installer, and the public
+/// `specialised_install_count`.
+fn with_cpu_backend<R>(f: impl FnOnce(&CpuBackend) -> R) -> R {
+    CPU_BACKEND.with(f)
+}
+
 // ─────────────────────────── MX05 specialisation singletons ───────────────────────────
 //
 // MX05 Phase 1 / 2a / 3 V1 / V2 / V3 shipped the Profiler /
@@ -220,22 +258,24 @@ pub fn spec_cache_len() -> usize {
 /// installs are in flight or when an install fails (e.g. compilation
 /// rejects the emitted MSL).
 ///
-/// On non-Apple targets this always returns `0` — there's no Metal
-/// executor to install onto, and the matrix-cpu auto-install path
-/// (which would need a closure source, not just a handle) is later
-/// MX05 phase work.
-#[cfg(feature = "metal-backend")]
+/// **MX05 Phase 4.9.**  Now counts installs on **both** the CPU and
+/// metal executors.  Before Phase 4.9 the CPU auto-install path
+/// didn't exist (matrix-cpu's `CpuSpecialiser` emitted opaque handles
+/// without closure sources), so this counter was metal-only and
+/// returned 0 on non-Apple builds.  The new
+/// `matrix_cpu::build_specialised_kernel` closes that gap, so the
+/// counter now reflects the **total** kernels registered across
+/// every backing executor in this process.
 pub fn specialised_install_count() -> usize {
-    match metal_backend() {
+    let cpu_count = with_cpu_backend(|b| b.executor.specialised_count());
+    #[cfg(feature = "metal-backend")]
+    let metal_count = match metal_backend() {
         Some(b) => b.executor.specialised_count(),
         None => 0,
-    }
-}
-
-/// **MX05 Phase 4.3.**  No-op stub for non-Apple targets.  Always `0`.
-#[cfg(not(feature = "metal-backend"))]
-pub fn specialised_install_count() -> usize {
-    0
+    };
+    #[cfg(not(feature = "metal-backend"))]
+    let metal_count = 0usize;
+    cpu_count + metal_count
 }
 
 /// **MX05 Phase 4.4.**  Number of dispatches the runtime has routed
@@ -292,29 +332,27 @@ static SPECIALISED_DISPATCH_COUNT: std::sync::atomic::AtomicUsize =
 //     end-to-end DispatchDone → speedup loop.  Splitting that work
 //     into its own PR keeps Phase 4.3 reviewable.
 
-/// Process-wide set of handles we've already attempted to install
-/// onto a metal executor.  Initialisation is lazy so non-metal builds
-/// never allocate.
-#[cfg(feature = "metal-backend")]
+/// Process-wide set of handles already installed on **any** backend
+/// (CPU or metal).  Phase 4.9: shared between the two backends so
+/// the auto-installer can short-circuit on already-installed handles
+/// regardless of which executor they ended up on.
 fn installed_handles() -> &'static Mutex<HashSet<u64>> {
     static SLOT: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();
     SLOT.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
-/// **MX05 Phase 4.4 / extended in 4.6.**  Per-handle metadata recorded
-/// at install time so the dispatch-routing path can validate buffer
-/// counts and pick the correct unfolded slot without re-emitting the
-/// kernel.  The tuple is
-/// `(input_buffer_count, output_buffer_count, folded_slot)`.
+/// **MX05 Phase 4.4 / extended in 4.6 / 4.9.**  Per-handle metadata
+/// recorded at install time so the dispatch-routing path can
+/// validate buffer counts and pick the correct unfolded slot without
+/// re-emitting the kernel.  Shared between CPU and metal install
+/// paths (Phase 4.9): both backends record the same
+/// `(n_in, n_out, folded_slot)` triple, keyed by the SpecKey's
+/// 64-bit handle.
 ///
 /// `folded_slot` is `Some(s)` for binary ops where the policy
 /// observed slot `s` as a constant, and `None` otherwise (e.g.
 /// commutative ops where slot doesn't matter, or future
-/// `RangeClass::FloatBits`/`Integer` shapes).  Phase 4.6 introduced
-/// this so non-commutative ops (Sub/Div/Pow) can route the
-/// **unfolded** input through `DispatchSpecialised` regardless of
-/// which side carried the constant.
-#[cfg(feature = "metal-backend")]
+/// `RangeClass::FloatBits`/`Integer` shapes).
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct KernelMetadata {
     pub n_in: usize,
@@ -327,7 +365,6 @@ pub(crate) struct KernelMetadata {
     pub folded_slot: Option<u8>,
 }
 
-#[cfg(feature = "metal-backend")]
 fn installed_kernel_metadata() -> &'static Mutex<HashMap<u64, KernelMetadata>> {
     static SLOT: OnceLock<Mutex<HashMap<u64, KernelMetadata>>> = OnceLock::new();
     SLOT.get_or_init(|| Mutex::new(HashMap::new()))
@@ -336,8 +373,10 @@ fn installed_kernel_metadata() -> &'static Mutex<HashMap<u64, KernelMetadata>> {
 /// **Test-only**.  Manually record kernel metadata for a handle.
 /// Used by integration tests that install a kernel directly via
 /// `MetalExecutor::install_specialised_from_emitted` rather than
-/// going through the auto-installer.
-#[cfg(all(test, feature = "metal-backend"))]
+/// going through the auto-installer.  Available on all platforms
+/// since Phase 4.9 because the CPU install path also exercises
+/// this metadata table.
+#[cfg(test)]
 pub(crate) fn record_test_kernel_metadata(
     handle: u64,
     n_in: usize,
@@ -381,12 +420,11 @@ pub(crate) fn record_test_kernel_metadata(
 /// mutex acquire inside `MetalExecutor::install_specialised_from_emitted`.
 /// Subsequent calls with the same handle are a single mutex acquire
 /// and a `HashSet::contains` — sub-microsecond.
-#[cfg(feature = "metal-backend")]
 fn try_auto_install_specialised(specialised: &SpecialisedKernel) -> bool {
-    let Some(backend) = metal_backend() else {
-        return false;
-    };
-    // Fast path: skip if already installed.
+    // Fast path: skip if already installed (on any backend).  The
+    // handle hash includes `backend_id`, so CPU and metal versions
+    // of the same SpecKey get distinct handles — no risk of
+    // confusing one for the other.
     {
         let installed = match installed_handles().lock() {
             Ok(g) => g,
@@ -396,23 +434,91 @@ fn try_auto_install_specialised(specialised: &SpecialisedKernel) -> bool {
             return false;
         }
     }
+
+    // Dispatch on `backend_id`:
+    //   0 → CPU (matrix_cpu::build_specialised_kernel + CpuExecutor::install_specialised)
+    //   1 → metal (matrix_metal::emit_specialised_kernel + install_specialised_from_emitted)
+    // Other values → ignore (no backend registered).
+    match specialised.key.backend_id {
+        0 => try_install_cpu(specialised),
+        #[cfg(feature = "metal-backend")]
+        1 => try_install_metal(specialised),
+        _ => false,
+    }
+}
+
+/// **MX05 Phase 4.9.**  Install a specialised kernel on the CPU
+/// executor singleton.  Returns `true` on a fresh install.
+fn try_install_cpu(specialised: &SpecialisedKernel) -> bool {
+    let Some(kernel) =
+        matrix_cpu::build_specialised_kernel(&specialised.key, specialised.handle)
+    else {
+        return false;
+    };
+    // matrix_cpu::CpuExecutor::install_specialised is infallible
+    // (no compile step on CPU).  No error path here — record and
+    // mark as installed.
+    with_cpu_backend(|b| {
+        b.executor.install_specialised(specialised.handle, kernel);
+    });
+    // Record metadata.  CPU kernels' (n_in, n_out) is determined by
+    // the SpecKey shape: unary memset → (0, 1); binary-with-folded
+    // → (1, 1).
+    let (n_in, n_out) = derive_buffer_counts(&specialised.key);
+    {
+        let mut installed = match installed_handles().lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        installed.insert(specialised.handle);
+    }
+    {
+        let mut md = match installed_kernel_metadata().lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        md.insert(
+            specialised.handle,
+            KernelMetadata {
+                n_in,
+                n_out,
+                folded_slot: specialised.key.folded_slot,
+            },
+        );
+    }
+    true
+}
+
+/// **MX05 Phase 4.9 helper.**  Reverse-engineer `(n_in, n_out)`
+/// from a SpecKey, mirroring the logic in
+/// `matrix_cpu::build_specialised_kernel`.  Used to populate
+/// `KernelMetadata` for CPU installs, where the kernel closure
+/// doesn't carry a separate descriptor.
+///
+/// Returns `(0, 1)` for unary-folded-input kernels (memset shape)
+/// and `(1, 1)` for binary-with-folded-constant kernels.
+fn derive_buffer_counts(key: &matrix_runtime::SpecKey) -> (usize, usize) {
+    // Unary ops with folded input → 0 inputs.
+    let is_unary_memset = matches!(key.op_kind, 0x00..=0x06)
+        && matches!(key.folded_slot, Some(0));
+    if is_unary_memset {
+        (0, 1)
+    } else {
+        // Binary-with-folded-constant → 1 input + 1 output.
+        (1, 1)
+    }
+}
+
+#[cfg(feature = "metal-backend")]
+fn try_install_metal(specialised: &SpecialisedKernel) -> bool {
+    let Some(backend) = metal_backend() else {
+        return false;
+    };
     // Slow path: emit MSL, compile, install.
     let Some(emitted) = matrix_metal::emit_specialised_kernel(&specialised.key, specialised.handle)
     else {
         return false;
     };
-    // **MX05 Phase 4.4 / extended in 4.6.**  Stash the kernel's
-    // input/output buffer counts plus the SpecKey's `folded_slot`
-    // before the EmittedKernel is consumed by the install call.
-    // The dispatch-routing path reads these to:
-    //   - trim `ir_op.inputs()` down to the buffers the specialised
-    //     kernel actually consumes (commonly 1 for a binary op + 1
-    //     folded constant);
-    //   - pick which IR input slot to pass: for a binary op with
-    //     `folded_slot = Some(s)`, the unfolded slot is `1 - s` (so
-    //     LHS-folded → pass RHS, RHS-folded → pass LHS).  Phase 4.6
-    //     lights this up; Phase 4.4 ignored slot and always passed
-    //     the first `n_in` inputs.
     let n_in = emitted.input_buffer_count;
     let n_out = emitted.output_buffer_count;
     let folded_slot = specialised.key.folded_slot;
@@ -448,11 +554,6 @@ fn try_auto_install_specialised(specialised: &SpecialisedKernel) -> bool {
             false
         }
     }
-}
-
-#[cfg(not(feature = "metal-backend"))]
-fn try_auto_install_specialised(_specialised: &matrix_runtime::SpecialisedKernel) -> bool {
-    false
 }
 
 /// Drive the MX05 specialisation pipeline for one placed graph:
@@ -595,18 +696,12 @@ fn drive_specialisation(placed: &ComputeGraph) -> HashMap<u32, u64> {
 /// the per-op installed-handle map even on cache hits where
 /// `try_auto_install_specialised` would have short-circuited and
 /// returned `false`.
-#[cfg(feature = "metal-backend")]
 fn handle_is_installed(handle: u64) -> bool {
     let installed = match installed_handles().lock() {
         Ok(g) => g,
         Err(poisoned) => poisoned.into_inner(),
     };
     installed.contains(&handle)
-}
-
-#[cfg(not(feature = "metal-backend"))]
-fn handle_is_installed(_handle: u64) -> bool {
-    false
 }
 
 // ─────────────────────────── Public entry point ───────────────────────────
@@ -641,8 +736,17 @@ pub fn run_graph_with_constant_inputs(
             return if only == metal_id {
                 dispatch_via(&metal.transport, placed, output_id, output_byte_count, "metal")
             } else if only == CPU_EXECUTOR {
-                let cpu_transport = matrix_cpu::local_transport();
-                dispatch_via(&cpu_transport, placed, output_id, output_byte_count, "cpu")
+                // **MX05 Phase 4.9.**  Run inside the thread-local
+                // CPU backend so the installed specialised kernels
+                // (registered in this same thread by earlier
+                // dispatches) are visible.  Per-thread isolation
+                // means parallel unit tests don't contaminate each
+                // other's `BufferStore`; persistence within a thread
+                // means real workflows with thousands of repeat
+                // dispatches see the auto-installer's installs.
+                with_cpu_backend(|b| {
+                    dispatch_via(&b.transport, placed, output_id, output_byte_count, "cpu")
+                })
             } else {
                 // The planner chose an executor we didn't register.
                 // Shouldn't happen with the registry above, but be
@@ -1317,8 +1421,12 @@ fn dispatch_cpu_only(
     let placed: ComputeGraph = runtime
         .plan(graph)
         .map_err(|e| GpuError::Other(format!("plan: {:?}", e)))?;
-    let transport = matrix_cpu::local_transport();
-    dispatch_via(&transport, placed, output_id, output_byte_count, "cpu")
+    // **MX05 Phase 4.9.**  Run inside the thread-local CPU backend
+    // so installed specialised kernels are visible.  Same pattern as
+    // the dual-backend path above.
+    with_cpu_backend(|b| {
+        dispatch_via(&b.transport, placed, output_id, output_byte_count, "cpu")
+    })
 }
 
 /// Returns `Some(id)` iff every `Compute` op and every constant in
@@ -2378,6 +2486,70 @@ mod tests {
             result,
             vec![8.0, 10.0, 12.0, 14.0],
             "Phase 4.8 multi-op chain Add+Mul must produce (x + 3) * 2"
+        );
+    }
+
+    /// **MX05 Phase 4.9 end-to-end test.**  Auto-installer + dispatch
+    /// routing on the **CPU** executor.  Phase 4.3 introduced the
+    /// auto-installer for metal but left the CPU side as a "Phase 4.9
+    /// or later" TODO.  Phase 4.9 closes that gap.
+    ///
+    /// This test drives a small Add-with-constant graph through
+    /// `run_graph_with_constant_inputs` enough times to fire
+    /// `DefaultPolicy` (1100 iterations).  After the policy fires:
+    ///   - `r.route(...)` returns `Some(SpecialisedKernel)` with
+    ///     `backend_id = 0` (CPU)
+    ///   - `try_auto_install_specialised` matches the CPU branch
+    ///     and calls `matrix_cpu::build_specialised_kernel` to
+    ///     produce a Rust closure
+    ///   - The closure is installed on the thread-local
+    ///     `cpu_backend().executor` via `CpuExecutor::install_specialised`
+    ///   - `specialised_install_count` rises above zero
+    ///
+    /// This is the CPU counterpart of Phase 4.3's
+    /// `auto_installer_registers_kernel_after_threshold` (which
+    /// covered the metal path).  Runs on **every platform** —
+    /// unlike the metal tests, this doesn't need an Apple device.
+    /// On non-Apple targets, the planner picks CPU anyway because
+    /// there's no metal executor registered.
+    #[test]
+    fn cpu_auto_installer_registers_kernel_after_threshold() {
+        use crate::specialised_install_count;
+        use matrix_ir::{DType, GraphBuilder, Shape};
+
+        let before = specialised_install_count();
+
+        // Same shape as the Phase 4.3 metal test: a tiny f32 Add
+        // with both operands as constants.  Tiny enough that the
+        // planner picks CPU on every platform.
+        for _ in 0..1100 {
+            let mut g = GraphBuilder::new();
+            let a_bytes: Vec<u8> = [1.0_f32, 2.0, 3.0, 4.0]
+                .iter()
+                .flat_map(|v| v.to_le_bytes())
+                .collect();
+            let b_bytes: Vec<u8> = [7.0_f32, 7.0, 7.0, 7.0]
+                .iter()
+                .flat_map(|v| v.to_le_bytes())
+                .collect();
+            let a = g.constant(DType::F32, Shape::from(&[4u32]), a_bytes);
+            let b = g.constant(DType::F32, Shape::from(&[4u32]), b_bytes);
+            let c = g.add(&a, &b);
+            g.output(&c);
+            let graph = g.build().expect("graph builds");
+            let _ = crate::pipeline::run_graph_with_constant_inputs(&graph, c.id, 16);
+        }
+
+        let after = specialised_install_count();
+        assert!(
+            after > before,
+            "Phase 4.9: CPU auto-installer must fire after 1100 invocations \
+             of an Add-with-constant graph; before = {}, after = {}.  If 0 \
+             here, either (a) the policy didn't fire (check tensor sampling \
+             in drive_specialisation), or (b) build_specialised_kernel \
+             returned None for the SpecKey (check matrix-cpu coverage).",
+            before,
+            after
         );
     }
 }

--- a/code/packages/rust/matrix-cpu/CHANGELOG.md
+++ b/code/packages/rust/matrix-cpu/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to `matrix-cpu` are documented here.
 
+## [0.5.0] — 2026-05-13
+
+### Added — MX05 Phase 4.9 (CpuSpecialiser closure builder)
+
+Closes the gap that's been open since Phase 4.3: matrix-cpu now
+emits **Rust closures** (`Box<SpecialisedKernelFn>`) for the same
+SpecKey shapes the matrix-metal MSL emitter handles.  This lets
+image-gpu-core's auto-installer install on the CPU executor too,
+not just metal.
+
+#### New public function
+
+`matrix_cpu::build_specialised_kernel(key: &SpecKey, _handle: u64)
+-> Option<Box<SpecialisedKernelFn>>`
+
+Mirrors `matrix_metal::emit_specialised_kernel` — instead of an
+MSL string, it returns a closure that operates on the
+`BufferStore` directly.  Coverage matches matrix-metal v0.9.0:
+
+  - **Commutative binary** (Add 0x07, Mul 0x09, Max 0x0B, Min 0x0C)
+    with folded constant — `out[i] = a[i] OP K`
+  - **Non-commutative binary** (Sub 0x08, Div 0x0A, Pow 0x0D) with
+    `folded_slot = Some(0)` or `Some(1)` — picks `K OP a[i]` or
+    `a[i] OP K`
+  - **Unary with folded input** (Neg 0x00, Abs 0x01, Sqrt 0x02,
+    Exp 0x03, Log 0x04, Tanh 0x05, Recip 0x06) — `f(K)` is
+    precomputed at build time; the closure becomes a memset
+
+f32 only in V1.
+
+### Changed — `dispatch::run` always reallocates constant buffers
+
+Previously matrix-cpu's `dispatch::run` had:
+```rust
+if !buffers.contains(c.residency.buffer) {
+    buffers.alloc(c.residency.buffer, c.bytes.len());
+}
+buffers.write(c.residency.buffer, 0, &c.bytes)?;
+```
+
+The `if !contains` guard was brittle once image-gpu-core promoted
+`CpuExecutor` to a long-lived (thread-local) singleton: a stale
+buffer with the wrong size could shadow a fresh constant's
+allocation, causing `write past end` errors.  The guard is gone;
+we now always call `buffers.alloc(...)` (which replaces, per its
+docstring).  Reallocation on host is cheap and matches matrix-metal's
+behaviour.
+
+### Tests
+
+All 33 existing tests still pass.  The new closure builder is
+exercised by image-gpu-core's
+`cpu_auto_installer_registers_kernel_after_threshold` integration
+test (v0.12.0).
+
 ## [0.4.1] — 2026-05-13
 
 ### Changed — MX05 Phase 4.6 (handle hash includes `folded_slot`)

--- a/code/packages/rust/matrix-cpu/Cargo.toml
+++ b/code/packages/rust/matrix-cpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-cpu"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "CPU reference executor for the matrix execution layer. Implements every matrix-ir op on every dtype using straight-line Rust. The always-available safety net that supports operations no GPU backend can take. v0.4 (MX05 Phase 4.1) adds the per-handle specialised kernel table and live DispatchSpecialised handler: install a closure under a u64 handle via install_specialised, then DispatchSpecialised invokes it and returns DispatchDone instead of NOT_IMPLEMENTED. Zero external dependencies."
 license = "MIT"

--- a/code/packages/rust/matrix-cpu/src/dispatch.rs
+++ b/code/packages/rust/matrix-cpu/src/dispatch.rs
@@ -87,9 +87,21 @@ pub fn run(buffers: &mut BufferStore, graph: &ComputeGraph) -> Result<Vec<OpTimi
         // Upload constant bytes to its declared buffer.
         // (The runtime would normally do this via UploadBuffer, but we
         // honour it here when the constant's bytes are still in the graph.)
-        if !buffers.contains(c.residency.buffer) {
-            buffers.alloc(c.residency.buffer, c.bytes.len());
-        }
+        //
+        // **MX05 Phase 4.9 fix.**  We now **always** allocate (which
+        // replaces any existing buffer at the same id, per
+        // `BufferStore::alloc`'s docstring).  The previous
+        // `if !buffers.contains(...)` check was brittle once
+        // image-gpu-core promoted `CpuExecutor` to a process-wide
+        // singleton (so installed specialised kernels persist
+        // across invocations) — concurrent dispatches across tests
+        // share BufferStore state, and a stale buffer with the
+        // wrong size could shadow a fresh constant's allocation,
+        // causing `write past end` errors when the new constant's
+        // bytes exceed the stale buffer's length.  Unconditionally
+        // reallocating is cheap (it's just a `Vec::new()` on the
+        // host) and matches matrix-metal's behaviour.
+        buffers.alloc(c.residency.buffer, c.bytes.len());
         buffers.write(c.residency.buffer, 0, &c.bytes)?;
     }
 

--- a/code/packages/rust/matrix-cpu/src/lib.rs
+++ b/code/packages/rust/matrix-cpu/src/lib.rs
@@ -38,7 +38,7 @@ mod specialiser;
 
 pub use calibrate::calibrate;
 pub use specialised_table::{SpecialisedKernelFn, SpecialisedTable};
-pub use specialiser::{specialiser, CpuSpecialiser};
+pub use specialiser::{build_specialised_kernel, specialiser, CpuSpecialiser};
 
 use compute_ir::{BufferId, KernelId};
 use executor_protocol::{

--- a/code/packages/rust/matrix-cpu/src/specialiser.rs
+++ b/code/packages/rust/matrix-cpu/src/specialiser.rs
@@ -80,6 +80,175 @@ pub fn specialiser() -> Box<dyn Specialiser> {
     Box::new(CpuSpecialiser::new())
 }
 
+/// **MX05 Phase 4.9.**  Given a `SpecKey`, build the Rust closure
+/// that implements the specialised op on a CPU `BufferStore`.  This
+/// is the matrix-cpu equivalent of matrix-metal's `msl_emitter` —
+/// instead of generating an MSL string, we generate a closure
+/// (`Box<SpecialisedKernelFn>`) ready to install on a `CpuExecutor`
+/// via [`crate::CpuExecutor::install_specialised`].
+///
+/// Mirrors matrix-metal's emitter coverage:
+///   - **Commutative binary** ops (Add, Mul, Max, Min) with a
+///     folded constant — `out[i] = a[i] OP K`.
+///   - **Non-commutative binary** ops (Sub, Div, Pow) with a
+///     `folded_slot` set — `out[i] = K OP a[i]` or `a[i] OP K`.
+///   - **Unary** ops (Neg, Abs, Sqrt, Exp, Log, Tanh, Recip) with a
+///     folded input constant — `out[i] = f(K)` (memset).
+///
+/// f32 only in V1, matching the metal emitter.  Returns `None` for
+/// shapes the matrix-cpu specialiser doesn't yet know how to lower.
+///
+/// ## Why a separate function, not a trait method
+///
+/// The `Specialiser` trait in matrix-profile lives in a crate that
+/// doesn't know about closures or executors — its
+/// `specialise(key) -> Option<SpecialisedKernel>` returns just the
+/// opaque handle.  Phase 4.9 keeps that contract intact and instead
+/// adds this dedicated function that downstream callers
+/// (image-gpu-core's auto-installer) invoke after a successful
+/// `route()` to build the matching closure.
+///
+/// Pattern matches matrix-metal's `emit_specialised_kernel(key, handle)`.
+pub fn build_specialised_kernel(
+    key: &SpecKey,
+    _handle: u64,
+) -> Option<Box<crate::SpecialisedKernelFn>> {
+    use matrix_ir::DType;
+    use matrix_profile::RangeClass;
+
+    // V1: f32 only, RangeClass::Constant only.
+    if key.dtype != DType::F32 {
+        return None;
+    }
+    let RangeClass::Constant { bytes } = &key.range_class else {
+        return None;
+    };
+    if bytes.len() != 4 {
+        return None;
+    }
+    let arr: [u8; 4] = bytes.as_slice().try_into().ok()?;
+    let constant = f32::from_le_bytes(arr);
+
+    // Commutative binary ops: same kernel regardless of which slot
+    // was folded.  Pass-through pattern: `a[i] OP K`.
+    let commutative: Option<fn(f32, f32) -> f32> = match key.op_kind {
+        0x07 => Some(|a, k| a + k), // Add
+        0x09 => Some(|a, k| a * k), // Mul
+        0x0B => Some(|a, k| a.max(k)), // Max
+        0x0C => Some(|a, k| a.min(k)), // Min
+        _ => None,
+    };
+    if let Some(op) = commutative {
+        return Some(build_binary_f32_kernel(constant, op));
+    }
+
+    // Unary with folded input: precompute f(K) at build time, then
+    // the closure is a pure memset of `precomputed` for every
+    // element.  `folded_slot` must be Some(0) since unary ops have
+    // exactly one input slot.
+    let folded_slot = key.folded_slot?;
+    let unary_precomputed: Option<f32> = match key.op_kind {
+        0x00 if folded_slot == 0 => Some(-constant),
+        0x01 if folded_slot == 0 => Some(constant.abs()),
+        0x02 if folded_slot == 0 => Some(constant.sqrt()),
+        0x03 if folded_slot == 0 => Some(constant.exp()),
+        0x04 if folded_slot == 0 => Some(constant.ln()),
+        0x05 if folded_slot == 0 => Some(constant.tanh()),
+        0x06 if folded_slot == 0 => Some(1.0_f32 / constant),
+        _ => None,
+    };
+    if let Some(precomputed) = unary_precomputed {
+        return Some(build_unary_memset_f32_kernel(precomputed));
+    }
+
+    // Non-commutative binary ops: pick the variant based on
+    // `folded_slot`.
+    //   Some(0) → constant is LHS → `out[i] = K OP a[i]`
+    //   Some(1) → constant is RHS → `out[i] = a[i] OP K`
+    let non_commutative_op: Option<(fn(f32, f32) -> f32, fn(f32, f32) -> f32)> = match key.op_kind {
+        0x08 => Some((|a, k| k - a, |a, k| a - k)), // Sub: (lhs-folded, rhs-folded)
+        0x0A => Some((|a, k| k / a, |a, k| a / k)), // Div
+        0x0D => Some((|a, k| k.powf(a), |a, k| a.powf(k))), // Pow
+        _ => None,
+    };
+    if let Some((lhs_op, rhs_op)) = non_commutative_op {
+        let op = match folded_slot {
+            0 => lhs_op,
+            1 => rhs_op,
+            _ => return None,
+        };
+        return Some(build_binary_f32_kernel(constant, op));
+    }
+
+    None
+}
+
+/// **MX05 Phase 4.9 helper.**  Build a closure that reads input[0]
+/// (f32 buffer) element-by-element and writes `op(in[i], K)` to
+/// output[0].  The kernel takes 1 input + 1 output buffer.
+fn build_binary_f32_kernel(
+    constant: f32,
+    op: fn(f32, f32) -> f32,
+) -> Box<crate::SpecialisedKernelFn> {
+    use executor_protocol::OpTiming;
+    Box::new(move |buffers, inputs, outputs| {
+        if inputs.len() != 1 {
+            return Err(format!(
+                "specialised binary kernel expects 1 input, got {}",
+                inputs.len()
+            ));
+        }
+        if outputs.len() != 1 {
+            return Err(format!(
+                "specialised binary kernel expects 1 output, got {}",
+                outputs.len()
+            ));
+        }
+        let in_data = buffers.get(inputs[0])?.to_vec();
+        let n_elems = in_data.len() / 4;
+        let mut out_data = vec![0u8; n_elems * 4];
+        for i in 0..n_elems {
+            let arr: [u8; 4] = in_data[i * 4..(i + 1) * 4].try_into().unwrap();
+            let a = f32::from_le_bytes(arr);
+            let result = op(a, constant);
+            out_data[i * 4..(i + 1) * 4].copy_from_slice(&result.to_le_bytes());
+        }
+        buffers.write(outputs[0], 0, &out_data)?;
+        Ok(vec![OpTiming { op_index: 0, ns: 0 }])
+    })
+}
+
+/// **MX05 Phase 4.9 helper.**  Build a closure that writes the
+/// precomputed `value` to every f32 element of `output[0]`.  Kernel
+/// takes 0 inputs + 1 output — matching matrix-metal's unary
+/// memset pattern from Phase 4.7.
+fn build_unary_memset_f32_kernel(value: f32) -> Box<crate::SpecialisedKernelFn> {
+    use executor_protocol::OpTiming;
+    Box::new(move |buffers, inputs, outputs| {
+        if !inputs.is_empty() {
+            return Err(format!(
+                "specialised unary memset kernel expects 0 inputs, got {}",
+                inputs.len()
+            ));
+        }
+        if outputs.len() != 1 {
+            return Err(format!(
+                "specialised unary memset kernel expects 1 output, got {}",
+                outputs.len()
+            ));
+        }
+        let out_len = buffers.get(outputs[0])?.len();
+        let n_elems = out_len / 4;
+        let mut out_data = vec![0u8; n_elems * 4];
+        let val_bytes = value.to_le_bytes();
+        for i in 0..n_elems {
+            out_data[i * 4..(i + 1) * 4].copy_from_slice(&val_bytes);
+        }
+        buffers.write(outputs[0], 0, &out_data)?;
+        Ok(vec![OpTiming { op_index: 0, ns: 0 }])
+    })
+}
+
 // ────────────────────────── deterministic handles ──────────────────────────
 
 /// Produce a deterministic 64-bit handle for a given `SpecKey`.

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -242,6 +242,33 @@ The compile happens in a background worker thread so live dispatches
 aren't blocked.  Once ready, the specialised pipeline is inserted
 into the cache.
 
+> **Implementation status (Phase 4.9 landed — matrix-cpu auto-install + dispatch routing)**:
+> Closes the gap that's been open since Phase 4.3 — the
+> auto-installer now installs on the **CPU executor** too, not just
+> metal.  matrix-cpu v0.5.0 ships `build_specialised_kernel(key,
+> handle) -> Option<Box<SpecialisedKernelFn>>` mirroring matrix-metal's
+> `emit_specialised_kernel`: f32 commutative binary (Add/Mul/Max/Min),
+> non-commutative binary (Sub/Div/Pow) with `folded_slot`, and
+> unary-with-folded-input (Neg/Abs/Sqrt/Exp/Log/Tanh/Recip) all
+> produce Rust closures that operate on `BufferStore` directly.
+> image-gpu-core v0.12.0 promotes the CPU executor to a
+> **thread-local singleton** (`with_cpu_backend(|b| ...)`)
+> so installed kernels persist within a thread but tests don't
+> cross-contaminate.  `try_auto_install_specialised` now branches
+> on `key.backend_id`: 0 → CPU, 1 → metal.  Public
+> `specialised_install_count()` sums both backends' counts.
+> Side-table state (`installed_handles`, `installed_kernel_metadata`,
+> `handle_is_installed`) is now always-on rather than metal-only.
+> End-to-end test
+> `cpu_auto_installer_registers_kernel_after_threshold` runs on
+> every platform (no Apple gate) — drives 1100 invocations of an
+> Add-with-constant graph and asserts `specialised_install_count`
+> rises.  Bonus matrix-cpu fix: `dispatch::run`'s constant-buffer
+> alloc is no longer guarded by `if !buffers.contains(...)` —
+> always reallocates to avoid stale-buffer size mismatches under
+> the long-lived executor.  Test counts: matrix-cpu 33, image-gpu-core
+> 33 → 34.
+
 > **Implementation status (Phase 4.8 landed — multi-op specialised dispatch)**:
 > image-gpu-core v0.11.0 lifts the Phase 4.4 restriction that
 > capped specialised dispatch routing at one non-Const Compute op


### PR DESCRIPTION
## Summary

Closes the gap that's been open since Phase 4.3 — the auto-installer now installs on the **CPU executor** too, not just metal. The auto-install + dispatch routing loop is finally complete on both backends, on every platform.

## matrix-cpu v0.5.0

New: \`build_specialised_kernel(key, _handle) -> Option<Box<SpecialisedKernelFn>>\`

Mirrors matrix-metal's \`emit_specialised_kernel\` — instead of an MSL string, returns a Rust closure that operates on \`BufferStore\` directly. Coverage matches metal:

- **Commutative binary** (Add 0x07, Mul 0x09, Max 0x0B, Min 0x0C) with folded constant
- **Non-commutative binary** (Sub 0x08, Div 0x0A, Pow 0x0D) with \`folded_slot\` → picks \`K OP a[i]\` or \`a[i] OP K\`
- **Unary with folded input** (Neg/Abs/Sqrt/Exp/Log/Tanh/Recip) — \`f(K)\` precomputed; closure is a memset

Bonus fix: \`dispatch::run\` always reallocates constant buffers (drops \`if !buffers.contains(...)\` guard). The conditional alloc broke under image-gpu-core's long-lived CpuExecutor when stale buffers shadowed fresh constants.

## image-gpu-core v0.12.0

- **\`CpuBackend\`** promoted to a \`thread_local!\` singleton. Persistence within a thread (real workloads' 1000+ repeats see installed kernels) + per-thread isolation (parallel tests don't cross-contaminate \`BufferStore\`).
- **\`with_cpu_backend(|b| ...)\`** API for thread-local access.
- **\`try_auto_install_specialised\`** dispatches on \`key.backend_id\`: 0 → CPU, 1 → metal. Both share \`INSTALLED_HANDLES\` and \`INSTALLED_KERNEL_METADATA\` (handles are unique per backend).
- **\`specialised_install_count()\`** sums both backends' counts.
- **Cfg cleanup**: side-table state no longer \`cfg(feature = \"metal-backend\")\`-gated.

## Test (33 → 34)

\`cpu_auto_installer_registers_kernel_after_threshold\` — the CPU counterpart of Phase 4.3's metal-only test.

Drives 1100 invocations of an Add-with-constant graph, asserts \`specialised_install_count\` rises. **Runs on every platform** — Linux/Windows CI included.

## Security review (passed)

- Closures bounds-check inputs/outputs at the start
- Buffer iteration is safe (n_elems = len/4, in-bounds slicing)
- HashMap-based side-tables: handles unique per backend (hash feeds on backend_id)
- thread_local! initialisation well-defined

## Test plan

- [x] matrix-cpu: 33 tests pass
- [x] image-gpu-core: 33 → 34 tests pass
- [x] Linux cross-compile clean
- [x] Security review passed (1 round)
- [x] Spec MX05 updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)