### PR TITLE
typescript(spice): expand netlist subcircuits

### DIFF
--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Add a first SPICE3 netlist parser slice for linear R/C/L circuits,
   independent V/I sources, VCCS elements, PWL/PULSE/SIN/EXP source waveforms,
   and `.op`, `.tran`, `.dc`, and `.ac` analysis cards.
+- Add first `.subckt` / `X` instance expansion for hierarchical netlists made
+  from supported primitive elements.

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -21,4 +21,5 @@ netlist.analyses;
 
 This first parser slice supports `R`, `C`, `L`, `V`, `I`, and `G` elements,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
-and `.op`, `.tran`, `.dc`, and `.ac` analysis cards.
+`.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
+analysis cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -76,6 +76,18 @@ export class ParsedNetlist {
   }
 }
 
+interface Statement {
+  readonly lineNumber: number;
+  readonly fields: string[];
+}
+
+interface SubcktDefinition {
+  readonly name: string;
+  readonly pins: string[];
+  readonly body: Statement[];
+  readonly lineNumber: number;
+}
+
 const VALUE_RE = /^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)([a-zA-Z]*)\s*$/;
 const SUFFIXES = new Map<string, number>([
   ["t", 1.0e12],
@@ -93,6 +105,9 @@ const SUFFIXES = new Map<string, number>([
 export function parseNetlist(text: string): ParsedNetlist {
   const circuit = new Circuit();
   const analyses: Analysis[] = [];
+  const statements: Statement[] = [];
+  const subckts = new Map<string, SubcktDefinition>();
+  let currentSubckt: SubcktDefinition | undefined;
   let title: string | undefined;
   let sawContent = false;
 
@@ -123,17 +138,57 @@ export function parseNetlist(text: string): ParsedNetlist {
       continue;
     }
     const head = fields[0];
-    if (head.toLowerCase() === ".end") {
-      break;
-    }
+    const headLower = head.toLowerCase();
+
     try {
-      if (head.startsWith(".")) {
-        analyses.push(parseDirective(fields));
-      } else {
-        circuit.add(parseElement(fields));
+      if (currentSubckt !== undefined) {
+        if (headLower === ".ends") {
+          finishSubckt(currentSubckt, fields);
+          subckts.set(currentSubckt.name.toLowerCase(), currentSubckt);
+          currentSubckt = undefined;
+        } else if (headLower === ".subckt") {
+          throw new NetlistParseError("nested .subckt definitions are not supported");
+        } else {
+          currentSubckt.body.push({ lineNumber, fields });
+        }
+        continue;
+      }
+      if (headLower === ".subckt") {
+        currentSubckt = startSubckt(fields, lineNumber, subckts);
+        continue;
+      }
+      if (headLower === ".ends") {
+        throw new NetlistParseError(".ends without matching .subckt");
       }
     } catch (error) {
       throw lineError(lineNumber, error);
+    }
+
+    if (headLower === ".end") {
+      break;
+    }
+    statements.push({ lineNumber, fields });
+  }
+
+  if (currentSubckt !== undefined) {
+    throw new NetlistParseError(
+      `line ${currentSubckt.lineNumber}: .subckt ${JSON.stringify(currentSubckt.name)} is missing .ends`,
+    );
+  }
+
+  for (const statement of statements) {
+    try {
+      if (statement.fields[0].startsWith(".")) {
+        analyses.push(parseDirective(statement.fields));
+      } else if (statement.fields[0].toUpperCase().startsWith("X")) {
+        for (const element of expandSubcktInstance(statement.fields, subckts, [])) {
+          circuit.add(element);
+        }
+      } else {
+        circuit.add(parseElement(statement.fields));
+      }
+    } catch (error) {
+      throw lineError(statement.lineNumber, error);
     }
   }
 
@@ -157,7 +212,7 @@ export function parseValue(token: string): number {
 
 function parseElement(fields: readonly string[]): Element {
   const name = fields[0];
-  const prefix = name[0].toUpperCase();
+  const prefix = elementPrefix(name);
   if (prefix === "R") {
     requireFields(fields, 4, "resistor");
     return resistor(name, fields[1], fields[2], parseValue(fields[3]));
@@ -189,6 +244,118 @@ function parseElement(fields: readonly string[]): Element {
     return vccs(name, fields[1], fields[2], fields[3], fields[4], parseValue(fields[5]));
   }
   throw new NetlistParseError(`unsupported element ${JSON.stringify(name)}`);
+}
+
+function startSubckt(
+  fields: readonly string[],
+  lineNumber: number,
+  subckts: ReadonlyMap<string, SubcktDefinition>,
+): SubcktDefinition {
+  requireMinFields(fields, 3, ".subckt");
+  const name = fields[1];
+  if (subckts.has(name.toLowerCase())) {
+    throw new NetlistParseError(`duplicate .subckt definition ${JSON.stringify(name)}`);
+  }
+  return { name, pins: fields.slice(2), body: [], lineNumber };
+}
+
+function finishSubckt(definition: SubcktDefinition, fields: readonly string[]): void {
+  if (fields.length > 2) {
+    throw new NetlistParseError(".ends expects at most a subcircuit name");
+  }
+  if (fields.length === 2 && fields[1].toLowerCase() !== definition.name.toLowerCase()) {
+    throw new NetlistParseError(
+      `.ends ${JSON.stringify(fields[1])} does not match .subckt ${JSON.stringify(definition.name)}`,
+    );
+  }
+}
+
+function expandSubcktInstance(
+  fields: readonly string[],
+  subckts: ReadonlyMap<string, SubcktDefinition>,
+  stack: readonly string[],
+): Element[] {
+  requireMinFields(fields, 3, "subcircuit instance");
+  const instanceName = fields[0];
+  const subcktName = fields[fields.length - 1];
+  const definition = subckts.get(subcktName.toLowerCase());
+  if (definition === undefined) {
+    throw new NetlistParseError(`unknown subcircuit ${JSON.stringify(subcktName)}`);
+  }
+  if (stack.includes(definition.name.toLowerCase())) {
+    const cycle = [...stack, definition.name.toLowerCase()].join(" -> ");
+    throw new NetlistParseError(`recursive subcircuit expansion is not supported: ${cycle}`);
+  }
+
+  const actualNodes = fields.slice(1, -1);
+  if (actualNodes.length !== definition.pins.length) {
+    throw new NetlistParseError(
+      `subcircuit ${JSON.stringify(definition.name)} expects ${definition.pins.length} pins, got ${actualNodes.length}`,
+    );
+  }
+
+  const nodeMap = new Map<string, string>();
+  for (let index = 0; index < definition.pins.length; index++) {
+    nodeMap.set(definition.pins[index], actualNodes[index]);
+    nodeMap.set(definition.pins[index].toLowerCase(), actualNodes[index]);
+  }
+
+  const elements: Element[] = [];
+  const nextStack = [...stack, definition.name.toLowerCase()];
+  for (const statement of definition.body) {
+    if (statement.fields[0].startsWith(".")) {
+      throw new NetlistParseError(
+        `line ${statement.lineNumber}: directives inside .subckt are not supported`,
+      );
+    }
+    const localFields = mapSubcktFields(statement.fields, instanceName, nodeMap);
+    if (elementPrefix(statement.fields[0]) === "X") {
+      elements.push(...expandSubcktInstance(localFields, subckts, nextStack));
+    } else {
+      elements.push(parseElement(localFields));
+    }
+  }
+  return elements;
+}
+
+function mapSubcktFields(
+  fields: readonly string[],
+  instanceName: string,
+  nodeMap: ReadonlyMap<string, string>,
+): string[] {
+  const mapped = [`${instanceName}.${fields[0]}`, ...fields.slice(1)];
+  const prefix = fields[0][0].toUpperCase();
+  if (["R", "C", "L", "V", "I"].includes(prefix)) {
+    requireMinFields(fields, 3, "subcircuit element");
+    mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
+    mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);
+  } else if (prefix === "G") {
+    requireMinFields(fields, 5, "subcircuit VCCS");
+    for (let index = 1; index < 5; index++) {
+      mapped[index] = mapSubcktNode(fields[index], instanceName, nodeMap);
+    }
+  } else if (prefix === "X") {
+    for (let index = 1; index < fields.length - 1; index++) {
+      mapped[index] = mapSubcktNode(fields[index], instanceName, nodeMap);
+    }
+  }
+  return mapped;
+}
+
+function mapSubcktNode(
+  node: string,
+  instanceName: string,
+  nodeMap: ReadonlyMap<string, string>,
+): string {
+  if (node.toLowerCase() === "0" || node.toLowerCase() === "gnd") {
+    return node;
+  }
+  return nodeMap.get(node) ?? nodeMap.get(node.toLowerCase()) ?? `${instanceName}.${node}`;
+}
+
+function elementPrefix(name: string): string {
+  const localName = name.split(".").at(-1) ?? name;
+  return localName[0].toUpperCase();
 }
 
 function parseSourceValue(fields: readonly string[]): readonly [number, Waveform | undefined] {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -75,6 +75,54 @@ I1 in 0 SIN(0 2m 1k 10u 5)
     expect(current.waveform?.valueAt(1.0e-6)).toBeCloseTo(0.0, 12);
   });
 
+  it("expands subcircuit instances into engine elements", () => {
+    const parsed = parseNetlist(`
+.subckt divider top mid bot
+Rtop top mid 1k
+Rbot mid bot 1k
+.ends divider
+V1 vin 0 DC 10
+Xdiv vin mid 0 divider
+.op
+`);
+
+    const elements = parsed.circuit.elements();
+    expect(elements.map((element) => element.name)).toEqual([
+      "V1",
+      "Xdiv.Rtop",
+      "Xdiv.Rbot",
+    ]);
+    expect(elements[1]).toMatchObject({
+      kind: "resistor",
+      n1: "vin",
+      n2: "mid",
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("mid")).toBeCloseTo(5.0, 9);
+  });
+
+  it("scopes subcircuit internal nodes by instance", () => {
+    const parsed = parseNetlist(`
+.subckt load in out
+R1 in inner 1k
+C1 inner out 1u
+.ends load
+Xleft a b load
+Xright c d load
+`);
+
+    const elements = parsed.circuit.elements();
+    expect(elements[0]).toMatchObject({
+      kind: "resistor",
+      n2: "Xleft.inner",
+    });
+    expect(elements[2]).toMatchObject({
+      kind: "resistor",
+      n2: "Xright.inner",
+    });
+  });
+
   it("parses engineering suffixes", () => {
     expect(parseValue("1k")).toBe(1.0e3);
     expect(parseValue("2.2meg")).toBe(2.2e6);
@@ -89,5 +137,11 @@ I1 in 0 SIN(0 2m 1k 10u 5)
 
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
+  });
+
+  it("rejects unknown subcircuit instances", () => {
+    expect(() => parseNetlist("X1 a b missing\n")).toThrow(
+      "line 1: unknown subcircuit \"missing\"",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add `.subckt` / `X` instance expansion to the TypeScript SPICE netlist parser
- scope subcircuit internal nodes and expanded element names per instance while preserving external pins and ground aliases
- cover executable resistor-divider expansion, internal-node isolation across instances, and unknown subcircuit errors

## Validation

- sh BUILD
- git diff --check