### PR TITLE
[codex] Add Board VM bootloader reboot command

### DIFF
--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -52,6 +52,7 @@ pub enum CliCommand {
     PicoUf2List,
     Smoke(SmokeOptions),
     Repl(ReplOptions),
+    BootloaderReboot(BootloaderRebootOptions),
     EjectBlink(EjectBlinkOptions),
     Help,
 }
@@ -161,6 +162,33 @@ pub struct ReplOptions {
 }
 
 impl ReplOptions {
+    pub fn serial_config(&self, port: &str) -> SerialConfig {
+        SerialConfig::new(port)
+            .baud_rate(self.baud_rate)
+            .timeout(Duration::from_millis(self.timeout_ms))
+            .dtr_on_open(true)
+            .clear_on_open(true)
+            .settle_on_open(Duration::from_millis(DEFAULT_OPEN_SETTLE_MS))
+    }
+
+    pub fn tcp_config(&self, endpoint: &str) -> TcpConfig {
+        TcpConfig::new(endpoint)
+            .connect_timeout(Duration::from_millis(self.timeout_ms))
+            .io_timeout(Duration::from_millis(self.timeout_ms))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootloaderRebootOptions {
+    pub port: Option<String>,
+    pub endpoint: Option<String>,
+    pub board: String,
+    pub baud_rate: u32,
+    pub timeout_ms: u64,
+    pub host_nonce: u32,
+}
+
+impl BootloaderRebootOptions {
     pub fn serial_config(&self, port: &str) -> SerialConfig {
         SerialConfig::new(port)
             .baud_rate(self.baud_rate)
@@ -422,6 +450,7 @@ where
         "pico-uf2-list" | "list-pico-uf2" | "list-pico" => Ok(CliCommand::PicoUf2List),
         "smoke" => parse_smoke_args(args),
         "repl" => parse_repl_args(args),
+        "bootloader-reboot" | "reboot-bootloader" => parse_bootloader_reboot_args(args),
         "eject" => parse_eject_args(args),
         "help" | "--help" | "-h" => Ok(CliCommand::Help),
         other => Err(CliError::UnknownCommand(other.to_owned())),
@@ -585,6 +614,21 @@ where
         timeout_ms: options.timeout_ms,
         program_id: options.program_id,
         instruction_budget: options.instruction_budget,
+        host_nonce: options.host_nonce,
+    }))
+}
+
+fn parse_bootloader_reboot_args<I>(mut args: I) -> Result<CliCommand, CliError>
+where
+    I: Iterator<Item = String>,
+{
+    let options = parse_session_options(&mut args)?;
+    Ok(CliCommand::BootloaderReboot(BootloaderRebootOptions {
+        port: options.port,
+        endpoint: options.endpoint,
+        board: options.board,
+        baud_rate: options.baud_rate,
+        timeout_ms: options.timeout_ms,
         host_nonce: options.host_nonce,
     }))
 }
@@ -826,6 +870,12 @@ pub struct SmokeReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootloaderRebootReport {
+    pub connection: SmokeConnectionReport,
+    pub hello: HelloAckInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SmokeConnectionReport {
     pub transport: SmokeConnectionTransport,
     pub label: String,
@@ -1022,6 +1072,19 @@ pub fn run_smoke(options: &SmokeOptions) -> Result<SmokeReport, CliError> {
     run_smoke_with_connection(options, connection_transport, connection_label, transport)
 }
 
+pub fn run_bootloader_reboot(
+    options: &BootloaderRebootOptions,
+) -> Result<BootloaderRebootReport, CliError> {
+    let (connection_transport, connection_label, transport) =
+        open_bootloader_reboot_transport(options)?;
+    run_bootloader_reboot_with_connection(
+        options,
+        connection_transport,
+        connection_label,
+        transport,
+    )
+}
+
 #[cfg(test)]
 fn run_smoke_with_transport<T>(
     options: &SmokeOptions,
@@ -1034,6 +1097,22 @@ where
         options,
         smoke_connection_transport(options),
         smoke_connection_label(options),
+        transport,
+    )
+}
+
+#[cfg(test)]
+fn run_bootloader_reboot_with_transport<T>(
+    options: &BootloaderRebootOptions,
+    transport: T,
+) -> Result<BootloaderRebootReport, CliError>
+where
+    T: RawFrameTransport,
+{
+    run_bootloader_reboot_with_connection(
+        options,
+        bootloader_reboot_connection_transport(options),
+        bootloader_reboot_connection_label(options),
         transport,
     )
 }
@@ -1088,6 +1167,28 @@ where
         descriptor,
         upload,
         run,
+    })
+}
+
+fn run_bootloader_reboot_with_connection<T>(
+    options: &BootloaderRebootOptions,
+    connection_transport: SmokeConnectionTransport,
+    connection_label: impl Into<String>,
+    transport: T,
+) -> Result<BootloaderRebootReport, CliError>
+where
+    T: RawFrameTransport,
+{
+    let mut client: BoardVmClient<_, 512, 768, 768> = BoardVmClient::new(transport);
+    let hello = client.hello_with_name(DEFAULT_HOST_NAME, options.host_nonce)?;
+    client.reboot_to_bootloader()?;
+    Ok(BootloaderRebootReport {
+        connection: SmokeConnectionReport {
+            transport: connection_transport,
+            label: connection_label.into(),
+            timeout_ms: options.timeout_ms,
+        },
+        hello,
     })
 }
 
@@ -1374,8 +1475,54 @@ fn smoke_connection_label(options: &SmokeOptions) -> String {
     }
 }
 
+#[cfg(test)]
+fn bootloader_reboot_connection_transport(
+    options: &BootloaderRebootOptions,
+) -> SmokeConnectionTransport {
+    if let Some(endpoint) = options.endpoint.as_deref() {
+        return SmokeConnectionTransport::from(
+            endpoint_transport(endpoint).expect("test bootloader endpoint should be valid"),
+        );
+    }
+    SmokeConnectionTransport::SerialPort
+}
+
+#[cfg(test)]
+fn bootloader_reboot_connection_label(options: &BootloaderRebootOptions) -> String {
+    if let Some(endpoint) = options.endpoint.as_deref() {
+        return format!("endpoint={endpoint}");
+    }
+    match options.port.as_deref() {
+        Some(port) => format!("port={port} baud={}", options.baud_rate),
+        None => format!("board={} baud={}", options.board, options.baud_rate),
+    }
+}
+
 fn open_smoke_transport(
     options: &SmokeOptions,
+) -> Result<(SmokeConnectionTransport, String, SessionTransport), CliError> {
+    if let Some(endpoint) = options.endpoint.as_deref() {
+        ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
+        let connection_transport = SmokeConnectionTransport::from(endpoint_transport(endpoint)?);
+        let transport = open_endpoint_transport(endpoint, &options.tcp_config(endpoint))?;
+        return Ok((
+            connection_transport,
+            format!("endpoint={endpoint}"),
+            transport,
+        ));
+    }
+
+    let port = resolve_session_port(options.port.as_deref(), &options.board)?;
+    let transport = BoardSerialTransport::<_, 1024>::open(&options.serial_config(&port))?;
+    Ok((
+        SmokeConnectionTransport::SerialPort,
+        format!("port={} baud={}", port, options.baud_rate),
+        SessionTransport::Serial(transport),
+    ))
+}
+
+fn open_bootloader_reboot_transport(
+    options: &BootloaderRebootOptions,
 ) -> Result<(SmokeConnectionTransport, String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
@@ -1831,7 +1978,7 @@ pub fn format_onboard_led(led: Option<OnboardLed>) -> String {
 }
 
 pub fn usage() -> &'static str {
-    "usage:\n  board-vm list-ports\n  board-vm list-targets\n  board-vm esp-detect --port <path> [--baud <rate>] [--timeout-ms <ms>] [--no-reset]\n  board-vm esp-upload --port <path> --image <path> [--offset <addr>] [--block-size <bytes>] [--flash-size <bytes>] [--baud <rate>] [--timeout-ms <ms>] [--no-reset] [--no-verify] [--stay-in-bootloader]\n  board-vm pico-uf2 --image <path.uf2> [--mount <RPI-RP2 mount>]\n  board-vm pico-uf2 --list\n  board-vm smoke [--port <path>|--endpoint tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm repl [--port <path>|--endpoint tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm eject blink --out <path> [--program-id <id>] [--slot <slot>] [--boot-policy store-only|run-at-boot|run-if-no-host|<u8>]"
+    "usage:\n  board-vm list-ports\n  board-vm list-targets\n  board-vm esp-detect --port <path> [--baud <rate>] [--timeout-ms <ms>] [--no-reset]\n  board-vm esp-upload --port <path> --image <path> [--offset <addr>] [--block-size <bytes>] [--flash-size <bytes>] [--baud <rate>] [--timeout-ms <ms>] [--no-reset] [--no-verify] [--stay-in-bootloader]\n  board-vm pico-uf2 --image <path.uf2> [--mount <RPI-RP2 mount>]\n  board-vm pico-uf2 --list\n  board-vm smoke [--port <path>|--endpoint tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm repl [--port <path>|--endpoint tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm bootloader-reboot [--port <path>|--endpoint tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--host-nonce <u32>]\n  board-vm eject blink --out <path> [--program-id <id>] [--slot <slot>] [--boot-policy store-only|run-at-boot|run-if-no-host|<u8>]"
 }
 
 #[cfg(test)]
@@ -1839,7 +1986,10 @@ mod tests {
     use super::*;
     use board_vm_client::{CapabilityInfo, TransportError};
     use board_vm_loopback::{LoopbackBoard, LOOPBACK_BOARD_ID, LOOPBACK_RUNTIME_ID};
-    use board_vm_protocol::RunStatus;
+    use board_vm_protocol::{
+        decode_frame, decode_hello, encode_frame, encode_hello_ack, Frame, HelloAck, MessageType,
+        RunStatus, FLAG_IS_RESPONSE,
+    };
 
     struct LoopbackSmokeTransport {
         board: LoopbackBoard<512, 8, 8>,
@@ -1864,6 +2014,64 @@ mod tests {
             self.board
                 .handle_raw_frame(request, &mut self.board_payload, response_out)
                 .map_err(|_| TransportError::Io)
+        }
+    }
+
+    struct BootloaderRebootTransport {
+        payload: [u8; 128],
+    }
+
+    impl BootloaderRebootTransport {
+        fn new() -> Self {
+            Self { payload: [0; 128] }
+        }
+    }
+
+    impl RawFrameTransport for BootloaderRebootTransport {
+        fn exchange_raw_frame(
+            &mut self,
+            request: &[u8],
+            response_out: &mut [u8],
+        ) -> Result<usize, TransportError> {
+            let request = decode_frame(request).map_err(|_| TransportError::Io)?;
+            match request.message_type {
+                MessageType::HELLO => {
+                    let hello = decode_hello(request.payload).map_err(|_| TransportError::Io)?;
+                    let payload_len = encode_hello_ack(
+                        &HelloAck {
+                            selected_version: 1,
+                            board_name: LOOPBACK_BOARD_ID,
+                            runtime_name: LOOPBACK_RUNTIME_ID,
+                            host_nonce: hello.host_nonce,
+                            board_nonce: 0xB04D_B007,
+                            max_frame_payload: 256,
+                        },
+                        &mut self.payload,
+                    )
+                    .map_err(|_| TransportError::Io)?;
+                    encode_frame(
+                        &Frame {
+                            flags: FLAG_IS_RESPONSE,
+                            message_type: MessageType::HELLO_ACK,
+                            request_id: request.request_id,
+                            payload: &self.payload[..payload_len],
+                        },
+                        response_out,
+                    )
+                    .map_err(|_| TransportError::Io)
+                }
+                MessageType::BOOTLOADER_REBOOT => encode_frame(
+                    &Frame {
+                        flags: FLAG_IS_RESPONSE,
+                        message_type: MessageType::BOOTLOADER_REBOOT,
+                        request_id: request.request_id,
+                        payload: &[],
+                    },
+                    response_out,
+                )
+                .map_err(|_| TransportError::Io),
+                _ => Err(TransportError::Io),
+            }
         }
     }
 
@@ -2372,6 +2580,35 @@ mod tests {
     }
 
     #[test]
+    fn parses_bootloader_reboot_defaults() {
+        let command = parse_args(["bootloader-reboot", "--port", "/dev/cu.usbmodem-test"]).unwrap();
+
+        assert_eq!(
+            command,
+            CliCommand::BootloaderReboot(BootloaderRebootOptions {
+                port: Some("/dev/cu.usbmodem-test".to_owned()),
+                endpoint: None,
+                board: "auto".to_owned(),
+                baud_rate: DEFAULT_BAUD_RATE,
+                timeout_ms: DEFAULT_TIMEOUT_MS,
+                host_nonce: DEFAULT_HOST_NONCE,
+            })
+        );
+
+        assert_eq!(
+            parse_args(["reboot-bootloader", "--board", "uno-r4-wifi"]).unwrap(),
+            CliCommand::BootloaderReboot(BootloaderRebootOptions {
+                port: None,
+                endpoint: None,
+                board: "uno-r4-wifi".to_owned(),
+                baud_rate: DEFAULT_BAUD_RATE,
+                timeout_ms: DEFAULT_TIMEOUT_MS,
+                host_nonce: DEFAULT_HOST_NONCE,
+            })
+        );
+    }
+
+    #[test]
     fn parses_smoke_ble_endpoint() {
         let endpoint = "ble://AA:BB:CC:DD:EE:FF?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e";
         let command = parse_args(["smoke", "--endpoint", endpoint]).unwrap();
@@ -2734,6 +2971,32 @@ caps board=loopback-uno-r4 runtime=board-vm-loopback max_program_bytes=512 stack
 upload program_id=3 bytes=42 crc32=0xCAFEBABE\n\
 blink program_id=3 status=Halted instructions=7 elapsed_ms=250 stack_depth=1 open_handles=0 returns=[99]\n"
         );
+    }
+
+    #[test]
+    fn bootloader_reboot_sequence_sends_hello_then_reboot() {
+        let options = BootloaderRebootOptions {
+            port: None,
+            endpoint: Some("tcp://127.0.0.1:4170".to_owned()),
+            board: "auto".to_owned(),
+            baud_rate: DEFAULT_BAUD_RATE,
+            timeout_ms: 750,
+            host_nonce: 0x1020_3040,
+        };
+
+        let report =
+            run_bootloader_reboot_with_transport(&options, BootloaderRebootTransport::new())
+                .unwrap();
+
+        assert_eq!(
+            report.connection.transport,
+            SmokeConnectionTransport::TcpSocket
+        );
+        assert_eq!(report.connection.label, "endpoint=tcp://127.0.0.1:4170");
+        assert_eq!(report.connection.timeout_ms, 750);
+        assert_eq!(report.hello.board_name, LOOPBACK_BOARD_ID);
+        assert_eq!(report.hello.runtime_name, LOOPBACK_RUNTIME_ID);
+        assert_eq!(report.hello.host_nonce, 0x1020_3040);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-cli/src/main.rs
+++ b/code/packages/rust/board-vm-cli/src/main.rs
@@ -2,8 +2,8 @@ use std::env;
 
 use board_vm_cli::{
     format_onboard_led, list_pico_bootsel_mounts, list_ports, list_targets, parse_args,
-    run_eject_blink, run_esp_detect, run_esp_upload, run_pico_uf2_upload, run_repl, run_smoke,
-    usage, write_smoke_report, CliCommand,
+    run_bootloader_reboot, run_eject_blink, run_esp_detect, run_esp_upload, run_pico_uf2_upload,
+    run_repl, run_smoke, usage, write_smoke_report, CliCommand,
 };
 
 fn main() {
@@ -89,6 +89,18 @@ fn run_command(command: CliCommand) -> Result<(), board_vm_cli::CliError> {
             let stdin = std::io::stdin();
             let stdout = std::io::stdout();
             run_repl(&options, stdin.lock(), stdout.lock())
+        }
+        CliCommand::BootloaderReboot(options) => {
+            let report = run_bootloader_reboot(&options)?;
+            println!(
+                "bootloader-reboot transport={} {} timeout_ms={} board={} runtime={}",
+                report.connection.transport,
+                report.connection.label,
+                report.connection.timeout_ms,
+                report.hello.board_name,
+                report.hello.runtime_name
+            );
+            Ok(())
         }
         CliCommand::EjectBlink(options) => {
             let report = run_eject_blink(&options)?;

--- a/code/packages/rust/board-vm-client/src/lib.rs
+++ b/code/packages/rust/board-vm-client/src/lib.rs
@@ -392,6 +392,16 @@ where
         self.expect_run_report(written.request_id, written.len)
     }
 
+    pub fn reboot_to_bootloader(&mut self) -> Result<(), ClientError> {
+        let written = self.session.bootloader_reboot_frame(&mut self.request)?;
+        self.exchange_checked(
+            written.request_id,
+            written.len,
+            MessageType::BOOTLOADER_REBOOT,
+        )?;
+        Ok(())
+    }
+
     pub fn blink_onboard_led(
         &mut self,
         program_id: u16,
@@ -618,6 +628,46 @@ mod tests {
 
         let run = client.run_background(2, 32).unwrap();
         assert_eq!(run.returns, vec![RunValue::Bool(false), RunValue::U32(42)]);
+    }
+
+    #[test]
+    fn requests_bootloader_reboot() {
+        use board_vm_protocol::{decode_frame, encode_frame, Frame, FLAG_IS_RESPONSE};
+
+        #[derive(Default)]
+        struct BootloaderRebootTransport {
+            reboot_seen: bool,
+        }
+
+        impl RawFrameTransport for BootloaderRebootTransport {
+            fn exchange_raw_frame(
+                &mut self,
+                request: &[u8],
+                response_out: &mut [u8],
+            ) -> Result<usize, TransportError> {
+                let request = decode_frame(request).map_err(|_| TransportError::Io)?;
+                assert_eq!(request.message_type, MessageType::BOOTLOADER_REBOOT);
+                assert!(request.payload.is_empty());
+                self.reboot_seen = true;
+                encode_frame(
+                    &Frame {
+                        flags: FLAG_IS_RESPONSE,
+                        message_type: MessageType::BOOTLOADER_REBOOT,
+                        request_id: request.request_id,
+                        payload: &[],
+                    },
+                    response_out,
+                )
+                .map_err(|_| TransportError::Io)
+            }
+        }
+
+        let mut client: BoardVmClient<_, 256, 512, 512> =
+            BoardVmClient::new(BootloaderRebootTransport::default());
+
+        client.reboot_to_bootloader().unwrap();
+
+        assert!(client.transport().reboot_seen);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -593,6 +593,7 @@ pub struct BoardVmDevice<
     program_id: u16,
     upload: UploadState,
     background: Option<BackgroundRun>,
+    bootloader_reboot_requested: bool,
 }
 
 impl<'a, H, const MAX_PROGRAM_BYTES: usize, const MAX_STACK: usize, const MAX_HANDLES: usize>
@@ -609,6 +610,7 @@ where
             program_id: 0,
             upload: UploadState::default(),
             background: None,
+            bootloader_reboot_requested: false,
         }
     }
 
@@ -646,6 +648,12 @@ where
 
     pub fn is_background_running(&self) -> bool {
         self.background.is_some()
+    }
+
+    pub fn take_bootloader_reboot_requested(&mut self) -> bool {
+        let requested = self.bootloader_reboot_requested;
+        self.bootloader_reboot_requested = false;
+        requested
     }
 
     pub fn poll_background(
@@ -709,6 +717,9 @@ where
             MessageType::PROGRAM_END => self.handle_program_end(request, payload_out, frame_out),
             MessageType::RUN => self.handle_run(request, payload_out, frame_out),
             MessageType::STOP => self.handle_stop(request, payload_out, frame_out),
+            MessageType::BOOTLOADER_REBOOT => {
+                self.handle_bootloader_reboot(request, payload_out, frame_out)
+            }
             _ => Err(BoardFault::UnsupportedMessage),
         }
     }
@@ -909,6 +920,29 @@ where
             MessageType::RUN_REPORT,
             request.request_id,
             &payload_out[..payload_len],
+            frame_out,
+        )
+    }
+
+    fn handle_bootloader_reboot(
+        &mut self,
+        request: Frame<'_>,
+        _payload_out: &mut [u8],
+        frame_out: &mut [u8],
+    ) -> Result<usize, BoardFault> {
+        if !request.payload.is_empty() {
+            return Err(BoardFault::InvalidFrame);
+        }
+        if !self.runtime.hal().supports_bootloader_reboot() {
+            return Err(BoardFault::UnsupportedMessage);
+        }
+        self.background = None;
+        self.runtime.reset_vm();
+        self.bootloader_reboot_requested = true;
+        write_response(
+            MessageType::BOOTLOADER_REBOOT,
+            request.request_id,
+            &[],
             frame_out,
         )
     }
@@ -1412,6 +1446,7 @@ mod tests {
         GpioOpen { pin: u16, mode: GpioMode },
         GpioWrite { token: u32, level: Level },
         SleepMs(u16),
+        BootloaderReboot,
     }
 
     struct FakeHal {
@@ -1420,6 +1455,7 @@ mod tests {
         events: [Option<Event>; 128],
         event_len: usize,
         capabilities: CapabilitySet,
+        supports_bootloader_reboot: bool,
     }
 
     impl FakeHal {
@@ -1430,7 +1466,13 @@ mod tests {
                 events: [None; 128],
                 event_len: 0,
                 capabilities,
+                supports_bootloader_reboot: false,
             }
+        }
+
+        fn with_bootloader_reboot(mut self) -> Self {
+            self.supports_bootloader_reboot = true;
+            self
         }
 
         fn push_event(&mut self, event: Event) {
@@ -1478,6 +1520,19 @@ mod tests {
 
         fn now_ms(&self) -> u32 {
             self.now_ms
+        }
+
+        fn supports_bootloader_reboot(&self) -> bool {
+            self.supports_bootloader_reboot
+        }
+
+        fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
+            if self.supports_bootloader_reboot {
+                self.push_event(Event::BootloaderReboot);
+                Ok(())
+            } else {
+                Err(HalError::UnsupportedMode)
+            }
         }
     }
 
@@ -1722,6 +1777,58 @@ mod tests {
         }
         decoder.finish().unwrap();
         assert!(found_time_now_ms);
+    }
+
+    #[test]
+    fn bootloader_reboot_request_is_acked_before_runtime_reset() {
+        let mut device = BoardVmDevice::new(
+            DeviceDescriptor::blink_mvp("test-board", 0xB04D_1001),
+            FakeHal::new(CapabilitySet::blink_mvp()).with_bootloader_reboot(),
+        );
+        let mut session = HostSession::new();
+        let mut request = [0u8; 64];
+        let mut device_payload = [0u8; 64];
+        let mut response = [0u8; 96];
+
+        let reboot = session.bootloader_reboot_frame(&mut request).unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..reboot.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+
+        assert_eq!(frame.flags, FLAG_IS_RESPONSE);
+        assert_eq!(frame.message_type, MessageType::BOOTLOADER_REBOOT);
+        assert_eq!(frame.request_id, reboot.request_id);
+        assert!(frame.payload.is_empty());
+        assert!(device.take_bootloader_reboot_requested());
+        assert!(!device.take_bootloader_reboot_requested());
+    }
+
+    #[test]
+    fn bootloader_reboot_request_reports_unsupported_when_hal_cannot_reset() {
+        let mut device = new_device();
+        let mut session = HostSession::new();
+        let mut request = [0u8; 64];
+        let mut device_payload = [0u8; 64];
+        let mut response = [0u8; 96];
+
+        let reboot = session.bootloader_reboot_frame(&mut request).unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..reboot.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        let error = decode_error_payload(frame.payload).unwrap();
+
+        assert_eq!(frame.message_type, MessageType::ERROR);
+        assert_eq!(error.code, ERROR_UNSUPPORTED_MESSAGE);
+        assert_eq!(error.message, "unsupported message");
+        assert!(!device.take_bootloader_reboot_requested());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -566,6 +566,13 @@ impl HostSession {
         self.request_frame(MessageType::STOP, &[], frame_out)
     }
 
+    pub fn bootloader_reboot_frame(
+        &mut self,
+        frame_out: &mut [u8],
+    ) -> Result<WrittenFrame, HostError> {
+        self.request_frame(MessageType::BOOTLOADER_REBOOT, &[], frame_out)
+    }
+
     pub fn request_stream_frame(
         &mut self,
         message_type: MessageType,
@@ -1586,6 +1593,20 @@ mod tests {
         assert_eq!(run_payload.flags, RUN_FLAG_KEEP_HANDLES_AFTER_RUN);
         assert_eq!(run_payload.instruction_budget, 777);
         assert_eq!(run_payload.time_budget_ms, 250);
+    }
+
+    #[test]
+    fn writes_bootloader_reboot_frame() {
+        let mut session = HostSession::with_next_request_id(42);
+        let mut frame = [0u8; 32];
+
+        let written = session.bootloader_reboot_frame(&mut frame).unwrap();
+        let decoded = decode_frame(&frame[..written.len]).unwrap();
+
+        assert_eq!(written.request_id, 42);
+        assert_eq!(decoded.flags, FLAG_RESPONSE_REQUIRED);
+        assert_eq!(decoded.message_type, MessageType::BOOTLOADER_REBOOT);
+        assert!(decoded.payload.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-protocol/src/lib.rs
+++ b/code/packages/rust/board-vm-protocol/src/lib.rs
@@ -93,6 +93,7 @@ impl MessageType {
     pub const ERROR: Self = Self(0x13);
     pub const PING: Self = Self(0x14);
     pub const PONG: Self = Self(0x15);
+    pub const BOOTLOADER_REBOOT: Self = Self(0x16);
 
     pub const fn is_vendor_extension(self) -> bool {
         self.0 >= 0x80
@@ -1210,6 +1211,12 @@ mod tests {
         let mut decoded_raw = [0u8; 32];
         let decoded = decode_stream_frame(&wire[..wire_len], &mut decoded_raw).unwrap();
         assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn reserves_bootloader_reboot_protocol_message() {
+        assert_eq!(MessageType::BOOTLOADER_REBOOT.0, 0x16);
+        assert!(!MessageType::BOOTLOADER_REBOOT.is_vendor_extension());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -73,6 +73,14 @@ pub trait BoardHal {
     fn led_matrix_frame(&mut self, _frame: [u32; 3]) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
+
+    fn supports_bootloader_reboot(&self) -> bool {
+        false
+    }
+
+    fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_server.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_server.rs
@@ -4,7 +4,7 @@
 #[cfg(target_arch = "arm")]
 mod firmware {
     use board_vm_device::{DeviceStreamPoll, DEFAULT_BACKGROUND_INSTRUCTION_SLICE};
-    use board_vm_runtime::Level;
+    use board_vm_runtime::{BoardHal, Level};
     use board_vm_uno_r4::UnoR4Board;
     use board_vm_uno_r4_firmware::serial_usb_server::{
         serial_usb_endpoint, serve_serial_usb_available,
@@ -32,7 +32,14 @@ mod firmware {
         loop {
             device.hal_mut().backend_mut().refresh_led_matrix_once();
             match serve_serial_usb_available(&mut endpoint, &mut device) {
-                Ok(DeviceStreamPoll::Served(_)) => {}
+                Ok(DeviceStreamPoll::Served(_)) => {
+                    if device.take_bootloader_reboot_requested()
+                        && device.hal_mut().reboot_to_bootloader().is_err()
+                    {
+                        let backend = device.hal_mut().backend_mut();
+                        backend.blink_pattern(1, 160, 120);
+                    }
+                }
                 Ok(DeviceStreamPoll::Idle) => {
                     if device
                         .poll_background(DEFAULT_BACKGROUND_INSTRUCTION_SLICE)

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -163,6 +163,10 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         true
     }
 
+    fn supports_bootloader_reboot(&self) -> bool {
+        true
+    }
+
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
         self.inner.led_matrix_frame(frame)
     }
@@ -182,6 +186,10 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         } else {
             Err(HalError::UnsupportedMode)
         }
+    }
+
+    fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
+        board_vm_uno_r4_usb_cdc::reboot_to_bootloader()
     }
 }
 

--- a/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
@@ -66,6 +66,11 @@ pub const fn bootloader_touch_requests_reset(
     line_coding.baud_rate == UNO_R4_WIFI_BOOTLOADER_TOUCH_BAUD && !control_line_state.dtr
 }
 
+#[cfg(target_arch = "arm")]
+pub fn reboot_to_bootloader() -> ! {
+    unsafe { arduino_bootloader_reset::go_bootloader() }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnoR4WifiSerialUsbCdc<A> {
     api: A,

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -297,6 +297,14 @@ pub trait UnoR4Backend {
     fn read_adc(&mut self, _pin: u8) -> Result<u16, HalError> {
         Err(HalError::UnsupportedMode)
     }
+
+    fn supports_bootloader_reboot(&self) -> bool {
+        false
+    }
+
+    fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
 }
 
 pub struct UnoR4Board<B>
@@ -401,6 +409,14 @@ where
             return Err(HalError::UnsupportedMode);
         }
         self.backend.led_matrix_frame(frame)
+    }
+
+    fn supports_bootloader_reboot(&self) -> bool {
+        self.backend.supports_bootloader_reboot()
+    }
+
+    fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
+        self.backend.reboot_to_bootloader()
     }
 }
 
@@ -520,6 +536,7 @@ mod tests {
         PwmWrite(u8, u16),
         AdcRead(u8),
         LedMatrixFrame([u32; 3]),
+        BootloaderReboot,
     }
 
     struct FakeBackend {
@@ -569,6 +586,10 @@ mod tests {
             true
         }
 
+        fn supports_bootloader_reboot(&self) -> bool {
+            true
+        }
+
         fn write_pwm(&mut self, pin: u8, duty: u16) -> Result<(), HalError> {
             self.events.push(Event::PwmWrite(pin, duty));
             Ok(())
@@ -581,6 +602,11 @@ mod tests {
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
             self.events.push(Event::LedMatrixFrame(frame));
+            Ok(())
+        }
+
+        fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
+            self.events.push(Event::BootloaderReboot);
             Ok(())
         }
     }
@@ -725,6 +751,16 @@ mod tests {
             board.led_matrix_frame([0, 0, 0]),
             Err(HalError::UnsupportedMode)
         );
+    }
+
+    #[test]
+    fn bootloader_reboot_runs_through_backend() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert!(board.supports_bootloader_reboot());
+        board.reboot_to_bootloader().unwrap();
+
+        assert_eq!(board.backend().events, vec![Event::BootloaderReboot]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a Board VM `BOOTLOADER_REBOOT` protocol request plus host/client/CLI helpers
- have the device ACK the request, stop/reset VM state, and expose a post-flush reboot flag for firmware loops
- wire the UNO R4 SerialUSB backend to the existing double-tap bootloader reset primitive after the ACK is flushed

## Validation
- `cargo fmt -p board-vm-protocol -p board-vm-host -p board-vm-client -p board-vm-device -p board-vm-runtime -p board-vm-uno-r4 -p board-vm-uno-r4-usb-cdc -p board-vm-uno-r4-firmware -p board-vm-cli`
- `cargo test -p board-vm-protocol -p board-vm-host -p board-vm-client -p board-vm-device -p board-vm-runtime -p board-vm-uno-r4 -p board-vm-uno-r4-usb-cdc -p board-vm-uno-r4-firmware -p board-vm-cli`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-uno-r4-bootloader-command RUSTC=$(rustup which --toolchain stable rustc) cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --core $HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3 --arm-toolchain-bin /opt/homebrew/bin`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD && git diff --cached --check && git diff --check`

## Hardware Note
- The linked SerialUSB firmware image builds and objcopies. This PR does not upload it; once this firmware is flashed, hosts can ask the live VM to reboot into the UNO R4 bootloader with `board-vm bootloader-reboot`.
