### PR TITLE
rust(spice): add VCCS controlled sources

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add a DC modified nodal analysis solver for resistors, independent voltage
   sources, and independent current sources.
+- Add voltage-controlled current sources (VCCS) for linear transconductance
+  stages.
 - Add DC source sweeps for independent voltage and current sources.
 - Add DC sensitivity analysis for resistor and independent source parameters.
 - Add DC small-signal transfer-function analysis with input/output impedance.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -15,5 +15,5 @@ The initial slices implement:
 - Backward-Euler transient analysis for linear RC/RL circuits.
 
 The package supports resistors, capacitors, inductors, independent current sources,
-independent voltage sources, ground aliases, node voltages, and voltage source
-branch currents.
+independent voltage sources, voltage-controlled current sources, ground aliases,
+node voltages, and voltage source branch currents.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -38,6 +38,7 @@ pub enum Element {
     Inductor(Inductor),
     VoltageSource(VoltageSource),
     CurrentSource(CurrentSource),
+    Vccs(Vccs),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -180,6 +181,36 @@ impl CurrentSource {
             positive: positive.into(),
             negative: negative.into(),
             current,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Vccs {
+    pub name: String,
+    pub positive: String,
+    pub negative: String,
+    pub control_positive: String,
+    pub control_negative: String,
+    pub transconductance_siemens: f64,
+}
+
+impl Vccs {
+    pub fn new(
+        name: impl Into<String>,
+        positive: impl Into<String>,
+        negative: impl Into<String>,
+        control_positive: impl Into<String>,
+        control_negative: impl Into<String>,
+        transconductance_siemens: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            positive: positive.into(),
+            negative: negative.into(),
+            control_positive: control_positive.into(),
+            control_negative: control_negative.into(),
+            transconductance_siemens,
         }
     }
 }
@@ -719,6 +750,11 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
         Element::CurrentSource(source) => {
             Some((source.name.clone(), "current".to_string(), source.current))
         }
+        Element::Vccs(source) => Some((
+            source.name.clone(),
+            "transconductance_siemens".to_string(),
+            source.transconductance_siemens,
+        )),
         Element::Capacitor(_) | Element::Inductor(_) => None,
     }
 }
@@ -732,6 +768,7 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::Resistor(resistor) => resistor.resistance_ohms += delta,
         Element::VoltageSource(source) => source.voltage += delta,
         Element::CurrentSource(source) => source.current += delta,
+        Element::Vccs(source) => source.transconductance_siemens += delta,
         Element::Capacitor(_) | Element::Inductor(_) => {}
     }
 }
@@ -819,6 +856,7 @@ fn solve_linear_circuit(
             Element::CurrentSource(source) => {
                 stamp_current_source(source, &node_indices, &mut rhs)?
             }
+            Element::Vccs(source) => stamp_vccs(source, &node_indices, &mut matrix)?,
         }
     }
 
@@ -881,6 +919,7 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             Element::CurrentSource(source) => {
                 stamp_ac_current_source(source, &node_indices, &mut rhs)?
             }
+            Element::Vccs(source) => stamp_ac_vccs(source, &node_indices, &mut matrix)?,
         }
     }
 
@@ -943,6 +982,9 @@ fn build_small_signal_matrix(
                     });
                 }
             }
+            Element::Vccs(source) => {
+                stamp_vccs(source, node_indices, &mut matrix)?;
+            }
         }
     }
 
@@ -998,6 +1040,12 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
             Element::CurrentSource(source) => {
                 insert_node(&mut names, &source.positive);
                 insert_node(&mut names, &source.negative);
+            }
+            Element::Vccs(source) => {
+                insert_node(&mut names, &source.positive);
+                insert_node(&mut names, &source.negative);
+                insert_node(&mut names, &source.control_positive);
+                insert_node(&mut names, &source.control_negative);
             }
         }
     }
@@ -1068,6 +1116,9 @@ fn find_input_source<'a>(
             }
             Element::Inductor(inductor) if inductor.name == input_source => {
                 return Err(input_source_type_error(input_source, "inductor"));
+            }
+            Element::Vccs(source) if source.name == input_source => {
+                return Err(input_source_type_error(input_source, "VCCS"));
             }
             _ => {}
         }
@@ -1442,6 +1493,59 @@ fn stamp_current_source(
     Ok(())
 }
 
+fn stamp_vccs(
+    source: &Vccs,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+) -> Result<(), SpiceError> {
+    if !source.transconductance_siemens.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "transconductance must be finite".to_string(),
+        });
+    }
+
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    let control_positive = node_index(node_indices, &source.control_positive);
+    let control_negative = node_index(node_indices, &source.control_negative);
+    stamp_transconductance(
+        matrix,
+        positive,
+        negative,
+        control_positive,
+        control_negative,
+        source.transconductance_siemens,
+    );
+    Ok(())
+}
+
+fn stamp_transconductance(
+    matrix: &mut [Vec<f64>],
+    positive: Option<usize>,
+    negative: Option<usize>,
+    control_positive: Option<usize>,
+    control_negative: Option<usize>,
+    transconductance: f64,
+) {
+    if let Some(i) = positive {
+        if let Some(cp) = control_positive {
+            matrix[i][cp] += transconductance;
+        }
+        if let Some(cn) = control_negative {
+            matrix[i][cn] -= transconductance;
+        }
+    }
+    if let Some(j) = negative {
+        if let Some(cp) = control_positive {
+            matrix[j][cp] -= transconductance;
+        }
+        if let Some(cn) = control_negative {
+            matrix[j][cn] += transconductance;
+        }
+    }
+}
+
 fn stamp_ac_resistor(
     resistor: &Resistor,
     node_indices: &HashMap<String, usize>,
@@ -1567,6 +1671,59 @@ fn stamp_ac_current_source(
         rhs[j] += current;
     }
     Ok(())
+}
+
+fn stamp_ac_vccs(
+    source: &Vccs,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<Complex>],
+) -> Result<(), SpiceError> {
+    if !source.transconductance_siemens.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "transconductance must be finite".to_string(),
+        });
+    }
+
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    let control_positive = node_index(node_indices, &source.control_positive);
+    let control_negative = node_index(node_indices, &source.control_negative);
+    stamp_complex_transconductance(
+        matrix,
+        positive,
+        negative,
+        control_positive,
+        control_negative,
+        Complex::new(source.transconductance_siemens, 0.0),
+    );
+    Ok(())
+}
+
+fn stamp_complex_transconductance(
+    matrix: &mut [Vec<Complex>],
+    positive: Option<usize>,
+    negative: Option<usize>,
+    control_positive: Option<usize>,
+    control_negative: Option<usize>,
+    transconductance: Complex,
+) {
+    if let Some(i) = positive {
+        if let Some(cp) = control_positive {
+            matrix[i][cp] += transconductance;
+        }
+        if let Some(cn) = control_negative {
+            matrix[i][cn] -= transconductance;
+        }
+    }
+    if let Some(j) = negative {
+        if let Some(cp) = control_positive {
+            matrix[j][cp] -= transconductance;
+        }
+        if let Some(cn) = control_negative {
+            matrix[j][cn] += transconductance;
+        }
+    }
 }
 
 fn solve_linear_system(

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,5 +1,6 @@
 use spice_engine::{
-    dc_op, dc_sweep, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, VoltageSource,
+    dc_op, dc_sweep, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, Vccs,
+    VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -38,6 +39,24 @@ fn dc_current_source_into_resistor_uses_positive_to_negative_orientation() {
     let result = dc_op(&circuit).unwrap();
 
     assert_close(result.voltage("n1").unwrap(), 1.0);
+}
+
+#[test]
+fn dc_vccs_injects_current_from_control_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vctrl", "ctrl", "0", 2.0,
+    )));
+    circuit.add(Element::Vccs(Vccs::new(
+        "G1", "0", "out", "ctrl", "0", 1.0e-3,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert_close(result.voltage("out").unwrap(), 2.0);
 }
 
 #[test]
@@ -176,5 +195,29 @@ fn dc_rejects_duplicate_voltage_source_names() {
     assert!(matches!(
         dc_op(&circuit),
         Err(SpiceError::InvalidElement { name, .. }) if name == "V1"
+    ));
+}
+
+#[test]
+fn dc_rejects_non_finite_vccs_transconductance() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vctrl", "ctrl", "0", 1.0,
+    )));
+    circuit.add(Element::Vccs(Vccs::new(
+        "Gbad",
+        "0",
+        "out",
+        "ctrl",
+        "0",
+        f64::NAN,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    assert!(matches!(
+        dc_op(&circuit),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Gbad"
     ));
 }

--- a/code/packages/rust/spice-engine/tests/sens_tests.rs
+++ b/code/packages/rust/spice-engine/tests/sens_tests.rs
@@ -1,5 +1,5 @@
 use spice_engine::{
-    sens_dc, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, VoltageSource,
+    sens_dc, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, Vccs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -78,6 +78,32 @@ fn sens_dc_reports_current_source_and_load_resistance_sensitivities() {
     );
     assert_close(
         entry(&result, "Rload", "resistance_ohms").relative_sensitivity,
+        1.0,
+    );
+}
+
+#[test]
+fn sens_dc_reports_vccs_transconductance_sensitivity() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Vccs(Vccs::new(
+        "Gm", "0", "out", "in", "0", 2.0e-3,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = sens_dc(&circuit, "out").unwrap();
+
+    assert_close(result.nominal_voltage, 2.0);
+    assert_close(
+        entry(&result, "Gm", "transconductance_siemens").sensitivity,
+        1_000.0,
+    );
+    assert_close(
+        entry(&result, "Gm", "transconductance_siemens").relative_sensitivity,
         1.0,
     );
 }

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -1,5 +1,5 @@
 use spice_engine::{
-    tf, Capacitor, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, TfResult,
+    tf, Capacitor, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, TfResult, Vccs,
     VoltageSource,
 };
 
@@ -77,6 +77,26 @@ fn tf_current_source_input_reports_transimpedance() {
 }
 
 #[test]
+fn tf_vccs_stage_reports_transconductance_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Vccs(Vccs::new(
+        "Gm", "0", "out", "in", "0", 2.0e-3,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = tf(&circuit, "out", "Vin").unwrap();
+
+    assert_close(result.gain(), 2.0);
+    assert_close(result.output_impedance_ohms, 1_000.0);
+    assert!(result.input_impedance_ohms.is_infinite());
+}
+
+#[test]
 fn tf_capacitor_is_open_and_inductor_is_short_at_dc_small_signal() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -119,5 +139,18 @@ fn tf_rejects_non_source_input_element() {
     assert!(matches!(
         tf(&circuit, "in", "Rin"),
         Err(SpiceError::InvalidElement { name, .. }) if name == "Rin"
+    ));
+}
+
+#[test]
+fn tf_rejects_vccs_as_input_source() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Vccs(Vccs::new(
+        "Gm", "0", "out", "in", "0", 1.0e-3,
+    )));
+
+    assert!(matches!(
+        tf(&circuit, "out", "Gm"),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Gm"
     ));
 }


### PR DESCRIPTION
## Summary
- add Rust SPICE voltage-controlled current source (VCCS) elements
- stamp VCCS transconductance through DC, AC, transient linear solves, and TF small-signal matrices
- include DC, TF, and sensitivity coverage for controlled-source behavior and validation

## Validation
- `cargo fmt -p spice-engine`
- `cargo test -p spice-engine`
- `git diff --check`
