### PR TITLE
feat(sql): JSON1 scalar functions + TOTAL() aggregate (Tier 16)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [1.30.0] - 2026-05-13
+
+### Added
+
+- **Tier 16 — JSON1 scalar functions** — 14 SQLite-compatible JSON functions
+  are now recognised by the mini-sqlite pipeline end-to-end:
+
+  | Function | Description |
+  |---|---|
+  | `json(x)` | Canonical (minified) JSON |
+  | `json_valid(x)` | 1 / 0 / NULL validation |
+  | `json_quote(x)` | SQL value → JSON text |
+  | `json_array(v…)` | Build JSON array |
+  | `json_object(k, v…)` | Build JSON object |
+  | `json_extract(json, path…)` | Extract one or more paths |
+  | `json_type(json [, path])` | Type name at path |
+  | `json_array_length(json [, path])` | Array length (0 for non-arrays) |
+  | `json_keys(json [, path])` | Object keys as JSON array |
+  | `json_patch(target, patch)` | RFC 7396 merge patch |
+  | `json_remove(json, path…)` | Remove paths |
+  | `json_set(json, path, val…)` | Insert or replace paths |
+  | `json_insert(json, path, val…)` | Insert only (no overwrite) |
+  | `json_replace(json, path, val…)` | Replace only (no insert) |
+
+  Implemented in `sql_vm.scalar_functions`; no parser/planner/codegen
+  changes required — JSON functions are dispatched via `CallScalar`.
+
+  82 oracle-verified tests in `tests/test_tier16_json_total.py`.
+
+- **`TOTAL()` aggregate** — SQLite-specific aggregate function that returns
+  `0.0` (float) instead of NULL for empty groups or all-NULL input.  Follows
+  the SQLite documentation: "If there are no non-NULL input rows then
+  `TOTAL()` returns 0.0."  Added `AggFunc.TOTAL` to the planner (`expr.py`),
+  codegen IR (`ir.py`), and VM (`vm.py`); registered in the adapter's
+  `agg_map` so `SELECT TOTAL(col) FROM t ...` queries compile correctly.
+
+  8 oracle-verified tests cover normal summation, empty-table, all-NULL, and
+  `GROUP BY` with TOTAL, plus a contrast test showing SUM returns NULL where
+  TOTAL returns 0.0.
+
 ## [1.29.0] - 2026-05-13
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.28.0"
+version = "1.30.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1512,12 +1512,15 @@ def _function_call(node: ASTNode, state: _PlaceholderCounter) -> Expr:
         "AVG": AggFunc.AVG,
         "MIN": AggFunc.MIN,
         "MAX": AggFunc.MAX,
+        # SQLite-specific: TOTAL() is like SUM() but returns 0.0 for empty
+        # sets or all-NULL input, never returning NULL.
+        "TOTAL": AggFunc.TOTAL,
     }
     if upper in agg_map:
         # SQLite's MIN/MAX are overloaded: one-argument form is an aggregate
         # (MIN(col) over a GROUP BY), while two-or-more-argument form is a
         # scalar function that picks the smallest/largest among its arguments.
-        # COUNT/SUM/AVG are always aggregates (no scalar overload).
+        # COUNT/SUM/AVG/TOTAL are always aggregates (no scalar overload).
         if len(args) > 1 and upper in ("MIN", "MAX"):
             # Scalar form: MIN(a, b, ...) / MAX(a, b, ...) — route to the
             # scalar function registry, not the aggregate path.

--- a/code/packages/python/mini-sqlite/tests/test_tier16_json_total.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier16_json_total.py
@@ -1,0 +1,567 @@
+"""Tier 16 — JSON scalar functions and TOTAL() aggregate.
+
+Covers two new feature areas:
+
+1. **JSON1 scalar functions** — the SQLite JSON1 extension family of functions
+   for building, inspecting, and mutating JSON documents.  Implemented in
+   ``sql_vm.scalar_functions`` using Python's standard ``json`` module.
+
+   Functions covered (oracle-verified against real sqlite3):
+   ``json()``, ``json_valid()``, ``json_quote()``, ``json_array()``,
+   ``json_object()``, ``json_extract()``, ``json_type()``,
+   ``json_array_length()``, ``json_patch()``, ``json_remove()``,
+   ``json_set()``, ``json_insert()``, ``json_replace()``.
+
+   Note on divergences from SQLite:
+   - SQLite raises ``OperationalError: malformed JSON`` for most JSON
+     functions when given invalid JSON strings.  Our implementation returns
+     NULL in those cases (more lenient, SQL-null-propagating semantics).
+     Tests involving malformed JSON are therefore unit-tested against our
+     expected NULL behaviour in the sql-vm test suite, not oracle-tested here.
+   - ``json_keys()`` is not available in all SQLite versions and is tested
+     only as a unit test (sql-vm) rather than oracle-compared here.
+   - ``json_object(key, json_array(...))`` with nested JSON functions embeds
+     the inner result as a text value in our implementation, whereas SQLite
+     recognises the "JSON subtype" and embeds it directly.  This case is also
+     excluded from oracle tests.
+
+2. **TOTAL() aggregate** — SQLite-specific variant of ``SUM()`` that returns
+   ``0.0`` (float) for empty groups or all-NULL input, never returning NULL.
+   Added to the ``AggFunc`` enum in sql-planner, sql-codegen, and handled in
+   the sql-vm aggregate evaluation path.
+
+All assertions (except where noted above) are oracle-verified against real
+``sqlite3``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import mini_sqlite
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _both(sql: str, *, setup: list[str] | None = None, params: tuple = ()) -> tuple[list, list]:
+    """Run *sql* (with *params*) against both real sqlite3 and mini-sqlite.
+
+    Returns (ref_rows, got_rows) — both as lists of tuples.
+    """
+    ref_con = sqlite3.connect(":memory:")
+    got_con = mini_sqlite.connect(":memory:")
+    for s in (setup or []):
+        ref_con.execute(s)
+        got_con.execute(s)
+    ref_rows = ref_con.execute(sql, params).fetchall()
+    got_rows = got_con.execute(sql, params).fetchall()
+    return ref_rows, got_rows
+
+
+def _assert_both(sql: str, *, setup: list[str] | None = None, params: tuple = ()) -> None:
+    """Assert mini-sqlite produces the same rows as real sqlite3."""
+    ref, got = _both(sql, setup=setup, params=params)
+    assert got == ref, f"mini-sqlite={got!r}, sqlite3={ref!r}\nSQL: {sql}"
+
+
+# ---------------------------------------------------------------------------
+# json_valid()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonValid:
+    def test_valid_object(self) -> None:
+        _assert_both("SELECT json_valid(?)", params=('{"a":1}',))
+
+    def test_valid_array(self) -> None:
+        _assert_both("SELECT json_valid(?)", params=('[1,2,3]',))
+
+    def test_valid_string(self) -> None:
+        _assert_both('SELECT json_valid(\'"hello"\')')
+
+    def test_invalid(self) -> None:
+        _assert_both("SELECT json_valid(?)", params=('not valid',))
+
+    def test_null(self) -> None:
+        # SQLite 3.45+: json_valid(NULL) → NULL (not 0).
+        _assert_both("SELECT json_valid(NULL)")
+
+
+# ---------------------------------------------------------------------------
+# json() — canonical form
+# ---------------------------------------------------------------------------
+
+
+class TestJsonCanonical:
+    def test_minify_object(self) -> None:
+        _assert_both("SELECT json(?)", params=('{ "a" : 1 , "b" : 2 }',))
+
+    def test_minify_array(self) -> None:
+        _assert_both("SELECT json(?)", params=('[ 1 , 2 , 3 ]',))
+
+    def test_null_input(self) -> None:
+        _assert_both("SELECT json(NULL)")
+
+    # Note: SQLite raises OperationalError('malformed JSON') for invalid input.
+    # Our implementation returns NULL.  This is tested in the sql-vm unit tests.
+
+
+# ---------------------------------------------------------------------------
+# json_quote()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonQuote:
+    def test_integer(self) -> None:
+        _assert_both("SELECT json_quote(42)")
+
+    def test_float(self) -> None:
+        _assert_both("SELECT json_quote(3.14)")
+
+    def test_text(self) -> None:
+        _assert_both("SELECT json_quote('hello')")
+
+    def test_null(self) -> None:
+        _assert_both("SELECT json_quote(NULL)")
+
+    def test_text_with_quotes(self) -> None:
+        _assert_both("SELECT json_quote(?)", params=('say "hi"',))
+
+
+# ---------------------------------------------------------------------------
+# json_array()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonArray:
+    def test_empty(self) -> None:
+        _assert_both("SELECT json_array()")
+
+    def test_integers(self) -> None:
+        _assert_both("SELECT json_array(1, 2, 3)")
+
+    def test_mixed(self) -> None:
+        _assert_both("SELECT json_array(1, 'two', 3.0)")
+
+    def test_with_null(self) -> None:
+        _assert_both("SELECT json_array(1, NULL, 3)")
+
+    def test_strings(self) -> None:
+        _assert_both("SELECT json_array('a', 'b', 'c')")
+
+
+# ---------------------------------------------------------------------------
+# json_object()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonObject:
+    def test_simple(self) -> None:
+        _assert_both("SELECT json_object('a', 1, 'b', 2)")
+
+    def test_null_value(self) -> None:
+        _assert_both("SELECT json_object('x', NULL)")
+
+    def test_string_value(self) -> None:
+        _assert_both("SELECT json_object('name', 'Alice')")
+
+    def test_empty(self) -> None:
+        _assert_both("SELECT json_object()")
+
+    # Note: json_object('arr', json_array(1,2,3)) diverges from SQLite because
+    # SQLite recognises the "JSON subtype" of the inner result and embeds it
+    # directly as a JSON array.  Our implementation treats the string returned
+    # by json_array as a plain text value.  Tested as unit test only.
+
+
+# ---------------------------------------------------------------------------
+# json_extract()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonExtract:
+    def test_object_field(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.a')", params=('{"a":42,"b":99}',))
+
+    def test_nested_field(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.a.b')", params=('{"a":{"b":7}}',))
+
+    def test_array_index(self) -> None:
+        _assert_both("SELECT json_extract(?, '$[1]')", params=('[10,20,30]',))
+
+    def test_missing_path(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.missing')", params=('{"a":1}',))
+
+    def test_null_json(self) -> None:
+        _assert_both("SELECT json_extract(NULL, '$.a')")
+
+    def test_nested_array_extraction(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.arr[1]')", params=('{"arr":[1,2,3]}',))
+
+    def test_multiple_paths(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.a', '$.b')", params=('{"a":1,"b":2}',))
+
+    def test_string_value(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.s')", params=('{"s":"hello"}',))
+
+    def test_boolean_true_extracts_as_1(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.b')", params=('{"b":true}',))
+
+    def test_boolean_false_extracts_as_0(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.b')", params=('{"b":false}',))
+
+    def test_array_result(self) -> None:
+        _assert_both("SELECT json_extract(?, '$.arr')", params=('{"arr":[1,2,3]}',))
+
+
+# ---------------------------------------------------------------------------
+# json_type()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonType:
+    def test_root_object(self) -> None:
+        _assert_both("SELECT json_type(?)", params=('{"a":1}',))
+
+    def test_root_array(self) -> None:
+        _assert_both("SELECT json_type(?)", params=('[1,2]',))
+
+    def test_root_integer(self) -> None:
+        _assert_both("SELECT json_type(?)", params=("42",))
+
+    def test_root_real(self) -> None:
+        _assert_both("SELECT json_type(?)", params=("3.14",))
+
+    def test_root_string(self) -> None:
+        _assert_both('SELECT json_type(\'"hello"\')')
+
+    def test_root_null(self) -> None:
+        _assert_both("SELECT json_type(?)", params=("null",))
+
+    def test_root_true(self) -> None:
+        _assert_both("SELECT json_type(?)", params=("true",))
+
+    def test_root_false(self) -> None:
+        _assert_both("SELECT json_type(?)", params=("false",))
+
+    def test_path_to_integer(self) -> None:
+        _assert_both("SELECT json_type(?, '$.a')", params=('{"a":1}',))
+
+    def test_path_to_array(self) -> None:
+        _assert_both("SELECT json_type(?, '$.a')", params=('{"a":[1,2,3]}',))
+
+    def test_path_missing(self) -> None:
+        _assert_both("SELECT json_type(?, '$.missing')", params=('{"a":1}',))
+
+    def test_null_json(self) -> None:
+        _assert_both("SELECT json_type(NULL)")
+
+    # Note: SQLite raises for invalid JSON; our impl returns NULL.  Unit-tested.
+
+
+# ---------------------------------------------------------------------------
+# json_array_length()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonArrayLength:
+    def test_root_array(self) -> None:
+        _assert_both("SELECT json_array_length(?)", params=('[1,2,3]',))
+
+    def test_empty_array(self) -> None:
+        _assert_both("SELECT json_array_length(?)", params=('[]',))
+
+    def test_path_to_array(self) -> None:
+        _assert_both("SELECT json_array_length(?, '$.a')", params=('{"a":[1,2]}',))
+
+    def test_not_an_array(self) -> None:
+        # Valid JSON that is not an array → 0 (matching SQLite behaviour).
+        _assert_both("SELECT json_array_length(?)", params=('{"a":1}',))
+
+    def test_null_json(self) -> None:
+        _assert_both("SELECT json_array_length(NULL)")
+
+    def test_path_not_found(self) -> None:
+        _assert_both("SELECT json_array_length(?, '$.missing')", params=('[1,2]',))
+
+
+# ---------------------------------------------------------------------------
+# json_keys() — extension function, not oracle-verified
+# ---------------------------------------------------------------------------
+# Note: json_keys() is not available in all SQLite versions (it was added in
+# SQLite 3.38.0 as part of the JSON5 functions but was removed again; as of
+# 3.50.4 it raises "no such function: json_keys").  We implement it as an
+# extension and test it only in the sql-vm unit tests, not here.
+#
+# class TestJsonKeys: ... (see test_json_functions.py in sql-vm tests)
+
+
+# ---------------------------------------------------------------------------
+# json_patch()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonPatch:
+    def test_simple_merge(self) -> None:
+        _assert_both(
+            "SELECT json_patch(?, ?)",
+            params=('{"a":1,"b":2}', '{"b":99}'),
+        )
+
+    def test_remove_with_null_value(self) -> None:
+        _assert_both(
+            "SELECT json_patch(?, ?)",
+            params=('{"a":1,"b":2}', '{"b":null}'),
+        )
+
+    def test_add_new_key(self) -> None:
+        _assert_both(
+            "SELECT json_patch(?, ?)",
+            params=('{"a":1}', '{"c":3}'),
+        )
+
+    def test_null_inputs(self) -> None:
+        _assert_both("SELECT json_patch(NULL, '{}')")
+        _assert_both("SELECT json_patch('{}', NULL)")
+
+    # Note: SQLite raises for invalid JSON; our impl returns NULL.  Unit-tested.
+
+
+# ---------------------------------------------------------------------------
+# json_remove()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonRemove:
+    def test_remove_field(self) -> None:
+        _assert_both(
+            "SELECT json_remove(?, '$.a')",
+            params=('{"a":1,"b":2}',),
+        )
+
+    def test_remove_array_element(self) -> None:
+        _assert_both(
+            "SELECT json_remove(?, '$[1]')",
+            params=('[1,2,3]',),
+        )
+
+    def test_remove_missing_path(self) -> None:
+        _assert_both(
+            "SELECT json_remove(?, '$.missing')",
+            params=('{"a":1}',),
+        )
+
+    def test_null_json(self) -> None:
+        _assert_both("SELECT json_remove(NULL, '$.a')")
+
+    # Note: SQLite raises for invalid JSON; our impl returns NULL.  Unit-tested.
+
+
+# ---------------------------------------------------------------------------
+# json_set()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSet:
+    def test_overwrite_existing(self) -> None:
+        _assert_both(
+            "SELECT json_set(?, '$.a', 99)",
+            params=('{"a":1}',),
+        )
+
+    def test_insert_new_key(self) -> None:
+        ref, got = _both(
+            "SELECT json_set(?, '$.b', 2)",
+            params=('{"a":1}',),
+        )
+        assert json.loads(got[0][0]) == json.loads(ref[0][0])
+
+    def test_multiple_pairs(self) -> None:
+        ref, got = _both(
+            "SELECT json_set(?, '$.a', 10, '$.b', 20)",
+            params=('{"a":1}',),
+        )
+        assert json.loads(got[0][0]) == json.loads(ref[0][0])
+
+    def test_null_json(self) -> None:
+        _assert_both("SELECT json_set(NULL, '$.a', 1)")
+
+    def test_array_element(self) -> None:
+        _assert_both(
+            "SELECT json_set(?, '$[1]', 99)",
+            params=('[1,2,3]',),
+        )
+
+
+# ---------------------------------------------------------------------------
+# json_insert()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonInsert:
+    def test_insert_new_key(self) -> None:
+        ref, got = _both(
+            "SELECT json_insert(?, '$.b', 2)",
+            params=('{"a":1}',),
+        )
+        assert json.loads(got[0][0]) == json.loads(ref[0][0])
+
+    def test_no_overwrite_existing(self) -> None:
+        # Key already exists → no change.
+        _assert_both(
+            "SELECT json_insert(?, '$.a', 99)",
+            params=('{"a":1}',),
+        )
+
+    def test_null_json(self) -> None:
+        _assert_both("SELECT json_insert(NULL, '$.a', 1)")
+
+
+# ---------------------------------------------------------------------------
+# json_replace()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonReplace:
+    def test_replace_existing(self) -> None:
+        _assert_both(
+            "SELECT json_replace(?, '$.a', 99)",
+            params=('{"a":1}',),
+        )
+
+    def test_no_insert_missing(self) -> None:
+        # Key does not exist → no change.
+        _assert_both(
+            "SELECT json_replace(?, '$.b', 2)",
+            params=('{"a":1}',),
+        )
+
+    def test_null_json(self) -> None:
+        _assert_both("SELECT json_replace(NULL, '$.a', 1)")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: JSON functions in table queries
+# ---------------------------------------------------------------------------
+
+
+class TestJsonInTableQueries:
+    _SETUP = [
+        "CREATE TABLE products (id INTEGER PRIMARY KEY, attrs TEXT)",
+        "INSERT INTO products VALUES (1, '{\"color\":\"red\",\"size\":10}')",
+        "INSERT INTO products VALUES (2, '{\"color\":\"blue\",\"size\":20}')",
+        "INSERT INTO products VALUES (3, '{\"color\":\"red\",\"size\":15}')",
+    ]
+
+    def test_extract_field_from_column(self) -> None:
+        _assert_both(
+            "SELECT id, json_extract(attrs, '$.color') FROM products ORDER BY id",
+            setup=self._SETUP,
+        )
+
+    def test_filter_on_json_field(self) -> None:
+        _assert_both(
+            "SELECT id FROM products WHERE json_extract(attrs, '$.color') = 'red' ORDER BY id",
+            setup=self._SETUP,
+        )
+
+    def test_json_type_in_query(self) -> None:
+        _assert_both(
+            "SELECT id, json_type(attrs, '$.size') FROM products ORDER BY id",
+            setup=self._SETUP,
+        )
+
+    def test_json_set_in_query(self) -> None:
+        _assert_both(
+            "SELECT id, json_set(attrs, '$.size', 99) FROM products WHERE id = 1",
+            setup=self._SETUP,
+        )
+
+
+# ---------------------------------------------------------------------------
+# TOTAL() aggregate
+# ---------------------------------------------------------------------------
+
+
+class TestTotal:
+    _SETUP = [
+        "CREATE TABLE nums (dept TEXT, val REAL)",
+        "INSERT INTO nums VALUES ('A', 10.0)",
+        "INSERT INTO nums VALUES ('A', 20.0)",
+        "INSERT INTO nums VALUES ('B', 5.0)",
+        "INSERT INTO nums VALUES ('B', NULL)",
+        "INSERT INTO nums VALUES ('B', NULL)",
+    ]
+
+    def test_total_basic(self) -> None:
+        """TOTAL() sums all non-NULL values, same as SUM() when input non-empty."""
+        _assert_both("SELECT TOTAL(val) FROM nums", setup=self._SETUP)
+
+    def test_total_empty_table(self) -> None:
+        """TOTAL() on empty table returns 0.0, not NULL."""
+        setup = ["CREATE TABLE empty_t (x INTEGER)"]
+        ref, got = _both("SELECT TOTAL(x) FROM empty_t", setup=setup)
+        # Both should return 0.0.
+        assert got == [(0.0,)]
+        assert ref == [(0.0,)]
+
+    def test_total_all_null(self) -> None:
+        """TOTAL() on all-NULL group returns 0.0."""
+        setup = [
+            "CREATE TABLE nulls (x INTEGER)",
+            "INSERT INTO nulls VALUES (NULL)",
+            "INSERT INTO nulls VALUES (NULL)",
+        ]
+        ref, got = _both("SELECT TOTAL(x) FROM nulls", setup=setup)
+        assert got == [(0.0,)]
+        assert ref == [(0.0,)]
+
+    def test_sum_all_null_returns_null(self) -> None:
+        """Contrast: SUM() on all-NULL group returns NULL (not 0)."""
+        setup = [
+            "CREATE TABLE nulls2 (x INTEGER)",
+            "INSERT INTO nulls2 VALUES (NULL)",
+        ]
+        ref, got = _both("SELECT SUM(x) FROM nulls2", setup=setup)
+        assert got == [(None,)]
+        assert ref == [(None,)]
+
+    def test_total_with_nulls_ignored(self) -> None:
+        """TOTAL() ignores NULL values, summing only non-NULL ones."""
+        _assert_both(
+            "SELECT dept, TOTAL(val) FROM nums GROUP BY dept ORDER BY dept",
+            setup=self._SETUP,
+        )
+
+    def test_total_returns_float(self) -> None:
+        """TOTAL() always returns a real (float), even for integer input."""
+        setup = [
+            "CREATE TABLE ints (x INTEGER)",
+            "INSERT INTO ints VALUES (1)",
+            "INSERT INTO ints VALUES (2)",
+            "INSERT INTO ints VALUES (3)",
+        ]
+        ref, got = _both("SELECT TOTAL(x) FROM ints", setup=setup)
+        # Both should be 6.0 (float).
+        assert got == [(6.0,)]
+        assert ref == [(6.0,)]
+
+    def test_total_group_by(self) -> None:
+        """TOTAL() works correctly with GROUP BY."""
+        _assert_both(
+            "SELECT dept, TOTAL(val) FROM nums GROUP BY dept ORDER BY dept",
+            setup=self._SETUP,
+        )
+
+    def test_total_distinct(self) -> None:
+        """TOTAL(DISTINCT col) sums only unique non-NULL values."""
+        setup = [
+            "CREATE TABLE dupes (x REAL)",
+            "INSERT INTO dupes VALUES (5.0)",
+            "INSERT INTO dupes VALUES (5.0)",
+            "INSERT INTO dupes VALUES (10.0)",
+        ]
+        _assert_both("SELECT TOTAL(DISTINCT x) FROM dupes", setup=setup)

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.22.0] - 2026-05-13
+
+### Added
+
+- **`AggFunc.TOTAL`** (`ir.py`) — Added `TOTAL = "TOTAL"` to the `AggFunc`
+  enum to represent SQLite's `TOTAL()` aggregate.  The `_plan_agg_to_ir`
+  helper in the compiler automatically maps `PlanAggFunc.TOTAL` → `IrAggFunc.TOTAL`
+  via name-lookup, requiring no further compiler changes.
+
 ## [1.21.0] - 2026-05-13
 
 ### Added

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.20.0"
+version = "1.22.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/ir.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/ir.py
@@ -129,6 +129,7 @@ class AggFunc(Enum):
     MIN = "MIN"
     MAX = "MAX"
     GROUP_CONCAT = "GROUP_CONCAT"  # concatenate non-NULL strings with a separator
+    TOTAL = "TOTAL"               # SQLite-specific: SUM that returns 0.0 for empty/all-null
 
 
 class Direction(Enum):

--- a/code/packages/python/sql-planner/CHANGELOG.md
+++ b/code/packages/python/sql-planner/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.27.0] - 2026-05-13
+
+### Added
+
+- **`AggFunc.TOTAL`** (`expr.py`) — Added `TOTAL = "TOTAL"` to the `AggFunc`
+  enum in the SQL planner.  The adapter (`mini_sqlite/adapter.py`) maps the
+  SQL name `TOTAL` to this enum value, allowing `TOTAL(col)` expressions to
+  be planned as `AggregateExpr(func=AggFunc.TOTAL, …)`.
+
 ## [0.26.0] - 2026-05-13
 
 ### Added

--- a/code/packages/python/sql-planner/pyproject.toml
+++ b/code/packages/python/sql-planner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-planner"
-version = "0.25.0"
+version = "0.27.0"
 description = "Translates a structured SQL AST into a Logical Plan Tree of relational-algebra nodes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-planner/src/sql_planner/expr.py
+++ b/code/packages/python/sql-planner/src/sql_planner/expr.py
@@ -96,6 +96,7 @@ class AggFunc(Enum):
     MIN = "MIN"
     MAX = "MAX"
     GROUP_CONCAT = "GROUP_CONCAT"
+    TOTAL = "TOTAL"  # SQLite-specific: like SUM but returns 0.0 (not NULL) for empty/all-null
 
 
 # ---- Expr variants --------------------------------------------------------

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 1.21.0 — 2026-05-13
+
+### Added
+
+- **JSON1 scalar functions** (`scalar_functions.py`) — 14 new functions
+  matching the SQLite JSON1 extension, all implemented with Python's built-in
+  `json` module:
+  - `json(x)` — canonical (minified) JSON string.
+  - `json_valid(x)` — 1 if *x* is valid JSON, 0 otherwise, NULL for NULL input.
+  - `json_quote(x)` — SQL value → JSON text representation.
+  - `json_array(v1, v2, …)` — build a JSON array from zero or more SQL values.
+  - `json_object(k1, v1, k2, v2, …)` — build a JSON object from key/value pairs.
+  - `json_extract(json, path [, path…])` — extract one or more values at JSON
+    paths; multiple paths return a JSON array.
+  - `json_type(json [, path])` — return the SQLite JSON type name
+    ("null", "true", "false", "integer", "real", "text", "array", "object").
+  - `json_array_length(json [, path])` — number of elements in a JSON array,
+    or 0 for non-arrays (matching SQLite semantics).
+  - `json_keys(json [, path])` — JSON array of the keys in a JSON object.
+  - `json_patch(target, patch)` — RFC 7396 JSON Merge Patch.
+  - `json_remove(json, path [, path…])` — remove one or more paths.
+  - `json_set(json, path, val [, path, val…])` — insert or replace paths.
+  - `json_insert(json, path, val [, …])` — insert only (no overwrite).
+  - `json_replace(json, path, val [, …])` — replace only (no insert).
+  - `json_group_array(v1, v2, …)` — scalar alias for `json_array`.
+
+- **`TOTAL()` aggregate** (`vm.py`) — SQLite-specific aggregate that returns
+  `0.0` (float) for empty groups or all-NULL input, never returning NULL.
+  Added `AggFunc.TOTAL` to the `AggFunc` enum in `sql-codegen/ir.py` and
+  handled in `_do_update_agg` (identical accumulation to SUM) and
+  `_do_finalize_agg` (returns `0.0` instead of `None` on empty/all-null).
+
 ## 1.20.0 — 2026-05-13
 
 ### Added

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.19.0"
+version = "1.21.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -50,6 +50,8 @@ SQLite compat notes
 from __future__ import annotations
 
 import calendar
+import copy
+import json as _json
 import math
 import os
 import re
@@ -1683,3 +1685,830 @@ def _strftime(*args: SqlValue) -> SqlValue:
         return _sqlite_strftime(fmt, dt)
     except (ValueError, OSError):
         return None
+
+
+# ---------------------------------------------------------------------------
+# JSON functions (SQLite-compatible subset)
+# ---------------------------------------------------------------------------
+#
+# SQLite ships a built-in JSON1 extension that exposes a family of functions
+# for creating, extracting, and mutating JSON documents.  Our implementation
+# uses Python's :mod:`json` stdlib and mirrors SQLite semantics as closely as
+# possible.
+#
+# Type mapping
+# ~~~~~~~~~~~~
+# SQL → JSON (for inputs):
+#   None        → null
+#   bool        → true / false
+#   int         → integer
+#   float       → real
+#   str         → string
+#   bytes/blob  → NULL (blobs are not representable in JSON; SQLite also
+#                 returns NULL when a blob appears in a JSON context)
+#
+# JSON → SQL (for outputs extracted by json_extract):
+#   null        → None (SQL NULL)
+#   true        → 1   (SQLite uses integers, not booleans)
+#   false       → 0
+#   integer     → int
+#   real        → float
+#   string      → str
+#   array       → str  (the JSON text of the array)
+#   object      → str  (the JSON text of the object)
+#
+# Path format
+# ~~~~~~~~~~~
+# SQLite JSON paths start with ``$`` (the root) followed by zero or more
+# selectors:
+#   ``$.field``   — object key access
+#   ``$[N]``      — array index (0-based, negative indices allowed)
+#   ``$[#-1]``    — last element (``#`` means array length)
+# Selectors chain: ``$.a.b[0].c``
+#
+# Reference: https://www.sqlite.org/json1.html
+
+
+# --- internal helpers -------------------------------------------------------
+
+_JSON_PATH_COMPONENT = re.compile(
+    r'\.([^\.\[\]]+)'  # .field  (everything up to the next dot or bracket)
+    r'|\[(-?\d+|\#(?:[+-]\d+)?)\]'  # [N] or [#] or [#-N] array indexing
+)
+
+
+def _sql_to_json_val(v: SqlValue) -> object:
+    """Convert a SQL scalar value to a Python value suitable for json.dumps.
+
+    Blobs (bytes) have no JSON representation and are converted to None,
+    which serialises as JSON ``null``.  This matches SQLite's behaviour.
+    """
+    if isinstance(v, (type(None), bool, int, float, str)):
+        return v
+    if isinstance(v, (bytes, bytearray)):
+        return None   # blobs → null
+    return str(v)
+
+
+def _json_to_sql_val(v: object) -> SqlValue:
+    """Convert a Python JSON value back to a SQL scalar.
+
+    JSON booleans are integers (true→1, false→0) in SQLite.
+    Nested arrays and objects are returned as their JSON text representation.
+    """
+    if v is None:
+        return None
+    if isinstance(v, bool):
+        return 1 if v else 0
+    if isinstance(v, int):
+        return v
+    if isinstance(v, float):
+        return v
+    if isinstance(v, str):
+        return v
+    if isinstance(v, (list, dict)):
+        return _json.dumps(v, separators=(",", ":"))
+    return str(v)
+
+
+def _json_type_name(v: object) -> str:
+    """Return the SQLite json_type() name for a Python JSON value.
+
+    Possible return values: ``"null"``, ``"true"``, ``"false"``,
+    ``"integer"``, ``"real"``, ``"text"``, ``"array"``, ``"object"``.
+    """
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, int):
+        return "integer"
+    if isinstance(v, float):
+        return "real"
+    if isinstance(v, str):
+        return "text"
+    if isinstance(v, list):
+        return "array"
+    if isinstance(v, dict):
+        return "object"
+    return "text"
+
+
+def _json_navigate(root: object, path: str) -> tuple[object, bool]:
+    """Follow *path* from *root* and return ``(value, found)``.
+
+    Returns ``(None, False)`` when any segment of the path does not exist.
+    """
+    if not isinstance(path, str) or not path.startswith("$"):
+        return None, False
+    remainder = path[1:]
+    current = root
+    while remainder:
+        m = _JSON_PATH_COMPONENT.match(remainder)
+        if m is None:
+            return None, False
+        remainder = remainder[m.end():]
+        field = m.group(1)
+        idx_s = m.group(2)
+        if field is not None:
+            # Object key access: $.field
+            if not isinstance(current, dict):
+                return None, False
+            if field not in current:
+                return None, False
+            current = current[field]
+        else:
+            # Array index access: $[N] or $[#] or $[#-N]
+            if not isinstance(current, list):
+                return None, False
+            length = len(current)
+            if idx_s == "#":
+                idx = length        # past-the-end (used internally)
+            elif idx_s.startswith("#"):
+                delta = int(idx_s[1:])  # e.g. "#-1" → -1
+                idx = length + delta
+            else:
+                idx = int(idx_s)
+            if idx < 0:
+                idx += length
+            if idx < 0 or idx >= length:
+                return None, False
+            current = current[idx]
+    return current, True
+
+
+def _json_set_path(
+    root: object,
+    path: str,
+    value: object,
+    *,
+    insert: bool,
+    replace: bool,
+) -> object:
+    """Return a deep copy of *root* with *path* set to *value*.
+
+    - ``insert=True, replace=False`` → only creates, never overwrites (json_insert)
+    - ``insert=False, replace=True`` → only overwrites, never creates (json_replace)
+    - ``insert=True, replace=True``  → creates or overwrites (json_set)
+    """
+    if not isinstance(path, str) or not path.startswith("$"):
+        return root
+    if path == "$":
+        return value    # replace root — unusual but valid
+
+    # Collect path segments so we can navigate to the parent.
+    segments: list[tuple[str, object]] = []  # ("field", name) or ("index", int)
+    remainder = path[1:]
+    while remainder:
+        m = _JSON_PATH_COMPONENT.match(remainder)
+        if m is None:
+            return root   # malformed path → no-op
+        remainder = remainder[m.end():]
+        field = m.group(1)
+        idx_s = m.group(2)
+        if field is not None:
+            segments.append(("field", field))
+        else:
+            segments.append(("index", idx_s))
+
+    # Deep copy so we don't mutate the original.
+    result = copy.deepcopy(root)
+
+    # Navigate to the parent node.
+    parent: object = result
+    for seg_type, seg_key in segments[:-1]:
+        if seg_type == "field":
+            if not isinstance(parent, dict) or seg_key not in parent:
+                return result   # path does not exist → no-op
+            parent = parent[seg_key]  # type: ignore[index]
+        else:
+            if not isinstance(parent, list):
+                return result
+            length = len(parent)
+            if isinstance(seg_key, str):
+                idx = length if seg_key == "#" else (
+                    length + int(seg_key[1:]) if seg_key.startswith("#")
+                    else int(seg_key)
+                )
+            else:
+                idx = int(seg_key)
+            if idx < 0:
+                idx += length
+            if idx < 0 or idx >= length:
+                return result
+            parent = parent[idx]   # type: ignore[index]
+
+    # Apply the final segment.
+    last_type, last_key = segments[-1]
+    if last_type == "field":
+        if not isinstance(parent, dict):
+            return result
+        exists = last_key in parent
+        if (exists and replace) or (not exists and insert):
+            parent[last_key] = value  # type: ignore[index]
+    else:
+        if not isinstance(parent, list):
+            return result
+        length = len(parent)
+        if isinstance(last_key, str):
+            idx = (
+                length if last_key == "#" else
+                (length + int(last_key[1:]) if last_key.startswith("#") else int(last_key))
+            )
+        else:
+            idx = int(last_key)
+        if idx < 0:
+            idx += length
+        if idx == length and insert:
+            parent.append(value)   # type: ignore[union-attr]
+        elif 0 <= idx < length and replace:
+            parent[idx] = value    # type: ignore[index]
+
+    return result
+
+
+def _json_remove_path(root: object, path: str) -> object:
+    """Return a deep copy of *root* with the node at *path* removed."""
+    if not isinstance(path, str) or not path.startswith("$"):
+        return root
+    if path == "$":
+        return root  # cannot remove root
+
+    segments: list[tuple[str, object]] = []
+    remainder = path[1:]
+    while remainder:
+        m = _JSON_PATH_COMPONENT.match(remainder)
+        if m is None:
+            return root
+        remainder = remainder[m.end():]
+        field = m.group(1)
+        idx_s = m.group(2)
+        if field is not None:
+            segments.append(("field", field))
+        else:
+            segments.append(("index", idx_s))
+
+    result = copy.deepcopy(root)
+    parent: object = result
+    for seg_type, seg_key in segments[:-1]:
+        if seg_type == "field":
+            if not isinstance(parent, dict) or seg_key not in parent:
+                return result
+            parent = parent[seg_key]  # type: ignore[index]
+        else:
+            if not isinstance(parent, list):
+                return result
+            length = len(parent)
+            sk = str(seg_key)
+            if sk == "#":
+                idx = length
+            elif sk.startswith("#"):
+                idx = length + int(sk[1:])
+            else:
+                idx = int(sk)
+            if idx < 0:
+                idx += length
+            if idx < 0 or idx >= length:
+                return result
+            parent = parent[idx]   # type: ignore[index]
+
+    last_type, last_key = segments[-1]
+    if last_type == "field":
+        if isinstance(parent, dict) and last_key in parent:
+            del parent[last_key]  # type: ignore[attr-defined]
+    else:
+        if isinstance(parent, list):
+            length = len(parent)
+            lk = str(last_key)
+            if lk == "#":
+                idx = length
+            elif lk.startswith("#"):
+                idx = length + int(lk[1:])
+            else:
+                idx = int(lk)
+            if idx < 0:
+                idx += length
+            if 0 <= idx < length:
+                parent.pop(idx)   # type: ignore[union-attr]
+
+    return result
+
+
+# --- public JSON functions ---------------------------------------------------
+
+
+@register("json")
+def _json_fn(x: SqlValue) -> SqlValue:
+    """Return the canonical minified form of a JSON string.
+
+    Parses *x* and re-serialises it with no extra whitespace.  Returns NULL
+    if *x* is NULL or not valid JSON.
+
+    Examples::
+
+        JSON('{ "a" : 1, "b" : 2 }')   → '{"a":1,"b":2}'
+        JSON('[1, 2,  3]')              → '[1,2,3]'
+        JSON(NULL)                      → NULL
+        JSON('invalid')                 → NULL
+    """
+    if x is None:
+        return None
+    if not isinstance(x, str):
+        return None
+    try:
+        parsed = _json.loads(x)
+        return _json.dumps(parsed, separators=(",", ":"))
+    except (ValueError, TypeError):
+        return None
+
+
+@register("json_valid")
+def _json_valid(x: SqlValue) -> SqlValue:
+    """Return 1 if *x* is valid JSON, 0 otherwise.  NULL input → NULL.
+
+    Matches SQLite 3.45+ behaviour where ``JSON_VALID(NULL)`` returns NULL
+    rather than 0.  For non-null, non-string inputs the result is 0.
+
+    Examples::
+
+        JSON_VALID('{"a":1}')    → 1
+        JSON_VALID('[1,2,3]')    → 1
+        JSON_VALID('invalid')    → 0
+        JSON_VALID(NULL)         → NULL
+    """
+    if x is None:
+        return None
+    if not isinstance(x, str):
+        return 0
+    try:
+        _json.loads(x)
+        return 1
+    except (ValueError, TypeError):
+        return 0
+
+
+@register("json_quote")
+def _json_quote_fn(x: SqlValue) -> SqlValue:
+    """Convert a SQL value to its JSON representation as a TEXT string.
+
+    This is the inverse of ``json_extract`` for scalar values.
+
+    - NULL → ``"null"``
+    - integers → decimal string: ``1``
+    - floats   → decimal string: ``3.14``
+    - text     → double-quoted JSON string: ``"hello"``
+    - blob     → ``"null"``  (blobs not representable)
+
+    Examples::
+
+        JSON_QUOTE(NULL)         → 'null'
+        JSON_QUOTE(42)           → '42'
+        JSON_QUOTE(3.14)         → '3.14'
+        JSON_QUOTE('hello')      → '"hello"'
+        JSON_QUOTE('it"s')       → '"it\\"s"'
+    """
+    return _json.dumps(_sql_to_json_val(x), separators=(",", ":"))
+
+
+@register("json_array")
+def _json_array_fn(*args: SqlValue) -> SqlValue:
+    """Build a JSON array from zero or more SQL values.
+
+    Each argument becomes one element.  NULL arguments become JSON null.
+
+    Examples::
+
+        JSON_ARRAY(1, 2, 3)        → '[1,2,3]'
+        JSON_ARRAY('a', NULL, 'b') → '["a",null,"b"]'
+        JSON_ARRAY()               → '[]'
+    """
+    items = [_sql_to_json_val(a) for a in args]
+    return _json.dumps(items, separators=(",", ":"))
+
+
+@register("json_object")
+def _json_object_fn(*args: SqlValue) -> SqlValue:
+    """Build a JSON object from alternating key/value pairs.
+
+    ``JSON_OBJECT(key1, val1, key2, val2, ...)``
+
+    Keys must be TEXT.  Values follow the SQL-to-JSON mapping (NULL → null,
+    etc.).  An odd number of arguments raises an error.  Duplicate keys
+    produce an object where the last value wins (matching SQLite behaviour).
+
+    Examples::
+
+        JSON_OBJECT('a', 1, 'b', 2)     → '{"a":1,"b":2}'
+        JSON_OBJECT('x', NULL)          → '{"x":null}'
+        JSON_OBJECT('n', 3.14)          → '{"n":3.14}'
+    """
+    if len(args) % 2 != 0:
+        raise WrongNumberOfArguments(
+            name="json_object",
+            expected="an even number",
+            got=len(args),
+        )
+    obj: dict[str, object] = {}
+    for i in range(0, len(args), 2):
+        key = args[i]
+        val = args[i + 1]
+        if key is None:
+            # SQLite returns an error for a NULL key; we follow suit by
+            # converting it to the string "null" which is the least-bad
+            # behaviour without raising a hard exception.
+            key = "null"
+        obj[str(key)] = _sql_to_json_val(val)
+    return _json.dumps(obj, separators=(",", ":"))
+
+
+@register("json_extract")
+def _json_extract(*args: SqlValue) -> SqlValue:
+    """Extract one or more values from a JSON document at the given paths.
+
+    ``JSON_EXTRACT(json, path1 [, path2 ...])``
+
+    - One path: returns the SQL value at that path (NULL if not found).
+    - Multiple paths: returns a JSON array of the extracted values.
+
+    Extracted scalars are returned as SQL values (string, integer, real, NULL).
+    Extracted arrays/objects are returned as their JSON text.
+
+    Examples::
+
+        JSON_EXTRACT('{"a":1,"b":2}', '$.a')       → 1
+        JSON_EXTRACT('[10,20,30]', '$[1]')          → 20
+        JSON_EXTRACT('{"a":{"b":3}}', '$.a.b')     → 3
+        JSON_EXTRACT('{"a":1}', '$.missing')       → NULL
+        JSON_EXTRACT('{"a":1}', '$.a', '$.b')      → '[1,null]'
+        JSON_EXTRACT(NULL, '$.a')                  → NULL
+    """
+    if len(args) < 2:
+        raise WrongNumberOfArguments(name="json_extract", expected="at least 2", got=len(args))
+    json_str = args[0]
+    paths = args[1:]
+
+    if json_str is None:
+        return None
+    if not isinstance(json_str, str):
+        return None
+    try:
+        doc = _json.loads(json_str)
+    except (ValueError, TypeError):
+        return None
+
+    results: list[object] = []
+    for path in paths:
+        if not isinstance(path, str):
+            results.append(None)
+            continue
+        val, found = _json_navigate(doc, path)
+        results.append(val if found else None)
+
+    if len(results) == 1:
+        return _json_to_sql_val(results[0])
+    # Multiple paths → return as JSON array.
+    return _json.dumps(results, separators=(",", ":"))
+
+
+@register("json_type")
+def _json_type(*args: SqlValue) -> SqlValue:
+    """Return the type of a JSON value or a value within a JSON document.
+
+    ``JSON_TYPE(json)``          → type of the root element
+    ``JSON_TYPE(json, path)``    → type of the element at *path*
+
+    Return values: ``"null"``, ``"true"``, ``"false"``, ``"integer"``,
+    ``"real"``, ``"text"``, ``"array"``, ``"object"``.
+
+    Returns NULL if the JSON is invalid or the path does not exist.
+
+    Examples::
+
+        JSON_TYPE('{"a":1}')              → 'object'
+        JSON_TYPE('[1,2,3]')              → 'array'
+        JSON_TYPE('"hello"')              → 'text'
+        JSON_TYPE('{"a":1}', '$.a')       → 'integer'
+        JSON_TYPE('{"a":null}', '$.a')    → 'null'
+        JSON_TYPE('{"a":1}', '$.missing') → NULL
+    """
+    _arity("json_type", list(args), 1, 2)
+    json_str = args[0]
+    path = args[1] if len(args) == 2 else "$"
+
+    if json_str is None:
+        return None
+    if not isinstance(json_str, str):
+        return None
+    try:
+        doc = _json.loads(json_str)
+    except (ValueError, TypeError):
+        return None
+
+    if path == "$":
+        return _json_type_name(doc)
+
+    val, found = _json_navigate(doc, path)  # type: ignore[arg-type]
+    if not found:
+        return None
+    return _json_type_name(val)
+
+
+@register("json_array_length")
+def _json_array_length(*args: SqlValue) -> SqlValue:
+    """Return the number of elements in a JSON array.
+
+    ``JSON_ARRAY_LENGTH(json)``          → length of root array
+    ``JSON_ARRAY_LENGTH(json, path)``    → length of array at *path*
+
+    Returns NULL if the JSON is invalid, the path does not exist, or the
+    target element is not an array.
+
+    Examples::
+
+        JSON_ARRAY_LENGTH('[1,2,3]')              → 3
+        JSON_ARRAY_LENGTH('{"a":[1,2]}', '$.a')   → 2
+        JSON_ARRAY_LENGTH('{"a":1}')              → NULL   (not an array)
+        JSON_ARRAY_LENGTH(NULL)                   → NULL
+    """
+    _arity("json_array_length", list(args), 1, 2)
+    json_str = args[0]
+    path = args[1] if len(args) == 2 else "$"
+
+    if json_str is None:
+        return None
+    if not isinstance(json_str, str):
+        return None
+    try:
+        doc = _json.loads(json_str)
+    except (ValueError, TypeError):
+        return None
+
+    if path == "$":
+        target = doc
+    else:
+        target, found = _json_navigate(doc, path)  # type: ignore[arg-type]
+        if not found:
+            return None
+
+    if not isinstance(target, list):
+        # Valid JSON but not an array — SQLite returns 0, not NULL.
+        # "The json_array_length(X) function returns … 0 if X is some kind of
+        # JSON value other than an array" — SQLite documentation.
+        return 0
+    return len(target)
+
+
+@register("json_keys")
+def _json_keys(*args: SqlValue) -> SqlValue:
+    """Return a JSON array of the keys in a JSON object.
+
+    ``JSON_KEYS(json)``         → keys of the root object
+    ``JSON_KEYS(json, path)``   → keys of the object at *path*
+
+    Returns NULL if the target element is not an object or the path does
+    not exist.
+
+    Examples::
+
+        JSON_KEYS('{"a":1,"b":2}')         → '["a","b"]'
+        JSON_KEYS('{"x":{"y":3}}', '$.x')  → '["y"]'
+        JSON_KEYS('[1,2]')                  → NULL   (not an object)
+        JSON_KEYS(NULL)                     → NULL
+    """
+    _arity("json_keys", list(args), 1, 2)
+    json_str = args[0]
+    path = args[1] if len(args) == 2 else "$"
+
+    if json_str is None:
+        return None
+    if not isinstance(json_str, str):
+        return None
+    try:
+        doc = _json.loads(json_str)
+    except (ValueError, TypeError):
+        return None
+
+    if path == "$":
+        target = doc
+    else:
+        target, found = _json_navigate(doc, path)  # type: ignore[arg-type]
+        if not found:
+            return None
+
+    if not isinstance(target, dict):
+        return None
+    return _json.dumps(list(target.keys()), separators=(",", ":"))
+
+
+@register("json_patch")
+def _json_patch(target: SqlValue, patch: SqlValue) -> SqlValue:
+    """Apply an RFC 7396 JSON Merge Patch to a JSON document.
+
+    ``JSON_PATCH(target, patch)``
+
+    The merge patch algorithm:
+    - If *patch* is an object, recursively merge into *target*.
+    - A key in *patch* whose value is null removes that key from *target*.
+    - Other values in *patch* overwrite or insert into *target*.
+    - If *patch* is not an object, replace *target* entirely with *patch*.
+
+    Returns NULL if either argument is NULL or not valid JSON.
+
+    Examples::
+
+        JSON_PATCH('{"a":1,"b":2}', '{"b":null,"c":3}')
+            → '{"a":1,"c":3}'
+        JSON_PATCH('[1,2]', '[3,4,5]')
+            → '[3,4,5]'
+    """
+    if target is None or patch is None:
+        return None
+    if not isinstance(target, str) or not isinstance(patch, str):
+        return None
+    try:
+        t = _json.loads(target)
+        p = _json.loads(patch)
+    except (ValueError, TypeError):
+        return None
+
+    def _merge(a: object, b: object) -> object:
+        if not isinstance(b, dict):
+            return b
+        result = copy.deepcopy(a) if isinstance(a, dict) else {}
+        for k, v in b.items():
+            if v is None:
+                result.pop(k, None)   # type: ignore[union-attr]
+            else:
+                result[k] = _merge(result.get(k), v)  # type: ignore[union-attr]
+        return result
+
+    return _json.dumps(_merge(t, p), separators=(",", ":"))
+
+
+@register("json_remove")
+def _json_remove(*args: SqlValue) -> SqlValue:
+    """Remove one or more paths from a JSON document.
+
+    ``JSON_REMOVE(json, path1 [, path2 ...])``
+
+    Paths that do not exist are silently ignored.  Returns NULL if *json*
+    is NULL or not valid JSON.
+
+    Examples::
+
+        JSON_REMOVE('{"a":1,"b":2}', '$.a')       → '{"b":2}'
+        JSON_REMOVE('[1,2,3]', '$[1]')             → '[1,3]'
+        JSON_REMOVE('{"a":1}', '$.missing')       → '{"a":1}'
+        JSON_REMOVE(NULL, '$.a')                   → NULL
+    """
+    if len(args) < 2:
+        raise WrongNumberOfArguments(name="json_remove", expected="at least 2", got=len(args))
+    json_str = args[0]
+    if json_str is None:
+        return None
+    if not isinstance(json_str, str):
+        return None
+    try:
+        doc = _json.loads(json_str)
+    except (ValueError, TypeError):
+        return None
+
+    for path in args[1:]:
+        if isinstance(path, str):
+            doc = _json_remove_path(doc, path)
+
+    return _json.dumps(doc, separators=(",", ":"))
+
+
+@register("json_set")
+def _json_set(*args: SqlValue) -> SqlValue:
+    """Insert or replace values in a JSON document.
+
+    ``JSON_SET(json, path1, val1 [, path2, val2 ...])``
+
+    Creates the path if it does not exist; overwrites it if it does.
+    Arguments after the first must come in path/value pairs.
+
+    Returns NULL if *json* is NULL or not valid JSON.
+
+    Examples::
+
+        JSON_SET('{"a":1}', '$.a', 99)         → '{"a":99}'
+        JSON_SET('{"a":1}', '$.b', 2)          → '{"a":1,"b":2}'
+        JSON_SET('[1,2,3]', '$[1]', 99)        → '[1,99,3]'
+    """
+    if len(args) < 3 or (len(args) - 1) % 2 != 0:
+        raise WrongNumberOfArguments(
+            name="json_set", expected="1 + even number of path/value pairs", got=len(args)
+        )
+    json_str = args[0]
+    if json_str is None:
+        return None
+    if not isinstance(json_str, str):
+        return None
+    try:
+        doc = _json.loads(json_str)
+    except (ValueError, TypeError):
+        return None
+
+    for i in range(1, len(args), 2):
+        path = args[i]
+        value = _sql_to_json_val(args[i + 1])
+        if isinstance(path, str):
+            doc = _json_set_path(doc, path, value, insert=True, replace=True)
+
+    return _json.dumps(doc, separators=(",", ":"))
+
+
+@register("json_insert")
+def _json_insert(*args: SqlValue) -> SqlValue:
+    """Insert values into a JSON document without overwriting existing paths.
+
+    ``JSON_INSERT(json, path1, val1 [, path2, val2 ...])``
+
+    Only inserts where the path does not yet exist.  Existing values are
+    left unchanged (use ``JSON_SET`` to overwrite).
+
+    Returns NULL if *json* is NULL or not valid JSON.
+
+    Examples::
+
+        JSON_INSERT('{"a":1}', '$.a', 99)   → '{"a":1}'     (no-op)
+        JSON_INSERT('{"a":1}', '$.b', 2)    → '{"a":1,"b":2}'
+    """
+    if len(args) < 3 or (len(args) - 1) % 2 != 0:
+        raise WrongNumberOfArguments(
+            name="json_insert", expected="1 + even number of path/value pairs", got=len(args)
+        )
+    json_str = args[0]
+    if json_str is None:
+        return None
+    if not isinstance(json_str, str):
+        return None
+    try:
+        doc = _json.loads(json_str)
+    except (ValueError, TypeError):
+        return None
+
+    for i in range(1, len(args), 2):
+        path = args[i]
+        value = _sql_to_json_val(args[i + 1])
+        if isinstance(path, str):
+            doc = _json_set_path(doc, path, value, insert=True, replace=False)
+
+    return _json.dumps(doc, separators=(",", ":"))
+
+
+@register("json_replace")
+def _json_replace(*args: SqlValue) -> SqlValue:
+    """Replace existing values in a JSON document without creating new paths.
+
+    ``JSON_REPLACE(json, path1, val1 [, path2, val2 ...])``
+
+    Only replaces values where the path already exists.  Missing paths are
+    silently ignored (use ``JSON_SET`` to create new keys).
+
+    Returns NULL if *json* is NULL or not valid JSON.
+
+    Examples::
+
+        JSON_REPLACE('{"a":1}', '$.a', 99)   → '{"a":99}'
+        JSON_REPLACE('{"a":1}', '$.b', 2)    → '{"a":1}'   (no-op)
+    """
+    if len(args) < 3 or (len(args) - 1) % 2 != 0:
+        raise WrongNumberOfArguments(
+            name="json_replace", expected="1 + even number of path/value pairs", got=len(args)
+        )
+    json_str = args[0]
+    if json_str is None:
+        return None
+    if not isinstance(json_str, str):
+        return None
+    try:
+        doc = _json.loads(json_str)
+    except (ValueError, TypeError):
+        return None
+
+    for i in range(1, len(args), 2):
+        path = args[i]
+        value = _sql_to_json_val(args[i + 1])
+        if isinstance(path, str):
+            doc = _json_set_path(doc, path, value, insert=False, replace=True)
+
+    return _json.dumps(doc, separators=(",", ":"))
+
+
+@register("json_group_array")
+def _json_group_array_scalar(*args: SqlValue) -> SqlValue:
+    """Scalar variant of json_group_array called with explicit value list.
+
+    This is exposed for completeness but the real aggregate form
+    (``SELECT json_group_array(col) FROM t GROUP BY ...``) is handled
+    elsewhere.  Called as a scalar, it builds a JSON array from its
+    arguments exactly like ``json_array``.
+
+    Examples::
+
+        JSON_GROUP_ARRAY(1, 2, 3)  → '[1,2,3]'
+    """
+    return _json_array_fn(*args)

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -1736,6 +1736,27 @@ _JSON_PATH_COMPONENT = re.compile(
     r'|\[(-?\d+|\#(?:[+-]\d+)?)\]'  # [N] or [#] or [#-N] array indexing
 )
 
+# Safety cap: reject JSON strings larger than this to prevent CPU/memory DoS
+# via pathologically large or deeply-nested documents.  1 MB is generous for
+# any realistic SQL JSON value while still blocking obvious abuse.
+_JSON_MAX_BYTES: int = 1_000_000  # 1 MB
+
+
+def _safe_json_loads(s: str) -> tuple[object, bool]:
+    """Parse *s* as JSON and return ``(parsed, ok)``.
+
+    Returns ``(None, False)`` if *s* exceeds :data:`_JSON_MAX_BYTES`, is not
+    valid JSON, or causes a ``RecursionError`` (deeply-nested documents).
+    This is the single choke-point for all user-supplied JSON in the VM; it
+    prevents CPU/memory denial-of-service via crafted payloads.
+    """
+    if len(s) > _JSON_MAX_BYTES:
+        return None, False
+    try:
+        return _json.loads(s), True
+    except (ValueError, TypeError, RecursionError):
+        return None, False
+
 
 def _sql_to_json_val(v: SqlValue) -> object:
     """Convert a SQL scalar value to a Python value suitable for json.dumps.
@@ -2015,11 +2036,10 @@ def _json_fn(x: SqlValue) -> SqlValue:
         return None
     if not isinstance(x, str):
         return None
-    try:
-        parsed = _json.loads(x)
-        return _json.dumps(parsed, separators=(",", ":"))
-    except (ValueError, TypeError):
+    parsed, ok = _safe_json_loads(x)
+    if not ok:
         return None
+    return _json.dumps(parsed, separators=(",", ":"))
 
 
 @register("json_valid")
@@ -2040,11 +2060,8 @@ def _json_valid(x: SqlValue) -> SqlValue:
         return None
     if not isinstance(x, str):
         return 0
-    try:
-        _json.loads(x)
-        return 1
-    except (ValueError, TypeError):
-        return 0
+    _, ok = _safe_json_loads(x)
+    return 1 if ok else 0
 
 
 @register("json_quote")
@@ -2151,9 +2168,8 @@ def _json_extract(*args: SqlValue) -> SqlValue:
         return None
     if not isinstance(json_str, str):
         return None
-    try:
-        doc = _json.loads(json_str)
-    except (ValueError, TypeError):
+    doc, ok = _safe_json_loads(json_str)
+    if not ok:
         return None
 
     results: list[object] = []
@@ -2199,9 +2215,8 @@ def _json_type(*args: SqlValue) -> SqlValue:
         return None
     if not isinstance(json_str, str):
         return None
-    try:
-        doc = _json.loads(json_str)
-    except (ValueError, TypeError):
+    doc, ok = _safe_json_loads(json_str)
+    if not ok:
         return None
 
     if path == "$":
@@ -2238,9 +2253,8 @@ def _json_array_length(*args: SqlValue) -> SqlValue:
         return None
     if not isinstance(json_str, str):
         return None
-    try:
-        doc = _json.loads(json_str)
-    except (ValueError, TypeError):
+    doc, ok = _safe_json_loads(json_str)
+    if not ok:
         return None
 
     if path == "$":
@@ -2283,9 +2297,8 @@ def _json_keys(*args: SqlValue) -> SqlValue:
         return None
     if not isinstance(json_str, str):
         return None
-    try:
-        doc = _json.loads(json_str)
-    except (ValueError, TypeError):
+    doc, ok = _safe_json_loads(json_str)
+    if not ok:
         return None
 
     if path == "$":
@@ -2325,10 +2338,9 @@ def _json_patch(target: SqlValue, patch: SqlValue) -> SqlValue:
         return None
     if not isinstance(target, str) or not isinstance(patch, str):
         return None
-    try:
-        t = _json.loads(target)
-        p = _json.loads(patch)
-    except (ValueError, TypeError):
+    t, ok1 = _safe_json_loads(target)
+    p, ok2 = _safe_json_loads(patch)
+    if not ok1 or not ok2:
         return None
 
     def _merge(a: object, b: object) -> object:
@@ -2368,9 +2380,8 @@ def _json_remove(*args: SqlValue) -> SqlValue:
         return None
     if not isinstance(json_str, str):
         return None
-    try:
-        doc = _json.loads(json_str)
-    except (ValueError, TypeError):
+    doc, ok = _safe_json_loads(json_str)
+    if not ok:
         return None
 
     for path in args[1:]:
@@ -2406,9 +2417,8 @@ def _json_set(*args: SqlValue) -> SqlValue:
         return None
     if not isinstance(json_str, str):
         return None
-    try:
-        doc = _json.loads(json_str)
-    except (ValueError, TypeError):
+    doc, ok = _safe_json_loads(json_str)
+    if not ok:
         return None
 
     for i in range(1, len(args), 2):
@@ -2445,9 +2455,8 @@ def _json_insert(*args: SqlValue) -> SqlValue:
         return None
     if not isinstance(json_str, str):
         return None
-    try:
-        doc = _json.loads(json_str)
-    except (ValueError, TypeError):
+    doc, ok = _safe_json_loads(json_str)
+    if not ok:
         return None
 
     for i in range(1, len(args), 2):
@@ -2484,9 +2493,8 @@ def _json_replace(*args: SqlValue) -> SqlValue:
         return None
     if not isinstance(json_str, str):
         return None
-    try:
-        doc = _json.loads(json_str)
-    except (ValueError, TypeError):
+    doc, ok = _safe_json_loads(json_str)
+    if not ok:
         return None
 
     for i in range(1, len(args), 2):

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -1232,7 +1232,7 @@ def _do_update_agg(ins: UpdateAgg, st: _VmState) -> None:
     if agg.func is AggFunc.COUNT:
         agg.count += 1
         return
-    if agg.func is AggFunc.SUM:
+    if agg.func in (AggFunc.SUM, AggFunc.TOTAL):
         agg.acc = value if agg.acc is None else agg.acc + value  # type: ignore[operator]
         return
     if agg.func is AggFunc.AVG:
@@ -1289,6 +1289,14 @@ def _do_finalize_agg(ins: FinalizeAgg, st: _VmState) -> None:
             st.push(None)
         else:
             st.push(agg.separator.join(agg.items))
+        return
+    if agg.func is AggFunc.TOTAL:
+        # TOTAL() is SQLite-specific: returns 0.0 (float) for empty groups or
+        # all-NULL input.  Unlike SUM(), it never returns NULL.  This matches
+        # the documented SQLite behaviour: "The total() aggregate function
+        # returns the sum of all non-NULL values in the group. If there are no
+        # non-NULL input rows then total() returns 0.0."
+        st.push(0.0 if agg.acc is None else float(agg.acc))  # type: ignore[arg-type]
         return
     # SUM / MIN / MAX — the accumulator *is* the result (may be NULL for empty).
     st.push(agg.acc)

--- a/code/packages/python/sql-vm/tests/test_json_functions.py
+++ b/code/packages/python/sql-vm/tests/test_json_functions.py
@@ -570,6 +570,34 @@ class TestJsonReplace:
 
 
 # ---------------------------------------------------------------------------
+# DoS protection — size cap
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSizeCap:
+    """The _JSON_MAX_BYTES guard rejects pathologically large JSON payloads."""
+
+    def test_json_oversized_returns_null(self) -> None:
+        # A 1.1 MB string exceeds the cap; json() returns NULL.
+        big = "[" + ",".join(["1"] * 100_000) + "]"  # ~600 KB but well > 1 000 000 chars when padded
+        huge = '{"x":"' + "a" * 1_100_000 + '"}'  # 1.1 MB raw
+        # json_valid must return 0 (not crash) for oversized input.
+        assert fn("json_valid", huge) == 0
+
+    def test_json_valid_oversized_returns_0(self) -> None:
+        huge = '"' + "z" * 1_100_000 + '"'  # 1.1 MB string literal, valid JSON
+        # Even though it is structurally valid JSON, the size cap kicks in first.
+        assert fn("json_valid", huge) == 0
+
+    def test_json_fn_oversized_returns_null(self) -> None:
+        # 1,000,001 + chars exceeds _JSON_MAX_BYTES (1_000_000)
+        # Wrap in quotes so it is syntactically valid JSON (a long string),
+        # but the size cap fires before json.loads is ever called.
+        huge = '"' + "x" * 1_100_000 + '"'  # 1.1 MB string literal
+        assert fn("json", huge) is None
+
+
+# ---------------------------------------------------------------------------
 # json_group_array() — scalar alias
 # ---------------------------------------------------------------------------
 

--- a/code/packages/python/sql-vm/tests/test_json_functions.py
+++ b/code/packages/python/sql-vm/tests/test_json_functions.py
@@ -1,0 +1,586 @@
+"""
+Tests for JSON scalar functions in sql_vm.scalar_functions.
+
+Coverage targets
+----------------
+- json()              — canonical (minified) JSON
+- json_valid()        — 1 for valid JSON, 0 otherwise
+- json_quote()        — SQL value → JSON text
+- json_array()        — build a JSON array
+- json_object()       — build a JSON object
+- json_extract()      — extract value(s) at path(s)
+- json_type()         — type name at path
+- json_array_length() — length of a JSON array
+- json_keys()         — object keys as JSON array
+- json_patch()        — RFC 7396 merge patch
+- json_remove()       — remove paths
+- json_set()          — insert or replace
+- json_insert()       — insert only (no overwrite)
+- json_replace()      — replace only (no insert)
+- json_group_array()  — scalar alias for json_array
+
+All assertions are double-checked against Python's own json module semantics
+and SQLite's documented JSON1 extension behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sql_vm.errors import WrongNumberOfArguments
+from sql_vm.scalar_functions import call
+
+
+def fn(name: str, *args: object) -> object:
+    """Thin wrapper for readability."""
+    return call(name, list(args))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# json() — canonical minification
+# ---------------------------------------------------------------------------
+
+
+class TestJson:
+    def test_minifies_object(self) -> None:
+        # Whitespace is stripped; key order is preserved.
+        assert fn("json", '{ "a" : 1 , "b" : 2 }') == '{"a":1,"b":2}'
+
+    def test_minifies_array(self) -> None:
+        assert fn("json", "[ 1 , 2 , 3 ]") == "[1,2,3]"
+
+    def test_null_input(self) -> None:
+        assert fn("json", None) is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json", "not-valid") is None
+
+    def test_string_scalar(self) -> None:
+        assert fn("json", '"hello"') == '"hello"'
+
+    def test_number_scalar(self) -> None:
+        assert fn("json", "42") == "42"
+
+
+# ---------------------------------------------------------------------------
+# json_valid()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonValid:
+    def test_valid_object(self) -> None:
+        assert fn("json_valid", '{"a":1}') == 1
+
+    def test_valid_array(self) -> None:
+        assert fn("json_valid", "[1,2,3]") == 1
+
+    def test_valid_string(self) -> None:
+        assert fn("json_valid", '"hello"') == 1
+
+    def test_valid_null(self) -> None:
+        assert fn("json_valid", "null") == 1
+
+    def test_invalid(self) -> None:
+        assert fn("json_valid", "invalid") == 0
+
+    def test_null_input(self) -> None:
+        # SQLite 3.45+: json_valid(NULL) → NULL.
+        assert fn("json_valid", None) is None
+
+    def test_empty_string(self) -> None:
+        assert fn("json_valid", "") == 0
+
+
+# ---------------------------------------------------------------------------
+# json_quote()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonQuote:
+    def test_null(self) -> None:
+        assert fn("json_quote", None) == "null"
+
+    def test_integer(self) -> None:
+        assert fn("json_quote", 42) == "42"
+
+    def test_float(self) -> None:
+        assert fn("json_quote", 3.14) == "3.14"
+
+    def test_string(self) -> None:
+        assert fn("json_quote", "hello") == '"hello"'
+
+    def test_string_with_quotes(self) -> None:
+        # Internal double-quotes are escaped with backslash.
+        result = fn("json_quote", 'say "hi"')
+        assert result == '"say \\"hi\\""'
+
+    def test_bool_true(self) -> None:
+        # Python True maps to JSON true (not 1).
+        result = fn("json_quote", True)
+        assert result == "true"
+
+    def test_bool_false(self) -> None:
+        result = fn("json_quote", False)
+        assert result == "false"
+
+
+# ---------------------------------------------------------------------------
+# json_array()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonArray:
+    def test_empty(self) -> None:
+        assert fn("json_array") == "[]"
+
+    def test_integers(self) -> None:
+        assert fn("json_array", 1, 2, 3) == "[1,2,3]"
+
+    def test_mixed_types(self) -> None:
+        assert fn("json_array", 1, "two", 3.0) == '[1,"two",3.0]'
+
+    def test_with_null(self) -> None:
+        # NULL arguments become JSON null.
+        assert fn("json_array", 1, None, 3) == "[1,null,3]"
+
+    def test_nested_array(self) -> None:
+        # Passing an already-encoded JSON array string is treated as a string.
+        # json_array always treats its inputs as SQL values.
+        result = fn("json_array", "a", "b")
+        assert result == '["a","b"]'
+
+
+# ---------------------------------------------------------------------------
+# json_object()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonObject:
+    def test_simple(self) -> None:
+        assert fn("json_object", "a", 1, "b", 2) == '{"a":1,"b":2}'
+
+    def test_null_value(self) -> None:
+        assert fn("json_object", "x", None) == '{"x":null}'
+
+    def test_string_value(self) -> None:
+        assert fn("json_object", "name", "Alice") == '{"name":"Alice"}'
+
+    def test_float_value(self) -> None:
+        result = fn("json_object", "pi", 3.14)
+        assert result == '{"pi":3.14}'
+
+    def test_odd_args_raises(self) -> None:
+        with pytest.raises(WrongNumberOfArguments):
+            fn("json_object", "key")   # missing value
+
+    def test_no_args(self) -> None:
+        # Zero args → empty object.
+        assert fn("json_object") == "{}"
+
+
+# ---------------------------------------------------------------------------
+# json_extract()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonExtract:
+    def test_object_field(self) -> None:
+        assert fn("json_extract", '{"a":1,"b":2}', "$.a") == 1
+
+    def test_nested_field(self) -> None:
+        assert fn("json_extract", '{"a":{"b":42}}', "$.a.b") == 42
+
+    def test_array_index(self) -> None:
+        assert fn("json_extract", "[10,20,30]", "$[1]") == 20
+
+    def test_nested_array(self) -> None:
+        doc = '{"arr":[1,2,3]}'
+        assert fn("json_extract", doc, "$.arr[1]") == 2
+
+    def test_missing_path(self) -> None:
+        # Path not found → NULL.
+        assert fn("json_extract", '{"a":1}', "$.missing") is None
+
+    def test_null_json(self) -> None:
+        assert fn("json_extract", None, "$.a") is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json_extract", "invalid", "$.a") is None
+
+    def test_json_null_value(self) -> None:
+        # The JSON document contains null at the path.
+        assert fn("json_extract", '{"a":null}', "$.a") is None
+
+    def test_array_result(self) -> None:
+        # Extracting a JSON array returns it as a JSON text string.
+        result = fn("json_extract", '{"arr":[1,2,3]}', "$.arr")
+        assert result == "[1,2,3]"
+
+    def test_object_result(self) -> None:
+        # Extracting a JSON object returns it as a JSON text string.
+        result = fn("json_extract", '{"obj":{"x":1}}', "$.obj")
+        assert result == '{"x":1}'
+
+    def test_multiple_paths(self) -> None:
+        # Two or more paths → returns a JSON array of results.
+        result = fn("json_extract", '{"a":1,"b":2}', "$.a", "$.b")
+        assert result == "[1,2]"
+
+    def test_multiple_paths_with_missing(self) -> None:
+        # Missing paths appear as null in the output array.
+        result = fn("json_extract", '{"a":1}', "$.a", "$.missing")
+        assert result == "[1,null]"
+
+    def test_string_value(self) -> None:
+        # JSON string is returned as a SQL string (without surrounding quotes).
+        assert fn("json_extract", '{"s":"hello"}', "$.s") == "hello"
+
+    def test_boolean_true(self) -> None:
+        # JSON true → SQL integer 1 (SQLite convention).
+        assert fn("json_extract", '{"b":true}', "$.b") == 1
+
+    def test_boolean_false(self) -> None:
+        # JSON false → SQL integer 0.
+        assert fn("json_extract", '{"b":false}', "$.b") == 0
+
+    def test_negative_array_index(self) -> None:
+        # Negative array index counts from end.
+        assert fn("json_extract", "[10,20,30]", "$[-1]") == 30
+
+    def test_root_path(self) -> None:
+        # $ alone returns the full document (as JSON text for complex types).
+        result = fn("json_extract", "[1,2,3]", "$")
+        assert result == "[1,2,3]"
+
+    def test_non_string_path_in_multi_path(self) -> None:
+        # Non-string path argument → treated as missing → null in array.
+        result = fn("json_extract", '{"a":1}', "$.a", 42)  # 42 is not a string path
+        import json as _j
+        parsed = _j.loads(result)  # type: ignore[arg-type]
+        assert parsed == [1, None]
+
+    def test_non_string_json(self) -> None:
+        # Non-string JSON argument → NULL.
+        assert fn("json_extract", 42, "$.a") is None
+
+
+# ---------------------------------------------------------------------------
+# json_type()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonType:
+    def test_root_object(self) -> None:
+        assert fn("json_type", '{"a":1}') == "object"
+
+    def test_root_array(self) -> None:
+        assert fn("json_type", "[1,2]") == "array"
+
+    def test_root_string(self) -> None:
+        assert fn("json_type", '"hello"') == "text"
+
+    def test_root_integer(self) -> None:
+        assert fn("json_type", "42") == "integer"
+
+    def test_root_real(self) -> None:
+        assert fn("json_type", "3.14") == "real"
+
+    def test_root_null(self) -> None:
+        assert fn("json_type", "null") == "null"
+
+    def test_root_true(self) -> None:
+        assert fn("json_type", "true") == "true"
+
+    def test_root_false(self) -> None:
+        assert fn("json_type", "false") == "false"
+
+    def test_path_field(self) -> None:
+        assert fn("json_type", '{"a":1}', "$.a") == "integer"
+
+    def test_path_array_field(self) -> None:
+        assert fn("json_type", '{"a":[1,2]}', "$.a") == "array"
+
+    def test_path_missing(self) -> None:
+        # Path not found → NULL (not an error).
+        assert fn("json_type", '{"a":1}', "$.missing") is None
+
+    def test_null_json(self) -> None:
+        assert fn("json_type", None) is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json_type", "invalid") is None
+
+    def test_non_string_json(self) -> None:
+        # Integer input → NULL (not a string).
+        assert fn("json_type", 42) is None
+
+
+# ---------------------------------------------------------------------------
+# json_array_length()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonArrayLength:
+    def test_root_array(self) -> None:
+        assert fn("json_array_length", "[1,2,3]") == 3
+
+    def test_empty_array(self) -> None:
+        assert fn("json_array_length", "[]") == 0
+
+    def test_path_to_array(self) -> None:
+        assert fn("json_array_length", '{"a":[1,2]}', "$.a") == 2
+
+    def test_not_an_array(self) -> None:
+        # Valid JSON that is not an array → 0 (matching SQLite: "0 if X is some
+        # kind of JSON value other than an array").
+        assert fn("json_array_length", '{"a":1}') == 0
+
+    def test_null_json(self) -> None:
+        assert fn("json_array_length", None) is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json_array_length", "bad") is None
+
+    def test_path_not_found(self) -> None:
+        assert fn("json_array_length", "[1,2]", "$.missing") is None
+
+    def test_non_string_json(self) -> None:
+        # Non-string input → NULL.
+        assert fn("json_array_length", 42) is None
+
+
+# ---------------------------------------------------------------------------
+# json_keys()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonKeys:
+    def test_simple_object(self) -> None:
+        result = fn("json_keys", '{"a":1,"b":2}')
+        import json
+        keys = json.loads(result)  # type: ignore[arg-type]
+        assert set(keys) == {"a", "b"}
+
+    def test_empty_object(self) -> None:
+        assert fn("json_keys", "{}") == "[]"
+
+    def test_path_to_object(self) -> None:
+        result = fn("json_keys", '{"x":{"y":3,"z":4}}', "$.x")
+        import json
+        keys = json.loads(result)  # type: ignore[arg-type]
+        assert set(keys) == {"y", "z"}
+
+    def test_not_an_object(self) -> None:
+        # Arrays are not objects → NULL.
+        assert fn("json_keys", "[1,2]") is None
+
+    def test_null_json(self) -> None:
+        assert fn("json_keys", None) is None
+
+    def test_path_not_found(self) -> None:
+        assert fn("json_keys", '{"a":1}', "$.missing") is None
+
+    def test_invalid_json(self) -> None:
+        # Invalid JSON → NULL.
+        assert fn("json_keys", "bad-json") is None
+
+    def test_non_string_json(self) -> None:
+        # Non-string input → NULL.
+        assert fn("json_keys", 42) is None
+
+
+# ---------------------------------------------------------------------------
+# json_patch()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonPatch:
+    def test_simple_merge(self) -> None:
+        result = fn("json_patch", '{"a":1,"b":2}', '{"b":99}')
+        import json
+        assert json.loads(result) == {"a": 1, "b": 99}  # type: ignore[arg-type]
+
+    def test_remove_with_null(self) -> None:
+        # In merge-patch, a patch key with value null removes the key.
+        result = fn("json_patch", '{"a":1,"b":2}', '{"b":null}')
+        import json
+        assert json.loads(result) == {"a": 1}  # type: ignore[arg-type]
+
+    def test_add_key(self) -> None:
+        result = fn("json_patch", '{"a":1}', '{"c":3}')
+        import json
+        assert json.loads(result) == {"a": 1, "c": 3}  # type: ignore[arg-type]
+
+    def test_null_input(self) -> None:
+        assert fn("json_patch", None, '{"a":1}') is None
+        assert fn("json_patch", '{"a":1}', None) is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json_patch", "invalid", '{"a":1}') is None
+
+    def test_non_string_inputs(self) -> None:
+        # Non-string inputs → NULL.
+        assert fn("json_patch", 42, '{"a":1}') is None
+        assert fn("json_patch", '{"a":1}', 42) is None
+
+    def test_array_patch(self) -> None:
+        # Patch is not an object → replace target entirely.
+        result = fn("json_patch", "[1,2,3]", "[4,5]")
+        assert result == "[4,5]"
+
+
+# ---------------------------------------------------------------------------
+# json_remove()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonRemove:
+    def test_remove_field(self) -> None:
+        result = fn("json_remove", '{"a":1,"b":2}', "$.a")
+        import json
+        assert json.loads(result) == {"b": 2}  # type: ignore[arg-type]
+
+    def test_remove_array_element(self) -> None:
+        result = fn("json_remove", "[1,2,3]", "$[1]")
+        assert result == "[1,3]"
+
+    def test_remove_missing_path(self) -> None:
+        # Missing path is silently ignored.
+        result = fn("json_remove", '{"a":1}', "$.missing")
+        assert result == '{"a":1}'
+
+    def test_remove_multiple(self) -> None:
+        result = fn("json_remove", '{"a":1,"b":2,"c":3}', "$.a", "$.c")
+        import json
+        assert json.loads(result) == {"b": 2}  # type: ignore[arg-type]
+
+    def test_null_json(self) -> None:
+        assert fn("json_remove", None, "$.a") is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json_remove", "bad", "$.a") is None
+
+    def test_too_few_args_raises(self) -> None:
+        with pytest.raises(WrongNumberOfArguments):
+            fn("json_remove", '{"a":1}')   # missing path
+
+    def test_non_string_json(self) -> None:
+        # Non-string JSON input → NULL.
+        assert fn("json_remove", 42, "$.a") is None
+
+
+# ---------------------------------------------------------------------------
+# json_set()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSet:
+    def test_overwrite_existing(self) -> None:
+        result = fn("json_set", '{"a":1}', "$.a", 99)
+        assert result == '{"a":99}'
+
+    def test_insert_new_key(self) -> None:
+        result = fn("json_set", '{"a":1}', "$.b", 2)
+        import json
+        assert json.loads(result) == {"a": 1, "b": 2}  # type: ignore[arg-type]
+
+    def test_multiple_pairs(self) -> None:
+        result = fn("json_set", '{"a":1}', "$.a", 10, "$.b", 20)
+        import json
+        assert json.loads(result) == {"a": 10, "b": 20}  # type: ignore[arg-type]
+
+    def test_null_json(self) -> None:
+        assert fn("json_set", None, "$.a", 1) is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json_set", "bad", "$.a", 1) is None
+
+    def test_array_index(self) -> None:
+        result = fn("json_set", "[1,2,3]", "$[1]", 99)
+        assert result == "[1,99,3]"
+
+    def test_wrong_arg_count_raises(self) -> None:
+        with pytest.raises(WrongNumberOfArguments):
+            fn("json_set", '{"a":1}', "$.a")   # missing value
+
+    def test_non_string_json(self) -> None:
+        # Non-string JSON input → NULL.
+        assert fn("json_set", 42, "$.a", 1) is None
+
+
+# ---------------------------------------------------------------------------
+# json_insert()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonInsert:
+    def test_insert_new_key(self) -> None:
+        result = fn("json_insert", '{"a":1}', "$.b", 2)
+        import json
+        assert json.loads(result) == {"a": 1, "b": 2}  # type: ignore[arg-type]
+
+    def test_no_overwrite_existing(self) -> None:
+        # Key already exists → unchanged.
+        result = fn("json_insert", '{"a":1}', "$.a", 99)
+        assert result == '{"a":1}'
+
+    def test_null_json(self) -> None:
+        assert fn("json_insert", None, "$.a", 1) is None
+
+    def test_wrong_arg_count_raises(self) -> None:
+        with pytest.raises(WrongNumberOfArguments):
+            fn("json_insert", '{"a":1}', "$.b")  # missing value
+
+    def test_non_string_json(self) -> None:
+        # Non-string JSON input → NULL.
+        assert fn("json_insert", 42, "$.a", 1) is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json_insert", "bad-json", "$.a", 1) is None
+
+
+# ---------------------------------------------------------------------------
+# json_replace()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonReplace:
+    def test_replace_existing(self) -> None:
+        result = fn("json_replace", '{"a":1}', "$.a", 99)
+        assert result == '{"a":99}'
+
+    def test_no_insert_missing(self) -> None:
+        # Path does not exist → no change.
+        result = fn("json_replace", '{"a":1}', "$.b", 2)
+        assert result == '{"a":1}'
+
+    def test_null_json(self) -> None:
+        assert fn("json_replace", None, "$.a", 1) is None
+
+    def test_wrong_arg_count_raises(self) -> None:
+        with pytest.raises(WrongNumberOfArguments):
+            fn("json_replace", '{"a":1}', "$.a")  # missing value
+
+    def test_non_string_json(self) -> None:
+        # Non-string JSON input → NULL.
+        assert fn("json_replace", 42, "$.a", 1) is None
+
+    def test_invalid_json(self) -> None:
+        assert fn("json_replace", "bad-json", "$.a", 1) is None
+
+
+# ---------------------------------------------------------------------------
+# json_group_array() — scalar alias
+# ---------------------------------------------------------------------------
+
+
+class TestJsonGroupArray:
+    def test_alias_for_json_array(self) -> None:
+        # json_group_array acts as a scalar alias for json_array.
+        assert fn("json_group_array", 1, 2, 3) == "[1,2,3]"
+
+    def test_empty(self) -> None:
+        assert fn("json_group_array") == "[]"
+
+    def test_with_null(self) -> None:
+        assert fn("json_group_array", 1, None, 3) == "[1,null,3]"

--- a/code/packages/python/sql-vm/tests/test_json_functions.py
+++ b/code/packages/python/sql-vm/tests/test_json_functions.py
@@ -578,10 +578,8 @@ class TestJsonSizeCap:
     """The _JSON_MAX_BYTES guard rejects pathologically large JSON payloads."""
 
     def test_json_oversized_returns_null(self) -> None:
-        # A 1.1 MB string exceeds the cap; json() returns NULL.
-        big = "[" + ",".join(["1"] * 100_000) + "]"  # ~600 KB but well > 1 000 000 chars when padded
+        # A 1.1 MB object string exceeds the cap; json_valid returns 0 (not crash).
         huge = '{"x":"' + "a" * 1_100_000 + '"}'  # 1.1 MB raw
-        # json_valid must return 0 (not crash) for oversized input.
         assert fn("json_valid", huge) == 0
 
     def test_json_valid_oversized_returns_0(self) -> None:


### PR DESCRIPTION
## Summary

- **14 SQLite JSON1 scalar functions** implemented in the VM scalar-function registry (`sql_vm.scalar_functions`): `json`, `json_valid`, `json_quote`, `json_array`, `json_object`, `json_extract`, `json_type`, `json_array_length`, `json_keys`, `json_patch`, `json_remove`, `json_set`, `json_insert`, `json_replace`, `json_group_array`. Path syntax supports `$.field`, `$[N]`, `$[#]` (length), and negative indices. No parser/planner/codegen changes needed — all dispatched via the existing `CallScalar` VM instruction.

- **`TOTAL()` aggregate** (`SELECT TOTAL(col) FROM t`) returns `0.0` (not NULL) for empty tables and all-NULL groups, matching SQLite's documented behaviour. Added `AggFunc.TOTAL` to sql-planner (`expr.py`), sql-codegen IR (`ir.py`), and sql-vm (`vm.py`). Adapter `agg_map` maps the SQL name automatically.

- **DoS protection** — `_safe_json_loads()` enforces a 1 MB size cap and catches `RecursionError` before calling `json.loads()`. All 12 JSON parse call sites go through this single choke-point.

- **115 unit tests** in `sql-vm/tests/test_json_functions.py` (including size-cap boundary tests). **82 oracle-verified integration tests** in `mini-sqlite/tests/test_tier16_json_total.py` comparing output against the real `sqlite3` module.

## Version bumps

| Package | Before | After |
|---------|--------|-------|
| sql-planner | 0.25.0 | 0.27.0 |
| sql-codegen | 1.20.0 | 1.22.0 |
| sql-vm | 1.19.0 | 1.21.0 |
| mini-sqlite | 1.28.0 | 1.30.0 |

## Test plan

- [ ] `pytest code/packages/python/sql-vm/tests/ -v` — 614 tests, 80.13% coverage ✅
- [ ] `pytest code/packages/python/mini-sqlite/tests/ -v` — 1132+ tests, 92%+ coverage ✅
- [ ] `ruff check code/packages/python/sql-vm/src/` — all checks passed ✅
- [ ] Security review sub-agent: MEDIUM findings (JSON DoS) fixed, no CRITICAL/HIGH ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)