### PR TITLE
docs(specs): x86_64 port — LANG43/44/45/46 (Linux + Windows end-to-end)

### DIFF
--- a/code/specs/LANG41-x86_64-encoder.md
+++ b/code/specs/LANG41-x86_64-encoder.md
@@ -1,0 +1,461 @@
+# LANG41 — `x86_64-encoder`: X86-64 Instruction Encoder
+
+**Status:** Draft — 2026-05-14
+
+## Motivation
+
+The LANG VM today has exactly one mature native backend: `aarch64-backend`
+on top of `aarch64-encoder`.  ARM64 covers Apple Silicon and modern Linux
+ARM hosts, but the *most common* desktop and server architecture in the
+field remains x86-64 (AMD64 / Intel 64).  CI runners, default cloud VMs,
+and the majority of contributor laptops run x86-64.
+
+To bring AOT and JIT compilation to those hosts, the LANG VM needs an
+x86-64 backend.  Following the established two-package pattern, this
+spec defines the lower of the two layers: a pure instruction encoder
+that produces raw `.text` bytes for the x86-64 instruction set.
+
+The companion spec **LANG43** defines `x86_64-backend`, which lowers
+CIR onto the encoder.  This spec stops at "given a method like
+`mov_r64_imm64(Reg::Rax, 42)`, what bytes come out?"
+
+## Non-goals
+
+- **Lowering**: no CIR awareness.  That belongs in `x86_64-backend`.
+- **Packaging**: no ELF / Mach-O / COFF wrappers.  `code-packager`
+  handles that.
+- **Relocations beyond branch fixups**: external symbol relocations
+  (CALL to runtime, RIP-relative globals) are surfaced as opaque slots
+  that the backend records and the packager resolves.  Branch
+  destinations *internal* to a function are resolved at `finish()`
+  time, exactly like in `aarch64-encoder`.
+- **AVX/SSE/x87**: floats and SIMD are out of scope for V1 (the
+  AArch64 encoder also defers floats).
+- **16-bit / 32-bit legacy modes**: only 64-bit (long) mode is
+  encoded.
+- **Microsoft x64 ABI quirks**: home-stack space, RVA32 relocations,
+  unwind data tables — those are layered above the encoder.  The
+  encoder produces the same bytes regardless of host OS; the choice
+  of ABI is a *backend* concern.
+
+## ISA reference
+
+All encodings cite **Intel® 64 and IA-32 Architectures Software
+Developer's Manual, Volume 2** (Vol. 2A/2B/2C/2D, instruction set
+reference) and **AMD64 Architecture Programmer's Manual, Volume 3**.
+The encoder uses the *Intel* mnemonic forms in API names; bit layouts
+follow the Intel manual.
+
+## Why x86-64 is harder than ARM64 to encode
+
+| Aspect | ARM64 | x86-64 |
+|---|---|---|
+| Instruction width | Fixed 4 bytes | Variable 1–15 bytes |
+| Operand encoding | Bit-packed fields | Prefixes + opcode + ModR/M + SIB + disp + imm |
+| Register file | 31 GPRs, regular numbering | 16 GPRs (8 legacy + 8 via REX.R/REX.B), irregular high/low byte aliases |
+| Immediate forms | One per family, sign-extended | Multiple sizes per family, varied sign/zero-extension |
+| Special clobbers | None for arithmetic | `IDIV` clobbers RDX:RAX; shifts use CL; CMPS uses RSI/RDI |
+| PC-relative addressing | Explicit (ADRP/ADR) | Implicit via `[RIP + disp32]` ModR/M form |
+| Alignment | 4-byte instructions | Bytes anywhere — no alignment to worry about, but jump targets can land mid-instruction (we don't) |
+
+The encoder's job is to hide as much of this as possible behind a
+typed API, while remaining a thin shim — no register allocation, no
+peephole optimisation, just bytes.
+
+---
+
+## Package layout
+
+```
+code/packages/rust/x86_64-encoder/
+├── Cargo.toml          # zero external deps (matches aarch64-encoder)
+├── README.md
+├── CHANGELOG.md
+└── src/
+    └── lib.rs
+```
+
+## Public API surface
+
+The shape mirrors `aarch64_encoder` so a reader who knows that crate
+can navigate this one immediately.
+
+### Registers
+
+64-bit GPR encoding:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reg {
+    Rax, Rcx, Rdx, Rbx,
+    Rsp, Rbp, Rsi, Rdi,
+    R8,  R9,  R10, R11,
+    R12, R13, R14, R15,
+}
+```
+
+Notes:
+
+- Encoding order is the Intel ModR/M numeric order (`RAX=0, RCX=1,
+  RDX=2, RBX=3, RSP=4, RBP=5, RSI=6, RDI=7`).  R8..R15 are `0..7`
+  *plus* a REX bit (R/B/X extension).
+- The encoder normalises the REX bit internally; callers always pass
+  the logical register.
+- `RSP` and `RBP` have special ModR/M behaviour (`mod=00 r/m=100`
+  forces SIB; `mod=00 r/m=101` forces RIP-relative).  The encoder
+  emits a SIB or non-zero displacement to side-step these rules
+  whenever the caller picks `RSP`/`RBP` as a base.
+
+8-bit register low halves are not exposed in V1.  We sign- or
+zero-extend during 8/16/32-bit ops by clearing the upper bits via the
+64-bit form (e.g., `mov r/m32, ...` zeroes the upper 32 bits as a
+matter of the ISA).
+
+### Condition codes
+
+x86-64 condition codes are 4-bit tags on `Jcc` / `SETcc` /
+`CMOVcc`.  We mirror the ARM `Cond` enum:
+
+```rust
+pub enum Cond {
+    O = 0x0, No = 0x1,
+    B = 0x2, Ae = 0x3,           // unsigned below / above-or-equal
+    E = 0x4, Ne = 0x5,
+    Be = 0x6, A = 0x7,           // unsigned below-or-equal / above
+    S = 0x8, Ns = 0x9,
+    P = 0xA, Np = 0xB,
+    L = 0xC, Ge = 0xD,           // signed less / greater-or-equal
+    Le = 0xE, G = 0xF,
+}
+```
+
+### Labels and fixups
+
+Verbatim copy of the AArch64 design: `LabelId`, `create_label`,
+`bind`, internal `Fixup { word_idx, target, kind }`, resolved in
+`finish()`.
+
+x86-64 has *two* near-branch displacement widths we care about:
+
+- `Rel8`  — `Jcc rel8`, `JMP rel8` (signed -128..+127, 1 byte)
+- `Rel32` — `Jcc rel32`, `JMP rel32`, `CALL rel32` (signed ±2 GiB)
+
+V1 emits **Rel32 forms only**, even for tiny forward jumps.  This
+wastes 4 bytes per branch versus the optimal short form, but avoids
+the two-pass shortening problem entirely.  A future PR can add a
+relaxation pass; the cost is bounded and predictable.
+
+### Errors
+
+```rust
+pub enum EncodeError {
+    UnboundLabel(LabelId),
+    LabelAlreadyBound(LabelId),
+    ImmediateOutOfRange { op: &'static str, bits: u32, value: i64 },
+    BranchOutOfRange { bits: u32, delta_bytes: i64 },
+    // x86-64-specific:
+    InvalidEffectiveAddress { reason: &'static str },
+}
+```
+
+The `BranchOutOfRange.delta_bytes` is in *bytes*, not words — x86-64
+displacements are byte counts.
+
+### External relocations
+
+`ExternalReloc` mirrors the AArch64 encoder's analogue and tracks the
+information a packager needs to patch a `CALL rel32` or
+`MOV r64, [RIP+disp32]` later:
+
+```rust
+pub struct ExternalReloc {
+    /// Byte offset in `.text` where the 32-bit field lives.
+    pub patch_offset: usize,
+    /// Logical symbol name (e.g., "__twig_print_i64").
+    pub symbol: String,
+    /// Reloc kind: PLT call, RIP-relative load, GOT load, …
+    pub kind: ExternalRelocKind,
+    /// Offset adjustment applied to the resolved address before patching.
+    pub addend: i32,
+}
+
+pub enum ExternalRelocKind {
+    /// `R_X86_64_PLT32` for ELF, `X86_64_RELOC_BRANCH` for Mach-O.
+    /// Used by `CALL rel32` to external functions.
+    PltRel32,
+    /// `R_X86_64_PC32` for ELF.  Used for RIP-relative loads/stores
+    /// of globals when the symbol resolves locally.
+    PcRel32,
+    /// `R_X86_64_REX_GOTPCRELX` (ELF) — RIP-relative GOT load for
+    /// possibly-external globals.
+    GotPcRel32,
+}
+```
+
+---
+
+## Coverage (V1)
+
+V1 covers exactly the same logical surface as `aarch64-encoder` after
+LANG38 + LANG39 + LANG40 lands, so the backend has a one-to-one
+mapping target.
+
+| Family | Methods | Notes |
+|---|---|---|
+| Move immediate | `mov_r64_imm32`, `mov_r64_imm64` | `mov r64, imm32` zero-extends; `MOVABS r64, imm64` for full-width |
+| Move register | `mov_r64_r64` | `MOV r/m64, r64` form |
+| Arithmetic (reg) | `add`, `sub`, `imul` | 64-bit `r/m64, r64` and `r/m64, r/m64` |
+| Arithmetic (imm) | `add_imm32`, `sub_imm32` | Sign-extended imm32 |
+| Division | `idiv`, `div` | Implicit RAX/RDX dividend; backend sequences `cqo`/`xor rdx,rdx` |
+| Sign extension | `cqo` | RAX → RDX:RAX before `IDIV` |
+| Compare | `cmp`, `cmp_imm32` | `CMP` is `SUB` with discarded result |
+| Logical (reg) | `and_`, `or_`, `xor_`, `not_` | 64-bit |
+| Shifts (variable) | `shl_cl`, `shr_cl`, `sar_cl` | Shift amount in CL only (x86 ISA constraint) |
+| Shifts (imm) | `shl_imm8`, `shr_imm8`, `sar_imm8` | 8-bit immediate |
+| Unary | `neg_` | Two's-complement negate |
+| Set on condition | `setcc(Cond, Reg)` | 8-bit destination; zero-extend with `movzx` from same reg |
+| Memory (load) | `mov_r64_mem` | `MOV r64, [base + disp32]` and `[RIP + disp32]` |
+| Memory (store) | `mov_mem_r64` | `MOV [base + disp32], r64` |
+| Memory (8-bit store) | `mov_mem8_imm8` | For `io_out` newline emission |
+| Stack | `push`, `pop` | 64-bit, for prologue/epilogue |
+| RIP-relative | `lea_rip_rel(Reg, Reloc)` | Emits `LEA r64, [RIP+disp32]` with external reloc |
+| Branch (cond) | `jcc(Cond, LabelId)` | `Jcc rel32` |
+| Branch (uncond) | `jmp(LabelId)` | `JMP rel32` |
+| Call (direct) | `call_rel32(Reloc)` | `CALL rel32` with external reloc |
+| Call (indirect) | `call_r64`, `ret` | For function-pointer dispatch and return |
+| Misc | `nop`, `ud2`, `int3` | Trap (`ud2`) for `type_assert` deopt |
+
+Everything outside this list is deferred.  The backend returns
+`BackendRefused` for opcodes the encoder cannot emit, exactly like the
+AArch64 path.
+
+### Truth tables — small but worth fixing in the spec
+
+**Calling-convention argument registers (System V AMD64):**
+
+| Arg # | Register |
+|---|---|
+| 1 | RDI |
+| 2 | RSI |
+| 3 | RDX |
+| 4 | RCX |
+| 5 | R8 |
+| 6 | R9 |
+| 7+ | Stack (right-to-left, 8-byte slots) |
+
+**Calling-convention argument registers (Microsoft x64):**
+
+| Arg # | Register |
+|---|---|
+| 1 | RCX |
+| 2 | RDX |
+| 3 | R8 |
+| 4 | R9 |
+| 5+ | Stack (with 32-byte "home" shadow space) |
+
+The encoder does not care about the ABI — these tables are
+documented here for the backend's reference.
+
+---
+
+## Encoding strategy
+
+x86-64 instructions are composed of up to five logical pieces:
+
+```
+[ legacy prefixes (0-4) ] [ REX (0-1) ] [ opcode (1-3) ] [ ModR/M (0-1) ] [ SIB (0-1) ] [ displacement (0/1/2/4) ] [ immediate (0/1/2/4/8) ]
+```
+
+Internal helpers (private):
+
+```rust
+fn rex(w: bool, r: bool, x: bool, b: bool) -> u8;
+fn modrm(mode: u8, reg: u8, rm: u8) -> u8;
+fn sib(scale: u8, index: u8, base: u8) -> u8;
+```
+
+These are pure functions; encoding remains testable in isolation.
+
+### REX prefix
+
+For 64-bit GPR ops we always emit `REX.W = 1` (`0x48` base).  Bits:
+
+- `W` = 1: 64-bit operand size
+- `R`: extension of ModR/M.reg (set when reg ≥ R8)
+- `X`: extension of SIB.index (set when index ≥ R8)
+- `B`: extension of ModR/M.r/m or SIB.base or opcode reg field (set when reg/base ≥ R8)
+
+The encoder omits REX when no extension is needed *and* the operand
+size matches the default (rare; for V1 we just always emit the REX).
+
+### ModR/M `mod` field summary
+
+| `mod` | Meaning |
+|---|---|
+| `00` | `[base]` (no displacement) — but `r/m=101` means `[RIP + disp32]`; `r/m=100` requires SIB |
+| `01` | `[base + disp8]` |
+| `10` | `[base + disp32]` |
+| `11` | Pure register operand |
+
+### Variable-length tradeoffs
+
+Two simple rules keep us safe:
+
+1. **Always use the long form for forward branches** — `Jcc rel32`,
+   `JMP rel32`, `CALL rel32`.  Never `Jcc rel8`.  Removes the need
+   for backpatching width.
+2. **Always use disp32 for stack-frame accesses** — even when disp8
+   would suffice.  Costs 3 extra bytes per access, eliminates a
+   width-selection branch in the encoder.
+
+These two rules together mean every instruction's byte length is
+known the moment its first byte is emitted, so label resolution is a
+straight "patch the rel32 field at the recorded offset" pass.
+
+---
+
+## Bit layouts (worked examples)
+
+These examples are sized to give an implementer immediate traction.
+Reference: Intel SDM Vol. 2.
+
+### `MOV r/m64, r64`  — `mov_r64_r64(dst, src)`
+
+Opcode `0x89 /r`.
+
+```
+[REX.W=1, R=src.high, B=dst.high] [0x89] [ModR/M(mod=11, reg=src.low3, rm=dst.low3)]
+```
+
+For `MOV RAX, RDI`: `48 89 F8`.
+
+### `ADD r/m64, r64`  — `add(dst, src)`
+
+Opcode `0x01 /r`.  Same encoding shape as MOV.
+
+For `ADD RAX, RCX`: `48 01 C8`.
+
+### `ADD r/m64, imm32` (sign-extended)  — `add_imm32(dst, imm)`
+
+Opcode `0x81 /0`.  ModR/M reg field is the opcode extension `0`.
+
+```
+[REX.W=1, B=dst.high] [0x81] [ModR/M(mod=11, reg=0, rm=dst.low3)] [imm32 LE]
+```
+
+For `ADD RAX, 1`: `48 83 C0 01` (note: `0x83` is the 8-bit-imm sign-extended
+variant, which we *also* use when the immediate fits in `i8`).  V1
+always emits the `0x81` form to keep encoding deterministic.
+
+### `MOV r64, imm64`  — `mov_r64_imm64(dst, imm)`
+
+Opcode `B8+rd`.  The destination register is encoded in the opcode
+byte's low 3 bits, with the high bit going into `REX.B`.
+
+```
+[REX.W=1, B=dst.high] [B8 + dst.low3] [imm64 LE]
+```
+
+For `MOV RAX, 0x1234567890ABCDEF`: `48 B8 EF CD AB 90 78 56 34 12`.
+
+### `CMP r/m64, r64`  — `cmp(lhs, rhs)`
+
+Opcode `0x39 /r`.  Like `SUB` but discards the result, sets flags.
+
+For `CMP RAX, RCX`: `48 39 C8`.
+
+### `Jcc rel32`  — `jcc(cond, label)`
+
+Two-byte opcode `0F 80+cc`.
+
+```
+[0F] [80 + cond_code] [rel32 LE — patched at finish()]
+```
+
+For `JE label`: `0F 84 ?? ?? ?? ??` with the `??` bytes recorded as a
+fixup.
+
+### `CALL rel32`  — `call_rel32(reloc)`
+
+Opcode `0xE8`.
+
+```
+[E8] [rel32 LE — patched by packager with PLT-relative offset]
+```
+
+The encoder emits `E8 00 00 00 00` and records an `ExternalReloc {
+patch_offset = current+1, kind = PltRel32, symbol, addend = -4 }`.
+The `-4` addend accounts for x86-64 PC-relative being relative to
+the *end* of the instruction.
+
+### `LEA r64, [RIP + disp32]`  — `lea_rip_rel(dst, reloc)`
+
+Opcode `0x8D /r` with `mod=00, r/m=101` (RIP-relative form).
+
+```
+[REX.W=1, R=dst.high] [8D] [ModR/M(mod=00, reg=dst.low3, rm=101)] [disp32 LE — patched]
+```
+
+Emits `48 8D 05 00 00 00 00` for `LEA RAX, [rel]` and records a
+`PcRel32` reloc.
+
+### `PUSH r64` / `POP r64`
+
+`50 + rd` / `58 + rd`.  REX.B extends the register.  No ModR/M needed.
+
+For `PUSH RBP`: `55`.  For `PUSH R15`: `41 57`.
+
+### `RET`
+
+Opcode `0xC3`.  Single byte.
+
+### `UD2` (deopt trap)
+
+Opcode `0x0F 0x0B`.  Two bytes.  Used to lower `type_assert` (no
+deopt in AOT — just trap; matches what AArch64 does with `UDF`).
+
+---
+
+## Test plan
+
+Mirror `aarch64-encoder`'s suite.  Coverage target ≥ 95%.
+
+1. **Per-instruction byte-exact tests** — every public method has at
+   least one test that asserts the encoded byte string against a
+   hand-verified reference (cross-checked with `objdump -d` /
+   `llvm-mc` output during development).
+2. **Register-extension tests** — emit the same instruction with
+   `RAX` and with `R15`; assert REX.B flips correctly and the low 3
+   bits stay the same.
+3. **Label resolution** — emit `JMP fwd; ... ; bind(fwd); RET`,
+   `finish()`, decode the rel32 field, assert it equals the byte
+   delta from the end of the JMP to the RET.
+4. **Unbound-label error** — `finish()` returns `UnboundLabel`.
+5. **External relocation recording** — `call_rel32(reloc)` records
+   `patch_offset` pointing at the `rel32` slot, not at the opcode.
+6. **Negative-immediate sign-extension** — `add_imm32(rax, -1)`
+   encodes as `48 81 C0 FF FF FF FF` and the value sign-extends to
+   `-1` when executed.
+7. **Round-trip with `iced-x86`** — for a subset of instructions,
+   decode the emitted bytes with the `iced-x86` crate (dev-only
+   dependency) and assert the decoded form matches the expected
+   mnemonic + operands.  Pure validation tool; not shipped in the
+   crate's regular dependency tree.
+
+`iced-x86` lives behind `#[cfg(test)]` only — production builds keep
+the zero-dep guarantee.
+
+---
+
+## Out of scope (deferred to follow-up specs)
+
+- **SSE/AVX float ops** — needed eventually for `f32`/`f64`; mirrors
+  the "floats NOT YET" line in `aarch64-encoder`.
+- **Short branch relaxation** (rel8 forms) — pure size optimisation.
+- **AVX-512** — not on the V1 path.
+- **Atomic ops (LOCK prefix)** — needed for `gc-core` interactions
+  later.
+- **Implicit-CL handling** — caller pre-loads `CL` before
+  `shl_cl`/`shr_cl`/`sar_cl`; the encoder does not insert it.
+- **REX prefix omission optimisation** — V1 always emits REX for 64-bit
+  ops, even when redundant; minor size cost.

--- a/code/specs/LANG43-x86_64-backend.md
+++ b/code/specs/LANG43-x86_64-backend.md
@@ -1,0 +1,417 @@
+# LANG43 — `x86_64-backend`: X86-64 Native Backend
+
+**Status:** Draft — 2026-05-14
+
+## Motivation
+
+`aarch64-backend` brings the LANG VM to ARM64 hosts (Apple Silicon,
+modern Linux ARM).  `x86_64-backend` brings it to x86-64 hosts —
+which today dominate CI runners, cloud VMs, and developer laptops.
+
+This spec defines the backend that consumes CIR via the `Backend`
+trait (LANG05) and produces x86-64 machine code via `x86_64-encoder`
+(LANG41).  It plugs into both `aot-core` (LANG04) and `jit-core`
+(LANG03) without changes to either — the `Backend` trait is
+target-agnostic.
+
+The goal of V1 is **functional parity with `aarch64-backend`** after
+LANG38 (arithmetic completeness) + LANG39 (globals) + LANG40 (I/O):
+every CIR opcode currently supported on ARM64 must also compile on
+x86-64.  Subsequent PRs match `aarch64-backend` PR-for-PR; this spec
+lays out the V1 cut and the major design decisions.
+
+## Non-goals (V1)
+
+- **Floating-point / SSE / AVX** — `aarch64-backend` has no float
+  support either.  Defer until both backends grow it together.
+- **Closures** (LANG34/35) — defer; mirrors the AArch64 path's
+  `closures: NOT YET` line.
+- **Local-register allocator** — V1 uses stack spill exclusively
+  (matches AArch64).  A real allocator can replace the spill core
+  later behind the same public API.
+- **Microsoft x64 ABI** — V1 targets **System V AMD64 ABI** only
+  (Linux, macOS x86-64, FreeBSD).  Windows x86-64 is a follow-up;
+  see § Out of scope below.
+
+## Package layout
+
+```
+code/packages/rust/x86_64-backend/
+├── Cargo.toml          # deps: x86_64-encoder, jit-core, vm-core
+├── README.md
+├── CHANGELOG.md
+└── src/
+    └── lib.rs
+```
+
+Mirror of `aarch64-backend`'s structure.
+
+---
+
+## Backend trait implementation
+
+```rust
+#[derive(Debug, Default, Clone, Copy)]
+pub struct X86_64Backend;
+
+impl X86_64Backend {
+    pub fn new() -> Self { X86_64Backend }
+}
+
+impl Backend for X86_64Backend {
+    fn name(&self) -> &str { "x86_64" }
+
+    fn compile_function(
+        &self,
+        ctx: &FunctionContext,
+        ir: &[CIRInstr],
+    ) -> Option<CompileResult> { /* … */ }
+
+    fn compile(&self, _ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        // Same "needs context" rationale as AArch64:
+        // we can't lay out a prologue without knowing arg count.
+        None
+    }
+}
+```
+
+`CompileResult` carries the byte stream plus the relocation list the
+packager will resolve (`ExternalReloc` from `x86_64-encoder`,
+re-exported as `Reloc` for parity with the AArch64 backend's API).
+
+---
+
+## ABI: System V AMD64
+
+V1 conforms strictly to the System V AMD64 ABI as documented in the
+draft revision 1.0 (Matz et al.).  The relevant rules for the LANG
+VM's integer-only V1:
+
+- **Argument registers** (in order): `RDI`, `RSI`, `RDX`, `RCX`,
+  `R8`, `R9`.  Up to six integer/pointer arguments fit in registers;
+  beyond that, push right-to-left on the stack.
+- **Return value**: `RAX`.
+- **Caller-saved (volatile)**: `RAX`, `RCX`, `RDX`, `RSI`, `RDI`,
+  `R8`–`R11`.  Subset our spill allocator may freely clobber as
+  scratch.
+- **Callee-saved**: `RBX`, `RBP`, `R12`–`R15`.  V1 only clobbers
+  `RBP` (used as frame pointer), so we save and restore it in the
+  prologue/epilogue.
+- **Stack alignment**: 16-byte-aligned **at the point of a `CALL`
+  instruction** (so on entry, RSP ≡ 8 (mod 16) because the CALL
+  pushed an 8-byte return address).  After `push rbp`, RSP ≡ 0 (mod
+  16) — the prologue's frame allocation must keep it that way.
+- **Red zone**: 128 bytes below RSP are scratch for leaf functions.
+  V1 *does not* use the red zone; all locals live in the proper
+  frame.
+
+### Prologue / epilogue
+
+```asm
+;  --- prologue ---
+push  rbp
+mov   rbp, rsp
+sub   rsp, <frame>          ; <frame> rounded up to 16-byte multiple
+
+;  spill arg registers to their stack slots
+mov   [rbp - 8 - N*8 - 0],  rdi      ; arg 0
+mov   [rbp - 8 - N*8 - 8],  rsi      ; arg 1
+... up to 6 args ...
+                                     ; arg 7+ already on stack, accessed via [rbp + 16 + ...]
+
+;  --- body ---
+
+;  --- epilogue ---
+mov   rsp, rbp                       ; or `add rsp, <frame>`; mov is one byte shorter for large frames
+pop   rbp
+ret
+```
+
+`<frame>` = `(num_virtuals * 8 + 15) & !15`.  Sub-128B frames could
+use the red zone, but uniformity wins for V1.
+
+### Stack alignment invariant
+
+After `push rbp; sub rsp, frame`, RSP must be `≡ 0 (mod 16)`.  Since
+`push rbp` shifts the alignment by 8, we need `frame ≡ 8 (mod 16)`.
+The allocator rounds `frame` up to 16 *and then adds 8 if needed*.
+The corresponding check is part of the test suite.
+
+When calling out (e.g., `__twig_print_i64`), the call site adjusts
+RSP if necessary to restore the 16-byte alignment at the call.  In
+V1, all locals are 8-byte slots and we don't pass stack arguments to
+external calls, so this works out naturally.
+
+---
+
+## Register allocation: stack spill (V1)
+
+Identical strategy to `aarch64-backend`:
+
+1. Each CIR virtual register `v0`, `v1`, … is assigned a fixed
+   8-byte stack slot at `[rbp - 8 - slot_idx * 8]` (so `v0` is at
+   `[rbp - 8]`, `v1` at `[rbp - 16]`, …).
+2. Every instruction:
+   - Loads its source operands into scratch registers (`RAX`, `RCX`,
+     `RDX` reserved as the three-way scratch set).
+   - Performs the operation.
+   - Stores the destination back to its stack slot.
+3. Constants are materialised into a scratch register fresh each
+   use.
+
+The choice of `RAX`/`RCX`/`RDX` as scratch is deliberate:
+
+- `RAX` is the return register; useful to dock results there
+  directly when the next instr is `ret`.
+- `RCX` is the only valid shift-count register (`SHL r/m, CL`); having
+  it in the scratch set means shift lowering doesn't need to move it
+  around.
+- `RDX` is the high half of the implicit dividend (`RDX:RAX`) for
+  `IDIV`/`DIV`; the divide lowering can sequence `CQO` (sign-extend
+  RAX into RDX) without touching anything else in the scratch set.
+
+`RBX`, `R12`–`R15` are callee-saved but unused by V1 — leaving them
+preserved means we don't have to save them in the prologue.
+
+---
+
+## CIR opcode coverage (V1)
+
+Matches `aarch64-backend` after LANG38+LANG39+LANG40.  See the table
+in `aarch64-backend/src/lib.rs` doc-comment for the canonical list.
+The mapping below shows how each family lowers on x86-64.
+
+### Constants
+
+| CIR | x86-64 lowering |
+|---|---|
+| `const_u8 .. const_u64` | `MOV reg, imm` (sign-extended imm32 for small, `MOVABS reg, imm64` for full) → `MOV [slot], reg` |
+| `const_i8 .. const_i64` | Same |
+| `const_bool` | `MOV reg, 0` or `MOV reg, 1` → `MOV [slot], reg` |
+
+### Integer arithmetic
+
+| CIR | Lowering |
+|---|---|
+| `add_<ty>` | `MOV rax, [lhs]; ADD rax, [rhs]; MOV [dst], rax` |
+| `sub_<ty>` | `MOV rax, [lhs]; SUB rax, [rhs]; MOV [dst], rax` |
+| `mul_<ty>` | `MOV rax, [lhs]; IMUL rax, [rhs]; MOV [dst], rax` |
+
+V1 uses 64-bit ops for *every* typed integer mnemonic — exactly like
+`aarch64-backend`'s "result is not masked to declared width" rule.
+A later PR can add explicit masking.
+
+### Division and modulo (matches LANG38 wave)
+
+x86-64 division is **awkward**: `IDIV r/m64` divides `RDX:RAX` by
+`r/m64`, yielding quotient in `RAX`, remainder in `RDX`.  We must:
+
+1. Load dividend into `RAX`.
+2. Sign-extend (`CQO`) or zero (`XOR RDX, RDX`) into `RDX`.
+3. `IDIV [divisor]` or `DIV [divisor]`.
+4. Move `RAX` (for `div`) or `RDX` (for `mod`) into the destination
+   slot.
+
+For signed:
+
+```
+mov  rax, [lhs]
+cqo                     ; RDX:RAX = sign-extend(RAX)
+mov  rcx, [rhs]
+idiv rcx
+mov  [dst], rax         ; or [dst], rdx for mod
+```
+
+For unsigned, replace `cqo` with `xor rdx, rdx` and `idiv` with
+`div`.
+
+The `RCX` move is necessary because `IDIV r/m64` cannot use an
+immediate operand and `[rhs]` lives in memory — loading into `RCX`
+keeps the encoding straightforward (rather than `IDIV qword ptr
+[rbp - ...]` which is encodable but adds disp32 handling).
+
+### Comparisons
+
+`cmp_<op>_<ty>` lowers to:
+
+```
+mov  rax, [lhs]
+cmp  rax, [rhs]
+set<cc>  cl              ; setcc has 8-bit destination
+movzx rax, cl            ; zero-extend to 64 bits
+mov  [dst], rax
+```
+
+Condition selection:
+
+| CIR predicate | Unsigned cc | Signed cc |
+|---|---|---|
+| `eq` | `E` | `E` |
+| `ne` | `NE` | `NE` |
+| `lt` | `B` | `L` |
+| `le` | `BE` | `LE` |
+| `gt` | `A` | `G` |
+| `ge` | `AE` | `GE` |
+
+### Logical (LANG38 parity)
+
+`and_<ty>`, `or_<ty>`, `xor_<ty>` → `AND` / `OR` / `XOR` on `RAX` after
+loading lhs/rhs, store to dst.
+
+### Shifts (LANG38 parity)
+
+Variable shift on x86-64 *must* use `CL` as the shift count.  The
+backend pre-loads `[rhs]` into `CL`:
+
+```
+mov  rax, [lhs]
+mov  rcx, [rhs]
+shl  rax, cl            ; or shr / sar
+mov  [dst], rax
+```
+
+`shr` for unsigned types, `sar` for signed.
+
+### Unary (LANG38 parity)
+
+- `neg_<ty>` → `MOV rax, [src]; NEG rax; MOV [dst], rax`.
+- `not_<ty>` → `MOV rax, [src]; NOT rax; MOV [dst], rax`.
+- `mov_<ty>` → `MOV rax, [src]; MOV [dst], rax`.
+
+### Control flow
+
+| CIR | Lowering |
+|---|---|
+| `label L` | `bind(L)` — no bytes emitted |
+| `jmp L` | `JMP rel32` to label |
+| `jmp_if_true v, L` | `MOV rax, [v]; TEST rax, rax; JNE L` |
+| `jmp_if_false v, L` | `MOV rax, [v]; TEST rax, rax; JE L` |
+
+### Returns
+
+- `ret_<ty> v` → `MOV rax, [v]; <epilogue>; RET`.
+- `ret_void` → `<epilogue>; RET`.
+
+The epilogue is `MOV RSP, RBP; POP RBP`.
+
+### Type guards
+
+`type_assert` → `UD2` (two-byte invalid-opcode trap).  Matches the
+AArch64 backend's `UDF` lowering — AOT has no deoptimisation, so
+guard failures abort.
+
+### Calls (matches LANG39 wave)
+
+Cross-function `call` uses `CALL rel32` with an `ExternalReloc` of
+kind `PltRel32`.  The packager resolves the displacement at link
+time.  Arguments are loaded into the System V argument registers
+(RDI, RSI, RDX, RCX, R8, R9) before the call; the return value
+arrives in `RAX` and is stored to the destination slot.
+
+V1 supports up to six arguments per call.  Beyond that → return
+`BackendRefused`.
+
+### Globals (matches LANG39 wave)
+
+`global_load name` →
+
+```
+lea  rax, [rip + name]   ; PcRel32 reloc
+mov  rax, [rax]
+mov  [dst], rax
+```
+
+`global_store name, v` →
+
+```
+mov  rcx, [v]
+lea  rax, [rip + name]   ; PcRel32 reloc
+mov  [rax], rcx
+```
+
+### I/O (matches LANG40 wave)
+
+`io_out v` lowers to a `CALL` to `__twig_print_i64` (Linux/macOS
+shared runtime), passing `[v]` in `RDI`:
+
+```
+mov  rdi, [v]
+call __twig_print_i64    ; PltRel32 reloc
+```
+
+The runtime archive provides the symbol, resolved by the system
+linker.
+
+---
+
+## Out of scope (deferred PRs)
+
+- **Microsoft x64 ABI** — argument registers differ (`RCX, RDX, R8,
+  R9`), 32-byte home stack space is required, unwind tables (`.pdata`
+  / `.xdata`) needed.  Follow-up spec **LANG44** or similar; the
+  backend stays inside `x86_64-backend` with a runtime ABI toggle.
+- **Floats / SSE2** — both backends will gain this together.
+- **Local register allocator** — replace the spill core in place; no
+  trait changes.
+- **Closures** — needs cross-platform lowering decision (see
+  LANG34/35).
+- **Variable-shift via BMI2 `SHLX`/`SHRX`/`SARX`** — modern CPUs only;
+  pure throughput optimisation.
+
+---
+
+## Test plan
+
+Coverage target ≥ 95%.  Mirror the AArch64 backend's test suite
+1-for-1:
+
+1. **Per-CIR-opcode unit tests** — small CIR sequences, assert the
+   emitted byte stream against a hand-verified reference.
+2. **Prologue/epilogue framing** — empty function, single-arg, six-arg,
+   seven-arg (must refuse); assert RSP is 16-byte aligned at the
+   point of a hypothetical inner call.
+3. **End-to-end factorial** — compile, run via JIT loader, assert
+   `factorial(10) == 3628800`.
+4. **Comparison polarity** — exhaustive signed/unsigned × six
+   predicates × tiny truth tables.
+5. **Division by zero trap** — `IDIV` by 0 raises `#DE`; the runtime
+   sees a SIGFPE; assert the test harness catches it.
+6. **Global load/store** — round-trip a 64-bit global through
+   `global_store` then `global_load`.
+7. **`io_out` integration** — call `__twig_print_i64`, capture
+   stdout, assert correct decimal output.
+8. **Backend refusal** — feed a `mul_f64` CIR instr, assert
+   `compile_function` returns `None` (deopt path).
+9. **Register allocation correctness** — function with 100 virtuals
+   spills correctly; no slot collisions; frame size matches.
+
+Cross-validation: a subset of tests decode emitted bytes via
+`iced-x86` and assert the disassembly matches the expected mnemonic
+sequence.  Dev-only dep.
+
+---
+
+## Registration
+
+Once V1 lands, `jit-core` and `aot-core` register the backend in
+their default backend registries:
+
+```rust
+// in codegen-core or wherever the default registry is built
+registry.register(Box::new(X86_64Backend::new()));
+```
+
+No trait changes; both pipelines transparently pick up the new
+target via `target_triple()`-based lookup.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Variable-length encoding edge cases (REX.B / SIB requirement when base ∈ {RSP, RBP, R12, R13}) | Encoder normalises these internally; backend never sees them. |
+| Division clobber surprises | All scratch regs (`RAX`, `RCX`, `RDX`) reserved up front; spill allocator never assumes their preservation across an instruction boundary. |
+| Stack alignment violations at calls | One test per call site shape; alignment check is a single arithmetic invariant. |
+| Mach-O vs ELF reloc kind differences | Encoder emits abstract `ExternalRelocKind`; `code-packager` maps to OS-specific reloc types. |
+| Mismatch between AArch64 and x86-64 CIR coverage as both backends evolve | Each future LANG NN that touches AArch64 backend should produce a sibling commit on x86-64.  This is a discipline issue, tracked in the changelog. |

--- a/code/specs/LANG43-x86_64-backend.md
+++ b/code/specs/LANG43-x86_64-backend.md
@@ -2,6 +2,12 @@
 
 **Status:** Draft — 2026-05-14
 
+> The x86-64 port spans four specs (LANG44 encoder, **LANG43** backend,
+> LANG45 object emitters, LANG46 twig-aot driver).  Together they bring
+> Twig source → native binary that runs on **Linux x86-64** and
+> **Windows x86-64**.  This spec is the CIR-lowering layer; both ABIs
+> are in V1 scope so neither OS waits behind the other.
+
 ## Motivation
 
 `aarch64-backend` brings the LANG VM to ARM64 hosts (Apple Silicon,
@@ -10,15 +16,16 @@ which today dominate CI runners, cloud VMs, and developer laptops.
 
 This spec defines the backend that consumes CIR via the `Backend`
 trait (LANG05) and produces x86-64 machine code via `x86_64-encoder`
-(LANG41).  It plugs into both `aot-core` (LANG04) and `jit-core`
+(LANG44).  It plugs into both `aot-core` (LANG04) and `jit-core`
 (LANG03) without changes to either — the `Backend` trait is
 target-agnostic.
 
 The goal of V1 is **functional parity with `aarch64-backend`** after
-LANG38 (arithmetic completeness) + LANG39 (globals) + LANG40 (I/O):
-every CIR opcode currently supported on ARM64 must also compile on
-x86-64.  Subsequent PRs match `aarch64-backend` PR-for-PR; this spec
-lays out the V1 cut and the major design decisions.
+LANG38 (arithmetic completeness) + LANG39 (globals) + LANG40 (I/O) +
+LANG41 (runtime library) on **both** Linux and Windows x86-64: every
+CIR opcode currently supported on ARM64 must also compile on x86-64,
+and the same Twig program must produce a working ELF executable on
+Linux and a working PE executable on Windows.
 
 ## Non-goals (V1)
 
@@ -29,9 +36,16 @@ lays out the V1 cut and the major design decisions.
 - **Local-register allocator** — V1 uses stack spill exclusively
   (matches AArch64).  A real allocator can replace the spill core
   later behind the same public API.
-- **Microsoft x64 ABI** — V1 targets **System V AMD64 ABI** only
-  (Linux, macOS x86-64, FreeBSD).  Windows x86-64 is a follow-up;
-  see § Out of scope below.
+- **macOS x86-64** — Intel Macs are a shrinking population; defer.
+  The encoder works there, but `code-packager` would need a Mach-O
+  variant tuned for `CPU_TYPE_X86_64` (LANG45 covers only ELF + PE
+  in V1).
+- **Windows SEH unwind tables** (`.pdata` / `.xdata`) — required for
+  proper exception unwinding from a debugger or another module.
+  V1 emits no unwind data; uncaught traps terminate the process,
+  which is the same behaviour Linux gets without `.eh_frame`.
+  Adding tables is a follow-up; spec stays in `x86_64-backend` once
+  needed.
 
 ## Package layout
 
@@ -81,66 +95,132 @@ re-exported as `Reloc` for parity with the AArch64 backend's API).
 
 ---
 
-## ABI: System V AMD64
+## ABI selection
 
-V1 conforms strictly to the System V AMD64 ABI as documented in the
-draft revision 1.0 (Matz et al.).  The relevant rules for the LANG
-VM's integer-only V1:
+`X86_64Backend` ships with **two ABI modes** in V1, selected at
+backend construction time:
 
-- **Argument registers** (in order): `RDI`, `RSI`, `RDX`, `RCX`,
-  `R8`, `R9`.  Up to six integer/pointer arguments fit in registers;
-  beyond that, push right-to-left on the stack.
-- **Return value**: `RAX`.
-- **Caller-saved (volatile)**: `RAX`, `RCX`, `RDX`, `RSI`, `RDI`,
-  `R8`–`R11`.  Subset our spill allocator may freely clobber as
-  scratch.
-- **Callee-saved**: `RBX`, `RBP`, `R12`–`R15`.  V1 only clobbers
-  `RBP` (used as frame pointer), so we save and restore it in the
-  prologue/epilogue.
-- **Stack alignment**: 16-byte-aligned **at the point of a `CALL`
-  instruction** (so on entry, RSP ≡ 8 (mod 16) because the CALL
-  pushed an 8-byte return address).  After `push rbp`, RSP ≡ 0 (mod
-  16) — the prologue's frame allocation must keep it that way.
-- **Red zone**: 128 bytes below RSP are scratch for leaf functions.
-  V1 *does not* use the red zone; all locals live in the proper
-  frame.
+```rust
+pub enum X86_64Abi {
+    /// System V AMD64 — Linux, FreeBSD, (Intel) macOS.
+    SysV,
+    /// Microsoft x64 — Windows desktop/server.
+    MsX64,
+}
 
-### Prologue / epilogue
+impl X86_64Backend {
+    pub fn new() -> Self { Self::with_abi(X86_64Abi::SysV) }
+    pub fn with_abi(abi: X86_64Abi) -> Self { /* ... */ }
+}
+```
+
+The choice flows from `FunctionContext::target_triple` or an explicit
+constructor argument from `twig-aot` (LANG46).  Both ABIs share the
+same CIR-lowering logic — only the prologue/epilogue, arg register
+table, callee-saved set, and call-site stack-alignment math differ.
+
+### Side-by-side: System V AMD64 vs Microsoft x64
+
+| Concern | System V AMD64 (Linux) | Microsoft x64 (Windows) |
+|---|---|---|
+| Reference | System V AMD64 ABI draft 1.0 (Matz et al.) | MSDN: "x64 calling convention" |
+| Integer arg registers (in order) | RDI, RSI, RDX, RCX, R8, R9 | RCX, RDX, R8, R9 |
+| Max GPR-passed integer args | 6 | 4 |
+| Return value | RAX | RAX |
+| Caller-saved (volatile) | RAX, RCX, RDX, RSI, RDI, R8–R11 | RAX, RCX, RDX, R8–R11 |
+| Callee-saved | RBX, RBP, R12–R15 | RBX, RBP, RDI, RSI, R12–R15 |
+| Shadow / home space | None | **32 bytes** allocated by caller, *always* (even for ≤4 args) |
+| Stack alignment at CALL | 16-byte | 16-byte |
+| Red zone | 128 B below RSP | **None** — must not read/write below RSP |
+| Unwind metadata | `.eh_frame` (optional in V1) | `.pdata` / `.xdata` (optional in V1; see Non-goals) |
+
+V1 implements all four shaded lines (arg regs, callee-saved, shadow
+space, red-zone discipline) and ignores the unwind-metadata rows.
+
+### Prologue / epilogue — System V
 
 ```asm
 ;  --- prologue ---
 push  rbp
 mov   rbp, rsp
-sub   rsp, <frame>          ; <frame> rounded up to 16-byte multiple
+sub   rsp, <frame>          ; <frame> chosen so RSP ≡ 0 (mod 16)
 
-;  spill arg registers to their stack slots
-mov   [rbp - 8 - N*8 - 0],  rdi      ; arg 0
-mov   [rbp - 8 - N*8 - 8],  rsi      ; arg 1
-... up to 6 args ...
-                                     ; arg 7+ already on stack, accessed via [rbp + 16 + ...]
+;  spill incoming arg registers to their slots (up to 6)
+mov   [rbp - 8],  rdi
+mov   [rbp - 16], rsi
+mov   [rbp - 24], rdx
+mov   [rbp - 32], rcx
+mov   [rbp - 40], r8
+mov   [rbp - 48], r9
 
 ;  --- body ---
 
 ;  --- epilogue ---
-mov   rsp, rbp                       ; or `add rsp, <frame>`; mov is one byte shorter for large frames
+mov   rsp, rbp
 pop   rbp
 ret
 ```
 
-`<frame>` = `(num_virtuals * 8 + 15) & !15`.  Sub-128B frames could
-use the red zone, but uniformity wins for V1.
+### Prologue / epilogue — Microsoft x64
+
+```asm
+;  --- prologue ---
+push  rbp
+mov   rbp, rsp
+sub   rsp, <frame>          ; <frame> chosen so RSP ≡ 0 (mod 16)
+
+;  spill incoming arg registers to their slots (up to 4)
+mov   [rbp - 8],  rcx
+mov   [rbp - 16], rdx
+mov   [rbp - 24], r8
+mov   [rbp - 32], r9
+
+;  --- body ---
+
+;  --- epilogue ---
+mov   rsp, rbp
+pop   rbp
+ret
+```
+
+The only structural difference is the arg-spill register set (RDI/RSI
+vs RCX/RDX/R8/R9 etc.).  Frame layout is otherwise identical.
 
 ### Stack alignment invariant
 
-After `push rbp; sub rsp, frame`, RSP must be `≡ 0 (mod 16)`.  Since
-`push rbp` shifts the alignment by 8, we need `frame ≡ 8 (mod 16)`.
-The allocator rounds `frame` up to 16 *and then adds 8 if needed*.
-The corresponding check is part of the test suite.
+For both ABIs: at every `CALL` instruction in the emitted body, RSP
+must be `≡ 0 (mod 16)`.  The prologue `push rbp` shifts the inherited
+`≡ 8 (mod 16)` (post-entry `CALL` alignment) to `≡ 0 (mod 16)`, so
+the frame `sub rsp, N` must keep `N ≡ 0 (mod 16)`.
 
-When calling out (e.g., `__twig_print_i64`), the call site adjusts
-RSP if necessary to restore the 16-byte alignment at the call.  In
-V1, all locals are 8-byte slots and we don't pass stack arguments to
-external calls, so this works out naturally.
+### Microsoft x64 shadow space at call sites
+
+Every call to an external function in Microsoft x64 must reserve **32
+bytes of "home" / "shadow" space** on the stack — the callee owns
+that space (it's where it would spill RCX/RDX/R8/R9 if it chose to).
+The callee does **not** clean it up; the caller deallocates.
+
+V1 reserves the shadow space in the *prologue* by adding 32 to the
+frame size whenever the function will issue any `CALL` (i.e., is not a
+leaf).  This is simpler than reserve-per-call and costs at most 32
+unused bytes for non-leaf functions.
+
+```asm
+;  --- prologue (MS x64, non-leaf) ---
+push  rbp
+mov   rbp, rsp
+sub   rsp, <frame> + 32     ; +32 = persistent shadow space for callees
+```
+
+System V has no analogous requirement.
+
+### Red zone
+
+System V grants a 128-byte red zone below RSP for *leaf functions* —
+they may read/write `[rsp - 0..128]` without subtracting from RSP.
+V1 does **not** use the red zone on either ABI; all locals live in
+the proper frame.  This keeps the prologue/epilogue uniform across
+both targets.
 
 ---
 
@@ -303,13 +383,27 @@ guard failures abort.
 ### Calls (matches LANG39 wave)
 
 Cross-function `call` uses `CALL rel32` with an `ExternalReloc` of
-kind `PltRel32`.  The packager resolves the displacement at link
-time.  Arguments are loaded into the System V argument registers
-(RDI, RSI, RDX, RCX, R8, R9) before the call; the return value
-arrives in `RAX` and is stored to the destination slot.
+kind `PltRel32`.  The packager (LANG45) translates the abstract
+reloc kind into:
 
-V1 supports up to six arguments per call.  Beyond that → return
-`BackendRefused`.
+- `R_X86_64_PLT32` (or `R_X86_64_PC32` for static calls) on ELF
+- `IMAGE_REL_AMD64_REL32` on PE/COFF
+- `X86_64_RELOC_BRANCH` on Mach-O (deferred V1)
+
+Arguments are loaded into the ABI's argument registers before the
+call:
+
+- **System V**: RDI, RSI, RDX, RCX, R8, R9 — up to **six** GPR args.
+- **MS x64**: RCX, RDX, R8, R9 — up to **four** GPR args.
+
+The return value arrives in `RAX` and is stored to the destination
+slot.
+
+Beyond the per-ABI max → return `BackendRefused`.
+
+On Microsoft x64, the prologue already allocated the 32-byte shadow
+space; the call site itself emits only the argument moves + `CALL
+rel32` + return-value store.
 
 ### Globals (matches LANG39 wave)
 
@@ -329,27 +423,36 @@ lea  rax, [rip + name]   ; PcRel32 reloc
 mov  [rax], rcx
 ```
 
-### I/O (matches LANG40 wave)
+### I/O (matches LANG40 / LANG41 waves)
 
-`io_out v` lowers to a `CALL` to `__twig_print_i64` (Linux/macOS
-shared runtime), passing `[v]` in `RDI`:
+`io_out v` lowers to a `CALL` to `__twig_print_i64`, passing `[v]`
+in the ABI's first argument register:
 
-```
-mov  rdi, [v]
-call __twig_print_i64    ; PltRel32 reloc
-```
+- **System V (Linux)**: arg 0 → `RDI`
+  ```
+  mov  rdi, [v]
+  call __twig_print_i64    ; PltRel32 reloc
+  ```
+- **MS x64 (Windows)**: arg 0 → `RCX`
+  ```
+  mov  rcx, [v]
+  call __twig_print_i64    ; PltRel32 reloc
+  ```
 
 The runtime archive provides the symbol, resolved by the system
-linker.
+linker.  Per LANG46, separate runtime archives are built for each
+target (Linux x86-64 ELF `.a`; Windows x86-64 COFF `.lib`).
 
 ---
 
 ## Out of scope (deferred PRs)
 
-- **Microsoft x64 ABI** — argument registers differ (`RCX, RDX, R8,
-  R9`), 32-byte home stack space is required, unwind tables (`.pdata`
-  / `.xdata`) needed.  Follow-up spec **LANG44** or similar; the
-  backend stays inside `x86_64-backend` with a runtime ABI toggle.
+- **macOS x86-64** — encoder works; needs Mach-O object emitter
+  tuned for `CPU_TYPE_X86_64`.  Defer to a follow-up after Linux +
+  Windows ship.
+- **Windows SEH unwind tables** (`.pdata` / `.xdata`) — needed for
+  proper debugger / cross-module unwind; not blocking
+  compile-and-run.  Follow-up.
 - **Floats / SSE2** — both backends will gain this together.
 - **Local register allocator** — replace the spill core in place; no
   trait changes.
@@ -412,6 +515,8 @@ target via `target_triple()`-based lookup.
 |---|---|
 | Variable-length encoding edge cases (REX.B / SIB requirement when base ∈ {RSP, RBP, R12, R13}) | Encoder normalises these internally; backend never sees them. |
 | Division clobber surprises | All scratch regs (`RAX`, `RCX`, `RDX`) reserved up front; spill allocator never assumes their preservation across an instruction boundary. |
-| Stack alignment violations at calls | One test per call site shape; alignment check is a single arithmetic invariant. |
-| Mach-O vs ELF reloc kind differences | Encoder emits abstract `ExternalRelocKind`; `code-packager` maps to OS-specific reloc types. |
+| Stack alignment violations at calls | One test per call site shape per ABI; alignment check is a single arithmetic invariant. |
+| ELF vs PE vs Mach-O reloc kind differences | Encoder emits abstract `ExternalRelocKind`; `code-packager` (LANG45) maps to OS-specific reloc type IDs. |
+| MS x64 shadow space forgotten on a call site | Always reserve 32 B in the prologue of a non-leaf function; one targeted test verifies a six-call function leaves the stack 16-byte aligned and shadow-spaced at each call. |
+| Linux vs Windows argument register mismatch in `io_out` | Backend dispatches on `X86_64Abi`; per-ABI golden-byte test fixes the first instruction (`mov rdi, …` vs `mov rcx, …`). |
 | Mismatch between AArch64 and x86-64 CIR coverage as both backends evolve | Each future LANG NN that touches AArch64 backend should produce a sibling commit on x86-64.  This is a discipline issue, tracked in the changelog. |

--- a/code/specs/LANG44-x86_64-encoder.md
+++ b/code/specs/LANG44-x86_64-encoder.md
@@ -1,6 +1,23 @@
-# LANG41 — `x86_64-encoder`: X86-64 Instruction Encoder
+# LANG44 — `x86_64-encoder`: X86-64 Instruction Encoder
 
 **Status:** Draft — 2026-05-14
+
+> The x86-64 port spans four specs.  Reading order is encoder → backend
+> → object format → twig-aot driver:
+>
+> - **LANG44** (this) — pure instruction encoder.  ABI-agnostic.
+> - **LANG43** — CIR → x86-64 lowering, with both **System V** (Linux)
+>   and **Microsoft x64** (Windows) ABIs in V1.
+> - **LANG45** — object-file emitters (`elf_object.rs`, `pe_object.rs`)
+>   that wrap the encoder's `.text` bytes with relocations the system
+>   linker on each OS expects.
+> - **LANG46** — `twig-aot` multi-target dispatch, per-target runtime
+>   archive build, and linker integration (`cc` on Linux,
+>   `link.exe` / `lld-link` on Windows).
+>
+> Number LANG41 in this repo is already claimed by the AOT runtime
+> library work (twig-aot 0.1.8 etc.) — that's why this spec lands at
+> LANG44.
 
 ## Motivation
 
@@ -19,6 +36,12 @@ The companion spec **LANG43** defines `x86_64-backend`, which lowers
 CIR onto the encoder.  This spec stops at "given a method like
 `mov_r64_imm64(Reg::Rax, 42)`, what bytes come out?"
 
+The encoder is **OS-agnostic and ABI-agnostic** — the same bytes
+encode on Linux, Windows, and macOS.  ABI choice (which registers
+hold arguments, whether a shadow space exists) lives in the backend.
+Object-format choice (ELF vs PE/COFF, which relocation type IDs to
+use) lives in `code-packager` per LANG45.
+
 ## Non-goals
 
 - **Lowering**: no CIR awareness.  That belongs in `x86_64-backend`.
@@ -33,10 +56,11 @@ CIR onto the encoder.  This spec stops at "given a method like
   AArch64 encoder also defers floats).
 - **16-bit / 32-bit legacy modes**: only 64-bit (long) mode is
   encoded.
-- **Microsoft x64 ABI quirks**: home-stack space, RVA32 relocations,
-  unwind data tables — those are layered above the encoder.  The
-  encoder produces the same bytes regardless of host OS; the choice
-  of ABI is a *backend* concern.
+- **Microsoft x64 ABI quirks**: 32-byte home/shadow stack space,
+  unwind data tables (`.pdata` / `.xdata` in PE/COFF) — those are
+  layered above the encoder.  The encoder produces the same bytes
+  regardless of host OS; the choice of ABI is a *backend* concern
+  (LANG43); object-format reloc IDs are a *packager* concern (LANG45).
 
 ## ISA reference
 
@@ -180,17 +204,26 @@ pub struct ExternalReloc {
 }
 
 pub enum ExternalRelocKind {
-    /// `R_X86_64_PLT32` for ELF, `X86_64_RELOC_BRANCH` for Mach-O.
-    /// Used by `CALL rel32` to external functions.
+    /// PC-relative branch.  Maps to `R_X86_64_PLT32` on ELF,
+    /// `IMAGE_REL_AMD64_REL32` on PE/COFF, `X86_64_RELOC_BRANCH` on
+    /// Mach-O.  Used by `CALL rel32` to external functions.
     PltRel32,
-    /// `R_X86_64_PC32` for ELF.  Used for RIP-relative loads/stores
-    /// of globals when the symbol resolves locally.
+    /// PC-relative 32-bit displacement.  Maps to `R_X86_64_PC32` on
+    /// ELF, `IMAGE_REL_AMD64_REL32` on PE/COFF, `X86_64_RELOC_SIGNED`
+    /// on Mach-O.  Used for RIP-relative loads/stores of globals when
+    /// the symbol resolves locally.
     PcRel32,
-    /// `R_X86_64_REX_GOTPCRELX` (ELF) — RIP-relative GOT load for
-    /// possibly-external globals.
+    /// RIP-relative GOT load.  Maps to `R_X86_64_REX_GOTPCRELX` on
+    /// ELF.  On PE/COFF and Mach-O this collapses to a regular
+    /// PC-relative reloc (no separate GOT).  Used for possibly-external
+    /// globals.
     GotPcRel32,
 }
 ```
+
+The encoder produces the same 32-bit slot regardless of which kind is
+chosen; the packager (LANG45) translates the abstract kind to the
+right OS-specific relocation type ID at emit time.
 
 ---
 

--- a/code/specs/LANG45-x86_64-object-formats.md
+++ b/code/specs/LANG45-x86_64-object-formats.md
@@ -1,0 +1,385 @@
+# LANG45 — `code-packager`: ELF64 & PE/COFF Object Emitters
+
+**Status:** Draft — 2026-05-14
+
+> Third of four specs in the x86-64 port (LANG44 encoder → LANG43
+> backend → **LANG45** packager → LANG46 twig-aot driver).  This one
+> teaches `code-packager` to emit *relocatable object files* (`.o`
+> for Linux, `.obj` for Windows) so the system linker on each OS
+> can produce a runnable executable.
+
+## Motivation
+
+The AArch64 / macOS pipeline (LANG41) delegates the final link step
+to Apple's `ld` because the kernel's provenance check kills binaries
+written by anyone else.  That works because `code-packager` has a
+**Mach-O object-file writer** (`macho_object.rs`) that emits
+`MH_OBJECT` with external relocations.
+
+Linux and Windows do not have provenance checks, but they have their
+own reasons to prefer the "emit an object file, hand it to the
+system linker" pattern:
+
+1. **Linker handles libc.**  `__twig_print_i64` calls `printf`, which
+   on Linux lives in `libc.so.6` and on Windows in
+   `ucrtbase.dll` / `msvcrt.dll`.  Generating a runnable executable
+   that finds and calls these dynamically is hundreds of lines of
+   ELF dynamic-section / PE import-directory glue per OS.  The
+   system linker does it for free.
+2. **Static analysis tools cope.**  `readelf`, `objdump`, `dumpbin`
+   all understand standard object files.  Our hand-rolled
+   `MH_EXECUTE` / `elf64.rs` minimal-executable writers don't
+   produce something a sanitizer or stripper expects.
+3. **Future debug info.**  DWARF (Linux/macOS) and CodeView (Windows)
+   are easier to attach to an object file that the linker then
+   merges, vs. a hand-built executable.
+
+This spec defines two new modules in `code-packager`:
+
+- `code/packages/rust/code-packager/src/elf_object.rs` — ELF64
+  `ET_REL` writer with `R_X86_64_*` relocations.
+- `code/packages/rust/code-packager/src/pe_object.rs` — PE/COFF
+  `IMAGE_FILE_HEADER` (no MZ stub — that's executable-only) writer
+  with `IMAGE_REL_AMD64_*` relocations.
+
+They mirror `macho_object.rs`'s API surface but target their
+respective formats.
+
+## Non-goals
+
+- **Executable formats** are already done (`elf64.rs`, `macho64.rs`,
+  `pe.rs`).  This spec is only about *relocatable object* files.
+- **Static libraries** (`.a` / `.lib`) — out of scope; we always
+  hand off a single `.o` / `.obj` to the linker, which handles
+  archive search.
+- **Cross-OS object reloc compatibility** — an ELF object only goes
+  to a Linux linker, a COFF object only goes to a Windows linker.
+  No magic to make a single object file work on both.
+- **DWARF / CodeView debug info** — explicitly deferred.
+- **Section attributes for `.eh_frame` / `.pdata` / `.xdata`** —
+  LANG43 V1 doesn't emit unwind data, so we don't need these
+  sections.
+- **TLS, COMDAT, weak symbols** — none of the V1 use cases need
+  them.
+
+## API surface
+
+Mirror of `macho_object::pack_object_with_globals_and_externals`:
+
+```rust
+// elf_object.rs
+pub fn pack_elf64_object_with_globals_and_externals(
+    text: &[u8],
+    entry_off: usize,
+    n_global_slots: u32,
+    global_relocs: &[GlobalByteReloc],
+    extern_relocs: &[ExternBranchReloc],
+    target: &Target,
+) -> Result<Vec<u8>, PackagerError>;
+
+// pe_object.rs
+pub fn pack_pe_object_with_globals_and_externals(
+    text: &[u8],
+    entry_off: usize,
+    n_global_slots: u32,
+    global_relocs: &[GlobalByteReloc],
+    extern_relocs: &[ExternBranchReloc],
+    target: &Target,
+) -> Result<Vec<u8>, PackagerError>;
+```
+
+Both consume the same `GlobalByteReloc` / `ExternBranchReloc`
+records `macho_object` uses today — no churn for the backend layer.
+
+### `Target` matching
+
+`twig-aot` / the registry dispatch on `Target` fields:
+
+| `target.arch` | `target.os` | `target.binary_format` | Module |
+|---|---|---|---|
+| `x86_64` | `linux`  | `elf_object` | `elf_object` |
+| `x86_64` | `windows` | `pe_object`  | `pe_object`  |
+| `aarch64` | `macos`  | `macho_object` | `macho_object` (existing) |
+| `aarch64` | `linux`  | `elf_object` | `elf_object` (free with this spec) |
+
+The third row drops out for free: once `elf_object.rs` exists, the
+existing ARM64 backend's Mach-O object can be re-pointed at ELF for
+Linux ARM64 with no new lowering code — handy for CI.
+
+## ELF64 object layout
+
+```text
+Offset             │ Size │ Content
+───────────────────┼──────┼───────────────────────────────────────────────
+              0    │  64  │ ELF64 header (e_type=ET_REL, e_machine=EM_X86_64)
+             64    │  N₁  │ .text section bytes (= text)
+       64 + N₁     │  N₂  │ .data section bytes (= 8 * n_global_slots zeros)
+                   │      │ Section alignment to 8
+       (aligned)   │  N₃  │ .rela.text relocation table (8 × num_text_relocs entries)
+       (aligned)   │  N₄  │ .rela.data relocation table (8 × num_data_relocs entries)
+       (aligned)   │  N₅  │ .symtab (24 × num_symbols entries)
+       (aligned)   │  N₆  │ .strtab string table
+       (aligned)   │  N₇  │ .shstrtab section name string table
+       (aligned)   │  N₈  │ Section header table (64 × num_sections entries)
+```
+
+### Section table
+
+Required sections (all 8-byte aligned in file):
+
+| Index | Name | Type | Flags | Notes |
+|---|---|---|---|---|
+| 0 | (null) | `SHT_NULL` | 0 | ELF mandatory |
+| 1 | `.text` | `SHT_PROGBITS` | `SHF_ALLOC \| SHF_EXECINSTR` | The code |
+| 2 | `.data` | `SHT_PROGBITS` | `SHF_ALLOC \| SHF_WRITE` | Globals zero-initialised; could be `.bss` but we use `.data` for parity with macho_object |
+| 3 | `.rela.text` | `SHT_RELA` | `SHF_INFO_LINK` | `sh_link = symtab`, `sh_info = .text` |
+| 4 | `.rela.data` | `SHT_RELA` | `SHF_INFO_LINK` | Same |
+| 5 | `.symtab` | `SHT_SYMTAB` | 0 | `sh_link = .strtab` |
+| 6 | `.strtab` | `SHT_STRTAB` | 0 | Symbol names |
+| 7 | `.shstrtab` | `SHT_STRTAB` | 0 | Section names |
+
+### Relocation type IDs (`R_X86_64_*`)
+
+| Abstract (LANG44) | ELF type | Hex |
+|---|---|---|
+| `PltRel32` | `R_X86_64_PLT32` | 4 |
+| `PcRel32` | `R_X86_64_PC32` | 2 |
+| `GotPcRel32` | `R_X86_64_REX_GOTPCRELX` | 42 |
+| (data section absolute) | `R_X86_64_64` | 1 |
+
+Encoded in the `Elf64_Rela` record:
+
+```c
+struct Elf64_Rela {
+    uint64_t r_offset;       // section-relative byte offset of the field
+    uint64_t r_info;         // (symbol_index << 32) | type_id
+    int64_t  r_addend;       // -4 for CALL rel32 / Jcc rel32; -4 also for LEA RIP-rel
+};
+```
+
+The `-4` addend is mandatory: x86-64 PC-relative displacements are
+relative to the *end* of the instruction (which is 4 bytes past the
+slot the encoder writes).
+
+### Symbol table
+
+Standard `Elf64_Sym`.  V1 emits:
+
+- One `STT_FUNC` symbol per Twig function (binding = `STB_GLOBAL`).
+- One `STT_OBJECT` symbol named `_twig_globals` for the data section
+  (binding = `STB_GLOBAL`).
+- One `STT_NOTYPE` undefined external symbol per distinct
+  `extern_relocs` symbol name (binding = `STB_GLOBAL`, `st_shndx =
+  SHN_UNDEF`).
+
+`STT_FILE` and section symbols are optional and skipped in V1.
+
+## PE/COFF object layout
+
+```text
+Offset             │ Size │ Content
+───────────────────┼──────┼───────────────────────────────────────────────
+              0    │  20  │ IMAGE_FILE_HEADER
+             20    │  40  │ IMAGE_SECTION_HEADER for .text
+             60    │  40  │ IMAGE_SECTION_HEADER for .data
+            100    │  N₁  │ .text raw bytes (= text)
+       100 + N₁    │  N₂  │ .data raw bytes (= 8 * n_global_slots zeros)
+       (offset)    │ 10×R₁│ IMAGE_RELOCATION entries for .text
+       (offset)    │ 10×R₂│ IMAGE_RELOCATION entries for .data
+       (offset)    │ 18×S │ IMAGE_SYMBOL entries
+       (offset)    │  ?   │ COFF string table
+```
+
+PE object files have **no MZ/DOS stub** (that's executables only).
+
+### `IMAGE_FILE_HEADER` (20 bytes)
+
+```text
+Machine               │ 0x8664 = IMAGE_FILE_MACHINE_AMD64
+NumberOfSections      │ 2 (.text + .data)
+TimeDateStamp         │ 0 (reproducible builds)
+PointerToSymbolTable  │ offset to symbol table
+NumberOfSymbols       │ count
+SizeOfOptionalHeader  │ 0 (object files have no optional header)
+Characteristics       │ 0
+```
+
+### Section header (40 bytes each)
+
+```text
+Name                 │ ".text\0\0\0" / ".data\0\0\0" (8-byte NUL-padded)
+VirtualSize          │ 0 (objects use raw size only)
+VirtualAddress       │ 0
+SizeOfRawData        │ N₁ / N₂
+PointerToRawData     │ file offset of section data
+PointerToRelocations │ file offset of reloc records
+PointerToLinenumbers │ 0
+NumberOfRelocations  │ R₁ / R₂
+NumberOfLinenumbers  │ 0
+Characteristics      │ .text: IMAGE_SCN_CNT_CODE | IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ | IMAGE_SCN_ALIGN_16BYTES
+                     │ .data: IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE | IMAGE_SCN_ALIGN_8BYTES
+```
+
+### Relocation type IDs (`IMAGE_REL_AMD64_*`)
+
+| Abstract (LANG44) | PE type | Hex |
+|---|---|---|
+| `PltRel32` | `IMAGE_REL_AMD64_REL32` | 0x04 |
+| `PcRel32` | `IMAGE_REL_AMD64_REL32` | 0x04 |
+| `GotPcRel32` | (collapses to) `IMAGE_REL_AMD64_REL32` | 0x04 |
+| (data section absolute) | `IMAGE_REL_AMD64_ADDR64` | 0x01 |
+
+Encoded in `IMAGE_RELOCATION` (10 bytes per record, unpadded):
+
+```c
+struct IMAGE_RELOCATION {
+    uint32_t VirtualAddress;       // section-relative byte offset
+    uint32_t SymbolTableIndex;     // 0-based index into symbol table
+    uint16_t Type;
+};
+```
+
+Note: PE/COFF `REL32` has the addend stored **inside the
+instruction's displacement bytes**, not in a separate field.  The
+encoder already writes the value with the `-4` adjustment baked in
+(see LANG44 `call_rel32` worked example), so the packager just
+emits the reloc record pointing at the slot.
+
+### Symbol table
+
+`IMAGE_SYMBOL` (18 bytes per entry):
+
+```text
+ShortName / Name    │ 8 bytes: literal if ≤ 8 chars; else 4 zeros + 4-byte string table offset
+Value               │ for static symbols: byte offset within section
+SectionNumber       │ 1-based section index; 0 = undefined external
+Type                │ 0x20 = function, 0 = not function
+StorageClass        │ 2 = external (global)
+NumberOfAuxSymbols  │ 0
+```
+
+V1 emits the same logical set as ELF: one external function symbol
+per Twig function, one external object symbol for `_twig_globals`,
+one undefined external per `extern_relocs` symbol name.
+
+Note: Windows expects symbol names to have a **leading underscore**
+in some toolchains but not in MSVC link.exe for 64-bit (where MS
+already drops the underscore convention).  V1 emits names verbatim —
+`__twig_print_i64` stays `__twig_print_i64`.
+
+## Linker invocation reference
+
+`code-packager` does not invoke the linker — that's `twig-aot`'s job
+(LANG46).  This section documents the expected invocation for
+reference.
+
+### Linux (System V AMD64 ABI)
+
+```
+cc -o <out> <input>.o <runtime>.a -lc -lm
+```
+
+`cc` is `gcc` or `clang`, whichever is on PATH.  Falls back to `ld`
+directly if `cc` is missing:
+
+```
+ld -dynamic-linker /lib64/ld-linux-x86-64.so.2 \
+   /usr/lib/x86_64-linux-gnu/Scrt1.o \
+   /usr/lib/x86_64-linux-gnu/crti.o \
+   <input>.o <runtime>.a -lc \
+   /usr/lib/x86_64-linux-gnu/crtn.o \
+   -o <out>
+```
+
+Going through `cc` is dramatically simpler — preferred.
+
+### Windows (Microsoft x64 ABI)
+
+MSVC `link.exe`:
+
+```
+link /OUT:<out>.exe /ENTRY:main /SUBSYSTEM:CONSOLE \
+     <input>.obj <runtime>.lib \
+     libcmt.lib  ;  legacy_stdio_definitions.lib
+```
+
+LLVM's `lld-link.exe`:
+
+```
+lld-link /OUT:<out>.exe /ENTRY:main /SUBSYSTEM:CONSOLE \
+         <input>.obj <runtime>.lib \
+         libcmt.lib  legacy_stdio_definitions.lib
+```
+
+MinGW / GCC on Windows (alternative):
+
+```
+gcc -o <out>.exe <input>.o <runtime>.a
+```
+
+LANG46 picks among these at runtime.
+
+## Test plan
+
+Coverage target ≥ 95%.
+
+### ELF tests
+
+1. **Magic bytes** — output starts with `7F 45 4C 46` (`\x7fELF`).
+2. **`ET_REL`** — `e_type = 1` (relocatable file, not executable).
+3. **`EM_X86_64`** — `e_machine = 62`.
+4. **Section table well-formed** — `readelf -SW <out>.o` lists
+   `.text`, `.data`, `.symtab`, `.strtab`, `.shstrtab`, `.rela.text`.
+5. **Reloc records decode** — for a `CALL __twig_print_i64`, the
+   `.rela.text` entry has `r_offset = call site +1`, `r_info` type
+   `R_X86_64_PLT32`, `r_addend = -4`.
+6. **End-to-end link** — write a tiny `factorial` object, link with
+   `cc factorial.o runtime.a -o factorial`, exec, assert exit
+   code = `factorial(5) & 0xFF` = 120.
+7. **`objdump -d`** disassembles the `.text` section back to the
+   expected mnemonic sequence.
+
+### PE/COFF tests
+
+1. **Machine = 0x8664** — first two bytes of the header.
+2. **No MZ stub** — third byte is `NumberOfSections` low, not `M`.
+3. **Section count = 2** — `.text` + `.data`.
+4. **Reloc records decode** — for `CALL __twig_print_i64`, the
+   `IMAGE_RELOCATION` has correct `VirtualAddress`, symbol index,
+   type `IMAGE_REL_AMD64_REL32`.
+5. **`dumpbin /HEADERS factorial.obj`** lists the sections, symbols,
+   and relocs we expect.
+6. **End-to-end link** — link with `lld-link`, run on Windows
+   (CI matrix has `windows-latest`), assert exit code = 120.
+7. **String table layout** — symbol names > 8 chars use the
+   `0 + offset` encoding; ≤ 8 chars use the literal form.
+
+### Cross-format sanity
+
+8. **Same Twig program → both formats** — compile `factorial.twig`
+   once via the AArch64-on-Linux path (ELF object), once via the
+   x86_64-on-Windows path (PE object).  Assert both produce a
+   working binary on their respective CI runners.
+
+## Out of scope (deferred follow-ups)
+
+- macOS x86-64 Mach-O object format — `macho_object.rs` already
+  exists for ARM64; teaching it to emit `CPU_TYPE_X86_64` headers
+  is a follow-up (small change; gated on demand from Intel-Mac
+  contributors).
+- Symbol visibility / weak symbols.
+- DWARF (Linux/macOS) and CodeView (Windows) debug info.
+- `.eh_frame` (Linux unwind) and `.pdata` / `.xdata` (Windows
+  unwind).
+- COMDAT / one-definition-rule sections.
+- Linker scripts.
+- LTO bitcode.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| ELF reloc addend semantics confused with PE in-instruction addend | Encoder bakes the `-4` into the displacement field for both targets; ELF re-asserts via `r_addend = -4`; PE packager omits the field entirely. Test 5 in each suite locks the contract. |
+| `.symtab` ordering (local symbols must precede globals; `sh_info` = first non-local index) | Lint pass in the packager validates ordering; one negative test confirms an unsorted symtab is rejected before write-out. |
+| Windows symbol name underscoring | V1 emits names verbatim; documented in this spec. Adopt prefix policy if/when MinGW users hit it. |
+| Section alignment / offset math drift between header and actual data | Single `aligned_offset()` helper used everywhere; assertion at end of packing confirms each `PointerToRawData` matches the section's actual file position. |

--- a/code/specs/LANG46-twig-aot-multi-target.md
+++ b/code/specs/LANG46-twig-aot-multi-target.md
@@ -1,0 +1,342 @@
+# LANG46 — `twig-aot`: Multi-Target Driver (Linux + Windows x86-64)
+
+**Status:** Draft — 2026-05-14
+
+> Last of four specs in the x86-64 port (LANG44 encoder → LANG43
+> backend → LANG45 packager → **LANG46** driver).  This one extends
+> `twig-aot` from "macOS ARM64 only" to support **Linux x86-64** and
+> **Windows x86-64** end-to-end: Twig source → native executable that
+> runs.
+
+## Motivation
+
+`twig-aot` today is hard-wired to a single pipeline:
+
+```
+Twig source → ARM64 backend → Mach-O object → ld → macOS ARM64 a.out
+```
+
+That's the pipeline `compile_macos_arm64_object` and
+`compile_file_macos_arm64` implement.  Extending to Linux x86-64 and
+Windows x86-64 needs four changes:
+
+1. **Backend selection** — pick `aarch64-backend` or `x86_64-backend`
+   based on the target.
+2. **Object-format selection** — pick `macho_object`, `elf_object`,
+   or `pe_object` based on the target.
+3. **Runtime archive selection** — embed the right pre-built archive
+   (`libtwig_aot_runtime-{linux,windows}-x86_64.a/.lib`) for the
+   target's linker to consume.
+4. **Linker invocation** — call `cc` on Linux, `link.exe` or
+   `lld-link.exe` on Windows.
+
+This spec lays out the design.  It assumes LANG43, LANG44, LANG45 have
+landed.
+
+## Non-goals
+
+- **Cross-compilation between hosts**.  V1 supports only
+  *host-targets-host* compilation: build x86-64 ELF on a Linux x86-64
+  host, build x86-64 PE on a Windows x86-64 host.  Cross-OS
+  cross-compilation (e.g., produce a Windows .exe from a Linux host)
+  is a follow-up; it requires either MinGW-style toolchain detection
+  or shipping target-specific linker binaries with `twig-aot`.
+- **macOS x86-64** — same reasoning as LANG43.
+- **Linux ARM64** — encoder + backend already support ARM64; the
+  only missing piece is `elf_object.rs` (covered in LANG45), so this
+  target drops out for free once LANG45 lands.  Not formally claimed
+  in V1 tests but tracked.
+- **Static-linked binaries** — V1 produces dynamically-linked
+  executables on Linux and Windows.  Static binaries (e.g.
+  `-static`) are a follow-up.
+- **Stripping / signing** — V1 ships unstripped, unsigned binaries.
+  Adequate for development and CI.
+
+## CLI surface
+
+The existing `twig-aot` CLI (`code/packages/rust/twig-aot/bin/twig_aot.rs`)
+gains a `--target` flag:
+
+```
+twig-aot compile <source.twig> [--target <triple>] [-o <out>]
+```
+
+Accepted target triples in V1:
+
+| Triple | Backend | Object format | Linker |
+|---|---|---|---|
+| `aarch64-apple-darwin` (default on macOS ARM64) | `aarch64-backend` | `macho_object` | `ld` |
+| `x86_64-unknown-linux-gnu` (default on Linux x86_64) | `x86_64-backend` (SysV) | `elf_object` | `cc` (or `ld`) |
+| `x86_64-pc-windows-msvc` (default on Windows x86_64) | `x86_64-backend` (MS x64) | `pe_object` | `link.exe` |
+| `x86_64-pc-windows-gnu` | `x86_64-backend` (MS x64) | `pe_object` | `lld-link.exe` or `gcc` (MinGW) |
+
+If `--target` is omitted, `twig-aot` defaults to the *host* triple
+(detected via `std::env::consts::OS` + `std::env::consts::ARCH`).
+V1 errors out on cross-OS combinations (e.g. host=linux,
+target=windows).
+
+## Pipeline (per target)
+
+### Linux x86-64
+
+```text
+Twig source
+   │ twig_ir_compiler::compile_source
+   ▼
+IIRModule
+   │ x86_64_backend::compile_function (one per fn, SysV ABI)
+   ▼
+Vec<(fn_name, Vec<u8>)>
+   │ aot_core::link::link
+   ▼
+(text_bytes, offsets)
+   │ code_packager::elf_object::pack_elf64_object_with_globals_and_externals
+   ▼
+factorial.o   (ET_REL, EM_X86_64, R_X86_64_PLT32 reloc for __twig_print_i64)
+   │ cc factorial.o libtwig_aot_runtime_linux_x86_64.a -lc -o factorial
+   ▼
+ELF64 executable, runs on any glibc Linux x86-64
+```
+
+### Windows x86-64
+
+```text
+Twig source
+   │ twig_ir_compiler::compile_source
+   ▼
+IIRModule
+   │ x86_64_backend::compile_function (one per fn, MS x64 ABI)
+   ▼
+Vec<(fn_name, Vec<u8>)>
+   │ aot_core::link::link
+   ▼
+(text_bytes, offsets)
+   │ code_packager::pe_object::pack_pe_object_with_globals_and_externals
+   ▼
+factorial.obj   (AMD64, IMAGE_REL_AMD64_REL32 reloc for __twig_print_i64)
+   │ link.exe /OUT:factorial.exe /SUBSYSTEM:CONSOLE /ENTRY:main
+   │     factorial.obj libtwig_aot_runtime_windows_x86_64.lib libcmt.lib legacy_stdio_definitions.lib
+   ▼
+factorial.exe, runs on Windows x86-64
+```
+
+Note: on Linux the prebuilt runtime is a `.a` archive of object
+files; on Windows it's a `.lib` import library wrapping the same
+object files (built with MSVC or MinGW at `twig-aot` build time).
+
+## Runtime archive: per-target builds
+
+Today `twig-aot/build.rs` invokes the `cc` crate once to build
+`twig_runtime.c` for the host triple, and embeds the result via
+`include_bytes!`.
+
+V1 extends this to build **all supported target archives at
+`twig-aot` crate build time**, embedding each:
+
+```rust
+// build.rs (post-LANG46)
+fn main() {
+    let runtimes = [
+        ("aarch64-apple-darwin",     "libtwig_aot_runtime_macos_arm64.a"),
+        ("x86_64-unknown-linux-gnu", "libtwig_aot_runtime_linux_x86_64.a"),
+        ("x86_64-pc-windows-msvc",   "twig_aot_runtime_windows_x86_64.lib"),
+    ];
+    for (triple, out_name) in runtimes {
+        if cc_can_build_for(triple) {
+            build_runtime_for(triple, out_name);
+            println!("cargo:rustc-env=TWIG_RUNTIME_ARCHIVE_{}={}/{}",
+                     triple.replace('-', "_").to_uppercase(),
+                     env::var("OUT_DIR").unwrap(),
+                     out_name);
+        } else {
+            // Emit a stub byte string so include_bytes! still works.
+            // Compile fails at *AOT* time if the user picks this
+            // target, with a clear "no toolchain for X on this host"
+            // error.
+            println!("cargo:rustc-env=TWIG_RUNTIME_ARCHIVE_{}=...",
+                     triple.replace('-', "_").to_uppercase());
+        }
+    }
+}
+```
+
+`cc_can_build_for(triple)` tries `cc --target=<triple>` (clang) or
+`{triple}-gcc` (cross-compiler).  If neither is available, the
+runtime for that triple is a stub — the AOT compiler refuses to
+emit for the target with a clear error.
+
+### Why build at crate build time, not at `twig-aot` run time
+
+- **No `cc` dependency on end-user machines.**  A Twig developer
+  doesn't need GCC/clang installed — only the system linker for
+  their host OS (which is universally present).
+- **Reproducible:**  same `twig-aot` binary → same runtime bytes,
+  always.
+- **Fast:**  no compile step per Twig program; just write embedded
+  bytes to a temp file and pass to the linker.
+- **Matches macOS pattern:**  `macos_arm64` already does this; the
+  multi-target extension is the obvious generalisation.
+
+### Test-friendly fallback
+
+For local development on a host that *doesn't* have a
+cross-compiler, `build.rs` emits a fallback diagnostic and the
+runtime variable carries 1 byte of zeros.  AOT compilation for that
+target will fail with `AotError::Runtime("no toolchain for
+x86_64-pc-windows-msvc on this host; install MSVC or MinGW")`.
+
+CI matrix already has `windows-latest` and `ubuntu-latest`, so
+runtime archives for both targets *will* be built in CI for every
+PR.
+
+## Linker invocation (per target)
+
+`twig-aot/src/lib.rs` gains a `link_executable` function with a
+per-target match.
+
+### Linux: prefer `cc`
+
+```rust
+Command::new(env::var("CC").unwrap_or_else(|_| "cc".into()))
+    .arg("-o").arg(out_path)
+    .arg(object_path)
+    .arg(runtime_archive_path)
+    .arg("-lc").arg("-lm")
+    .status()
+```
+
+If `cc` is missing, fall back to `ld` with explicit `crt1.o` /
+`crti.o` / `crtn.o` paths (best-effort).
+
+### Windows: prefer `link.exe` then `lld-link.exe` then `gcc`
+
+```rust
+// Try link.exe from MSVC installation (resolved via vswhere)
+// then lld-link.exe (if LLVM is on PATH)
+// then gcc (MinGW)
+let linker = find_windows_linker()?;
+match linker {
+    WinLinker::Link(path) => Command::new(path)
+        .arg(format!("/OUT:{}", out_path.display()))
+        .arg("/ENTRY:main")
+        .arg("/SUBSYSTEM:CONSOLE")
+        .arg(object_path)
+        .arg(runtime_archive_path)
+        .arg("libcmt.lib")
+        .arg("legacy_stdio_definitions.lib")
+        .status(),
+    WinLinker::LldLink(path) => /* same flags */,
+    WinLinker::MinGwGcc(path) => Command::new(path)
+        .arg("-o").arg(out_path)
+        .arg(object_path)
+        .arg(runtime_archive_path)
+        .status(),
+}
+```
+
+`find_windows_linker()` is small: probe PATH for `link.exe`, then
+`lld-link.exe`, then `gcc.exe`.  V1 does *not* attempt to locate an
+unregistered MSVC install via `vswhere` — the user is expected to
+have run `vcvarsall.bat` or have LLVM/MinGW on PATH.
+
+## Entry-point conventions
+
+A Twig program's `main` function returns `u64`.  The runtime needs
+to route that return value to the OS's exit code.
+
+| Target | OS entry | How Twig's `main` is wired |
+|---|---|---|
+| Linux x86-64 | `_start` (libc-supplied via `Scrt1.o`) calls `main` | Twig emits a symbol named `main` returning `int64_t`; libc's `_start` passes it to `exit(2)`.  We compile `main` to clear the upper 32 bits before returning, so the exit code matches `main() & 0xFF`. |
+| Windows x86-64 | `mainCRTStartup` calls `main` | Same: emit a symbol named `main`; CRT routes return to `ExitProcess`. |
+| macOS ARM64 (existing) | `_start` calls `_main` | Existing AArch64 path emits `_main`; unchanged. |
+
+Note the leading-underscore difference: macOS uses `_main`,
+Linux/Windows use `main`.  `twig-aot` selects the symbol name per
+target.
+
+## Symbol-name convention summary
+
+| Symbol | macOS ARM64 | Linux x86-64 | Windows x86-64 |
+|---|---|---|---|
+| Entry point | `_main` | `main` | `main` |
+| Runtime print | `___twig_print_i64` (double underscore by Apple convention) | `__twig_print_i64` | `__twig_print_i64` |
+| Globals slab | `_twig_globals` | `_twig_globals` | `_twig_globals` |
+
+The first row matters because macOS adds an extra leading
+underscore for `_start`-style entries.  Linux and Windows don't.
+
+## End-to-end acceptance tests
+
+V1 adds two new integration tests:
+
+1. `code/packages/rust/twig-aot/tests/linux_x86_64_smoke.rs`
+   (`#[cfg(target_os = "linux")]`):
+   ```rust
+   #[test]
+   fn factorial_runs_on_linux_x86_64() {
+       let out = tempfile();
+       compile_file(&factorial_twig_path(), &out,
+           Target::linux_x86_64()).unwrap();
+       let status = Command::new(&out).status().unwrap();
+       assert_eq!(status.code(), Some(120)); // 5! = 120
+   }
+   ```
+2. `code/packages/rust/twig-aot/tests/windows_x86_64_smoke.rs`
+   (`#[cfg(target_os = "windows")]`):
+   ```rust
+   #[test]
+   fn factorial_runs_on_windows_x86_64() {
+       let out = tempfile_with_extension("exe");
+       compile_file(&factorial_twig_path(), &out,
+           Target::windows_x86_64()).unwrap();
+       let status = Command::new(&out).status().unwrap();
+       assert_eq!(status.code(), Some(120));
+   }
+   ```
+
+Both tests run in CI on their respective `*-latest` runners.
+
+A third test on `macos_arm64_smoke.rs` (existing) continues to
+guard the ARM64 path against regressions.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Cross-compiler not present on user's host → runtime archive empty | `build.rs` emits stub bytes + clear AOT-time error referencing the missing toolchain |
+| Linker invocation path differs across distros / Windows installs | V1 probes PATH in priority order; documents the assumption in error messages.  Follow-up: integrate `vswhere` for MSVC discovery. |
+| Symbol name mismatch (`_main` vs `main`) breaks one platform | Single `target.entry_symbol()` helper used everywhere; one test per platform locks the convention. |
+| Windows exit-code truncation (`int` is 32-bit on Win64) | Twig's `main` returns `u64`; ABI says low 32 bits → `eax` becomes the process exit code → Windows truncates to 32 bits → shell shows it as `& 0xFF`. Document this explicitly; test asserts `code() == Some(120)` works. |
+| Embedded archive bloat | Each runtime archive is ~5 KB. Three targets ≈ 15 KB embedded in `twig-aot`. Acceptable. |
+| Future-target onboarding pain | The per-target table is the single source of truth; adding a target = one row + one `build.rs` entry + one acceptance test. |
+
+## Out of scope (deferred follow-ups)
+
+- Cross-OS cross-compilation (build Windows .exe from Linux, etc.).
+- Stripped / signed binaries.
+- Static linking (`-static` on Linux, `/MT` on Windows already used).
+- LTO across runtime + user code.
+- Multiple-source-file Twig programs (depends on module-system work).
+- macOS x86-64.
+
+## Sequencing
+
+This spec lands as part of the PR series that brings x86-64 to
+parity:
+
+1. LANG44 spec (encoder) and LANG43 amendment (both ABIs) and LANG45
+   spec and LANG46 spec — single PR (#3183).
+2. `x86_64-encoder` crate.
+3. `x86_64-backend` V1 (System V + MS x64 in one go).
+4. `x86_64-backend` LANG38 parity (div / logical / shifts).
+5. `x86_64-backend` calls + relocs.
+6. `x86_64-backend` globals + `io_out`.
+7. `code-packager::elf_object`.
+8. `code-packager::pe_object`.
+9. `twig-aot` multi-target runtime archives in `build.rs`.
+10. `twig-aot` target dispatch + linker shell-out + Linux/Windows
+    acceptance tests.
+
+After PR 10, `cargo run -p twig-aot -- compile factorial.twig` on a
+Linux x86-64 or Windows x86-64 host produces a working native
+binary.


### PR DESCRIPTION
## Summary

Four specifications for porting LANG VM AOT + JIT to **Linux x86-64** and **Windows x86-64** end-to-end (source → native binary that runs):

- **LANG44 — `x86_64-encoder`** — pure-Rust instruction encoder; ABI-agnostic, OS-agnostic. Mirrors the `aarch64-encoder` shape. Always emits Rel32 / disp32 to sidestep variable-length two-pass shortening. External relocations surfaced as abstract `PltRel32` / `PcRel32` / `GotPcRel32` slots; the packager maps to the OS-specific reloc type ID.
- **LANG43 — `x86_64-backend`** — CIR → x86-64 lowering. **Both System V AMD64 (Linux) and Microsoft x64 (Windows) ABIs in V1** — neither OS waits behind the other. Side-by-side ABI table, two prologue/epilogue templates, 32-byte shadow-space discipline for MS x64, per-ABI `io_out` lowering (arg 0 in RDI vs RCX).
- **LANG45 — `code-packager` object-file emitters** — `elf_object.rs` (ET_REL, EM_X86_64, R_X86_64_PLT32) and `pe_object.rs` (AMD64 IMAGE_FILE_HEADER, IMAGE_REL_AMD64_REL32). The system linker on each OS then produces the executable. Mirrors `macho_object.rs`'s API.
- **LANG46 — `twig-aot` multi-target driver** — `--target` flag, per-target runtime archive (built via `cc` cross-compilation in `build.rs`, embedded via `include_bytes!`), linker shell-out (`cc` on Linux, `link.exe` / `lld-link` on Windows), end-to-end acceptance tests on `ubuntu-latest` and `windows-latest`.

## Why this scope

A previous draft of LANG43 deferred Microsoft x64 ABI to a follow-up. That was wrong for the goal — without MS x64 there's no Windows path, and Linux + Windows are the targets users actually want unblocked.

LANG41 in this repo is already claimed (twig-aot 0.1.8, code-packager 0.2.2, aarch64-backend 0.2.3 — released yesterday). The encoder spec is renumbered to LANG44 to dodge the conflict.

## Follow-up PRs (10 total)

| # | Scope |
|---|---|
| 2 | `x86_64-encoder` crate (LANG44) |
| 3 | `x86_64-backend` V1 — both ABIs, integer arith + control flow + returns |
| 4 | `x86_64-backend` div/mod/logical/shifts (LANG38 parity) |
| 5 | `x86_64-backend` calls + external relocations |
| 6 | `x86_64-backend` globals + `io_out` (LANG39/40 parity) |
| 7 | `code-packager::elf_object` |
| 8 | `code-packager::pe_object` |
| 9 | `twig-aot` per-target runtime archive build (build.rs cross-compiles via `cc` crate) |
| 10 | `twig-aot` multi-target dispatch + linker integration + Linux/Windows smoke tests |

## Test plan

- [x] CI matrix already covers `ubuntu-latest`, `macos-latest`, `windows-latest` — Linux + Windows acceptance tests in PR 10 will be verifiable in CI
- [x] Spec numbering: LANG44 (encoder, renamed from LANG41), LANG43 (backend, expanded), LANG45 (object emitters, new), LANG46 (twig-aot driver, new)
- [x] LANG43 risk register names the four major footguns (shadow space, ELF/PE/Mach-O reloc differences, alignment violations, AArch64↔x86-64 coverage drift)
- [x] LANG45 + LANG46 risk registers cover format-specific traps (PE in-instruction addend vs ELF separate field, symbol-name underscoring, cross-compiler availability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)