### PR TITLE
typescript(macsyma): factor multivariate perfect cubes

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add TypeScript MACSYMA parity for perfect-cube expansions, so
+  `factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3)` returns `(x+y)^3` and
+  `factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3)` returns `(x-y)^3` through the
+  shared symbolic VM handler.
 - Delegate `factor` to the canonical TypeScript symbolic VM handler so common
   multivariate terms such as `factor(x^2*y - y)` reduce through the shared CAS
   substrate.

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -238,6 +238,39 @@ describe("macsyma-runtime", () => {
     ]));
   });
 
+  it("factors bivariate perfect cube sums through the runtime", () => {
+    // factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3) → (x+y)^3
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3);");
+
+    expect(result.output.kind).toBe("apply");
+    if (result.output.kind !== "apply") return;
+    expect(result.output.head).toEqual(sym("Pow"));
+    const [base, exponent] = result.output.args;
+    expect(exponent).toEqual(int(3));
+    expect(base.kind).toBe("apply");
+    if (base.kind !== "apply") return;
+    expect(base.head).toEqual(sym("Add"));
+    const baseKeys = new Set(base.args.map((a) => (a.kind === "symbol" ? a.name : "")));
+    expect(baseKeys).toEqual(new Set(["x", "y"]));
+  });
+
+  it("factors bivariate perfect cube differences through the runtime", () => {
+    // factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3) → (x-y)^3
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3);");
+
+    expect(result.output.kind).toBe("apply");
+    if (result.output.kind !== "apply") return;
+    expect(result.output.head).toEqual(sym("Pow"));
+    const [base, exponent] = result.output.args;
+    expect(exponent).toEqual(int(3));
+    expect(base.kind).toBe("apply");
+    if (base.kind !== "apply") return;
+    expect(base.head).toEqual(sym("Sub"));
+    expect(base.args).toEqual([sym("x"), sym("y")]);
+  });
+
   it("tracks the showtime option flag through normal assignments", () => {
     const session = new MacsymaSession();
     const [enabled, timed, disabled, untimed] = session.evalSource(

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added a bivariate perfect-cube factoring foothold so `Factor` recognises
+  four-term binomial cube expansions: `x^3 + 3x^2y + 3xy^2 + y^3` as
+  `(x+y)^3` and `x^3 - 3x^2y + 3xy^2 - y^3` as `(x-y)^3`.
 - Added a canonical symbolic `Factor` handler backed by `cas-factor`, including
   a small common-symbolic-factor extraction pass for multivariate expressions
   like `x^2*y - y`.

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -373,6 +373,8 @@ function factorHandler(vm: VM, expr: IRApply): IRNode {
 
   const coeffs = irToIntegerPoly(inner, variable);
   if (coeffs === undefined) {
+    const perfectCube = extractMultivariatePerfectCube(inner);
+    if (perfectCube !== undefined) return perfectCube;
     const cubicIdentity = extractMultivariateCubicIdentity(inner);
     if (cubicIdentity !== undefined) return cubicIdentity;
     const difference = extractMultivariateDifferenceOfSquares(inner);
@@ -745,6 +747,115 @@ function extractMultivariateCubicIdentity(inner: IRNode): IRNode | undefined {
       app(POW, [second, int(2)]),
     ]),
   ]);
+}
+
+function extractMultivariatePerfectCube(inner: IRNode): IRNode | undefined {
+  // Recognise (a±b)^3 perfect-cube expansions.
+  //
+  //   a^3 + 3·a^2·b + 3·a·b^2 + b^3  →  (a + b)^3   [sum cube]
+  //   a^3 − 3·a^2·b + 3·a·b^2 − b^3  →  (a − b)^3   [difference cube]
+  //
+  // Requires exactly 4 additive terms: 2 pure-cube terms (|coeff|=1, one
+  // variable, exponent=3) and 2 cross terms (two variables, |coeff|=3).
+  const terms = flattenAddTerms(inner);
+  if (terms.length !== 4) return undefined;
+
+  const parsed = terms.map((term) => splitIntegerCoefficientAndPowers(term));
+  if (parsed.some((term) => term === undefined)) return undefined;
+
+  const pureCubes: Array<{ readonly coefficient: bigint; readonly base: IRNode }> = [];
+  const crossTerms: Array<{ readonly coefficient: bigint; readonly powers: Map<string, FactorPower> }> = [];
+
+  for (const parsedTerm of parsed) {
+    if (parsedTerm === undefined) return undefined;
+    const { coefficient, powers } = parsedTerm;
+    if (powers.size === 1) {
+      const [power] = [...powers.values()];
+      if (power.exponent === 3 && (coefficient === 1n || coefficient === -1n)) {
+        pureCubes.push({ coefficient, base: power.base });
+        continue;
+      }
+    }
+    if (powers.size === 2) {
+      crossTerms.push({ coefficient, powers });
+      continue;
+    }
+    return undefined; // unexpected shape (wrong exponent or variable count)
+  }
+
+  if (pureCubes.length !== 2 || crossTerms.length !== 2) return undefined;
+
+  // Identify a and b; determine sum vs. difference from the pure-cube signs.
+  let aNode: IRNode;
+  let bNode: IRNode;
+  let isSum: boolean;
+
+  if (pureCubes[0].coefficient === 1n && pureCubes[1].coefficient === 1n) {
+    // Sum: (a + b)^3 — both cubic terms positive.
+    aNode = pureCubes[0].base;
+    bNode = pureCubes[1].base;
+    isSum = true;
+  } else if (
+    pureCubes.some((c) => c.coefficient === 1n)
+    && pureCubes.some((c) => c.coefficient === -1n)
+  ) {
+    // Difference: (a − b)^3 — a^3 positive, b^3 negative.
+    const pos = pureCubes.find((c) => c.coefficient === 1n);
+    const neg = pureCubes.find((c) => c.coefficient === -1n);
+    if (pos === undefined || neg === undefined) return undefined;
+    aNode = pos.base;
+    bNode = neg.base;
+    isSum = false;
+  } else {
+    return undefined;
+  }
+
+  // Cross-term variable sets must equal exactly {aNode, bNode}.
+  const aKey = nodeKey(aNode);
+  const bKey = nodeKey(bNode);
+  const variablePair = new Set([aKey, bKey]);
+  for (const { powers } of crossTerms) {
+    if (powers.size !== 2) return undefined;
+    if (![...powers.keys()].every((k) => variablePair.has(k))) return undefined;
+  }
+
+  // Validate cross-term coefficients and exponent distributions.
+  if (isSum) {
+    // Expect +3·a^2·b and +3·a·b^2 in any order.
+    let foundA2b = false;
+    let foundAb2 = false;
+    for (const { coefficient, powers } of crossTerms) {
+      const expA = powers.get(aKey)?.exponent ?? 0;
+      const expB = powers.get(bKey)?.exponent ?? 0;
+      if (coefficient === 3n && expA === 2 && expB === 1) {
+        foundA2b = true;
+      } else if (coefficient === 3n && expA === 1 && expB === 2) {
+        foundAb2 = true;
+      } else {
+        return undefined;
+      }
+    }
+    if (!foundA2b || !foundAb2) return undefined;
+    return app(POW, [app(ADD, [aNode, bNode]), int(3)]);
+  }
+
+  // Difference: expect −3·a^2·b and +3·a·b^2.
+  // The a^2·b sign flips because (a−b)^3 expansion gives −3a^2b.
+  let foundNegA2b = false;
+  let foundPosAb2 = false;
+  for (const { coefficient, powers } of crossTerms) {
+    const expA = powers.get(aKey)?.exponent ?? 0;
+    const expB = powers.get(bKey)?.exponent ?? 0;
+    if (coefficient === -3n && expA === 2 && expB === 1) {
+      foundNegA2b = true;
+    } else if (coefficient === 3n && expA === 1 && expB === 2) {
+      foundPosAb2 = true;
+    } else {
+      return undefined;
+    }
+  }
+  if (!foundNegA2b || !foundPosAb2) return undefined;
+  return app(POW, [app(SUB, [aNode, bNode]), int(3)]);
 }
 
 function commonSymbolicPowers(terms: readonly IRNode[]): Map<string, FactorPower> {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -221,6 +221,50 @@ describe("symbolic-vm", () => {
     ]));
   });
 
+  it("factors bivariate perfect cube sums", () => {
+    // (a + b)^3 = a^3 + 3a^2b + 3ab^2 + b^3
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    // Build x^3 + 3*x^2*y + 3*x*y^2 + y^3 as nested ADD nodes
+    const expr = app(FACTOR, [
+      app(ADD, [
+        app(ADD, [
+          app(ADD, [
+            app(POW, [x, int(3)]),
+            app(MUL, [int(3), app(MUL, [app(POW, [x, int(2)]), y])]),
+          ]),
+          app(MUL, [int(3), app(MUL, [x, app(POW, [y, int(2)])])]),
+        ]),
+        app(POW, [y, int(3)]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(POW, [app(ADD, [x, y]), int(3)]));
+  });
+
+  it("factors bivariate perfect cube differences", () => {
+    // (a - b)^3 = a^3 - 3a^2b + 3ab^2 - b^3
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const y = sym("y");
+    // Build x^3 - 3*x^2*y + 3*x*y^2 - y^3 using SUB to negate the right terms
+    const expr = app(FACTOR, [
+      app(ADD, [
+        app(SUB, [
+          app(ADD, [
+            app(POW, [x, int(3)]),
+            app(MUL, [int(3), app(MUL, [x, app(POW, [y, int(2)])])]),
+          ]),
+          app(MUL, [int(3), app(MUL, [app(POW, [x, int(2)]), y])]),
+        ]),
+        app(MUL, [int(-1), app(POW, [y, int(3)])]),
+      ]),
+    ]);
+
+    expect(vm.eval(expr)).toEqual(app(POW, [app(SUB, [x, y]), int(3)]));
+  });
+
   it("supports assignment and later lookup", () => {
     const vm = new VM(new SymbolicBackend());
     expect(vm.eval(app(ASSIGN, [sym("x"), app(ADD, [int(2), int(3)])]))).toEqual(int(5));


### PR DESCRIPTION
## Summary

- Adds `extractMultivariatePerfectCube` to the TypeScript symbolic-vm handler — parity with Python PR #3116
- Sum case: `x^3 + 3x^2y + 3xy^2 + y^3` → `(x+y)^3`
- Difference case: `x^3 - 3x^2y + 3xy^2 - y^3` → `(x-y)^3`
- Registered in `factorHandler` before `extractMultivariateCubicIdentity` (no overlap: 4-term vs 2-term patterns)

## Test plan

- [x] `symbolic-vm`: 2 new unit tests (total 41 pass)
- [x] `macsyma-runtime`: 2 new pipeline tests via `evalSource` (total 63 pass)
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)