### PR TITLE
feat(typescript/symbolic-vm): EllipticE and EllipticPi integration recognition (v0.3.0)

### DIFF
--- a/code/packages/typescript/macsyma-runtime/package-lock.json
+++ b/code/packages/typescript/macsyma-runtime/package-lock.json
@@ -279,7 +279,7 @@
     },
     "../symbolic-vm": {
       "name": "@coding-adventures/symbolic-vm",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/cas-factor": "file:../cas-factor",

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -305,6 +305,36 @@ describe("macsyma-runtime", () => {
     expect(result.output).toEqual(app(sym("EllipticK"), [sym("k")]));
   });
 
+  it("recognizes complete elliptic second-kind integrals through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("integrate(sqrt(1-k^2*sin(theta)^2), theta, 0, %pi/2);");
+
+    expect(result.output).toEqual(app(sym("EllipticE"), [sym("k")]));
+  });
+
+  it("recognizes incomplete elliptic second-kind integrals through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("integrate(sqrt(1-k^2*sin(theta)^2), theta);");
+
+    expect(result.output).toEqual(app(sym("EllipticE"), [sym("theta"), sym("k")]));
+  });
+
+  it("recognizes complete elliptic third-kind integrals through the runtime", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource(
+      "integrate(1/((1+n*sin(theta)^2)*sqrt(1-k^2*sin(theta)^2)), theta, 0, %pi/2);",
+    );
+
+    expect(result.output).toEqual(app(sym("EllipticPi"), [sym("n"), sym("k")]));
+  });
+
+  it("regression: still recognizes complete elliptic first-kind integrals after adding second and third kind", () => {
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("integrate(1/sqrt(1-k^2*sin(theta)^2), theta, 0, %pi/2);");
+
+    expect(result.output).toEqual(app(sym("EllipticK"), [sym("k")]));
+  });
+
   it("tracks the showtime option flag through normal assignments", () => {
     const session = new MacsymaSession();
     const [enabled, timed, disabled, untimed] = session.evalSource(

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0] — 2026-05-14
+
+- Added EllipticE (second kind) integration recognition:
+  - `∫₀^(π/2) sqrt(1-k²sin²θ) dθ` → `EllipticE(k)` (complete)
+  - `∫ sqrt(1-k²sin²θ) dθ` → `EllipticE(θ, k)` (incomplete)
+- Added EllipticPi (third kind) complete integration recognition:
+  - `∫₀^(π/2) 1/((1+n·sin²θ)·sqrt(1-k²sin²θ)) dθ` → `EllipticPi(n, k)`
+- New helper functions: `ellipticSecondKindRadicand`, `completeEllipticSecondKind`,
+  `incompleteEllipticSecondKind`, `extractCharacteristicN`, `ellipticThirdKindParams`,
+  `completeEllipticThirdKind`
+
 ## [0.2.0] — 2026-05-14
 
 ### Added

--- a/code/packages/typescript/symbolic-vm/package-lock.json
+++ b/code/packages/typescript/symbolic-vm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/symbolic-vm",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/cas-factor": "file:../cas-factor",

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1046,8 +1046,13 @@ function integrate(): Handler {
       return expr;
     }
     if (expr.args.length === 4) {
-      const result = completeEllipticFirstKind(f, x, expr.args[2], expr.args[3]);
-      return result === undefined ? expr : vm.eval(result);
+      const resultK = completeEllipticFirstKind(f, x, expr.args[2], expr.args[3]);
+      if (resultK !== undefined) return vm.eval(resultK);
+      const resultE = completeEllipticSecondKind(f, x, expr.args[2], expr.args[3]);
+      if (resultE !== undefined) return vm.eval(resultE);
+      const resultPi = completeEllipticThirdKind(f, x, expr.args[2], expr.args[3]);
+      if (resultPi !== undefined) return vm.eval(resultPi);
+      return expr;
     }
     const result = integrateIndefinite(f, x);
     if (result === undefined) {
@@ -1067,6 +1072,10 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
   const elliptic = incompleteEllipticFirstKind(f, x);
   if (elliptic !== undefined) {
     return elliptic;
+  }
+  const ellipticE = incompleteEllipticSecondKind(f, x);
+  if (ellipticE !== undefined) {
+    return ellipticE;
   }
   if (f.kind !== "apply") {
     return undefined;
@@ -1204,6 +1213,81 @@ function isPiOverTwo(node: IRNode): boolean {
   }
   const [numerator, denominator] = binaryArgs(node);
   return numerator.kind === "symbol" && numerator.name === "%pi" && equals(denominator, int(2));
+}
+
+/** Return k when f = Sqrt(1 - k² sin²(x)), else undefined. */
+function ellipticSecondKindRadicand(f: IRNode, x: IRNode): IRNode | undefined {
+  if (f.kind !== "apply" || !equals(f.head, SQRT)) return undefined;
+  const [radicand] = unaryArgs(f);
+  if (radicand.kind !== "apply" || !equals(radicand.head, SUB)) return undefined;
+  const [constant, product] = binaryArgs(radicand);
+  if (!isOne(constant) || product.kind !== "apply" || !equals(product.head, MUL)) return undefined;
+  const [left, right] = binaryArgs(product);
+  return modulusFromSquaredFactor(left, right, x) ?? modulusFromSquaredFactor(right, left, x);
+}
+
+/** ∫₀^(π/2) sqrt(1-k²sin²θ)dθ → EllipticE(k) */
+function completeEllipticSecondKind(f: IRNode, x: IRNode, lower: IRNode, upper: IRNode): IRNode | undefined {
+  if (!isZero(lower) || !isPiOverTwo(upper)) return undefined;
+  const modulus = ellipticSecondKindRadicand(f, x);
+  return modulus === undefined ? undefined : app(sym("EllipticE"), [modulus]);
+}
+
+/** ∫ sqrt(1-k²sin²θ)dθ → EllipticE(θ, k) */
+function incompleteEllipticSecondKind(f: IRNode, x: IRNode): IRNode | undefined {
+  const modulus = ellipticSecondKindRadicand(f, x);
+  return modulus === undefined ? undefined : app(sym("EllipticE"), [x, modulus]);
+}
+
+/** Return n when bracket = Add(1, Mul(n, Pow(Sin(x), 2))), else undefined. */
+function extractCharacteristicN(bracket: IRNode, x: IRNode): IRNode | undefined {
+  if (bracket.kind !== "apply" || !equals(bracket.head, ADD)) return undefined;
+  const [a, b] = binaryArgs(bracket);
+  for (const [onePart, prodPart] of [[a, b], [b, a]] as [IRNode, IRNode][]) {
+    if (!isOne(onePart)) continue;
+    if (prodPart.kind !== "apply" || !equals(prodPart.head, MUL)) continue;
+    const [p1, p2] = binaryArgs(prodPart);
+    for (const [nCandidate, sinSq] of [[p1, p2], [p2, p1]] as [IRNode, IRNode][]) {
+      if (sinSq.kind !== "apply" || !equals(sinSq.head, POW)) continue;
+      const [sine, sineExp] = binaryArgs(sinSq);
+      if (!equals(sineExp, int(2))) continue;
+      if (sine.kind !== "apply" || !equals(sine.head, SIN)) continue;
+      const [inner] = unaryArgs(sine);
+      if (!equals(inner, x)) continue;
+      if (!dependsOn(nCandidate, x)) return nCandidate;
+    }
+  }
+  return undefined;
+}
+
+/** Return {n, k} when f = 1/((1+n·sin²x)·sqrt(1-k²sin²x)), else undefined. */
+function ellipticThirdKindParams(f: IRNode, x: IRNode): { n: IRNode; k: IRNode } | undefined {
+  if (f.kind !== "apply" || !equals(f.head, DIV)) return undefined;
+  const [numerator, denominator] = binaryArgs(f);
+  if (!isOne(numerator)) return undefined;
+  if (denominator.kind !== "apply" || !equals(denominator.head, MUL)) return undefined;
+  const [a, b] = binaryArgs(denominator);
+  for (const [bracket, sqrtTerm] of [[a, b], [b, a]] as [IRNode, IRNode][]) {
+    if (sqrtTerm.kind !== "apply" || !equals(sqrtTerm.head, SQRT)) continue;
+    const [radicand] = unaryArgs(sqrtTerm);
+    if (radicand.kind !== "apply" || !equals(radicand.head, SUB)) continue;
+    const [constant, product] = binaryArgs(radicand);
+    if (!isOne(constant) || product.kind !== "apply" || !equals(product.head, MUL)) continue;
+    const [left, right] = binaryArgs(product);
+    const k = modulusFromSquaredFactor(left, right, x) ?? modulusFromSquaredFactor(right, left, x);
+    if (k === undefined) continue;
+    const n = extractCharacteristicN(bracket, x);
+    if (n === undefined) continue;
+    return { n, k };
+  }
+  return undefined;
+}
+
+/** ∫₀^(π/2) 1/((1+n·sin²θ)·sqrt(1-k²sin²θ))dθ → EllipticPi(n, k) */
+function completeEllipticThirdKind(f: IRNode, x: IRNode, lower: IRNode, upper: IRNode): IRNode | undefined {
+  if (!isZero(lower) || !isPiOverTwo(upper)) return undefined;
+  const params = ellipticThirdKindParams(f, x);
+  return params === undefined ? undefined : app(sym("EllipticPi"), [params.n, params.k]);
 }
 
 function differentiate(): Handler {


### PR DESCRIPTION
## Summary

- Ported Python `symbolic-vm` Phase 25 elliptic integral recognition to TypeScript
- Bumped `symbolic-vm` version **0.2.0 → 0.3.0**
- Added 4 new end-to-end pipeline tests in `macsyma-runtime` (total: 71 passing)
- Cleanly rebased onto `main` after #3170 and #3171 merged

## New recognition rules

| Integrand form | Result |
|---|---|
| `∫₀^(π/2) √(1-k²sin²θ) dθ` | `EllipticE(k)` |
| `∫ √(1-k²sin²θ) dθ` | `EllipticE(θ, k)` |
| `∫₀^(π/2) 1/((1+n·sin²θ)·√(1-k²sin²θ)) dθ` | `EllipticPi(n, k)` |

## Test plan

- [x] 44 symbolic-vm unit tests pass
- [x] 71 macsyma-runtime pipeline tests pass

Replaces #3176 (closed due to merge conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)