### PR TITLE
TypeScript factor multivariate integer content

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Delegate `factor` to the canonical TypeScript symbolic VM handler so common
   multivariate terms such as `factor(x^2*y - y)` reduce through the shared CAS
   substrate.
+- Add TypeScript MACSYMA parity for shared integer content in multivariate
+  common-factor expressions, so `factor(2*x*y + 2*x*z)` returns `2*x*(y+z)`.
 - Add TypeScript MACSYMA parity for the bivariate perfect-square factoring
   foothold, so `factor(x^2 + 2*x*y + y^2)` returns `(x+y)^2`.
 - Add TypeScript MACSYMA parity for the bivariate difference-of-squares

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -166,6 +166,26 @@ describe("macsyma-runtime", () => {
     ]));
   });
 
+  it("factors common multivariate integer content through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(2*x*y + 2*x*z);");
+
+    expect(result.output).toEqual(app(MUL, [
+      app(MUL, [int(2), sym("x")]),
+      app(ADD, [sym("y"), sym("z")]),
+    ]));
+  });
+
+  it("factors negative common multivariate integer content through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(-2*x*y - 2*x*z);");
+
+    expect(result.output).toEqual(app(MUL, [
+      app(MUL, [int(-2), sym("x")]),
+      app(ADD, [sym("y"), sym("z")]),
+    ]));
+  });
+
   it("factors bivariate perfect squares through the runtime", () => {
     const session = new MacsymaSession();
     const [result] = session.evalSource("factor(x^2 + 2*x*y + y^2);");

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added a canonical symbolic `Factor` handler backed by `cas-factor`, including
   a small common-symbolic-factor extraction pass for multivariate expressions
   like `x^2*y - y`.
+- Extended the common multivariate factoring foothold to extract shared integer
+  content as well as symbolic powers, so `2*x*y + 2*x*z` factors to
+  `2*x*(y+z)`.
 - Added a bivariate perfect-square factoring foothold so `Factor` recognises
   expressions like `x^2 + 2*x*y + y^2` as `(x+y)^2`.
 - Added a bivariate difference-of-squares factoring foothold so `Factor`

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -541,23 +541,45 @@ function splitCommonFactorTerm(node: IRNode): Map<string, FactorPower> {
 function splitIntegerCoefficientAndPowers(node: IRNode): CoefficientPowers | undefined {
   let coefficient = 1n;
   const powers = new Map<string, FactorPower>();
-  for (const factor of flattenFactorTerms(node)) {
+
+  const visitFactor = (factor: IRNode): boolean => {
     if (factor.kind === "integer") {
       coefficient *= factor.value;
-      continue;
+      return true;
     }
-    if (factor.kind === "symbol" && factor.name.startsWith("%")) return undefined;
+    if (factor.kind === "apply" && equals(factor.head, NEG) && factor.args.length === 1) {
+      coefficient *= -1n;
+      for (const nested of flattenFactorTerms(factor.args[0])) {
+        if (!visitFactor(nested)) return false;
+      }
+      return true;
+    }
+    if (factor.kind === "symbol" && factor.name.startsWith("%")) return false;
 
     if (factor.kind === "apply" && equals(factor.head, POW) && factor.args.length === 2) {
       const [base, exponent] = factor.args;
       if (exponent.kind === "integer" && exponent.value > 0n) {
         addPower(powers, base, Number(exponent.value));
-        continue;
+        return true;
       }
     }
     addPower(powers, factor, 1);
+    return true;
+  };
+
+  for (const factor of flattenFactorTerms(node)) {
+    if (!visitFactor(factor)) return undefined;
   }
   return { coefficient, powers };
+}
+
+function termFromIntegerCoefficientAndPowers(coefficient: bigint, powers: ReadonlyMap<string, FactorPower>): IRNode {
+  const terms: IRNode[] = [];
+  if (coefficient !== 1n || powers.size === 0) terms.push(int(coefficient));
+  terms.push(...[...powers.values()]
+    .sort((a, b) => nodeKey(a.base).localeCompare(nodeKey(b.base)))
+    .map((power) => powNode(power.base, power.exponent)));
+  return multiplyNodes(terms);
 }
 
 function addPower(powers: Map<string, FactorPower>, base: IRNode, exponent: number): void {
@@ -596,13 +618,44 @@ function removeCommonFactor(node: IRNode, common: ReadonlyMap<string, FactorPowe
   return multiplyNodes(rebuilt);
 }
 
+function gcdBigInt(a: bigint, b: bigint): bigint {
+  let x = a < 0n ? -a : a;
+  let y = b < 0n ? -b : b;
+  while (y !== 0n) {
+    const next = x % y;
+    x = y;
+    y = next;
+  }
+  return x;
+}
+
+function maybeFactorResidual(residual: IRNode): IRNode {
+  const variable = findVariable(residual);
+  return variable !== undefined && irToIntegerPoly(residual, variable) !== undefined
+    ? app(FACTOR, [residual])
+    : residual;
+}
+
 function extractCommonSymbolicFactor(inner: IRNode): IRNode | undefined {
   const terms = flattenAddTerms(inner);
   if (terms.length < 2) return undefined;
 
-  const perTerm = terms.map((term) => splitCommonFactorTerm(term));
-  const common = new Map(perTerm[0]);
-  for (const powers of perTerm.slice(1)) {
+  const parsed = terms.map((term) => splitIntegerCoefficientAndPowers(term));
+  if (parsed.some((term) => term === undefined)) return undefined;
+
+  const parsedTerms = parsed as CoefficientPowers[];
+  const coefficients = parsedTerms.map((term) => term.coefficient);
+  let commonCoefficient = coefficients.reduce(
+    (acc, coefficient) => gcdBigInt(acc, coefficient),
+    0n,
+  );
+  if (commonCoefficient !== 0n && coefficients.every((coefficient) => coefficient < 0n)) {
+    commonCoefficient = -commonCoefficient;
+  }
+  if (commonCoefficient === 0n) commonCoefficient = 1n;
+
+  const common = new Map(parsedTerms[0].powers);
+  for (const { powers } of parsedTerms.slice(1)) {
     for (const [key, power] of [...common.entries()]) {
       const shared = Math.min(power.exponent, powers.get(key)?.exponent ?? 0);
       if (shared > 0) {
@@ -612,13 +665,18 @@ function extractCommonSymbolicFactor(inner: IRNode): IRNode | undefined {
       }
     }
   }
-  if (common.size === 0) return undefined;
+  if (commonCoefficient === 1n && common.size === 0) return undefined;
 
-  const commonTerms = [...common.values()]
-    .sort((a, b) => nodeKey(a.base).localeCompare(nodeKey(b.base)))
-    .map((power) => powNode(power.base, power.exponent));
-  const residualTerms = terms.map((term) => removeCommonFactor(term, common));
-  return app(MUL, [multiplyNodes(commonTerms), app(FACTOR, [addNodes(residualTerms)])]);
+  const commonFactor = termFromIntegerCoefficientAndPowers(commonCoefficient, common);
+  const residualTerms = parsedTerms.map(({ coefficient, powers }) => {
+    const residualPowers = new Map<string, FactorPower>();
+    for (const [key, power] of powers.entries()) {
+      const exponent = power.exponent - (common.get(key)?.exponent ?? 0);
+      if (exponent > 0) residualPowers.set(key, { base: power.base, exponent });
+    }
+    return termFromIntegerCoefficientAndPowers(coefficient / commonCoefficient, residualPowers);
+  });
+  return app(MUL, [commonFactor, maybeFactorResidual(addNodes(residualTerms))]);
 }
 
 function extractMultivariatePerfectSquare(inner: IRNode): IRNode | undefined {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -102,6 +102,42 @@ describe("symbolic-vm", () => {
     ]));
   });
 
+  it("extracts common integer content from multivariate factors", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    const z = sym("z");
+    const expr = app(FACTOR, [
+      app(ADD, [
+        app(MUL, [int(2), app(MUL, [x, y])]),
+        app(MUL, [int(2), app(MUL, [x, z])]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(MUL, [
+      app(MUL, [int(2), x]),
+      app(ADD, [y, z]),
+    ]));
+  });
+
+  it("extracts negative common integer content from multivariate factors", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    const z = sym("z");
+    const expr = app(FACTOR, [
+      app(ADD, [
+        app(MUL, [int(-2), app(MUL, [x, y])]),
+        app(MUL, [int(-2), app(MUL, [x, z])]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(MUL, [
+      app(MUL, [int(-2), x]),
+      app(ADD, [y, z]),
+    ]));
+  });
+
   it("factors bivariate perfect squares", () => {
     const vm = new VM(new SymbolicBackend());
     const x = sym("x");


### PR DESCRIPTION
## Summary
- extend the TypeScript symbolic-vm common multivariate factor foothold to extract shared integer content as well as symbolic powers
- make factor(2*x*y + 2*x*z) and the all-negative parsed form produce signed content times the residual sum
- cover the behavior through direct symbolic-vm tests and MACSYMA runtime tests

## Validation
- `npm test` in `code/packages/typescript/symbolic-vm`
- `npm test` in `code/packages/typescript/macsyma-runtime`
- `npm run build` in `code/packages/typescript/symbolic-vm`
- `npm run build` in `code/packages/typescript/macsyma-runtime`
- `git diff --check`
