### PR TITLE
Add UNO R4 ADC read capability

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -2,14 +2,14 @@ use std::ffi::{c_char, c_int, c_long, c_void};
 use std::ptr;
 use std::slice;
 
-use board_vm_host::PwmWriteProgram;
 use board_vm_host::{
-    BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
-    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, LedMatrixFrameProgram, TimeNowProgram,
-    TimeSleepMsProgram, BLINK_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN,
-    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
-    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
-    TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    AdcReadProgram, BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram,
+    GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram, GpioWriteProgram,
+    LedMatrixFrameProgram, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
+    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
+    GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
@@ -18,7 +18,7 @@ use board_vm_language_core::{
     build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
     build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
     build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
-    build_program_end_wire_frame, build_pwm_write_module, build_raw_module,
+    build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
     build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
@@ -227,6 +227,19 @@ extern "C" fn session_pwm_write_module(
 
     let module = build_pwm_write_module_value(pin, duty, max_stack)
         .unwrap_or_else(|error| raise_core_error("pwm_write_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_adc_read_module(
+    _self_val: VALUE,
+    pin_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let pin = rb_u8(pin_val, "pin");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_adc_read_module_value(pin, max_stack)
+        .unwrap_or_else(|error| raise_core_error("adc_read_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1390,6 +1403,13 @@ fn build_pwm_write_module_value(
     Ok(module)
 }
 
+fn build_adc_read_module_value(pin: u8, max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; ADC_READ_MODULE_LEN];
+    let len = build_adc_read_module(AdcReadProgram { pin, max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_raw_module_value(
     flags: u8,
     max_stack: u8,
@@ -1692,6 +1712,12 @@ pub extern "C" fn Init_board_vm_native() {
         "pwm_write_module",
         session_pwm_write_module as *const c_void,
         3,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "adc_read_module",
+        session_adc_read_module as *const c_void,
+        2,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/capabilities.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/capabilities.rb
@@ -92,6 +92,14 @@ module CodingAdventures
         capabilities.select { |capability| capability.name.start_with?("time.") }
       end
 
+      def pwm
+        capabilities.select { |capability| capability.name.start_with?("pwm.") }
+      end
+
+      def adc
+        capabilities.select { |capability| capability.name.start_with?("adc.") }
+      end
+
       def program
         capabilities.select { |capability| capability.name.start_with?("program.") }
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -102,6 +102,10 @@ module CodingAdventures
         Pwm.new(self)
       end
 
+      def adc
+        Adc.new(self)
+      end
+
       def eject
         Ejector.new(self)
       end
@@ -239,6 +243,26 @@ module CodingAdventures
           budget: budget,
           pin: pin,
           duty: duty,
+          max_stack: max_stack,
+          handshake: true,
+          query_caps: true,
+          host_nonce: host_nonce
+        )
+      end
+
+      def adc_read!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        pin:,
+        max_stack: 1
+      )
+        ensure_uno_r4_wifi!
+
+        session.adc_read(
+          program_id: program_id,
+          budget: budget,
+          pin: pin,
           max_stack: max_stack,
           handshake: true,
           query_caps: true,
@@ -930,6 +954,28 @@ module CodingAdventures
 
       def full(pin:, **options)
         write(pin: pin, duty: 0xFFFF, **options)
+      end
+    end
+
+    class Adc
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def read(
+        pin:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        max_stack: 1
+      )
+        @connection.adc_read!(
+          program_id: program_id,
+          budget: budget,
+          host_nonce: host_nonce,
+          pin: pin,
+          max_stack: max_stack
+        )
       end
     end
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -201,6 +201,10 @@ module CodingAdventures
         native_session.pwm_write_module(pin, pwm_duty_value(duty), max_stack)
       end
 
+      def adc_read_module(pin:, max_stack: 1)
+        native_session.adc_read_module(pin, max_stack)
+      end
+
       def gpio_open_module(pin:, mode: :output, max_stack: 2)
         native_session.gpio_open_module(pin, gpio_mode(mode), max_stack)
       end
@@ -250,6 +254,17 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: pwm_write_module(pin: pin, duty: duty, max_stack: max_stack)
+        )
+      end
+
+      def upload_adc_read(
+        program_id: @program_id,
+        pin:,
+        max_stack: 1
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: adc_read_module(pin: pin, max_stack: max_stack)
         )
       end
 
@@ -516,6 +531,34 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def adc_read(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        pin:,
+        max_stack: 1,
+        handshake: false,
+        query_caps: false,
+        host_name: @host_name,
+        host_nonce: @host_nonce
+      )
+        results = []
+        results << hello(host_name: host_name, host_nonce: host_nonce) if handshake
+        results << capabilities if query_caps
+        results.concat(
+          upload_adc_read(
+            program_id: program_id,
+            pin: pin,
+            max_stack: max_stack
+          ).results
+        )
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget
+        )
+        SessionResult.new(results: results)
+      end
+
       def gpio_open(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -711,6 +754,8 @@ module CodingAdventures
           upload_gpio_write(**gpio_write_command_options(words, command, options, require_budget: false))
         when "upload-pwm-write", "upload-pwm.write"
           upload_pwm_write(**pwm_write_command_options(words, command, options, require_budget: false))
+        when "upload-adc-read", "upload-adc.read"
+          upload_adc_read(**adc_read_command_options(words, command, options, require_budget: false))
         when "upload-gpio-open", "upload-gpio.open"
           upload_gpio_open(**gpio_open_command_options(words, command, options, require_budget: false))
         when "upload-gpio-handle-read", "upload-gpio.handle-read"
@@ -743,6 +788,8 @@ module CodingAdventures
           gpio_write(**gpio_write_command_options(words, command, options))
         when "pwm-write", "pwm.write"
           pwm_write(**pwm_write_command_options(words, command, options))
+        when "adc-read", "adc.read"
+          adc_read(**adc_read_command_options(words, command, options))
         when "gpio-high", "gpio.high"
           gpio_write(**gpio_level_command_options(words, command, options, value: true))
         when "gpio-low", "gpio.low"
@@ -941,6 +988,20 @@ module CodingAdventures
         ensure_no_extra_arguments!(words, command)
         raise ArgumentError, "#{command} requires pin" unless merged.key?(:pin)
         raise ArgumentError, "#{command} requires duty" unless merged.key?(:duty)
+
+        merged
+      end
+
+      def adc_read_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:pin] = integer_argument(words.shift, "#{command} pin") unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires pin" unless merged.key?(:pin)
 
         merged
       end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -36,6 +36,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "transport.bluetooth_le"
         assert_includes uno_r4_wifi["capabilities"], "led_matrix.frame"
         assert_includes uno_r4_wifi["capabilities"], "pwm.write"
+        assert_includes uno_r4_wifi["capabilities"], "adc.read"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -51,6 +52,10 @@ module CodingAdventures
         assert d3["supports_pwm"]
         assert d3["supports_interrupt"]
         refute d3["supports_adc"]
+        a0 = uno_r4_wifi["digital_pins"].find { |pin| pin["pin"] == 14 }
+        assert_equal "A0/D14", a0["label"]
+        assert a0["supports_adc"]
+        refute a0["supports_pwm"]
         assert_equal "esp32", esp32["family"]
         assert_equal "board-vm-esp32", esp32["runtime_id"]
         assert_equal({ "kind" => "gpio", "pin" => 2 }, esp32["onboard_led"])
@@ -1219,6 +1224,28 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_adc_read_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          result = board.adc.read(pin: 14, program_id: 10, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 6, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal transport.frames, result.frames
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          result.results.map(&:command)
+      end
+
       def test_store_program_dispatches_native_protocol_frame_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1573,6 +1600,26 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_adc_read
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("adc-read 14 24", program_id: 9)
+          upload = board.session.run_command("upload-adc-read 14", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
       def test_board_descriptor_wraps_rust_decoded_capability_report
         decoded = {
           "kind" => "caps_report",
@@ -1685,6 +1732,10 @@ module CodingAdventures
         pwm_module_bytes = session.pwm_write_module(3, 0x8000, 2)
         assert_instance_of String, pwm_module_bytes
         assert_operator pwm_module_bytes.bytesize, :>, 0
+
+        adc_module_bytes = session.adc_read_module(14, 1)
+        assert_instance_of String, adc_module_bytes
+        assert_operator adc_module_bytes.bytesize, :>, 0
 
         gpio_module_bytes = session.gpio_read_module(13, 2, 2)
         assert_instance_of String, gpio_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use board_vm_ir::{
-    parse_module, validate, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE,
-    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    parse_module, validate, CAP_ADC_READ, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ,
+    CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -179,6 +179,114 @@ pub const BLINK_MVP_WITH_PWM_CAPABILITIES: [CapabilityDescriptor<'static>; 8] = 
     },
 ];
 
+pub const BLINK_MVP_WITH_ADC_CAPABILITIES: [CapabilityDescriptor<'static>; 8] = [
+    CapabilityDescriptor {
+        id: CAP_GPIO_OPEN,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.open",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_CLOSE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.close",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_SLEEP_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.sleep_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_NOW_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.now_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_ADC_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "adc.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_PROGRAM_RAM_EXEC,
+        version: 1,
+        flags: CAP_FLAG_PROTOCOL_FEATURE,
+        name: "program.ram_exec",
+    },
+];
+
+pub const BLINK_MVP_WITH_PWM_AND_ADC_CAPABILITIES: [CapabilityDescriptor<'static>; 9] = [
+    CapabilityDescriptor {
+        id: CAP_GPIO_OPEN,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.open",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_CLOSE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.close",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_SLEEP_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.sleep_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_NOW_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.now_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_PWM_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "pwm.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_ADC_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "adc.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_PROGRAM_RAM_EXEC,
+        version: 1,
+        flags: CAP_FLAG_PROTOCOL_FEATURE,
+        name: "program.ram_exec",
+    },
+];
+
 pub const BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>; 9] = [
     CapabilityDescriptor {
         id: CAP_GPIO_OPEN,
@@ -221,6 +329,126 @@ pub const BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<
         version: 1,
         flags: CAP_FLAG_BYTECODE_CALLABLE,
         name: "pwm.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_LED_MATRIX_FRAME,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "led_matrix.frame",
+    },
+    CapabilityDescriptor {
+        id: CAP_PROGRAM_RAM_EXEC,
+        version: 1,
+        flags: CAP_FLAG_PROTOCOL_FEATURE,
+        name: "program.ram_exec",
+    },
+];
+
+pub const BLINK_MVP_WITH_ADC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>; 9] = [
+    CapabilityDescriptor {
+        id: CAP_GPIO_OPEN,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.open",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_CLOSE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.close",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_SLEEP_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.sleep_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_NOW_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.now_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_ADC_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "adc.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_LED_MATRIX_FRAME,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "led_matrix.frame",
+    },
+    CapabilityDescriptor {
+        id: CAP_PROGRAM_RAM_EXEC,
+        version: 1,
+        flags: CAP_FLAG_PROTOCOL_FEATURE,
+        name: "program.ram_exec",
+    },
+];
+
+pub const BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>; 10] = [
+    CapabilityDescriptor {
+        id: CAP_GPIO_OPEN,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.open",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.read",
+    },
+    CapabilityDescriptor {
+        id: CAP_GPIO_CLOSE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "gpio.close",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_SLEEP_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.sleep_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_TIME_NOW_MS,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "time.now_ms",
+    },
+    CapabilityDescriptor {
+        id: CAP_PWM_WRITE,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "pwm.write",
+    },
+    CapabilityDescriptor {
+        id: CAP_ADC_READ,
+        version: 1,
+        flags: CAP_FLAG_BYTECODE_CALLABLE,
+        name: "adc.read",
     },
     CapabilityDescriptor {
         id: CAP_LED_MATRIX_FRAME,

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,7 +1,7 @@
 use board_vm_ir::{
-    parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_GPIO_CLOSE,
-    CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
-    CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
+    parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ,
+    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME,
+    CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
     FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
@@ -36,6 +36,8 @@ pub const TIME_SLEEP_MS_CODE_LEN: usize = 5;
 pub const TIME_SLEEP_MS_MODULE_LEN: usize = 15;
 pub const PWM_WRITE_CODE_LEN: usize = 8;
 pub const PWM_WRITE_MODULE_LEN: usize = 18;
+pub const ADC_READ_CODE_LEN: usize = 5;
+pub const ADC_READ_MODULE_LEN: usize = 15;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -158,6 +160,12 @@ pub struct PwmWriteProgram {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdcReadProgram {
+    pub pin: u8,
+    pub max_stack: u8,
+}
+
 impl GpioOpenProgram {
     pub const fn output(pin: u8) -> Self {
         Self {
@@ -263,6 +271,12 @@ impl PwmWriteProgram {
 
     pub const fn full(pin: u8) -> Self {
         Self::new(pin, u16::MAX)
+    }
+}
+
+impl AdcReadProgram {
+    pub const fn new(pin: u8) -> Self {
+        Self { pin, max_stack: 1 }
     }
 }
 
@@ -1018,6 +1032,39 @@ pub fn write_pwm_write_module(
     Ok(offset)
 }
 
+pub fn write_adc_read_code(program: AdcReadProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if out.len() < ADC_READ_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.pin)?;
+    write_call_u8(out, &mut offset, CAP_ADC_READ)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_adc_read_module(program: AdcReadProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if out.len() < ADC_READ_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; ADC_READ_CODE_LEN];
+    let code_len = write_adc_read_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(0, program.max_stack, &code[..code_len]),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_adc(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_led_matrix_frame_code(
     program: LedMatrixFrameProgram,
     out: &mut [u8],
@@ -1167,7 +1214,7 @@ mod tests {
     use super::*;
     use board_vm_ir::{
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
-        CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+        CAP_ADC_READ, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -1210,6 +1257,9 @@ mod tests {
     const PWM_WRITE_HALF_MODULE_HEX: [u8; PWM_WRITE_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x02, 0x00, 0x08, 0x12, 0x03, 0x13, 0x00, 0x80, 0x40,
         0x20, 0x00, 0x00,
+    ];
+    const ADC_READ_A0_MODULE_HEX: [u8; ADC_READ_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x05, 0x12, 0x0E, 0x40, 0x21, 0x50, 0x00,
     ];
     const LED_MATRIX_HEART_MODULE_HEX: [u8; LED_MATRIX_FRAME_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x12, 0x14, 0x44, 0xA4, 0x84, 0x31, 0x14,
@@ -1369,6 +1419,20 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_PWM_WRITE]);
+    }
+
+    #[test]
+    fn builds_adc_read_module() {
+        let mut module = [0u8; ADC_READ_MODULE_LEN];
+        let len = write_adc_read_module(AdcReadProgram::new(14), &mut module).unwrap();
+        assert_eq!(len, ADC_READ_MODULE_LEN);
+        assert_eq!(module, ADC_READ_A0_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_adc(), 1).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_ADC_READ]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -17,6 +17,7 @@ pub const CAP_GPIO_CLOSE: u16 = 0x04;
 pub const CAP_TIME_SLEEP_MS: u16 = 0x10;
 pub const CAP_TIME_NOW_MS: u16 = 0x11;
 pub const CAP_PWM_WRITE: u16 = 0x20;
+pub const CAP_ADC_READ: u16 = 0x21;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -26,6 +27,7 @@ const CAP_GPIO_CLOSE_U8: u8 = CAP_GPIO_CLOSE as u8;
 const CAP_TIME_SLEEP_MS_U8: u8 = CAP_TIME_SLEEP_MS as u8;
 const CAP_TIME_NOW_MS_U8: u8 = CAP_TIME_NOW_MS as u8;
 const CAP_PWM_WRITE_U8: u8 = CAP_PWM_WRITE as u8;
+const CAP_ADC_READ_U8: u8 = CAP_ADC_READ as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -99,6 +101,7 @@ pub struct CapabilitySet {
     pub gpio_digital: bool,
     pub time: bool,
     pub pwm: bool,
+    pub adc: bool,
     pub led_matrix: bool,
 }
 
@@ -108,6 +111,7 @@ impl CapabilitySet {
             gpio_digital: false,
             time: false,
             pwm: false,
+            adc: false,
             led_matrix: false,
         }
     }
@@ -117,12 +121,17 @@ impl CapabilitySet {
             gpio_digital: true,
             time: true,
             pwm: false,
+            adc: false,
             led_matrix: false,
         }
     }
 
     pub const fn with_pwm(self) -> Self {
         Self { pwm: true, ..self }
+    }
+
+    pub const fn with_adc(self) -> Self {
+        Self { adc: true, ..self }
     }
 
     pub const fn with_led_matrix(self) -> Self {
@@ -137,6 +146,7 @@ impl CapabilitySet {
             CAP_GPIO_OPEN | CAP_GPIO_WRITE | CAP_GPIO_READ | CAP_GPIO_CLOSE => self.gpio_digital,
             CAP_TIME_SLEEP_MS | CAP_TIME_NOW_MS => self.time,
             CAP_PWM_WRITE => self.pwm,
+            CAP_ADC_READ => self.adc,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -370,6 +380,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_TIME_SLEEP_MS_U8) | Op::CallU16(CAP_TIME_SLEEP_MS) => (1, 0),
         Op::CallU8(CAP_TIME_NOW_MS_U8) | Op::CallU16(CAP_TIME_NOW_MS) => (0, 1),
         Op::CallU8(CAP_PWM_WRITE_U8) | Op::CallU16(CAP_PWM_WRITE) => (2, 0),
+        Op::CallU8(CAP_ADC_READ_U8) | Op::CallU16(CAP_ADC_READ) => (1, 1),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -540,6 +551,21 @@ mod tests {
     }
 
     #[test]
+    fn validates_adc_read_capability() {
+        let module = Module {
+            flags: 0,
+            max_stack: 1,
+            code: &[0x12, 14, 0x40, CAP_ADC_READ as u8, 0x50],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_adc(), 1).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_ADC_READ]);
+    }
+
+    #[test]
     fn rejects_pwm_write_without_capability() {
         let module = Module {
             flags: 0,
@@ -551,6 +577,21 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 2),
             Err(ValidateError::UnsupportedCapability(CAP_PWM_WRITE))
+        );
+    }
+
+    #[test]
+    fn rejects_adc_read_without_capability() {
+        let module = Module {
+            flags: 0,
+            max_stack: 1,
+            code: &[0x12, 14, 0x40, CAP_ADC_READ as u8, 0x50],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 1),
+            Err(ValidateError::UnsupportedCapability(CAP_ADC_READ))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -35,17 +35,18 @@ use board_vm_esp_rom::{
     DEFAULT_TIMEOUT_MS as ESP_DEFAULT_TIMEOUT_MS,
 };
 use board_vm_host::{
-    write_blink_module, write_gpio_handle_close_module, write_gpio_handle_read_module,
-    write_gpio_handle_write_module, write_gpio_open_module, write_gpio_read_module,
-    write_gpio_write_module, write_led_matrix_frame_module, write_module, write_pwm_write_module,
-    write_time_now_module, write_time_sleep_ms_module, BlinkProgram, GpioHandleCloseProgram,
-    GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
-    GpioWriteProgram, HostError, HostSession, LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram,
-    TimeNowProgram, TimeSleepMsProgram, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
-    DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN,
-    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
-    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
-    TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    write_adc_read_module, write_blink_module, write_gpio_handle_close_module,
+    write_gpio_handle_read_module, write_gpio_handle_write_module, write_gpio_open_module,
+    write_gpio_read_module, write_gpio_write_module, write_led_matrix_frame_module, write_module,
+    write_pwm_write_module, write_time_now_module, write_time_sleep_ms_module, AdcReadProgram,
+    BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
+    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession,
+    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
+    DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
+    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
+    GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -1587,6 +1588,13 @@ pub fn build_pwm_write_module(
     Ok(write_pwm_write_module(program, out)?)
 }
 
+pub fn build_adc_read_module(
+    program: AdcReadProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_adc_read_module(program, out)?)
+}
+
 pub fn build_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2252,6 +2260,23 @@ pub unsafe extern "C" fn board_vm_language_pwm_write_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_adc_read_module(
+    pin: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_adc_read_module(AdcReadProgram { pin, max_stack }, module_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2562,6 +2587,11 @@ pub extern "C" fn board_vm_language_pwm_write_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_adc_read_module_len() -> u64 {
+    ADC_READ_MODULE_LEN as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_led_matrix_frame_module_len() -> u64 {
     LED_MATRIX_FRAME_MODULE_LEN as u64
 }
@@ -2785,7 +2815,11 @@ mod tests {
         assert!(uno_d3.supports_pwm);
         assert!(uno_d3.supports_interrupt);
         assert!(!uno_d3.supports_adc);
+        let uno_a0 = uno.digital_pins.iter().find(|pin| pin.pin == 14).unwrap();
+        assert_eq!(uno_a0.label, "A0/D14");
+        assert!(uno_a0.supports_adc);
         assert!(uno.capabilities.contains(&"pwm.write".to_owned()));
+        assert!(uno.capabilities.contains(&"adc.read".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -3565,6 +3599,18 @@ mod tests {
         };
         assert_eq!(pwm_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(pwm_status.len, PWM_WRITE_MODULE_LEN as u64);
+
+        let mut adc_module = [0u8; ADC_READ_MODULE_LEN];
+        let adc_status = unsafe {
+            board_vm_language_adc_read_module(
+                14,
+                1,
+                adc_module.as_mut_ptr(),
+                adc_module.len() as u64,
+            )
+        };
+        assert_eq!(adc_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(adc_status.len, ADC_READ_MODULE_LEN as u64);
 
         let mut gpio_read_module = [0u8; GPIO_READ_MODULE_LEN];
         let gpio_read_status = unsafe {

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 
 use board_vm_ir::{
-    decode_next, validate, CapabilitySet, Module, Op, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ,
-    CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
+    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS,
+    CAP_TIME_SLEEP_MS,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,6 +63,10 @@ pub trait BoardHal {
     fn now_ms(&self) -> u32;
 
     fn pwm_write(&mut self, _pin: u16, _duty: u16) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn adc_read(&mut self, _pin: u16) -> Result<u16, HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -404,6 +409,14 @@ where
                     kind: hal_error_kind(err),
                 })
             }
+            CAP_ADC_READ => {
+                let pin = self.pop_u16(ip)?;
+                let sample = self.hal.adc_read(pin).map_err(|err| RuntimeError {
+                    ip,
+                    kind: hal_error_kind(err),
+                })?;
+                self.push(Value::U16(sample), ip)
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -635,6 +648,7 @@ mod tests {
         Write(u32, Level),
         Sleep(u16),
         PwmWrite(u16, u16),
+        AdcRead(u16),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -654,7 +668,10 @@ mod tests {
 
     impl BoardHal for FakeHal {
         fn capabilities(&self) -> CapabilitySet {
-            CapabilitySet::blink_mvp().with_pwm().with_led_matrix()
+            CapabilitySet::blink_mvp()
+                .with_pwm()
+                .with_adc()
+                .with_led_matrix()
         }
 
         fn gpio_open(&mut self, pin: u16, mode: GpioMode) -> Result<u32, HalError> {
@@ -688,6 +705,11 @@ mod tests {
         fn pwm_write(&mut self, pin: u16, duty: u16) -> Result<(), HalError> {
             self.events.push(Event::PwmWrite(pin, duty));
             Ok(())
+        }
+
+        fn adc_read(&mut self, pin: u16) -> Result<u16, HalError> {
+            self.events.push(Event::AdcRead(pin));
+            Ok(0x03ff)
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -801,5 +823,17 @@ mod tests {
 
         assert_eq!(report.status, RunStatus::Halted);
         assert_eq!(runtime.hal().events, vec![Event::PwmWrite(3, 0x8000)]);
+    }
+
+    #[test]
+    fn adc_read_dispatches_pin_and_returns_sample() {
+        let mut runtime: Runtime<FakeHal, 4, 1> = Runtime::new(FakeHal::new());
+        let code = [0x12, 14, 0x40, CAP_ADC_READ as u8, 0x50];
+
+        let report = runtime.run_code(&code, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.return_value, Value::U16(0x03ff));
+        assert_eq!(runtime.hal().events, vec![Event::AdcRead(14)]);
     }
 }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -99,7 +99,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 9] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 10] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -108,10 +108,11 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 9] = [
     "time.sleep_ms",
     "time.now_ms",
     "pwm.write",
+    "adc.read",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 13] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 14] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -123,6 +124,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 13] = [
     "time.sleep_ms",
     "time.now_ms",
     "pwm.write",
+    "adc.read",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -219,7 +221,7 @@ pub const PICO_W_WIRELESS: [WirelessInterfaceInfo; 3] = [
     },
 ];
 
-pub const UNO_R4_DIGITAL_PINS: [DigitalPinInfo; 14] =
+pub const UNO_R4_DIGITAL_PINS: [DigitalPinInfo; 20] =
     map_uno_r4_digital_pins(board_vm_uno_r4::UNO_R4_DIGITAL_PINS);
 
 pub const ESP32_DIGITAL_PINS: [DigitalPinInfo; 30] =
@@ -248,7 +250,7 @@ const fn uno_r4_digital_pin(pin: board_vm_uno_r4::DigitalPinDescriptor) -> Digit
         supports_output: true,
         supports_pullup: true,
         supports_pulldown: false,
-        supports_adc: false,
+        supports_adc: pin.supports_adc,
         supports_pwm: pin.supports_pwm,
         supports_touch: false,
         supports_interrupt: pin.supports_interrupt,
@@ -499,6 +501,11 @@ mod tests {
         assert!(d13.notes.contains("onboard LED"));
         assert!(!d13.supports_pwm);
 
+        let a0 = uno.digital_pins.iter().find(|pin| pin.pin == 14).unwrap();
+        assert_eq!(a0.label, "A0/D14");
+        assert!(a0.supports_adc);
+        assert!(!a0.supports_pwm);
+
         let pico = find_target("raspberry-pi-pico").unwrap();
         let adc0 = pico.digital_pins.iter().find(|pin| pin.pin == 26).unwrap();
         assert!(adc0.supports_adc);
@@ -521,6 +528,7 @@ mod tests {
 
         let uno = find_target("arduino-uno-r4-wifi").unwrap();
         assert!(uno.capabilities.contains(&"pwm.write"));
+        assert!(uno.capabilities.contains(&"adc.read"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -2,7 +2,9 @@
 
 use board_vm_device::{
     BoardVmDevice, DeviceDescriptor, BLINK_MVP_CAPABILITIES,
-    BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_ADC_AND_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_ADC_CAPABILITIES,
+    BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_AND_ADC_CAPABILITIES, BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES,
     BLINK_MVP_WITH_PWM_CAPABILITIES, DEFAULT_MAX_FRAME_PAYLOAD,
 };
 use board_vm_ir::CapabilitySet;
@@ -58,15 +60,17 @@ pub struct DigitalPinDescriptor {
     pub arduino_pin: u8,
     pub label: &'static str,
     pub supports_pwm: bool,
+    pub supports_adc: bool,
     pub supports_interrupt: bool,
     pub notes: &'static str,
 }
 
-pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
+pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
     DigitalPinDescriptor {
         arduino_pin: 0,
         label: "D0/RX0",
         supports_pwm: false,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 0 / Serial 0 receiver",
     },
@@ -74,6 +78,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 1,
         label: "D1/TX0",
         supports_pwm: false,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 1 / Serial 0 transmitter",
     },
@@ -81,6 +86,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 2,
         label: "D2",
         supports_pwm: false,
+        supports_adc: false,
         supports_interrupt: true,
         notes: "GPIO 2 / external interrupt",
     },
@@ -88,6 +94,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 3,
         label: "D3",
         supports_pwm: true,
+        supports_adc: false,
         supports_interrupt: true,
         notes: "GPIO 3 / PWM / external interrupt",
     },
@@ -95,6 +102,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 4,
         label: "D4",
         supports_pwm: false,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 4 / CAN alternate function on Minima header docs",
     },
@@ -102,6 +110,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 5,
         label: "D5",
         supports_pwm: true,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 5 / PWM",
     },
@@ -109,6 +118,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 6,
         label: "D6",
         supports_pwm: true,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 6 / PWM",
     },
@@ -116,6 +126,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 7,
         label: "D7",
         supports_pwm: false,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 7",
     },
@@ -123,6 +134,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 8,
         label: "D8",
         supports_pwm: false,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 8",
     },
@@ -130,6 +142,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 9,
         label: "D9",
         supports_pwm: true,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 9 / PWM",
     },
@@ -137,6 +150,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 10,
         label: "D10/CS",
         supports_pwm: true,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 10 / PWM / SPI chip select",
     },
@@ -144,6 +158,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 11,
         label: "D11/COPI",
         supports_pwm: true,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 11 / PWM / SPI controller out",
     },
@@ -151,6 +166,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 12,
         label: "D12/CIPO",
         supports_pwm: false,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 12 / SPI controller in",
     },
@@ -158,8 +174,57 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 14] = [
         arduino_pin: 13,
         label: "D13/SCK",
         supports_pwm: false,
+        supports_adc: false,
         supports_interrupt: false,
         notes: "GPIO 13 / SPI clock / onboard LED",
+    },
+    DigitalPinDescriptor {
+        arduino_pin: 14,
+        label: "A0/D14",
+        supports_pwm: false,
+        supports_adc: true,
+        supports_interrupt: false,
+        notes: "Analog input A0 / DAC output / digital pin 14",
+    },
+    DigitalPinDescriptor {
+        arduino_pin: 15,
+        label: "A1/D15",
+        supports_pwm: false,
+        supports_adc: true,
+        supports_interrupt: false,
+        notes: "Analog input A1 / digital pin 15",
+    },
+    DigitalPinDescriptor {
+        arduino_pin: 16,
+        label: "A2/D16",
+        supports_pwm: false,
+        supports_adc: true,
+        supports_interrupt: false,
+        notes: "Analog input A2 / digital pin 16",
+    },
+    DigitalPinDescriptor {
+        arduino_pin: 17,
+        label: "A3/D17",
+        supports_pwm: false,
+        supports_adc: true,
+        supports_interrupt: false,
+        notes: "Analog input A3 / digital pin 17",
+    },
+    DigitalPinDescriptor {
+        arduino_pin: 18,
+        label: "A4/SDA/D18",
+        supports_pwm: false,
+        supports_adc: true,
+        supports_interrupt: false,
+        notes: "Analog input A4 / I2C SDA / digital pin 18",
+    },
+    DigitalPinDescriptor {
+        arduino_pin: 19,
+        label: "A5/SCL/D19",
+        supports_pwm: false,
+        supports_adc: true,
+        supports_interrupt: false,
+        notes: "Analog input A5 / I2C SCL / digital pin 19",
     },
 ];
 
@@ -179,7 +244,7 @@ pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     onboard_led_pin: UNO_R4_ONBOARD_LED_PIN,
     supports_wifi_module: false,
     supports_led_matrix: false,
-    capabilities: CapabilitySet::blink_mvp().with_pwm(),
+    capabilities: CapabilitySet::blink_mvp().with_pwm().with_adc(),
     digital_pins: &UNO_R4_DIGITAL_PINS,
 };
 
@@ -199,7 +264,10 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
     onboard_led_pin: UNO_R4_ONBOARD_LED_PIN,
     supports_wifi_module: true,
     supports_led_matrix: true,
-    capabilities: CapabilitySet::blink_mvp().with_pwm().with_led_matrix(),
+    capabilities: CapabilitySet::blink_mvp()
+        .with_pwm()
+        .with_adc()
+        .with_led_matrix(),
     digital_pins: &UNO_R4_DIGITAL_PINS,
 };
 
@@ -214,11 +282,19 @@ pub trait UnoR4Backend {
         false
     }
 
+    fn supports_adc(&self) -> bool {
+        false
+    }
+
     fn led_matrix_frame(&mut self, _frame: [u32; 3]) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
 
     fn write_pwm(&mut self, _pin: u8, _duty: u16) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn read_adc(&mut self, _pin: u8) -> Result<u16, HalError> {
         Err(HalError::UnsupportedMode)
     }
 }
@@ -269,6 +345,7 @@ where
     fn resolved_capabilities(&self) -> CapabilitySet {
         let mut capabilities = self.target.capabilities;
         capabilities.pwm = self.backend.supports_pwm();
+        capabilities.adc = self.backend.supports_adc();
         capabilities
     }
 }
@@ -314,6 +391,11 @@ where
         self.backend.write_pwm(pin, duty)
     }
 
+    fn adc_read(&mut self, pin: u16) -> Result<u16, HalError> {
+        let pin = normalize_adc_pin(pin)?;
+        self.backend.read_adc(pin)
+    }
+
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
         if !self.target.supports_led_matrix {
             return Err(HalError::UnsupportedMode);
@@ -329,13 +411,22 @@ pub fn digital_pin(pin: u8) -> Option<&'static DigitalPinDescriptor> {
 }
 
 pub fn is_valid_digital_pin(pin: u16) -> bool {
-    pin <= 13
+    u8::try_from(pin).ok().and_then(digital_pin).is_some()
 }
 
 fn normalize_pwm_pin(pin: u16) -> Result<u8, HalError> {
     let pin = normalize_digital_pin(pin)?;
     match digital_pin(pin) {
         Some(descriptor) if descriptor.supports_pwm => Ok(pin),
+        Some(_) => Err(HalError::UnsupportedMode),
+        None => Err(HalError::InvalidPin),
+    }
+}
+
+fn normalize_adc_pin(pin: u16) -> Result<u8, HalError> {
+    let pin = normalize_digital_pin(pin)?;
+    match digital_pin(pin) {
+        Some(descriptor) if descriptor.supports_adc => Ok(pin),
         Some(_) => Err(HalError::UnsupportedMode),
         None => Err(HalError::InvalidPin),
     }
@@ -359,12 +450,20 @@ fn uno_r4_device_descriptor_for_capabilities(
         board_nonce,
         max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
         supports_store_program: false,
-        capabilities: if target.supports_led_matrix && capabilities.pwm {
+        capabilities: if target.supports_led_matrix && capabilities.pwm && capabilities.adc {
+            &BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_led_matrix && capabilities.pwm {
             &BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_led_matrix && capabilities.adc {
+            &BLINK_MVP_WITH_ADC_AND_LED_MATRIX_CAPABILITIES
         } else if target.supports_led_matrix {
             &BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES
+        } else if capabilities.pwm && capabilities.adc {
+            &BLINK_MVP_WITH_PWM_AND_ADC_CAPABILITIES
         } else if capabilities.pwm {
             &BLINK_MVP_WITH_PWM_CAPABILITIES
+        } else if capabilities.adc {
+            &BLINK_MVP_WITH_ADC_CAPABILITIES
         } else {
             &BLINK_MVP_CAPABILITIES
         },
@@ -419,6 +518,7 @@ mod tests {
         Write(u8, Level),
         Sleep(u16),
         PwmWrite(u8, u16),
+        AdcRead(u8),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -465,9 +565,18 @@ mod tests {
             true
         }
 
+        fn supports_adc(&self) -> bool {
+            true
+        }
+
         fn write_pwm(&mut self, pin: u8, duty: u16) -> Result<(), HalError> {
             self.events.push(Event::PwmWrite(pin, duty));
             Ok(())
+        }
+
+        fn read_adc(&mut self, pin: u8) -> Result<u16, HalError> {
+            self.events.push(Event::AdcRead(pin));
+            Ok(0x02aa)
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -491,6 +600,15 @@ mod tests {
         let d13 = digital_pin(13).unwrap();
         assert_eq!(d13.label, "D13/SCK");
         assert!(d13.notes.contains("onboard LED"));
+    }
+
+    #[test]
+    fn knows_uno_r4_analog_header_pins() {
+        let a0 = digital_pin(14).unwrap();
+        assert_eq!(a0.label, "A0/D14");
+        assert!(a0.supports_adc);
+        assert!(!a0.supports_pwm);
+        assert!(is_valid_digital_pin(19));
     }
 
     #[test]
@@ -531,14 +649,18 @@ mod tests {
         assert_eq!(descriptor.max_frame_payload, DEFAULT_MAX_FRAME_PAYLOAD);
         assert_eq!(
             descriptor.capabilities.len(),
-            BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES.len()
+            BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES.len()
         );
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
+        assert!(UNO_R4_WIFI.capabilities.supports(board_vm_ir::CAP_ADC_READ));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_ADC_READ));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -578,6 +700,22 @@ mod tests {
 
         assert_eq!(board.pwm_write(2, 0x8000), Err(HalError::UnsupportedMode));
         assert_eq!(board.pwm_write(99, 0x8000), Err(HalError::InvalidPin));
+    }
+
+    #[test]
+    fn adc_read_runs_through_analog_pin_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(board.adc_read(14).unwrap(), 0x02aa);
+        assert_eq!(board.backend().events, vec![Event::AdcRead(14)]);
+    }
+
+    #[test]
+    fn adc_read_rejects_non_adc_pin() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(board.adc_read(13), Err(HalError::UnsupportedMode));
+        assert_eq!(board.adc_read(99), Err(HalError::InvalidPin));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add VM-level `adc.read` capability, validation stack effects, runtime dispatch, and host module builder
- expose UNO R4 A0-A5 analog header metadata plus Rust-owned target capability metadata
- add thin Ruby native/session/connection wrappers for `board.adc.read(pin: ...)` and REPL commands

## Validation
- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core`
- `cargo test -p board-vm-uno-r4-firmware`
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

## Notes
- This slice adds the VM protocol/module/front-end path and UNO R4 metadata. The physical UNO R4 ADC firmware backend remains the next slice; live runtime descriptor advertising is still backend-gated.