### PR TITLE
docs(specs): mark EllipticE/Pi sprint complete across all three languages

### DIFF
--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -1,9 +1,11 @@
 # SPICE Engine & MACSYMA Pipeline — Status and Pending Work
 
 > **Living document.** Updated each time a PR lands or new work is planned.
-> Last updated: 2026-05-14. Sprint: TypeScript 0.2.0 releases (PR #3170),
-> Rust 0.2.0 releases (PR #3171), Python EllipticE/Pi — `symbolic-vm` 0.54.0
-> (PR #3173), TypeScript/Rust EllipticE/Pi — `symbolic-vm` 0.3.0 (in progress).
+> Last updated: 2026-05-14. Sprint complete: TypeScript 0.2.0 releases (PR #3170 ✅
+> merged), Rust 0.2.0 releases (PR #3171 ✅ merged), Python EllipticE/Pi —
+> `symbolic-vm` 0.54.0 (PR #3173 ✅ merged), TypeScript EllipticE/Pi —
+> `symbolic-vm` 0.3.0 (PR #3179 ✅ merged), Rust EllipticE/Pi —
+> `symbolic-vm` 0.3.0 (PR #3178 ✅ merged).
 
 This document is the canonical reference for resuming work on either project.
 It records exactly what is on `main`, what is in flight, and what has not been
@@ -126,26 +128,32 @@ Every item below is wired end-to-end: surface syntax → compile → VM → corr
 | Package | Version | What it provides |
 |---|---|---|
 | `symbolic-ir` | latest | `IRSymbol`, `IRInteger`, `IRRational`, `IRFloat`, `IRString`, `IRApply` node types |
-| `symbolic-vm` | 0.53.0 | Pluggable VM, `SymbolicBackend`, arithmetic, Risch integration (phases 1–14+, Phase 25 EllipticF/K), numeric folding, 100+ handlers |
+| `symbolic-vm` | 0.54.0 | Pluggable VM, `SymbolicBackend`, arithmetic, Risch integration (phases 1–14+, Phase 25 EllipticF/K/E/Pi), numeric folding, 100+ handlers |
 | `macsyma-lexer` | 0.1.0 | Grammar-driven tokenizer |
 | `macsyma-parser` | 0.1.0 | Grammar-driven parser |
 | `macsyma-compiler` | 0.9.0 | AST → IR; 60+ MACSYMA identifier mappings in name table |
 | `macsyma-runtime` | 1.25.0 | History (`%`, `%i1`, `%o1`, …), `;`/`$` terminators, `kill`, `ev`, `MacsymaBackend` |
 
-#### TypeScript port version releases (PR #3170 — in review)
+#### TypeScript port version releases (PR #3170 ✅ merged)
 
 The TypeScript port was at v0.1.0 with all implemented features in an "Unreleased"
-CHANGELOG section. PR #3170 cuts a proper 0.2.0 release.
+CHANGELOG section. PR #3170 cut proper 0.2.0 releases.
 
 | Package | Version | Notes |
 |---|---|---|
 | `typescript/symbolic-vm` | 0.2.0 | EllipticF/K, multivariate Factor footholds, D derivative handler, reciprocal hyperbolic |
 | `typescript/macsyma-runtime` | 0.2.0 | Elliptic pipeline, multivariate factor, `?` help, assume/declare, ev display2d, list/solve wiring |
 
-#### Rust port version releases (PR #3171 — in review)
+#### TypeScript EllipticE/Pi integration recognition (PR #3179 ✅ merged)
+
+| Package | Version | Notes |
+|---|---|---|
+| `typescript/symbolic-vm` | 0.3.0 | EllipticE (complete + incomplete), EllipticPi (complete) pattern recognition |
+
+#### Rust port version releases (PR #3171 ✅ merged)
 
 The Rust port was at v0.1.x with all implemented features in an "Unreleased"
-CHANGELOG section. PR #3171 cuts proper 0.2.0 releases and creates the missing
+CHANGELOG section. PR #3171 cut proper 0.2.0 releases and created the missing
 `cas-ode` CHANGELOG.
 
 | Package | Version | Notes |
@@ -153,6 +161,12 @@ CHANGELOG section. PR #3171 cuts proper 0.2.0 releases and creates the missing
 | `rust/symbolic-vm` | 0.2.0 | Same feature set as TypeScript 0.2.0 |
 | `rust/macsyma-runtime` | 0.2.0 | Same feature set as TypeScript 0.2.0 |
 | `rust/cas-ode` | 0.1.0 | CHANGELOG.md created — documents all 9 ODE types (Phase 18–20) |
+
+#### Rust EllipticE/Pi integration recognition (PR #3178 ✅ merged)
+
+| Package | Version | Notes |
+|---|---|---|
+| `rust/symbolic-vm` | 0.3.0 | EllipticE (complete + incomplete), EllipticPi (complete) pattern recognition |
 
 #### CAS substrate packages — all fully wired
 
@@ -256,8 +270,8 @@ The Risch integration suite is ~90% complete. Known remaining gaps:
 | Case | Example | Status |
 |---|---|---|
 | Elliptic integrals — first-kind foothold | `∫ 1/√(1-k²sin²θ) dθ` | ✅ #3141: returns `EllipticF(θ,k)`; definite 0…π/2 returns `EllipticK(k)` |
-| Elliptic integrals — second kind | `∫ √(1-k²sin²θ) dθ`, `∫₀^(π/2) √(1-k²sin²θ) dθ` | ✅ Python `symbolic-vm` 0.54.0 PR #3173; TS/Rust 0.3.0 in progress |
-| Elliptic integrals — third kind | `∫₀^(π/2) 1/((1+n·sin²θ)·√(1-k²sin²θ)) dθ` | ✅ Python `symbolic-vm` 0.54.0 PR #3173; TS/Rust 0.3.0 in progress |
+| Elliptic integrals — second kind | `∫ √(1-k²sin²θ) dθ`, `∫₀^(π/2) √(1-k²sin²θ) dθ` | ✅ Python PR #3173, TypeScript PR #3179, Rust PR #3178 — all three languages at 0.3.0/0.54.0 |
+| Elliptic integrals — third kind | `∫₀^(π/2) 1/((1+n·sin²θ)·√(1-k²sin²θ)) dθ` | ✅ Python PR #3173, TypeScript PR #3179, Rust PR #3178 — all three languages at 0.3.0/0.54.0 |
 | `∫ f(x)·g(x)` where neither integrates alone | General IBP fallback missing; only specific matched patterns work | Open |
 
 #### Completed REPL and session features


### PR DESCRIPTION
## Summary

- Marks all six sprint PRs as ✅ merged in the spec header
- Bumps Python `symbolic-vm` version table entry from 0.53.0 → 0.54.0, adds EllipticF/K/E/Pi to Phase 25 description
- Marks TypeScript and Rust 0.2.0 release sections (PRs #3170, #3171) as merged
- Adds new TypeScript 0.3.0 (PR #3179) and Rust 0.3.0 (PR #3178) EllipticE/Pi sections
- Updates integration gap table: EllipticE and EllipticPi now ✅ in all three languages (Python PR #3173, TypeScript PR #3179, Rust PR #3178)

## Sprint PRs closed this cycle

| PR | Description |
|---|---|
| #3170 ✅ | TypeScript symbolic-vm + macsyma-runtime 0.2.0 releases |
| #3171 ✅ | Rust symbolic-vm + macsyma-runtime 0.2.0 releases + cas-ode CHANGELOG |
| #3173 ✅ | Python symbolic-vm 0.54.0 — EllipticE/Pi Phase 25 |
| #3174 ✅ | Spec update (sprint kickoff) |
| #3178 ✅ | Rust symbolic-vm 0.3.0 — EllipticE/Pi |
| #3179 ✅ | TypeScript symbolic-vm 0.3.0 — EllipticE/Pi |

## Test plan

- [ ] Verify no code files changed (spec-only PR)
- [ ] Confirm all PR numbers and versions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)