### PR TITLE
python(spice): expand netlist subcircuits

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Add a first SPICE3 netlist parser slice for linear R/C/L circuits,
   independent V/I sources, VCCS elements, PWL/PULSE/SIN/EXP source waveforms,
   and `.op`, `.tran`, `.dc`, and `.ac` analysis cards.
+- Add first `.subckt` / `X` instance expansion for hierarchical netlists made
+  from supported primitive elements.

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -20,4 +20,5 @@ netlist.analyses
 
 This first parser slice supports `R`, `C`, `L`, `V`, `I`, and `G` elements,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
-and `.op`, `.tran`, `.dc`, and `.ac` analysis cards.
+`.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
+analysis cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -61,6 +61,20 @@ class AcAnalysis:
 type Analysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis
 
 
+@dataclass(frozen=True, slots=True)
+class _Statement:
+    line_number: int
+    fields: list[str]
+
+
+@dataclass(slots=True)
+class _SubcktDefinition:
+    name: str
+    pins: list[str]
+    body: list[_Statement] = field(default_factory=list)
+    line_number: int = 0
+
+
 @dataclass(slots=True)
 class ParsedNetlist:
     """Parsed SPICE3 netlist with an executable SPICE engine circuit."""
@@ -104,6 +118,9 @@ def parse_netlist(text: str) -> ParsedNetlist:
     """Parse SPICE3 netlist text into a :class:`ParsedNetlist`."""
 
     parsed = ParsedNetlist()
+    statements: list[_Statement] = []
+    subckts: dict[str, _SubcktDefinition] = {}
+    current_subckt: _SubcktDefinition | None = None
     saw_content = False
     for line_number, raw_line in enumerate(text.splitlines(), start=1):
         stripped = raw_line.strip()
@@ -119,15 +136,47 @@ def parse_netlist(text: str) -> ParsedNetlist:
         if not fields:
             continue
         head = fields[0]
-        if head.lower() == ".end":
-            break
+        head_lower = head.lower()
+
         try:
-            if head.startswith("."):
-                parsed.analyses.append(_parse_directive(fields))
-            else:
-                parsed.circuit.add(_parse_element(fields))
+            if current_subckt is not None:
+                if head_lower == ".ends":
+                    _finish_subckt(current_subckt, fields)
+                    subckts[current_subckt.name.lower()] = current_subckt
+                    current_subckt = None
+                elif head_lower == ".subckt":
+                    raise NetlistParseError("nested .subckt definitions are not supported")
+                else:
+                    current_subckt.body.append(_Statement(line_number, fields))
+                continue
+            if head_lower == ".subckt":
+                current_subckt = _start_subckt(fields, line_number, subckts)
+                continue
+            if head_lower == ".ends":
+                raise NetlistParseError(".ends without matching .subckt")
         except NetlistParseError as exc:
             raise NetlistParseError(f"line {line_number}: {exc}") from exc
+
+        if head_lower == ".end":
+            break
+        statements.append(_Statement(line_number, fields))
+
+    if current_subckt is not None:
+        raise NetlistParseError(
+            f"line {current_subckt.line_number}: .subckt {current_subckt.name!r} is missing .ends"
+        )
+
+    for statement in statements:
+        try:
+            if statement.fields[0].startswith("."):
+                parsed.analyses.append(_parse_directive(statement.fields))
+            elif statement.fields[0].upper().startswith("X"):
+                for element in _expand_subckt_instance(statement.fields, subckts, []):
+                    parsed.circuit.add(element)
+            else:
+                parsed.circuit.add(_parse_element(statement.fields))
+        except NetlistParseError as exc:
+            raise NetlistParseError(f"line {statement.line_number}: {exc}") from exc
     return parsed
 
 
@@ -145,7 +194,7 @@ def parse_value(token: str) -> float:
 
 def _parse_element(fields: list[str]) -> object:
     name = fields[0]
-    prefix = name[0].upper()
+    prefix = _element_prefix(name)
     if prefix == "R":
         _require_fields(fields, 4, "resistor")
         return Resistor(name, fields[1], fields[2], parse_value(fields[3]))
@@ -167,6 +216,103 @@ def _parse_element(fields: list[str]) -> object:
         _require_fields(fields, 6, "VCCS")
         return VCCS(name, fields[1], fields[2], fields[3], fields[4], parse_value(fields[5]))
     raise NetlistParseError(f"unsupported element {name!r}")
+
+
+def _start_subckt(
+    fields: list[str], line_number: int, subckts: dict[str, _SubcktDefinition]
+) -> _SubcktDefinition:
+    _require_min_fields(fields, 3, ".subckt")
+    name = fields[1]
+    key = name.lower()
+    if key in subckts:
+        raise NetlistParseError(f"duplicate .subckt definition {name!r}")
+    return _SubcktDefinition(name=name, pins=fields[2:], line_number=line_number)
+
+
+def _finish_subckt(definition: _SubcktDefinition, fields: list[str]) -> None:
+    if len(fields) > 2:
+        raise NetlistParseError(".ends expects at most a subcircuit name")
+    if len(fields) == 2 and fields[1].lower() != definition.name.lower():
+        raise NetlistParseError(
+            f".ends {fields[1]!r} does not match .subckt {definition.name!r}"
+        )
+
+
+def _expand_subckt_instance(
+    fields: list[str],
+    subckts: dict[str, _SubcktDefinition],
+    stack: list[str],
+) -> list[object]:
+    _require_min_fields(fields, 3, "subcircuit instance")
+    instance_name = fields[0]
+    subckt_name = fields[-1]
+    definition = subckts.get(subckt_name.lower())
+    if definition is None:
+        raise NetlistParseError(f"unknown subcircuit {subckt_name!r}")
+    if definition.name.lower() in stack:
+        cycle = " -> ".join([*stack, definition.name.lower()])
+        raise NetlistParseError(f"recursive subcircuit expansion is not supported: {cycle}")
+
+    actual_nodes = fields[1:-1]
+    if len(actual_nodes) != len(definition.pins):
+        raise NetlistParseError(
+            f"subcircuit {definition.name!r} expects {len(definition.pins)} pins, "
+            f"got {len(actual_nodes)}"
+        )
+
+    node_map = {pin: actual for pin, actual in zip(definition.pins, actual_nodes, strict=True)}
+    node_map.update(
+        {pin.lower(): actual for pin, actual in zip(definition.pins, actual_nodes, strict=True)}
+    )
+    elements: list[object] = []
+    next_stack = [*stack, definition.name.lower()]
+    for statement in definition.body:
+        if statement.fields[0].startswith("."):
+            raise NetlistParseError(
+                f"line {statement.line_number}: directives inside .subckt are not supported"
+            )
+        local_fields = _map_subckt_fields(statement.fields, instance_name, node_map)
+        if _element_prefix(statement.fields[0]) == "X":
+            elements.extend(_expand_subckt_instance(local_fields, subckts, next_stack))
+        else:
+            elements.append(_parse_element(local_fields))
+    return elements
+
+
+def _map_subckt_fields(
+    fields: list[str], instance_name: str, node_map: dict[str, str]
+) -> list[str]:
+    name = f"{instance_name}.{fields[0]}"
+    prefix = fields[0][0].upper()
+    mapped = [name, *fields[1:]]
+    if prefix in {"R", "C", "L", "V", "I"}:
+        _require_min_fields(fields, 3, "subcircuit element")
+        mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
+        mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)
+    elif prefix == "G":
+        _require_min_fields(fields, 5, "subcircuit VCCS")
+        for index in range(1, 5):
+            mapped[index] = _map_subckt_node(fields[index], instance_name, node_map)
+    elif prefix == "X":
+        mapped[1:-1] = [
+            _map_subckt_node(node, instance_name, node_map) for node in fields[1:-1]
+        ]
+    return mapped
+
+
+def _map_subckt_node(node: str, instance_name: str, node_map: dict[str, str]) -> str:
+    if node.lower() in {"0", "gnd"}:
+        return node
+    if node in node_map:
+        return node_map[node]
+    if node.lower() in node_map:
+        return node_map[node.lower()]
+    return f"{instance_name}.{node}"
+
+
+def _element_prefix(name: str) -> str:
+    local_name = name.rsplit(".", 1)[-1]
+    return local_name[0].upper()
 
 
 def _parse_source_value(fields: list[str]) -> tuple[float, Waveform | None]:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -85,6 +85,53 @@ I1 in 0 SIN(0 2m 1k 10u 5)
     assert isclose(current.waveform(1.0e-6), 0.0, abs_tol=1e-12)
 
 
+def test_expands_subcircuit_instances_into_engine_elements() -> None:
+    parsed = parse_netlist(
+        """
+.subckt divider top mid bot
+Rtop top mid 1k
+Rbot mid bot 1k
+.ends divider
+V1 vin 0 DC 10
+Xdiv vin mid 0 divider
+.op
+"""
+    )
+
+    assert [element.name for element in parsed.circuit.elements] == [
+        "V1",
+        "Xdiv.Rtop",
+        "Xdiv.Rbot",
+    ]
+    assert isinstance(parsed.circuit.elements[1], Resistor)
+    assert parsed.circuit.elements[1].n_plus == "vin"
+    assert parsed.circuit.elements[1].n_minus == "mid"
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert isclose(result.node_voltages["mid"], 5.0, abs_tol=1e-9)
+
+
+def test_subcircuit_internal_nodes_are_instance_scoped() -> None:
+    parsed = parse_netlist(
+        """
+.subckt load in out
+R1 in inner 1k
+C1 inner out 1u
+.ends load
+Xleft a b load
+Xright c d load
+"""
+    )
+
+    left_resistor = parsed.circuit.elements[0]
+    right_resistor = parsed.circuit.elements[2]
+    assert isinstance(left_resistor, Resistor)
+    assert isinstance(right_resistor, Resistor)
+    assert left_resistor.n_minus == "Xleft.inner"
+    assert right_resistor.n_minus == "Xright.inner"
+
+
 def test_engineering_suffixes() -> None:
     assert parse_value("1k") == 1.0e3
     assert parse_value("2.2meg") == 2.2e6
@@ -104,3 +151,8 @@ D1 a 0 diode
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")
+
+
+def test_rejects_unknown_subcircuit_instance() -> None:
+    with pytest.raises(NetlistParseError, match="line 1: unknown subcircuit 'missing'"):
+        parse_netlist("X1 a b missing\n")


### PR DESCRIPTION
## Summary

- add first `.subckt` / `X` instance expansion to the Python SPICE netlist parser
- scope subcircuit internal nodes and element names per instance while preserving external pins and ground aliases
- cover executable resistor-divider expansion, internal-node isolation across instances, and unknown subcircuit errors

## Validation

- sh BUILD
- uv pip install ruff --quiet && .venv/bin/python -m ruff check .
- git diff --check