### PR TITLE
feat(iir-refinement-pass): wire refinement checker into twig-aot pipeline (LANG42)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -564,6 +564,7 @@ members = [
     "brainfuck-iir-compiler",
     "ir-to-beam",
     "iir-builtin-lowering",
+    "iir-refinement-pass",
     "iir-linker",
     "iir-to-beam",
     "iir-to-wasm",

--- a/code/packages/rust/iir-refinement-pass/CHANGELOG.md
+++ b/code/packages/rust/iir-refinement-pass/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — `iir-refinement-pass`
+
+## [0.1.0] — 2026-05-13
+
+### Added (LANG42)
+
+- Initial release. Implements the pre-codegen refinement obligation pass for
+  the Twig AOT pipeline.
+- `check_module(module, mode) -> Vec<RefinementError>` — the single public
+  entry point. Scans every function for call-site and return-site refinement
+  violations.
+- `RefinementMode::Lenient` (default) — only `ProvenUnsafe` outcomes become
+  compile errors; `Unknown` outcomes are silently accepted (future LANG46 will
+  insert runtime checks).
+- `RefinementMode::Strict` — both `ProvenUnsafe` and `Unknown` outcomes become
+  compile errors, used for `(typed strict)` modules (TW05-A).
+- `RefinementError` struct with `function`, `site`, `counter_example`, and
+  `description` fields; implements `Display` with the `error[E0042]` prefix.
+- `const_prop::build_const_map` — single-pass forward scan that collects
+  integer-literal `const` assignments into a `HashMap<String, i128>`, with
+  conservative eviction on duplicate writes.
+- `call_checker::check_calls` — checks each `call` instruction's arguments
+  against the callee's `param_refinements` using resolved evidence.
+- `ret_checker::check_returns` — checks each `ret` instruction against the
+  function's `return_refinement` using resolved evidence.
+- Evidence resolution: `Operand::Int(v)` → `Concrete`, `Operand::Var` in
+  ConstMap → `Concrete`, everything else → `Unconstrained`.
+- 30+ unit tests across all four source files, including all 10 tests
+  specified in the LANG42 spec.

--- a/code/packages/rust/iir-refinement-pass/Cargo.toml
+++ b/code/packages/rust/iir-refinement-pass/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "iir-refinement-pass"
+version = "0.1.0"
+edition = "2021"
+description = "LANG42 — pre-codegen pass that discharges refinement proof obligations against the IIR before machine-code emission."
+
+[dependencies]
+interpreter-ir         = { path = "../interpreter-ir" }
+lang-refined-types     = { path = "../lang-refined-types" }
+lang-refinement-checker = { path = "../lang-refinement-checker" }

--- a/code/packages/rust/iir-refinement-pass/README.md
+++ b/code/packages/rust/iir-refinement-pass/README.md
@@ -1,0 +1,92 @@
+# `iir-refinement-pass`
+
+**LANG42** — pre-codegen refinement obligation checker for the Twig AOT
+pipeline.
+
+## What it does
+
+LANG23 built a complete refinement-type infrastructure:
+
+- `lang-refined-types` — `RefinedType`, `Predicate`, `Kind` data types
+- `constraint-vm` + `constraint-engine` — DPLL SAT solver + Cooper's LIA
+- `lang-refinement-checker` — per-binding `Checker` + function/module/program
+  scoped checkers
+- `twig-ir-compiler` — populates `IIRFunction::param_refinements` and
+  `return_refinement` from parsed type annotations
+
+However, the IIR never reached the checker: refinement annotations were parsed
+and stored but never validated.  Any violation silently produced broken machine
+code.
+
+`iir-refinement-pass` wires the checker into the pipeline.  It runs **before
+any lowering passes**, directly on the original IIR emitted by the compiler,
+so variable names still correspond to their annotations.
+
+## Algorithm
+
+For each function in the module:
+
+1. **Constant-propagation map** — one forward scan of `const` instructions
+   builds `HashMap<String, i128>` of compile-time integer literals.  A
+   variable is tracked only if it is assigned exactly once; re-assignments are
+   conservatively evicted.
+
+2. **Call-site checking** — for every `call` instruction:
+   - Look up the callee's `param_refinements`
+   - Resolve each argument's evidence (Concrete if literal/ConstMap hit;
+     Unconstrained otherwise)
+   - Call `lang_refinement_checker::Checker::check(annotation, evidence)`
+   - `ProvenUnsafe` → `RefinementError` with a counter-example value
+
+3. **Return-site checking** — same as call-site but for `ret` instructions
+   checked against the function's `return_refinement`.
+
+## Modes
+
+| Mode | `ProvenUnsafe` | `Unknown` |
+|---|---|---|
+| `Lenient` (default) | compile error | silent |
+| `Strict` | compile error | compile error |
+
+Use `Strict` for `(typed strict)` modules (LANG TW05-A) or
+correctness-critical pipelines.
+
+## Usage
+
+```rust
+use iir_refinement_pass::{check_module, RefinementMode};
+
+let errors = check_module(&iir_module, RefinementMode::Lenient);
+if !errors.is_empty() {
+    for e in &errors {
+        eprintln!("{e}");
+    }
+    return Err(AotError::RefinementViolations(errors));
+}
+```
+
+## Where it fits in the pipeline
+
+```
+twig-ir-compiler::compile_source → IIRModule
+       │
+       ▼  ← iir_refinement_pass::check_module  (LANG42, this crate)
+              if errors → Err(AotError::RefinementViolations)
+       │
+       ▼
+prepare_module_for_aot (lower_builtins, …)
+       │
+       ▼
+compile each function → ARM64 machine code
+```
+
+## Future work
+
+- **CFG-based path-sensitive checking** (`FunctionChecker`, `ModuleChecker`)
+  — requires building `CfgNode` trees from IIR.  Planned for LANG45.
+- **Runtime check insertion** — `Unknown` outcomes should insert a
+  `type_assert`-style guard.  Planned for LANG46.
+- **Refinement narrowing** — proven-safe checks should narrow the downstream
+  `RefinedType`.  Planned for LANG47.
+- **`(typed strict)` module declaration** — TW05-A syntax extension that sets
+  the module-level default to `Strict`.

--- a/code/packages/rust/iir-refinement-pass/src/call_checker.rs
+++ b/code/packages/rust/iir-refinement-pass/src/call_checker.rs
@@ -1,0 +1,356 @@
+//! Call-site refinement checker for the `iir-refinement-pass`.
+//!
+//! # Responsibility
+//!
+//! For every `call` instruction in a function, this module:
+//!
+//! 1. Resolves the callee name from `srcs[0]` (a `Var` operand).
+//! 2. Looks up the callee's [`IIRFunction`] in the module to find its
+//!    `param_refinements`.
+//! 3. For each argument `srcs[i+1]` that has a corresponding annotation,
+//!    resolves evidence via the constant-propagation map and calls
+//!    [`Checker::check`].
+//! 4. Translates each [`CheckOutcome`] into zero or one [`RefinementError`]
+//!    entries according to the current [`RefinementMode`].
+//!
+//! # Evidence resolution
+//!
+//! | Argument operand | Evidence |
+//! |---|---|
+//! | `Operand::Int(v)` | `Evidence::Concrete(v as i128)` |
+//! | `Operand::Var(name)` where `name ∈ ConstMap` | `Evidence::Concrete(map[name])` |
+//! | `Operand::Var(name)` where `name ∉ ConstMap` | `Evidence::Unconstrained` |
+//! | `Operand::Bool(_)` / `Operand::Float(_)` / `Operand::Str(_)` | `Evidence::Unconstrained` |
+//!
+//! # Mode behaviour
+//!
+//! - **Lenient**: only `ProvenUnsafe` outcomes become errors.
+//! - **Strict**: both `ProvenUnsafe` and `Unknown` outcomes become errors.
+
+use interpreter_ir::instr::Operand;
+use interpreter_ir::module::IIRModule;
+use interpreter_ir::function::IIRFunction;
+use lang_refinement_checker::{Checker, Evidence, CheckOutcome};
+
+use crate::const_prop::ConstMap;
+use crate::{RefinementError, RefinementMode};
+
+/// Check every `call` instruction in `func` against the callee's
+/// `param_refinements`.
+///
+/// Results are appended to `errors`.  The function is the owner of the caller
+/// context (used in error messages), and `module` is needed to look up each
+/// callee.
+pub fn check_calls(
+    func: &IIRFunction,
+    module: &IIRModule,
+    const_map: &ConstMap,
+    mode: RefinementMode,
+    errors: &mut Vec<RefinementError>,
+) {
+    let mut checker = Checker::new();
+
+    for instr in &func.instructions {
+        // Only `call` instructions carry argument evidence.
+        if instr.op != "call" {
+            continue;
+        }
+
+        // srcs[0] = callee name (Var).  srcs[1..] = arguments.
+        let callee_name = match instr.srcs.first() {
+            Some(Operand::Var(name)) => name.as_str(),
+            _ => continue, // malformed call; skip gracefully
+        };
+
+        // Look up the callee function definition.
+        let callee = match module.get_function(callee_name) {
+            Some(f) => f,
+            None => continue, // external function; no annotation to check
+        };
+
+        // Nothing to check if the callee has no refinement annotations.
+        if callee.param_refinements.is_empty() {
+            continue;
+        }
+
+        // Walk arguments (srcs[1..]) and check each annotated parameter.
+        for (i, arg_operand) in instr.srcs[1..].iter().enumerate() {
+            // Get the annotation for parameter i (if any).
+            let annotation = match callee.param_refinements.get(i) {
+                Some(Some(ann)) => ann,
+                _ => continue, // no annotation for this parameter index
+            };
+
+            // Resolve compile-time evidence for this argument.
+            let evidence = resolve_evidence(arg_operand, const_map);
+
+            // Ask the solver.
+            let outcome = checker.check(annotation, &evidence);
+
+            match outcome {
+                CheckOutcome::ProvenSafe => {
+                    // No error — value provably satisfies the annotation.
+                }
+                CheckOutcome::ProvenUnsafe(cx) => {
+                    errors.push(RefinementError {
+                        function: func.name.clone(),
+                        site: format!(
+                            "call to `{}`, argument {}",
+                            callee_name, i
+                        ),
+                        counter_example: cx.value,
+                        description: cx.description,
+                    });
+                }
+                CheckOutcome::Unknown(msg) => {
+                    if mode == RefinementMode::Strict {
+                        errors.push(RefinementError {
+                            function: func.name.clone(),
+                            site: format!(
+                                "call to `{}`, argument {} (UNKNOWN in strict mode)",
+                                callee_name, i
+                            ),
+                            counter_example: 0,
+                            description: msg,
+                        });
+                    }
+                    // In Lenient mode, UNKNOWN is silently ignored.
+                }
+            }
+        }
+    }
+}
+
+/// Resolve compile-time evidence from a single `call` argument operand.
+///
+/// - `Operand::Int(v)` → `Concrete(v as i128)` (literal in the call itself)
+/// - `Operand::Var(name)` in `const_map` → `Concrete(map[name])`
+/// - everything else → `Unconstrained`
+fn resolve_evidence(operand: &Operand, const_map: &ConstMap) -> Evidence {
+    match operand {
+        Operand::Int(v) => Evidence::Concrete(*v as i128),
+        Operand::Var(name) => {
+            if let Some(&v) = const_map.get(name.as_str()) {
+                Evidence::Concrete(v)
+            } else {
+                Evidence::Unconstrained
+            }
+        }
+        _ => Evidence::Unconstrained,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+    use lang_refined_types::{RefinedType, Kind};
+    use lang_refined_types::Predicate;
+    use std::collections::HashMap;
+
+    /// Build a module with two functions: caller and callee.
+    ///
+    /// `callee` has `param_refinements[0] = Some(annotation)`.
+    /// `caller` has the provided instruction list.
+    fn make_module(
+        annotation: RefinedType,
+        caller_instrs: Vec<IIRInstr>,
+    ) -> IIRModule {
+        // Callee: takes one parameter annotated with `annotation`.
+        let callee = IIRFunction {
+            name: "callee".into(),
+            params: vec![("x".into(), "i64".into())],
+            param_refinements: vec![Some(annotation)],
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i64"),
+            ],
+            ..Default::default()
+        };
+
+        // Caller: user-supplied instructions.
+        let caller = IIRFunction {
+            name: "caller".into(),
+            instructions: caller_instrs,
+            ..Default::default()
+        };
+
+        let mut module = IIRModule::new("test.twig", "twig");
+        module.functions.push(callee);
+        module.functions.push(caller);
+        module
+    }
+
+    /// `(Int 0 128)` annotation: valid range [0, 128).
+    fn range_0_128() -> RefinedType {
+        RefinedType::refined(
+            Kind::Int,
+            Predicate::Range {
+                lo: Some(0),
+                hi: Some(127),
+                inclusive_hi: true,
+            },
+        )
+    }
+
+    #[test]
+    fn literal_in_range_no_error() {
+        // Call callee with literal 42 — in [0, 128) — no error.
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("callee".into()), Operand::Int(42)],
+            "i64",
+        );
+        let module = make_module(range_0_128(), vec![call_instr]);
+        let caller = module.get_function("caller").unwrap();
+        let mut errors = Vec::new();
+        check_calls(caller, &module, &HashMap::new(), RefinementMode::Lenient, &mut errors);
+        assert!(errors.is_empty(), "no error expected for value 42 in [0,128)");
+    }
+
+    #[test]
+    fn literal_out_of_range_error() {
+        // Call callee with literal 200 — violates [0, 128) → error.
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("callee".into()), Operand::Int(200)],
+            "i64",
+        );
+        let module = make_module(range_0_128(), vec![call_instr]);
+        let caller = module.get_function("caller").unwrap();
+        let mut errors = Vec::new();
+        check_calls(caller, &module, &HashMap::new(), RefinementMode::Lenient, &mut errors);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].counter_example, 200);
+    }
+
+    #[test]
+    fn const_tracked_variable_violation() {
+        // const arg0 = 500, then call callee arg0 → caught via ConstMap.
+        let const_instr = IIRInstr::new(
+            "const",
+            Some("arg0".into()),
+            vec![Operand::Int(500)],
+            "i64",
+        );
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("callee".into()), Operand::Var("arg0".into())],
+            "i64",
+        );
+        let module = make_module(range_0_128(), vec![const_instr.clone(), call_instr]);
+        let caller = module.get_function("caller").unwrap();
+        // Build const_map manually (as lib.rs would).
+        let mut const_map = HashMap::new();
+        const_map.insert("arg0".to_string(), 500i128);
+        let mut errors = Vec::new();
+        check_calls(caller, &module, &const_map, RefinementMode::Lenient, &mut errors);
+        assert_eq!(errors.len(), 1, "500 violates [0,128)");
+        assert_eq!(errors[0].counter_example, 500);
+    }
+
+    #[test]
+    fn unconstrained_variable_lenient_silent() {
+        // An unknown variable → Unconstrained → UNKNOWN outcome → silent in Lenient.
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("callee".into()), Operand::Var("unknown_var".into())],
+            "i64",
+        );
+        let module = make_module(range_0_128(), vec![call_instr]);
+        let caller = module.get_function("caller").unwrap();
+        let mut errors = Vec::new();
+        check_calls(caller, &module, &HashMap::new(), RefinementMode::Lenient, &mut errors);
+        assert!(errors.is_empty(), "unconstrained should be silent in Lenient mode");
+    }
+
+    #[test]
+    fn unconstrained_variable_strict_error() {
+        // Same unknown variable → UNKNOWN → error in Strict mode.
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("callee".into()), Operand::Var("unknown_var".into())],
+            "i64",
+        );
+        let module = make_module(range_0_128(), vec![call_instr]);
+        let caller = module.get_function("caller").unwrap();
+        let mut errors = Vec::new();
+        check_calls(caller, &module, &HashMap::new(), RefinementMode::Strict, &mut errors);
+        assert_eq!(errors.len(), 1, "UNKNOWN should be an error in Strict mode");
+    }
+
+    #[test]
+    fn unannotated_callee_skipped() {
+        // Callee with no param_refinements → always skipped.
+        let unannotated_callee = IIRFunction {
+            name: "unann".into(),
+            params: vec![("x".into(), "i64".into())],
+            param_refinements: vec![], // empty — no annotations
+            ..Default::default()
+        };
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("unann".into()), Operand::Int(9999)],
+            "i64",
+        );
+        let caller = IIRFunction {
+            name: "caller".into(),
+            instructions: vec![call_instr],
+            ..Default::default()
+        };
+        let mut module = IIRModule::new("test.twig", "twig");
+        module.functions.push(unannotated_callee);
+        module.functions.push(caller);
+
+        let caller_fn = module.get_function("caller").unwrap();
+        let mut errors = Vec::new();
+        check_calls(caller_fn, &module, &HashMap::new(), RefinementMode::Strict, &mut errors);
+        assert!(errors.is_empty(), "unannotated callee must be skipped entirely");
+    }
+
+    #[test]
+    fn multiple_violations_all_reported() {
+        // Callee with two annotated params; both violated → two errors.
+        let callee = IIRFunction {
+            name: "two_params".into(),
+            params: vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+            param_refinements: vec![Some(range_0_128()), Some(range_0_128())],
+            ..Default::default()
+        };
+        // Both 200 and 300 violate [0, 128).
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![
+                Operand::Var("two_params".into()),
+                Operand::Int(200),
+                Operand::Int(300),
+            ],
+            "i64",
+        );
+        let caller = IIRFunction {
+            name: "caller".into(),
+            instructions: vec![call_instr],
+            ..Default::default()
+        };
+        let mut module = IIRModule::new("test.twig", "twig");
+        module.functions.push(callee);
+        module.functions.push(caller);
+
+        let caller_fn = module.get_function("caller").unwrap();
+        let mut errors = Vec::new();
+        check_calls(caller_fn, &module, &HashMap::new(), RefinementMode::Lenient, &mut errors);
+        assert_eq!(errors.len(), 2, "both violations should be reported");
+    }
+}

--- a/code/packages/rust/iir-refinement-pass/src/const_prop.rs
+++ b/code/packages/rust/iir-refinement-pass/src/const_prop.rs
@@ -1,0 +1,186 @@
+//! Constant-propagation map for the refinement pass.
+//!
+//! # What we compute
+//!
+//! For each function we make a single forward scan of the instruction list and
+//! build a mapping:
+//!
+//! ```text
+//! ConstMap : HashMap<String, i128>
+//! ```
+//!
+//! A variable name `v` is entered in the map if and only if **exactly one**
+//! `const` instruction in the function writes an integer literal to `dest = v`.
+//!
+//! If a second `const` writes to the same destination we **evict** the entry
+//! (conservative: we no longer know the compile-time value).  We also skip any
+//! `const` whose source is not `Operand::Int`.
+//!
+//! # Why single-pass is enough
+//!
+//! The IIR produced by the Twig compiler is in SSA-style: each virtual register
+//! is written at most once in normal code.  The eviction rule is a safety net
+//! for hand-crafted test modules and potential future passes that do inline
+//! substitution.
+//!
+//! # Example
+//!
+//! ```text
+//! const  arg0 = 500      ; Operand::Int(500) → ConstMap["arg0"] = 500
+//! call   callee arg0     ; call_checker can now use Evidence::Concrete(500)
+//! ```
+
+use std::collections::HashMap;
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::Operand;
+
+/// A compile-time integer-constant map for a single function.
+///
+/// Built by [`build_const_map`].  The checker uses it to turn
+/// `Operand::Var(name)` into `Evidence::Concrete(v)` when the variable is
+/// provably a constant integer.
+pub type ConstMap = HashMap<String, i128>;
+
+/// Scan `func`'s instruction list once and return every variable that is
+/// unconditionally assigned a single compile-time integer literal.
+///
+/// # Algorithm
+///
+/// 1. Walk each instruction in definition order.
+/// 2. When `op == "const"`, `dest == Some(name)`, and `srcs[0] == Operand::Int(v)`:
+///    - First occurrence → insert `name → v as i128`.
+///    - Second (or later) occurrence → evict `name` (conservative: treat as
+///      unconstrained so we never claim a wrong value).
+/// 3. All other instructions are ignored.
+///
+/// The result is a stable, read-only snapshot; the caller uses it while
+/// checking call sites and return sites in the same function.
+pub fn build_const_map(func: &IIRFunction) -> ConstMap {
+    // Track which names we have already seen (for eviction on duplicates).
+    let mut seen: HashMap<String, bool> = HashMap::new(); // true = evicted
+    let mut map: ConstMap = HashMap::new();
+
+    for instr in &func.instructions {
+        // Only `const` instructions contribute to the literal map.
+        if instr.op != "const" {
+            continue;
+        }
+
+        // The destination register must be named.
+        let name = match &instr.dest {
+            Some(n) => n.clone(),
+            None => continue,
+        };
+
+        // The source must be an integer literal.
+        let value: i128 = match instr.srcs.first() {
+            Some(Operand::Int(v)) => *v as i128,
+            _ => continue,
+        };
+
+        // Eviction rule: a second const to the same dest removes the entry.
+        match seen.get(&name) {
+            None => {
+                // First time: record and enter into map.
+                seen.insert(name.clone(), false);
+                map.insert(name, value);
+            }
+            Some(false) => {
+                // Second time: evict — mark as seen-evicted, remove from map.
+                seen.insert(name.clone(), true);
+                map.remove(&name);
+            }
+            Some(true) => {
+                // Already evicted; nothing to do.
+            }
+        }
+    }
+
+    map
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+
+    /// Helper: build a minimal function with the given instructions.
+    fn func_with_instrs(instrs: Vec<IIRInstr>) -> IIRFunction {
+        IIRFunction {
+            name: "test".into(),
+            instructions: instrs,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn single_int_const_is_captured() {
+        // A single `const arg0 = 42` should appear in the map.
+        let f = func_with_instrs(vec![
+            IIRInstr::new("const", Some("arg0".into()), vec![Operand::Int(42)], "i64"),
+        ]);
+        let map = build_const_map(&f);
+        assert_eq!(map.get("arg0"), Some(&42i128));
+    }
+
+    #[test]
+    fn two_consts_same_dest_evicts() {
+        // Writing twice to the same dest → evict; map should be empty.
+        let f = func_with_instrs(vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(2)], "i64"),
+        ]);
+        let map = build_const_map(&f);
+        assert!(!map.contains_key("v"), "eviction should have removed 'v'");
+    }
+
+    #[test]
+    fn non_int_const_is_skipped() {
+        // A `const` with a Bool source should not appear in the map.
+        let f = func_with_instrs(vec![
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Bool(true)], "bool"),
+        ]);
+        let map = build_const_map(&f);
+        assert!(!map.contains_key("b"));
+    }
+
+    #[test]
+    fn non_const_instructions_are_ignored() {
+        // An `add` instruction should not contribute anything to the map.
+        let f = func_with_instrs(vec![
+            IIRInstr::new("add", Some("r".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "i64"),
+        ]);
+        let map = build_const_map(&f);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn multiple_distinct_consts() {
+        // Multiple consts with different dests all appear in the map.
+        let f = func_with_instrs(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(10)], "i64"),
+            IIRInstr::new("const", Some("y".into()), vec![Operand::Int(20)], "i64"),
+            IIRInstr::new("const", Some("z".into()), vec![Operand::Int(30)], "i64"),
+        ]);
+        let map = build_const_map(&f);
+        assert_eq!(map.get("x"), Some(&10i128));
+        assert_eq!(map.get("y"), Some(&20i128));
+        assert_eq!(map.get("z"), Some(&30i128));
+    }
+
+    #[test]
+    fn negative_int_const() {
+        // Negative literals must also be stored faithfully.
+        let f = func_with_instrs(vec![
+            IIRInstr::new("const", Some("neg".into()), vec![Operand::Int(-99)], "i64"),
+        ]);
+        let map = build_const_map(&f);
+        assert_eq!(map.get("neg"), Some(&(-99i128)));
+    }
+}

--- a/code/packages/rust/iir-refinement-pass/src/lib.rs
+++ b/code/packages/rust/iir-refinement-pass/src/lib.rs
@@ -1,0 +1,438 @@
+//! `iir-refinement-pass` — LANG42 pre-codegen refinement obligation checker.
+//!
+//! # What this crate does
+//!
+//! LANG23 built the entire refinement-type infrastructure:
+//!
+//! - **`lang-refined-types`** — `RefinedType`, `Predicate`, `Kind` data types.
+//! - **`constraint-vm` + `constraint-engine`** — DPLL SAT solver + Cooper's LIA.
+//! - **`lang-refinement-checker`** — per-binding `Checker`, plus function-,
+//!   module-, and program-scope checkers.
+//! - **`twig-ir-compiler`** — populates `IIRFunction::param_refinements` and
+//!   `return_refinement` from parsed type annotations.
+//!
+//! However, the IIR never reached the checker: the `twig-aot` pipeline compiled
+//! and emitted machine code without asking whether any refinement obligation
+//! was violated.
+//!
+//! **LANG42** wires the checker into the pipeline.  After `twig-ir-compiler`
+//! emits an `IIRModule`, a new pre-codegen pass (this crate) scans call sites
+//! and return sites, resolves argument evidence via lightweight constant
+//! propagation, and discharges proof obligations through the existing
+//! `lang-refinement-checker` API.
+//!
+//! The result: a literal argument that provably violates a parameter
+//! annotation becomes a **compile error with a counter-example** rather than
+//! silently producing broken machine code.
+//!
+//! # Algorithm summary
+//!
+//! For each function in the module:
+//!
+//! 1. **Constant-propagation map** — scan `const` instructions for
+//!    `Operand::Int` assignments; build `ConstMap: HashMap<String, i128>`.
+//! 2. **Call-site checking** — for each `call` instruction, look up the
+//!    callee's `param_refinements`, resolve each argument's evidence (Concrete
+//!    if a literal or ConstMap hit; Unconstrained otherwise), and call
+//!    [`lang_refinement_checker::Checker::check`].
+//! 3. **Return-site checking** — for each `ret` instruction in a function
+//!    with `return_refinement = Some(ann)`, check the returned value's
+//!    evidence against `ann`.
+//!
+//! # Modes
+//!
+//! | Mode | `ProvenUnsafe` | `Unknown` |
+//! |---|---|---|
+//! | [`RefinementMode::Lenient`] | compile error | silent |
+//! | [`RefinementMode::Strict`]  | compile error | compile error |
+//!
+//! # Public API
+//!
+//! ```
+//! use iir_refinement_pass::{check_module, RefinementMode};
+//! use interpreter_ir::module::IIRModule;
+//!
+//! let module = IIRModule::new("test.twig", "twig");
+//! let errors = check_module(&module, RefinementMode::Lenient);
+//! assert!(errors.is_empty());
+//! ```
+
+pub mod call_checker;
+pub mod const_prop;
+pub mod ret_checker;
+
+use interpreter_ir::module::IIRModule;
+
+// Re-export the checker infrastructure we rely on so downstream callers that
+// want to inspect outcomes can import them from one place.
+pub use lang_refinement_checker::{Evidence, CheckOutcome};
+
+// ---------------------------------------------------------------------------
+// RefinementMode
+// ---------------------------------------------------------------------------
+
+/// How to handle `Unknown` outcomes from the constraint solver.
+///
+/// `ProvenUnsafe` always becomes a compile error regardless of mode.
+///
+/// # Background
+///
+/// The per-binding solver uses Cooper's LIA for integer ranges and DPLL for
+/// membership sets.  When the evidence is `Unconstrained` (the value comes
+/// from user input, a function parameter, or a heap load), the solver cannot
+/// determine whether the annotation is satisfied — it returns `Unknown`.
+///
+/// - **Lenient** (default): silently accept `Unknown`.  This matches the
+///   behaviour of a type system that only *rejects* programs it can *prove*
+///   wrong.  A future pass (LANG46) will insert runtime checks for these
+///   sites.
+/// - **Strict**: treat `Unknown` as an error.  Used for `(typed strict)`
+///   modules (TW05-A) and for pipelines where soundness is mandatory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RefinementMode {
+    /// `ProvenUnsafe` → error.  `Unknown` → silent.
+    #[default]
+    Lenient,
+    /// `ProvenUnsafe` → error.  `Unknown` → error.
+    Strict,
+}
+
+// ---------------------------------------------------------------------------
+// RefinementError
+// ---------------------------------------------------------------------------
+
+/// A refinement violation found during the pass.
+///
+/// One `RefinementError` is produced for each proof obligation that the
+/// solver determines is `ProvenUnsafe`, or for `Unknown` outcomes when running
+/// in [`RefinementMode::Strict`].
+///
+/// # Fields
+///
+/// - **`function`** — the function that contains the violation (the *caller*
+///   for call-site errors, the *callee* for return-site errors).
+/// - **`site`** — human-readable label identifying which parameter or return
+///   site triggered the error.
+/// - **`counter_example`** — the concrete integer value that witnesses the
+///   violation (0 for `Unknown`-promoted errors in strict mode).
+/// - **`description`** — a full sentence from the solver explaining the
+///   violation or the reason the outcome is unknown.
+#[derive(Debug, Clone)]
+pub struct RefinementError {
+    /// The function containing the violation.
+    pub function: String,
+    /// Human-readable description: which parameter or return, what annotation.
+    pub site: String,
+    /// Counter-example value that proves the violation (0 for `Unknown`).
+    pub counter_example: i128,
+    /// Full description from the checker or solver.
+    pub description: String,
+}
+
+impl std::fmt::Display for RefinementError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "error[E0042]: refinement violation\n  → function `{}`, {}\n  counter-example: {}\n  detail: {}",
+            self.function,
+            self.site,
+            self.counter_example,
+            self.description,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// check_module — the main entry point
+// ---------------------------------------------------------------------------
+
+/// Run the refinement obligation pass over all functions in `module`.
+///
+/// Returns a (possibly empty) list of violations.  The caller decides whether
+/// to abort compilation (all errors in `twig-aot`) or emit warnings.
+///
+/// # Order of operations
+///
+/// For each function in `module.functions`:
+///
+/// 1. Build a [`const_prop::ConstMap`] by scanning `const` instructions for
+///    integer literals.
+/// 2. Call [`call_checker::check_calls`] to scan `call` instructions.
+/// 3. Call [`ret_checker::check_returns`] to scan `ret` instructions.
+///
+/// The pass runs on the **original IIR before any lowering** (before
+/// `prepare_module_for_aot`), so variable names still correspond to the
+/// annotations the compiler attached.  Running it after lowering would break
+/// the name correspondence.
+///
+/// # Example
+///
+/// ```
+/// use iir_refinement_pass::{check_module, RefinementMode};
+/// use interpreter_ir::module::IIRModule;
+///
+/// let module = IIRModule::new("empty.twig", "twig");
+/// let errors = check_module(&module, RefinementMode::Lenient);
+/// assert!(errors.is_empty(), "empty module has no violations");
+/// ```
+pub fn check_module(module: &IIRModule, mode: RefinementMode) -> Vec<RefinementError> {
+    let mut errors = Vec::new();
+
+    for func in &module.functions {
+        // Step 1: build the constant-propagation map for this function.
+        let const_map = const_prop::build_const_map(func);
+
+        // Step 2: check each call site against callee param_refinements.
+        call_checker::check_calls(func, module, &const_map, mode, &mut errors);
+
+        // Step 3: check each return site against this function's return_refinement.
+        ret_checker::check_returns(func, &const_map, mode, &mut errors);
+    }
+
+    errors
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests for check_module
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+    use lang_refined_types::{RefinedType, Kind};
+    use lang_refined_types::Predicate;
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /// Closed range annotation [lo, hi].
+    fn range(lo: i128, hi: i128) -> RefinedType {
+        RefinedType::refined(
+            Kind::Int,
+            Predicate::Range { lo: Some(lo), hi: Some(hi), inclusive_hi: true },
+        )
+    }
+
+    /// Membership annotation `{values...}`.
+    fn membership(values: Vec<i128>) -> RefinedType {
+        RefinedType::refined(
+            Kind::Int,
+            Predicate::Membership { values },
+        )
+    }
+
+    /// Build a module with a callee (annotated param) and a caller (single call).
+    fn module_with_call(annotation: RefinedType, arg: Operand) -> IIRModule {
+        let callee = IIRFunction {
+            name: "callee".into(),
+            params: vec![("x".into(), "i64".into())],
+            param_refinements: vec![Some(annotation)],
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i64"),
+            ],
+            ..Default::default()
+        };
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("callee".into()), arg],
+            "i64",
+        );
+        let caller = IIRFunction {
+            name: "main".into(),
+            instructions: vec![call_instr],
+            ..Default::default()
+        };
+        let mut m = IIRModule::new("test.twig", "twig");
+        m.functions.push(callee);
+        m.functions.push(caller);
+        m
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn concrete_literal_violates_range() {
+        // The spec test: literal 200 violates [0, 128) → one error.
+        let m = module_with_call(range(0, 127), Operand::Int(200));
+        let errs = check_module(&m, RefinementMode::Lenient);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].counter_example, 200);
+    }
+
+    #[test]
+    fn concrete_literal_in_range() {
+        // 42 ∈ [0, 128) → no errors.
+        let m = module_with_call(range(0, 127), Operand::Int(42));
+        let errs = check_module(&m, RefinementMode::Lenient);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn const_tracked_variable_violates() {
+        // `const arg0 = 500; call callee arg0` — 500 violates [0, 128).
+        let ann = range(0, 127);
+        let callee = IIRFunction {
+            name: "callee".into(),
+            params: vec![("x".into(), "i64".into())],
+            param_refinements: vec![Some(ann)],
+            ..Default::default()
+        };
+        let caller = IIRFunction {
+            name: "main".into(),
+            instructions: vec![
+                IIRInstr::new("const", Some("arg0".into()), vec![Operand::Int(500)], "i64"),
+                IIRInstr::new("call", Some("r".into()),
+                    vec![Operand::Var("callee".into()), Operand::Var("arg0".into())], "i64"),
+            ],
+            ..Default::default()
+        };
+        let mut m = IIRModule::new("test.twig", "twig");
+        m.functions.push(callee);
+        m.functions.push(caller);
+        let errs = check_module(&m, RefinementMode::Lenient);
+        assert_eq!(errs.len(), 1, "500 should be caught via ConstMap");
+    }
+
+    #[test]
+    fn unconstrained_variable_lenient() {
+        // Unknown variable → Unconstrained → UNKNOWN → silent in Lenient.
+        let m = module_with_call(range(0, 127), Operand::Var("unknown".into()));
+        let errs = check_module(&m, RefinementMode::Lenient);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn unconstrained_variable_strict() {
+        // Unknown variable → UNKNOWN → error in Strict.
+        let m = module_with_call(range(0, 127), Operand::Var("unknown".into()));
+        let errs = check_module(&m, RefinementMode::Strict);
+        assert_eq!(errs.len(), 1);
+    }
+
+    #[test]
+    fn return_literal_violates_return_type() {
+        // A function annotated `-> (Int 0 255)` that returns 300 → error.
+        let func = IIRFunction {
+            name: "f".into(),
+            return_refinement: Some(range(0, 255)),
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Int(300)], "i64"),
+            ],
+            ..Default::default()
+        };
+        let mut m = IIRModule::new("test.twig", "twig");
+        m.functions.push(func);
+        let errs = check_module(&m, RefinementMode::Lenient);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].counter_example, 300);
+    }
+
+    #[test]
+    fn return_literal_satisfies_return_type() {
+        // 42 ∈ [0, 255] → no error.
+        let func = IIRFunction {
+            name: "f".into(),
+            return_refinement: Some(range(0, 255)),
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Int(42)], "i64"),
+            ],
+            ..Default::default()
+        };
+        let mut m = IIRModule::new("test.twig", "twig");
+        m.functions.push(func);
+        let errs = check_module(&m, RefinementMode::Lenient);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn unannotated_function_skipped() {
+        // No param_refinements anywhere → always 0 errors even for
+        // clearly out-of-range literals.
+        let callee = IIRFunction {
+            name: "callee".into(),
+            params: vec![("x".into(), "i64".into())],
+            param_refinements: vec![], // empty
+            ..Default::default()
+        };
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("callee".into()), Operand::Int(9999)],
+            "i64",
+        );
+        let caller = IIRFunction {
+            name: "main".into(),
+            instructions: vec![call_instr],
+            ..Default::default()
+        };
+        let mut m = IIRModule::new("test.twig", "twig");
+        m.functions.push(callee);
+        m.functions.push(caller);
+        let errs = check_module(&m, RefinementMode::Strict);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn membership_predicate_violation() {
+        // `(Int {1, 2, 5})` — only 1, 2, 5 are valid; 3 is a violation.
+        let m = module_with_call(membership(vec![1, 2, 5]), Operand::Int(3));
+        let errs = check_module(&m, RefinementMode::Lenient);
+        assert_eq!(errs.len(), 1, "3 ∉ {{1,2,5}} should be an error");
+    }
+
+    #[test]
+    fn multiple_violations_all_reported() {
+        // Callee with two annotated parameters; both arguments violate.
+        let callee = IIRFunction {
+            name: "callee".into(),
+            params: vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+            param_refinements: vec![Some(range(0, 127)), Some(range(0, 127))],
+            ..Default::default()
+        };
+        let call_instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![
+                Operand::Var("callee".into()),
+                Operand::Int(200), // violates [0,127]
+                Operand::Int(300), // violates [0,127]
+            ],
+            "i64",
+        );
+        let caller = IIRFunction {
+            name: "main".into(),
+            instructions: vec![call_instr],
+            ..Default::default()
+        };
+        let mut m = IIRModule::new("test.twig", "twig");
+        m.functions.push(callee);
+        m.functions.push(caller);
+        let errs = check_module(&m, RefinementMode::Lenient);
+        assert_eq!(errs.len(), 2, "both violations should be reported");
+    }
+
+    #[test]
+    fn empty_module_no_errors() {
+        let m = IIRModule::new("empty.twig", "twig");
+        let errs = check_module(&m, RefinementMode::Strict);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn error_display_format() {
+        // Verify the Display impl produces the expected format string.
+        let err = RefinementError {
+            function: "main".into(),
+            site: "call to `ascii-info`, argument 0".into(),
+            counter_example: 200,
+            description: "value 200 is not in [0, 128)".into(),
+        };
+        let s = format!("{err}");
+        assert!(s.contains("E0042"));
+        assert!(s.contains("main"));
+        assert!(s.contains("200"));
+    }
+}

--- a/code/packages/rust/iir-refinement-pass/src/ret_checker.rs
+++ b/code/packages/rust/iir-refinement-pass/src/ret_checker.rs
@@ -1,0 +1,237 @@
+//! Return-site refinement checker for the `iir-refinement-pass`.
+//!
+//! # Responsibility
+//!
+//! For each function that has a `return_refinement`, this module scans the
+//! function's instruction list for every `ret` instruction and checks whether
+//! the returned value provably satisfies the declared return annotation.
+//!
+//! The evidence-resolution and outcome-handling logic is identical to the
+//! call-site checker ([`call_checker`](crate::call_checker)): we use the
+//! function's [`ConstMap`] to turn constant-valued variable references into
+//! concrete evidence, and we respect the current [`RefinementMode`] when
+//! deciding whether `Unknown` outcomes become errors.
+//!
+//! # Example
+//!
+//! ```text
+//! ; function annotated `-> (Int 0 256)`
+//! const v = 500
+//! ret   v         ; v is tracked in ConstMap → Evidence::Concrete(500) → PROVEN_UNSAFE
+//! ```
+
+use interpreter_ir::instr::Operand;
+use interpreter_ir::function::IIRFunction;
+use lang_refinement_checker::{Checker, Evidence, CheckOutcome};
+
+use crate::const_prop::ConstMap;
+use crate::{RefinementError, RefinementMode};
+
+/// Check every `ret` instruction in `func` against `func.return_refinement`.
+///
+/// If the function carries no `return_refinement` the function returns
+/// immediately with no errors.  Results are appended to `errors`.
+pub fn check_returns(
+    func: &IIRFunction,
+    const_map: &ConstMap,
+    mode: RefinementMode,
+    errors: &mut Vec<RefinementError>,
+) {
+    // Fast path: no return annotation means nothing to check.
+    let annotation = match &func.return_refinement {
+        Some(ann) => ann,
+        None => return,
+    };
+
+    let mut checker = Checker::new();
+
+    for instr in &func.instructions {
+        if instr.op != "ret" {
+            continue;
+        }
+
+        // Resolve the returned value's evidence.
+        let evidence = match instr.srcs.first() {
+            Some(Operand::Int(v))   => Evidence::Concrete(*v as i128),
+            Some(Operand::Var(name)) => {
+                if let Some(&v) = const_map.get(name.as_str()) {
+                    Evidence::Concrete(v)
+                } else {
+                    Evidence::Unconstrained
+                }
+            }
+            _ => Evidence::Unconstrained,
+        };
+
+        let outcome = checker.check(annotation, &evidence);
+
+        match outcome {
+            CheckOutcome::ProvenSafe => {}
+            CheckOutcome::ProvenUnsafe(cx) => {
+                errors.push(RefinementError {
+                    function: func.name.clone(),
+                    site: "return site".to_string(),
+                    counter_example: cx.value,
+                    description: cx.description,
+                });
+            }
+            CheckOutcome::Unknown(msg) => {
+                if mode == RefinementMode::Strict {
+                    errors.push(RefinementError {
+                        function: func.name.clone(),
+                        site: "return site (UNKNOWN in strict mode)".to_string(),
+                        counter_example: 0,
+                        description: msg,
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use lang_refined_types::{RefinedType, Kind};
+    use lang_refined_types::Predicate;
+    use std::collections::HashMap;
+
+    /// `(Int 0 255)` — closed range [0, 255].
+    fn byte_annotation() -> RefinedType {
+        RefinedType::refined(
+            Kind::Int,
+            Predicate::Range {
+                lo: Some(0),
+                hi: Some(255),
+                inclusive_hi: true,
+            },
+        )
+    }
+
+    fn func_returning_literal(literal: i64, annotation: RefinedType) -> IIRFunction {
+        IIRFunction {
+            name: "f".into(),
+            return_refinement: Some(annotation),
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Int(literal)], "i64"),
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn return_literal_in_range_no_error() {
+        // 42 ∈ [0, 255] → ProvenSafe → no error.
+        let func = func_returning_literal(42, byte_annotation());
+        let mut errors = Vec::new();
+        check_returns(&func, &HashMap::new(), RefinementMode::Lenient, &mut errors);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn return_literal_out_of_range_error() {
+        // 300 ∉ [0, 255] → ProvenUnsafe → error.
+        let func = func_returning_literal(300, byte_annotation());
+        let mut errors = Vec::new();
+        check_returns(&func, &HashMap::new(), RefinementMode::Lenient, &mut errors);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].counter_example, 300);
+        assert_eq!(errors[0].site, "return site");
+    }
+
+    #[test]
+    fn return_const_tracked_variable_violation() {
+        // `const v = 999; ret v` with v tracked → caught.
+        let ann = byte_annotation();
+        let func = IIRFunction {
+            name: "f".into(),
+            return_refinement: Some(ann),
+            instructions: vec![
+                IIRInstr::new("const", Some("v".into()), vec![Operand::Int(999)], "i64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+            ],
+            ..Default::default()
+        };
+        let mut const_map = HashMap::new();
+        const_map.insert("v".to_string(), 999i128);
+        let mut errors = Vec::new();
+        check_returns(&func, &const_map, RefinementMode::Lenient, &mut errors);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].counter_example, 999);
+    }
+
+    #[test]
+    fn return_unconstrained_lenient_silent() {
+        // Unknown variable → Unconstrained → UNKNOWN → silent in Lenient.
+        let func = IIRFunction {
+            name: "f".into(),
+            return_refinement: Some(byte_annotation()),
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i64"),
+            ],
+            ..Default::default()
+        };
+        let mut errors = Vec::new();
+        check_returns(&func, &HashMap::new(), RefinementMode::Lenient, &mut errors);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn return_unconstrained_strict_error() {
+        // Unknown variable → UNKNOWN → error in Strict.
+        let func = IIRFunction {
+            name: "f".into(),
+            return_refinement: Some(byte_annotation()),
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i64"),
+            ],
+            ..Default::default()
+        };
+        let mut errors = Vec::new();
+        check_returns(&func, &HashMap::new(), RefinementMode::Strict, &mut errors);
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn no_return_annotation_skipped() {
+        // Function with no return_refinement → fast path → no errors even for
+        // an obviously bad literal.
+        let func = IIRFunction {
+            name: "f".into(),
+            return_refinement: None,
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Int(99999)], "i64"),
+            ],
+            ..Default::default()
+        };
+        let mut errors = Vec::new();
+        check_returns(&func, &HashMap::new(), RefinementMode::Strict, &mut errors);
+        assert!(errors.is_empty(), "no annotation → nothing to check");
+    }
+
+    #[test]
+    fn multiple_ret_sites_all_checked() {
+        // Two `ret` instructions in the same function → both checked.
+        let ann = byte_annotation();
+        let func = IIRFunction {
+            name: "f".into(),
+            return_refinement: Some(ann),
+            instructions: vec![
+                IIRInstr::new("ret", None, vec![Operand::Int(42)],  "i64"),
+                IIRInstr::new("ret", None, vec![Operand::Int(300)], "i64"),
+            ],
+            ..Default::default()
+        };
+        let mut errors = Vec::new();
+        check_returns(&func, &HashMap::new(), RefinementMode::Lenient, &mut errors);
+        // Only 300 violates the annotation.
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].counter_example, 300);
+    }
+}

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog — `twig-aot`
 
+## 0.1.9 — 2026-05-13 (LANG42)
+
+**Wire the refinement obligation checker into the AOT pipeline.**
+
+LANG23 built a complete refinement-type infrastructure (solver, checker, type
+annotations on `IIRFunction`), but the IIR never reached the checker —
+annotations silently did nothing.  LANG42 fixes this by adding a pre-codegen
+pass that runs immediately after `twig-ir-compiler` emits the `IIRModule`,
+before any lowering, and discharges every proof obligation through the existing
+`lang-refinement-checker` API.
+
+### New dependency
+
+- **`iir-refinement-pass = { path = "../iir-refinement-pass" }`** — new crate
+  that implements `check_module(module, mode) -> Vec<RefinementError>`.
+
+### New `AotError` variant
+
+- **`AotError::RefinementViolations(Vec<iir_refinement_pass::RefinementError>)`** —
+  returned when one or more proof obligations are `ProvenUnsafe` (Lenient mode)
+  or `ProvenUnsafe | Unknown` (Strict mode).
+
+### Changed
+
+- **`compile_module_macos_arm64_object`** now calls `check_refinements` before
+  `compile_module_to_text`.  In `Lenient` mode (default) only `ProvenUnsafe`
+  outcomes abort compilation.
+
+- **`compile_module_macos_arm64_object_with_mode`** — new public function
+  accepting an explicit `RefinementMode`.  The old function delegates to it
+  with `Lenient`.
+
+### Tests added
+
+- `refinement_violation_becomes_aot_error` — a literal that violates a
+  `(Int 0 128)` annotation returns `Err(AotError::RefinementViolations)`.
+- `safe_annotated_program_compiles_ok` — a literal within range compiles
+  normally.
+
+---
+
 ## 0.1.8 — 2026-05-13 (LANG41)
 
 **Replace macOS-specific `emit_print_helper` injection with a portable C

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source."
 
@@ -13,6 +13,7 @@ jit-core              = { path = "../jit-core" }
 code-packager         = { path = "../code-packager" }
 cli-builder           = { path = "../cli-builder" }
 iir-builtin-lowering  = { path = "../iir-builtin-lowering" }
+iir-refinement-pass   = { path = "../iir-refinement-pass" }
 tempfile             = "3"
 
 [[bin]]

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -83,6 +83,7 @@ use interpreter_ir::function::IIRFunction;
 use interpreter_ir::instr::{IIRInstr, Operand};
 use interpreter_ir::module::IIRModule;
 use iir_builtin_lowering::lower_global_io;
+use iir_refinement_pass::{check_module as check_refinements, RefinementMode};
 use jit_core::backend::FunctionContext;
 
 // ---------------------------------------------------------------------------
@@ -116,6 +117,11 @@ pub enum AotError {
         /// `ld`'s stderr, captured for diagnostics.
         stderr: String,
     },
+    /// One or more refinement proof obligations were violated (LANG42).
+    ///
+    /// In `Lenient` mode this fires only for `ProvenUnsafe` outcomes.
+    /// In `Strict` mode it also fires for `Unknown` outcomes.
+    RefinementViolations(Vec<iir_refinement_pass::RefinementError>),
 }
 
 impl std::fmt::Display for AotError {
@@ -129,6 +135,13 @@ impl std::fmt::Display for AotError {
             AotError::Io(e)                 => write!(f, "io: {e}"),
             AotError::Linker { status, stderr } =>
                 write!(f, "linker (ld) failed: status={status:?}: {stderr}"),
+            AotError::RefinementViolations(errs) => {
+                write!(f, "{} refinement violation(s):", errs.len())?;
+                for e in errs {
+                    write!(f, "\n  {e}")?;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -166,6 +179,31 @@ pub fn compile_macos_arm64_object(source: &str, module_name: &str) -> Result<Vec
 /// relocation records so that the system linker (`ld`) can patch the
 /// `ADRP + ADD` instruction pairs that address `_twig_globals`.
 pub fn compile_module_macos_arm64_object(module: &IIRModule) -> Result<Vec<u8>, AotError> {
+    compile_module_macos_arm64_object_with_mode(module, RefinementMode::Lenient)
+}
+
+/// Like [`compile_module_macos_arm64_object`] but with an explicit
+/// [`RefinementMode`].
+///
+/// Use `RefinementMode::Strict` for `(typed strict)` modules (TW05-A) or any
+/// pipeline that must treat `Unknown` solver outcomes as hard errors.
+pub fn compile_module_macos_arm64_object_with_mode(
+    module: &IIRModule,
+    refinement_mode: RefinementMode,
+) -> Result<Vec<u8>, AotError> {
+    // ── LANG42: refinement obligation pass ──────────────────────────────────
+    //
+    // Run the pass on the *original* IIR before any lowering.  After
+    // `prepare_module_for_aot` runs, variable names are rewritten and the
+    // correspondence between names and annotations is lost — so we must check
+    // before we mutate the module.
+    //
+    // `check_refinements` returns an empty Vec if there are no violations.
+    let refinement_errors = check_refinements(module, refinement_mode);
+    if !refinement_errors.is_empty() {
+        return Err(AotError::RefinementViolations(refinement_errors));
+    }
+
     let entry = module.entry_point.as_deref().ok_or(AotError::NoEntryPoint)?;
     let (text, offsets, n_global_slots, global_relocs, extern_relocs) =
         compile_module_to_text(module)?;
@@ -1208,5 +1246,54 @@ mod tests {
         assert_eq!(&bytes[0..4], &[0xCF, 0xFA, 0xED, 0xFE]);
         let filetype = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
         assert_eq!(filetype, 1, "MH_OBJECT");
+    }
+
+    // ── LANG42: refinement checker wired into twig-aot ────────────────────
+    //
+    // The Twig IR compiler already parses `(param : (Int lo hi))` syntax and
+    // wires the annotation into `IIRFunction::param_refinements`.  LANG42 adds
+    // the pass that *checks* those annotations before codegen.
+    //
+    // These tests use the source-string path (`compile_macos_arm64_object`) so
+    // we don't need to add `lang-refined-types` to twig-aot's dev-dependencies.
+
+    #[test]
+    fn refinement_violation_becomes_aot_error() {
+        // The worked example from the LANG42 spec (top-level expression form,
+        // same pattern as `fib_compiles_ok` which avoids BackendRefused):
+        //
+        //   (define (ascii-info (codepoint : (Int 0 128))) codepoint)
+        //   (ascii-info 200)        ← 200 violates [0, 128)
+        //
+        // The refinement pass fires BEFORE prepare_module_for_aot so we catch
+        // the violation even though the module might fail codegen later.
+        //
+        // 200 violates (Int 0 128) → ProvenUnsafe → AotError::RefinementViolations.
+        let src = "(define (ascii-info (codepoint : (Int 0 128))) codepoint) \
+                   (ascii-info 200)";
+        let result = compile_macos_arm64_object(src, "refinement_test");
+        assert!(
+            matches!(result, Err(AotError::RefinementViolations(_))),
+            "expected RefinementViolations, got: {:?}",
+            result.as_ref().err(),
+        );
+        if let Err(AotError::RefinementViolations(errs)) = result {
+            assert!(!errs.is_empty(), "at least one error expected");
+            assert_eq!(errs[0].counter_example, 200, "counter-example should be 200");
+        }
+    }
+
+    #[test]
+    fn safe_annotated_program_compiles_ok() {
+        // (ascii-info 42) — 42 ∈ [0, 128) → ProvenSafe → no refinement error.
+        // Same top-level expression form as fib_compiles_ok.
+        let src = "(define (ascii-info (codepoint : (Int 0 128))) codepoint) \
+                   (ascii-info 42)";
+        let result = compile_macos_arm64_object(src, "refinement_safe");
+        assert!(
+            result.is_ok(),
+            "safe annotated program should compile; got: {:?}",
+            result.err(),
+        );
     }
 }

--- a/code/specs/LANG42-refinement-checker-wiring.md
+++ b/code/specs/LANG42-refinement-checker-wiring.md
@@ -1,0 +1,257 @@
+# LANG42 — Refinement Obligation Checker Wired into `twig-aot`
+
+## Motivation
+
+LANG23 built the entire refinement-type infrastructure:
+
+- `lang-refined-types` — `RefinedType`, `Predicate`, `Kind` data types
+- `constraint-vm` + `constraint-engine` — DPLL SAT solver + Cooper's LIA
+- `lang-refinement-checker` — four-tier checker (per-binding, function-scope,
+  module-scope, program-scope)
+- `twig-ir-compiler` — populates `IIRFunction::param_refinements` and
+  `IIRFunction::return_refinement` from parsed type annotations
+
+But the IIR never reaches the checker.  The annotations silently do nothing:
+the `twig-aot` pipeline compiles functions, runs the AOT linker, and emits
+machine code — never asking whether any refinement obligation is violated.
+
+LANG42 wires the checker into the pipeline.  After `twig-ir-compiler` emits
+an `IIRModule`, a new pre-codegen pass (`iir-refinement-pass`) scans call
+sites and return sites, resolves argument evidence via lightweight constant
+propagation, and discharges proof obligations through the existing
+`lang-refinement-checker` API.
+
+The result: a literal argument that provably violates a parameter annotation
+becomes a **compile error with a counter-example** rather than silently
+producing broken machine code.
+
+---
+
+## New crate: `iir-refinement-pass`
+
+```
+code/packages/rust/iir-refinement-pass/
+  Cargo.toml
+  CHANGELOG.md
+  README.md
+  src/
+    lib.rs            — public API: check_module, RefinementMode, RefinementError
+    const_prop.rs     — ConstMap: scan IIR instructions for compile-time literals
+    call_checker.rs   — check call-site arguments against callee param_refinements
+    ret_checker.rs    — check return values against function return_refinement
+```
+
+### Public API
+
+```rust
+/// Operating mode — how to handle UNKNOWN outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RefinementMode {
+    /// PROVEN_UNSAFE → compile error.  UNKNOWN → silent (emit runtime check
+    /// when the runtime-check insertion pass is implemented; for now no-op).
+    #[default]
+    Lenient,
+    /// PROVEN_UNSAFE → compile error.  UNKNOWN → compile error.
+    /// Used by (typed strict) modules and for correctness-critical pipelines.
+    Strict,
+}
+
+/// A refinement violation found during the pass.
+#[derive(Debug, Clone)]
+pub struct RefinementError {
+    /// The function containing the violation.
+    pub function: String,
+    /// Human-readable description: which parameter or return, what annotation.
+    pub site: String,
+    /// Counter-example value that proves the violation.
+    pub counter_example: i128,
+    /// Full description from the checker.
+    pub description: String,
+}
+
+/// Run the refinement obligation pass over all functions in `module`.
+///
+/// Returns a (possibly empty) list of violations.  The caller decides
+/// whether to abort compilation (all errors) or emit warnings (lenient).
+pub fn check_module(module: &IIRModule, mode: RefinementMode) -> Vec<RefinementError>;
+```
+
+---
+
+## Algorithm
+
+### Step 1 — Constant propagation map
+
+For each function, scan its instruction list once and build:
+
+```
+ConstMap: HashMap<String, i128>
+```
+
+A variable `v` is entered into the map if and only if exactly one `const`
+instruction in the function sets `dest = Some("v")` with `srcs[0] =
+Operand::Int(n)`.  Re-assignments (multiple `const` to same dest) evict the
+entry (conservative: treat as `Unconstrained`).
+
+This is a simple, single-pass, intra-procedural constant map — no dataflow,
+no join points, no loops.  It handles the common pattern:
+
+```
+const  arg0 = 500     ; Operand::Int(500) → ConstMap["arg0"] = 500
+call   callee arg0    ; evidence for arg0 = Concrete(500)
+```
+
+### Step 2 — Call-site checking
+
+For every `call` instruction (`op == "call"`):
+
+1. `callee_name` = `srcs[0]` as `Var` string
+2. Look up `callee_fn` in `module.functions` by name
+3. If `callee_fn.param_refinements` is empty → skip (no annotations)
+4. For each `(i, arg)` in `srcs[1..]` (argument list):
+   - `annotation` = `callee_fn.param_refinements.get(i)` → if `None`, skip
+   - Resolve evidence:
+     - `Operand::Int(v)` → `Evidence::Concrete(v as i128)`
+     - `Operand::Var(name)` + `name ∈ ConstMap` → `Evidence::Concrete(map[name])`
+     - Otherwise → `Evidence::Unconstrained`
+   - `outcome` = `Checker::check(annotation, evidence)`
+   - `ProvenUnsafe(cx)` → push `RefinementError`
+   - `Unknown(_)` and `mode == Strict` → push `RefinementError` (with no counter-example value, description = solver message)
+   - `ProvenSafe` → silent
+
+### Step 3 — Return-site checking
+
+For every `ret` instruction (`op == "ret"`) in a function with
+`return_refinement = Some(annotation)`:
+
+1. Resolve evidence from `srcs[0]`:
+   - `Operand::Int(v)` → `Evidence::Concrete(v as i128)`
+   - `Operand::Var(name)` + `name ∈ ConstMap` → `Evidence::Concrete(map[name])`
+   - Otherwise → `Evidence::Unconstrained`
+2. Check and emit errors identically to call-site step.
+
+---
+
+## Integration into `twig-aot`
+
+### Location in pipeline
+
+```
+twig-ir-compiler::compile_source → IIRModule  (has param_refinements, return_refinement)
+       │
+       ▼  ← NEW: iir_refinement_pass::check_module(&module, mode)
+                  if errors → return Err(AotError::RefinementViolations(errors))
+       │
+       ▼
+prepare_module_for_aot (lower_builtins, lower_global_io, …)
+       │
+       ▼
+compile each function → ARM64 machine code
+```
+
+The pass runs on the **original IIR before any lowering**, so annotations
+refer to the same variable names the compiler produced.  Running it after
+`prepare_module_for_aot` would see rewritten instructions where the
+correspondence between variable names and annotations is lost.
+
+### New `AotError` variant
+
+```rust
+/// One or more refinement proof obligations were violated.
+///
+/// In lenient mode this only fires for PROVEN_UNSAFE outcomes.
+/// In strict mode it also fires for UNKNOWN outcomes.
+RefinementViolations(Vec<iir_refinement_pass::RefinementError>),
+```
+
+### `RefinementMode` exposure
+
+`compile_macos_arm64_object` and `compile_module_macos_arm64_object` gain an
+optional `refinement_mode: RefinementMode` parameter (default `Lenient`).
+The internal helper `compile_module_to_text` threads it through.
+
+---
+
+## Worked example
+
+```scheme
+; source.twig
+(define (ascii-info (codepoint : (Int 0 128)))
+  codepoint)
+
+(define (main)
+  (ascii-info 200))   ; ← 200 violates [0, 128)
+```
+
+LANG42 output (lenient mode):
+
+```
+error[E0042]: refinement violation
+  → function main, call to ascii-info, argument 0
+  annotation: (Int 0 128)
+  counter-example: value 200 violates annotation
+```
+
+```scheme
+(define (clamp-byte (x : (Int 0 256)) -> (Int 0 256))
+  x)
+
+(define (main)
+  (clamp-byte 42))    ; ← 42 ∈ [0, 256) → ProvenSafe → no error
+```
+
+No error emitted.
+
+---
+
+## Tests to add
+
+### `iir-refinement-pass`
+
+- `concrete_literal_violates_range` — call with literal out of range → `RefinementError`
+- `concrete_literal_in_range` → no errors
+- `const_tracked_variable_violates` — const then call via variable → caught
+- `unconstrained_variable_lenient` — variable with unknown value → silent
+- `unconstrained_variable_strict` — same in strict mode → error
+- `return_literal_violates_return_type` → `RefinementError`
+- `return_literal_satisfies_return_type` → no errors
+- `unannotated_function_skipped` — no `param_refinements` → always 0 errors
+- `membership_predicate_violation` — `(Int {1, 2, 5})` with value 3 → error
+- `multiple_violations_all_reported` — two bad args → two errors
+
+### `twig-aot`
+
+- `refinement_violation_becomes_aot_error` — `compile_macos_arm64_object` with a
+  violating source returns `Err(AotError::RefinementViolations(...))`
+- `safe_annotated_program_compiles_ok` — annotated but valid program compiles
+
+---
+
+## What this does NOT do (future work)
+
+- **CFG-based path-sensitive checking** (FunctionChecker, ModuleChecker) —
+  requires building `CfgNode` trees from IIR.  Planned for LANG45.
+- **Runtime check insertion** — UNKNOWN outcomes should insert a
+  `type_assert`-style guard in the IIR.  Planned for LANG46.
+- **Refinement narrowing** — proven-safe checks should narrow the downstream
+  `RefinedType`.  Planned for LANG47.
+- **`(typed strict)` module declaration** — the TW05-A syntax extension that
+  sets the module-level default to `Strict`.  Planned for TW05-A.
+
+---
+
+## Files to create / update
+
+| File | Action |
+|------|--------|
+| `code/specs/LANG42-refinement-checker-wiring.md` | CREATE (this file) |
+| `code/packages/rust/iir-refinement-pass/Cargo.toml` | CREATE |
+| `code/packages/rust/iir-refinement-pass/src/lib.rs` | CREATE |
+| `code/packages/rust/iir-refinement-pass/src/const_prop.rs` | CREATE |
+| `code/packages/rust/iir-refinement-pass/src/call_checker.rs` | CREATE |
+| `code/packages/rust/iir-refinement-pass/src/ret_checker.rs` | CREATE |
+| `code/packages/rust/iir-refinement-pass/CHANGELOG.md` | CREATE |
+| `code/packages/rust/iir-refinement-pass/README.md` | CREATE |
+| `code/packages/rust/twig-aot/Cargo.toml` | UPDATE — add `iir-refinement-pass` dep |
+| `code/packages/rust/twig-aot/src/lib.rs` | UPDATE — call pass before codegen |
+| `code/packages/rust/Cargo.toml` | UPDATE — add `iir-refinement-pass` to workspace |


### PR DESCRIPTION
## Summary

- **New crate `iir-refinement-pass`**: implements `check_module(module, mode) -> Vec<RefinementError>`, a pre-codegen pass that discharges refinement proof obligations against the IIR using the existing `lang-refinement-checker` infrastructure (DPLL SAT + Cooper's LIA).
- **Wired into `twig-aot`**: `compile_module_macos_arm64_object` now calls the pass on the original IIR before any lowering; literal arguments that provably violate parameter annotations become `AotError::RefinementViolations` instead of silently producing broken machine code.
- **Two modes**: `Lenient` (default, `ProvenUnsafe` → error, `Unknown` → silent) and `Strict` (both → error), exposed via new `compile_module_macos_arm64_object_with_mode`.

### Algorithm
1. Build `ConstMap<String, i128>` from `const` instructions (single-pass, SSA-conservative eviction on re-assignment)
2. For each `call` instruction: resolve evidence (Concrete if literal/const-tracked, else Unconstrained), check against callee `param_refinements`
3. For each `ret` instruction in annotated function: check against `return_refinement`

### Tests
- 32 unit tests + 2 doc tests in `iir-refinement-pass` (all 10 spec-defined tests covered)
- 2 integration tests in `twig-aot`: `refinement_violation_becomes_aot_error`, `safe_annotated_program_compiles_ok`

## Test plan

- [ ] `cargo test -p iir-refinement-pass` — 32 tests pass
- [ ] `cargo test -p twig-aot` — 8 unit + 5 integration tests pass
- [ ] Security review: passed (no vulnerabilities found)
- [ ] `cargo build --workspace` — no new compile errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)