### PR TITLE
ts(spice): add DC source sweeps

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add DC source sweeps for independent voltage and current sources.
 - Add capacitor support and backward-Euler RC transient analysis.
 - Add ideal-short DC and backward-Euler transient support for inductors.
 

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -3,8 +3,9 @@
 `@coding-adventures/spice-engine` provides SPICE-style circuit analysis
 primitives for TypeScript.
 
-The current slices implement DC operating-point analysis and fixed-step RC/RL
-transient analysis for linear circuits using modified nodal analysis (MNA). The
-package supports resistors, capacitors, inductors, independent current sources,
-independent voltage sources, ground aliases, node voltages, voltage source
-branch currents, and backward-Euler reactive-element companion models.
+The current slices implement DC operating-point analysis, DC source sweeps, and
+fixed-step RC/RL transient analysis for linear circuits using modified nodal
+analysis (MNA). The package supports resistors, capacitors, inductors,
+independent current sources, independent voltage sources, ground aliases, node
+voltages, voltage source branch currents, and backward-Euler reactive-element
+companion models.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -51,6 +51,11 @@ export interface DcResult {
   branchCurrent(sourceName: string): number | undefined;
 }
 
+export interface DcSweepPoint {
+  readonly value: number;
+  readonly result: DcResult;
+}
+
 export interface TransientPoint {
   readonly time: number;
   readonly nodeVoltages: ReadonlyMap<string, number>;
@@ -166,6 +171,28 @@ export function dcOp(circuit: Circuit): DcResult {
   return makeDcResult(solution.nodeVoltages, solution.branchCurrents);
 }
 
+export function dcSweep(
+  circuit: Circuit,
+  sourceName: string,
+  start: number,
+  stop: number,
+  step: number,
+): DcSweepPoint[] {
+  validateSweep(sourceName, start, stop, step);
+
+  const points: DcSweepPoint[] = [];
+  const epsilon = Math.abs(step) * 1.0e-9;
+  for (
+    let value = start;
+    sweepIncludes(value, stop, step, epsilon);
+    value += step
+  ) {
+    const swept = circuitWithSweptSource(circuit, sourceName, value);
+    points.push({ value, result: dcOp(swept) });
+  }
+  return points;
+}
+
 export function transient(
   circuit: Circuit,
   timeStep: number,
@@ -192,6 +219,70 @@ export function transient(
     );
   }
   return points;
+}
+
+function validateSweep(
+  sourceName: string,
+  start: number,
+  stop: number,
+  step: number,
+): void {
+  if (sourceName.length === 0) {
+    throw invalidElement("dcSweep", "source name must not be empty");
+  }
+  if (
+    !Number.isFinite(start) ||
+    !Number.isFinite(stop) ||
+    !Number.isFinite(step) ||
+    step === 0.0
+  ) {
+    throw invalidElement(
+      sourceName,
+      "sweep bounds and step must be finite, with non-zero step",
+    );
+  }
+  if (Math.sign(stop - start) !== Math.sign(step) && start !== stop) {
+    throw invalidElement(
+      sourceName,
+      "sweep step direction must move from start toward stop",
+    );
+  }
+}
+
+function sweepIncludes(
+  value: number,
+  stop: number,
+  step: number,
+  epsilon: number,
+): boolean {
+  return step > 0.0 ? value <= stop + epsilon : value >= stop - epsilon;
+}
+
+function circuitWithSweptSource(
+  circuit: Circuit,
+  sourceName: string,
+  value: number,
+): Circuit {
+  let found = false;
+  const swept = new Circuit();
+  for (const element of circuit.elements()) {
+    if (element.kind === "voltage-source" && element.name === sourceName) {
+      swept.add({ ...element, voltage: value });
+      found = true;
+    } else if (element.kind === "current-source" && element.name === sourceName) {
+      swept.add({ ...element, current: value });
+      found = true;
+    } else {
+      swept.add(element);
+    }
+  }
+  if (!found) {
+    throw invalidElement(
+      sourceName,
+      "sweep source must be an independent voltage or current source",
+    );
+  }
+  return swept;
 }
 
 interface CapacitorState {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -4,6 +4,7 @@ import {
   SpiceError,
   currentSource,
   dcOp,
+  dcSweep,
   inductor,
   resistor,
   voltageSource,
@@ -71,6 +72,52 @@ describe("dcOp", () => {
 
     expectClose(result.voltage("out"), 0.0);
     expectClose(result.branchCurrent("L1"), 1.0e-3);
+  });
+
+  it("sweeps voltage sources and collects operating points", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "vin", "0", 0.0));
+    circuit.add(resistor("R1", "vin", "mid", 1_000.0));
+    circuit.add(resistor("R2", "mid", "0", 1_000.0));
+
+    const points = dcSweep(circuit, "V1", 0.0, 2.0, 1.0);
+
+    expect(points).toHaveLength(3);
+    expectClose(points[0].value, 0.0);
+    expectClose(points[0].result.voltage("mid"), 0.0);
+    expectClose(points[1].value, 1.0);
+    expectClose(points[1].result.voltage("mid"), 0.5);
+    expectClose(points[2].value, 2.0);
+    expectClose(points[2].result.voltage("mid"), 1.0);
+  });
+
+  it("sweeps current sources and collects operating points", () => {
+    const circuit = new Circuit();
+    circuit.add(currentSource("I1", "0", "n1", 0.0));
+    circuit.add(resistor("R1", "n1", "0", 1_000.0));
+
+    const points = dcSweep(circuit, "I1", 0.0, 2.0e-3, 1.0e-3);
+
+    expect(points).toHaveLength(3);
+    expectClose(points[0].result.voltage("n1"), 0.0);
+    expectClose(points[1].result.voltage("n1"), 1.0);
+    expectClose(points[2].result.voltage("n1"), 2.0);
+  });
+
+  it("rejects sweep steps that do not reach the stop value", () => {
+    const circuit = new Circuit();
+
+    expect(() => dcSweep(circuit, "V1", 0.0, 1.0, -0.1)).toThrowError(
+      "sweep step direction",
+    );
+  });
+
+  it("rejects missing sweep sources", () => {
+    const circuit = new Circuit();
+
+    expect(() => dcSweep(circuit, "Vmissing", 0.0, 1.0, 1.0)).toThrowError(
+      "sweep source must be an independent voltage or current source",
+    );
   });
 
   it("returns a singular matrix error for a floating resistor", () => {


### PR DESCRIPTION
## Summary
- add DC source sweep support to the TypeScript `@coding-adventures/spice-engine` package
- sweep named independent voltage and current sources over inclusive ranges
- mirror the Rust sweep behavior with voltage-source, current-source, direction-validation, and missing-source tests

## Validation
- `sh BUILD`
- `git diff --check`
