### PR TITLE
Harden UNO R4 bootloader port recovery

### DIFF
--- a/code/packages/rust/board-vm-serial/src/lib.rs
+++ b/code/packages/rust/board-vm-serial/src/lib.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 use board_vm_client::{RawFrameTransport, TransportError};
 use board_vm_stream::{StreamTransport, StreamTransportError};
 pub use serialport::{
-    ClearBuffer, DataBits, FlowControl, Parity, SerialPort, SerialPortInfo, StopBits,
+    ClearBuffer, DataBits, FlowControl, Parity, SerialPort, SerialPortInfo, SerialPortType,
+    StopBits, UsbPortInfo,
 };
 
 pub const DEFAULT_BAUD_RATE: u32 = 115_200;

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -220,12 +220,14 @@ Silicon this keeps the upload path on Arduino's patched BOSSA build; install
 Rosetta if that packaged uploader is x86-only. Override `--rustc`, `--arm-gcc`,
 `--arm-gxx`, `--arm-ar`, `--arm-compat-root`, `--objcopy`, `--arduino-cli`,
 `--bossac-path`, `--target-dir`, `--baud`, or `--timeout-ms` for local tooling
-differences. Before upload, the helper now performs the Arduino-compatible
-1200-baud bootloader touch on the requested port and polls for the bootloader
-port before invoking Arduino CLI. Pass `--no-bootloader-touch` when the board is
-already in bootloader mode, or tune
+differences. Before upload, the helper performs the Arduino-compatible
+1200-baud bootloader touch on the requested port and waits for the UNO R4 WiFi
+bootloader USB identity before invoking Arduino CLI. It no longer treats an
+unchanged runtime port as flashable after a failed touch; if the bootloader PID
+does not appear, retry with a manual double-tap or tune
 `--bootloader-touch-timeout-ms`, `--bootloader-touch-settle-ms`, and
-`--bootloader-port-wait-ms` for local USB timing.
+`--bootloader-port-wait-ms` for local USB timing. Pass `--no-bootloader-touch`
+only when the board is already in bootloader mode.
 
 After flashing any Board VM server image manually, run the host smoke test
 against the adapter serial port:

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
@@ -10,11 +10,15 @@ use std::thread;
 use std::time::{Duration, Instant};
 use std::vec::Vec;
 
-use board_vm_serial::{available_ports, touch_arduino_bootloader_with_timing};
+use board_vm_serial::{
+    available_ports, touch_arduino_bootloader_with_timing, SerialPortInfo, SerialPortType,
+};
 
 use crate::arduino_usb_link::{
     ARDUINO_ARM_AR_ENV_VAR, ARDUINO_ARM_COMPAT_ROOT_ENV_VAR, ARDUINO_ARM_GCC_ENV_VAR,
-    ARDUINO_ARM_GXX_ENV_VAR, ARDUINO_CORE_ENV_VAR, ARDUINO_USB_LINK_ENV_VAR, UNO_R4_WIFI_FQBN,
+    ARDUINO_ARM_GXX_ENV_VAR, ARDUINO_CORE_ENV_VAR, ARDUINO_USB_LINK_ENV_VAR,
+    UNO_R4_WIFI_BOOTLOADER_USB_PID, UNO_R4_WIFI_FQBN, UNO_R4_WIFI_RUNTIME_USB_PID,
+    UNO_R4_WIFI_RUNTIME_USB_VID,
 };
 
 pub const SERIAL_USB_SERVER_BIN: &str = "uno-r4-wifi-serialusb-server";
@@ -289,7 +293,7 @@ impl SerialUsbArtifactOptions {
     }
 
     pub fn touch_bootloader_port(&self, port: &str) -> Result<String, ArtifactCliError> {
-        let before = serial_port_names()?;
+        let before = serial_ports()?;
         touch_arduino_bootloader_with_timing(
             port,
             Duration::from_millis(self.bootloader_touch_timeout_ms),
@@ -357,40 +361,78 @@ pub fn parse_new_upload_port(output: &str) -> Option<String> {
 
 pub fn choose_bootloader_port(
     requested: &str,
-    before: &[String],
-    after: &[String],
+    before: &[SerialPortInfo],
+    after: &[SerialPortInfo],
 ) -> Option<String> {
+    let is_new = |port: &SerialPortInfo| {
+        !before
+            .iter()
+            .any(|candidate| candidate.port_name == port.port_name)
+    };
+
     after
         .iter()
-        .find(|port| !before.contains(port) && port.contains("usbmodem"))
-        .or_else(|| after.iter().find(|port| !before.contains(port)))
-        .or_else(|| after.iter().find(|port| port.as_str() == requested))
-        .cloned()
+        .find(|port| port.port_name == requested && is_uno_r4_bootloader_port(port))
+        .or_else(|| {
+            after
+                .iter()
+                .find(|port| is_new(port) && is_uno_r4_bootloader_port(port))
+        })
+        .or_else(|| {
+            after.iter().find(|port| {
+                is_new(port) && port.port_name.contains("usbmodem") && !is_uno_r4_runtime_port(port)
+            })
+        })
+        .or_else(|| {
+            after
+                .iter()
+                .find(|port| is_new(port) && !is_uno_r4_runtime_port(port))
+        })
+        .map(|port| port.port_name.clone())
 }
 
 fn wait_for_bootloader_port(
     requested: &str,
-    before: &[String],
+    before: &[SerialPortInfo],
     wait: Duration,
     poll: Duration,
 ) -> Result<String, ArtifactCliError> {
     let deadline = Instant::now() + wait;
     loop {
-        let after = serial_port_names()?;
+        let after = serial_ports()?;
         if let Some(port) = choose_bootloader_port(requested, before, &after) {
             return Ok(port);
         }
         if Instant::now() >= deadline {
-            return Ok(requested.to_string());
+            return Err(ArtifactCliError::BootloaderPortTimeout {
+                port: requested.to_string(),
+                wait_ms: wait.as_millis(),
+            });
         }
         thread::sleep(poll);
     }
 }
 
-fn serial_port_names() -> Result<Vec<String>, ArtifactCliError> {
-    available_ports()
-        .map(|ports| ports.into_iter().map(|port| port.port_name).collect())
-        .map_err(|error| ArtifactCliError::BootloaderPortList(error.to_string()))
+fn serial_ports() -> Result<Vec<SerialPortInfo>, ArtifactCliError> {
+    available_ports().map_err(|error| ArtifactCliError::BootloaderPortList(error.to_string()))
+}
+
+fn is_uno_r4_bootloader_port(port: &SerialPortInfo) -> bool {
+    matches!(
+        &port.port_type,
+        SerialPortType::UsbPort(usb)
+            if usb.vid == UNO_R4_WIFI_RUNTIME_USB_VID
+                && usb.pid == UNO_R4_WIFI_BOOTLOADER_USB_PID
+    )
+}
+
+fn is_uno_r4_runtime_port(port: &SerialPortInfo) -> bool {
+    matches!(
+        &port.port_type,
+        SerialPortType::UsbPort(usb)
+            if usb.vid == UNO_R4_WIFI_RUNTIME_USB_VID
+                && usb.pid == UNO_R4_WIFI_RUNTIME_USB_PID
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -412,6 +454,7 @@ pub enum ArtifactCliError {
     InvalidNumber { option: &'static str, value: String },
     BootloaderTouch(String),
     BootloaderPortList(String),
+    BootloaderPortTimeout { port: String, wait_ms: u128 },
     UnknownOption(String),
 }
 
@@ -425,6 +468,10 @@ impl fmt::Display for ArtifactCliError {
             }
             Self::BootloaderTouch(error) => write!(f, "bootloader touch failed: {error}"),
             Self::BootloaderPortList(error) => write!(f, "bootloader port listing failed: {error}"),
+            Self::BootloaderPortTimeout { port, wait_ms } => write!(
+                f,
+                "bootloader port did not appear after touching {port}; waited {wait_ms}ms for UNO R4 WiFi USB VID 0x{UNO_R4_WIFI_RUNTIME_USB_VID:04X} PID 0x{UNO_R4_WIFI_BOOTLOADER_USB_PID:04X}"
+            ),
             Self::UnknownOption(option) => write!(f, "unknown option: {option}"),
         }
     }
@@ -660,6 +707,7 @@ fn shell_escape(value: &OsStr) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use board_vm_serial::UsbPortInfo;
     use std::ffi::OsString;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -709,6 +757,26 @@ mod tests {
         ));
         let _ = fs::remove_dir_all(&dir);
         dir
+    }
+
+    fn unknown_port(name: &str) -> SerialPortInfo {
+        SerialPortInfo {
+            port_name: name.to_string(),
+            port_type: SerialPortType::Unknown,
+        }
+    }
+
+    fn usb_port(name: &str, vid: u16, pid: u16) -> SerialPortInfo {
+        SerialPortInfo {
+            port_name: name.to_string(),
+            port_type: SerialPortType::UsbPort(UsbPortInfo {
+                vid,
+                pid,
+                serial_number: None,
+                manufacturer: None,
+                product: None,
+            }),
+        }
     }
 
     #[test]
@@ -930,13 +998,17 @@ mod tests {
     #[test]
     fn bootloader_port_selection_prefers_new_usbmodem_ports() {
         let before = vec![
-            "/dev/cu.debug-console".to_string(),
-            "/dev/cu.usbmodem1101".to_string(),
+            unknown_port("/dev/cu.debug-console"),
+            usb_port(
+                "/dev/cu.usbmodem1101",
+                UNO_R4_WIFI_RUNTIME_USB_VID,
+                UNO_R4_WIFI_RUNTIME_USB_PID,
+            ),
         ];
         let after = vec![
-            "/dev/cu.debug-console".to_string(),
-            "/dev/cu.usbserial-abc".to_string(),
-            "/dev/cu.usbmodem2201".to_string(),
+            unknown_port("/dev/cu.debug-console"),
+            unknown_port("/dev/cu.usbserial-abc"),
+            unknown_port("/dev/cu.usbmodem2201"),
         ];
 
         assert_eq!(
@@ -946,13 +1018,62 @@ mod tests {
     }
 
     #[test]
-    fn bootloader_port_selection_falls_back_to_requested_port() {
-        let before = vec!["/dev/cu.usbmodem1101".to_string()];
-        let after = vec!["/dev/cu.usbmodem1101".to_string()];
+    fn bootloader_port_selection_accepts_requested_port_when_it_is_bootloader() {
+        let before = vec![usb_port(
+            "/dev/cu.usbmodem1101",
+            UNO_R4_WIFI_RUNTIME_USB_VID,
+            UNO_R4_WIFI_RUNTIME_USB_PID,
+        )];
+        let after = vec![usb_port(
+            "/dev/cu.usbmodem1101",
+            UNO_R4_WIFI_RUNTIME_USB_VID,
+            UNO_R4_WIFI_BOOTLOADER_USB_PID,
+        )];
 
         assert_eq!(
             choose_bootloader_port("/dev/cu.usbmodem1101", &before, &after),
             Some("/dev/cu.usbmodem1101".to_string())
+        );
+    }
+
+    #[test]
+    fn bootloader_port_selection_rejects_unchanged_runtime_port() {
+        let before = vec![usb_port(
+            "/dev/cu.usbmodem1101",
+            UNO_R4_WIFI_RUNTIME_USB_VID,
+            UNO_R4_WIFI_RUNTIME_USB_PID,
+        )];
+        let after = before.clone();
+
+        assert_eq!(
+            choose_bootloader_port("/dev/cu.usbmodem1101", &before, &after),
+            None
+        );
+    }
+
+    #[test]
+    fn bootloader_port_selection_rejects_new_runtime_identity() {
+        let before = vec![usb_port(
+            "/dev/cu.usbmodem1101",
+            UNO_R4_WIFI_RUNTIME_USB_VID,
+            UNO_R4_WIFI_RUNTIME_USB_PID,
+        )];
+        let after = vec![
+            usb_port(
+                "/dev/cu.usbmodem1101",
+                UNO_R4_WIFI_RUNTIME_USB_VID,
+                UNO_R4_WIFI_RUNTIME_USB_PID,
+            ),
+            usb_port(
+                "/dev/cu.usbmodem2201",
+                UNO_R4_WIFI_RUNTIME_USB_VID,
+                UNO_R4_WIFI_RUNTIME_USB_PID,
+            ),
+        ];
+
+        assert_eq!(
+            choose_bootloader_port("/dev/cu.usbmodem1101", &before, &after),
+            None
         );
     }
 


### PR DESCRIPTION
## Summary
- Wait for the UNO R4 WiFi bootloader USB VID/PID before invoking Arduino CLI upload after a 1200-baud touch.
- Stop treating an unchanged runtime serial port as flashable, so failed reset attempts fail early with a precise bootloader-not-seen error.
- Re-export serial USB metadata for host-side board identity checks and document the updated recovery behavior.

## Validation
- `cargo fmt -p board-vm-serial -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-serial -p board-vm-uno-r4-firmware`
- `cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --print-only --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" --arm-toolchain-bin /opt/homebrew/bin --port /dev/cu.usbmodem1101 --upload --smoke`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

## Hardware Note
- The attached UNO R4 WiFi remained visible as runtime PID `0x006D`; a physical `--upload --smoke` attempt with a 10000 ms bootloader wait stopped before upload with the expected error that bootloader PID `0x1002` never appeared. This keeps BOSSA from trying the wrong runtime port and leaves the next recovery step explicit.