### PR TITLE
ts(spice): add VCCS controlled sources

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add voltage-controlled current source support across DC, AC, transfer
+  function, and sensitivity analyses.
 - Add DC sensitivity analysis for resistor and independent source parameters.
 - Add DC small-signal transfer-function analysis with input/output impedance.
 - Add AC small-signal frequency sweeps for linear RC/RL circuits.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -8,5 +8,6 @@ sensitivity analysis, DC small-signal transfer-function analysis, AC
 small-signal frequency sweeps, and fixed-step RC/RL transient analysis for
 linear circuits using modified nodal analysis (MNA). The package supports
 resistors, capacitors, inductors, independent current sources, independent
-voltage sources, ground aliases, node voltages, voltage source branch currents,
-and backward-Euler reactive-element companion models.
+voltage sources, voltage-controlled current sources (VCCS), ground aliases,
+node voltages, voltage source branch currents, and backward-Euler
+reactive-element companion models.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1,7 +1,13 @@
 const PIVOT_EPSILON = 1.0e-12;
 const TWO_PI = Math.PI * 2.0;
 
-export type Element = Resistor | Capacitor | Inductor | VoltageSource | CurrentSource;
+export type Element =
+  | Resistor
+  | Capacitor
+  | Inductor
+  | VoltageSource
+  | CurrentSource
+  | Vccs;
 
 export interface Resistor {
   readonly kind: "resistor";
@@ -43,6 +49,16 @@ export interface CurrentSource {
   readonly positive: string;
   readonly negative: string;
   readonly current: number;
+}
+
+export interface Vccs {
+  readonly kind: "vccs";
+  readonly name: string;
+  readonly positive: string;
+  readonly negative: string;
+  readonly controlPositive: string;
+  readonly controlNegative: string;
+  readonly transconductanceSiemens: number;
 }
 
 export interface DcResult {
@@ -200,6 +216,25 @@ export function currentSource(
   current: number,
 ): CurrentSource {
   return { kind: "current-source", name, positive, negative, current };
+}
+
+export function vccs(
+  name: string,
+  positive: string,
+  negative: string,
+  controlPositive: string,
+  controlNegative: string,
+  transconductanceSiemens: number,
+): Vccs {
+  return {
+    kind: "vccs",
+    name,
+    positive,
+    negative,
+    controlPositive,
+    controlNegative,
+    transconductanceSiemens,
+  };
 }
 
 export function complexAbs(value: Complex): number {
@@ -491,6 +526,12 @@ function elementParameter(element: Element): ElementParameter | undefined {
         parameter: "current",
         nominalValue: element.current,
       };
+    case "vccs":
+      return {
+        elementName: element.name,
+        parameter: "transconductanceSiemens",
+        nominalValue: element.transconductanceSiemens,
+      };
     case "capacitor":
     case "inductor":
       return undefined;
@@ -525,6 +566,12 @@ function circuitWithPerturbedElement(
         break;
       case "current-source":
         perturbed.add({ ...element, current: element.current + delta });
+        break;
+      case "vccs":
+        perturbed.add({
+          ...element,
+          transconductanceSiemens: element.transconductanceSiemens + delta,
+        });
         break;
       case "capacitor":
       case "inductor":
@@ -611,6 +658,9 @@ function solveLinearCircuit(
       case "current-source":
         stampCurrentSource(element, nodeIndices, rhs);
         break;
+      case "vccs":
+        stampVccs(element, nodeIndices, matrix);
+        break;
     }
   }
 
@@ -682,6 +732,9 @@ function buildSmallSignalMatrix(
           throw invalidElement(element.name, "current must be finite");
         }
         break;
+      case "vccs":
+        stampVccs(element, nodeIndices, matrix);
+        break;
     }
   }
 
@@ -727,6 +780,9 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
         break;
       case "current-source":
         stampAcCurrentSource(element, nodeIndices, rhs);
+        break;
+      case "vccs":
+        stampAcVccs(element, nodeIndices, matrix);
         break;
     }
   }
@@ -857,6 +913,12 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.positive);
         insertNode(names, element.negative);
         break;
+      case "vccs":
+        insertNode(names, element.positive);
+        insertNode(names, element.negative);
+        insertNode(names, element.controlPositive);
+        insertNode(names, element.controlNegative);
+        break;
     }
   }
 
@@ -908,7 +970,8 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
     if (
       (element.kind === "resistor" ||
         element.kind === "capacitor" ||
-        element.kind === "inductor") &&
+        element.kind === "inductor" ||
+        element.kind === "vccs") &&
       element.name === inputSource
     ) {
       throw invalidElement(
@@ -1281,6 +1344,51 @@ function stampCurrentSource(
   }
 }
 
+function stampVccs(
+  element: Vccs,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+): void {
+  if (!Number.isFinite(element.transconductanceSiemens)) {
+    throw invalidElement(element.name, "transconductance must be finite");
+  }
+
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  const controlPositive = nodeIndex(nodeIndices, element.controlPositive);
+  const controlNegative = nodeIndex(nodeIndices, element.controlNegative);
+  stampTransconductance(
+    matrix,
+    positive,
+    negative,
+    controlPositive,
+    controlNegative,
+    element.transconductanceSiemens,
+  );
+}
+
+function stampTransconductance(
+  matrix: number[][],
+  positive: number | undefined,
+  negative: number | undefined,
+  controlPositive: number | undefined,
+  controlNegative: number | undefined,
+  transconductance: number,
+): void {
+  if (positive !== undefined && controlPositive !== undefined) {
+    matrix[positive][controlPositive] += transconductance;
+  }
+  if (positive !== undefined && controlNegative !== undefined) {
+    matrix[positive][controlNegative] -= transconductance;
+  }
+  if (negative !== undefined && controlPositive !== undefined) {
+    matrix[negative][controlPositive] -= transconductance;
+  }
+  if (negative !== undefined && controlNegative !== undefined) {
+    matrix[negative][controlNegative] += transconductance;
+  }
+}
+
 function stampAcResistor(
   element: Resistor,
   nodeIndices: ReadonlyMap<string, number>,
@@ -1399,6 +1507,63 @@ function stampAcCurrentSource(
   }
   if (negative !== undefined) {
     rhs[negative] = complexAdd(rhs[negative], current);
+  }
+}
+
+function stampAcVccs(
+  element: Vccs,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: Complex[][],
+): void {
+  if (!Number.isFinite(element.transconductanceSiemens)) {
+    throw invalidElement(element.name, "transconductance must be finite");
+  }
+
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  const controlPositive = nodeIndex(nodeIndices, element.controlPositive);
+  const controlNegative = nodeIndex(nodeIndices, element.controlNegative);
+  stampComplexTransconductance(
+    matrix,
+    positive,
+    negative,
+    controlPositive,
+    controlNegative,
+    complex(element.transconductanceSiemens, 0.0),
+  );
+}
+
+function stampComplexTransconductance(
+  matrix: Complex[][],
+  positive: number | undefined,
+  negative: number | undefined,
+  controlPositive: number | undefined,
+  controlNegative: number | undefined,
+  transconductance: Complex,
+): void {
+  if (positive !== undefined && controlPositive !== undefined) {
+    matrix[positive][controlPositive] = complexAdd(
+      matrix[positive][controlPositive],
+      transconductance,
+    );
+  }
+  if (positive !== undefined && controlNegative !== undefined) {
+    matrix[positive][controlNegative] = complexSub(
+      matrix[positive][controlNegative],
+      transconductance,
+    );
+  }
+  if (negative !== undefined && controlPositive !== undefined) {
+    matrix[negative][controlPositive] = complexSub(
+      matrix[negative][controlPositive],
+      transconductance,
+    );
+  }
+  if (negative !== undefined && controlNegative !== undefined) {
+    matrix[negative][controlNegative] = complexAdd(
+      matrix[negative][controlNegative],
+      transconductance,
+    );
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -7,6 +7,7 @@ import {
   dcSweep,
   inductor,
   resistor,
+  vccs,
   voltageSource,
 } from "../src/index.js";
 
@@ -72,6 +73,26 @@ describe("dcOp", () => {
 
     expectClose(result.voltage("out"), 0.0);
     expectClose(result.branchCurrent("L1"), 1.0e-3);
+  });
+
+  it("stamps VCCS current from control voltage", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vctrl", "ctrl", "0", 1.0));
+    circuit.add(vccs("G1", "0", "out", "ctrl", "0", 1.0e-3));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expectClose(result.voltage("out"), 1.0);
+  });
+
+  it("rejects non-finite VCCS transconductance", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vctrl", "ctrl", "0", 1.0));
+    circuit.add(vccs("Gbad", "0", "out", "ctrl", "0", Number.NaN));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    expect(() => dcOp(circuit)).toThrowError("transconductance must be finite");
   });
 
   it("sweeps voltage sources and collects operating points", () => {

--- a/code/packages/typescript/spice-engine/tests/sens.test.ts
+++ b/code/packages/typescript/spice-engine/tests/sens.test.ts
@@ -6,6 +6,7 @@ import {
   currentSource,
   resistor,
   sensDc,
+  vccs,
   voltageSource,
 } from "../src/index.js";
 
@@ -72,6 +73,25 @@ describe("sensDc", () => {
     );
     expectClose(
       entry(result, "Rload", "resistanceOhms").relativeSensitivity,
+      1.0,
+    );
+  });
+
+  it("reports VCCS transconductance sensitivity", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(vccs("Gm", "0", "out", "in", "0", 2.0e-3));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = sensDc(circuit, "out");
+
+    expectClose(result.nominalVoltage, 2.0);
+    expectClose(
+      entry(result, "Gm", "transconductanceSiemens").sensitivity,
+      1_000.0,
+    );
+    expectClose(
+      entry(result, "Gm", "transconductanceSiemens").relativeSensitivity,
       1.0,
     );
   });

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -6,6 +6,7 @@ import {
   inductor,
   resistor,
   tf,
+  vccs,
   voltageSource,
 } from "../src/index.js";
 
@@ -77,6 +78,18 @@ describe("tf", () => {
     expect(result.outputImpedanceOhms).toBeLessThan(1.0e-6);
   });
 
+  it("reports VCCS transconductance gain", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(vccs("Gm", "0", "out", "in", "0", 2.0e-3));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = tf(circuit, "out", "Vin");
+
+    expectClose(result.gain(), 2.0);
+    expectClose(result.outputImpedanceOhms, 1_000.0);
+  });
+
   it("rejects missing output nodes", () => {
     const circuit = new Circuit();
 
@@ -90,6 +103,16 @@ describe("tf", () => {
     circuit.add(resistor("Rin", "in", "0", 1_000.0));
 
     expect(() => tf(circuit, "in", "Rin")).toThrowError(
+      "input element must be an independent voltage or current source",
+    );
+  });
+
+  it("rejects VCCS elements as input sources", () => {
+    const circuit = new Circuit();
+    circuit.add(vccs("Gm", "0", "out", "in", "0", 1.0e-3));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    expect(() => tf(circuit, "out", "Gm")).toThrowError(
       "input element must be an independent voltage or current source",
     );
   });


### PR DESCRIPTION
## Summary
- add TypeScript SPICE voltage-controlled current source (VCCS) elements
- stamp VCCS transconductance through DC, AC, transient linear solves, and TF small-signal matrices
- include DC, TF, and sensitivity coverage for controlled-source behavior and validation

## Validation
- `sh BUILD`
- `git diff --check`
