### PR TITLE
[codex] Reconcile Board VM capability specs

### DIFF
--- a/code/specs/BVM00-board-vm-architecture.md
+++ b/code/specs/BVM00-board-vm-architecture.md
@@ -156,8 +156,9 @@ A capability is a stable, portable operation family exposed by the board:
 |---|---|---|
 | `gpio.digital` | configure pin, write pin, read pin | pin registers / HAL GPIO |
 | `time.sleep` | sleep or yield for milliseconds | timer peripheral / RTOS delay |
-| `pwm.output` | set duty cycle and frequency | timer channel |
-| `adc.input` | sample analog input | ADC peripheral |
+| `pwm.write` | set duty cycle on a PWM-capable pin | timer channel |
+| `adc.read` | sample analog input | ADC peripheral |
+| `dac.write_u12` | write analog output sample | DAC peripheral |
 | `i2c.master` | write/read I2C transactions | I2C peripheral |
 | `serial.log` | stream text or binary logs | current transport or extra UART |
 | `program.store` | save bytecode for boot | flash / EEPROM / filesystem |

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -170,9 +170,21 @@ SDKs can grow without renumbering.
 
 | ID | Name | Args | Returns |
 |---:|---|---|---|
-| `0x20` | `pwm.open` | `pin: u16/u8`, `frequency_hz: u16` | `handle` |
-| `0x21` | `pwm.set_duty_u16` | `handle`, `duty: u16` | `unit` |
-| `0x22` | `pwm.close` | `handle` | `unit` |
+| `0x20` | `pwm.write` | `pin: u16/u8`, `duty: u16` | `unit` |
+
+`pwm.write` is the v1 direct-control operation used by the host SDKs and UNO R4
+runtime. It intentionally avoids allocating a persistent PWM handle. A later
+streaming/motor-control tranche can add handle-oriented PWM operations if it
+needs frequency selection, ramping, or lifetime-managed timer ownership.
+
+### ADC
+
+| ID | Name | Args | Returns |
+|---:|---|---|---|
+| `0x21` | `adc.read` | `pin: u16/u8` | `u16` |
+
+`adc.read` returns a normalized 16-bit sample. Board adapters choose the
+underlying hardware resolution and scale into the portable result range.
 
 ### LED Matrix
 

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -241,8 +241,9 @@ descriptor and fake-backend target, but it is not complete for standalone use.
 | `serial.log` | required for dev builds | optional | optional |
 | `program.ram_exec` | required | required | optional |
 | `program.store` | optional | optional | optional |
-| `pwm.output` | early | early | later |
-| `adc.input` | early | early | later |
+| `pwm.write` | early | early | later |
+| `adc.read` | early | early | later |
+| `dac.write_u12` | early when present | later when present | unlikely first |
 | `i2c.master` | early | later | unlikely first |
 | `spi.master` | early | later | unlikely first |
 | `led_matrix.frame` | board-specific | board-specific | unlikely first |

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -25,9 +25,9 @@ Source snapshot:
 | Built-in LED | D13 | implemented through GPIO | GPIO metadata should identify `onboard_led_pin = 13` |
 | Millisecond time | runtime clock/sleep | implemented | `time.sleep_ms`, `time.now_ms` |
 | RAM program execution | protocol upload/run path | implemented | `program.ram_exec` |
-| LED matrix | 12x8 matrix, 96 pixels, UNO R4 WiFi only | implemented by this tranche | `led_matrix.frame` |
-| PWM output | D3, D5, D6, D9, D10, D11 in the Arduino variant init path | pending | `pwm.open`, `pwm.set_duty_u16`, `pwm.close` |
-| Analog input | A0-A5 | pending | `adc.open`, `adc.read_u16`, `adc.close` |
+| LED matrix | 12x8 matrix, 96 pixels, UNO R4 WiFi only | implemented | `led_matrix.frame` |
+| PWM output | D3, D5, D6, D9, D10, D11 in the Arduino variant init path | implemented as direct write | `pwm.write` |
+| Analog input | A0-A5 | implemented as direct read | `adc.read` |
 | DAC output | A0, one 12-bit DAC channel | pending | `dac.write_u12` or `analog.write` |
 | I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | pending | `i2c.open`, `i2c.write`, `i2c.read`, `i2c.transfer` |
 | SPI master | MOSI D11, MISO D12, SCK D13, CS D10 | pending | `spi.open`, `spi.transfer`, `spi.close` |
@@ -61,12 +61,15 @@ reject conflicting handles.
 
 1. Keep `gpio.*`, `time.*`, `program.ram_exec`, transports, and
    `led_matrix.frame` as the proven vertical slice.
-2. Add descriptor metadata for header pins, hidden pins, onboard LED, LED
-   matrix dimensions, PWM-capable pins, analog-capable pins, and bus pin groups.
-3. Implement PWM and ADC next because they extend the existing handle model
-   without requiring multi-device bus transactions.
-4. Implement I2C and SPI as bus handles with explicit transfer boundaries.
-5. Add DAC, UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
+2. Descriptor metadata for header pins, onboard LED, LED matrix dimensions,
+   PWM-capable pins, and analog-capable pins is present; keep deepening it with
+   hidden pins, reserved pins, and bus pin groups.
+3. `pwm.write` and `adc.read` are the first direct analog-adjacent VM
+   operations. Add handle-oriented PWM/ADC variants only when a later streaming
+   or event tranche needs persistent resource ownership.
+4. Add DAC output on A0 as the next scalar analog capability.
+5. Implement I2C and SPI as bus handles with explicit transfer boundaries.
+6. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 
 Every tranche should include the same layers: spec entry, IR capability id,


### PR DESCRIPTION
## Summary
- update the Board VM architecture and target matrix specs to name the landed direct `pwm.write` and `adc.read` capabilities
- reconcile BVM02 with the current bytecode ids for `pwm.write`, `adc.read`, and `led_matrix.frame`
- mark UNO R4 LED matrix, PWM, and ADC status as implemented in the feature inventory, with DAC as the next scalar analog capability

## Validation
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
