### PR TITLE
ts(macsyma): recognize elliptic first-kind integrals

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add TypeScript MACSYMA parity for elliptic first-kind integration, so
+  `integrate(1/sqrt(1-k^2*sin(theta)^2), theta)` returns
+  `EllipticF(theta, k)` and the `[0, %pi/2]` definite form returns
+  `EllipticK(k)`.
 - Add TypeScript MACSYMA parity for perfect-cube expansions, so
   `factor(x^3 + 3*x^2*y + 3*x*y^2 + y^3)` returns `(x+y)^3` and
   `factor(x^3 - 3*x^2*y + 3*x*y^2 - y^3)` returns `(x-y)^3` through the

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -291,6 +291,20 @@ describe("macsyma-runtime", () => {
     expect(base.args).toEqual([sym("x"), sym("y")]);
   });
 
+  it("recognizes elliptic first-kind integrals through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("integrate(1/sqrt(1-k^2*sin(theta)^2), theta);");
+
+    expect(result.output).toEqual(app(sym("EllipticF"), [sym("theta"), sym("k")]));
+  });
+
+  it("recognizes complete elliptic first-kind integrals through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("integrate(1/sqrt(1-k^2*sin(theta)^2), theta, 0, %pi/2);");
+
+    expect(result.output).toEqual(app(sym("EllipticK"), [sym("k")]));
+  });
+
   it("tracks the showtime option flag through normal assignments", () => {
     const session = new MacsymaSession();
     const [enabled, timed, disabled, untimed] = session.evalSource(

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added symbolic integration recognition for the canonical elliptic first-kind
+  forms, returning `EllipticF(theta, k)` and complete `EllipticK(k)` nodes.
 - Added a bivariate perfect-cube factoring foothold so `Factor` recognises
   four-term binomial cube expansions: `x^3 + 3x^2y + 3xy^2 + y^3` as
   `(x+y)^3` and `x^3 - 3x^2y + 3xy^2 - y^3` as `(x-y)^3`.

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1038,12 +1038,16 @@ function nodeKey(node: IRNode): string {
 
 function integrate(): Handler {
   return (vm, expr) => {
-    if (expr.args.length !== 2) {
-      throw new ArityError(`Integrate expects 2 arguments, got ${expr.args.length}`);
+    if (expr.args.length !== 2 && expr.args.length !== 4) {
+      throw new ArityError(`Integrate expects 2 or 4 arguments, got ${expr.args.length}`);
     }
     const [f, x] = expr.args;
     if (x.kind !== "symbol") {
       return expr;
+    }
+    if (expr.args.length === 4) {
+      const result = completeEllipticFirstKind(f, x, expr.args[2], expr.args[3]);
+      return result === undefined ? expr : vm.eval(result);
     }
     const result = integrateIndefinite(f, x);
     if (result === undefined) {
@@ -1059,6 +1063,10 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
   }
   if (equals(f, x)) {
     return app(MUL, [rational(1, 2), app(POW, [x, int(2)])]);
+  }
+  const elliptic = incompleteEllipticFirstKind(f, x);
+  if (elliptic !== undefined) {
+    return elliptic;
   }
   if (f.kind !== "apply") {
     return undefined;
@@ -1127,6 +1135,75 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
   }
 
   return undefined;
+}
+
+function completeEllipticFirstKind(f: IRNode, x: IRNode, lower: IRNode, upper: IRNode): IRNode | undefined {
+  if (!isZero(lower) || !isPiOverTwo(upper)) {
+    return undefined;
+  }
+  const modulus = ellipticFirstKindModulus(f, x);
+  return modulus === undefined ? undefined : app(sym("EllipticK"), [modulus]);
+}
+
+function incompleteEllipticFirstKind(f: IRNode, x: IRNode): IRNode | undefined {
+  const modulus = ellipticFirstKindModulus(f, x);
+  return modulus === undefined ? undefined : app(sym("EllipticF"), [x, modulus]);
+}
+
+function ellipticFirstKindModulus(f: IRNode, x: IRNode): IRNode | undefined {
+  let radicand: IRNode | undefined;
+  if (f.kind === "apply" && equals(f.head, DIV)) {
+    const [numerator, denominator] = binaryArgs(f);
+    if (isOne(numerator) && denominator.kind === "apply" && equals(denominator.head, SQRT)) {
+      [radicand] = unaryArgs(denominator);
+    }
+  } else if (f.kind === "apply" && equals(f.head, POW)) {
+    const [base, exponent] = binaryArgs(f);
+    const n = exactRational(exponent);
+    if (n?.numer === -1n && n.denom === 2n) {
+      radicand = base;
+    }
+  }
+  if (radicand?.kind !== "apply" || !equals(radicand.head, SUB)) {
+    return undefined;
+  }
+
+  const [constant, product] = binaryArgs(radicand);
+  if (!isOne(constant) || product.kind !== "apply" || !equals(product.head, MUL)) {
+    return undefined;
+  }
+  const [left, right] = binaryArgs(product);
+  return modulusFromSquaredFactor(left, right, x) ?? modulusFromSquaredFactor(right, left, x);
+}
+
+function modulusFromSquaredFactor(modulusSquare: IRNode, sineSquare: IRNode, x: IRNode): IRNode | undefined {
+  if (sineSquare.kind !== "apply" || !equals(sineSquare.head, POW)) {
+    return undefined;
+  }
+  const [sine, sineExponent] = binaryArgs(sineSquare);
+  if (!equals(sineExponent, int(2)) || sine.kind !== "apply" || !equals(sine.head, SIN)) {
+    return undefined;
+  }
+  const [inner] = unaryArgs(sine);
+  if (!equals(inner, x)) {
+    return undefined;
+  }
+  if (modulusSquare.kind !== "apply" || !equals(modulusSquare.head, POW)) {
+    return undefined;
+  }
+  const [modulus, modulusExponent] = binaryArgs(modulusSquare);
+  return equals(modulusExponent, int(2)) ? modulus : undefined;
+}
+
+function isPiOverTwo(node: IRNode): boolean {
+  if (node.kind === "float") {
+    return Math.abs(node.value - Math.PI / 2) < 1e-12;
+  }
+  if (node.kind !== "apply" || !equals(node.head, DIV)) {
+    return false;
+  }
+  const [numerator, denominator] = binaryArgs(node);
+  return numerator.kind === "symbol" && numerator.name === "%pi" && equals(denominator, int(2));
 }
 
 function differentiate(): Handler {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -537,6 +537,29 @@ describe("symbolic-vm", () => {
     );
   });
 
+  it("recognizes elliptic first-kind integrals", () => {
+    const vm = new VM(new SymbolicBackend());
+    const theta = sym("theta");
+    const k = sym("k");
+    const integrand = app(DIV, [
+      int(1),
+      app(SQRT, [
+        app(SUB, [
+          int(1),
+          app(MUL, [
+            app(POW, [k, int(2)]),
+            app(POW, [app(SIN, [theta]), int(2)]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    expect(vm.eval(app(INTEGRATE, [integrand, theta]))).toEqual(app(sym("EllipticF"), [theta, k]));
+    expect(vm.eval(app(INTEGRATE, [integrand, theta, int(0), app(DIV, [sym("%pi"), int(2)])]))).toEqual(
+      app(sym("EllipticK"), [k]),
+    );
+  });
+
   it("leaves unknown dependent integrals unevaluated", () => {
     const vm = new VM(new SymbolicBackend());
     const expr = app(INTEGRATE, [app(sym("F"), [sym("x")]), sym("x")]);


### PR DESCRIPTION
## Summary

- recognize canonical TypeScript symbolic VM first-kind elliptic integrals as `EllipticF(theta, k)`
- recognize the complete `[0, %pi/2]` first-kind definite form as `EllipticK(k)`
- add MACSYMA runtime parity coverage for both forms

## Validation

- `npm test -- symbolic-vm.test.ts -t elliptic` in `code/packages/typescript/symbolic-vm`
- `npm test -- runtime.test.ts -t elliptic` in `code/packages/typescript/macsyma-runtime`
- `npm test` in `code/packages/typescript/symbolic-vm`
- `npm test` in `code/packages/typescript/macsyma-runtime`
- `npm run build` in `code/packages/typescript/symbolic-vm`
- `npm run build` in `code/packages/typescript/macsyma-runtime`
- `git diff --check`
