### PR TITLE
feat(matrix-cuda): MX06 Phase 3 — NVRTC kernels + buffer-op wiring

### DIFF
--- a/code/packages/rust/cuda-compute/CHANGELOG.md
+++ b/code/packages/rust/cuda-compute/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — cuda-compute
 
+## 0.1.1 — 2026-05-13
+
+### Added
+
+- `unsafe impl Send for CudaBuffer {}` — mirrors the existing
+  `Send` impls on `CudaDevice`, `CudaModuleInner`, and
+  `CudaFunction`.  Lets callers move buffers into a `Mutex<...>`,
+  which is required for `matrix-cuda`'s `Mutex<State>` to compile
+  once `BufferStore` (which holds `CudaBuffer`s) moves inside the
+  executor state.
+- `Sync` is intentionally NOT impl'd: concurrent calls against the
+  same buffer from multiple threads have undefined ordering in the
+  CUDA driver API.  Callers serialise via their own `Mutex`.
+
+Justification: `CUdeviceptr` is a `u64`-typed opaque driver handle;
+NVIDIA's docs say it's safe to transfer between threads.  The
+thread-bound entity is the CUDA *context*, not individual
+allocations.
+
 ## 0.1.0 — 2026-04-23
 
 Initial release.

--- a/code/packages/rust/cuda-compute/Cargo.toml
+++ b/code/packages/rust/cuda-compute/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "cuda-compute"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "G09 Layer 4B: Real CUDA GPU compute via dynamically-loaded libcuda + NVRTC — zero link-time NVIDIA dependency"

--- a/code/packages/rust/cuda-compute/src/lib.rs
+++ b/code/packages/rust/cuda-compute/src/lib.rs
@@ -763,6 +763,17 @@ impl Drop for CudaBuffer {
     }
 }
 
+// `CudaBuffer` carries a `CUdeviceptr` (a `u64`-typed device pointer) and an
+// `Arc<CudaLib>`.  The pointer is an opaque driver handle that the docs say is
+// safe to transfer between threads (the bound entity is the CUDA *context*, not
+// individual allocations).  Adding `Send` lets callers move buffers into a
+// `Mutex<...>` — required by `matrix-cuda`'s `Mutex<State>` pattern.
+//
+// `Sync` is deliberately NOT impl'd: concurrent calls to `upload` / `download`
+// against the same `CudaBuffer` from multiple threads have undefined ordering
+// in the driver API.  Callers must serialise (which `Mutex<BufferStore>` does).
+unsafe impl Send for CudaBuffer {}
+
 impl CudaBuffer {
     pub fn len(&self) -> usize {
         self.len

--- a/code/packages/rust/matrix-cuda/CHANGELOG.md
+++ b/code/packages/rust/matrix-cuda/CHANGELOG.md
@@ -1,5 +1,103 @@
 # Changelog — matrix-cuda
 
+## 0.3.0 — 2026-05-13
+
+### Added — MX06 Phase 3 (generic NVRTC kernels + buffer-op wiring)
+
+This phase lands two things in one PR:
+
+1. The handwritten CUDA C source for the V1 op set, compiled
+   through NVRTC at executor startup via `cuda-compute`'s
+   `CudaDevice::compile`.
+2. The executor's `handle()` dispatch surface for `AllocBuffer` /
+   `UploadBuffer` / `DownloadBuffer` / `FreeBuffer` is now wired
+   through the per-`State` `BufferStore` (Phase 2 shipped the
+   module standalone; this PR moves it into `Mutex<State>` and
+   routes the four request variants).
+
+#### `src/kernels.rs`
+
+- `pub const KERNELS_CUDA_C: &str` — single source string with
+  every V1 kernel: 7 unary (`neg_f32`, `abs_f32`, `sqrt_f32`,
+  `exp_f32`, `log_f32`, `tanh_f32`, `recip_f32`), 7 binary
+  (`add_f32`, `sub_f32`, `mul_f32`, `div_f32`, `max_f32`,
+  `min_f32`, `pow_f32`), plus `matmul_f32` (rank-2 row-major).
+  Mirrors `matrix-metal::KERNELS_MSL` in shape.
+- `pub const KERNEL_ENTRY_POINTS: &[&str]` — every entry-point
+  name; `Kernels::new` errors if any name fails to resolve.
+- `pub struct Kernels { module, fns: HashMap<&'static str, CudaFunction> }`
+  with:
+  - `new(device) -> Result<Self, String>` — compiles once, caches
+    every function.
+  - `get(name)` — function lookup.
+  - `launch_unary` / `launch_binary` / `launch_matmul` — launch
+    helpers with synchronise.  Used by tests and by Phase 5
+    dispatch.
+- `Const` (op tag 0x1B) is intentionally not a kernel — it's
+  handled by buffer upload (`BufferStore::write`).
+
+#### Executor wiring
+
+- `State` gains a `buffers: BufferStore` field and a
+  `next_buffer: u64` counter.
+- `handle()` now routes `AllocBuffer` / `UploadBuffer` /
+  `DownloadBuffer` / `FreeBuffer` through `BufferStore` (using
+  `split-borrow` of the Mutex guard to satisfy the borrow checker).
+- `Dispatch` / `DispatchSpecialised` / `PrepareKernel` /
+  `CancelJob` still return `NOT_IMPLEMENTED` — those land in
+  Phase 5.
+
+#### `cuda-compute` 0.1.1 (companion change)
+
+- `unsafe impl Send for CudaBuffer {}` — mirrors the existing
+  `Send` impls on sibling types.  Lets `BufferStore` live behind
+  `Mutex<State>`.  Sync is intentionally not impl'd; callers
+  serialise via their own `Mutex`.
+
+### Deferred to Phase 5
+
+- Lifting `Kernels` into `State` requires `cuda-compute`'s
+  `CudaLib` / `NvrtcLib` / `CudaModuleInner` to be `Send + Sync`.
+  That wider audit belongs in the Phase 5 PR that also wires the
+  `Dispatch` request.  Until then `Kernels` is callable directly.
+- `supported_ops_bitset()` stays at `0`; Phase 5 flips it on at
+  the same time `Dispatch` becomes real, so the planner never
+  routes an op to us that we can't execute.
+
+### Tests
+
+18 new unit tests in `kernels::tests`:
+
+- `kernels_new_compiles_all_entry_points` — every name in
+  `KERNEL_ENTRY_POINTS` resolves after compilation.
+- `unknown_kernel_name_errors` — graceful error path.
+- One test per unary kernel (`neg`, `abs`, `sqrt`, `exp`, `log`,
+  `tanh`, `recip`) comparing GPU output to a CPU oracle.
+- One test per binary kernel (`add`, `sub`, `mul`, `div`, `max`,
+  `min`, `pow`).
+- `matmul_f32_2x2_matches_cpu` — small handwritten case.
+- `matmul_f32_3x4_4x2_matches_cpu_oracle` — non-square,
+  computed CPU oracle.
+
+All device-gated: on hosts without an NVIDIA driver
+(`CudaDevice::new(0)` fails) the tests silently pass.  On a
+real CUDA box they exercise the full compile → launch →
+download → compare loop.
+
+Total crate test count: 44 (26 from Phases 1+2 + 18 new).
+
+### Why this is its own PR
+
+Phase 3 ships **two coherent pieces**: the kernels themselves (so
+later phases have a known source surface to dispatch against) and
+the buffer-op wiring (so the executor's protocol surface stops
+returning `NOT_IMPLEMENTED` for buffer requests).
+
+Splitting kernel + buffer wiring across two PRs would have been
+artificial — both depend on `CudaBuffer: Send` (which cuda-compute
+0.1.1 ships in the same PR) and the kernel tests need allocated
+buffers anyway.
+
 ## 0.2.0 — 2026-05-13
 
 ### Added — MX06 Phase 2 (`BufferStore` over `cuMemAlloc` / `cuMemcpy*`)

--- a/code/packages/rust/matrix-cuda/Cargo.toml
+++ b/code/packages/rust/matrix-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-cuda"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "MX06 Phase 1 — CUDA GPU executor skeleton for the matrix execution layer. Wraps the runtime-loaded `cuda-compute` driver wrapper so the crate compiles on every platform; when libcuda is unavailable at runtime, constructors return Err(...) and the planner silently skips this executor. Phase 1 ships the executor shell, capability declaration, and stubbed dispatch handler; Phases 2–7 land buffers, kernels, the specialised emitter, real Executor impl, MX05 hooks, and planner integration."
 license = "MIT"

--- a/code/packages/rust/matrix-cuda/README.md
+++ b/code/packages/rust/matrix-cuda/README.md
@@ -38,29 +38,34 @@ for the full design.  Phased rollout, one PR per phase:
 | Phase | Lands                                                  | Status |
 | ----- | ------------------------------------------------------ | ------ |
 | 1     | crate skeleton, `BackendProfile`, stubbed dispatch     | landed (0.1.0) |
-| 2     | `BufferStore` over `cuMemAlloc` / `cuMemcpy*`           | **this PR** (0.2.0) |
-| 3     | `kernels.rs` — generic NVRTC-compiled kernels (also adds `Send` to `CudaBuffer` and wires the buffer store into `handle()`) | pending |
+| 2     | `BufferStore` over `cuMemAlloc` / `cuMemcpy*`           | landed (0.2.0) |
+| 3     | `kernels.rs` — generic NVRTC-compiled kernels + buffer-op wiring (adds `Send` to `CudaBuffer`) | **this PR** (0.3.0) |
 | 4     | `cuda_emitter.rs` — specialised-kernel code generator   | pending |
-| 5     | `specialised_table.rs` + real `Executor` impl           | pending |
+| 5     | `specialised_table.rs` + real `Executor` impl (flips `supported_ops_bitset` on, lifts `Kernels` into `State`) | pending |
 | 6     | MX05 hooks — `backend_id = 2` in image-gpu-core         | pending |
 | 7     | Planner integration — cost-model coefficients           | pending |
 
-## Phase 2 additions
+## Phase 3 additions
 
-- `pub mod buffers` — `BufferStore` over `cuda-compute`'s
-  `CudaDevice::alloc` / `upload` / `download`.  Same shape as
-  `matrix-metal::BufferStore`, suitable for the dispatch wiring that
-  Phase 3 will add.
-- Re-exported as `matrix_cuda::BufferStore`.
-- 14 new unit tests (most device-gated; silent pass on non-NVIDIA
-  hosts).
+- `pub mod kernels` with:
+  - `KERNELS_CUDA_C` — single CUDA C source string for all V1
+    kernels (7 unary, 7 binary, MatMul).
+  - `KERNEL_ENTRY_POINTS` — names exposed by the compiled module.
+  - `Kernels::new(device)` — NVRTC-compiles + caches every
+    function on first call.  ~100 ms one-time cost.
+  - `launch_unary` / `launch_binary` / `launch_matmul` — direct
+    kernel launch helpers (used by Phase 5 dispatch and by the
+    device-gated unit tests).
+- Executor `handle()` now serves `AllocBuffer` / `UploadBuffer` /
+  `DownloadBuffer` / `FreeBuffer` through `BufferStore`
+  (`Mutex<State>`).  `Dispatch` is still `NOT_IMPLEMENTED` —
+  Phase 5.
+- `cuda-compute` v0.1.1 adds `unsafe impl Send for CudaBuffer {}`
+  so `BufferStore` can live inside the executor's mutex.
 
-**Note**: the `handle()` dispatch surface still returns
-`NOT_IMPLEMENTED` for `AllocBuffer` / `UploadBuffer` /
-`DownloadBuffer` / `FreeBuffer`.  Wiring the store through the
-executor's `Mutex<State>` requires `CudaBuffer: Send`, which
-`cuda-compute` doesn't ship yet — both changes land together in
-Phase 3.
+**Note**: `supported_ops_bitset()` stays at `0` until Phase 5
+wires `Dispatch`, so the planner never routes an op to us we
+can't yet execute.  `Kernels` is callable directly today.
 
 ## What this phase ships
 

--- a/code/packages/rust/matrix-cuda/src/kernels.rs
+++ b/code/packages/rust/matrix-cuda/src/kernels.rs
@@ -1,0 +1,576 @@
+//! # CUDA C kernels for the V1 op set
+//!
+//! MX06 Phase 3.  Mirrors `matrix-metal::kernels` but in CUDA C
+//! compiled at runtime through NVRTC (via `cuda-compute`'s
+//! `CudaDevice::compile`).  V1 ops are F32-only:
+//!
+//! - Elementwise unary (op tags `0x00..=0x06`): `Neg`, `Abs`, `Sqrt`,
+//!   `Exp`, `Log`, `Tanh`, `Recip`.
+//! - Elementwise binary (op tags `0x07..=0x0D`): `Add`, `Sub`, `Mul`,
+//!   `Div`, `Max`, `Min`, `Pow`.
+//! - `MatMul` (op tag `0x15`, rank-2, row-major).
+//! - `Const` (op tag `0x1B`) is handled by buffer upload, not by a
+//!   kernel — see `BufferStore::write`.
+//!
+//! Everything else (reductions, casts, shape ops, integer dtypes)
+//! is V2 work; the planner's capability filter falls back to CPU.
+//!
+//! ## Why compile at executor startup
+//!
+//! We compile the entire CUDA C source once on first
+//! [`Kernels::new`] call.  NVRTC compilation is ~100 ms on a modern
+//! card — paying it once at startup keeps dispatches latency-free.
+//! Matches `matrix-metal`'s startup-compile strategy.
+//!
+//! ## Threadblock sizing
+//!
+//! Elementwise kernels launch with a 1-D grid of 256-thread blocks.
+//! MatMul launches with a 2-D grid of 16×16 blocks.  These are
+//! conservative defaults; Phase 7 (planner integration) will revisit
+//! once we have a calibration workload.
+
+use cuda_compute::{CudaBuffer, CudaDevice, CudaFunction, CudaModule};
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+/// The bundled CUDA C source for every V1 kernel.  Compiled once at
+/// executor startup; the resulting [`CudaModule`] is cached for the
+/// lifetime of the executor.
+pub const KERNELS_CUDA_C: &str = r#"
+// ──────────────── elementwise unary (F32) ────────────────
+
+#define UNARY_F32(NAME, EXPR) \
+extern "C" __global__ void NAME ( \
+    const float* __restrict__ in, \
+    float* __restrict__ out, \
+    unsigned int n \
+) { \
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x; \
+    if (gid >= n) return; \
+    float x = in[gid]; \
+    out[gid] = (EXPR); \
+}
+
+UNARY_F32(neg_f32,   -x)
+UNARY_F32(abs_f32,   fabsf(x))
+UNARY_F32(sqrt_f32,  sqrtf(x))
+UNARY_F32(exp_f32,   expf(x))
+UNARY_F32(log_f32,   logf(x))
+UNARY_F32(tanh_f32,  tanhf(x))
+UNARY_F32(recip_f32, 1.0f / x)
+
+// ──────────────── elementwise binary (F32) ────────────────
+
+#define BINARY_F32(NAME, EXPR) \
+extern "C" __global__ void NAME ( \
+    const float* __restrict__ a, \
+    const float* __restrict__ b, \
+    float* __restrict__ out, \
+    unsigned int n \
+) { \
+    unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x; \
+    if (gid >= n) return; \
+    float x = a[gid]; \
+    float y = b[gid]; \
+    out[gid] = (EXPR); \
+}
+
+BINARY_F32(add_f32, x + y)
+BINARY_F32(sub_f32, x - y)
+BINARY_F32(mul_f32, x * y)
+BINARY_F32(div_f32, x / y)
+BINARY_F32(max_f32, fmaxf(x, y))
+BINARY_F32(min_f32, fminf(x, y))
+BINARY_F32(pow_f32, powf(x, y))
+
+// ──────────────── matmul (F32, rank-2, row-major) ────────────────
+//
+// One thread per output element.  c[i,j] = sum_kk a[i,kk] * b[kk,j].
+// 2-D grid; 16×16 block by convention.  Phase 7 may tune.
+
+extern "C" __global__ void matmul_f32(
+    const float* __restrict__ a,
+    const float* __restrict__ b,
+    float* __restrict__ c,
+    unsigned int m,
+    unsigned int k,
+    unsigned int n
+) {
+    unsigned int i = blockIdx.y * blockDim.y + threadIdx.y;
+    unsigned int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= m || j >= n) return;
+    float acc = 0.0f;
+    for (unsigned int kk = 0; kk < k; ++kk) {
+        acc += a[i * k + kk] * b[kk * n + j];
+    }
+    c[i * n + j] = acc;
+}
+"#;
+
+/// Every kernel entry-point name we expect to find in
+/// [`KERNELS_CUDA_C`].  Adding a kernel?  Add to both this list and
+/// the source string above — [`Kernels::new`] returns an error if any
+/// name fails to resolve.
+pub const KERNEL_ENTRY_POINTS: &[&str] = &[
+    // unary
+    "neg_f32",
+    "abs_f32",
+    "sqrt_f32",
+    "exp_f32",
+    "log_f32",
+    "tanh_f32",
+    "recip_f32",
+    // binary
+    "add_f32",
+    "sub_f32",
+    "mul_f32",
+    "div_f32",
+    "max_f32",
+    "min_f32",
+    "pow_f32",
+    // matmul
+    "matmul_f32",
+];
+
+/// Compiled-and-cached kernel set for one [`CudaDevice`].
+///
+/// Owned by `CudaExecutor::State`.  Construction is the slow part
+/// (NVRTC compile); subsequent kernel lookups are `HashMap` reads.
+pub struct Kernels {
+    /// The compiled module is kept alive so the functions remain
+    /// valid for the executor's lifetime.  `CudaFunction` internally
+    /// shares an `Arc<CudaModuleInner>`, so this field is partly
+    /// redundant — but explicit ownership reads better.
+    _module: CudaModule,
+    /// Lookup table from kernel entry-point name → cached function
+    /// handle.  Populated once at construction.
+    fns: HashMap<&'static str, CudaFunction>,
+}
+
+impl Kernels {
+    /// Compile [`KERNELS_CUDA_C`] on the given device and cache one
+    /// [`CudaFunction`] per entry in [`KERNEL_ENTRY_POINTS`].
+    ///
+    /// Returns `Err(String)` if compilation or function lookup fails.
+    /// The error message includes the entry-point name so failures
+    /// to add a new kernel to one of the two lists surface clearly.
+    pub fn new(device: &CudaDevice) -> Result<Self, String> {
+        let module = device
+            .compile(KERNELS_CUDA_C)
+            .map_err(|e| format!("matrix-cuda: NVRTC compile: {:?}", e))?;
+        let mut fns: HashMap<&'static str, CudaFunction> =
+            HashMap::with_capacity(KERNEL_ENTRY_POINTS.len());
+        for &name in KERNEL_ENTRY_POINTS {
+            let f = module
+                .function(name)
+                .map_err(|e| format!("matrix-cuda: function {}: {:?}", name, e))?;
+            fns.insert(name, f);
+        }
+        Ok(Kernels {
+            _module: module,
+            fns,
+        })
+    }
+
+    /// Look up a cached function by entry-point name.  Returns
+    /// `Err(String)` if the name isn't in [`KERNEL_ENTRY_POINTS`] —
+    /// callers must use one of the documented kernel names.
+    pub fn get(&self, name: &str) -> Result<&CudaFunction, String> {
+        self.fns
+            .get(name)
+            .ok_or_else(|| format!("matrix-cuda: unknown kernel '{}'", name))
+    }
+
+    /// Dispatch one of the elementwise-unary kernels.  `n` is the
+    /// element count; both buffers must hold at least `n * 4` bytes.
+    ///
+    /// Used by Phase 3+ dispatch code and by the device-gated
+    /// tests in this module.
+    pub fn launch_unary(
+        &self,
+        device: &CudaDevice,
+        name: &str,
+        input: &mut CudaBuffer,
+        output: &mut CudaBuffer,
+        n: u32,
+    ) -> Result<(), String> {
+        let func = self.get(name)?;
+        let block: [u32; 3] = [256, 1, 1];
+        let grid: [u32; 3] = [n.div_ceil(block[0]).max(1), 1, 1];
+        // SAFETY: pointers below remain valid until launch returns.
+        // We assemble the args array and call launch in the same
+        // expression — no moves of `input`/`output`/`n` in between.
+        unsafe {
+            let mut n_local = n;
+            let mut args: [*mut c_void; 3] = [
+                input.as_kernel_arg(),
+                output.as_kernel_arg(),
+                &mut n_local as *mut u32 as *mut c_void,
+            ];
+            device
+                .launch(func, grid, block, &mut args)
+                .map_err(|e| format!("launch {}: {:?}", name, e))?;
+        }
+        device
+            .synchronize()
+            .map_err(|e| format!("synchronize after {}: {:?}", name, e))
+    }
+
+    /// Dispatch one of the elementwise-binary kernels.  `n` is the
+    /// element count; all three buffers must hold at least `n * 4`
+    /// bytes.
+    pub fn launch_binary(
+        &self,
+        device: &CudaDevice,
+        name: &str,
+        a: &mut CudaBuffer,
+        b: &mut CudaBuffer,
+        output: &mut CudaBuffer,
+        n: u32,
+    ) -> Result<(), String> {
+        let func = self.get(name)?;
+        let block: [u32; 3] = [256, 1, 1];
+        let grid: [u32; 3] = [n.div_ceil(block[0]).max(1), 1, 1];
+        unsafe {
+            let mut n_local = n;
+            let mut args: [*mut c_void; 4] = [
+                a.as_kernel_arg(),
+                b.as_kernel_arg(),
+                output.as_kernel_arg(),
+                &mut n_local as *mut u32 as *mut c_void,
+            ];
+            device
+                .launch(func, grid, block, &mut args)
+                .map_err(|e| format!("launch {}: {:?}", name, e))?;
+        }
+        device
+            .synchronize()
+            .map_err(|e| format!("synchronize after {}: {:?}", name, e))
+    }
+
+    /// Dispatch the rank-2 row-major MatMul: `c = a * b` where
+    /// `a` is `[m, k]`, `b` is `[k, n]`, and `c` is `[m, n]`.
+    ///
+    /// Buffers must be F32 of the correct sizes; this method doesn't
+    /// validate (the executor's pre-dispatch validation is upstream).
+    pub fn launch_matmul(
+        &self,
+        device: &CudaDevice,
+        a: &mut CudaBuffer,
+        b: &mut CudaBuffer,
+        c: &mut CudaBuffer,
+        m: u32,
+        k: u32,
+        n: u32,
+    ) -> Result<(), String> {
+        let func = self.get("matmul_f32")?;
+        let block: [u32; 3] = [16, 16, 1];
+        let grid: [u32; 3] = [n.div_ceil(block[0]).max(1), m.div_ceil(block[1]).max(1), 1];
+        unsafe {
+            let mut m_local = m;
+            let mut k_local = k;
+            let mut n_local = n;
+            let mut args: [*mut c_void; 6] = [
+                a.as_kernel_arg(),
+                b.as_kernel_arg(),
+                c.as_kernel_arg(),
+                &mut m_local as *mut u32 as *mut c_void,
+                &mut k_local as *mut u32 as *mut c_void,
+                &mut n_local as *mut u32 as *mut c_void,
+            ];
+            device
+                .launch(func, grid, block, &mut args)
+                .map_err(|e| format!("launch matmul_f32: {:?}", e))?;
+        }
+        device
+            .synchronize()
+            .map_err(|e| format!("synchronize after matmul_f32: {:?}", e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn device_or_skip() -> Option<CudaDevice> {
+        CudaDevice::new(0).ok()
+    }
+
+    /// Round-trip a single elementwise kernel through the CUDA
+    /// device, comparing to a CPU oracle.  Used by every unary /
+    /// binary kernel test.
+    fn round_trip_unary(name: &str, input: &[f32], expect_fn: impl Fn(f32) -> f32) {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let kernels = Kernels::new(&device).expect("compile kernels");
+
+        let n = input.len() as u32;
+        let bytes = (n as usize) * 4;
+        let mut in_buf = device.alloc(bytes).unwrap();
+        let mut out_buf = device.alloc(bytes).unwrap();
+        device
+            .upload(&in_buf, bytemuck_like(input))
+            .unwrap();
+
+        kernels
+            .launch_unary(&device, name, &mut in_buf, &mut out_buf, n)
+            .unwrap();
+
+        let got_bytes = device.download(&out_buf).unwrap();
+        let got = bytes_to_f32(&got_bytes);
+
+        for (i, (g, x)) in got.iter().zip(input.iter()).enumerate() {
+            let expected = expect_fn(*x);
+            assert!(
+                approx_eq(*g, expected),
+                "{} mismatch at {}: got {}, expected {} (input {})",
+                name,
+                i,
+                g,
+                expected,
+                x
+            );
+        }
+    }
+
+    fn round_trip_binary(
+        name: &str,
+        a: &[f32],
+        b: &[f32],
+        expect_fn: impl Fn(f32, f32) -> f32,
+    ) {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let kernels = Kernels::new(&device).expect("compile kernels");
+
+        let n = a.len() as u32;
+        let bytes = (n as usize) * 4;
+        let mut a_buf = device.alloc(bytes).unwrap();
+        let mut b_buf = device.alloc(bytes).unwrap();
+        let mut out_buf = device.alloc(bytes).unwrap();
+        device.upload(&a_buf, bytemuck_like(a)).unwrap();
+        device.upload(&b_buf, bytemuck_like(b)).unwrap();
+
+        kernels
+            .launch_binary(&device, name, &mut a_buf, &mut b_buf, &mut out_buf, n)
+            .unwrap();
+
+        let got_bytes = device.download(&out_buf).unwrap();
+        let got = bytes_to_f32(&got_bytes);
+
+        for (i, ((g, x), y)) in got.iter().zip(a.iter()).zip(b.iter()).enumerate() {
+            let expected = expect_fn(*x, *y);
+            assert!(
+                approx_eq(*g, expected),
+                "{} mismatch at {}: got {}, expected {} (a={}, b={})",
+                name,
+                i,
+                g,
+                expected,
+                x,
+                y
+            );
+        }
+    }
+
+    /// Hand-rolled bytemuck — we don't want to pull in the bytemuck
+    /// dep just for tests.  Same memory layout, no transmute fancy.
+    fn bytemuck_like(xs: &[f32]) -> &[u8] {
+        // SAFETY: f32 has size 4 and alignment 4; reading its bytes
+        // is well-defined.  Lifetime tied to input slice.
+        unsafe { std::slice::from_raw_parts(xs.as_ptr() as *const u8, xs.len() * 4) }
+    }
+
+    fn bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+        assert_eq!(bytes.len() % 4, 0);
+        let mut out = Vec::with_capacity(bytes.len() / 4);
+        for chunk in bytes.chunks_exact(4) {
+            out.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+        }
+        out
+    }
+
+    /// Loose float equality — kernels run in single precision and
+    /// transcendentals can vary by a few ULPs vs the host's libm.
+    fn approx_eq(a: f32, b: f32) -> bool {
+        if a.is_nan() && b.is_nan() {
+            return true;
+        }
+        if a.is_infinite() && b.is_infinite() && a.signum() == b.signum() {
+            return true;
+        }
+        let diff = (a - b).abs();
+        let scale = a.abs().max(b.abs()).max(1.0);
+        diff <= scale * 1.0e-4
+    }
+
+    // ── kernels compile ─────────────────────────────────────────────
+
+    #[test]
+    fn kernels_new_compiles_all_entry_points() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let kernels = Kernels::new(&device).unwrap();
+        for &name in KERNEL_ENTRY_POINTS {
+            assert!(kernels.get(name).is_ok(), "missing {}", name);
+        }
+    }
+
+    #[test]
+    fn unknown_kernel_name_errors() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let kernels = Kernels::new(&device).unwrap();
+        assert!(kernels.get("not_a_real_kernel").is_err());
+    }
+
+    // ── unary kernels ───────────────────────────────────────────────
+
+    #[test]
+    fn neg_f32_matches_cpu() {
+        round_trip_unary("neg_f32", &[1.0, -2.0, 3.5, 0.0], |x| -x);
+    }
+
+    #[test]
+    fn abs_f32_matches_cpu() {
+        round_trip_unary("abs_f32", &[1.0, -2.0, -3.5, 0.0, -0.0], |x| x.abs());
+    }
+
+    #[test]
+    fn sqrt_f32_matches_cpu() {
+        round_trip_unary("sqrt_f32", &[1.0, 4.0, 9.0, 16.25], |x| x.sqrt());
+    }
+
+    #[test]
+    fn exp_f32_matches_cpu() {
+        round_trip_unary("exp_f32", &[0.0, 1.0, -1.0, 2.5], |x| x.exp());
+    }
+
+    #[test]
+    fn log_f32_matches_cpu() {
+        round_trip_unary("log_f32", &[1.0, std::f32::consts::E, 10.0, 100.0], |x| x.ln());
+    }
+
+    #[test]
+    fn tanh_f32_matches_cpu() {
+        round_trip_unary("tanh_f32", &[-2.0, -0.5, 0.0, 0.5, 2.0], |x| x.tanh());
+    }
+
+    #[test]
+    fn recip_f32_matches_cpu() {
+        round_trip_unary("recip_f32", &[1.0, 2.0, -4.0, 0.5], |x| 1.0 / x);
+    }
+
+    // ── binary kernels ──────────────────────────────────────────────
+
+    #[test]
+    fn add_f32_matches_cpu() {
+        round_trip_binary("add_f32", &[1.0, 2.0, 3.0], &[10.0, 20.0, 30.0], |a, b| a + b);
+    }
+
+    #[test]
+    fn sub_f32_matches_cpu() {
+        round_trip_binary("sub_f32", &[5.0, 7.0, 9.0], &[1.0, 2.0, 3.0], |a, b| a - b);
+    }
+
+    #[test]
+    fn mul_f32_matches_cpu() {
+        round_trip_binary("mul_f32", &[2.0, 3.0, 4.0], &[5.0, 6.0, 7.0], |a, b| a * b);
+    }
+
+    #[test]
+    fn div_f32_matches_cpu() {
+        round_trip_binary("div_f32", &[10.0, 20.0, 30.0], &[2.0, 4.0, 5.0], |a, b| a / b);
+    }
+
+    #[test]
+    fn max_f32_matches_cpu() {
+        round_trip_binary("max_f32", &[1.0, 5.0, -3.0], &[2.0, 4.0, -1.0], |a, b| a.max(b));
+    }
+
+    #[test]
+    fn min_f32_matches_cpu() {
+        round_trip_binary("min_f32", &[1.0, 5.0, -3.0], &[2.0, 4.0, -1.0], |a, b| a.min(b));
+    }
+
+    #[test]
+    fn pow_f32_matches_cpu() {
+        round_trip_binary("pow_f32", &[2.0, 3.0, 4.0], &[2.0, 0.5, 3.0], |a, b| a.powf(b));
+    }
+
+    // ── matmul ──────────────────────────────────────────────────────
+
+    #[test]
+    fn matmul_f32_2x2_matches_cpu() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let kernels = Kernels::new(&device).expect("compile kernels");
+
+        // A = [[1, 2], [3, 4]], B = [[5, 6], [7, 8]] → C = [[19,22],[43,50]]
+        let a: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
+        let b: Vec<f32> = vec![5.0, 6.0, 7.0, 8.0];
+
+        let mut a_buf = device.alloc(16).unwrap();
+        let mut b_buf = device.alloc(16).unwrap();
+        let mut c_buf = device.alloc(16).unwrap();
+        device.upload(&a_buf, bytemuck_like(&a)).unwrap();
+        device.upload(&b_buf, bytemuck_like(&b)).unwrap();
+
+        kernels
+            .launch_matmul(&device, &mut a_buf, &mut b_buf, &mut c_buf, 2, 2, 2)
+            .unwrap();
+
+        let got = bytes_to_f32(&device.download(&c_buf).unwrap());
+        assert!(approx_eq(got[0], 19.0));
+        assert!(approx_eq(got[1], 22.0));
+        assert!(approx_eq(got[2], 43.0));
+        assert!(approx_eq(got[3], 50.0));
+    }
+
+    #[test]
+    fn matmul_f32_3x4_4x2_matches_cpu_oracle() {
+        let Some(device) = device_or_skip() else {
+            return;
+        };
+        let kernels = Kernels::new(&device).expect("compile kernels");
+
+        // m=3, k=4, n=2
+        let a: Vec<f32> = (1..=12).map(|x| x as f32).collect(); // 3x4
+        let b: Vec<f32> = (1..=8).map(|x| x as f32 * 0.5).collect(); // 4x2
+
+        let mut a_buf = device.alloc(48).unwrap();
+        let mut b_buf = device.alloc(32).unwrap();
+        let mut c_buf = device.alloc(24).unwrap();
+        device.upload(&a_buf, bytemuck_like(&a)).unwrap();
+        device.upload(&b_buf, bytemuck_like(&b)).unwrap();
+
+        kernels
+            .launch_matmul(&device, &mut a_buf, &mut b_buf, &mut c_buf, 3, 4, 2)
+            .unwrap();
+
+        let got = bytes_to_f32(&device.download(&c_buf).unwrap());
+
+        // CPU oracle:
+        for i in 0..3 {
+            for j in 0..2 {
+                let mut acc = 0.0f32;
+                for kk in 0..4 {
+                    acc += a[i * 4 + kk] * b[kk * 2 + j];
+                }
+                assert!(
+                    approx_eq(got[i * 2 + j], acc),
+                    "matmul mismatch at ({}, {}): got {}, expected {}",
+                    i,
+                    j,
+                    got[i * 2 + j],
+                    acc
+                );
+            }
+        }
+    }
+}

--- a/code/packages/rust/matrix-cuda/src/lib.rs
+++ b/code/packages/rust/matrix-cuda/src/lib.rs
@@ -61,7 +61,10 @@
 #![warn(rust_2018_idioms)]
 
 mod buffers;
+pub mod kernels;
+
 pub use buffers::BufferStore;
+pub use kernels::{Kernels, KERNELS_CUDA_C, KERNEL_ENTRY_POINTS};
 
 use compute_ir::ExecutorId;
 use executor_protocol::{
@@ -151,14 +154,29 @@ pub struct CudaExecutor {
 
 struct State {
     /// The CUDA device handle, kept alive for the executor's lifetime
-    /// so dispatches in later phases don't pay the device-init cost
-    /// per call.  `Option` so we can still construct the struct in
-    /// test paths that don't have a real device — Phase 1 always
-    /// puts `Some` here (errors out before constructing State if the
-    /// device probe fails) but Phase 2+ may want a zero-device test
-    /// double.
-    #[allow(dead_code)]
+    /// so dispatches don't pay the device-init cost per call.
+    /// `Option` so test paths can construct the struct without a
+    /// real device — `CudaExecutor::new` always puts `Some` here
+    /// (errors before constructing State if the device probe fails).
     device: Option<cuda_compute::CudaDevice>,
+    /// **MX06 Phase 2/3.**  Per-executor map of `BufferId → CudaBuffer`.
+    /// Lives under the executor's `Mutex` so concurrent buffer
+    /// requests serialise.
+    buffers: BufferStore,
+    /// Monotonically incrementing `BufferId` counter.  Hands out a
+    /// fresh id for each `AllocBuffer` request.  Matches
+    /// `matrix-metal::State::next_buffer` semantics.
+    ///
+    /// **Note (Phase 3)**: the kernel cache ([`Kernels`]) is
+    /// intentionally **not** stored on `State` yet.  Adding
+    /// `Kernels` here would require `cuda-compute::CudaModuleInner`
+    /// to be `Send + Sync` (it currently has only `Send`); the wider
+    /// `Send + Sync` audit of `CudaLib` / `NvrtcLib` belongs in the
+    /// Phase 5 PR that also wires `Dispatch`.  For now `Kernels::new`
+    /// is callable directly — `dispatch.rs` (Phase 5) will lift it
+    /// into State at the same time it lifts the `Dispatch` request
+    /// handling.
+    next_buffer: u64,
     /// `ExecutorId` assigned by the runtime when we registered.  Same
     /// purpose as `matrix-metal::State::our_id`: lets dispatch detect
     /// mis-routed graphs.
@@ -184,45 +202,125 @@ impl CudaExecutor {
         Ok(CudaExecutor {
             state: Mutex::new(State {
                 device: Some(device),
+                buffers: BufferStore::new(),
+                next_buffer: 1,
                 our_id: ExecutorId(u32::MAX),
             }),
         })
     }
 
-    /// Handle a single `ExecutorRequest`.  Phase 1 stubs the entire
-    /// protocol surface:
+    /// Handle a single `ExecutorRequest`.  As of MX06 Phase 3 the
+    /// buffer-management surface is live:
     ///
-    /// - `Register` echoes back our currently-stored `ExecutorId`
-    ///   (default `u32::MAX` until [`set_our_id`] is called from the
-    ///   runtime registration helper).  Matches `matrix-metal`'s
-    ///   behaviour.
-    /// - `Heartbeat` replies `Alive { profile }` so liveness probes
-    ///   work end-to-end in this phase.
-    /// - `Shutdown` is treated as a graceful no-op — Phase 1 has no
-    ///   resources to release.
-    /// - Every other variant returns `NOT_IMPLEMENTED` with a
-    ///   pointer to the spec so future readers know where to look.
+    /// - `Register` echoes our currently-stored `ExecutorId`.
+    /// - `Heartbeat` replies `Alive { profile }`.
+    /// - `Shutdown` graceful no-op (buffers free on `BufferStore`
+    ///   drop).
+    /// - `AllocBuffer`, `UploadBuffer`, `DownloadBuffer`,
+    ///   `FreeBuffer` route through the `Mutex<State>`-protected
+    ///   [`BufferStore`] (Phase 3 wiring).
+    /// - `Dispatch`, `DispatchSpecialised`, `CancelJob`,
+    ///   `PrepareKernel` still return `NOT_IMPLEMENTED` — those land
+    ///   in Phase 5 (real `Executor` impl).
     ///
-    /// **Note (MX06 Phase 2)**: the new [`BufferStore`] module is
-    /// callable directly (see its docs) but is **not** wired into
-    /// this dispatch handler yet — that requires `cuda-compute`'s
-    /// `CudaBuffer` to be `Send` so it can live behind the
-    /// executor's `Mutex<State>`.  Phase 3 will land both the
-    /// `Send` impl on `CudaBuffer` and the wiring here in one
-    /// coherent change, alongside generic kernel compilation.
+    /// Kernels are available via [`Kernels`] for callers that want
+    /// to launch directly; the V1 op bitset stays at `0` until
+    /// Phase 5 wires `Dispatch` so the planner doesn't route ops to
+    /// us prematurely.
     pub fn handle(&self, req: ExecutorRequest) -> ExecutorResponse {
-        let our_id = match self.state.lock() {
-            Ok(g) => g.our_id,
-            Err(p) => p.into_inner().our_id,
+        let mut s = match self.state.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
         };
         match req {
             ExecutorRequest::Register { .. } => ExecutorResponse::Registered {
-                executor_id: our_id,
+                executor_id: s.our_id,
             },
             ExecutorRequest::Heartbeat => ExecutorResponse::Alive { profile: profile() },
             ExecutorRequest::Shutdown => ExecutorResponse::Registered {
-                executor_id: our_id,
+                executor_id: s.our_id,
             },
+
+            // ── Phase 3: buffer ops ──────────────────────────────────
+            ExecutorRequest::AllocBuffer { bytes } => {
+                use compute_ir::BufferId;
+                let id = BufferId(s.next_buffer);
+                s.next_buffer += 1;
+                // Split the borrow so `buffers.alloc(device, ...)` can
+                // mutably take `buffers` while reading `device`.
+                let State {
+                    buffers, device, ..
+                } = &mut *s;
+                let Some(device) = device.as_ref() else {
+                    return ExecutorResponse::Error {
+                        code: ErrorCode::DEVICE_LOST,
+                        message: "matrix-cuda: no CUDA device bound".to_string(),
+                        job_id: None,
+                    };
+                };
+                if let Err(e) = buffers.alloc(device, id, bytes as usize) {
+                    return ExecutorResponse::Error {
+                        code: ErrorCode::OUT_OF_MEMORY,
+                        message: format!("AllocBuffer: {}", e),
+                        job_id: None,
+                    };
+                }
+                ExecutorResponse::BufferAllocated { buffer: id }
+            }
+            ExecutorRequest::UploadBuffer {
+                buffer,
+                offset,
+                data,
+            } => {
+                let State {
+                    buffers, device, ..
+                } = &mut *s;
+                let Some(device) = device.as_ref() else {
+                    return ExecutorResponse::Error {
+                        code: ErrorCode::DEVICE_LOST,
+                        message: "matrix-cuda: no CUDA device bound".to_string(),
+                        job_id: None,
+                    };
+                };
+                match buffers.write(device, buffer, offset as usize, &data) {
+                    Ok(()) => ExecutorResponse::BufferUploaded { buffer },
+                    Err(e) => ExecutorResponse::Error {
+                        code: ErrorCode::OUT_OF_MEMORY,
+                        message: format!("UploadBuffer: {}", e),
+                        job_id: None,
+                    },
+                }
+            }
+            ExecutorRequest::DownloadBuffer {
+                buffer,
+                offset,
+                len,
+            } => {
+                let State {
+                    buffers, device, ..
+                } = &mut *s;
+                let Some(device) = device.as_ref() else {
+                    return ExecutorResponse::Error {
+                        code: ErrorCode::DEVICE_LOST,
+                        message: "matrix-cuda: no CUDA device bound".to_string(),
+                        job_id: None,
+                    };
+                };
+                match buffers.read(device, buffer, offset as usize, len as usize) {
+                    Ok(data) => ExecutorResponse::BufferData { buffer, data },
+                    Err(e) => ExecutorResponse::Error {
+                        code: ErrorCode::OUT_OF_MEMORY,
+                        message: format!("DownloadBuffer: {}", e),
+                        job_id: None,
+                    },
+                }
+            }
+            ExecutorRequest::FreeBuffer { buffer } => {
+                s.buffers.free(buffer);
+                ExecutorResponse::BufferFreed
+            }
+
+            // ── Phases 5+: still stubbed ────────────────────────────
             ExecutorRequest::Dispatch { job_id, .. }
             | ExecutorRequest::DispatchSpecialised { job_id, .. }
             | ExecutorRequest::CancelJob { job_id } => ExecutorResponse::Error {
@@ -232,14 +330,10 @@ impl CudaExecutor {
                         .to_string(),
                 job_id: Some(job_id),
             },
-            ExecutorRequest::PrepareKernel { .. }
-            | ExecutorRequest::AllocBuffer { .. }
-            | ExecutorRequest::UploadBuffer { .. }
-            | ExecutorRequest::DownloadBuffer { .. }
-            | ExecutorRequest::FreeBuffer { .. } => ExecutorResponse::Error {
+            ExecutorRequest::PrepareKernel { .. } => ExecutorResponse::Error {
                 code: ErrorCode::NOT_IMPLEMENTED,
                 message:
-                    "matrix-cuda: buffer / kernel dispatch wiring lands in Phase 3 (BufferStore module is callable directly, see crate docs)"
+                    "matrix-cuda: PrepareKernel unused — kernels compile at Kernels::new (Phase 3)"
                         .to_string(),
                 job_id: None,
             },


### PR DESCRIPTION
## Summary

Lands two coherent pieces in one PR:

1. **`src/kernels.rs`** — handwritten CUDA C source for the V1 op set (7 unary + 7 binary F32 elementwise + MatMul) compiled through NVRTC at executor startup. `Kernels::new(device)` compiles + caches; `launch_unary` / `launch_binary` / `launch_matmul` are the launch helpers Phase 5 will call from `Dispatch`.
2. **Buffer-op wiring** — the executor's `handle()` now routes `AllocBuffer` / `UploadBuffer` / `DownloadBuffer` / `FreeBuffer` through a `Mutex<State>`-protected `BufferStore`. Phase 2 shipped the module standalone; this PR moves it into State.

Companion change in `cuda-compute` v0.1.1: `unsafe impl Send for CudaBuffer {}` (mirrors existing Send impls on sibling types) so `BufferStore` can live inside the executor mutex.

## Roadmap

| Phase | Lands                                              | Status |
| ----- | -------------------------------------------------- | ------ |
| 1     | crate skeleton                                     | landed |
| 2     | `BufferStore` module                               | landed |
| 3     | NVRTC kernels + buffer-op wiring                   | **this PR** (0.3.0) |
| 4     | `cuda_emitter.rs` — specialised-kernel generator   | pending |
| 5     | `specialised_table.rs` + real `Executor` impl, flips `supported_ops_bitset`, lifts `Kernels` into `State` | pending |
| 6     | MX05 hooks — `backend_id = 2` in image-gpu-core    | pending |
| 7     | Planner cost-model calibration                      | pending |

## Deferred to Phase 5

- Lifting `Kernels` into `State` requires `cuda-compute`'s `CudaLib` / `NvrtcLib` / `CudaModuleInner` to be `Send + Sync`. That wider audit belongs in the Phase 5 PR that also wires `Dispatch`. Until then `Kernels` is callable directly.
- `supported_ops_bitset()` stays at `0`; Phase 5 flips it on at the same time `Dispatch` becomes real, so the planner never routes an op to us we can't execute. (matrix-cuda isn't registered anywhere yet — Phase 6.)

## Test plan

- [x] `cargo test -p matrix-cuda` — 44 tests passing (26 from Phases 1+2 + 18 new). All kernel tests are device-gated; on this macOS host they silently pass.
- [x] `cargo test -p cuda-compute` — 3 unit tests + 1 device-gated test, all passing.
- [x] `/security-review` — passed. Three small `unsafe` blocks in `launch_*` are documented; `as_kernel_arg` pointer lifetimes are sound (buffers passed as `&mut`, scalars are local lets, launch + sync in the same scope). NVRTC sees only the fixed const str — no user input is interpolated. Buffer-op dispatch path has overflow checks on `offset+len` and bounds vs `buf.len()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)