### PR TITLE
feat(rust/x86_64-backend): division, logical, shifts, unary (LANG38 parity)

### DIFF
--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog — `x86_64-backend`
 
+## 0.2.0 — 2026-05-14 (LANG43 — LANG38-parity wave)
+
+Extends the V1 backend with the same opcodes `aarch64-backend` gained
+in its LANG38 release.  Same CIR coverage now compiles on both
+backends.
+
+**New CIR opcodes:**
+
+- `div_<ty>`, `mod_<ty>` — integer division and modulo.  Signed types
+  use `CQO` + `IDIV`; unsigned types use `XOR rdx, rdx` + `DIV`.
+  Quotient lives in `RAX`, remainder in `RDX` (sequenced by hand —
+  no register-allocator surprises because RAX/RCX/RDX were already
+  reserved in V1).
+- `and_<ty>`, `or_<ty>`, `xor_<ty>` — bitwise logical (64-bit).
+- `not_<ty>` — bitwise complement (`NOT r/m64`).
+- `shl_<ty>` — logical shift left (`SHL r/m64, CL`).
+- `shr_<ty>` — arithmetic shift right (`SAR`) for signed types,
+  logical shift right (`SHR`) for unsigned types.
+- `neg_<ty>` — two's-complement negate (`NEG r/m64`).
+
+All shifts use `CL` as the count register (x86-64 ISA constraint);
+the backend pre-loads `rhs` into `RCX` before issuing the shift.
+
+Still out of scope (added by later phases):
+- Calls + external relocations (phase 5)
+- Globals + `io_out` (phase 6)
+- Floats / closures
+
 ## 0.1.0 — 2026-05-14 (LANG43)
 
 Initial release.  V1 backend matching the `aarch64-backend` V1 baseline.

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/README.md
+++ b/code/packages/rust/x86_64-backend/README.md
@@ -40,22 +40,26 @@ let backend = X86_64Backend::with_abi(X86_64Abi::MsX64);  // Windows
 `X86_64Backend::new()` defaults to `SysV`.  `twig-aot` will pick the
 right ABI based on `--target` (LANG46).
 
-## V1 scope
+## Scope
 
-Matches the aarch64-backend V1 baseline:
+Matches the aarch64-backend baseline through LANG38:
 
 | Family | CIR mnemonics |
 |---|---|
 | Constants | `const_u8` … `const_u64`, `const_i8` … `const_i64`, `const_bool` |
 | Integer arithmetic | `add_<ty>`, `sub_<ty>`, `mul_<ty>` |
+| Division | `div_<ty>` (IDIV / DIV via RDX:RAX), `mod_<ty>` |
+| Logical | `and_<ty>`, `or_<ty>`, `xor_<ty>`, `not_<ty>` |
+| Shifts | `shl_<ty>`, `shr_<ty>` (SAR for `i*`, SHR for `u*`) |
+| Unary | `neg_<ty>` |
 | Comparisons | `cmp_eq_<ty>`, `cmp_ne_<ty>`, `cmp_lt_<ty>`, `cmp_le_<ty>`, `cmp_gt_<ty>`, `cmp_ge_<ty>` (signed and unsigned) |
 | Control flow | `label`, `jmp`, `jmp_if_true`, `jmp_if_false` |
 | Returns | `ret_<ty>`, `ret_void` |
 | Moves | `mov_<ty>` |
 | Type guards | `type_assert` (lowered to `UD2` trap — AOT has no deopt) |
 
-Division, modulo, logical ops, shifts, calls, globals, and `io_out`
-are added by subsequent waves (LANG43 phases 4–6).
+Calls, globals, and `io_out` are added by subsequent waves
+(LANG43 phases 5–6).
 
 ## Register allocation
 

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -439,7 +439,166 @@ fn emit_instr(
         return emit_cmp(asm, alloc, instr, rel, signed);
     }
 
+    // --- LANG38-parity additions ---
+
+    // div_<ty> / mod_<ty> — signed types use IDIV, unsigned use DIV.
+    if let Some(ty) = op.strip_prefix("div_") { return emit_divmod(asm, alloc, instr, ty, false); }
+    if let Some(ty) = op.strip_prefix("mod_") { return emit_divmod(asm, alloc, instr, ty, true);  }
+
+    // and_<ty> / or_<ty> / xor_<ty>
+    if op.starts_with("and_") { return emit_bitwise(asm, alloc, instr, Bitwise::And); }
+    if op.starts_with("or_")  { return emit_bitwise(asm, alloc, instr, Bitwise::Or);  }
+    if op.starts_with("xor_") { return emit_bitwise(asm, alloc, instr, Bitwise::Xor); }
+
+    // shl_<ty>: logical shift left (same for signed/unsigned).
+    if op.starts_with("shl_") { return emit_shift(asm, alloc, instr, ShiftKind::Shl); }
+    // shr_<ty>: arithmetic for signed (SAR), logical for unsigned (SHR).
+    if let Some(ty) = op.strip_prefix("shr_") {
+        let kind = if ty.starts_with('i') { ShiftKind::Sar } else { ShiftKind::Shr };
+        return emit_shift(asm, alloc, instr, kind);
+    }
+
+    // neg_<ty> dest = -src
+    if op.starts_with("neg_") {
+        let dest = require_dest(instr)?;
+        let src = instr.srcs.first()
+            .ok_or_else(|| BackendError::MalformedInstr(format!("{op} needs srcs[0]")))?;
+        load_operand(asm, alloc, Reg::Rax, src);
+        asm.neg_(Reg::Rax);
+        let slot = alloc.slot_of(dest);
+        asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+        return Ok(());
+    }
+
+    // not_<ty> dest = ~src
+    if op.starts_with("not_") {
+        let dest = require_dest(instr)?;
+        let src = instr.srcs.first()
+            .ok_or_else(|| BackendError::MalformedInstr(format!("{op} needs srcs[0]")))?;
+        load_operand(asm, alloc, Reg::Rax, src);
+        asm.not_(Reg::Rax);
+        let slot = alloc.slot_of(dest);
+        asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+        return Ok(());
+    }
+
     Err(BackendError::UnsupportedOp(op.to_string()))
+}
+
+// ===========================================================================
+// Division and modulo
+// ===========================================================================
+
+/// `div_<ty>` and `mod_<ty>` both go through this helper.
+///
+/// x86-64 division is awkward: `IDIV r/m64` consumes `RDX:RAX` as the
+/// 128-bit dividend and produces quotient in `RAX`, remainder in `RDX`.
+/// For signed types we must sign-extend `RAX` into `RDX:RAX` with `CQO`;
+/// for unsigned we just zero `RDX`.
+///
+/// Sequence (signed div):
+///
+/// ```text
+/// mov  rax, [lhs]
+/// cqo                     ; rdx:rax = sign-extend(rax)
+/// mov  rcx, [rhs]
+/// idiv rcx
+/// mov  [dst], rax         ; (for mod_, [dst], rdx)
+/// ```
+fn emit_divmod(
+    asm: &mut Assembler,
+    alloc: &mut RegAlloc,
+    instr: &CIRInstr,
+    ty: &str,
+    is_mod: bool,
+) -> Result<(), BackendError> {
+    let dest = require_dest(instr)?;
+    let lhs = instr.srcs.first()
+        .ok_or_else(|| BackendError::MalformedInstr("div/mod needs srcs[0]".into()))?;
+    let rhs = instr.srcs.get(1)
+        .ok_or_else(|| BackendError::MalformedInstr("div/mod needs srcs[1]".into()))?;
+    let signed = ty.starts_with('i');
+
+    load_operand(asm, alloc, Reg::Rax, lhs);
+    // Sign-/zero-extend RAX into RDX.
+    if signed {
+        asm.cqo();
+    } else {
+        asm.xor_(Reg::Rdx, Reg::Rdx);
+    }
+    // Load divisor into RCX (IDIV/DIV r/m64 form — divisor in a register).
+    load_operand(asm, alloc, Reg::Rcx, rhs);
+    if signed { asm.idiv(Reg::Rcx); } else { asm.div(Reg::Rcx); }
+    // Result lives in RAX (quotient) or RDX (remainder).
+    let result_reg = if is_mod { Reg::Rdx } else { Reg::Rax };
+    let slot = alloc.slot_of(dest);
+    asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), result_reg);
+    Ok(())
+}
+
+// ===========================================================================
+// Bitwise ops (AND / OR / XOR)
+// ===========================================================================
+
+#[derive(Debug, Clone, Copy)]
+enum Bitwise { And, Or, Xor }
+
+fn emit_bitwise(
+    asm: &mut Assembler,
+    alloc: &mut RegAlloc,
+    instr: &CIRInstr,
+    op: Bitwise,
+) -> Result<(), BackendError> {
+    let dest = require_dest(instr)?;
+    let lhs = instr.srcs.first()
+        .ok_or_else(|| BackendError::MalformedInstr("bitwise needs srcs[0]".into()))?;
+    let rhs = instr.srcs.get(1)
+        .ok_or_else(|| BackendError::MalformedInstr("bitwise needs srcs[1]".into()))?;
+    load_operand(asm, alloc, Reg::Rax, lhs);
+    load_operand(asm, alloc, Reg::Rcx, rhs);
+    match op {
+        Bitwise::And => asm.and_(Reg::Rax, Reg::Rcx),
+        Bitwise::Or  => asm.or_(Reg::Rax,  Reg::Rcx),
+        Bitwise::Xor => asm.xor_(Reg::Rax, Reg::Rcx),
+    }
+    let slot = alloc.slot_of(dest);
+    asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+    Ok(())
+}
+
+// ===========================================================================
+// Variable shifts (SHL / SHR / SAR)
+// ===========================================================================
+
+/// Variable shift kind.  Signed-shift-right (SAR) preserves the sign bit;
+/// logical-shift-right (SHR) zero-fills.
+#[derive(Debug, Clone, Copy)]
+enum ShiftKind { Shl, Shr, Sar }
+
+fn emit_shift(
+    asm: &mut Assembler,
+    alloc: &mut RegAlloc,
+    instr: &CIRInstr,
+    kind: ShiftKind,
+) -> Result<(), BackendError> {
+    let dest = require_dest(instr)?;
+    let lhs = instr.srcs.first()
+        .ok_or_else(|| BackendError::MalformedInstr("shift needs srcs[0]".into()))?;
+    let rhs = instr.srcs.get(1)
+        .ok_or_else(|| BackendError::MalformedInstr("shift needs srcs[1]".into()))?;
+    // x86-64 variable shift uses CL as the count.  Load the value to be
+    // shifted into RAX and the count into RCX (which has CL in its low
+    // byte), then issue `shl/shr/sar rax, cl`.
+    load_operand(asm, alloc, Reg::Rax, lhs);
+    load_operand(asm, alloc, Reg::Rcx, rhs);
+    match kind {
+        ShiftKind::Shl => asm.shl_cl(Reg::Rax),
+        ShiftKind::Shr => asm.shr_cl(Reg::Rax),
+        ShiftKind::Sar => asm.sar_cl(Reg::Rax),
+    }
+    let slot = alloc.slot_of(dest);
+    asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+    Ok(())
 }
 
 // ===========================================================================
@@ -841,6 +1000,170 @@ mod tests {
     fn backend_trait_name_reflects_abi() {
         assert_eq!(X86_64Backend::with_abi(X86_64Abi::SysV).name(), "x86_64-sysv");
         assert_eq!(X86_64Backend::with_abi(X86_64Abi::MsX64).name(), "x86_64-msx64");
+    }
+
+    // ---- LANG38-parity opcodes ----
+
+    fn body_contains(bytes: &[u8], needle: &[u8]) -> bool {
+        bytes.windows(needle.len()).any(|w| w == needle)
+    }
+
+    #[test]
+    fn fn_div_i64_emits_cqo_idiv() {
+        // fn d(a: i64, b: i64) -> i64 { return a / b; }
+        let params = vec![
+            ("a".to_string(), "i64".to_string()),
+            ("b".to_string(), "i64".to_string()),
+        ];
+        let ctx = fn_ctx("d", &params, "i64");
+        let ir = vec![
+            instr("div_i64", Some("q"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("ret_i64", None, vec![Op::Var("q".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        assert!(body_contains(&bytes, &[0x48, 0x99]),         "cqo missing");      // CQO
+        assert!(body_contains(&bytes, &[0x48, 0xF7, 0xF9]),   "idiv rcx missing"); // IDIV rcx
+    }
+
+    #[test]
+    fn fn_div_u64_emits_xor_div() {
+        let params = vec![
+            ("a".to_string(), "u64".to_string()),
+            ("b".to_string(), "u64".to_string()),
+        ];
+        let ctx = fn_ctx("d", &params, "u64");
+        let ir = vec![
+            instr("div_u64", Some("q"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("ret_u64", None, vec![Op::Var("q".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // Unsigned div: XOR RDX, RDX (48 31 D2) then DIV RCX (48 F7 F1)
+        assert!(body_contains(&bytes, &[0x48, 0x31, 0xD2]),   "xor rdx,rdx missing");
+        assert!(body_contains(&bytes, &[0x48, 0xF7, 0xF1]),   "div rcx missing");
+    }
+
+    #[test]
+    fn fn_mod_i64_stores_rdx() {
+        // mod: result is the remainder (RDX), not the quotient.
+        let params = vec![
+            ("a".to_string(), "i64".to_string()),
+            ("b".to_string(), "i64".to_string()),
+        ];
+        let ctx = fn_ctx("m", &params, "i64");
+        let ir = vec![
+            instr("mod_i64", Some("r"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("ret_i64", None, vec![Op::Var("r".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // After IDIV, the result slot is written from RDX (encoded as
+        // ModR/M reg=2): `mov [rbp - off], rdx`  →  48 89 95 .. .. .. ..
+        // The reg field's low 3 bits = 2, so ModR/M = (10 << 6) | (010 << 3) | rm = 0x95 when rm=5 (RBP).
+        // We assert the `48 89 95` byte trio appears somewhere after IDIV.
+        assert!(body_contains(&bytes, &[0x48, 0x89, 0x95]),
+                "mov [rbp+disp32], rdx missing — should be storing remainder");
+    }
+
+    #[test]
+    fn fn_and_or_xor_emit_correct_opcodes() {
+        let params = vec![
+            ("a".to_string(), "u64".to_string()),
+            ("b".to_string(), "u64".to_string()),
+        ];
+        let ctx = fn_ctx("f", &params, "u64");
+        let ir = vec![
+            instr("and_u64", Some("v0"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("or_u64",  Some("v1"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("xor_u64", Some("v2"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("ret_u64", None, vec![Op::Var("v2".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        assert!(body_contains(&bytes, &[0x48, 0x21, 0xC8]), "and rax,rcx missing");
+        assert!(body_contains(&bytes, &[0x48, 0x09, 0xC8]), "or  rax,rcx missing");
+        assert!(body_contains(&bytes, &[0x48, 0x31, 0xC8]), "xor rax,rcx missing");
+    }
+
+    #[test]
+    fn fn_shl_u64_emits_shl_cl() {
+        let params = vec![
+            ("a".to_string(), "u64".to_string()),
+            ("b".to_string(), "u64".to_string()),
+        ];
+        let ctx = fn_ctx("s", &params, "u64");
+        let ir = vec![
+            instr("shl_u64", Some("v"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("ret_u64", None, vec![Op::Var("v".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // shl rax, cl: 48 D3 E0
+        assert!(body_contains(&bytes, &[0x48, 0xD3, 0xE0]), "shl rax,cl missing");
+    }
+
+    #[test]
+    fn fn_shr_signed_emits_sar() {
+        // shr_i64 must lower to SAR (arithmetic shift), not SHR (logical).
+        let params = vec![
+            ("a".to_string(), "i64".to_string()),
+            ("b".to_string(), "i64".to_string()),
+        ];
+        let ctx = fn_ctx("s", &params, "i64");
+        let ir = vec![
+            instr("shr_i64", Some("v"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("ret_i64", None, vec![Op::Var("v".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // sar rax, cl: 48 D3 F8
+        assert!(body_contains(&bytes, &[0x48, 0xD3, 0xF8]), "sar rax,cl missing");
+        // And NOT shr: 48 D3 E8
+        assert!(!body_contains(&bytes, &[0x48, 0xD3, 0xE8]), "shr unexpectedly present");
+    }
+
+    #[test]
+    fn fn_shr_unsigned_emits_shr() {
+        let params = vec![
+            ("a".to_string(), "u64".to_string()),
+            ("b".to_string(), "u64".to_string()),
+        ];
+        let ctx = fn_ctx("s", &params, "u64");
+        let ir = vec![
+            instr("shr_u64", Some("v"),
+                  vec![Op::Var("a".into()), Op::Var("b".into())]),
+            instr("ret_u64", None, vec![Op::Var("v".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        assert!(body_contains(&bytes, &[0x48, 0xD3, 0xE8]), "shr rax,cl missing");
+        assert!(!body_contains(&bytes, &[0x48, 0xD3, 0xF8]), "sar unexpectedly present");
+    }
+
+    #[test]
+    fn fn_neg_emits_neg() {
+        let params = vec![("a".to_string(), "i64".to_string())];
+        let ctx = fn_ctx("n", &params, "i64");
+        let ir = vec![
+            instr("neg_i64", Some("v"), vec![Op::Var("a".into())]),
+            instr("ret_i64", None, vec![Op::Var("v".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        assert!(body_contains(&bytes, &[0x48, 0xF7, 0xD8]), "neg rax missing");
+    }
+
+    #[test]
+    fn fn_not_emits_not() {
+        let params = vec![("a".to_string(), "u64".to_string())];
+        let ctx = fn_ctx("n", &params, "u64");
+        let ir = vec![
+            instr("not_u64", Some("v"), vec![Op::Var("a".into())]),
+            instr("ret_u64", None, vec![Op::Var("v".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        assert!(body_contains(&bytes, &[0x48, 0xF7, 0xD0]), "not rax missing");
     }
 
     #[test]


### PR DESCRIPTION
## Phase 4 of the x86-64 port to Linux + Windows

Extends [`x86_64-backend`](code/packages/rust/x86_64-backend/) with the same CIR opcodes [`aarch64-backend`](code/packages/rust/aarch64-backend/) gained in its LANG38 wave. Same Twig programs that compile on ARM64 now compile on x86-64. Implements [LANG43](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/LANG43-x86_64-backend.md).

## Summary

New CIR opcodes:

| Family | CIR | x86-64 lowering |
|---|---|---|
| Division | `div_<ty>` | Signed: `CQO` + `IDIV r/m64`. Unsigned: `XOR rdx,rdx` + `DIV r/m64`. Quotient → RAX → dst slot. |
| Modulo | `mod_<ty>` | Same setup as div; result lives in RDX (remainder). |
| Bitwise | `and_<ty>`, `or_<ty>`, `xor_<ty>` | `AND` / `OR` / `XOR` reg-reg |
| Unary | `not_<ty>` | `NOT r/m64` |
| Unary | `neg_<ty>` | `NEG r/m64` |
| Shift left | `shl_<ty>` | `SHL r/m64, CL` (RHS pre-loaded into RCX) |
| Shift right | `shr_<ty>` | `SAR r/m64, CL` for signed types, `SHR r/m64, CL` for unsigned |

All shifts use CL as the count (x86-64 ISA constraint). RAX/RCX/RDX were already reserved as scratch in V1, so adding IDIV / shifts requires no allocator changes.

## Test plan

- [x] 23 unit tests pass on Windows host (was 14 in V1, added 9 for the new opcodes)
- [x] `div_i64` emits `CQO` + `IDIV rcx` golden bytes
- [x] `div_u64` emits `XOR rdx,rdx` + `DIV rcx` (no CQO)
- [x] `mod_i64` stores RDX (remainder), not RAX
- [x] `shr_i64` lowers to `SAR rax,cl` — verified `SHR` is NOT also emitted
- [x] `shr_u64` lowers to `SHR rax,cl` — verified `SAR` is NOT also emitted
- [x] `neg_` / `not_` emit `NEG` / `NOT`
- [x] `cargo clippy --no-deps -- -D warnings` clean

CI will additionally verify on `ubuntu-latest`, `macos-latest`, `windows-latest`.

## Next phases

| # | Branch | Scope |
|---|---|---|
| 5 | `feat/x86_64-backend-calls` | calls + relocations |
| 6 | `feat/x86_64-backend-io` | globals + `io_out` (LANG39/40 parity) |
| 7 | `feat/x86_64-elf-object` | `code-packager::elf_object` |
| 8 | `feat/x86_64-pe-object` | `code-packager::pe_object` |
| 9 | `feat/x86_64-runtime-archives` | per-target runtime archives |
| 10 | `feat/x86_64-twig-aot-driver` | multi-target dispatch + Linux/Windows smoke tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)