### PR TITLE
ts(spice): add source waveforms

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add PWL, SIN, PULSE, and EXP source waveforms for transient voltage and
+  current sources while preserving static source values for DC, AC, transfer
+  function, sensitivity, and sweep analyses.
 - Add voltage-controlled current source support across DC, AC, transfer
   function, and sensitivity analyses.
 - Add DC sensitivity analysis for resistor and independent source parameters.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -8,6 +8,34 @@ sensitivity analysis, DC small-signal transfer-function analysis, AC
 small-signal frequency sweeps, and fixed-step RC/RL transient analysis for
 linear circuits using modified nodal analysis (MNA). The package supports
 resistors, capacitors, inductors, independent current sources, independent
-voltage sources, voltage-controlled current sources (VCCS), ground aliases,
-node voltages, voltage source branch currents, and backward-Euler
-reactive-element companion models.
+voltage sources, voltage-controlled current sources (VCCS), PWL/SIN/PULSE/EXP
+source waveforms for transient analysis, ground aliases, node voltages,
+voltage source branch currents, and backward-Euler reactive-element companion
+models.
+
+```ts
+import {
+  Circuit,
+  PwlWaveform,
+  resistor,
+  transient,
+  voltageSourceWithWaveform,
+} from "@coding-adventures/spice-engine";
+
+const circuit = new Circuit();
+circuit.add(
+  voltageSourceWithWaveform(
+    "Vin",
+    "in",
+    "0",
+    0.0,
+    new PwlWaveform([
+      [0.0, 0.0],
+      [1.0e-9, 1.8],
+    ]),
+  ),
+);
+circuit.add(resistor("Rload", "in", "0", 1_000.0));
+
+const points = transient(circuit, 0.5e-9, 1.0e-9);
+```

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -35,12 +35,227 @@ export interface Inductor {
   readonly initialCurrent: number;
 }
 
+export type Waveform =
+  | PwlWaveform
+  | SinWaveform
+  | PulseWaveform
+  | ExpWaveform;
+
+export class PwlWaveform {
+  constructor(readonly points: readonly (readonly [number, number])[]) {}
+
+  valueAt(timeSeconds: number): number {
+    if (this.points.length === 0) {
+      return Number.NaN;
+    }
+    if (timeSeconds <= this.points[0][0]) {
+      return this.points[0][1];
+    }
+    const last = this.points[this.points.length - 1];
+    if (timeSeconds >= last[0]) {
+      return last[1];
+    }
+
+    for (let index = 0; index < this.points.length - 1; index++) {
+      const [leftTime, leftValue] = this.points[index];
+      const [rightTime, rightValue] = this.points[index + 1];
+      if (timeSeconds <= rightTime) {
+        const phase = (timeSeconds - leftTime) / (rightTime - leftTime);
+        return leftValue + (rightValue - leftValue) * phase;
+      }
+    }
+    return last[1];
+  }
+
+  validate(): string | undefined {
+    if (this.points.length < 2) {
+      return "PWL waveform requires at least two points";
+    }
+    let previousTime = Number.NEGATIVE_INFINITY;
+    for (const [time, value] of this.points) {
+      if (!Number.isFinite(time) || !Number.isFinite(value)) {
+        return "PWL waveform times and values must be finite";
+      }
+      if (time <= previousTime) {
+        return "PWL waveform times must be strictly increasing";
+      }
+      previousTime = time;
+    }
+    return undefined;
+  }
+}
+
+export class SinWaveform {
+  constructor(
+    readonly offset = 0.0,
+    readonly amplitude = 1.0,
+    readonly frequencyHz = 1.0,
+    readonly delaySeconds = 0.0,
+    readonly damping = 0.0,
+  ) {}
+
+  valueAt(timeSeconds: number): number {
+    if (timeSeconds < this.delaySeconds) {
+      return this.offset;
+    }
+    const shiftedTime = timeSeconds - this.delaySeconds;
+    const envelope =
+      this.damping === 0.0 ? 1.0 : Math.exp(-this.damping * shiftedTime);
+    return (
+      this.offset +
+      this.amplitude *
+        Math.sin(TWO_PI * this.frequencyHz * shiftedTime) *
+        envelope
+    );
+  }
+
+  validate(): string | undefined {
+    if (
+      !Number.isFinite(this.offset) ||
+      !Number.isFinite(this.amplitude) ||
+      !Number.isFinite(this.frequencyHz) ||
+      !Number.isFinite(this.delaySeconds) ||
+      !Number.isFinite(this.damping)
+    ) {
+      return "SIN waveform parameters must be finite";
+    }
+    if (this.frequencyHz < 0.0) {
+      return "SIN waveform frequency must be non-negative";
+    }
+    if (this.delaySeconds < 0.0) {
+      return "SIN waveform delay must be non-negative";
+    }
+    return undefined;
+  }
+}
+
+export class PulseWaveform {
+  constructor(
+    readonly initialValue = 0.0,
+    readonly pulsedValue = 1.0,
+    readonly delaySeconds = 0.0,
+    readonly riseTimeSeconds = 0.0,
+    readonly fallTimeSeconds = 0.0,
+    readonly pulseWidthSeconds = 0.5,
+    readonly periodSeconds = 1.0,
+  ) {}
+
+  valueAt(timeSeconds: number): number {
+    if (timeSeconds < this.delaySeconds) {
+      return this.initialValue;
+    }
+    const elapsed =
+      (timeSeconds - this.delaySeconds) % this.periodSeconds;
+    if (this.riseTimeSeconds > 0.0 && elapsed < this.riseTimeSeconds) {
+      const phase = elapsed / this.riseTimeSeconds;
+      return this.initialValue + (this.pulsedValue - this.initialValue) * phase;
+    }
+    if (elapsed < this.riseTimeSeconds + this.pulseWidthSeconds) {
+      return this.pulsedValue;
+    }
+    const fallStart = this.riseTimeSeconds + this.pulseWidthSeconds;
+    if (this.fallTimeSeconds > 0.0 && elapsed < fallStart + this.fallTimeSeconds) {
+      const phase = (elapsed - fallStart) / this.fallTimeSeconds;
+      return this.pulsedValue + (this.initialValue - this.pulsedValue) * phase;
+    }
+    return this.initialValue;
+  }
+
+  validate(): string | undefined {
+    if (
+      !Number.isFinite(this.initialValue) ||
+      !Number.isFinite(this.pulsedValue) ||
+      !Number.isFinite(this.delaySeconds) ||
+      !Number.isFinite(this.riseTimeSeconds) ||
+      !Number.isFinite(this.fallTimeSeconds) ||
+      !Number.isFinite(this.pulseWidthSeconds) ||
+      !Number.isFinite(this.periodSeconds)
+    ) {
+      return "PULSE waveform parameters must be finite";
+    }
+    if (
+      this.delaySeconds < 0.0 ||
+      this.riseTimeSeconds < 0.0 ||
+      this.fallTimeSeconds < 0.0 ||
+      this.pulseWidthSeconds < 0.0 ||
+      this.periodSeconds <= 0.0
+    ) {
+      return "PULSE waveform timing values must be non-negative and period positive";
+    }
+    if (
+      this.riseTimeSeconds + this.pulseWidthSeconds + this.fallTimeSeconds >
+      this.periodSeconds
+    ) {
+      return "PULSE waveform high interval must fit within the period";
+    }
+    return undefined;
+  }
+}
+
+export class ExpWaveform {
+  constructor(
+    readonly initialValue = 0.0,
+    readonly pulsedValue = 1.0,
+    readonly riseDelaySeconds = 0.0,
+    readonly riseTimeConstantSeconds = 1.0,
+    readonly fallDelaySeconds = 1.0,
+    readonly fallTimeConstantSeconds = 1.0,
+  ) {}
+
+  valueAt(timeSeconds: number): number {
+    if (timeSeconds <= this.riseDelaySeconds) {
+      return this.initialValue;
+    }
+    let value =
+      this.initialValue +
+      (this.pulsedValue - this.initialValue) *
+        (1.0 -
+          Math.exp(
+            -(timeSeconds - this.riseDelaySeconds) /
+              this.riseTimeConstantSeconds,
+          ));
+    if (timeSeconds >= this.fallDelaySeconds) {
+      value +=
+        (this.initialValue - this.pulsedValue) *
+        (1.0 -
+          Math.exp(
+            -(timeSeconds - this.fallDelaySeconds) /
+              this.fallTimeConstantSeconds,
+          ));
+    }
+    return value;
+  }
+
+  validate(): string | undefined {
+    if (
+      !Number.isFinite(this.initialValue) ||
+      !Number.isFinite(this.pulsedValue) ||
+      !Number.isFinite(this.riseDelaySeconds) ||
+      !Number.isFinite(this.riseTimeConstantSeconds) ||
+      !Number.isFinite(this.fallDelaySeconds) ||
+      !Number.isFinite(this.fallTimeConstantSeconds)
+    ) {
+      return "EXP waveform parameters must be finite";
+    }
+    if (
+      this.riseDelaySeconds < 0.0 ||
+      this.fallDelaySeconds < 0.0 ||
+      this.riseTimeConstantSeconds <= 0.0 ||
+      this.fallTimeConstantSeconds <= 0.0
+    ) {
+      return "EXP waveform delays must be non-negative and time constants positive";
+    }
+    return undefined;
+  }
+}
+
 export interface VoltageSource {
   readonly kind: "voltage-source";
   readonly name: string;
   readonly positive: string;
   readonly negative: string;
   readonly voltage: number;
+  readonly waveform?: Waveform;
 }
 
 export interface CurrentSource {
@@ -49,6 +264,7 @@ export interface CurrentSource {
   readonly positive: string;
   readonly negative: string;
   readonly current: number;
+  readonly waveform?: Waveform;
 }
 
 export interface Vccs {
@@ -209,6 +425,23 @@ export function voltageSource(
   return { kind: "voltage-source", name, positive, negative, voltage };
 }
 
+export function voltageSourceWithWaveform(
+  name: string,
+  positive: string,
+  negative: string,
+  voltage: number,
+  waveform: Waveform,
+): VoltageSource {
+  return {
+    kind: "voltage-source",
+    name,
+    positive,
+    negative,
+    voltage,
+    waveform,
+  };
+}
+
 export function currentSource(
   name: string,
   positive: string,
@@ -216,6 +449,23 @@ export function currentSource(
   current: number,
 ): CurrentSource {
   return { kind: "current-source", name, positive, negative, current };
+}
+
+export function currentSourceWithWaveform(
+  name: string,
+  positive: string,
+  negative: string,
+  current: number,
+  waveform: Waveform,
+): CurrentSource {
+  return {
+    kind: "current-source",
+    name,
+    positive,
+    negative,
+    current,
+    waveform,
+  };
 }
 
 export function vccs(
@@ -246,7 +496,7 @@ export function complexPhase(value: Complex): number {
 }
 
 export function dcOp(circuit: Circuit): DcResult {
-  const solution = solveLinearCircuit(circuit, [], []);
+  const solution = solveLinearCircuit(circuit, [], [], undefined);
   return makeDcResult(solution.nodeVoltages, solution.branchCurrents);
 }
 
@@ -426,7 +676,12 @@ export function transient(
   const inductorStates = initialInductorStates(circuit, timeStep);
   const points: TransientPoint[] = [];
   for (let time = timeStep; time <= stopTime + timeStep * 1.0e-9; time += timeStep) {
-    const solution = solveLinearCircuit(circuit, capacitorStates, inductorStates);
+    const solution = solveLinearCircuit(
+      circuit,
+      capacitorStates,
+      inductorStates,
+      time,
+    );
     updateCapacitorStates(circuit, solution.nodeVoltages, capacitorStates);
     updateInductorStates(circuit, solution.nodeVoltages, inductorStates);
     points.push(
@@ -610,6 +865,7 @@ function solveLinearCircuit(
   circuit: Circuit,
   capacitorStates: readonly CapacitorState[],
   inductorStates: readonly InductorState[],
+  sourceTime: number | undefined,
 ): LinearSolution {
   const nodeIndices = collectNodeIndices(circuit);
   const voltageSources = collectVoltageSources(circuit, inductorStates);
@@ -653,10 +909,11 @@ function solveLinearCircuit(
           nodeCount,
           matrix,
           rhs,
+          sourceTime,
         );
         break;
       case "current-source":
-        stampCurrentSource(element, nodeIndices, rhs);
+        stampCurrentSource(element, nodeIndices, rhs, sourceTime);
         break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
@@ -1291,8 +1548,10 @@ function stampVoltageSource(
   nodeCount: number,
   matrix: number[][],
   rhs: number[],
+  sourceTime: number | undefined,
 ): void {
-  if (!Number.isFinite(element.voltage)) {
+  const voltage = sourceVoltageAt(element, sourceTime);
+  if (!Number.isFinite(voltage)) {
     throw invalidElement(element.name, "voltage must be finite");
   }
 
@@ -1306,7 +1565,7 @@ function stampVoltageSource(
   const negative = nodeIndex(nodeIndices, element.negative);
 
   stampBranchMatrix(matrix, branch, positive, negative);
-  rhs[branch] += element.voltage;
+  rhs[branch] += voltage;
 }
 
 function stampBranchMatrix(
@@ -1329,19 +1588,49 @@ function stampCurrentSource(
   element: CurrentSource,
   nodeIndices: ReadonlyMap<string, number>,
   rhs: number[],
+  sourceTime: number | undefined,
 ): void {
-  if (!Number.isFinite(element.current)) {
+  const current = sourceCurrentAt(element, sourceTime);
+  if (!Number.isFinite(current)) {
     throw invalidElement(element.name, "current must be finite");
   }
 
   const positive = nodeIndex(nodeIndices, element.positive);
   const negative = nodeIndex(nodeIndices, element.negative);
   if (positive !== undefined) {
-    rhs[positive] -= element.current;
+    rhs[positive] -= current;
   }
   if (negative !== undefined) {
-    rhs[negative] += element.current;
+    rhs[negative] += current;
   }
+}
+
+function sourceVoltageAt(
+  source: VoltageSource,
+  sourceTime: number | undefined,
+): number {
+  if (sourceTime !== undefined && source.waveform !== undefined) {
+    const reason = source.waveform.validate();
+    if (reason !== undefined) {
+      throw invalidElement(source.name, reason);
+    }
+    return source.waveform.valueAt(sourceTime);
+  }
+  return source.voltage;
+}
+
+function sourceCurrentAt(
+  source: CurrentSource,
+  sourceTime: number | undefined,
+): number {
+  if (sourceTime !== undefined && source.waveform !== undefined) {
+    const reason = source.waveform.validate();
+    if (reason !== undefined) {
+      throw invalidElement(source.name, reason);
+    }
+    return source.waveform.valueAt(sourceTime);
+  }
+  return source.current;
 }
 
 function stampVccs(

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   Circuit,
+  SinWaveform,
   SpiceError,
   currentSource,
   dcOp,
@@ -9,6 +10,7 @@ import {
   resistor,
   vccs,
   voltageSource,
+  voltageSourceWithWaveform,
 } from "../src/index.js";
 
 function expectClose(actual: number | undefined, expected: number): void {
@@ -93,6 +95,24 @@ describe("dcOp", () => {
     circuit.add(resistor("Rload", "out", "0", 1_000.0));
 
     expect(() => dcOp(circuit)).toThrowError("transconductance must be finite");
+  });
+
+  it("uses static source value when a waveform is present", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "V1",
+        "n1",
+        "0",
+        3.0,
+        new SinWaveform(0.0, 10.0, 1_000.0),
+      ),
+    );
+    circuit.add(resistor("R1", "n1", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expectClose(result.voltage("n1"), 3.0);
   });
 
   it("sweeps voltage sources and collects operating points", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
   Circuit,
+  ExpWaveform,
+  PulseWaveform,
+  PwlWaveform,
+  SinWaveform,
   SpiceError,
   capacitor,
   capacitorWithInitialVoltage,
+  currentSourceWithWaveform,
   inductor,
   inductorWithInitialCurrent,
   resistor,
   transient,
   voltageSource,
+  voltageSourceWithWaveform,
 } from "../src/index.js";
 
 function expectClose(actual: number | undefined, expected: number): void {
@@ -99,6 +105,155 @@ describe("transient", () => {
     expect(() => transient(circuit, 0.0, 1.0e-3)).toThrowError(SpiceError);
     expect(() => transient(circuit, 0.0, 1.0e-3)).toThrowError(
       "invalid element transient",
+    );
+  });
+
+  it("interpolates and clamps PWL waveforms", () => {
+    const waveform = new PwlWaveform([
+      [0.0, 0.0],
+      [0.5, 1.0],
+      [1.0, -1.0],
+    ]);
+
+    expectClose(waveform.valueAt(-1.0), 0.0);
+    expectClose(waveform.valueAt(0.25), 0.5);
+    expectClose(waveform.valueAt(0.75), 0.0);
+    expectClose(waveform.valueAt(2.0), -1.0);
+  });
+
+  it("uses a PWL waveform on a transient voltage source", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "Vin",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [0.5, 1.0],
+          [1.0, 1.0],
+        ]),
+      ),
+    );
+    circuit.add(resistor("Rload", "in", "0", 1_000.0));
+
+    const points = transient(circuit, 0.25, 1.0);
+
+    expect(points).toHaveLength(4);
+    expectClose(points[0].voltage("in"), 0.5);
+    expectClose(points[1].voltage("in"), 1.0);
+    expectClose(points[2].voltage("in"), 1.0);
+    expectClose(points[3].voltage("in"), 1.0);
+  });
+
+  it("respects SIN waveform delay and damping", () => {
+    const waveform = new SinWaveform(1.0, 2.0, 1.0, 0.5, 1.0);
+
+    expectClose(waveform.valueAt(0.25), 1.0);
+    expect(waveform.valueAt(0.75)).toBeCloseTo(
+      1.0 + 2.0 * Math.exp(-0.25),
+      12,
+    );
+  });
+
+  it("uses a SIN waveform on a transient voltage source", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "Vin",
+        "in",
+        "0",
+        0.0,
+        new SinWaveform(0.0, 2.0, 1.0),
+      ),
+    );
+    circuit.add(resistor("Rload", "in", "0", 1_000.0));
+
+    const points = transient(circuit, 0.25, 0.5);
+
+    expectClose(points[0].voltage("in"), 2.0);
+    expectClose(points[1].voltage("in"), 0.0);
+  });
+
+  it("repeats PULSE waveforms with edges", () => {
+    const waveform = new PulseWaveform(0.0, 5.0, 0.0, 0.2, 0.2, 0.4, 1.0);
+
+    expectClose(waveform.valueAt(0.1), 2.5);
+    expectClose(waveform.valueAt(0.3), 5.0);
+    expectClose(waveform.valueAt(0.7), 2.5);
+    expectClose(waveform.valueAt(1.3), 5.0);
+  });
+
+  it("uses a PULSE waveform on a transient current source", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      currentSourceWithWaveform(
+        "Iin",
+        "0",
+        "out",
+        0.0,
+        new PulseWaveform(0.0, 0.01, 0.0, 0.0, 0.0, 0.5, 1.0),
+      ),
+    );
+    circuit.add(resistor("Rload", "out", "0", 100.0));
+
+    const points = transient(circuit, 0.25, 0.75);
+
+    expectClose(points[0].voltage("out"), 1.0);
+    expectClose(points[1].voltage("out"), 0.0);
+    expectClose(points[2].voltage("out"), 0.0);
+  });
+
+  it("rises and falls EXP waveforms", () => {
+    const waveform = new ExpWaveform(0.0, 2.0, 0.0, 0.5, 1.0, 0.5);
+
+    const rising = waveform.valueAt(0.5);
+    const falling = waveform.valueAt(2.0);
+
+    expect(rising).toBeGreaterThan(0.0);
+    expect(rising).toBeLessThan(2.0);
+    expect(falling).toBeLessThan(rising);
+  });
+
+  it("uses an EXP waveform on a transient voltage source", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "Vin",
+        "in",
+        "0",
+        0.0,
+        new ExpWaveform(0.0, 1.0, 0.0, 0.5, 10.0, 1.0),
+      ),
+    );
+    circuit.add(resistor("Rload", "in", "0", 1_000.0));
+
+    const points = transient(circuit, 0.5, 1.0);
+
+    expectClose(points[0].voltage("in"), 1.0 - Math.exp(-1.0));
+    expectClose(points[1].voltage("in"), 1.0 - Math.exp(-2.0));
+  });
+
+  it("rejects invalid PWL waveforms during transient analysis", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "Vin",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [0.0, 1.0],
+        ]),
+      ),
+    );
+    circuit.add(resistor("Rload", "in", "0", 1_000.0));
+
+    expect(() => transient(circuit, 0.1, 0.1)).toThrowError(SpiceError);
+    expect(() => transient(circuit, 0.1, 0.1)).toThrowError(
+      "invalid element Vin",
     );
   });
 });


### PR DESCRIPTION
## Summary

- add PWL, SIN, PULSE, and EXP waveform classes for TypeScript SPICE sources
- let transient voltage/current sources evaluate waveform values at simulation time while DC/AC/TF/sensitivity keep static source values
- add focused DC and transient coverage plus README/changelog docs

## Validation

- sh BUILD
- git diff --check