### PR TITLE
rust(spice): add DC sensitivity analysis

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add a DC modified nodal analysis solver for resistors, independent voltage
   sources, and independent current sources.
 - Add DC source sweeps for independent voltage and current sources.
+- Add DC sensitivity analysis for resistor and independent source parameters.
 - Add DC small-signal transfer-function analysis with input/output impedance.
 - Add AC small-signal frequency sweeps for linear RC/RL circuits.
 - Add backward-Euler transient analysis for linear RC circuits.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -7,6 +7,8 @@ The initial slices implement:
 - DC operating-point analysis for linear circuits using modified nodal analysis
   (MNA).
 - DC source sweeps over independent voltage and current sources.
+- DC sensitivity analysis for output-node voltage changes with respect to
+  resistor and independent source parameters.
 - DC small-signal transfer-function (`.tf`) analysis with input and output
   impedance estimates.
 - AC small-signal frequency sweeps for linear RC/RL circuits.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -209,6 +209,30 @@ impl TfResult {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SensEntry {
+    pub element_name: String,
+    pub parameter: String,
+    pub nominal_value: f64,
+    pub sensitivity: f64,
+    pub relative_sensitivity: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SensResult {
+    pub output_node: String,
+    pub nominal_voltage: f64,
+    pub entries: Vec<SensEntry>,
+}
+
+impl SensResult {
+    pub fn entry(&self, element_name: &str, parameter: &str) -> Option<&SensEntry> {
+        self.entries
+            .iter()
+            .find(|entry| entry.element_name == element_name && entry.parameter == parameter)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Complex {
     pub real: f64,
@@ -485,6 +509,60 @@ pub fn tf(
     })
 }
 
+pub fn sens_dc(circuit: &Circuit, output_node: &str) -> Result<SensResult, SpiceError> {
+    let node_indices = collect_node_indices(circuit);
+    if !is_ground(output_node) && !node_indices.contains_key(output_node) {
+        return Err(SpiceError::InvalidElement {
+            name: output_node.to_string(),
+            reason: "output node was not found in circuit".to_string(),
+        });
+    }
+
+    let nominal = dc_op(circuit)?;
+    let nominal_voltage = nominal.voltage(output_node).unwrap_or(0.0);
+    let mut entries = Vec::new();
+
+    for element_index in 0..circuit.elements.len() {
+        if let Some((element_name, parameter, nominal_value)) =
+            element_parameter(&circuit.elements[element_index])
+        {
+            let delta = perturbation_for(nominal_value);
+            let mut perturbed = circuit.clone();
+            perturb_element_parameter(&mut perturbed.elements[element_index], delta);
+            let perturbed_result = dc_op(&perturbed)?;
+            let perturbed_voltage = perturbed_result.voltage(output_node).unwrap_or(0.0);
+            let sensitivity = (perturbed_voltage - nominal_voltage) / delta;
+            let relative_sensitivity = if nominal_voltage.abs() > 1.0e-30 {
+                sensitivity * nominal_value / nominal_voltage
+            } else {
+                0.0
+            };
+            entries.push(SensEntry {
+                element_name,
+                parameter,
+                nominal_value,
+                sensitivity,
+                relative_sensitivity,
+            });
+        }
+    }
+
+    entries.sort_by(|left, right| {
+        right
+            .relative_sensitivity
+            .abs()
+            .total_cmp(&left.relative_sensitivity.abs())
+            .then_with(|| left.element_name.cmp(&right.element_name))
+            .then_with(|| left.parameter.cmp(&right.parameter))
+    });
+
+    Ok(SensResult {
+        output_node: output_node.to_string(),
+        nominal_voltage,
+        entries,
+    })
+}
+
 pub fn ac_sweep(
     circuit: &Circuit,
     start_hz: f64,
@@ -626,6 +704,36 @@ fn set_source_value(
         name: source_name.to_string(),
         reason: "sweep source must be an independent voltage or current source".to_string(),
     })
+}
+
+fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
+    match element {
+        Element::Resistor(resistor) => Some((
+            resistor.name.clone(),
+            "resistance_ohms".to_string(),
+            resistor.resistance_ohms,
+        )),
+        Element::VoltageSource(source) => {
+            Some((source.name.clone(), "voltage".to_string(), source.voltage))
+        }
+        Element::CurrentSource(source) => {
+            Some((source.name.clone(), "current".to_string(), source.current))
+        }
+        Element::Capacitor(_) | Element::Inductor(_) => None,
+    }
+}
+
+fn perturbation_for(value: f64) -> f64 {
+    (value.abs() * 1.0e-6).max(1.0e-9)
+}
+
+fn perturb_element_parameter(element: &mut Element, delta: f64) {
+    match element {
+        Element::Resistor(resistor) => resistor.resistance_ohms += delta,
+        Element::VoltageSource(source) => source.voltage += delta,
+        Element::CurrentSource(source) => source.current += delta,
+        Element::Capacitor(_) | Element::Inductor(_) => {}
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/code/packages/rust/spice-engine/tests/sens_tests.rs
+++ b/code/packages/rust/spice-engine/tests/sens_tests.rs
@@ -1,0 +1,115 @@
+use spice_engine::{
+    sens_dc, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, VoltageSource,
+};
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 1.0e-6,
+        "expected {expected}, got {actual}"
+    );
+}
+
+fn entry<'a>(
+    result: &'a SensResult,
+    element_name: &str,
+    parameter: &str,
+) -> &'a spice_engine::SensEntry {
+    result
+        .entry(element_name, parameter)
+        .unwrap_or_else(|| panic!("missing sensitivity entry for {element_name}.{parameter}"))
+}
+
+#[test]
+fn sens_dc_reports_divider_source_and_resistor_sensitivities() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "vin", "0", 10.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rtop", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rbot", "out", "0", 1_000.0,
+    )));
+
+    let result = sens_dc(&circuit, "out").unwrap();
+
+    assert_eq!(result.output_node, "out");
+    assert_close(result.nominal_voltage, 5.0);
+    assert_eq!(result.entries.len(), 3);
+    assert_close(entry(&result, "Vin", "voltage").sensitivity, 0.5);
+    assert_close(entry(&result, "Vin", "voltage").relative_sensitivity, 1.0);
+    assert_close(
+        entry(&result, "Rtop", "resistance_ohms").sensitivity,
+        -0.0025,
+    );
+    assert_close(
+        entry(&result, "Rtop", "resistance_ohms").relative_sensitivity,
+        -0.5,
+    );
+    assert_close(
+        entry(&result, "Rbot", "resistance_ohms").sensitivity,
+        0.0025,
+    );
+    assert_close(
+        entry(&result, "Rbot", "resistance_ohms").relative_sensitivity,
+        0.5,
+    );
+}
+
+#[test]
+fn sens_dc_reports_current_source_and_load_resistance_sensitivities() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::CurrentSource(CurrentSource::new(
+        "Iin", "0", "out", 1.0e-3,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = sens_dc(&circuit, "out").unwrap();
+
+    assert_close(result.nominal_voltage, 1.0);
+    assert_close(entry(&result, "Iin", "current").sensitivity, 1_000.0);
+    assert_close(entry(&result, "Iin", "current").relative_sensitivity, 1.0);
+    assert_close(
+        entry(&result, "Rload", "resistance_ohms").sensitivity,
+        1.0e-3,
+    );
+    assert_close(
+        entry(&result, "Rload", "resistance_ohms").relative_sensitivity,
+        1.0,
+    );
+}
+
+#[test]
+fn sens_dc_sorts_entries_by_absolute_relative_sensitivity() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "vin", "0", 10.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rtop", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rbot", "out", "0", 1_000.0,
+    )));
+
+    let result = sens_dc(&circuit, "out").unwrap();
+
+    assert_eq!(result.entries[0].element_name, "Vin");
+    assert!(
+        result.entries[0].relative_sensitivity.abs()
+            >= result.entries[1].relative_sensitivity.abs()
+    );
+}
+
+#[test]
+fn sens_dc_rejects_missing_output_node() {
+    let circuit = Circuit::new();
+
+    assert!(matches!(
+        sens_dc(&circuit, "missing"),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "missing"
+    ));
+}


### PR DESCRIPTION
## Summary
- add Rust SPICE `.sens`-style DC sensitivity analysis for output-node voltage
- report nominal voltage, absolute sensitivities, and normalized relative sensitivities for resistors and independent sources
- cover voltage-divider, current-source load, ordering, and missing-node behavior

## Validation
- `cargo fmt -p spice-engine`
- `cargo test -p spice-engine`
- `git diff --check`
