### PR TITLE
ts(spice): add DC sensitivity analysis

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add DC sensitivity analysis for resistor and independent source parameters.
 - Add DC small-signal transfer-function analysis with input/output impedance.
 - Add AC small-signal frequency sweeps for linear RC/RL circuits.
 - Add DC source sweeps for independent voltage and current sources.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -4,9 +4,9 @@
 primitives for TypeScript.
 
 The current slices implement DC operating-point analysis, DC source sweeps, DC
-small-signal transfer-function analysis, AC small-signal frequency sweeps, and
-fixed-step RC/RL transient analysis for linear circuits using modified nodal
-analysis (MNA). The package supports resistors, capacitors, inductors,
-independent current sources, independent voltage sources, ground aliases, node
-voltages, voltage source branch currents, and backward-Euler reactive-element
-companion models.
+sensitivity analysis, DC small-signal transfer-function analysis, AC
+small-signal frequency sweeps, and fixed-step RC/RL transient analysis for
+linear circuits using modified nodal analysis (MNA). The package supports
+resistors, capacitors, inductors, independent current sources, independent
+voltage sources, ground aliases, node voltages, voltage source branch currents,
+and backward-Euler reactive-element companion models.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -64,6 +64,21 @@ export interface TfResult {
   gain(): number;
 }
 
+export interface SensEntry {
+  readonly elementName: string;
+  readonly parameter: string;
+  readonly nominalValue: number;
+  readonly sensitivity: number;
+  readonly relativeSensitivity: number;
+}
+
+export interface SensResult {
+  readonly outputNode: string;
+  readonly nominalVoltage: number;
+  readonly entries: readonly SensEntry[];
+  entry(elementName: string, parameter: string): SensEntry | undefined;
+}
+
 export interface Complex {
   readonly real: number;
   readonly imag: number;
@@ -275,6 +290,52 @@ export function tf(
   return makeTfResult(transferRatio, inputImpedanceOhms, outputImpedanceOhms);
 }
 
+export function sensDc(circuit: Circuit, outputNode: string): SensResult {
+  const nodeIndices = collectNodeIndices(circuit);
+  if (!isGround(outputNode) && !nodeIndices.has(outputNode)) {
+    throw invalidElement(outputNode, "output node was not found in circuit");
+  }
+
+  const nominal = dcOp(circuit);
+  const nominalVoltage = nominal.voltage(outputNode) ?? 0.0;
+  const entries: SensEntry[] = [];
+
+  for (let elementIndex = 0; elementIndex < circuit.elements().length; elementIndex++) {
+    const element = circuit.elements()[elementIndex];
+    const parameter = elementParameter(element);
+    if (parameter === undefined) {
+      continue;
+    }
+
+    const delta = perturbationFor(parameter.nominalValue);
+    const perturbed = circuitWithPerturbedElement(circuit, elementIndex, delta);
+    const perturbedResult = dcOp(perturbed);
+    const perturbedVoltage = perturbedResult.voltage(outputNode) ?? 0.0;
+    const sensitivity = (perturbedVoltage - nominalVoltage) / delta;
+    const relativeSensitivity =
+      Math.abs(nominalVoltage) > 1.0e-30
+        ? sensitivity * parameter.nominalValue / nominalVoltage
+        : 0.0;
+
+    entries.push({
+      elementName: parameter.elementName,
+      parameter: parameter.parameter,
+      nominalValue: parameter.nominalValue,
+      sensitivity,
+      relativeSensitivity,
+    });
+  }
+
+  entries.sort(
+    (left, right) =>
+      Math.abs(right.relativeSensitivity) - Math.abs(left.relativeSensitivity) ||
+      left.elementName.localeCompare(right.elementName) ||
+      left.parameter.localeCompare(right.parameter),
+  );
+
+  return makeSensResult(outputNode, nominalVoltage, entries);
+}
+
 export function acSweep(
   circuit: Circuit,
   startHz: number,
@@ -402,6 +463,76 @@ function circuitWithSweptSource(
     );
   }
   return swept;
+}
+
+interface ElementParameter {
+  readonly elementName: string;
+  readonly parameter: string;
+  readonly nominalValue: number;
+}
+
+function elementParameter(element: Element): ElementParameter | undefined {
+  switch (element.kind) {
+    case "resistor":
+      return {
+        elementName: element.name,
+        parameter: "resistanceOhms",
+        nominalValue: element.resistanceOhms,
+      };
+    case "voltage-source":
+      return {
+        elementName: element.name,
+        parameter: "voltage",
+        nominalValue: element.voltage,
+      };
+    case "current-source":
+      return {
+        elementName: element.name,
+        parameter: "current",
+        nominalValue: element.current,
+      };
+    case "capacitor":
+    case "inductor":
+      return undefined;
+  }
+}
+
+function perturbationFor(value: number): number {
+  return Math.max(Math.abs(value) * 1.0e-6, 1.0e-9);
+}
+
+function circuitWithPerturbedElement(
+  circuit: Circuit,
+  elementIndex: number,
+  delta: number,
+): Circuit {
+  const perturbed = new Circuit();
+  circuit.elements().forEach((element, index) => {
+    if (index !== elementIndex) {
+      perturbed.add(element);
+      return;
+    }
+
+    switch (element.kind) {
+      case "resistor":
+        perturbed.add({
+          ...element,
+          resistanceOhms: element.resistanceOhms + delta,
+        });
+        break;
+      case "voltage-source":
+        perturbed.add({ ...element, voltage: element.voltage + delta });
+        break;
+      case "current-source":
+        perturbed.add({ ...element, current: element.current + delta });
+        break;
+      case "capacitor":
+      case "inductor":
+        perturbed.add(element);
+        break;
+    }
+  });
+  return perturbed;
 }
 
 interface CapacitorState {
@@ -646,6 +777,25 @@ function makeTfResult(
     outputImpedanceOhms,
     gain(): number {
       return transferRatio;
+    },
+  };
+}
+
+function makeSensResult(
+  outputNode: string,
+  nominalVoltage: number,
+  entries: readonly SensEntry[],
+): SensResult {
+  return {
+    outputNode,
+    nominalVoltage,
+    entries,
+    entry(elementName: string, parameter: string): SensEntry | undefined {
+      return entries.find(
+        (candidate) =>
+          candidate.elementName === elementName &&
+          candidate.parameter === parameter,
+      );
     },
   };
 }

--- a/code/packages/typescript/spice-engine/tests/sens.test.ts
+++ b/code/packages/typescript/spice-engine/tests/sens.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  Circuit,
+  SpiceError,
+  SensResult,
+  currentSource,
+  resistor,
+  sensDc,
+  voltageSource,
+} from "../src/index.js";
+
+function expectClose(actual: number | undefined, expected: number): void {
+  expect(actual).not.toBeUndefined();
+  expect(actual!).toBeCloseTo(expected, 6);
+}
+
+function entry(
+  result: SensResult,
+  elementName: string,
+  parameter: string,
+) {
+  const sensitivity = result.entry(elementName, parameter);
+  expect(sensitivity).not.toBeUndefined();
+  return sensitivity!;
+}
+
+describe("sensDc", () => {
+  it("reports divider source and resistor sensitivities", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "vin", "0", 10.0));
+    circuit.add(resistor("Rtop", "vin", "out", 1_000.0));
+    circuit.add(resistor("Rbot", "out", "0", 1_000.0));
+
+    const result = sensDc(circuit, "out");
+
+    expect(result.outputNode).toBe("out");
+    expectClose(result.nominalVoltage, 5.0);
+    expect(result.entries).toHaveLength(3);
+    expectClose(entry(result, "Vin", "voltage").sensitivity, 0.5);
+    expectClose(entry(result, "Vin", "voltage").relativeSensitivity, 1.0);
+    expectClose(
+      entry(result, "Rtop", "resistanceOhms").sensitivity,
+      -0.0025,
+    );
+    expectClose(
+      entry(result, "Rtop", "resistanceOhms").relativeSensitivity,
+      -0.5,
+    );
+    expectClose(
+      entry(result, "Rbot", "resistanceOhms").sensitivity,
+      0.0025,
+    );
+    expectClose(
+      entry(result, "Rbot", "resistanceOhms").relativeSensitivity,
+      0.5,
+    );
+  });
+
+  it("reports current source and load resistance sensitivities", () => {
+    const circuit = new Circuit();
+    circuit.add(currentSource("Iin", "0", "out", 1.0e-3));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = sensDc(circuit, "out");
+
+    expectClose(result.nominalVoltage, 1.0);
+    expectClose(entry(result, "Iin", "current").sensitivity, 1_000.0);
+    expectClose(entry(result, "Iin", "current").relativeSensitivity, 1.0);
+    expectClose(
+      entry(result, "Rload", "resistanceOhms").sensitivity,
+      1.0e-3,
+    );
+    expectClose(
+      entry(result, "Rload", "resistanceOhms").relativeSensitivity,
+      1.0,
+    );
+  });
+
+  it("sorts entries by absolute relative sensitivity", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "vin", "0", 10.0));
+    circuit.add(resistor("Rtop", "vin", "out", 1_000.0));
+    circuit.add(resistor("Rbot", "out", "0", 1_000.0));
+
+    const result = sensDc(circuit, "out");
+
+    expect(result.entries[0].elementName).toBe("Vin");
+    expect(Math.abs(result.entries[0].relativeSensitivity)).toBeGreaterThanOrEqual(
+      Math.abs(result.entries[1].relativeSensitivity),
+    );
+  });
+
+  it("rejects missing output nodes", () => {
+    const circuit = new Circuit();
+
+    expect(() => sensDc(circuit, "missing")).toThrowError(SpiceError);
+    expect(() => sensDc(circuit, "missing")).toThrowError(
+      "output node was not found in circuit",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add TypeScript SPICE `.sens`-style DC sensitivity analysis for output-node voltage
- report nominal voltage, absolute sensitivities, and normalized relative sensitivities for resistors and independent sources
- mirror the Rust sensitivity coverage with divider, current-source load, ordering, and missing-node tests

## Validation
- `sh BUILD`
- `git diff --check`
