### PR TITLE
rust(spice): add DC source sweeps

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -4,5 +4,6 @@
 
 - Add a DC modified nodal analysis solver for resistors, independent voltage
   sources, and independent current sources.
+- Add DC source sweeps for independent voltage and current sources.
 - Add backward-Euler transient analysis for linear RC circuits.
 - Add ideal-short DC and backward-Euler transient support for inductors.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -6,6 +6,7 @@ The initial slices implement:
 
 - DC operating-point analysis for linear circuits using modified nodal analysis
   (MNA).
+- DC source sweeps over independent voltage and current sources.
 - Backward-Euler transient analysis for linear RC/RL circuits.
 
 The package supports resistors, capacitors, inductors, independent current sources,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -190,6 +190,12 @@ pub struct DcResult {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct DcSweepPoint {
+    pub value: f64,
+    pub result: DcResult,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct TransientPoint {
     pub time: f64,
     pub node_voltages: BTreeMap<String, f64>,
@@ -260,6 +266,30 @@ pub fn dc_op(circuit: &Circuit) -> Result<DcResult, SpiceError> {
     })
 }
 
+pub fn dc_sweep(
+    circuit: &Circuit,
+    source_name: &str,
+    start: f64,
+    stop: f64,
+    step: f64,
+) -> Result<Vec<DcSweepPoint>, SpiceError> {
+    validate_sweep(source_name, start, stop, step)?;
+
+    let mut points = Vec::new();
+    let mut value = start;
+    let epsilon = step.abs() * 1.0e-9;
+    while sweep_includes(value, stop, step, epsilon) {
+        let mut swept = circuit.clone();
+        set_source_value(&mut swept, source_name, value)?;
+        points.push(DcSweepPoint {
+            value,
+            result: dc_op(&swept)?,
+        });
+        value += step;
+    }
+    Ok(points)
+}
+
 pub fn transient(
     circuit: &Circuit,
     time_step: f64,
@@ -304,6 +334,60 @@ pub fn transient(
         time += time_step;
     }
     Ok(points)
+}
+
+fn validate_sweep(source_name: &str, start: f64, stop: f64, step: f64) -> Result<(), SpiceError> {
+    if source_name.is_empty() {
+        return Err(SpiceError::InvalidElement {
+            name: "dc_sweep".to_string(),
+            reason: "source name must not be empty".to_string(),
+        });
+    }
+    if !start.is_finite() || !stop.is_finite() || !step.is_finite() || step == 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: source_name.to_string(),
+            reason: "sweep bounds and step must be finite, with non-zero step".to_string(),
+        });
+    }
+    if (stop - start).signum() != step.signum() && start != stop {
+        return Err(SpiceError::InvalidElement {
+            name: source_name.to_string(),
+            reason: "sweep step direction must move from start toward stop".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn sweep_includes(value: f64, stop: f64, step: f64, epsilon: f64) -> bool {
+    if step > 0.0 {
+        value <= stop + epsilon
+    } else {
+        value >= stop - epsilon
+    }
+}
+
+fn set_source_value(
+    circuit: &mut Circuit,
+    source_name: &str,
+    value: f64,
+) -> Result<(), SpiceError> {
+    for element in &mut circuit.elements {
+        match element {
+            Element::VoltageSource(source) if source.name == source_name => {
+                source.voltage = value;
+                return Ok(());
+            }
+            Element::CurrentSource(source) if source.name == source_name => {
+                source.current = value;
+                return Ok(());
+            }
+            _ => {}
+        }
+    }
+    Err(SpiceError::InvalidElement {
+        name: source_name.to_string(),
+        reason: "sweep source must be an independent voltage or current source".to_string(),
+    })
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,5 +1,5 @@
 use spice_engine::{
-    dc_op, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, VoltageSource,
+    dc_op, dc_sweep, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -84,6 +84,64 @@ fn dc_inductor_behaves_as_ideal_short() {
 
     assert_close(result.voltage("out").unwrap(), 0.0);
     assert_close(result.branch_current("L1").unwrap(), 1.0e-3);
+}
+
+#[test]
+fn dc_sweep_varies_voltage_source_and_collects_operating_points() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vin", "0", 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "R1", "vin", "mid", 1_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("R2", "mid", "0", 1_000.0)));
+
+    let points = dc_sweep(&circuit, "V1", 0.0, 2.0, 1.0).unwrap();
+
+    assert_eq!(points.len(), 3);
+    assert_close(points[0].value, 0.0);
+    assert_close(points[0].result.voltage("mid").unwrap(), 0.0);
+    assert_close(points[1].value, 1.0);
+    assert_close(points[1].result.voltage("mid").unwrap(), 0.5);
+    assert_close(points[2].value, 2.0);
+    assert_close(points[2].result.voltage("mid").unwrap(), 1.0);
+}
+
+#[test]
+fn dc_sweep_supports_current_sources() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::CurrentSource(CurrentSource::new(
+        "I1", "0", "n1", 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("R1", "n1", "0", 1_000.0)));
+
+    let points = dc_sweep(&circuit, "I1", 0.0, 2.0e-3, 1.0e-3).unwrap();
+
+    assert_eq!(points.len(), 3);
+    assert_close(points[0].result.voltage("n1").unwrap(), 0.0);
+    assert_close(points[1].result.voltage("n1").unwrap(), 1.0);
+    assert_close(points[2].result.voltage("n1").unwrap(), 2.0);
+}
+
+#[test]
+fn dc_sweep_rejects_step_that_does_not_reach_stop() {
+    let circuit = Circuit::new();
+
+    assert!(matches!(
+        dc_sweep(&circuit, "V1", 0.0, 1.0, -0.1),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "V1"
+    ));
+}
+
+#[test]
+fn dc_sweep_rejects_missing_source() {
+    let circuit = Circuit::new();
+
+    assert!(matches!(
+        dc_sweep(&circuit, "Vmissing", 0.0, 1.0, 1.0),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Vmissing"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add DC source sweep support to the Rust `spice-engine` package
- sweep named independent voltage and current sources over inclusive ranges
- cover voltage-source sweeps, current-source sweeps, step direction validation, and missing-source errors

## Validation
- `cargo fmt -p spice-engine`
- `cargo test -p spice-engine`
- `git diff --check`
