### PR TITLE
feat(typescript): release symbolic-vm 0.2.0 and macsyma-runtime 0.2.0

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.2.0] — 2026-05-14
 
 - Add TypeScript MACSYMA parity for elliptic first-kind integration, so
   `integrate(1/sqrt(1-k^2*sin(theta)^2), theta)` returns

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/macsyma-runtime",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pure TypeScript MACSYMA runtime session over the symbolic VM",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.2.0] — 2026-05-14
 
 ### Added
 

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

This PR cuts proper 0.2.0 releases for two TypeScript CAS packages. The code and tests already exist and pass — this is purely version housekeeping.

### symbolic-vm 0.2.0

- Symbolic integration recognition for elliptic first-kind forms, returning `EllipticF(theta, k)` and complete `EllipticK(k)` nodes
- Bivariate perfect-cube, perfect-square, difference-of-squares, and cubic-identity factoring footholds in `Factor`
- Canonical `Factor` handler backed by `cas-factor`, including common-symbolic-factor extraction for multivariate expressions like `x^2*y - y`
- Extended multivariate factoring to extract shared integer content (e.g. `2*x*y + 2*x*z` → `2*x*(y+z)`)
- Four-term bilinear grouping factoring foothold (e.g. `x*y + x*z + y + z` → `(x+1)*(y+z)`)
- Symbolic-backend-only `D` handler for pure IR differentiation: arithmetic, power, elementary, hyperbolic, inverse hyperbolic chain rules
- Reciprocal hyperbolic `Coth`, `Sech`, `Csch` numeric handlers and derivative chain rules

### macsyma-runtime 0.2.0

- TypeScript MACSYMA parity for all symbolic-vm 0.2.0 factoring and integration features
- `?` / `? topic` help-query handling for MACSYMA sessions and JSON responses
- `assume`, `forget`, `is`, `declare`, `properties`, `propvars` wired to a session assumption context
- `ev(expr, display2d)` routed through the `cas-pretty-printer` 2D box renderer
- `TrigReduce` dispatch to `cas-trig`; `Simplify`, `RatSimplify`, `TrigSimplify`, `TrigExpand` to `cas-simplify`/`cas-trig`
- `Subst(value, variable, expr)` wired to `cas-substitution`
- Deterministic list heads (`Length`, `First`, `Rest`, `Last`, `Append`, `Reverse`, `Range`, `Map`, `Apply`, `Sort`, `Part`, `Flatten`, `Join`) via `cas-list-operations`
- `Solve` extended: transcendental equations, polynomial inequalities, and linear systems

## Test plan

- [x] `symbolic-vm`: `npx vitest run` — 44 tests pass
- [x] `macsyma-runtime`: `npx vitest run` — 67 tests pass
- [ ] CI green on all TypeScript jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)