### PR TITLE
feat(matrix-cuda): MX06 Phase 5a — specialised_table + Send/Sync foundation

### DIFF
--- a/code/packages/rust/cuda-compute/CHANGELOG.md
+++ b/code/packages/rust/cuda-compute/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog — cuda-compute
 
+## 0.1.2 — 2026-05-13
+
+### Added
+
+- `unsafe impl {Send, Sync} for CudaLib {}` and `for NvrtcLib {}`.
+  Both wrap a `dynlib::DynLib` (a `*mut c_void` library handle from
+  `dlopen` / `LoadLibrary`) plus function pointers; the dynamic
+  linker explicitly supports concurrent reads, and function
+  pointers are already `Send + Sync` by default.
+- `unsafe impl Sync for CudaModuleInner {}` (Send was already
+  there).  Lets `Arc<CudaModuleInner>` be `Send`, which in turn
+  makes `CudaModule` and `CudaFunction` `Send`.
+- `unsafe impl Sync for CudaFunction {}` (Send was already there).
+
+### Why
+
+`matrix-cuda` Phase 5 lifts `Kernels` (which holds a `CudaModule`
+and a `HashMap<&str, CudaFunction>`) into its executor's
+`Mutex<State>`.  For that to compile, every type inside `State`
+must be `Send`, which means `Arc<...>` of these types must be
+`Send + Sync`, which means the inner type must be both.  The Sync
+adds in this release are the missing pieces.
+
+Concurrent driver calls against the same module / function from
+multiple threads remain undefined; callers serialise via
+`Mutex<State>`.  Sync here means "transferring shared refs is
+safe," not "concurrent driver calls are safe."
+
 ## 0.1.1 — 2026-05-13
 
 ### Added

--- a/code/packages/rust/cuda-compute/Cargo.toml
+++ b/code/packages/rust/cuda-compute/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "cuda-compute"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "G09 Layer 4B: Real CUDA GPU compute via dynamically-loaded libcuda + NVRTC — zero link-time NVIDIA dependency"

--- a/code/packages/rust/cuda-compute/src/lib.rs
+++ b/code/packages/rust/cuda-compute/src/lib.rs
@@ -421,6 +421,19 @@ struct NvrtcLib {
     nvrtc_destroy_program:  FnNvrtcDestroyProgram,
 }
 
+// `dynlib::DynLib` carries an opaque `*mut c_void` library handle that the
+// dynamic linker (`dlopen`/`LoadLibrary`) returned.  Sharing or transferring
+// that handle between threads is safe — POSIX `dlsym` and Windows
+// `GetProcAddress` are explicitly thread-safe.  Function pointers are
+// already `Send + Sync` so the rest of the struct propagates trivially.
+// Adding Send + Sync lets `Arc<CudaLib>` / `Arc<NvrtcLib>` cross thread
+// boundaries, which `matrix-cuda`'s `Mutex<State>` needs to compile when
+// it holds a `Kernels` (Phase 5).
+unsafe impl Send for CudaLib {}
+unsafe impl Sync for CudaLib {}
+unsafe impl Send for NvrtcLib {}
+unsafe impl Sync for NvrtcLib {}
+
 impl NvrtcLib {
     fn load() -> Option<Self> {
         #[cfg(unix)]
@@ -832,7 +845,13 @@ impl Drop for CudaModuleInner {
 
 // CUmodule is an opaque driver handle; CUDA docs say it is safe to transfer
 // between threads (the context, not the module, is the thread-bound entity).
+// Adding Sync alongside Send lets `Arc<CudaModuleInner>` itself be Send +
+// Sync, which in turn lets `CudaModule` and `CudaFunction` (both wrap
+// `Arc<CudaModuleInner>`) move freely across thread boundaries.  Callers
+// must still serialise launches against a given module — Sync here means
+// "transferring shared refs is OK," not "concurrent driver calls are OK."
 unsafe impl Send for CudaModuleInner {}
+unsafe impl Sync for CudaModuleInner {}
 
 /// A loaded CUDA module (compiled PTX).
 ///
@@ -886,7 +905,10 @@ pub struct CudaFunction {
 }
 
 // CUfunction is an opaque driver handle; safe to transfer between threads.
+// Sync added alongside Send so `Arc<CudaFunction>` works in callers that
+// share function handles across threads (read-only after compile).
 unsafe impl Send for CudaFunction {}
+unsafe impl Sync for CudaFunction {}
 
 // --------------------------------------------------------------------------
 // Tests

--- a/code/packages/rust/matrix-cuda/CHANGELOG.md
+++ b/code/packages/rust/matrix-cuda/CHANGELOG.md
@@ -1,5 +1,95 @@
 # Changelog — matrix-cuda
 
+## 0.5.0 — 2026-05-13
+
+### Added — MX06 Phase 5a (`specialised_table` + Send/Sync foundation)
+
+Phase 5 is large enough to split.  This release is **Phase 5a**: the
+foundation needed by Phase 5b (real `Dispatch` wiring).  Two pieces:
+
+1. New `src/specialised_table.rs` module — per-executor
+   `HashMap<u64 handle, Box<closure>>` of installed specialised
+   kernels.  Mirrors `matrix-metal::SpecialisedTable` shape exactly.
+2. Companion `cuda-compute` v0.1.2 release adds `Sync` to
+   `CudaModuleInner` and `CudaFunction`, and both `Send + Sync` to
+   `CudaLib` / `NvrtcLib`.  This makes `Kernels` (which holds an
+   `Arc<CudaModuleInner>` and `HashMap<&str, CudaFunction>`)
+   `Send + Sync` so Phase 5b can lift it into `CudaExecutor::State`.
+
+#### `src/specialised_table.rs`
+
+- `pub type CudaSpecialisedKernelFn` — closure signature
+  `Fn(&CudaDevice, &mut BufferStore, &[BufferId], &[BufferId])
+   -> Result<Vec<OpTiming>, String> + Send`.
+- `pub struct SpecialisedTable` wrapping the closure HashMap.
+- Methods: `new`, `install`, `get`, `contains`, `len`, `is_empty`,
+  `evict`, plus a `Default` impl and a `Debug` impl that hides
+  closure pointers (prints sorted handle list).
+- `install` is monotonic up to overwriting: re-installing under the
+  same handle replaces the prior closure, matching matrix-metal's
+  Phase 5 deopt-without-evict-step contract.
+
+#### Compile-time invariants
+
+- `kernels::Kernels: Send + Sync` — verified by a new compile-only
+  test (`kernels_is_send_and_sync`).  This is the test that fails
+  loudly if cuda-compute regresses on its `Send + Sync` promise.
+- `SpecialisedTable: Send` — verified similarly.
+
+### Tests
+
+9 new unit tests in `specialised_table::tests`:
+
+- `new_table_is_empty`, `default_matches_new`, `is_empty` /
+  `len` accounting.
+- `install_then_lookup_finds_kernel`,
+  `lookup_of_missing_handle_returns_none`.
+- `install_overwrites_prior_kernel` — len stays at 1 after replace.
+- `evict_removes_kernel_and_returns_true`,
+  `evict_missing_handle_returns_false`.
+- `specialised_table_is_send` — compile-only.
+- `debug_impl_shows_handles_in_sorted_order` — guards against
+  accidental closure-pointer leaks.
+
+Plus the new `kernels_is_send_and_sync` test that verifies the
+cuda-compute Send/Sync audit landed before Phase 5b tries to lift
+Kernels into State.
+
+Total crate test count: 78 (68 from Phases 1–4 + 10 new in 5a).
+
+### Why split Phase 5
+
+The cron-defined Phase 5 covers seven sub-items (table + Send audit
++ lift Kernels + real Dispatch + DispatchSpecialised + install +
+evict + flip bitset).  Phase 5a ships the **foundation** that all
+the others depend on, with no behavioural change yet: `Dispatch`
+still returns `NOT_IMPLEMENTED`, `supported_ops_bitset()` stays at
+`0`, `install_specialised_from_emitted` still errors.
+
+Phase 5b will wire the executor state changes (lift Kernels into
+State, implement real Dispatch by walking ComputeGraph PlacedOps,
+implement DispatchSpecialised via the new table, implement
+install_specialised_from_emitted backed by `cuda_emitter`, and flip
+the supported_ops bitset to claim V1 ops).
+
+Splitting keeps each PR reviewable.  Phase 5a is purely additive —
+no executor behaviour changed.
+
+### Companion: cuda-compute v0.1.2
+
+Adds:
+- `unsafe impl Sync for CudaModuleInner {}` (Send was already there).
+- `unsafe impl Sync for CudaFunction {}` (Send was already there).
+- `unsafe impl {Send, Sync} for CudaLib {}` and `for NvrtcLib {}`.
+
+All justified: the underlying `*mut c_void` library handles from
+`dlopen` / `LoadLibrary` are thread-safe to share (POSIX `dlsym`
+and Windows `GetProcAddress` are explicitly thread-safe), and CUDA
+driver handles (`CUmodule`, `CUfunction`) are thread-safe to share
+per NVIDIA's docs.  Concurrent driver calls against the same
+module / function remain undefined; callers serialise via their
+own `Mutex` — Sync here means "transferring shared refs is safe."
+
 ## 0.4.0 — 2026-05-13
 
 ### Added — MX06 Phase 4 (`cuda_emitter` — specialised-kernel codegen)

--- a/code/packages/rust/matrix-cuda/Cargo.toml
+++ b/code/packages/rust/matrix-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-cuda"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "MX06 Phase 1 — CUDA GPU executor skeleton for the matrix execution layer. Wraps the runtime-loaded `cuda-compute` driver wrapper so the crate compiles on every platform; when libcuda is unavailable at runtime, constructors return Err(...) and the planner silently skips this executor. Phase 1 ships the executor shell, capability declaration, and stubbed dispatch handler; Phases 2–7 land buffers, kernels, the specialised emitter, real Executor impl, MX05 hooks, and planner integration."
 license = "MIT"

--- a/code/packages/rust/matrix-cuda/README.md
+++ b/code/packages/rust/matrix-cuda/README.md
@@ -40,10 +40,31 @@ for the full design.  Phased rollout, one PR per phase:
 | 1     | crate skeleton, `BackendProfile`, stubbed dispatch     | landed (0.1.0) |
 | 2     | `BufferStore` over `cuMemAlloc` / `cuMemcpy*`           | landed (0.2.0) |
 | 3     | `kernels.rs` — generic NVRTC-compiled kernels + buffer-op wiring (adds `Send` to `CudaBuffer`) | landed (0.3.0) |
-| 4     | `cuda_emitter.rs` — specialised-kernel code generator   | **this PR** (0.4.0) |
-| 5     | `specialised_table.rs` + real `Executor` impl (flips `supported_ops_bitset` on, lifts `Kernels` into `State`) | pending |
+| 4     | `cuda_emitter.rs` — specialised-kernel code generator   | landed (0.4.0) |
+| 5a    | `specialised_table.rs` module + cuda-compute Send/Sync audit | **this PR** (0.5.0) |
+| 5b    | Real `Dispatch` + `DispatchSpecialised` + `install_specialised_from_emitted` + `evict_specialised` + flip `supported_ops_bitset` | pending |
 | 6     | MX05 hooks — `backend_id = 2` in image-gpu-core         | pending |
 | 7     | Planner integration — cost-model coefficients           | pending |
+
+## Phase 5a additions
+
+- New `pub mod specialised_table` with `SpecialisedTable` — the
+  per-executor `HashMap<u64 handle, Box<closure>>` of installed
+  specialised kernels.  Same shape as `matrix-metal`'s table; the
+  closure signature differs because CUDA closures capture their own
+  `CudaFunction` and launch through `CudaDevice` directly.
+- Companion `cuda-compute` v0.1.2 release adds `Sync` to
+  `CudaModuleInner` / `CudaFunction` and both `Send + Sync` to
+  `CudaLib` / `NvrtcLib`.  This makes `Kernels: Send + Sync`,
+  unlocking the Phase 5b lift into `Mutex<State>`.
+- New compile-only test `kernels_is_send_and_sync` that fails the
+  build if cuda-compute ever regresses on its Send/Sync promise.
+
+**Note**: Phase 5a is **purely additive** — no executor behaviour
+changed.  `Dispatch` still returns `NOT_IMPLEMENTED`,
+`supported_ops_bitset()` stays at `0`, and
+`install_specialised_from_emitted` still errors.  Phase 5b wires
+all of that in one coherent change.
 
 ## Phase 4 additions
 

--- a/code/packages/rust/matrix-cuda/src/kernels.rs
+++ b/code/packages/rust/matrix-cuda/src/kernels.rs
@@ -406,6 +406,20 @@ mod tests {
         diff <= scale * 1.0e-4
     }
 
+    /// **MX06 Phase 5a invariant.**  `Kernels` must be `Send + Sync`
+    /// so it can live in `CudaExecutor::State` behind a `Mutex<State>`.
+    /// Verified via cuda-compute 0.1.2's Send + Sync impls on
+    /// `CudaModuleInner` and `CudaFunction`.
+    ///
+    /// Compile-only — no runtime cost; if Kernels ever drops Send or
+    /// Sync this test breaks the build, which is exactly what we want
+    /// before Phase 5b tries to wire Dispatch.
+    #[test]
+    fn kernels_is_send_and_sync() {
+        fn require_send_sync<T: Send + Sync>() {}
+        require_send_sync::<Kernels>();
+    }
+
     // ── kernels compile ─────────────────────────────────────────────
 
     #[test]

--- a/code/packages/rust/matrix-cuda/src/lib.rs
+++ b/code/packages/rust/matrix-cuda/src/lib.rs
@@ -63,10 +63,12 @@
 mod buffers;
 pub mod cuda_emitter;
 pub mod kernels;
+pub mod specialised_table;
 
 pub use buffers::BufferStore;
 pub use cuda_emitter::{emit_specialised_kernel, EmittedKernel};
 pub use kernels::{Kernels, KERNELS_CUDA_C, KERNEL_ENTRY_POINTS};
+pub use specialised_table::{CudaSpecialisedKernelFn, SpecialisedTable};
 
 use compute_ir::ExecutorId;
 use executor_protocol::{

--- a/code/packages/rust/matrix-cuda/src/specialised_table.rs
+++ b/code/packages/rust/matrix-cuda/src/specialised_table.rs
@@ -1,0 +1,228 @@
+//! `SpecialisedTable` — per-`CudaExecutor` table of installed
+//! specialised kernel closures, keyed by the opaque `u64` handle a
+//! backend `Specialiser` emits.
+//!
+//! Mirrors `matrix_metal::SpecialisedTable` and (further upstream)
+//! `matrix_cpu::SpecialisedTable`.  The structural shape is identical
+//! (a `HashMap<u64, Box<dyn Fn>>`); the closure signature differs
+//! because each backend's closure captures backend-specific state:
+//!
+//! - `matrix-cpu` closures take `&mut BufferStore` (host-resident
+//!   slices).
+//! - `matrix-metal` closures take a `DispatchCtx<'_>` that bundles
+//!   the device, command queue, and pipeline cache.
+//! - `matrix-cuda` closures take `(&CudaDevice, &mut BufferStore,
+//!   &[BufferId], &[BufferId])`.  The simpler signature works because
+//!   a CUDA closure typically captures its own `CudaFunction` and
+//!   launches it directly through the device handle.
+//!
+//! # Cross-platform
+//!
+//! The table is callable on every platform.  `CudaBuffer` is `Send`
+//! (cuda-compute v0.1.1) and `CudaFunction` is `Send + Sync`
+//! (cuda-compute v0.1.2), so a `Box<dyn Fn(...) + Send>` closure can
+//! capture either freely.  Non-NVIDIA hosts simply never install
+//! anything — the table stays empty.
+
+use compute_ir::BufferId;
+use cuda_compute::CudaDevice;
+use executor_protocol::OpTiming;
+use std::collections::HashMap;
+
+use crate::BufferStore;
+
+/// Closure signature for a CUDA-side specialised kernel.
+///
+/// Takes:
+/// - `&CudaDevice` — for launching kernels and synchronising.
+/// - `&mut BufferStore` — for resolving `BufferId`s to `CudaBuffer`s
+///   and (less commonly) allocating scratch space.
+/// - `inputs` / `outputs` — the runtime-supplied `BufferId`s from
+///   the `DispatchSpecialised` request, in slot order.
+///
+/// Returns either per-op timings (Phase 5+) or a human-readable
+/// error.  Closures should be **pure with respect to captured
+/// state** — the observer model behind specialisation breaks if the
+/// kernel mutates closure-captured values across calls.  All
+/// mutation goes through the explicit `&mut BufferStore` argument.
+///
+/// ## Why `Send` but not `Sync`
+///
+/// The closure runs only while the executor holds `Mutex<State>`,
+/// so `Sync` would force callers to add a wrapper lock with no
+/// real safety benefit.  This matches `matrix-metal`'s policy.
+pub type CudaSpecialisedKernelFn = dyn for<'a> Fn(
+        &'a CudaDevice,
+        &'a mut BufferStore,
+        &[BufferId],
+        &[BufferId],
+    ) -> Result<Vec<OpTiming>, String>
+    + Send;
+
+/// Per-executor table of installed specialised kernel closures.
+///
+/// Wraps the `HashMap` so we have a natural place to:
+/// - document invariants (install replaces, allowing
+///   Phase 5 deoptimisation to swap a closure without an explicit
+///   evict-then-install dance);
+/// - hang a `Debug` impl that hides closure pointers (only the
+///   installed handles, in decimal, are printed);
+/// - choke-point future changes (LRU caps, telemetry) without
+///   touching every call site.
+#[derive(Default)]
+pub struct SpecialisedTable {
+    /// `handle → kernel closure`.  Boxed so the table is sized.
+    kernels: HashMap<u64, Box<CudaSpecialisedKernelFn>>,
+}
+
+impl SpecialisedTable {
+    /// Construct an empty table.
+    pub fn new() -> Self {
+        SpecialisedTable {
+            kernels: HashMap::new(),
+        }
+    }
+
+    /// Install a kernel under `handle`.  Overwrites any prior
+    /// closure at the same handle.  Overwriting is intentional so
+    /// MX05 Phase 5 deoptimisation can swap a closure for a fresh
+    /// one without a separate `evict-then-install` step — same
+    /// contract as `matrix-metal`'s table.
+    pub fn install(&mut self, handle: u64, kernel: Box<CudaSpecialisedKernelFn>) {
+        self.kernels.insert(handle, kernel);
+    }
+
+    /// Look up a kernel by handle.  Returns `None` if the handle
+    /// was never installed (or has since been evicted).
+    pub fn get(&self, handle: u64) -> Option<&CudaSpecialisedKernelFn> {
+        self.kernels.get(&handle).map(|b| b.as_ref())
+    }
+
+    /// True iff the handle is installed.
+    pub fn contains(&self, handle: u64) -> bool {
+        self.kernels.contains_key(&handle)
+    }
+
+    /// Number of installed kernels.
+    pub fn len(&self) -> usize {
+        self.kernels.len()
+    }
+
+    /// Whether the table has no installed kernels.
+    pub fn is_empty(&self) -> bool {
+        self.kernels.is_empty()
+    }
+
+    /// **MX05 Phase 5 deoptimisation hook.**  Evict the kernel
+    /// under `handle`.  Returns `true` if an entry was removed.
+    ///
+    /// Used when an observation reveals that a previously-folded
+    /// constant has changed — the compiled `CudaModule` in the
+    /// closure encodes the *old* constant and is now wrong, so the
+    /// runtime drops it.  The driver releases the underlying PTX
+    /// module when the boxed closure drops (it owns the
+    /// `CudaModule` Arc).
+    pub fn evict(&mut self, handle: u64) -> bool {
+        self.kernels.remove(&handle).is_some()
+    }
+}
+
+impl std::fmt::Debug for SpecialisedTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut handles: Vec<u64> = self.kernels.keys().copied().collect();
+        handles.sort();
+        f.debug_struct("SpecialisedTable")
+            .field("installed_handles", &handles)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A no-op kernel closure for tests.  Returns an empty timings
+    /// vec.  Closures capture nothing, so the test doesn't depend
+    /// on `CudaDevice` being constructible (and therefore runs on
+    /// every platform).
+    fn dummy_kernel() -> Box<CudaSpecialisedKernelFn> {
+        Box::new(|_dev, _buf, _ins, _outs| Ok(Vec::new()))
+    }
+
+    #[test]
+    fn new_table_is_empty() {
+        let t = SpecialisedTable::new();
+        assert!(t.is_empty());
+        assert_eq!(t.len(), 0);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let a = SpecialisedTable::new();
+        let b = SpecialisedTable::default();
+        assert_eq!(a.is_empty(), b.is_empty());
+        assert_eq!(a.len(), b.len());
+    }
+
+    #[test]
+    fn install_then_lookup_finds_kernel() {
+        let mut t = SpecialisedTable::new();
+        assert!(!t.contains(0xABCD));
+        t.install(0xABCD, dummy_kernel());
+        assert!(t.contains(0xABCD));
+        assert_eq!(t.len(), 1);
+        assert!(t.get(0xABCD).is_some());
+    }
+
+    #[test]
+    fn lookup_of_missing_handle_returns_none() {
+        let t = SpecialisedTable::new();
+        assert!(t.get(0xFEED).is_none());
+        assert!(!t.contains(0xFEED));
+    }
+
+    #[test]
+    fn install_overwrites_prior_kernel() {
+        let mut t = SpecialisedTable::new();
+        t.install(42, dummy_kernel());
+        t.install(42, Box::new(|_, _, _, _| Err("v2".to_string())));
+        // Re-install replaces; len stays at 1.
+        assert_eq!(t.len(), 1);
+    }
+
+    #[test]
+    fn evict_removes_kernel_and_returns_true() {
+        let mut t = SpecialisedTable::new();
+        t.install(7, dummy_kernel());
+        assert!(t.evict(7));
+        assert!(!t.contains(7));
+        assert_eq!(t.len(), 0);
+    }
+
+    #[test]
+    fn evict_missing_handle_returns_false() {
+        let mut t = SpecialisedTable::new();
+        assert!(!t.evict(0xBAD));
+    }
+
+    /// `SpecialisedTable` must be `Send` so it can live inside the
+    /// executor's `Mutex<State>` (and the executor stays `Sync`
+    /// because `Mutex<T>: Sync where T: Send`).
+    #[test]
+    fn specialised_table_is_send() {
+        fn require_send<T: Send>() {}
+        require_send::<SpecialisedTable>();
+    }
+
+    #[test]
+    fn debug_impl_shows_handles_in_sorted_order() {
+        let mut t = SpecialisedTable::new();
+        t.install(0xCAFE, dummy_kernel());
+        t.install(0x42, dummy_kernel());
+        let printed = format!("{:?}", t);
+        // 0x42 (66) appears before 0xCAFE (51966) when sorted.
+        let idx_66 = printed.find("66").unwrap();
+        let idx_caf = printed.find("51966").unwrap();
+        assert!(idx_66 < idx_caf, "got: {}", printed);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 is large enough to split. This is **Phase 5a — the foundation** Phase 5b will build on (real Dispatch wiring). Two pieces:

1. **`src/specialised_table.rs`** — per-executor `HashMap<u64 handle, Box<closure>>` of installed specialised kernels. Mirrors `matrix-metal::SpecialisedTable` shape.
2. **`cuda-compute` v0.1.2** companion — adds `Sync` to `CudaModuleInner` / `CudaFunction`, and both `Send + Sync` to `CudaLib` / `NvrtcLib`. This makes `Kernels` (which holds an `Arc<CudaModuleInner>` and `HashMap<&str, CudaFunction>`) `Send + Sync`, so Phase 5b can lift it into `CudaExecutor::State` behind `Mutex<State>`.

## Why split

Phase 5 in the cron covers seven sub-items (table + Send audit + lift Kernels + real Dispatch + DispatchSpecialised + install + evict + flip bitset). Phase 5a ships the **foundation** that all the others depend on, with **no behavioural change**: `Dispatch` still returns `NOT_IMPLEMENTED`, `supported_ops_bitset()` stays at `0`, `install_specialised_from_emitted` still errors. Phase 5b will wire all of that in one coherent change.

## Soundness justification (per security review)

- `DynLib`'s `*mut c_void` handle from `dlopen` / `LoadLibrary` is thread-safe to share — POSIX `dlsym` and Windows `GetProcAddress` are documented thread-safe.
- CUDA driver handles (`CUmodule`, `CUfunction`) are context-bound, not thread-bound; safe to transfer between threads per NVIDIA's docs.
- No interior mutability in any of the four newly Sync-ified types — sharing immutable refs can't introduce Rust data races.
- **Sync means "transferring shared refs is safe," NOT "concurrent driver calls are safe."** Callers serialise via their own `Mutex<State>`.
- `CudaDevice` remains `!Sync` — its `ctx: CUcontext` field auto-disables Sync, preserving the thread-bound-context invariant.

## Test plan

- [x] `cargo test -p matrix-cuda` — 78 tests passing (68 from Phases 1–4 + 10 new in 5a).
- [x] `cargo test -p cuda-compute` — all tests passing.
- [x] Compile-only `kernels_is_send_and_sync` test locks in the cuda-compute Send/Sync audit so Phase 5b's lift compiles.
- [x] Compile-only `specialised_table_is_send` test verifies the table can move into `Mutex<State>`.
- [x] `/security-review` — passed. The auditor confirmed each Sync impl is sound and noted a Phase-5b-relevant caveat about Mutex<State> drop on the wrong-context thread (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)