### PR TITLE
rust(macsyma): factor multivariate perfect cubes

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Added Rust MACSYMA parity for four-term bilinear grouping, so
   `factor(x*y + x*z + y + z)` returns `(x + 1) * (y + z)` through the shared
   symbolic VM handler.
+- Added Rust MACSYMA parity for four-term perfect-cube expansions, so
+  `factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3)` returns `(x + y)^3` and
+  `factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3)` returns `(x - y)^3` through the
+  shared symbolic VM handler.
 - Added `?` / `? topic` help-query handling for Rust MACSYMA sessions.
 - Wired `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
   Rust MACSYMA session assumption context so declared properties feed property

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -256,6 +256,45 @@ fn factors_grouped_multivariate_terms_with_signed_residuals_through_runtime() {
     );
 }
 
+// Perfect-cube expansions: a^3 ± 3a^2b ± 3ab^2 ± b^3 = (a ± b)^3
+// These are four-term patterns and are detected before the two-term cubic
+// identity a^3 ± b^3, so they must be tested here to confirm the dispatch
+// order does not swallow them as a partial match.
+
+#[test]
+fn factors_multivariate_perfect_cube_sum_through_runtime() {
+    // x^3 + 3*x^2*y + 3*x*y^2 + y^3  =  (x + y)^3
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3);")
+        .unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(POW),
+            vec![apply(sym(ADD), vec![sym("x"), sym("y")]), int(3)],
+        )
+    );
+}
+
+#[test]
+fn factors_multivariate_perfect_cube_difference_through_runtime() {
+    // x^3 - 3*x^2*y + 3*x*y^2 - y^3  =  (x - y)^3
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3);")
+        .unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(POW),
+            vec![apply(sym(SUB), vec![sym("x"), sym("y")]), int(3)],
+        )
+    );
+}
+
 #[test]
 fn question_mark_without_topic_lists_help_topics() {
     let mut session = MacsymaSession::new();

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -15,6 +15,9 @@
   `x^3 + y^3`, rewriting them to their canonical linear/quadratic products.
 - `Factor` recognises four-term bilinear grouping such as
   `x*y + x*z + y + z` and rewrites it as `(x + 1) * (y + z)`.
+- `Factor` recognises four-term bivariate perfect-cube expansions such as
+  `x^3 + 3*x^2*y + 3*x*y^2 + y^3` and `x^3 - 3*x^2*y + 3*x*y^2 - y^3`,
+  rewriting them as `(x + y)^3` and `(x - y)^3` respectively.
 - `SymbolicBackend` installs a `D` derivative handler for symbolic-only
   differentiation of arithmetic, elementary, hyperbolic, and inverse
   hyperbolic expressions; `StrictBackend` continues to reject `D` as an

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1374,6 +1374,10 @@ fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
         }
     }
 
+    if let Some(rewritten) = factor_multivariate_perfect_cube(input) {
+        return rewritten;
+    }
+
     if let Some(rewritten) = factor_multivariate_cubic_identity(input) {
         return rewritten;
     }
@@ -1665,6 +1669,120 @@ fn factor_multivariate_grouping(node: &IRNode) -> Option<IRNode> {
     }
 
     None
+}
+
+/// Recognise `(a±b)^3` perfect-cube expansions.
+///
+/// The two identities handled are:
+///
+/// ```text
+/// a^3 + 3·a^2·b + 3·a·b^2 + b^3  →  (a + b)^3   [sum cube]
+/// a^3 − 3·a^2·b + 3·a·b^2 − b^3  →  (a − b)^3   [difference cube]
+/// ```
+///
+/// Requires exactly four additive terms: two *pure-cube* terms (`|coeff|=1`,
+/// one variable, exponent 3) and two *cross terms* (two variables, `|coeff|=3`).
+/// Returns `None` on any mismatch so `factor_handler` can continue to the next
+/// pattern.
+fn factor_multivariate_perfect_cube(node: &IRNode) -> Option<IRNode> {
+    let terms = additive_terms(node)?;
+    if terms.len() != 4 {
+        return None;
+    }
+
+    let mut pure_cubes: Vec<(i64, IRNode)> = Vec::new(); // (sign, base)
+    let mut cross_terms: Vec<(i64, HashMap<IRNode, usize>)> = Vec::new();
+
+    for term in &terms {
+        let (coefficient, powers) = term_integer_coefficient_and_powers(term)?;
+        match powers.len() {
+            1 => {
+                let (base, exponent) = powers.into_iter().next()?;
+                if exponent == 3 && (coefficient == 1 || coefficient == -1) {
+                    pure_cubes.push((coefficient, base));
+                } else {
+                    return None; // wrong exponent or coeff
+                }
+            }
+            2 => {
+                cross_terms.push((coefficient, powers));
+            }
+            _ => return None,
+        }
+    }
+
+    if pure_cubes.len() != 2 || cross_terms.len() != 2 {
+        return None;
+    }
+
+    // Identify a and b; derive sum vs. difference from pure-cube signs.
+    let (a_node, b_node, is_sum) = {
+        let (c0, ref b0) = pure_cubes[0];
+        let (c1, ref b1) = pure_cubes[1];
+        match (c0, c1) {
+            (1, 1) => (b0.clone(), b1.clone(), true),
+            (1, -1) => (b0.clone(), b1.clone(), false),
+            (-1, 1) => (b1.clone(), b0.clone(), false),
+            _ => return None,
+        }
+    };
+
+    // Cross-term variable sets must equal exactly {a_node, b_node}.
+    let variable_pair: HashSet<IRNode> =
+        [a_node.clone(), b_node.clone()].into_iter().collect();
+    for (_, powers) in &cross_terms {
+        if powers.len() != 2 {
+            return None;
+        }
+        let keys: HashSet<IRNode> = powers.keys().cloned().collect();
+        if keys != variable_pair {
+            return None;
+        }
+    }
+
+    // Validate cross-term coefficients and exponent distributions.
+    if is_sum {
+        // Expect +3·a^2·b and +3·a·b^2 in any order.
+        let mut found_a2b = false;
+        let mut found_ab2 = false;
+        for (coefficient, powers) in &cross_terms {
+            let exp_a = powers.get(&a_node).copied().unwrap_or(0);
+            let exp_b = powers.get(&b_node).copied().unwrap_or(0);
+            match (*coefficient, exp_a, exp_b) {
+                (3, 2, 1) => found_a2b = true,
+                (3, 1, 2) => found_ab2 = true,
+                _ => return None,
+            }
+        }
+        if !found_a2b || !found_ab2 {
+            return None;
+        }
+        Some(apply_node(
+            POW,
+            vec![apply_node(ADD, vec![a_node, b_node]), IRNode::Integer(3)],
+        ))
+    } else {
+        // Expect −3·a^2·b and +3·a·b^2.
+        // The sign on a^2·b flips because (a−b)^3 = a^3 − 3a^2b + 3ab^2 − b^3.
+        let mut found_neg_a2b = false;
+        let mut found_pos_ab2 = false;
+        for (coefficient, powers) in &cross_terms {
+            let exp_a = powers.get(&a_node).copied().unwrap_or(0);
+            let exp_b = powers.get(&b_node).copied().unwrap_or(0);
+            match (*coefficient, exp_a, exp_b) {
+                (-3, 2, 1) => found_neg_a2b = true,
+                (3, 1, 2) => found_pos_ab2 = true,
+                _ => return None,
+            }
+        }
+        if !found_neg_a2b || !found_pos_ab2 {
+            return None;
+        }
+        Some(apply_node(
+            POW,
+            vec![apply_node(SUB, vec![a_node, b_node]), IRNode::Integer(3)],
+        ))
+    }
 }
 
 fn common_symbolic_powers(terms: &[IRNode]) -> HashMap<IRNode, usize> {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -457,6 +457,123 @@ fn symbolic_factor_extracts_grouped_multivariate_terms_with_signed_residuals() {
     );
 }
 
+#[test]
+fn symbolic_factor_extracts_multivariate_perfect_cube_sum() {
+    // Factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3) → (x+y)^3
+    //
+    // The binomial cube expansion (a+b)^3 = a^3 + 3a^2b + 3ab^2 + b^3 is a
+    // 4-term pattern handled by factor_multivariate_perfect_cube, distinct
+    // from the 2-term cubic identity (a^3 ± b^3).
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(
+                            sym(ADD),
+                            vec![
+                                apply(sym(POW), vec![sym("x"), int(3)]),
+                                apply(
+                                    sym(MUL),
+                                    vec![
+                                        int(3),
+                                        apply(
+                                            sym(MUL),
+                                            vec![
+                                                apply(sym(POW), vec![sym("x"), int(2)]),
+                                                sym("y"),
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                        apply(
+                            sym(MUL),
+                            vec![
+                                int(3),
+                                apply(
+                                    sym(MUL),
+                                    vec![sym("x"), apply(sym(POW), vec![sym("y"), int(2)])],
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                apply(sym(POW), vec![sym("y"), int(3)]),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(sym(POW), vec![apply(sym(ADD), vec![sym("x"), sym("y")]), int(3)])
+    );
+}
+
+#[test]
+fn symbolic_factor_extracts_multivariate_perfect_cube_difference() {
+    // Factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3) → (x-y)^3
+    //
+    // The difference expansion (a-b)^3 = a^3 - 3a^2b + 3ab^2 - b^3 has
+    // a negative cross term (-3a^2b) and a negative cubic (-b^3), which
+    // distinguishes it from the sum case.
+    let expr = apply(
+        sym("Factor"),
+        vec![apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(SUB),
+                    vec![
+                        apply(
+                            sym(ADD),
+                            vec![
+                                apply(sym(POW), vec![sym("x"), int(3)]),
+                                apply(
+                                    sym(MUL),
+                                    vec![
+                                        int(3),
+                                        apply(
+                                            sym(MUL),
+                                            vec![
+                                                sym("x"),
+                                                apply(sym(POW), vec![sym("y"), int(2)]),
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                        apply(
+                            sym(MUL),
+                            vec![
+                                int(3),
+                                apply(
+                                    sym(MUL),
+                                    vec![
+                                        apply(sym(POW), vec![sym("x"), int(2)]),
+                                        sym("y"),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                apply(sym(MUL), vec![int(-1), apply(sym(POW), vec![sym("y"), int(3)])]),
+            ],
+        )],
+    );
+
+    assert_eq!(
+        symbolic().eval(expr),
+        apply(sym(POW), vec![apply(sym(SUB), vec![sym("x"), sym("y")]), int(3)])
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Symbol resolution
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `factor_multivariate_perfect_cube` to the shared Rust CAS backend in `symbolic-vm` so `factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3)` → `(x + y)^3` and `factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3)` → `(x - y)^3`
- Dispatched before `factor_multivariate_cubic_identity` (two-term a³ ± b³) so the four-term pattern always gets first crack
- Adds 2 unit tests in `symbolic-vm/tests/test_vm.rs` (81 pass) and 2 pipeline tests in `macsyma-runtime/tests/test_runtime.rs` (51 pass)
- CHANGELOGs updated for both `symbolic-vm` and `macsyma-runtime`
- Brings Rust to parity with the Python (#3116) and TypeScript (#3125) perfect-cube implementations

## Test plan

- [x] `cargo test` in `code/packages/rust/symbolic-vm` — 81 tests pass
- [x] `cargo test` in `code/packages/rust/macsyma-runtime` — 51 tests pass
- [x] Security review passed (pure IR tree manipulation, no unsafe, no I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)