### PR TITLE
feat(rust/x86_64-backend): cross-function calls + external relocations

### DIFF
--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog — `x86_64-backend`
 
+## 0.3.0 — 2026-05-14 (LANG43 phase 5 — calls + relocations)
+
+Adds cross-function `call` lowering and external relocation surfacing.
+
+**New CIR opcode:**
+
+- `call callee_name, arg0, …, argN` — argument marshalling into the
+  ABI's argument registers (System V: RDI/RSI/RDX/RCX/R8/R9 up to 6;
+  MS x64: RCX/RDX/R8/R9 up to 4), then `CALL rel32` to the callee, then
+  store RAX into the destination slot.
+  - Self-recursive calls (callee == current function) emit
+    `call_label(entry_label)` resolved within this function's bytes
+    by the encoder's fixup pass.
+  - Cross-function calls emit `call_rel32(callee_name, PltRel32)` and
+    record an external relocation for the AOT linker to patch after
+    all function bodies are concatenated.
+
+**New public function:**
+
+- `compile_function_with_relocs(ctx, ir, abi) -> (Vec<u8>, Vec<Reloc>)`
+  — returns both the function bytes and the list of external
+  relocations.  `compile_function` is unchanged for callers that
+  don't need them.
+
+Re-exports `x86_64_encoder::ExternalReloc as Reloc` for parity with
+`aarch64-backend`'s `Reloc` re-export.
+
 ## 0.2.0 — 2026-05-14 (LANG43 — LANG38-parity wave)
 
 Extends the V1 backend with the same opcodes `aarch64-backend` gained

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/README.md
+++ b/code/packages/rust/x86_64-backend/README.md
@@ -52,14 +52,14 @@ Matches the aarch64-backend baseline through LANG38:
 | Logical | `and_<ty>`, `or_<ty>`, `xor_<ty>`, `not_<ty>` |
 | Shifts | `shl_<ty>`, `shr_<ty>` (SAR for `i*`, SHR for `u*`) |
 | Unary | `neg_<ty>` |
+| Calls | `call callee_name, arg0, …, argN` — `CALL rel32` (self-recursive: label fixup; cross-function: `PltRel32` external reloc) |
 | Comparisons | `cmp_eq_<ty>`, `cmp_ne_<ty>`, `cmp_lt_<ty>`, `cmp_le_<ty>`, `cmp_gt_<ty>`, `cmp_ge_<ty>` (signed and unsigned) |
 | Control flow | `label`, `jmp`, `jmp_if_true`, `jmp_if_false` |
 | Returns | `ret_<ty>`, `ret_void` |
 | Moves | `mov_<ty>` |
 | Type guards | `type_assert` (lowered to `UD2` trap — AOT has no deopt) |
 
-Calls, globals, and `io_out` are added by subsequent waves
-(LANG43 phases 5–6).
+Globals and `io_out` are added by phase 6.
 
 ## Register allocation
 

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -58,7 +58,11 @@ use std::collections::HashMap;
 use jit_core::backend::{Backend, FunctionContext};
 use jit_core::cir::{CIRInstr, CIROperand};
 use vm_core::value::Value;
-use x86_64_encoder::{Assembler, Cond, EncodeError, LabelId, Reg};
+use x86_64_encoder::{
+    Assembler, Cond, EncodeError, ExternalReloc, ExternalRelocKind, LabelId, Reg,
+};
+
+pub use x86_64_encoder::ExternalReloc as Reloc;
 
 // ===========================================================================
 // ABI selection
@@ -158,11 +162,32 @@ impl Backend for X86_64Backend {
 /// Compile a single function with the given ABI.  Returns the
 /// function's machine-code bytes on success, or a diagnostic string on
 /// failure (for surfaceable errors from tests).
+///
+/// External relocations (cross-function calls, runtime helpers) are
+/// silently discarded.  Use [`compile_function_with_relocs`] when the
+/// AOT linker needs the relocation list.
 pub fn compile_function(
     ctx: &FunctionContext<'_>,
     ir: &[CIRInstr],
     abi: X86_64Abi,
 ) -> Result<Vec<u8>, String> {
+    compile_inner(ctx, ir, abi)
+        .map(|(bytes, _relocs)| bytes)
+        .map_err(|e| format!("x86_64-backend: {e:?}"))
+}
+
+/// Like [`compile_function`] but also returns the list of external
+/// relocations the AOT linker must patch after concatenating all
+/// function bodies into a single text section.
+///
+/// Each [`Reloc`] points at a 32-bit slot in the function's bytes
+/// (`patch_offset`) plus the symbol name and reloc kind the packager
+/// (LANG45) translates to an OS-specific relocation record.
+pub fn compile_function_with_relocs(
+    ctx: &FunctionContext<'_>,
+    ir: &[CIRInstr],
+    abi: X86_64Abi,
+) -> Result<(Vec<u8>, Vec<Reloc>), String> {
     compile_inner(ctx, ir, abi)
         .map_err(|e| format!("x86_64-backend: {e:?}"))
 }
@@ -228,7 +253,7 @@ fn compile_inner(
     ctx: &FunctionContext<'_>,
     ir: &[CIRInstr],
     abi: X86_64Abi,
-) -> Result<Vec<u8>, BackendError> {
+) -> Result<(Vec<u8>, Vec<ExternalReloc>), BackendError> {
     if ctx.params.len() > abi.max_args() {
         return Err(BackendError::TooManyParams {
             abi: match abi { X86_64Abi::SysV => "SysV", X86_64Abi::MsX64 => "MsX64" },
@@ -285,6 +310,23 @@ fn compile_inner(
                     .or_insert_with(|| asm.create_label());
             }
         }
+        // Self-recursive call: pre-create a label for the callee name so
+        // it can be bound at the function entry below.
+        if instr.op == "call" {
+            if let Some(CIROperand::Var(name)) = instr.srcs.first() {
+                labels.entry(name.clone())
+                    .or_insert_with(|| asm.create_label());
+            }
+        }
+    }
+
+    // Bind the current function's own name to the very start of the
+    // prologue.  `call <fn_name>` instructions in the body emit
+    // `call_label(entry_label)` which re-enters the function here,
+    // re-executing the full prologue (push rbp + spill args) for each
+    // new call frame.
+    if let Some(&entry_label) = labels.get(ctx.name) {
+        asm.bind(entry_label).map_err(BackendError::from)?;
     }
 
     // ---- Prologue ----------------------------------------------------------
@@ -304,14 +346,15 @@ fn compile_inner(
 
     // ---- Body --------------------------------------------------------------
     for instr in ir {
-        emit_instr(&mut asm, instr, &mut alloc, &labels, frame)?;
+        emit_instr(&mut asm, instr, &mut alloc, &labels, frame, ctx.name, abi)?;
     }
 
     // ---- Defensive epilogue (in case CIR falls off the end) ----------------
     emit_epilogue(&mut asm, frame);
 
+    let external_relocs = std::mem::take(&mut asm.external_relocs);
     let bytes = asm.finish().map_err(BackendError::from)?;
-    Ok(bytes)
+    Ok((bytes, external_relocs))
 }
 
 fn emit_epilogue(asm: &mut Assembler, _frame: u32) {
@@ -334,6 +377,8 @@ fn emit_instr(
     alloc: &mut RegAlloc,
     labels: &HashMap<String, LabelId>,
     frame: u32,
+    fn_name: &str,
+    abi: X86_64Abi,
 ) -> Result<(), BackendError> {
     let op = instr.op.as_str();
 
@@ -437,6 +482,57 @@ fn emit_instr(
         let (rel, signed) = parse_cmp_suffix(rest)
             .ok_or_else(|| BackendError::MalformedInstr(format!("bad cmp mnemonic: {op}")))?;
         return emit_cmp(asm, alloc, instr, rel, signed);
+    }
+
+    // --- call callee_name, arg0, ..., argN ---
+    //
+    // CIR encoding: srcs[0] = Var(callee_name), srcs[1..] = arguments.
+    // The dest slot (if any) receives the return value from RAX.
+    //
+    // Self-recursive calls (callee == fn_name) emit `call_label(entry_label)`
+    // resolved within this function's bytes; cross-function calls emit
+    // `call_rel32(callee_name, PltRel32)` and rely on the AOT linker to
+    // patch the displacement once all function bodies are concatenated.
+    if op == "call" {
+        let callee_name = match instr.srcs.first() {
+            Some(CIROperand::Var(name)) => name.as_str(),
+            _ => return Err(BackendError::MalformedInstr(
+                "call: srcs[0] must be Var(function_name)".into(),
+            )),
+        };
+        let arg_srcs = &instr.srcs[1..];
+        if arg_srcs.len() > abi.max_args() {
+            return Err(BackendError::UnsupportedOp(format!(
+                "call: too many arguments ({}) for {:?} ABI — max {}",
+                arg_srcs.len(), abi, abi.max_args()
+            )));
+        }
+
+        // Load each argument from its stack slot into the ABI's arg register.
+        // With stack-spill allocation, all values are already on the stack,
+        // so loading left-to-right is correct — no aliasing between an arg's
+        // source slot and another arg's destination register.
+        let arg_regs = abi.arg_regs();
+        for (i, src) in arg_srcs.iter().enumerate() {
+            load_operand(asm, alloc, arg_regs[i], src);
+        }
+
+        // Emit the call itself.
+        if callee_name == fn_name {
+            let target_id = *labels.get(callee_name).ok_or_else(|| {
+                BackendError::MalformedInstr(format!("call: no label for '{callee_name}'"))
+            })?;
+            asm.call_label(target_id);
+        } else {
+            asm.call_rel32(callee_name, ExternalRelocKind::PltRel32);
+        }
+
+        // Save the return value from RAX into the destination slot.
+        if let Some(dest) = &instr.dest {
+            let slot = alloc.slot_of(dest);
+            asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+        }
+        return Ok(());
     }
 
     // --- LANG38-parity additions ---
@@ -1152,6 +1248,83 @@ mod tests {
         ];
         let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
         assert!(body_contains(&bytes, &[0x48, 0xF7, 0xD8]), "neg rax missing");
+    }
+
+    // ---- Calls ----
+
+    #[test]
+    fn fn_call_external_records_reloc() {
+        // fn caller() -> u64 { return external(42); }
+        // CIR: const_u64 v0=42; call external, v0 → r; ret_u64 r
+        let ctx = fn_ctx("caller", &[], "u64");
+        let ir = vec![
+            instr("const_u64", Some("v0"), vec![Op::Int(42)]),
+            instr("call", Some("r"),
+                  vec![Op::Var("external".into()), Op::Var("v0".into())]),
+            instr("ret_u64", None, vec![Op::Var("r".into())]),
+        ];
+        let (bytes, relocs) = compile_function_with_relocs(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // Must contain `mov rdi, [rbp-...]` (System V arg 0)
+        // and `call rel32` (E8 ?? ?? ?? ??) with a recorded reloc.
+        assert!(body_contains(&bytes, &[0xE8]),
+                "expected `call rel32` opcode (E8) in {bytes:02X?}");
+        assert_eq!(relocs.len(), 1, "expected exactly one external reloc");
+        assert_eq!(relocs[0].symbol, "external");
+        assert_eq!(relocs[0].kind, ExternalRelocKind::PltRel32);
+        assert_eq!(relocs[0].addend, -4);
+    }
+
+    #[test]
+    fn fn_self_recursive_call_no_reloc() {
+        // fn fact(n: u64) -> u64 { return fact(n); }  (degenerate but tests the wiring)
+        // CIR: call fact, n → r; ret_u64 r
+        let params = vec![("n".to_string(), "u64".to_string())];
+        let ctx = fn_ctx("fact", &params, "u64");
+        let ir = vec![
+            instr("call", Some("r"),
+                  vec![Op::Var("fact".into()), Op::Var("n".into())]),
+            instr("ret_u64", None, vec![Op::Var("r".into())]),
+        ];
+        let (bytes, relocs) = compile_function_with_relocs(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // Self-recursive: no external relocation.
+        assert!(relocs.is_empty(),
+                "self-recursive call should not record external reloc, got {relocs:?}");
+        // Must contain a CALL opcode (E8).
+        assert!(body_contains(&bytes, &[0xE8]),
+                "expected `call rel32` opcode (E8) in {bytes:02X?}");
+    }
+
+    #[test]
+    fn fn_call_msx64_loads_into_rcx() {
+        // MS x64: arg 0 → RCX, not RDI.
+        let ctx = fn_ctx("caller", &[], "u64");
+        let ir = vec![
+            instr("const_u64", Some("v0"), vec![Op::Int(42)]),
+            instr("call", Some("r"),
+                  vec![Op::Var("external".into()), Op::Var("v0".into())]),
+            instr("ret_u64", None, vec![Op::Var("r".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::MsX64).unwrap();
+        // Look for `mov rcx, [rbp-disp]` — encoded as 48 8B 8D .. .. .. ..
+        assert!(body_contains(&bytes, &[0x48, 0x8B, 0x8D]),
+                "expected `mov rcx, [rbp+disp32]` in MS x64 call setup");
+        // And NOT `mov rdi, [rbp-disp]` (48 8B BD) — the SysV arg-0 load.
+        assert!(!body_contains(&bytes, &[0x48, 0x8B, 0xBD]),
+                "should NOT emit `mov rdi, ...` on MS x64");
+    }
+
+    #[test]
+    fn fn_call_too_many_args_msx64() {
+        // 5 args > 4 GPR slots on MS x64.
+        let ctx = fn_ctx("caller", &[], "u64");
+        let mut srcs = vec![Op::Var("external".into())];
+        for i in 0..5 { srcs.push(Op::Int(i)); }
+        let ir = vec![
+            instr("call", Some("r"), srcs),
+            instr("ret_u64", None, vec![Op::Var("r".into())]),
+        ];
+        let result = compile_function(&ctx, &ir, X86_64Abi::MsX64);
+        assert!(result.is_err(), "expected `too many args` error");
     }
 
     #[test]

--- a/code/packages/rust/x86_64-encoder/CHANGELOG.md
+++ b/code/packages/rust/x86_64-encoder/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — `x86_64-encoder`
 
+## 0.2.0 — 2026-05-14 (LANG43 phase 5 — calls)
+
+Added `call_label(LabelId)` — `CALL rel32` to an internal label,
+resolved at `finish()` time exactly like `jmp` / `jcc`.  Used by
+`x86_64-backend` for self-recursive calls where the callee lives at
+a label inside the same function's bytes; cross-function calls
+continue to use `call_rel32(symbol, kind)` with an external
+relocation.
+
 ## 0.1.0 — 2026-05-14 (LANG44)
 
 Initial release.  Covers the V1 instruction set from LANG44:

--- a/code/packages/rust/x86_64-encoder/Cargo.toml
+++ b/code/packages/rust/x86_64-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-encoder"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Pure-Rust x86-64 (AMD64 / Intel 64) instruction encoder — covers the subset needed by jit-core / aot-core to lower CIR to native machine code on Linux and Windows."
 

--- a/code/packages/rust/x86_64-encoder/src/lib.rs
+++ b/code/packages/rust/x86_64-encoder/src/lib.rs
@@ -719,6 +719,21 @@ impl Assembler {
         });
     }
 
+    /// `CALL rel32` to an *internal* label (same `.text` section).
+    /// Opcode `0xE8 cd`.  Used for self-recursive calls where the
+    /// callee is bound to a label inside this function's bytes; the
+    /// displacement is resolved at [`Assembler::finish`] time exactly
+    /// like a [`Assembler::jmp`].
+    ///
+    /// 5 bytes total.
+    pub fn call_label(&mut self, target: LabelId) {
+        self.emit_u8(0xE8);
+        let slot_offset = self.code.len();
+        self.emit_u32_le(0);
+        let instr_end_offset = self.code.len();
+        self.fixups.push(Fixup { slot_offset, instr_end_offset, target });
+    }
+
     /// `CALL r/m64` — indirect call through a register.  Opcode
     /// `0xFF /2`.
     pub fn call_r64(&mut self, target: Reg) {
@@ -1111,6 +1126,23 @@ mod tests {
         assert_eq!(relocs[0].kind, ExternalRelocKind::PltRel32);
         assert_eq!(relocs[0].addend, -4);
         assert_eq!(relocs[0].patch_offset, 1);
+    }
+
+    #[test]
+    fn call_label_back_edge() {
+        // bind(top); nop                      → 90       (top = offset 0)
+        // call top                            → E8 ?? ?? ?? ??   (rel32 from instr end)
+        let mut a = Assembler::new();
+        let top = a.create_label();
+        a.bind(top).unwrap();
+        a.nop();
+        a.call_label(top);
+        let bytes = finish(a);
+        // Bytes: 90 E8 disp32
+        assert_eq!(&bytes[..2], &[0x90, 0xE8]);
+        let disp = i32::from_le_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]);
+        // Instruction ends at byte 6; target is byte 0 → delta = -6.
+        assert_eq!(disp, -6);
     }
 
     #[test]


### PR DESCRIPTION
## Phase 5 of the x86-64 port to Linux + Windows

Implements [LANG43](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/LANG43-x86_64-backend.md) §calls: the `call` CIR opcode with both self-recursive and cross-function paths. Mirrors `aarch64-backend`'s `bl(label)` / `bl_external(name)` distinction.

## Summary

[`x86_64-encoder`](code/packages/rust/x86_64-encoder/) 0.2.0:
- New `call_label(LabelId)` — `CALL rel32` to an internal label, resolved by the encoder's fixup pass exactly like `jmp` / `jcc`.

[`x86_64-backend`](code/packages/rust/x86_64-backend/) 0.3.0:
- New `call` CIR opcode lowering:
  - Self-recursive (`callee == fn_name`): `call_label(entry_label)`. Entry label binds at the start of the prologue, so the callee re-executes `push rbp` + arg spilling for each new frame — matching `aarch64-backend`'s bl-self-label shape.
  - Cross-function: `call_rel32(callee_name, PltRel32)` records an `ExternalReloc` for the AOT linker to patch.
- Argument marshalling per ABI:
  - **System V**: RDI, RSI, RDX, RCX, R8, R9 — ≤ 6 args
  - **MS x64**: RCX, RDX, R8, R9 — ≤ 4 args
  - Exceeding → `BackendError::UnsupportedOp` → backend refused → caller falls back to interpreter (matches aarch64-backend behaviour).
- Return value flows RAX → dest slot.
- New `compile_function_with_relocs(ctx, ir, abi)` public entry point alongside the existing `compile_function`. Re-exports `Reloc` for parity with `aarch64-backend`.

## Test plan

- [x] 27 backend + 40 encoder tests pass on Windows host (was 23+39)
- [x] External call records exactly one `PltRel32` reloc with the right symbol name and `-4` addend
- [x] Self-recursive call records ZERO external relocs (internal fixup only)
- [x] MS x64 call site loads arg 0 into RCX, not RDI (byte-exact golden test)
- [x] Too-many-args error at 5+ args on MS x64 (4-arg ABI limit)
- [x] Encoder `call_label` back-edge correctly resolves rel32 displacement
- [x] `cargo clippy --no-deps -- -D warnings` clean on both crates

CI will additionally verify on `ubuntu-latest`, `macos-latest`, `windows-latest`.

## Next phases

| # | Branch | Scope |
|---|---|---|
| 6 | `feat/x86_64-backend-io` | globals + `io_out` (LANG39/40 parity) |
| 7 | `feat/x86_64-elf-object` | `code-packager::elf_object` |
| 8 | `feat/x86_64-pe-object` | `code-packager::pe_object` |
| 9 | `feat/x86_64-runtime-archives` | per-target runtime archives |
| 10 | `feat/x86_64-twig-aot-driver` | multi-target dispatch + Linux/Windows smoke tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)