### PR TITLE
Wire UNO R4 physical ADC backend

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -142,7 +142,8 @@ the built-in USB path: Arduino core version `1.5.3`, FQBN
 `arduino:renesas_uno:unor4wifi`, required TinyUSB C objects, `USB.cpp`,
 `IRQManager.cpp`, the Arduino GPT/AGT PWM objects, the Uno R4 WiFi `libfsp.a`,
 include directories, compile defines, and the Rust-provided C++ ABI hook
-symbols. The firmware build script uses the same manifest when
+symbols. The same bridge exposes FSP-backed PWM writes and ADC reads to the
+VM-owned firmware backend. The firmware build script uses the same manifest when
 `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, keeping CI independent from a local
 Arduino install while giving hardware builds an explicit link path.
 
@@ -166,12 +167,13 @@ rustup run stable cargo build \
   --release
 ```
 
-The build script compiles the manifest's Arduino/TinyUSB/PWM C/C++ sources into
+The build script compiles the manifest's Arduino/TinyUSB/PWM/ADC C/C++ sources into
 a small archive under Cargo's `OUT_DIR`, links it with the Uno R4 WiFi
 `libfsp.a` for `uno-r4-wifi-serialusb-server`, and leaves the other firmware
 binaries on the pure-Rust link path. With that link enabled, the SerialUSB
 server swaps in the PWM-capable firmware backend and advertises `pwm.write` for
-the board's PWM-capable digital pins. Override `BOARD_VM_UNO_R4_ARM_GCC`,
+the board's PWM-capable digital pins plus `adc.read` for A0-A5. Override
+`BOARD_VM_UNO_R4_ARM_GCC`,
 `BOARD_VM_UNO_R4_ARM_GXX`, or `BOARD_VM_UNO_R4_ARM_AR` if the Arduino-packaged
 toolchain cannot run on the host. When using a native ARM compiler that does
 not carry Newlib/libstdc++ headers, point `BOARD_VM_UNO_R4_ARM_COMPAT_ROOT` at

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -3,7 +3,8 @@
 // The Rust firmware owns the VM, protocol, device state, and CDC byte stream.
 // Arduino's Renesas core still owns the RA4M1 TinyUSB descriptors, IRQ
 // plumbing, FSP USB driver objects needed by `__USBStart`, and the low-level
-// GPT/AGT timer setup behind the SerialUSB firmware's PWM backend.
+// GPT/AGT timer setup behind the SerialUSB firmware's PWM backend, plus the
+// FSP ADC driver used by the physical analog-read backend.
 
 pub const ARDUINO_RENESAS_UNO_CORE_VERSION: &str = "1.5.3";
 pub const UNO_R4_WIFI_FQBN: &str = "arduino:renesas_uno:unor4wifi";
@@ -27,6 +28,7 @@ pub const ARDUINO_ARM_COMPAT_ROOT_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_COMPAT_RO
 
 pub const ARDUINO_USB_START_SYMBOL: &str = "_Z10__USBStartv";
 pub const BOARD_VM_UNO_R4_PWM_WRITE_SYMBOL: &str = "board_vm_uno_r4_pwm_write";
+pub const BOARD_VM_UNO_R4_ADC_READ_SYMBOL: &str = "board_vm_uno_r4_adc_read";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
@@ -268,6 +270,7 @@ mod tests {
             BOARD_VM_UNO_R4_PWM_WRITE_SYMBOL,
             "board_vm_uno_r4_pwm_write"
         );
+        assert_eq!(BOARD_VM_UNO_R4_ADC_READ_SYMBOL, "board_vm_uno_r4_adc_read");
         assert_eq!(
             BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE,
             "src/uno_r4_wifi_pwm_bridge.cpp"

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -159,13 +159,26 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         true
     }
 
+    fn supports_adc(&self) -> bool {
+        true
+    }
+
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
         self.inner.led_matrix_frame(frame)
     }
 
     fn write_pwm(&mut self, pin: u8, duty: u16) -> Result<(), HalError> {
-        if unsafe { pwm_ffi::board_vm_uno_r4_pwm_write(pin, duty) } {
+        if unsafe { board_io_ffi::board_vm_uno_r4_pwm_write(pin, duty) } {
             Ok(())
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+
+    fn read_adc(&mut self, pin: u8) -> Result<u16, HalError> {
+        let mut sample = 0;
+        if unsafe { board_io_ffi::board_vm_uno_r4_adc_read(pin, &mut sample) } {
+            Ok(sample)
         } else {
             Err(HalError::UnsupportedMode)
         }
@@ -173,8 +186,9 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
 }
 
 #[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
-mod pwm_ffi {
+mod board_io_ffi {
     unsafe extern "C" {
         pub fn board_vm_uno_r4_pwm_write(pin: u8, duty: u16) -> bool;
+        pub fn board_vm_uno_r4_adc_read(pin: u8, sample: *mut u16) -> bool;
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -4,13 +4,19 @@
 #include <new>
 
 #include "Arduino.h"
+#include "hal_data.h"
 #include "pwm.h"
 #include "pinmux.inc"
+#include "r_adc.h"
 
 namespace {
 
 constexpr uint8_t kPwmPins[] = {3, 5, 6, 9, 10, 11};
+constexpr uint8_t kAdcPins[] = {14, 15, 16, 17, 18, 19};
 constexpr size_t kOperatorNewHeapBytes = 2048;
+constexpr uint32_t kAdcRawMax = (1u << BSP_FEATURE_ADC_MAX_RESOLUTION_BITS) - 1u;
+constexpr uint32_t kAdcNormalizedMax = 65535u;
+constexpr uint32_t kAdcScanPollLimit = 100000u;
 
 struct PwmSlot {
   uint8_t pin;
@@ -30,6 +36,11 @@ PwmSlot g_pwm_slots[] = {
   {11, {}, nullptr, false},
 };
 bool g_pwm_channels_reserved = false;
+adc_instance_ctrl_t g_board_vm_adc_ctrl = {};
+adc_extended_cfg_t g_board_vm_adc_extend = {};
+adc_cfg_t g_board_vm_adc_cfg = {};
+adc_channel_cfg_t g_board_vm_adc_channel_cfg = {};
+bool g_board_vm_adc_initialized = false;
 
 PwmSlot *find_slot(uint8_t pin) {
   for (auto &slot : g_pwm_slots) {
@@ -86,9 +97,78 @@ bool pin_cfg_matches(uint16_t cfg, PinCfgReq_t req) {
   switch (req) {
     case PIN_CFG_REQ_PWM:
       return IS_PIN_PWM(cfg);
+    case PIN_CFG_REQ_ADC:
+      return IS_PIN_ANALOG(cfg);
     default:
       return false;
   }
+}
+
+bool is_adc_header_pin(uint8_t pin) {
+  for (uint8_t candidate : kAdcPins) {
+    if (candidate == pin) {
+      return true;
+    }
+  }
+  return false;
+}
+
+adc_resolution_t adc_hardware_resolution() {
+#if 12U == BSP_FEATURE_ADC_MAX_RESOLUTION_BITS
+  return ADC_RESOLUTION_12_BIT;
+#elif 14U == BSP_FEATURE_ADC_MAX_RESOLUTION_BITS
+  return ADC_RESOLUTION_14_BIT;
+#elif 16U == BSP_FEATURE_ADC_MAX_RESOLUTION_BITS
+  return ADC_RESOLUTION_16_BIT;
+#else
+#error Unsupported Uno R4 ADC hardware resolution.
+#endif
+}
+
+void initialize_adc_config() {
+  if (g_board_vm_adc_initialized) {
+    return;
+  }
+
+  g_board_vm_adc_extend.add_average_count = ADC_ADD_OFF;
+  g_board_vm_adc_extend.clearing = ADC_CLEAR_AFTER_READ_ON;
+  g_board_vm_adc_extend.trigger_group_b = ADC_TRIGGER_SYNC_ELC;
+  g_board_vm_adc_extend.double_trigger_mode = ADC_DOUBLE_TRIGGER_DISABLED;
+  g_board_vm_adc_extend.adc_vref_control = ADC_VREF_CONTROL_AVCC0_AVSS0;
+  g_board_vm_adc_extend.enable_adbuf = 0;
+  g_board_vm_adc_extend.window_a_irq = FSP_INVALID_VECTOR;
+  g_board_vm_adc_extend.window_b_irq = FSP_INVALID_VECTOR;
+  g_board_vm_adc_extend.window_a_ipl = 12;
+  g_board_vm_adc_extend.window_b_ipl = 12;
+
+  g_board_vm_adc_cfg.unit = 0;
+  g_board_vm_adc_cfg.mode = ADC_MODE_SINGLE_SCAN;
+  g_board_vm_adc_cfg.resolution = adc_hardware_resolution();
+  g_board_vm_adc_cfg.alignment = ADC_ALIGNMENT_RIGHT;
+  g_board_vm_adc_cfg.trigger = ADC_TRIGGER_SOFTWARE;
+  g_board_vm_adc_cfg.scan_end_irq = FSP_INVALID_VECTOR;
+  g_board_vm_adc_cfg.scan_end_b_irq = FSP_INVALID_VECTOR;
+  g_board_vm_adc_cfg.scan_end_ipl = 12;
+  g_board_vm_adc_cfg.scan_end_b_ipl = 12;
+  g_board_vm_adc_cfg.p_callback = nullptr;
+  g_board_vm_adc_cfg.p_context = nullptr;
+  g_board_vm_adc_cfg.p_extend = &g_board_vm_adc_extend;
+
+  g_board_vm_adc_channel_cfg.scan_mask = 0;
+  g_board_vm_adc_channel_cfg.scan_mask_group_b = 0;
+  g_board_vm_adc_channel_cfg.add_mask = 0;
+  g_board_vm_adc_channel_cfg.p_window_cfg = nullptr;
+  g_board_vm_adc_channel_cfg.priority_group_a = ADC_GROUP_A_PRIORITY_OFF;
+  g_board_vm_adc_channel_cfg.sample_hold_mask = 0;
+  g_board_vm_adc_channel_cfg.sample_hold_states = 24;
+
+  g_board_vm_adc_initialized = true;
+}
+
+uint16_t normalize_adc_sample(uint16_t raw) {
+  uint32_t scaled =
+      (static_cast<uint32_t>(raw) * kAdcNormalizedMax + (kAdcRawMax / 2u)) / kAdcRawMax;
+  return static_cast<uint16_t>(scaled);
 }
 
 }  // namespace
@@ -124,6 +204,12 @@ extern "C" const PinMuxCfg_t g_pin_cfg[] = {
   {BSP_IO_PORT_04_PIN_11, P411}, /* (11) D11~ */
   {BSP_IO_PORT_04_PIN_10, P410}, /* (12) D12 */
   {BSP_IO_PORT_01_PIN_02, P102}, /* (13) D13 */
+  {BSP_IO_PORT_00_PIN_14, P014}, /* (14) A0 */
+  {BSP_IO_PORT_00_PIN_00, P000}, /* (15) A1 */
+  {BSP_IO_PORT_00_PIN_01, P001}, /* (16) A2 */
+  {BSP_IO_PORT_00_PIN_02, P002}, /* (17) A3 */
+  {BSP_IO_PORT_01_PIN_01, P101}, /* (18) A4/SDA */
+  {BSP_IO_PORT_01_PIN_00, P100}, /* (19) A5/SCL */
 };
 
 extern "C" ioport_instance_ctrl_t g_ioport_ctrl = {};
@@ -189,4 +275,65 @@ extern "C" bool board_vm_uno_r4_pwm_write(uint8_t pin, uint16_t duty) {
 
   float duty_percent = (static_cast<float>(duty) * 100.0f) / 65535.0f;
   return pwm->pulse_perc(duty_percent);
+}
+
+extern "C" bool board_vm_uno_r4_adc_read(uint8_t pin, uint16_t *sample) {
+  if (sample == nullptr || !is_adc_header_pin(pin)) {
+    return false;
+  }
+
+  auto cfg = getPinCfgs(pin, PIN_CFG_REQ_ADC);
+  if (cfg[0] == 0) {
+    return false;
+  }
+
+  initialize_adc_config();
+
+  if (g_board_vm_adc_ctrl.opened) {
+    R_ADC_Close(&g_board_vm_adc_ctrl);
+  }
+
+  uint8_t channel = GET_CHANNEL(cfg[0]);
+  g_board_vm_adc_channel_cfg.scan_mask = 1u << channel;
+  g_board_vm_adc_channel_cfg.scan_mask_group_b = 0;
+  g_board_vm_adc_channel_cfg.add_mask = 0;
+  g_board_vm_adc_channel_cfg.sample_hold_mask = 0;
+
+  fsp_err_t pin_status =
+      R_IOPORT_PinCfg(&g_ioport_ctrl, g_pin_cfg[pin].pin, IOPORT_CFG_ANALOG_ENABLE);
+  if (pin_status != FSP_SUCCESS) {
+    return false;
+  }
+
+  if (R_ADC_Open(&g_board_vm_adc_ctrl, &g_board_vm_adc_cfg) != FSP_SUCCESS) {
+    return false;
+  }
+  if (R_ADC_ScanCfg(&g_board_vm_adc_ctrl, &g_board_vm_adc_channel_cfg) != FSP_SUCCESS) {
+    return false;
+  }
+  if (R_ADC_ScanStart(&g_board_vm_adc_ctrl) != FSP_SUCCESS) {
+    return false;
+  }
+
+  adc_status_t status;
+  status.state = ADC_STATE_SCAN_IN_PROGRESS;
+  for (uint32_t poll = 0; poll < kAdcScanPollLimit; poll++) {
+    if (R_ADC_StatusGet(&g_board_vm_adc_ctrl, &status) != FSP_SUCCESS) {
+      return false;
+    }
+    if (status.state != ADC_STATE_SCAN_IN_PROGRESS) {
+      break;
+    }
+  }
+  if (status.state == ADC_STATE_SCAN_IN_PROGRESS) {
+    return false;
+  }
+
+  uint16_t raw = 0;
+  if (R_ADC_Read(&g_board_vm_adc_ctrl, static_cast<adc_channel_t>(channel), &raw) != FSP_SUCCESS) {
+    return false;
+  }
+
+  *sample = normalize_adc_sample(raw);
+  return true;
 }


### PR DESCRIPTION
## Summary
- expose `adc.read` from the Arduino/TinyUSB SerialUSB firmware backend by adding an FSP-backed ADC bridge for UNO R4 WiFi A0-A5
- advertise ADC support from the physical SerialUSB backend alongside PWM and LED matrix support
- document the PWM/ADC bridge in the UNO R4 firmware README

## Validation
- `cargo fmt -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-uno-r4-firmware -p board-vm-uno-r4`
- `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1 BOARD_VM_UNO_R4_ARDUINO_CORE="$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" BOARD_VM_UNO_R4_ARM_GCC=/opt/homebrew/bin/arm-none-eabi-gcc BOARD_VM_UNO_R4_ARM_GXX=/opt/homebrew/bin/arm-none-eabi-g++ BOARD_VM_UNO_R4_ARM_AR=/opt/homebrew/bin/arm-none-eabi-ar BOARD_VM_UNO_R4_ARM_COMPAT_ROOT="$HOME/Library/Arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4" RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-server --release`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

## Hardware note
- Built and objcopied the linked SerialUSB firmware image successfully.
- Physical upload/smoke is still blocked locally because the attached UNO R4 WiFi on `/dev/cu.usbmodem1101` did not enter SAM-BA from the helper's 1200-baud bootloader touch; `arduino-cli upload` reported `No device found on cu.usbmodem1101`.
- A direct Board VM smoke query afterward failed during hello with `Transport(Io)`, so this PR keeps the firmware backend landable while the next slice should improve bootloader reset/recovery or require a manual double-tap before flashing.
