### PR TITLE
python(macsyma): recognize elliptic first-kind integrals

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added MACSYMA integration parity for the first elliptic-integral foothold:
+  `integrate(1/sqrt(1-k^2*sin(theta)^2), theta)` now returns
+  `EllipticF(theta,k)`, and the corresponding `0` to `%pi/2` definite integral
+  returns `EllipticK(k)`.
 - Added MACSYMA `factor` parity for shared integer content in multivariate
   common-factor expressions, so `factor(2*x*y + 2*x*z)` now returns
   `2*x*(y+z)` through the canonical symbolic VM handler.

--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -976,6 +976,24 @@ def test_pipeline_integrate_sum() -> None:
     assert result.head.name != "Integrate"
 
 
+def test_pipeline_integrate_elliptic_first_kind() -> None:
+    """integrate(1/sqrt(1-k^2*sin(theta)^2), theta) → EllipticF(theta,k)."""
+    result = _eval("integrate(1/sqrt(1-k^2*sin(theta)^2), theta)")
+
+    assert result == IRApply(
+        IRSymbol("EllipticF"), (IRSymbol("theta"), IRSymbol("k"))
+    )
+
+
+def test_pipeline_definite_integrate_complete_elliptic_first_kind() -> None:
+    """integrate(..., theta, 0, %pi/2) → EllipticK(k)."""
+    result = _eval(
+        "integrate(1/sqrt(1-k^2*sin(theta)^2), theta, 0, %pi/2)"
+    )
+
+    assert result == IRApply(IRSymbol("EllipticK"), (IRSymbol("k"),))
+
+
 # ---------------------------------------------------------------------------
 # Section T — Matrix operations and numeric functions
 # ---------------------------------------------------------------------------

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Recognised the first elliptic integration foothold: `Integrate` now returns
+  `EllipticF(theta, k)` for `1/sqrt(1-k^2*sin(theta)^2)` and `EllipticK(k)`
+  for the corresponding definite integral from `0` to `%pi/2`.
 - Extended the common multivariate factoring foothold to extract shared
   integer content as well as symbolic powers, so expressions like
   `2*x*y + 2*x*z` now factor to `2*x*(y+z)`.

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -66,6 +66,7 @@ strict mode ``Integrate`` falls through to
 
 from __future__ import annotations
 
+import math
 from fractions import Fraction
 
 from polynomial import (
@@ -150,6 +151,10 @@ from symbolic_vm.trig_poly_integral import trig_cos_integral, trig_sin_integral
 
 ONE = IRInteger(1)
 TWO = IRInteger(2)
+ZERO = IRInteger(0)
+_PI_SYM = IRSymbol("%pi")
+_ELLIPTIC_F = IRSymbol("EllipticF")
+_ELLIPTIC_K = IRSymbol("EllipticK")
 
 
 def integrate() -> Handler:
@@ -175,6 +180,10 @@ def integrate() -> Handler:
             f, x, a, b = expr.args
             if not isinstance(x, IRSymbol):
                 return expr
+
+            elliptic_k = _try_complete_elliptic_k(f, x, a, b)
+            if elliptic_k is not None:
+                return elliptic_k
 
             F: IRNode | None = None
 
@@ -228,10 +237,124 @@ def integrate() -> Handler:
                 _sf_result = _sf_try(f, x)
                 if _sf_result is not None:
                     return vm.eval(_sf_result)
+            _elliptic_result = _try_incomplete_elliptic_f(f, x)
+            if _elliptic_result is not None:
+                return _elliptic_result
             return IRApply(INTEGRATE, (f, x))
         return vm.eval(result)
 
     return handler
+
+
+def _try_complete_elliptic_k(
+    f: IRNode, x: IRSymbol, lower: IRNode, upper: IRNode
+) -> IRNode | None:
+    """Recognise the complete elliptic integral of the first kind.
+
+    ``∫₀^(π/2) 1/sqrt(1-k² sin²(x)) dx`` is returned as ``EllipticK(k)``.
+    """
+    if lower != ZERO:
+        return None
+    if not _is_pi_over_two(upper):
+        return None
+    modulus = _elliptic_first_kind_modulus(f, x)
+    if modulus is None:
+        return None
+    return IRApply(_ELLIPTIC_K, (modulus,))
+
+
+def _try_incomplete_elliptic_f(f: IRNode, x: IRSymbol) -> IRNode | None:
+    """Recognise the incomplete elliptic integral of the first kind.
+
+    ``∫ 1/sqrt(1-k² sin²(x)) dx`` is non-elementary; returning
+    ``EllipticF(x, k)`` makes the special-function form explicit instead of
+    leaving a generic unevaluated ``Integrate`` node.
+    """
+    modulus = _elliptic_first_kind_modulus(f, x)
+    if modulus is None:
+        return None
+    return IRApply(_ELLIPTIC_F, (x, modulus))
+
+
+def _elliptic_first_kind_modulus(f: IRNode, x: IRSymbol) -> IRNode | None:
+    """Return ``k`` when *f* is ``1/sqrt(1-k² sin²(x))``."""
+    if not (
+        isinstance(f, IRApply)
+        and f.head == DIV
+        and len(f.args) == 2
+        and f.args[0] == ONE
+    ):
+        return None
+    denominator = f.args[1]
+    if not (
+        isinstance(denominator, IRApply)
+        and denominator.head == SQRT
+        and len(denominator.args) == 1
+    ):
+        return None
+    radicand = denominator.args[0]
+    if not (
+        isinstance(radicand, IRApply)
+        and radicand.head == SUB
+        and len(radicand.args) == 2
+        and radicand.args[0] == ONE
+    ):
+        return None
+    product = radicand.args[1]
+    if not (
+        isinstance(product, IRApply)
+        and product.head == MUL
+        and len(product.args) == 2
+    ):
+        return None
+
+    first, second = product.args
+    return _modulus_from_squared_factor(first, second, x) or _modulus_from_squared_factor(
+        second, first, x
+    )
+
+
+def _modulus_from_squared_factor(
+    modulus_square: IRNode, sine_square: IRNode, x: IRSymbol
+) -> IRNode | None:
+    if not (
+        isinstance(sine_square, IRApply)
+        and sine_square.head == POW
+        and len(sine_square.args) == 2
+        and sine_square.args[1] == TWO
+    ):
+        return None
+    sine = sine_square.args[0]
+    if not (
+        isinstance(sine, IRApply)
+        and sine.head == SIN
+        and len(sine.args) == 1
+        and sine.args[0] == x
+    ):
+        return None
+    if not (
+        isinstance(modulus_square, IRApply)
+        and modulus_square.head == POW
+        and len(modulus_square.args) == 2
+        and modulus_square.args[1] == TWO
+    ):
+        return None
+    modulus = modulus_square.args[0]
+    if _depends_on(modulus, x):
+        return None
+    return modulus
+
+
+def _is_pi_over_two(node: IRNode) -> bool:
+    if isinstance(node, IRFloat):
+        return math.isclose(node.value, math.pi / 2, rel_tol=0.0, abs_tol=1e-12)
+    return (
+        isinstance(node, IRApply)
+        and node.head == DIV
+        and len(node.args) == 2
+        and node.args[0] == _PI_SYM
+        and node.args[1] == TWO
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/symbolic-vm/tests/test_integrate.py
+++ b/code/packages/python/symbolic-vm/tests/test_integrate.py
@@ -38,10 +38,45 @@ def vm() -> VM:
 
 X = IRSymbol("x")
 Y = IRSymbol("y")
+K = IRSymbol("k")
+THETA = IRSymbol("theta")
 
 
 def _integrate(f):
     return IRApply(INTEGRATE, (f, X))
+
+
+def _elliptic_integrand() -> IRApply:
+    return IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(
+                SQRT,
+                (
+                    IRApply(
+                        SUB,
+                        (
+                            IRInteger(1),
+                            IRApply(
+                                MUL,
+                                (
+                                    IRApply(POW, (K, IRInteger(2))),
+                                    IRApply(
+                                        POW,
+                                        (
+                                            IRApply(SIN, (THETA,)),
+                                            IRInteger(2),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +160,30 @@ def test_integrate_exponential_constant_base(vm: VM) -> None:
         ),
     )
     assert vm.eval(expr) == expected
+
+
+def test_integrate_elliptic_first_kind_returns_named_form(vm: VM) -> None:
+    expr = IRApply(INTEGRATE, (_elliptic_integrand(), THETA))
+
+    assert vm.eval(expr) == IRApply(
+        IRSymbol("EllipticF"), (THETA, K)
+    )
+
+
+def test_definite_integrate_elliptic_first_kind_returns_complete_form(
+    vm: VM,
+) -> None:
+    expr = IRApply(
+        INTEGRATE,
+        (
+            _elliptic_integrand(),
+            THETA,
+            IRInteger(0),
+            IRApply(DIV, (IRSymbol("%pi"), IRInteger(2))),
+        ),
+    )
+
+    assert vm.eval(expr) == IRApply(IRSymbol("EllipticK"), (K,))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- recognize the canonical incomplete elliptic first-kind integral as `EllipticF(theta, k)`
- recognize the complete first-kind definite form over `[0, %pi/2]` as `EllipticK(k)`
- add symbolic VM and MACSYMA pipeline coverage for both forms

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-macsyma-elliptic-integral PYTHONPATH=$(printf '%s:' /Users/adhithya/Downloads/Codex/coding-adventures-python-macsyma-elliptic-integral/code/packages/python/*/src) pytest -q code/packages/python/symbolic-vm/tests/test_integrate.py --no-cov`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-macsyma-elliptic-integral PYTHONPATH=$(printf '%s:' /Users/adhithya/Downloads/Codex/coding-adventures-python-macsyma-elliptic-integral/code/packages/python/*/src) pytest -q code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py -k 'integrate' --no-cov`
- `git diff --check`
