### PR TITLE
feat(rust/symbolic-vm): EllipticE and EllipticPi integration recognition (v0.3.0)

### DIFF
--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -419,6 +419,60 @@ fn recognizes_complete_elliptic_first_kind_integrals_through_runtime() {
 }
 
 #[test]
+fn recognizes_elliptic_second_kind_integrals_through_runtime() {
+    // ∫ sqrt(1 - k^2 * sin(theta)^2) dtheta  →  EllipticE(theta, k)
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("integrate(sqrt(1-k^2*sin(theta)^2), theta);")
+        .unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(sym("EllipticE"), vec![sym("theta"), sym("k")])
+    );
+}
+
+#[test]
+fn recognizes_complete_elliptic_second_kind_integrals_through_runtime() {
+    // ∫₀^(π/2) sqrt(1 - k^2 * sin(theta)^2) dtheta  →  EllipticE(k)
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("integrate(sqrt(1-k^2*sin(theta)^2), theta, 0, %pi/2);")
+        .unwrap();
+
+    assert_eq!(results[0].output, apply(sym("EllipticE"), vec![sym("k")]));
+}
+
+#[test]
+fn recognizes_complete_elliptic_third_kind_integrals_through_runtime() {
+    // ∫₀^(π/2) 1/((1 + n*sin(theta)^2) * sqrt(1 - k^2*sin(theta)^2)) dtheta  →  EllipticPi(n, k)
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source(
+            "integrate(1/((1+n*sin(theta)^2)*sqrt(1-k^2*sin(theta)^2)), theta, 0, %pi/2);",
+        )
+        .unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(sym("EllipticPi"), vec![sym("n"), sym("k")])
+    );
+}
+
+#[test]
+fn elliptic_first_kind_regression_still_works() {
+    // Regression: the existing EllipticK recognition must still fire after the new handlers are
+    // tried first, since complete_elliptic_second_kind and complete_elliptic_third_kind are
+    // attempted before the fallback but must not accidentally consume the 1/sqrt(...) form.
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("integrate(1/sqrt(1-k^2*sin(theta)^2), theta, 0, %pi/2);")
+        .unwrap();
+
+    assert_eq!(results[0].output, apply(sym("EllipticK"), vec![sym("k")]));
+}
+
+#[test]
 fn question_mark_without_topic_lists_help_topics() {
     let mut session = MacsymaSession::new();
     let results = session.eval_source("?").unwrap();

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog — symbolic-vm (Rust)
 
-## [0.2.0] — 2026-05-14
+## Unreleased
+
+## [0.3.0] — 2026-05-14
 
 ### Added
 

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog — symbolic-vm (Rust)
 
-## Unreleased
+## [0.2.0] — 2026-05-14
+
+### Added
+
+- Added EllipticE (second kind) integration recognition:
+  - `∫₀^(π/2) √(1-k²sin²θ) dθ` → `EllipticE(k)` (complete)
+  - `∫ √(1-k²sin²θ) dθ` → `EllipticE(θ, k)` (incomplete)
+- Added EllipticPi (third kind) complete integration recognition:
+  - `∫₀^(π/2) 1/((1+n·sin²θ)·√(1-k²sin²θ)) dθ` → `EllipticPi(n, k)`
+- New helper functions: `elliptic_second_kind_radicand`, `complete_elliptic_second_kind`,
+  `incomplete_elliptic_second_kind`, `extract_characteristic_n`,
+  `elliptic_third_kind_params`, `complete_elliptic_third_kind`
+
+## [0.1.1] — 2026-04-28
 
 ## [0.2.0] — 2026-05-14
 

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1012,8 +1012,13 @@ fn integrate_handler() -> Handler {
         };
 
         if expr.args.len() == 4 {
-            if let Some(result) = complete_elliptic_first_kind(&f, &x, &expr.args[2], &expr.args[3])
-            {
+            if let Some(result) = complete_elliptic_first_kind(&f, &x, &expr.args[2], &expr.args[3]) {
+                return vm.eval(result);
+            }
+            if let Some(result) = complete_elliptic_second_kind(&f, &x, &expr.args[2], &expr.args[3]) {
+                return vm.eval(result);
+            }
+            if let Some(result) = complete_elliptic_third_kind(&f, &x, &expr.args[2], &expr.args[3]) {
                 return vm.eval(result);
             }
             return IRNode::Apply(Box::new(expr));
@@ -1045,6 +1050,10 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
     }
 
     if let Some(result) = incomplete_elliptic_first_kind(f, x) {
+        return result;
+    }
+
+    if let Some(result) = incomplete_elliptic_second_kind(f, x) {
         return result;
     }
 
@@ -1236,6 +1245,131 @@ fn is_pi_over_two(node: &IRNode) -> bool {
         }
         _ => false,
     }
+}
+
+/// Return `k` when `f = Sqrt(Sub(1, Mul(Pow(k,2), Pow(Sin(x),2))))`.
+///
+/// This matches the integrand `sqrt(1 - k^2 * sin(x)^2)` which is the
+/// integrand for the complete and incomplete elliptic integrals of the
+/// second kind.
+fn elliptic_second_kind_radicand(f: &IRNode, x: &str) -> Option<IRNode> {
+    let IRNode::Apply(sqrt) = f else { return None };
+    if sqrt.head != IRNode::Symbol(SQRT.to_string()) { return None; }
+    let [radicand] = sqrt.args.as_slice() else { return None };
+    let IRNode::Apply(sub) = radicand else { return None };
+    if sub.head != IRNode::Symbol(SUB.to_string()) { return None; }
+    let [constant, product] = sub.args.as_slice() else { return None };
+    if !to_numeric(constant).is_some_and(Numeric::is_one) { return None; }
+    let IRNode::Apply(mul) = product else { return None };
+    if mul.head != IRNode::Symbol(MUL.to_string()) { return None; }
+    let [left, right] = mul.args.as_slice() else { return None };
+    modulus_from_squared_factor(left, right, x)
+        .or_else(|| modulus_from_squared_factor(right, left, x))
+}
+
+/// `∫₀^(π/2) sqrt(1-k²sin²θ)dθ` → `EllipticE(k)`
+///
+/// Recognises the complete elliptic integral of the second kind over the
+/// canonical interval `[0, π/2]` and returns `EllipticE(k)`.
+fn complete_elliptic_second_kind(
+    f: &IRNode,
+    x: &str,
+    lower: &IRNode,
+    upper: &IRNode,
+) -> Option<IRNode> {
+    if !to_numeric(lower).is_some_and(Numeric::is_zero) || !is_pi_over_two(upper) {
+        return None;
+    }
+    elliptic_second_kind_radicand(f, x).map(|modulus| apply_node("EllipticE", vec![modulus]))
+}
+
+/// `∫ sqrt(1-k²sin²θ)dθ` → `EllipticE(θ, k)`
+///
+/// Recognises the incomplete elliptic integral of the second kind and
+/// returns `EllipticE(θ, k)`.
+fn incomplete_elliptic_second_kind(f: &IRNode, x: &str) -> Option<IRNode> {
+    elliptic_second_kind_radicand(f, x).map(|modulus| {
+        apply_node("EllipticE", vec![IRNode::Symbol(x.to_string()), modulus])
+    })
+}
+
+/// Return `n` when `bracket = Add(1, Mul(n, Pow(Sin(x), 2)))`.
+///
+/// This matches the characteristic factor `(1 + n*sin(x)^2)` in the
+/// denominator of the elliptic integral of the third kind.
+fn extract_characteristic_n(bracket: &IRNode, x: &str) -> Option<IRNode> {
+    let IRNode::Apply(add) = bracket else { return None };
+    if add.head != IRNode::Symbol(ADD.to_string()) { return None; }
+    let [a, b] = add.args.as_slice() else { return None };
+    for (one_part, prod_part) in [(a, b), (b, a)] {
+        if !to_numeric(one_part).is_some_and(Numeric::is_one) { continue; }
+        let IRNode::Apply(mul) = prod_part else { continue };
+        if mul.head != IRNode::Symbol(MUL.to_string()) { continue; }
+        let [p1, p2] = mul.args.as_slice() else { continue };
+        for (n_candidate, sin_sq) in [(p1, p2), (p2, p1)] {
+            let IRNode::Apply(pow) = sin_sq else { continue };
+            if pow.head != IRNode::Symbol(POW.to_string()) { continue; }
+            let [sine, exp] = pow.args.as_slice() else { continue };
+            if exp != &IRNode::Integer(2) { continue; }
+            let IRNode::Apply(sin_call) = sine else { continue };
+            if sin_call.head != IRNode::Symbol(SIN.to_string()) { continue; }
+            let [inner] = sin_call.args.as_slice() else { continue };
+            if inner != &IRNode::Symbol(x.to_string()) { continue; }
+            if !depends_on(n_candidate, x) {
+                return Some(n_candidate.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Return `(n, k)` when `f = Div(1, Mul(bracket, Sqrt(Sub(1, Mul(Pow(k,2), Pow(Sin(x),2))))))`.
+///
+/// This matches the integrand `1/((1 + n*sin(x)^2) * sqrt(1 - k^2*sin(x)^2))`
+/// for the complete elliptic integral of the third kind.
+fn elliptic_third_kind_params(f: &IRNode, x: &str) -> Option<(IRNode, IRNode)> {
+    let IRNode::Apply(div) = f else { return None };
+    if div.head != IRNode::Symbol(DIV.to_string()) { return None; }
+    let [numerator, denominator] = div.args.as_slice() else { return None };
+    if !to_numeric(numerator).is_some_and(Numeric::is_one) { return None; }
+    let IRNode::Apply(mul) = denominator else { return None };
+    if mul.head != IRNode::Symbol(MUL.to_string()) { return None; }
+    let [a, b] = mul.args.as_slice() else { return None };
+    for (bracket, sqrt_term) in [(a, b), (b, a)] {
+        let IRNode::Apply(sqrt) = sqrt_term else { continue };
+        if sqrt.head != IRNode::Symbol(SQRT.to_string()) { continue; }
+        let [radicand] = sqrt.args.as_slice() else { continue };
+        let IRNode::Apply(sub) = radicand else { continue };
+        if sub.head != IRNode::Symbol(SUB.to_string()) { continue; }
+        let [constant, product] = sub.args.as_slice() else { continue };
+        if !to_numeric(constant).is_some_and(Numeric::is_one) { continue; }
+        let IRNode::Apply(prod_mul) = product else { continue };
+        if prod_mul.head != IRNode::Symbol(MUL.to_string()) { continue; }
+        let [f1, f2] = prod_mul.args.as_slice() else { continue };
+        let k = modulus_from_squared_factor(f1, f2, x)
+            .or_else(|| modulus_from_squared_factor(f2, f1, x));
+        let Some(k) = k else { continue };
+        let Some(n) = extract_characteristic_n(bracket, x) else { continue };
+        return Some((n, k));
+    }
+    None
+}
+
+/// `∫₀^(π/2) 1/((1+n·sin²θ)·sqrt(1-k²sin²θ))dθ` → `EllipticPi(n, k)`
+///
+/// Recognises the complete elliptic integral of the third kind over the
+/// canonical interval `[0, π/2]` and returns `EllipticPi(n, k)`.
+fn complete_elliptic_third_kind(
+    f: &IRNode,
+    x: &str,
+    lower: &IRNode,
+    upper: &IRNode,
+) -> Option<IRNode> {
+    if !to_numeric(lower).is_some_and(Numeric::is_zero) || !is_pi_over_two(upper) {
+        return None;
+    }
+    elliptic_third_kind_params(f, x)
+        .map(|(n, k)| apply_node("EllipticPi", vec![n, k]))
 }
 
 fn integrate_power_of_x(exponent: &IRNode, x: &str) -> IRNode {


### PR DESCRIPTION
## Summary

- Ported Python `symbolic-vm` Phase 25 elliptic integral recognition to Rust
- Bumped `symbolic-vm` version **0.2.0 → 0.3.0**
- Added new end-to-end pipeline tests in `macsyma-runtime` (total: 62 passing, up from 58)
- Cleanly rebased onto `main` after #3170 and #3171 merged

## New recognition rules

| Integrand form | Result |
|---|---|
| `∫₀^(π/2) √(1-k²sin²θ) dθ` | `EllipticE(k)` |
| `∫ √(1-k²sin²θ) dθ` | `EllipticE(θ, k)` |
| `∫₀^(π/2) 1/((1+n·sin²θ)·√(1-k²sin²θ)) dθ` | `EllipticPi(n, k)` |

## Test plan

- [x] 87 + 2 doc-tests in symbolic-vm all pass
- [x] 62 macsyma-runtime pipeline tests pass

Replaces #3175 (closed due to merge conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)