### PR TITLE
ts(spice): add RL transient analysis

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add capacitor support and backward-Euler RC transient analysis.
+- Add ideal-short DC and backward-Euler transient support for inductors.
 
 ## 0.1.0
 

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -3,8 +3,8 @@
 `@coding-adventures/spice-engine` provides SPICE-style circuit analysis
 primitives for TypeScript.
 
-The current slices implement DC operating-point analysis and fixed-step RC
+The current slices implement DC operating-point analysis and fixed-step RC/RL
 transient analysis for linear circuits using modified nodal analysis (MNA). The
-package supports resistors, capacitors, independent current sources,
+package supports resistors, capacitors, inductors, independent current sources,
 independent voltage sources, ground aliases, node voltages, voltage source
-branch currents, and backward-Euler capacitor companion models.
+branch currents, and backward-Euler reactive-element companion models.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1,6 +1,6 @@
 const PIVOT_EPSILON = 1.0e-12;
 
-export type Element = Resistor | Capacitor | VoltageSource | CurrentSource;
+export type Element = Resistor | Capacitor | Inductor | VoltageSource | CurrentSource;
 
 export interface Resistor {
   readonly kind: "resistor";
@@ -17,6 +17,15 @@ export interface Capacitor {
   readonly n2: string;
   readonly capacitanceFarads: number;
   readonly initialVoltage: number;
+}
+
+export interface Inductor {
+  readonly kind: "inductor";
+  readonly name: string;
+  readonly n1: string;
+  readonly n2: string;
+  readonly inductanceHenrys: number;
+  readonly initialCurrent: number;
 }
 
 export interface VoltageSource {
@@ -108,6 +117,32 @@ export function capacitorWithInitialVoltage(
   };
 }
 
+export function inductor(
+  name: string,
+  n1: string,
+  n2: string,
+  inductanceHenrys: number,
+): Inductor {
+  return inductorWithInitialCurrent(name, n1, n2, inductanceHenrys, 0.0);
+}
+
+export function inductorWithInitialCurrent(
+  name: string,
+  n1: string,
+  n2: string,
+  inductanceHenrys: number,
+  initialCurrent: number,
+): Inductor {
+  return {
+    kind: "inductor",
+    name,
+    n1,
+    n2,
+    inductanceHenrys,
+    initialCurrent,
+  };
+}
+
 export function voltageSource(
   name: string,
   positive: string,
@@ -127,7 +162,7 @@ export function currentSource(
 }
 
 export function dcOp(circuit: Circuit): DcResult {
-  const solution = solveLinearCircuit(circuit, []);
+  const solution = solveLinearCircuit(circuit, [], []);
   return makeDcResult(solution.nodeVoltages, solution.branchCurrents);
 }
 
@@ -143,13 +178,15 @@ export function transient(
     throw invalidElement("transient", "stop time must be finite and non-negative");
   }
 
-  validateCapacitors(circuit);
+  validateReactiveElements(circuit);
 
   const capacitorStates = initialCapacitorStates(circuit, timeStep);
+  const inductorStates = initialInductorStates(circuit, timeStep);
   const points: TransientPoint[] = [];
   for (let time = timeStep; time <= stopTime + timeStep * 1.0e-9; time += timeStep) {
-    const solution = solveLinearCircuit(circuit, capacitorStates);
+    const solution = solveLinearCircuit(circuit, capacitorStates, inductorStates);
     updateCapacitorStates(circuit, solution.nodeVoltages, capacitorStates);
+    updateInductorStates(circuit, solution.nodeVoltages, inductorStates);
     points.push(
       makeTransientPoint(time, solution.nodeVoltages, solution.branchCurrents),
     );
@@ -163,6 +200,12 @@ interface CapacitorState {
   readonly timeStep: number;
 }
 
+interface InductorState {
+  readonly name: string;
+  previousCurrent: number;
+  readonly timeStep: number;
+}
+
 interface LinearSolution {
   readonly nodeVoltages: ReadonlyMap<string, number>;
   readonly branchCurrents: ReadonlyMap<string, number>;
@@ -171,9 +214,10 @@ interface LinearSolution {
 function solveLinearCircuit(
   circuit: Circuit,
   capacitorStates: readonly CapacitorState[],
+  inductorStates: readonly InductorState[],
 ): LinearSolution {
   const nodeIndices = collectNodeIndices(circuit);
-  const voltageSources = collectVoltageSources(circuit);
+  const voltageSources = collectVoltageSources(circuit, inductorStates);
   const nodeCount = nodeIndices.size;
   const branchCount = voltageSources.size;
   const matrixSize = nodeCount + branchCount;
@@ -194,6 +238,17 @@ function solveLinearCircuit(
         break;
       case "capacitor":
         stampCapacitor(element, capacitorStates, nodeIndices, matrix, rhs);
+        break;
+      case "inductor":
+        stampInductor(
+          element,
+          inductorStates,
+          nodeIndices,
+          voltageSources,
+          nodeCount,
+          matrix,
+          rhs,
+        );
         break;
       case "voltage-source":
         stampVoltageSource(
@@ -224,6 +279,12 @@ function solveLinearCircuit(
   for (const [sourceName, branchIndex] of voltageSources.entries()) {
     branchCurrents.set(`I(${sourceName})`, solution[nodeCount + branchIndex]);
   }
+  insertTransientInductorCurrents(
+    circuit,
+    inductorStates,
+    nodeVoltages,
+    branchCurrents,
+  );
 
   return { nodeVoltages, branchCurrents };
 }
@@ -274,6 +335,7 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
     switch (element.kind) {
       case "resistor":
       case "capacitor":
+      case "inductor":
         insertNode(names, element.n1);
         insertNode(names, element.n2);
         break;
@@ -292,18 +354,35 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
   return nodeIndices;
 }
 
-function collectVoltageSources(circuit: Circuit): Map<string, number> {
+function collectVoltageSources(
+  circuit: Circuit,
+  inductorStates: readonly InductorState[],
+): Map<string, number> {
   const sources = new Map<string, number>();
   for (const element of circuit.elements()) {
-    if (element.kind !== "voltage-source") {
-      continue;
+    if (element.kind === "voltage-source") {
+      insertBranchName(sources, element.name, "duplicate voltage source name");
+    } else if (element.kind === "inductor") {
+      if (sources.has(element.name)) {
+        throw invalidElement(element.name, "duplicate branch element name");
+      }
+      if (!inductorStates.some((state) => state.name === element.name)) {
+        sources.set(element.name, sources.size);
+      }
     }
-    if (sources.has(element.name)) {
-      throw invalidElement(element.name, "duplicate voltage source name");
-    }
-    sources.set(element.name, sources.size);
   }
   return sources;
+}
+
+function insertBranchName(
+  sources: Map<string, number>,
+  name: string,
+  duplicateReason: string,
+): void {
+  if (sources.has(name)) {
+    throw invalidElement(name, duplicateReason);
+  }
+  sources.set(name, sources.size);
 }
 
 function insertNode(nodes: Set<string>, node: string): void {
@@ -365,6 +444,50 @@ function stampCapacitor(
   }
 }
 
+function stampInductor(
+  element: Inductor,
+  inductorStates: readonly InductorState[],
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  nodeCount: number,
+  matrix: number[][],
+  rhs: number[],
+): void {
+  validateInductor(element);
+  const n1 = nodeIndex(nodeIndices, element.n1);
+  const n2 = nodeIndex(nodeIndices, element.n2);
+  const state = inductorStates.find((candidate) => candidate.name === element.name);
+  if (state === undefined) {
+    stampZeroVoltageBranch(element.name, voltageSources, nodeCount, matrix, n1, n2);
+    return;
+  }
+
+  const conductance = state.timeStep / element.inductanceHenrys;
+  stampConductance(matrix, n1, n2, conductance);
+  if (n1 !== undefined) {
+    rhs[n1] -= state.previousCurrent;
+  }
+  if (n2 !== undefined) {
+    rhs[n2] += state.previousCurrent;
+  }
+}
+
+function stampZeroVoltageBranch(
+  name: string,
+  voltageSources: ReadonlyMap<string, number>,
+  nodeCount: number,
+  matrix: number[][],
+  positive: number | undefined,
+  negative: number | undefined,
+): void {
+  const sourceIndex = voltageSources.get(name);
+  if (sourceIndex === undefined) {
+    throw invalidElement(name, "branch element was not indexed");
+  }
+  const branch = nodeCount + sourceIndex;
+  stampBranchMatrix(matrix, branch, positive, negative);
+}
+
 function stampConductance(
   matrix: number[][],
   n1: number | undefined,
@@ -383,10 +506,12 @@ function stampConductance(
   }
 }
 
-function validateCapacitors(circuit: Circuit): void {
+function validateReactiveElements(circuit: Circuit): void {
   for (const element of circuit.elements()) {
     if (element.kind === "capacitor") {
       validateCapacitor(element);
+    } else if (element.kind === "inductor") {
+      validateInductor(element);
     }
   }
 }
@@ -400,6 +525,15 @@ function validateCapacitor(element: Capacitor): void {
   }
 }
 
+function validateInductor(element: Inductor): void {
+  if (!Number.isFinite(element.inductanceHenrys) || element.inductanceHenrys <= 0.0) {
+    throw invalidElement(element.name, "inductance must be finite and positive");
+  }
+  if (!Number.isFinite(element.initialCurrent)) {
+    throw invalidElement(element.name, "initial current must be finite");
+  }
+}
+
 function initialCapacitorStates(
   circuit: Circuit,
   timeStep: number,
@@ -410,6 +544,23 @@ function initialCapacitorStates(
       states.push({
         name: element.name,
         previousVoltage: element.initialVoltage,
+        timeStep,
+      });
+    }
+  }
+  return states;
+}
+
+function initialInductorStates(
+  circuit: Circuit,
+  timeStep: number,
+): InductorState[] {
+  const states: InductorState[] = [];
+  for (const element of circuit.elements()) {
+    if (element.kind === "inductor") {
+      states.push({
+        name: element.name,
+        previousCurrent: element.initialCurrent,
         timeStep,
       });
     }
@@ -435,6 +586,58 @@ function updateCapacitorStates(
     state.previousVoltage =
       voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
   }
+}
+
+function updateInductorStates(
+  circuit: Circuit,
+  nodeVoltages: ReadonlyMap<string, number>,
+  inductorStates: InductorState[],
+): void {
+  for (const state of inductorStates) {
+    const element = circuit
+      .elements()
+      .find(
+        (candidate): candidate is Inductor =>
+          candidate.kind === "inductor" && candidate.name === state.name,
+      );
+    if (element === undefined) {
+      continue;
+    }
+    state.previousCurrent = inductorCurrent(element, state, nodeVoltages);
+  }
+}
+
+function insertTransientInductorCurrents(
+  circuit: Circuit,
+  inductorStates: readonly InductorState[],
+  nodeVoltages: ReadonlyMap<string, number>,
+  branchCurrents: Map<string, number>,
+): void {
+  for (const state of inductorStates) {
+    const element = circuit
+      .elements()
+      .find(
+        (candidate): candidate is Inductor =>
+          candidate.kind === "inductor" && candidate.name === state.name,
+      );
+    if (element === undefined) {
+      continue;
+    }
+    branchCurrents.set(
+      `I(${element.name})`,
+      inductorCurrent(element, state, nodeVoltages),
+    );
+  }
+}
+
+function inductorCurrent(
+  element: Inductor,
+  state: InductorState,
+  nodeVoltages: ReadonlyMap<string, number>,
+): number {
+  const conductance = state.timeStep / element.inductanceHenrys;
+  const voltage = voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
+  return state.previousCurrent + conductance * voltage;
 }
 
 function voltageAt(
@@ -465,6 +668,16 @@ function stampVoltageSource(
   const positive = nodeIndex(nodeIndices, element.positive);
   const negative = nodeIndex(nodeIndices, element.negative);
 
+  stampBranchMatrix(matrix, branch, positive, negative);
+  rhs[branch] += element.voltage;
+}
+
+function stampBranchMatrix(
+  matrix: number[][],
+  branch: number,
+  positive: number | undefined,
+  negative: number | undefined,
+): void {
   if (positive !== undefined) {
     matrix[positive][branch] += 1.0;
     matrix[branch][positive] += 1.0;
@@ -473,7 +686,6 @@ function stampVoltageSource(
     matrix[negative][branch] -= 1.0;
     matrix[branch][negative] -= 1.0;
   }
-  rhs[branch] += element.voltage;
 }
 
 function stampCurrentSource(

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -4,6 +4,7 @@ import {
   SpiceError,
   currentSource,
   dcOp,
+  inductor,
   resistor,
   voltageSource,
 } from "../src/index.js";
@@ -58,6 +59,18 @@ describe("dcOp", () => {
     expectClose(result.voltage("n1"), 3.3);
     expectClose(result.voltage("gnd"), 0.0);
     expectClose(result.voltage("GND"), 0.0);
+  });
+
+  it("treats inductors as ideal shorts in DC", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "vin", "0", 1.0));
+    circuit.add(resistor("R1", "vin", "out", 1_000.0));
+    circuit.add(inductor("L1", "out", "0", 1.0));
+
+    const result = dcOp(circuit);
+
+    expectClose(result.voltage("out"), 0.0);
+    expectClose(result.branchCurrent("L1"), 1.0e-3);
   });
 
   it("returns a singular matrix error for a floating resistor", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -4,6 +4,8 @@ import {
   SpiceError,
   capacitor,
   capacitorWithInitialVoltage,
+  inductor,
+  inductorWithInitialCurrent,
   resistor,
   transient,
   voltageSource,
@@ -41,6 +43,36 @@ describe("transient", () => {
     expectClose(points[1].voltage("out"), 0.25);
   });
 
+  it("uses a backward-Euler inductor companion for an RL step", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "vin", "0", 1.0));
+    circuit.add(resistor("R1", "vin", "out", 1_000.0));
+    circuit.add(inductor("L1", "out", "0", 1.0));
+
+    const points = transient(circuit, 1.0e-3, 3.0e-3);
+
+    expect(points).toHaveLength(3);
+    expectClose(points[0].voltage("out"), 0.5);
+    expectClose(points[0].branchCurrent("L1"), 0.5e-3);
+    expectClose(points[1].voltage("out"), 0.25);
+    expectClose(points[1].branchCurrent("L1"), 0.75e-3);
+    expectClose(points[2].voltage("out"), 0.125);
+    expectClose(points[2].branchCurrent("L1"), 0.875e-3);
+  });
+
+  it("respects inductor initial current", () => {
+    const circuit = new Circuit();
+    circuit.add(resistor("R1", "out", "0", 1_000.0));
+    circuit.add(inductorWithInitialCurrent("L1", "out", "0", 1.0, 1.0e-3));
+
+    const points = transient(circuit, 1.0e-3, 2.0e-3);
+
+    expectClose(points[0].voltage("out"), -0.5);
+    expectClose(points[0].branchCurrent("L1"), 0.5e-3);
+    expectClose(points[1].voltage("out"), -0.25);
+    expectClose(points[1].branchCurrent("L1"), 0.25e-3);
+  });
+
   it("rejects non-positive capacitance", () => {
     const circuit = new Circuit();
     circuit.add(capacitor("Cbad", "out", "0", 0.0));
@@ -48,6 +80,16 @@ describe("transient", () => {
     expect(() => transient(circuit, 1.0e-3, 1.0e-3)).toThrowError(SpiceError);
     expect(() => transient(circuit, 1.0e-3, 1.0e-3)).toThrowError(
       "invalid element Cbad",
+    );
+  });
+
+  it("rejects non-positive inductance", () => {
+    const circuit = new Circuit();
+    circuit.add(inductor("Lbad", "out", "0", 0.0));
+
+    expect(() => transient(circuit, 1.0e-3, 1.0e-3)).toThrowError(SpiceError);
+    expect(() => transient(circuit, 1.0e-3, 1.0e-3)).toThrowError(
+      "invalid element Lbad",
     );
   });
 


### PR DESCRIPTION
## Summary
- add `Inductor` support to the TypeScript `spice-engine` package
- model inductors as ideal shorts in DC operating-point analysis
- add backward-Euler RL transient analysis with inductor branch currents and initial-current handling

## Validation
- `sh BUILD`
- `git diff --check`
