### PR TITLE
feat(image-gpu-core): MX06 Phase 6 — CUDA backend wired in

### DIFF
--- a/code/packages/rust/image-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/image-gpu-core/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog — image-gpu-core
 
+## 0.15.0 — 2026-05-13
+
+### Added — MX06 Phase 6 (CUDA backend wired in)
+
+Wires `matrix-cuda` (MX06 Phase 5b) into the image-gpu-core
+pipeline so the planner can route work to NVIDIA GPUs on Linux /
+Windows / WSL2.  Mirrors the existing matrix-metal integration:
+
+- New `cuda-backend` Cargo feature, default-on alongside
+  `metal-backend`.  When enabled, image-gpu-core depends on
+  `matrix-cuda` and registers the executor.
+- New `CudaBackend` singleton (`Arc<CudaExecutor>` + `LocalTransport`
+  + `BackendProfile`) — parallel to `MetalBackend`.  Lazily
+  initialises on first use via `OnceLock`; on hosts without a CUDA
+  driver `CudaExecutor::new()` returns `Err` and the singleton
+  permanently holds `None`.
+- Dispatch flow gains a Step 2 "CPU + CUDA" branch reached when the
+  metal singleton is absent (typical on Linux + NVIDIA).  Same
+  single-executor / mixed-placement → CPU-only-fallback policy as
+  the metal path.
+- Auto-installer gains a `2 => try_install_cuda(specialised)` arm.
+  `try_install_cuda` parallels `try_install_metal`: calls
+  `matrix_cuda::emit_specialised_kernel`, hands the result to
+  `CudaExecutor::install_specialised_from_emitted` (NVRTC compile +
+  closure capture), records the handle in `installed_handles` and
+  the metadata in `installed_kernel_metadata`.
+- `scan_and_deoptimise` gains a `cuda.executor.evict_specialised`
+  call alongside the existing CPU + metal evicts.  Completes the
+  MX05 Phase 5 deopt loop on the third backend.
+
+### Why this matters
+
+NVIDIA users (most ML practitioners, gamers, scientific computing
+hobbyists) get GPU acceleration *automatically* through the same
+narrow-waist abstraction Apple users have had since matrix-metal
+landed.  No user-facing config; the planner's cost model picks per
+graph.  When the user writes `gpu_brightness(...)`, it runs on:
+
+- macOS: `matrix-metal` when available, else CPU.
+- Linux/Windows + NVIDIA: `matrix-cuda` when available, else CPU.
+- Everywhere else: CPU.
+
+### Tests
+
+All 36 existing image-gpu-core tests continue to pass on macOS
+(where `cuda_backend()` returns `None` and the new Step 2 branch
+is never taken).  Real CUDA exercise lands when a GPU CI runner
+arrives (Phase 7).
+
+### What this PR does NOT change
+
+- No GPU CI runner — Phase 7.
+- No cost-model calibration for CUDA — Phase 7.  The planner's
+  default thresholds work but aren't tuned to specific cards yet.
+- Three-way mixed placement (CPU + Metal + CUDA on the same host)
+  still falls back to CPU-only.  In practice no host has both
+  Apple Silicon and an NVIDIA GPU, so this isn't a real limitation.
+
 ## 0.14.0 — 2026-05-14
 
 ### Added — MX05 Phase 5 (deoptimisation when observed assumptions fail)

--- a/code/packages/rust/image-gpu-core/Cargo.toml
+++ b/code/packages/rust/image-gpu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image-gpu-core"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). v0.3 wires the optional matrix-metal GPU backend. v0.4 wires the MX05 specialisation pipeline. v0.5 installs CpuSpecialiser. v0.6 adds tensor-byte sampling. v0.7 (MX05 Phase 4.3) adds the runtime-side auto-installer with a specialised_install_count() counter. v0.8 (MX05 Phase 4.4) closes the dispatch half: when a single-Compute-op graph has an installed specialised kernel on metal, image-gpu-core now routes the dispatch through ExecutorRequest::DispatchSpecialised (a prep Dispatch sets up buffers, then DispatchSpecialised invokes the installed kernel by handle). Counter specialised_dispatch_count() tracks how many invocations went specialised."
 
@@ -17,13 +17,25 @@ pixel-container   = { path = "../pixel-container" }
 # matrix-cpu.  The feature is default-on so a plain `cargo build` picks
 # up the GPU automatically when available.
 matrix-metal      = { path = "../matrix-metal", optional = true }
+# Optional NVIDIA-GPU backend (MX06 Phase 6).  Compiles on every
+# platform: cuda-compute loads libcuda at runtime via dlopen, so the
+# crate links cleanly even on macOS.  At runtime, CudaExecutor::new
+# returns Err when no CUDA driver is present and image-gpu-core
+# transparently falls back to matrix-cpu / matrix-metal.
+matrix-cuda       = { path = "../matrix-cuda", optional = true }
 
 [features]
-default = ["metal-backend"]
+default = ["metal-backend", "cuda-backend"]
 # When enabled, image-gpu-core registers `matrix-metal` alongside
 # `matrix-cpu` and lets the planner pick per graph.  Disable to force
 # CPU-only dispatch (useful for benchmarks isolating the CPU path).
 metal-backend = ["dep:matrix-metal"]
+# When enabled, image-gpu-core registers `matrix-cuda` alongside the
+# other backends.  On hosts without a CUDA driver the executor is
+# silently skipped (CudaExecutor::new returns Err), so enabling the
+# feature is harmless on macOS / NVIDIA-less Linux / NVIDIA-less
+# Windows.  Disable to force non-CUDA paths.
+cuda-backend = ["dep:matrix-cuda"]
 
 [dev-dependencies]
 image-point-ops = { path = "../image-point-ops" }

--- a/code/packages/rust/image-gpu-core/src/pipeline.rs
+++ b/code/packages/rust/image-gpu-core/src/pipeline.rs
@@ -144,6 +144,49 @@ fn metal_backend() -> Option<&'static MetalBackend> {
     .as_ref()
 }
 
+// ─────────────────────────── CUDA backend singleton (MX06 Phase 6) ───────────────────────────
+//
+// Parallel to `MetalBackend` but for NVIDIA hardware.  `cuda-compute`
+// loads `libcuda.so.1` / `nvcuda.dll` at runtime via `dlopen`/
+// `LoadLibrary`, so this whole singleton compiles on every platform.
+// `CudaExecutor::new()` returns `Err` when CUDA isn't installed — we
+// store `None` and never call this backend again.
+//
+// NVRTC compilation of the V1 generic kernel set is ~100 ms.  Doing
+// it once at first use, then caching, matches the metal singleton's
+// strategy.
+
+#[cfg(feature = "cuda-backend")]
+struct CudaBackend {
+    /// Direct reference to the CUDA executor so the auto-installer
+    /// ([`try_install_cuda`]) can call
+    /// [`matrix_cuda::CudaExecutor::install_specialised_from_emitted`]
+    /// when the `SpecRouter` produces a kernel.  Mirrors
+    /// `MetalBackend::executor`.
+    executor: Arc<matrix_cuda::CudaExecutor>,
+    transport: LocalTransport,
+    profile: executor_protocol::BackendProfile,
+}
+
+#[cfg(feature = "cuda-backend")]
+fn cuda_backend() -> Option<&'static CudaBackend> {
+    static SLOT: OnceLock<Option<CudaBackend>> = OnceLock::new();
+    SLOT.get_or_init(|| match matrix_cuda::CudaExecutor::new() {
+        Ok(exec) => {
+            let exec = Arc::new(exec);
+            let exec2 = exec.clone();
+            let transport = LocalTransport::new(move |req| exec2.handle(req));
+            Some(CudaBackend {
+                executor: exec,
+                transport,
+                profile: matrix_cuda::profile(),
+            })
+        }
+        Err(_) => None,
+    })
+    .as_ref()
+}
+
 // ─────────────────────────── CPU backend singleton (Phase 4.9) ───────────────────────────
 //
 // Up to Phase 4.8 the CPU dispatch path called `matrix_cpu::local_transport()`
@@ -453,11 +496,14 @@ fn try_auto_install_specialised_with_origin(
     // Dispatch on `backend_id`:
     //   0 → CPU (matrix_cpu::build_specialised_kernel + CpuExecutor::install_specialised)
     //   1 → metal (matrix_metal::emit_specialised_kernel + install_specialised_from_emitted)
+    //   2 → CUDA (matrix_cuda::emit_specialised_kernel + install_specialised_from_emitted)
     // Other values → ignore (no backend registered).
     let installed = match specialised.key.backend_id {
         0 => try_install_cpu(specialised),
         #[cfg(feature = "metal-backend")]
         1 => try_install_metal(specialised),
+        #[cfg(feature = "cuda-backend")]
+        2 => try_install_cuda(specialised),
         _ => false,
     };
 
@@ -567,6 +613,10 @@ fn scan_and_deoptimise() -> usize {
             #[cfg(feature = "metal-backend")]
             if let Some(metal) = metal_backend() {
                 metal.executor.evict_specialised(handle);
+            }
+            #[cfg(feature = "cuda-backend")]
+            if let Some(cuda) = cuda_backend() {
+                cuda.executor.evict_specialised(handle);
             }
             // Drop our side-table records.
             {
@@ -716,6 +766,62 @@ fn try_install_metal(specialised: &SpecialisedKernel) -> bool {
             // may want to retry this handle.
             false
         }
+    }
+}
+
+/// **MX06 Phase 6.**  Install a specialised kernel on the CUDA
+/// executor singleton.  Parallel to [`try_install_metal`] but emits
+/// CUDA C via `matrix_cuda::emit_specialised_kernel` and compiles
+/// through NVRTC.
+///
+/// Returns `false` (without installing) when:
+/// - No CUDA driver is present on the host (the singleton is `None`).
+/// - The emitter doesn't support this `SpecKey` shape (returns `None`).
+/// - NVRTC compilation fails.
+///
+/// On `false` the dispatcher falls back to either generic CUDA
+/// dispatch (when the planner has already routed the op to CUDA) or
+/// to whichever backend the planner picks.
+#[cfg(feature = "cuda-backend")]
+fn try_install_cuda(specialised: &SpecialisedKernel) -> bool {
+    let Some(backend) = cuda_backend() else {
+        return false;
+    };
+    let Some(emitted) =
+        matrix_cuda::emit_specialised_kernel(&specialised.key, specialised.handle)
+    else {
+        return false;
+    };
+    let n_in = emitted.input_buffer_count;
+    let n_out = emitted.output_buffer_count;
+    let folded_slot = specialised.key.folded_slot;
+    match backend
+        .executor
+        .install_specialised_from_emitted(specialised.handle, emitted)
+    {
+        Ok(()) => {
+            {
+                let mut installed = match installed_handles().lock() {
+                    Ok(g) => g,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                installed.insert(specialised.handle);
+            }
+            let mut md = match installed_kernel_metadata().lock() {
+                Ok(g) => g,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            md.insert(
+                specialised.handle,
+                KernelMetadata {
+                    n_in,
+                    n_out,
+                    folded_slot,
+                },
+            );
+            true
+        }
+        Err(_) => false,
     }
 }
 
@@ -948,7 +1054,38 @@ pub fn run_graph_with_constant_inputs(
         // Mixed placement.  V1 falls back to CPU-only.
     }
 
-    // ── Step 2: CPU-only fallback. ──
+    // ── Step 2 (MX06 Phase 6): try the CPU + CUDA path. ──
+    //
+    // Reached on non-Apple hosts (or Apple hosts where Metal
+    // initialisation failed).  Mirrors the metal path one-for-one:
+    // register CUDA as a second executor, plan, dispatch through
+    // the chosen single executor, fall back to CPU-only on mixed
+    // placement.
+    #[cfg(feature = "cuda-backend")]
+    if let Some(cuda) = cuda_backend() {
+        let mut runtime = Runtime::new(matrix_cpu::profile());
+        let cuda_id = runtime.register("cuda", cuda.profile.clone());
+
+        let placed: ComputeGraph = runtime
+            .plan(graph)
+            .map_err(|e| GpuError::Other(format!("plan: {:?}", e)))?;
+
+        if let Some(only) = single_executor(&placed) {
+            return if only == cuda_id {
+                dispatch_via(&cuda.transport, placed, output_id, output_byte_count, "cuda")
+            } else if only == CPU_EXECUTOR {
+                with_cpu_backend(|b| {
+                    dispatch_via(&b.transport, placed, output_id, output_byte_count, "cpu")
+                })
+            } else {
+                dispatch_cpu_only(graph, output_id, output_byte_count)
+            };
+        }
+        // Mixed placement.  Fall back to CPU-only — same V1 policy
+        // as the metal path.
+    }
+
+    // ── Step 3: CPU-only fallback. ──
     dispatch_cpu_only(graph, output_id, output_byte_count)
 }
 


### PR DESCRIPTION
## Summary

Wires `matrix-cuda` (MX06 Phase 5b) into `image-gpu-core` so the planner can route work to NVIDIA GPUs on Linux / Windows / WSL2. Mirrors the existing `matrix-metal` integration one-for-one.

## What lands

- New `cuda-backend` Cargo feature, default-on alongside `metal-backend`. Adds optional `matrix-cuda` dep.
- New `CudaBackend` singleton (`Arc<CudaExecutor>` + `LocalTransport` + `BackendProfile`). Parallel to `MetalBackend`. Lazily initialises via `OnceLock`; on hosts without a CUDA driver the singleton holds `None` permanently.
- Dispatch flow gains a **Step 2 "CPU + CUDA"** branch reached when the Metal singleton is absent (typical on Linux + NVIDIA). Same single-executor / mixed-placement → CPU-only-fallback policy as the Metal path.
- Auto-installer gains a `2 => try_install_cuda(specialised)` arm. `try_install_cuda` parallels `try_install_metal`: calls `matrix_cuda::emit_specialised_kernel`, hands to `CudaExecutor::install_specialised_from_emitted` (NVRTC compile + closure capture), records handle + metadata.
- `scan_and_deoptimise` gains a `cuda.executor.evict_specialised(handle)` call alongside the existing CPU + Metal evicts. **Completes the MX05 Phase 5 deopt loop on the third backend.**

## Why this matters

NVIDIA users get GPU acceleration **automatically**, through the same narrow-waist abstraction Apple users have had since matrix-metal landed. No user-facing config. When the user writes `gpu_brightness(...)`, it now runs on:

| Host                      | Picked executor                  |
| ------------------------- | -------------------------------- |
| macOS                     | `matrix-metal` when available    |
| Linux / Windows + NVIDIA  | `matrix-cuda` when available     |
| Everywhere else           | `matrix-cpu`                     |

## Test plan

- [x] `cargo test -p image-gpu-core` — 36 tests passing on macOS (where `cuda_backend()` returns `None` and the new Step 2 branch is never taken).
- [x] `cargo build -p image-gpu-core` — clean, both features on.
- [x] `/security-review` — passed. No new unsafe. OnceLock + Arc pattern matches the existing Metal singleton; CudaExecutor is `Send + Sync` per cuda-compute v0.1.2. Mutex poisoning handled consistently. No user-controlled inputs reach the backend dispatch arms.

## What this PR does NOT change

- No GPU CI runner — Phase 7.
- No cost-model calibration for CUDA — Phase 7.
- Three-way mixed placement (CPU + Metal + CUDA on the same host) still falls back to CPU-only. Apple + NVIDIA on the same machine isn't a real case so this isn't a real limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)