### PR TITLE
rust(spice): add DC Monte Carlo analysis

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -8,6 +8,8 @@
   stages.
 - Add DC source sweeps for independent voltage and current sources.
 - Add DC sensitivity analysis for resistor and independent source parameters.
+- Add seeded DC Monte Carlo analysis for linear element parameters with
+  Gaussian and uniform tolerance distributions.
 - Add DC small-signal transfer-function analysis with input/output impedance.
 - Add AC small-signal frequency sweeps for linear RC/RL circuits.
 - Add backward-Euler transient analysis for linear RC circuits.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -9,6 +9,8 @@ The initial slices implement:
 - DC source sweeps over independent voltage and current sources.
 - DC sensitivity analysis for output-node voltage changes with respect to
   resistor and independent source parameters.
+- Seeded DC Monte Carlo analysis for linear element tolerances with Gaussian
+  and uniform distributions.
 - DC small-signal transfer-function (`.tf`) analysis with input and output
   impedance estimates.
 - AC small-signal frequency sweeps for linear RC/RL circuits.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -564,6 +564,65 @@ pub struct DcSweepPoint {
     pub result: DcResult,
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum McDistribution {
+    Gaussian,
+    Uniform,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct McOptions {
+    pub tolerance: f64,
+    pub distribution: McDistribution,
+    pub seed: Option<u64>,
+}
+
+impl Default for McOptions {
+    fn default() -> Self {
+        Self {
+            tolerance: 0.05,
+            distribution: McDistribution::Gaussian,
+            seed: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct McPoint {
+    pub trial: usize,
+    pub node_voltages: BTreeMap<String, f64>,
+    pub branch_currents: BTreeMap<String, f64>,
+    pub converged: bool,
+}
+
+impl McPoint {
+    pub fn voltage(&self, node: &str) -> Option<f64> {
+        if is_ground(node) {
+            Some(0.0)
+        } else {
+            self.node_voltages.get(node).copied()
+        }
+    }
+
+    pub fn branch_current(&self, source_name: &str) -> Option<f64> {
+        let key = if source_name.starts_with("I(") {
+            source_name.to_string()
+        } else {
+            format!("I({source_name})")
+        };
+        self.branch_currents.get(&key).copied()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct McResult {
+    pub output_node: String,
+    pub points: Vec<McPoint>,
+    pub n_trials: usize,
+    pub mean: f64,
+    pub std_dev: f64,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct TfResult {
     pub transfer_ratio: f64,
@@ -799,6 +858,73 @@ pub fn dc_sweep(
         value += step;
     }
     Ok(points)
+}
+
+pub fn mc_dc(
+    circuit: &Circuit,
+    output_node: &str,
+    n_trials: usize,
+    options: McOptions,
+) -> Result<McResult, SpiceError> {
+    let node_indices = collect_node_indices(circuit);
+    if !is_ground(output_node) && !node_indices.contains_key(output_node) {
+        return Err(SpiceError::InvalidElement {
+            name: output_node.to_string(),
+            reason: "output node was not found in circuit".to_string(),
+        });
+    }
+    if n_trials == 0 {
+        return Err(SpiceError::InvalidElement {
+            name: "mc_dc".to_string(),
+            reason: "n_trials must be positive".to_string(),
+        });
+    }
+    if !options.tolerance.is_finite() || options.tolerance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: "mc_dc".to_string(),
+            reason: "tolerance must be finite and non-negative".to_string(),
+        });
+    }
+
+    let mut rng = McRng::new(options.seed.unwrap_or(0x6d2b_79f5));
+    let mut points = Vec::with_capacity(n_trials);
+    for trial in 0..n_trials {
+        let trial_circuit = circuit_with_randomized_elements(
+            circuit,
+            options.tolerance,
+            options.distribution,
+            &mut rng,
+        );
+        match dc_op(&trial_circuit) {
+            Ok(result) => points.push(McPoint {
+                trial,
+                node_voltages: result.node_voltages,
+                branch_currents: result.branch_currents,
+                converged: true,
+            }),
+            Err(SpiceError::SingularMatrix) => points.push(McPoint {
+                trial,
+                node_voltages: BTreeMap::new(),
+                branch_currents: BTreeMap::new(),
+                converged: false,
+            }),
+            Err(error) => return Err(error),
+        }
+    }
+
+    let converged_voltages: Vec<f64> = points
+        .iter()
+        .filter(|point| point.converged)
+        .map(|point| point.voltage(output_node).unwrap_or(0.0))
+        .collect();
+
+    Ok(McResult {
+        output_node: output_node.to_string(),
+        points,
+        n_trials,
+        mean: sample_mean(&converged_voltages),
+        std_dev: sample_std_dev(&converged_voltages),
+    })
 }
 
 pub fn tf(
@@ -1109,6 +1235,116 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::Vccs(source) => source.transconductance_siemens += delta,
         Element::Capacitor(_) | Element::Inductor(_) => {}
     }
+}
+
+#[derive(Debug, Clone)]
+struct McRng {
+    state: u64,
+}
+
+impl McRng {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_f64(&mut self) -> f64 {
+        self.state = self.state.wrapping_add(0x6d2b_79f5);
+        let mut value = self.state as u32;
+        value = (value ^ (value >> 15)).wrapping_mul(value | 1);
+        value ^= value.wrapping_add((value ^ (value >> 7)).wrapping_mul(value | 61));
+        ((value ^ (value >> 14)) as f64) / 4_294_967_296.0
+    }
+
+    fn gaussian(&mut self) -> f64 {
+        let u1 = self.next_f64().max(f64::MIN_POSITIVE);
+        let u2 = self.next_f64();
+        (-2.0 * u1.ln()).sqrt() * (TWO_PI * u2).cos()
+    }
+}
+
+fn randomized_value(
+    nominal_value: f64,
+    tolerance: f64,
+    distribution: McDistribution,
+    rng: &mut McRng,
+) -> f64 {
+    if tolerance == 0.0 {
+        return nominal_value;
+    }
+    match distribution {
+        McDistribution::Gaussian => nominal_value * (1.0 + rng.gaussian() * tolerance / 3.0),
+        McDistribution::Uniform => nominal_value * (1.0 + tolerance * (2.0 * rng.next_f64() - 1.0)),
+    }
+}
+
+fn circuit_with_randomized_elements(
+    circuit: &Circuit,
+    tolerance: f64,
+    distribution: McDistribution,
+    rng: &mut McRng,
+) -> Circuit {
+    let mut randomized = Circuit::new();
+    for element in circuit.elements() {
+        randomized.add(randomized_element(element, tolerance, distribution, rng));
+    }
+    randomized
+}
+
+fn randomized_element(
+    element: &Element,
+    tolerance: f64,
+    distribution: McDistribution,
+    rng: &mut McRng,
+) -> Element {
+    match element {
+        Element::Resistor(resistor) => {
+            let mut varied = resistor.clone();
+            varied.resistance_ohms =
+                randomized_value(varied.resistance_ohms, tolerance, distribution, rng);
+            Element::Resistor(varied)
+        }
+        Element::VoltageSource(source) => {
+            let mut varied = source.clone();
+            varied.voltage = randomized_value(varied.voltage, tolerance, distribution, rng);
+            Element::VoltageSource(varied)
+        }
+        Element::CurrentSource(source) => {
+            let mut varied = source.clone();
+            varied.current = randomized_value(varied.current, tolerance, distribution, rng);
+            Element::CurrentSource(varied)
+        }
+        Element::Vccs(source) => {
+            let mut varied = source.clone();
+            varied.transconductance_siemens = randomized_value(
+                varied.transconductance_siemens,
+                tolerance,
+                distribution,
+                rng,
+            );
+            Element::Vccs(varied)
+        }
+        Element::Capacitor(_) | Element::Inductor(_) => element.clone(),
+    }
+}
+
+fn sample_mean(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / values.len() as f64
+}
+
+fn sample_std_dev(values: &[f64]) -> f64 {
+    if values.len() < 2 {
+        return 0.0;
+    }
+    let mean = sample_mean(values);
+    let variance = values
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>()
+        / (values.len() - 1) as f64;
+    variance.sqrt()
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/code/packages/rust/spice-engine/tests/mc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/mc_tests.rs
@@ -1,0 +1,191 @@
+use spice_engine::{
+    mc_dc, Circuit, CurrentSource, Element, McDistribution, McOptions, Resistor, SpiceError, Vccs,
+    VoltageSource,
+};
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 1.0e-9,
+        "expected {expected}, got {actual}"
+    );
+}
+
+fn divider() -> Circuit {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 10.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rtop", "in", "mid", 1_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rbot", "mid", "0", 1_000.0,
+    )));
+    circuit
+}
+
+fn mid_voltages(result: &spice_engine::McResult) -> Vec<f64> {
+    result
+        .points
+        .iter()
+        .map(|point| point.voltage("mid").unwrap())
+        .collect()
+}
+
+#[test]
+fn mc_dc_returns_trial_points_and_zero_spread_at_zero_tolerance() {
+    let result = mc_dc(
+        &divider(),
+        "mid",
+        8,
+        McOptions {
+            tolerance: 0.0,
+            seed: Some(7),
+            ..McOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.output_node, "mid");
+    assert_eq!(result.n_trials, 8);
+    assert_eq!(result.points.len(), 8);
+    assert_eq!(
+        result
+            .points
+            .iter()
+            .map(|point| point.trial)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 2, 3, 4, 5, 6, 7]
+    );
+    assert!(result.points.iter().all(|point| point.converged));
+    assert_close(result.mean, 5.0);
+    assert_close(result.std_dev, 0.0);
+    for point in &result.points {
+        assert_close(point.voltage("mid").unwrap(), 5.0);
+        assert_close(point.voltage("0").unwrap(), 0.0);
+        assert!(point.branch_current("Vin").is_some());
+    }
+}
+
+#[test]
+fn mc_dc_reproduces_with_same_seed() {
+    let options = McOptions {
+        tolerance: 0.05,
+        distribution: McDistribution::Uniform,
+        seed: Some(42),
+    };
+
+    let left = mc_dc(&divider(), "mid", 20, options).unwrap();
+    let right = mc_dc(&divider(), "mid", 20, options).unwrap();
+
+    assert_eq!(left.mean, right.mean);
+    assert_eq!(left.std_dev, right.std_dev);
+    assert_eq!(mid_voltages(&left), mid_voltages(&right));
+}
+
+#[test]
+fn mc_dc_uses_different_seeds_for_different_trial_vectors() {
+    let left = mc_dc(
+        &divider(),
+        "mid",
+        20,
+        McOptions {
+            tolerance: 0.05,
+            distribution: McDistribution::Uniform,
+            seed: Some(1),
+        },
+    )
+    .unwrap();
+    let right = mc_dc(
+        &divider(),
+        "mid",
+        20,
+        McOptions {
+            tolerance: 0.05,
+            distribution: McDistribution::Uniform,
+            seed: Some(2),
+        },
+    )
+    .unwrap();
+
+    assert_ne!(mid_voltages(&left), mid_voltages(&right));
+}
+
+#[test]
+fn mc_dc_reports_spread_near_nominal_divider_voltage() {
+    let result = mc_dc(
+        &divider(),
+        "mid",
+        200,
+        McOptions {
+            tolerance: 0.05,
+            seed: Some(3),
+            ..McOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.points.iter().all(|point| point.converged));
+    assert!(result.mean > 4.5, "mean was {}", result.mean);
+    assert!(result.mean < 5.5, "mean was {}", result.mean);
+    assert!(result.std_dev > 0.0, "std_dev was {}", result.std_dev);
+}
+
+#[test]
+fn mc_dc_varies_current_source_and_vccs_parameters() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vctrl", "ctrl", "0", 1.0,
+    )));
+    circuit.add(Element::Vccs(Vccs::new(
+        "Gm", "0", "out", "ctrl", "0", 1.0e-3,
+    )));
+    circuit.add(Element::CurrentSource(CurrentSource::new(
+        "Ibias", "0", "out", 1.0e-3,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = mc_dc(
+        &circuit,
+        "out",
+        40,
+        McOptions {
+            tolerance: 0.05,
+            distribution: McDistribution::Uniform,
+            seed: Some(9),
+        },
+    )
+    .unwrap();
+
+    assert!(result.mean > 1.5, "mean was {}", result.mean);
+    assert!(result.mean < 2.5, "mean was {}", result.mean);
+    assert!(result.std_dev > 0.0, "std_dev was {}", result.std_dev);
+}
+
+#[test]
+fn mc_dc_rejects_invalid_inputs() {
+    let circuit = divider();
+
+    assert!(matches!(
+        mc_dc(&circuit, "missing", 1, McOptions::default()),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "missing"
+    ));
+    assert!(matches!(
+        mc_dc(&circuit, "mid", 0, McOptions::default()),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "mc_dc"
+    ));
+    assert!(matches!(
+        mc_dc(
+            &circuit,
+            "mid",
+            1,
+            McOptions {
+                tolerance: f64::NAN,
+                ..McOptions::default()
+            },
+        ),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "mc_dc"
+    ));
+}


### PR DESCRIPTION
## Summary

- add Rust `mc_dc` with seeded Gaussian and uniform tolerance variation for linear DC parameters
- expose `McDistribution`, `McOptions`, `McPoint`, and `McResult` in the existing crate style
- cover zero-tolerance trials, seed reproducibility, spread statistics, VCCS/current-source variation, and validation errors

## Validation

- cargo fmt -p spice-engine
- sh BUILD
- git diff --check