### PR TITLE
typescript(spice): add DC Monte Carlo analysis

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add seeded DC Monte Carlo analysis for linear element parameters with
+  Gaussian and uniform tolerance distributions.
 - Add PWL, SIN, PULSE, and EXP source waveforms for transient voltage and
   current sources while preserving static source values for DC, AC, transfer
   function, sensitivity, and sweep analyses.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -4,9 +4,10 @@
 primitives for TypeScript.
 
 The current slices implement DC operating-point analysis, DC source sweeps, DC
-sensitivity analysis, DC small-signal transfer-function analysis, AC
-small-signal frequency sweeps, and fixed-step RC/RL transient analysis for
-linear circuits using modified nodal analysis (MNA). The package supports
+sensitivity analysis, seeded DC Monte Carlo analysis, DC small-signal
+transfer-function analysis, AC small-signal frequency sweeps, and fixed-step
+RC/RL transient analysis for linear circuits using modified nodal analysis
+(MNA). The package supports
 resistors, capacitors, inductors, independent current sources, independent
 voltage sources, voltage-controlled current sources (VCCS), PWL/SIN/PULSE/EXP
 source waveforms for transient analysis, ground aliases, node voltages,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -289,6 +289,31 @@ export interface DcSweepPoint {
   readonly result: DcResult;
 }
 
+export type McDistribution = "gaussian" | "uniform";
+
+export interface McOptions {
+  readonly tolerance?: number;
+  readonly distribution?: McDistribution;
+  readonly seed?: number;
+}
+
+export interface McPoint {
+  readonly trial: number;
+  readonly nodeVoltages: ReadonlyMap<string, number>;
+  readonly branchCurrents: ReadonlyMap<string, number>;
+  readonly converged: boolean;
+  voltage(node: string): number | undefined;
+  branchCurrent(sourceName: string): number | undefined;
+}
+
+export interface McResult {
+  readonly outputNode: string;
+  readonly points: readonly McPoint[];
+  readonly nTrials: number;
+  readonly mean: number;
+  readonly stdDev: number;
+}
+
 export interface TfResult {
   readonly transferRatio: number;
   readonly inputImpedanceOhms: number;
@@ -520,6 +545,75 @@ export function dcSweep(
     points.push({ value, result: dcOp(swept) });
   }
   return points;
+}
+
+export function mcDc(
+  circuit: Circuit,
+  outputNode: string,
+  nTrials = 100,
+  options: McOptions = {},
+): McResult {
+  const nodeIndices = collectNodeIndices(circuit);
+  if (!isGround(outputNode) && !nodeIndices.has(outputNode)) {
+    throw invalidElement(outputNode, "output node was not found in circuit");
+  }
+  if (!Number.isInteger(nTrials) || nTrials < 1) {
+    throw invalidElement("mcDc", "nTrials must be a positive integer");
+  }
+
+  const tolerance = options.tolerance ?? 0.05;
+  const distribution = options.distribution ?? "gaussian";
+  if (!Number.isFinite(tolerance) || tolerance < 0.0) {
+    throw invalidElement("mcDc", "tolerance must be finite and non-negative");
+  }
+  if (distribution !== "gaussian" && distribution !== "uniform") {
+    throw invalidElement(
+      "mcDc",
+      "distribution must be 'gaussian' or 'uniform'",
+    );
+  }
+
+  const rng = seededRandom(options.seed);
+  const points: McPoint[] = [];
+
+  for (let trial = 0; trial < nTrials; trial++) {
+    const trialCircuit = circuitWithRandomizedElements(
+      circuit,
+      tolerance,
+      distribution,
+      rng,
+    );
+
+    try {
+      const result = dcOp(trialCircuit);
+      points.push(
+        makeMcPoint(
+          trial,
+          result.nodeVoltages,
+          result.branchCurrents,
+          true,
+        ),
+      );
+    } catch (error) {
+      if (error instanceof SpiceError && error.code === "SINGULAR_MATRIX") {
+        points.push(makeMcPoint(trial, new Map(), new Map(), false));
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  const convergedVoltages = points
+    .filter((point) => point.converged)
+    .map((point) => point.voltage(outputNode) ?? 0.0);
+
+  return makeMcResult(
+    outputNode,
+    points,
+    nTrials,
+    sampleMean(convergedVoltages),
+    sampleStdDev(convergedVoltages),
+  );
 }
 
 export function tf(
@@ -837,6 +931,117 @@ function circuitWithPerturbedElement(
   return perturbed;
 }
 
+type RandomSource = () => number;
+
+function seededRandom(seed: number | undefined): RandomSource {
+  if (seed === undefined) {
+    return Math.random;
+  }
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function randomizedValue(
+  nominalValue: number,
+  tolerance: number,
+  distribution: McDistribution,
+  rng: RandomSource,
+): number {
+  if (tolerance === 0.0) {
+    return nominalValue;
+  }
+  if (distribution === "uniform") {
+    return nominalValue * (1.0 + tolerance * (2.0 * rng() - 1.0));
+  }
+  return nominalValue * (1.0 + gaussian(rng) * tolerance / 3.0);
+}
+
+function gaussian(rng: RandomSource): number {
+  const u1 = Math.max(rng(), Number.MIN_VALUE);
+  const u2 = rng();
+  return Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(TWO_PI * u2);
+}
+
+function circuitWithRandomizedElements(
+  circuit: Circuit,
+  tolerance: number,
+  distribution: McDistribution,
+  rng: RandomSource,
+): Circuit {
+  const randomized = new Circuit();
+  for (const element of circuit.elements()) {
+    randomized.add(randomizedElement(element, tolerance, distribution, rng));
+  }
+  return randomized;
+}
+
+function randomizedElement(
+  element: Element,
+  tolerance: number,
+  distribution: McDistribution,
+  rng: RandomSource,
+): Element {
+  switch (element.kind) {
+    case "resistor":
+      return {
+        ...element,
+        resistanceOhms: randomizedValue(
+          element.resistanceOhms,
+          tolerance,
+          distribution,
+          rng,
+        ),
+      };
+    case "voltage-source":
+      return {
+        ...element,
+        voltage: randomizedValue(element.voltage, tolerance, distribution, rng),
+      };
+    case "current-source":
+      return {
+        ...element,
+        current: randomizedValue(element.current, tolerance, distribution, rng),
+      };
+    case "vccs":
+      return {
+        ...element,
+        transconductanceSiemens: randomizedValue(
+          element.transconductanceSiemens,
+          tolerance,
+          distribution,
+          rng,
+        ),
+      };
+    case "capacitor":
+    case "inductor":
+      return element;
+  }
+}
+
+function sampleMean(values: readonly number[]): number {
+  if (values.length === 0) {
+    return 0.0;
+  }
+  return values.reduce((sum, value) => sum + value, 0.0) / values.length;
+}
+
+function sampleStdDev(values: readonly number[]): number {
+  if (values.length < 2) {
+    return 0.0;
+  }
+  const mean = sampleMean(values);
+  const variance =
+    values.reduce((sum, value) => sum + (value - mean) ** 2, 0.0) /
+    (values.length - 1);
+  return Math.sqrt(variance);
+}
+
 interface CapacitorState {
   readonly name: string;
   previousVoltage: number;
@@ -1110,6 +1315,45 @@ function makeSensResult(
           candidate.parameter === parameter,
       );
     },
+  };
+}
+
+function makeMcPoint(
+  trial: number,
+  nodeVoltages: ReadonlyMap<string, number>,
+  branchCurrents: ReadonlyMap<string, number>,
+  converged: boolean,
+): McPoint {
+  return {
+    trial,
+    nodeVoltages,
+    branchCurrents,
+    converged,
+    voltage(node: string): number | undefined {
+      return isGround(node) ? 0.0 : nodeVoltages.get(node);
+    },
+    branchCurrent(sourceName: string): number | undefined {
+      const key = sourceName.startsWith("I(")
+        ? sourceName
+        : `I(${sourceName})`;
+      return branchCurrents.get(key);
+    },
+  };
+}
+
+function makeMcResult(
+  outputNode: string,
+  points: readonly McPoint[],
+  nTrials: number,
+  mean: number,
+  stdDev: number,
+): McResult {
+  return {
+    outputNode,
+    points,
+    nTrials,
+    mean,
+    stdDev,
   };
 }
 

--- a/code/packages/typescript/spice-engine/tests/mc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/mc.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  Circuit,
+  SpiceError,
+  currentSource,
+  mcDc,
+  resistor,
+  vccs,
+  voltageSource,
+} from "../src/index.js";
+
+function divider(): Circuit {
+  const circuit = new Circuit();
+  circuit.add(voltageSource("Vin", "in", "0", 10.0));
+  circuit.add(resistor("Rtop", "in", "mid", 1_000.0));
+  circuit.add(resistor("Rbot", "mid", "0", 1_000.0));
+  return circuit;
+}
+
+function voltages(result: ReturnType<typeof mcDc>): number[] {
+  return result.points.map((point) => point.voltage("mid") ?? Number.NaN);
+}
+
+describe("mcDc", () => {
+  it("returns trial-indexed operating points and zero spread at zero tolerance", () => {
+    const result = mcDc(divider(), "mid", 8, { seed: 7, tolerance: 0.0 });
+
+    expect(result.outputNode).toBe("mid");
+    expect(result.nTrials).toBe(8);
+    expect(result.points).toHaveLength(8);
+    expect(result.points.map((point) => point.trial)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7,
+    ]);
+    expect(result.points.every((point) => point.converged)).toBe(true);
+    expect(result.mean).toBeCloseTo(5.0, 12);
+    expect(result.stdDev).toBe(0.0);
+    for (const point of result.points) {
+      expect(point.voltage("mid")).toBeCloseTo(5.0, 12);
+      expect(point.voltage("0")).toBe(0.0);
+      expect(point.branchCurrent("Vin")).toBeDefined();
+    }
+  });
+
+  it("is reproducible with the same seed", () => {
+    const left = mcDc(divider(), "mid", 20, {
+      seed: 42,
+      tolerance: 0.05,
+      distribution: "uniform",
+    });
+    const right = mcDc(divider(), "mid", 20, {
+      seed: 42,
+      tolerance: 0.05,
+      distribution: "uniform",
+    });
+
+    expect(left.mean).toBe(right.mean);
+    expect(left.stdDev).toBe(right.stdDev);
+    expect(voltages(left)).toEqual(voltages(right));
+  });
+
+  it("uses different seeds for different trial vectors", () => {
+    const left = mcDc(divider(), "mid", 20, {
+      seed: 1,
+      tolerance: 0.05,
+      distribution: "uniform",
+    });
+    const right = mcDc(divider(), "mid", 20, {
+      seed: 2,
+      tolerance: 0.05,
+      distribution: "uniform",
+    });
+
+    expect(voltages(left)).not.toEqual(voltages(right));
+  });
+
+  it("reports a spread near the nominal divider voltage", () => {
+    const result = mcDc(divider(), "mid", 200, {
+      seed: 3,
+      tolerance: 0.05,
+      distribution: "gaussian",
+    });
+
+    expect(result.points.every((point) => point.converged)).toBe(true);
+    expect(result.mean).toBeGreaterThan(4.5);
+    expect(result.mean).toBeLessThan(5.5);
+    expect(result.stdDev).toBeGreaterThan(0.0);
+  });
+
+  it("varies current source and VCCS DC parameters", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vctrl", "ctrl", "0", 1.0));
+    circuit.add(vccs("Gm", "0", "out", "ctrl", "0", 1.0e-3));
+    circuit.add(currentSource("Ibias", "0", "out", 1.0e-3));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = mcDc(circuit, "out", 40, {
+      seed: 9,
+      tolerance: 0.05,
+      distribution: "uniform",
+    });
+
+    expect(result.mean).toBeGreaterThan(1.5);
+    expect(result.mean).toBeLessThan(2.5);
+    expect(result.stdDev).toBeGreaterThan(0.0);
+  });
+
+  it("rejects invalid inputs", () => {
+    const circuit = divider();
+
+    expect(() => mcDc(circuit, "missing")).toThrowError(SpiceError);
+    expect(() => mcDc(circuit, "missing")).toThrowError(
+      "output node was not found in circuit",
+    );
+    expect(() => mcDc(circuit, "mid", 0)).toThrowError(
+      "nTrials must be a positive integer",
+    );
+    expect(() =>
+      mcDc(circuit, "mid", 1, { tolerance: Number.NaN }),
+    ).toThrowError("tolerance must be finite and non-negative");
+    expect(() =>
+      mcDc(circuit, "mid", 1, { distribution: "triangular" as never }),
+    ).toThrowError("distribution must be 'gaussian' or 'uniform'");
+  });
+});


### PR DESCRIPTION
## Summary

- add `mcDc` with seeded Gaussian and uniform tolerance variation for linear DC parameters
- expose `McPoint`, `McResult`, and Monte Carlo options matching the existing TypeScript result style
- cover zero-tolerance, seed reproducibility, spread statistics, VCCS/current-source variation, and validation errors

## Validation

- sh BUILD
- git diff --check