### PR TITLE
feat(matrix-cuda): MX06 Phase 2 — BufferStore over cuMemAlloc / cuMemcpy*

### DIFF
--- a/code/packages/rust/matrix-cuda/CHANGELOG.md
+++ b/code/packages/rust/matrix-cuda/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog — matrix-cuda
 
+## 0.2.0 — 2026-05-13
+
+### Added — MX06 Phase 2 (`BufferStore` over `cuMemAlloc` / `cuMemcpy*`)
+
+Lands the device-memory module, the per-executor `HashMap<BufferId,
+CudaBuffer>` that Phase 3+ dispatch will use to alloc / upload /
+download / free GPU buffers.
+
+- New module `src/buffers.rs` with `pub struct BufferStore`:
+  - `new()` / `default()` — empty store.
+  - `alloc(device, id, bytes) -> Result<(), String>` —
+    `cuMemAlloc` via `cuda-compute`, replaces any prior buffer at
+    `id`, propagates `cuda-compute`'s typed error on zero-length
+    allocations.
+  - `write(device, id, offset, data)` — `cuMemcpyHtoD` via
+    `cuda-compute::CudaDevice::upload`.  Phase 2 supports
+    `offset = 0` only (every caller in `matrix-metal::dispatch`
+    uses 0 today; partial writes land in a later phase).
+  - `read(device, id, offset, len) -> Result<Vec<u8>, _>` —
+    `cuMemcpyDtoH` via `cuda-compute::CudaDevice::download`, then
+    slice on the host.  Supports arbitrary offset / len.
+  - `free(id)` — idempotent.
+  - `get(id) -> Result<&CudaBuffer, _>` — used by Phase 3 dispatch
+    to look up `CUdeviceptr`s for `cuLaunchKernel`.
+  - `contains(id)`, `len()`, `is_empty()`.
+- Re-exported from `lib.rs` as `matrix_cuda::BufferStore`.
+
+### Why this is its own PR
+
+Phase 2 ships the module **alone**, without wiring it into the
+executor's `Mutex<State>` and `handle()`.  That deferral exists
+because `cuda-compute::CudaBuffer` doesn't yet implement `Send` —
+adding it (and wiring the alloc/upload/download/free request paths
+through the executor mutex) is a coherent unit of work that
+belongs in Phase 3 alongside generic NVRTC kernel compilation.
+
+The module is usable directly today (see the unit tests for
+example call patterns); Phase 3 will simply replace the existing
+`NOT_IMPLEMENTED` branches for `AllocBuffer` / `UploadBuffer` /
+`DownloadBuffer` / `FreeBuffer` with delegation to a
+`Mutex<BufferStore>` field on the executor.
+
+### Tests
+
+14 new unit tests in `buffers::tests`, all passing:
+
+- `new_store_is_empty`, `default_matches_new`,
+  `free_unknown_id_is_idempotent_noop`, `get_unknown_id_errors`
+  run on every platform.
+- `alloc_then_free_round_trips`, `alloc_replaces_existing_buffer_at_same_id`,
+  `round_trip_write_then_read_matches_input`,
+  `read_with_offset_returns_correct_slice`,
+  `write_unknown_id_errors`, `write_nonzero_offset_errors_in_phase_2`,
+  `read_unknown_id_errors`, `read_past_end_errors`,
+  `read_offset_plus_len_overflow_errors`, `alloc_zero_bytes_errors`
+  are device-gated: on hosts without an NVIDIA driver
+  (`CudaDevice::new(0)` fails) they silently pass.  On the Linux
+  CI runner they currently no-op for the same reason; Phase 5 will
+  add a `MATRIX_CUDA_TESTS=1` env-gated suite for real GPU
+  coverage.
+
+Total crate test count: 26 (12 from Phase 1 + 14 new).
+
+### No public surface broken
+
+Phase 1's API is unchanged.  `BufferStore` is a strictly additive
+addition.  `local_transport()`, `register()`, `CudaExecutor::new()`
+all behave exactly as before.
+
+### No `unsafe` introduced
+
+`buffers.rs` is `unsafe`-free; all FFI safety lives in
+`cuda-compute`.
+
 ## 0.1.0 — 2026-05-13
 
 ### Added — MX06 Phase 1 (crate skeleton + stub)

--- a/code/packages/rust/matrix-cuda/Cargo.toml
+++ b/code/packages/rust/matrix-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-cuda"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "MX06 Phase 1 — CUDA GPU executor skeleton for the matrix execution layer. Wraps the runtime-loaded `cuda-compute` driver wrapper so the crate compiles on every platform; when libcuda is unavailable at runtime, constructors return Err(...) and the planner silently skips this executor. Phase 1 ships the executor shell, capability declaration, and stubbed dispatch handler; Phases 2–7 land buffers, kernels, the specialised emitter, real Executor impl, MX05 hooks, and planner integration."
 license = "MIT"

--- a/code/packages/rust/matrix-cuda/README.md
+++ b/code/packages/rust/matrix-cuda/README.md
@@ -37,13 +37,30 @@ for the full design.  Phased rollout, one PR per phase:
 
 | Phase | Lands                                                  | Status |
 | ----- | ------------------------------------------------------ | ------ |
-| 1     | crate skeleton, `BackendProfile`, stubbed dispatch     | **this PR** |
-| 2     | `BufferStore` over `cuMemAlloc` / `cuMemcpy*`           | pending |
-| 3     | `kernels.rs` — generic NVRTC-compiled kernels           | pending |
+| 1     | crate skeleton, `BackendProfile`, stubbed dispatch     | landed (0.1.0) |
+| 2     | `BufferStore` over `cuMemAlloc` / `cuMemcpy*`           | **this PR** (0.2.0) |
+| 3     | `kernels.rs` — generic NVRTC-compiled kernels (also adds `Send` to `CudaBuffer` and wires the buffer store into `handle()`) | pending |
 | 4     | `cuda_emitter.rs` — specialised-kernel code generator   | pending |
 | 5     | `specialised_table.rs` + real `Executor` impl           | pending |
 | 6     | MX05 hooks — `backend_id = 2` in image-gpu-core         | pending |
 | 7     | Planner integration — cost-model coefficients           | pending |
+
+## Phase 2 additions
+
+- `pub mod buffers` — `BufferStore` over `cuda-compute`'s
+  `CudaDevice::alloc` / `upload` / `download`.  Same shape as
+  `matrix-metal::BufferStore`, suitable for the dispatch wiring that
+  Phase 3 will add.
+- Re-exported as `matrix_cuda::BufferStore`.
+- 14 new unit tests (most device-gated; silent pass on non-NVIDIA
+  hosts).
+
+**Note**: the `handle()` dispatch surface still returns
+`NOT_IMPLEMENTED` for `AllocBuffer` / `UploadBuffer` /
+`DownloadBuffer` / `FreeBuffer`.  Wiring the store through the
+executor's `Mutex<State>` requires `CudaBuffer: Send`, which
+`cuda-compute` doesn't ship yet — both changes land together in
+Phase 3.
 
 ## What this phase ships
 

--- a/code/packages/rust/matrix-cuda/src/buffers.rs
+++ b/code/packages/rust/matrix-cuda/src/buffers.rs
@@ -1,0 +1,367 @@
+//! `BufferStore` for matrix-cuda — owns a `HashMap<BufferId, CudaBuffer>`.
+//!
+//! Mirrors `matrix-metal::buffers::BufferStore` and `matrix-cpu`'s buffer
+//! store in shape, so the dispatch code in Phase 3+ can be written
+//! parallel to its Metal counterpart.
+//!
+//! Differences from the Metal store:
+//!
+//! - `MetalBuffer` lives in unified memory on Apple Silicon, so the
+//!   Metal store exposes `as_slice` / `as_slice_mut` and writes are
+//!   in-place memcpys.  CUDA device memory lives behind PCIe — we
+//!   round-trip through `cuMemcpyHtoD` (`CudaDevice::upload`) and
+//!   `cuMemcpyDtoH` (`CudaDevice::download`).
+//!
+//! - Phase 2 supports **offset = 0 only**.  Every caller in
+//!   `matrix-metal::dispatch` uses `offset = 0` today (confirmed via
+//!   grep), so this isn't a functional limitation for the upcoming
+//!   Phase 3 dispatch code.  When a real need for offset writes
+//!   appears, we'll either add an offset variant to `cuda-compute`'s
+//!   API or do the download / patch / upload dance here.
+//!
+//! - Cross-platform: `cuda-compute` already loads `libcuda.so` /
+//!   `nvcuda.dll` at runtime via `dlopen`/`LoadLibrary` and returns
+//!   `Err(CudaError::NotAvailable)` when the driver is absent.  We
+//!   thread that error through transparently — no `#[cfg]` split.
+
+use compute_ir::BufferId;
+use cuda_compute::{CudaBuffer, CudaDevice};
+use std::collections::HashMap;
+
+/// Process-local map of `BufferId → CudaBuffer`.
+///
+/// Owned by `CudaExecutor::State` (Phase 3 onwards) and accessed
+/// only under the executor's `Mutex`, so the store itself can stay
+/// `!Sync` without extra wrapping.
+pub struct BufferStore {
+    buffers: HashMap<BufferId, CudaBuffer>,
+}
+
+impl BufferStore {
+    /// Construct an empty store.
+    pub fn new() -> Self {
+        BufferStore {
+            buffers: HashMap::new(),
+        }
+    }
+
+    /// Number of currently-resident buffers.  Useful for tests and
+    /// for leak detection — the executor's drop path should leave
+    /// this at zero on shutdown.
+    pub fn len(&self) -> usize {
+        self.buffers.len()
+    }
+
+    /// Is the store empty?
+    pub fn is_empty(&self) -> bool {
+        self.buffers.is_empty()
+    }
+
+    /// Allocate `bytes` of device memory at `id`.
+    ///
+    /// Replaces any existing buffer at that id — matches matrix-cpu /
+    /// matrix-metal semantics.  The dropped buffer's destructor
+    /// (provided by `cuda-compute::CudaBuffer`) will run, freeing the
+    /// device allocation.
+    ///
+    /// `cuda-compute` rejects zero-length allocations with a typed
+    /// error; we forward that decision so call sites get a clear
+    /// message instead of a confusing silent zero-byte handle.
+    pub fn alloc(
+        &mut self,
+        device: &CudaDevice,
+        id: BufferId,
+        bytes: usize,
+    ) -> Result<(), String> {
+        let buf = device
+            .alloc(bytes)
+            .map_err(|e| format!("alloc {} bytes: {:?}", bytes, e))?;
+        self.buffers.insert(id, buf);
+        Ok(())
+    }
+
+    /// Free a buffer.  Idempotent — freeing an unknown id is a no-op,
+    /// matching the matrix-metal and matrix-cpu contract.
+    pub fn free(&mut self, id: BufferId) {
+        self.buffers.remove(&id);
+    }
+
+    /// Write `data` into the buffer at `id`, starting at byte
+    /// `offset`.
+    ///
+    /// **Phase 2 limitation**: `offset` must be `0`.  See the module
+    /// doc-comment for why.
+    ///
+    /// Errors if:
+    /// - The buffer doesn't exist.
+    /// - `offset != 0` (Phase 2 restriction).
+    /// - `data.len() > buffer.len()` — `cuda-compute` enforces this
+    ///   itself and returns a typed error that we propagate.
+    pub fn write(
+        &mut self,
+        device: &CudaDevice,
+        id: BufferId,
+        offset: usize,
+        data: &[u8],
+    ) -> Result<(), String> {
+        if offset != 0 {
+            return Err(format!(
+                "matrix-cuda Phase 2: write offset must be 0 (got {}); \
+                 partial writes land in a later phase",
+                offset
+            ));
+        }
+        let buf = self
+            .buffers
+            .get(&id)
+            .ok_or_else(|| format!("buffer {} not found", id.0))?;
+        device
+            .upload(buf, data)
+            .map_err(|e| format!("upload to buffer {}: {:?}", id.0, e))
+    }
+
+    /// Read `len` bytes from the buffer at `id`, starting at byte
+    /// `offset`.
+    ///
+    /// Phase 2 supports arbitrary `offset` / `len` ranges by
+    /// downloading the whole buffer (single device→host transfer)
+    /// and slicing on the host.  This is wasteful for large buffers
+    /// but is the minimum-viable read implementation — Phase 3+ can
+    /// introduce a partial-download path when a real workload
+    /// justifies it.
+    ///
+    /// Errors if the buffer doesn't exist, or if `offset + len`
+    /// extends past the buffer.
+    pub fn read(
+        &self,
+        device: &CudaDevice,
+        id: BufferId,
+        offset: usize,
+        len: usize,
+    ) -> Result<Vec<u8>, String> {
+        let buf = self
+            .buffers
+            .get(&id)
+            .ok_or_else(|| format!("buffer {} not found", id.0))?;
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| "offset + len overflows usize".to_string())?;
+        if end > buf.len() {
+            return Err(format!(
+                "read past end: offset {} + len {} > buffer size {}",
+                offset,
+                len,
+                buf.len()
+            ));
+        }
+        let host = device
+            .download(buf)
+            .map_err(|e| format!("download buffer {}: {:?}", id.0, e))?;
+        Ok(host[offset..end].to_vec())
+    }
+
+    /// Borrow a buffer immutably by id.  Returns `Err` if the buffer
+    /// doesn't exist.  Dispatch code (Phase 3+) calls this to look
+    /// up `CUdeviceptr`s for `cuLaunchKernel`.
+    pub fn get(&self, id: BufferId) -> Result<&CudaBuffer, String> {
+        self.buffers
+            .get(&id)
+            .ok_or_else(|| format!("buffer {} not found", id.0))
+    }
+
+    /// Does the store hold a buffer at `id`?
+    pub fn contains(&self, id: BufferId) -> bool {
+        self.buffers.contains_key(&id)
+    }
+}
+
+impl Default for BufferStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn device_or_skip() -> Option<CudaDevice> {
+        // The tests below need a live CUDA device.  On hosts without
+        // an NVIDIA driver (macOS, NVIDIA-less Linux, NVIDIA-less
+        // Windows), `CudaDevice::new(0)` fails and the test is a
+        // silent pass — matches matrix-metal's "skip if no device"
+        // convention.
+        CudaDevice::new(0).ok()
+    }
+
+    #[test]
+    fn new_store_is_empty() {
+        let s = BufferStore::new();
+        assert_eq!(s.len(), 0);
+        assert!(s.is_empty());
+        assert!(!s.contains(BufferId(0)));
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let a = BufferStore::new();
+        let b = BufferStore::default();
+        assert_eq!(a.len(), b.len());
+        assert_eq!(a.is_empty(), b.is_empty());
+    }
+
+    #[test]
+    fn alloc_then_free_round_trips() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let mut s = BufferStore::new();
+        let id = BufferId(7);
+        s.alloc(&device, id, 64).expect("alloc 64 bytes");
+        assert_eq!(s.len(), 1);
+        assert!(s.contains(id));
+        s.free(id);
+        assert_eq!(s.len(), 0);
+        assert!(!s.contains(id));
+    }
+
+    #[test]
+    fn free_unknown_id_is_idempotent_noop() {
+        let mut s = BufferStore::new();
+        s.free(BufferId(42)); // would panic if not idempotent
+        s.free(BufferId(42));
+        assert_eq!(s.len(), 0);
+    }
+
+    #[test]
+    fn alloc_replaces_existing_buffer_at_same_id() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let mut s = BufferStore::new();
+        let id = BufferId(3);
+        s.alloc(&device, id, 16).unwrap();
+        s.alloc(&device, id, 32).unwrap();
+        // Still one buffer at `id`; the prior allocation was dropped.
+        assert_eq!(s.len(), 1);
+        let buf = s.get(id).unwrap();
+        assert_eq!(buf.len(), 32);
+    }
+
+    #[test]
+    fn round_trip_write_then_read_matches_input() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let mut s = BufferStore::new();
+        let id = BufferId(1);
+        let payload: Vec<u8> = (0..32).collect();
+        s.alloc(&device, id, payload.len()).unwrap();
+        s.write(&device, id, 0, &payload).unwrap();
+        let out = s.read(&device, id, 0, payload.len()).unwrap();
+        assert_eq!(out, payload);
+    }
+
+    #[test]
+    fn read_with_offset_returns_correct_slice() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let mut s = BufferStore::new();
+        let id = BufferId(2);
+        let payload: Vec<u8> = (0..32).collect();
+        s.alloc(&device, id, payload.len()).unwrap();
+        s.write(&device, id, 0, &payload).unwrap();
+        // Read bytes 4..12 inclusive of 4, exclusive of 12 → 8 bytes.
+        let out = s.read(&device, id, 4, 8).unwrap();
+        assert_eq!(out, vec![4, 5, 6, 7, 8, 9, 10, 11]);
+    }
+
+    #[test]
+    fn write_unknown_id_errors() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let mut s = BufferStore::new();
+        let err = s
+            .write(&device, BufferId(99), 0, &[0u8; 4])
+            .unwrap_err();
+        assert!(err.contains("not found"), "{}", err);
+    }
+
+    #[test]
+    fn write_nonzero_offset_errors_in_phase_2() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let mut s = BufferStore::new();
+        let id = BufferId(5);
+        s.alloc(&device, id, 8).unwrap();
+        let err = s.write(&device, id, 1, &[0u8; 4]).unwrap_err();
+        assert!(err.contains("offset must be 0"), "{}", err);
+    }
+
+    #[test]
+    fn read_unknown_id_errors() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let s = BufferStore::new();
+        let err = s.read(&device, BufferId(123), 0, 4).unwrap_err();
+        assert!(err.contains("not found"), "{}", err);
+    }
+
+    #[test]
+    fn read_past_end_errors() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let mut s = BufferStore::new();
+        let id = BufferId(6);
+        s.alloc(&device, id, 8).unwrap();
+        let err = s.read(&device, id, 4, 100).unwrap_err();
+        assert!(err.contains("read past end"), "{}", err);
+    }
+
+    #[test]
+    fn read_offset_plus_len_overflow_errors() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let mut s = BufferStore::new();
+        let id = BufferId(7);
+        s.alloc(&device, id, 16).unwrap();
+        let err = s
+            .read(&device, id, usize::MAX, 1)
+            .unwrap_err();
+        assert!(err.contains("overflow"), "{}", err);
+    }
+
+    #[test]
+    fn alloc_zero_bytes_errors() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        // cuda-compute rejects zero-length allocations.  We surface
+        // its typed error transparently.
+        let mut s = BufferStore::new();
+        let err = s.alloc(&device, BufferId(8), 0).unwrap_err();
+        assert!(
+            err.contains("alloc 0 bytes") || err.contains("zero-length"),
+            "{}",
+            err
+        );
+    }
+
+    #[test]
+    fn get_unknown_id_errors() {
+        let s = BufferStore::new();
+        // CudaBuffer doesn't implement Debug, so .unwrap_err()
+        // doesn't compile.  Pattern-match instead — same coverage,
+        // doesn't add a Debug bound to cuda-compute.
+        match s.get(BufferId(0)) {
+            Ok(_) => panic!("expected Err on unknown id"),
+            Err(msg) => assert!(msg.contains("not found"), "{}", msg),
+        }
+    }
+}

--- a/code/packages/rust/matrix-cuda/src/lib.rs
+++ b/code/packages/rust/matrix-cuda/src/lib.rs
@@ -60,6 +60,9 @@
 
 #![warn(rust_2018_idioms)]
 
+mod buffers;
+pub use buffers::BufferStore;
+
 use compute_ir::ExecutorId;
 use executor_protocol::{
     BackendProfile, ErrorCode, ExecutorRequest, ExecutorResponse, LocalTransport,
@@ -199,6 +202,14 @@ impl CudaExecutor {
     ///   resources to release.
     /// - Every other variant returns `NOT_IMPLEMENTED` with a
     ///   pointer to the spec so future readers know where to look.
+    ///
+    /// **Note (MX06 Phase 2)**: the new [`BufferStore`] module is
+    /// callable directly (see its docs) but is **not** wired into
+    /// this dispatch handler yet — that requires `cuda-compute`'s
+    /// `CudaBuffer` to be `Send` so it can live behind the
+    /// executor's `Mutex<State>`.  Phase 3 will land both the
+    /// `Send` impl on `CudaBuffer` and the wiring here in one
+    /// coherent change, alongside generic kernel compilation.
     pub fn handle(&self, req: ExecutorRequest) -> ExecutorResponse {
         let our_id = match self.state.lock() {
             Ok(g) => g.our_id,
@@ -210,9 +221,6 @@ impl CudaExecutor {
             },
             ExecutorRequest::Heartbeat => ExecutorResponse::Alive { profile: profile() },
             ExecutorRequest::Shutdown => ExecutorResponse::Registered {
-                // Shutdown has no dedicated reply; mirror matrix-metal's
-                // pattern of echoing Registered when we have nothing to
-                // tear down.
                 executor_id: our_id,
             },
             ExecutorRequest::Dispatch { job_id, .. }
@@ -220,7 +228,7 @@ impl CudaExecutor {
             | ExecutorRequest::CancelJob { job_id } => ExecutorResponse::Error {
                 code: ErrorCode::NOT_IMPLEMENTED,
                 message:
-                    "matrix-cuda: Phase 1 stub — dispatch lands in Phase 5; see code/specs/MX06-cuda-executor.md"
+                    "matrix-cuda: dispatch lands in Phase 5; see code/specs/MX06-cuda-executor.md"
                         .to_string(),
                 job_id: Some(job_id),
             },
@@ -231,7 +239,7 @@ impl CudaExecutor {
             | ExecutorRequest::FreeBuffer { .. } => ExecutorResponse::Error {
                 code: ErrorCode::NOT_IMPLEMENTED,
                 message:
-                    "matrix-cuda: Phase 1 stub — buffer / kernel ops land in Phases 2–3"
+                    "matrix-cuda: buffer / kernel dispatch wiring lands in Phase 3 (BufferStore module is callable directly, see crate docs)"
                         .to_string(),
                 job_id: None,
             },


### PR DESCRIPTION
## Summary

- Adds `src/buffers.rs` to `matrix-cuda` — the per-executor `HashMap<BufferId, CudaBuffer>` module that wraps `cuda-compute`'s alloc / upload / download / free calls.
- Shape mirrors `matrix-metal::buffers::BufferStore` so Phase 3 dispatch code can be written parallel to its Metal counterpart.
- Re-exported as `matrix_cuda::BufferStore`.

## Why split from Phase 3

Phase 2 ships the module **alone**, without wiring into the executor's `Mutex<State>` and `handle()`. That deferral exists because `cuda-compute::CudaBuffer` doesn't yet implement `Send` — adding the `Send` impl on `CudaBuffer` AND wiring `AllocBuffer` / `UploadBuffer` / `DownloadBuffer` / `FreeBuffer` request paths through the executor mutex belongs in Phase 3, alongside the generic NVRTC kernel compilation, as one coherent change.

The module is fully usable today (see the unit tests for call patterns).

## Test plan

- [x] `cargo test -p matrix-cuda` — 26 tests passing (12 from Phase 1 + 14 new).
- [x] 4 device-independent buffer tests run on every platform.
- [x] 10 device-gated buffer tests silently pass on this macOS host (`CudaDevice::new(0)` returns `Err`). They will exercise real device paths once a `MATRIX_CUDA_TESTS=1` env-gated CI matrix entry lands in Phase 5.
- [x] `/security-review` — passed (no unsafe in this file, bounds + overflow checks on read, offset=0 restriction on write, idempotent free).
- [x] No public surface broken; Phase 1's API is unchanged.

## What this phase does NOT change

- `handle()` still returns `NOT_IMPLEMENTED` for buffer ops — Phase 3 wires them.
- No GPU dispatch (Phase 5).
- No `image-gpu-core` wiring (Phase 6).
- No planner cost-model calibration (Phase 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)