### PR TITLE
feat(rust): string heap objects and builtins (LANG47)

### DIFF
--- a/code/packages/rust/lispy-runtime/CHANGELOG.md
+++ b/code/packages/rust/lispy-runtime/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog — lispy-runtime
 
+## [0.3.0] — 2026-05-14
+
+### Added — LANG47 string heap objects and builtins
+
+- **`heap::LangString`** — new `#[repr(C)]` heap object type
+  (`CLASS_STRING = 3`).  Stores an immutable UTF-8 byte sequence as a
+  `Box<[u8]>` fat pointer.  Layout is 32 bytes (same as `ConsCell`),
+  8-byte aligned.
+
+- **`heap::CLASS_STRING`** — class id constant `3` (alongside
+  `CLASS_CONS = 1` and `CLASS_CLOSURE = 2`).
+
+- **`heap::alloc_string(bytes: &[u8]) -> LispyValue`** — allocate a
+  `LangString` from a byte slice; returns a heap-tagged `LispyValue`.
+
+- **`heap::is_string(v: LispyValue) -> bool`** — `unsafe` predicate;
+  reads the `class_or_kind` from the heap header.
+
+- **`heap::string_bytes(v: LispyValue) -> Option<&'static [u8]>`** —
+  `unsafe` accessor; returns the string's UTF-8 bytes.
+
+- **`LispyClass::String`** — new variant in the `LispyClass` enum.
+  `class_of` now returns `Some(LispyClass::String)` for heap strings.
+
+- **`LispyBinding::equal`** now byte-compares two `LangString` values
+  (structural equality via the `LangBinding` trait).
+
+- **`LispyBinding::trace_object`** handles `CLASS_STRING` (strings
+  have no interior `LispyValue` references).
+
+- **22 string builtins** registered in `resolve_builtin`:
+  `string?`, `string-length`, `string-ref`, `substring`,
+  `string-append`, `make-string`, `string=?`, `string<?`, `string>?`,
+  `number->string`, `string->number`, `string->symbol`, `symbol->string`,
+  `char-alphabetic?`, `char-numeric?`, `char-whitespace?`,
+  `char-upper-case?`, `char-lower-case?`, `char->integer`,
+  `integer->char`, `char-upcase`, `char-downcase`.
+
+- **30 new unit tests** covering all of the above.
+
+---
+
 ## [0.2.0] — 2026-04-29
 
 ### Added — supporting LANG20 PR 5 (twig-vm closures / globals / symbols)

--- a/code/packages/rust/lispy-runtime/Cargo.toml
+++ b/code/packages/rust/lispy-runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lispy-runtime"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "LANG20 PRs 2 + 5 — LispyBinding: shared LangBinding implementation for Lisp/Scheme/Twig/Clojure (tagged-i64 values, cons cells, closures with builtin-flag, immediate symbols, full builtin set)"
+description = "LANG20 PRs 2 + 5 + LANG47 — LispyBinding: shared LangBinding implementation for Lisp/Scheme/Twig/Clojure (tagged-i64 values, cons cells, closures, LangString heap objects, full string builtin set)"
 
 [dependencies]
 lang-runtime-core = { path = "../lang-runtime-core" }

--- a/code/packages/rust/lispy-runtime/README.md
+++ b/code/packages/rust/lispy-runtime/README.md
@@ -7,9 +7,9 @@
 | Module | What |
 |--------|------|
 | [`value`](src/value.rs) | `LispyValue` — tagged i64 (immediate ints / nil / true / false / symbols + heap-tagged pointers) |
-| [`heap`](src/heap.rs) | `ConsCell`, `Closure` — `#[repr(C)]` with the LANG20 16-byte header. `alloc_cons`, `alloc_closure`, `car`, `cdr`, `is_*`, `as_closure` |
+| [`heap`](src/heap.rs) | `ConsCell`, `Closure`, `LangString` — `#[repr(C)]` with the LANG20 16-byte header. `alloc_cons`, `alloc_closure`, `alloc_string`, `car`, `cdr`, `is_*`, `as_closure`, `string_bytes` |
 | [`intern`](src/intern.rs) | Process-global symbol intern table with `intern(name)` / `name_of(id)` |
-| [`builtins`](src/builtins.rs) | TW00 builtin handlers: `+ - * / = < >`, `cons car cdr`, `null? pair? number? symbol?`, `print` |
+| [`builtins`](src/builtins.rs) | TW00 builtin handlers: `+ - * / = < >`, `cons car cdr`, `null? pair? number? symbol?`, `print`; **LANG47** string builtins: `string?`, `string-length`, `string-ref`, `substring`, `string-append`, `make-string`, `string=?`, `string<?`, `string>?`, `number->string`, `string->number`, `string->symbol`, `symbol->string`, and all `char-*` predicates/converters |
 | [`binding`](src/binding.rs) | `LispyBinding` — full `LangBinding` impl + `LispyClass` + `LispyICEntry` |
 | [`abi`](src/abi.rs) | `extern "C"` surface: `lispy_cons`, `lispy_car`, `lispy_cdr`, `lispy_make_symbol`, `lispy_make_closure`, `lispy_apply_closure`, `lispy_closure_capture_count` |
 

--- a/code/packages/rust/lispy-runtime/src/binding.rs
+++ b/code/packages/rust/lispy-runtime/src/binding.rs
@@ -38,7 +38,7 @@ use lang_runtime_core::{
 };
 
 use crate::builtins;
-use crate::heap::{self, CLASS_CLOSURE, CLASS_CONS};
+use crate::heap::{self, CLASS_CLOSURE, CLASS_CONS, CLASS_STRING};
 use crate::value::LispyValue;
 
 // ---------------------------------------------------------------------------
@@ -65,6 +65,8 @@ pub enum LispyClass {
     Cons,
     /// A heap-allocated closure.
     Closure,
+    /// A heap-allocated UTF-8 string (LANG47).
+    String,
 }
 
 impl LispyClass {
@@ -79,6 +81,7 @@ impl LispyClass {
             LispyClass::Symbol => 13,
             LispyClass::Cons => CLASS_CONS,
             LispyClass::Closure => CLASS_CLOSURE,
+            LispyClass::String => CLASS_STRING,
         })
     }
 }
@@ -150,6 +153,7 @@ impl LangBinding for LispyBinding {
         if value.is_symbol() { return Some(LispyClass::Symbol); }
         if unsafe { heap::is_cons(value) } { return Some(LispyClass::Cons); }
         if unsafe { heap::is_closure(value) } { return Some(LispyClass::Closure); }
+        if unsafe { heap::is_string(value) } { return Some(LispyClass::String); }
         None
     }
 
@@ -173,6 +177,15 @@ impl LangBinding for LispyBinding {
             unsafe {
                 return Self::equal(heap::car(a).unwrap(), heap::car(b).unwrap())
                     && Self::equal(heap::cdr(a).unwrap(), heap::cdr(b).unwrap());
+            }
+        }
+        // String equality: byte-for-byte comparison (LANG47).
+        // SAFETY: is_string checks the heap tag + class id.
+        if unsafe { heap::is_string(a) && heap::is_string(b) } {
+            unsafe {
+                let a_bytes = heap::string_bytes(a).unwrap_or(&[]);
+                let b_bytes = heap::string_bytes(b).unwrap_or(&[]);
+                return a_bytes == b_bytes;
             }
         }
         false
@@ -216,6 +229,12 @@ impl LangBinding for LispyBinding {
                 for cap in unsafe { (*clos).captures.iter() } {
                     visitor.visit_value(cap.bits());
                 }
+            }
+            CLASS_STRING => {
+                // LangString contains only a Box<[u8]> — no
+                // LispyValue references inside.  The GC does not
+                // need to trace through strings.
+                let _ = obj_header; // suppress dead-read warning
             }
             _ => {
                 // Unknown class — defensively do nothing rather
@@ -331,6 +350,30 @@ impl LangBinding for LispyBinding {
             "make_symbol" => Some(builtins::make_symbol),
             "make_closure" => Some(builtins::make_closure),
             "make_builtin_closure" => Some(builtins::make_builtin_closure),
+            // ── String builtins (LANG47) ────────────────────────────────
+            "string?"         => Some(builtins::string_p),
+            "string-length"   => Some(builtins::string_length),
+            "string-ref"      => Some(builtins::string_ref),
+            "substring"       => Some(builtins::substring),
+            "string-append"   => Some(builtins::string_append),
+            "make-string"     => Some(builtins::make_string),
+            "string=?"        => Some(builtins::string_eq_p),
+            "string<?"        => Some(builtins::string_lt_p),
+            "string>?"        => Some(builtins::string_gt_p),
+            "number->string"  => Some(builtins::number_to_string),
+            "string->number"  => Some(builtins::string_to_number),
+            "string->symbol"  => Some(builtins::string_to_symbol),
+            "symbol->string"  => Some(builtins::symbol_to_string),
+            // Character predicates / converters (LANG47)
+            "char-alphabetic?" => Some(builtins::char_alphabetic_p),
+            "char-numeric?"    => Some(builtins::char_numeric_p),
+            "char-whitespace?" => Some(builtins::char_whitespace_p),
+            "char-upper-case?" => Some(builtins::char_upper_case_p),
+            "char-lower-case?" => Some(builtins::char_lower_case_p),
+            "char->integer"    => Some(builtins::char_to_integer),
+            "integer->char"    => Some(builtins::integer_to_char),
+            "char-upcase"      => Some(builtins::char_upcase),
+            "char-downcase"    => Some(builtins::char_downcase),
             _ => None,
         }
     }

--- a/code/packages/rust/lispy-runtime/src/builtins.rs
+++ b/code/packages/rust/lispy-runtime/src/builtins.rs
@@ -388,6 +388,368 @@ pub fn make_builtin_closure(args: &[LispyValue]) -> Result<LispyValue, RuntimeEr
 }
 
 // ---------------------------------------------------------------------------
+// String builtins (LANG47)
+// ---------------------------------------------------------------------------
+//
+// Strings are `LangString` heap objects (CLASS_STRING = 3).  Character
+// operations work on Unicode scalar values (code points) represented as
+// `i64` integers — the same type as Twig integers.  Positions are
+// 0-indexed code-point offsets, *not* byte offsets.
+//
+// Helper: extract bytes from a LispyValue or return a TypeError.
+
+fn as_str_bytes<'a>(name: &str, v: LispyValue) -> Result<&'a [u8], RuntimeError> {
+    // SAFETY: v came from the Lispy value space — either a constant produced
+    // by alloc_string, or a builtin result.  The `Box::leak` allocator keeps
+    // all heap objects live for the process lifetime.
+    unsafe {
+        heap::string_bytes(v).ok_or_else(|| {
+            RuntimeError::TypeError(format!("{name}: expected String, got {v}"))
+        })
+    }
+}
+
+/// Count Unicode code points in a byte slice.  Tries UTF-8 first; falls
+/// back to the byte count if the bytes aren't valid UTF-8 (shouldn't happen
+/// in well-formed Twig source, but we prefer a useful value over a panic).
+fn count_codepoints(bytes: &[u8]) -> usize {
+    if let Ok(s) = std::str::from_utf8(bytes) {
+        s.chars().count()
+    } else {
+        bytes.len()
+    }
+}
+
+/// Collect an iterator of code points up to index `n` and return the
+/// byte offset of the n-th code point boundary.  Returns `None` if there
+/// are fewer than `n` code points.
+fn byte_offset_of_nth_codepoint(bytes: &[u8], n: usize) -> Option<usize> {
+    if let Ok(s) = std::str::from_utf8(bytes) {
+        let mut offset = 0;
+        for (i, ch) in s.char_indices() {
+            if offset == n {
+                return Some(i);
+            }
+            offset += 1;
+            let _ = ch;
+        }
+        if offset == n { Some(bytes.len()) } else { None }
+    } else {
+        // Byte-mode fallback.
+        if n <= bytes.len() { Some(n) } else { None }
+    }
+}
+
+/// `(string? v) → Bool` — type predicate (LANG47).
+pub fn string_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("string?", 1, args.len()));
+    }
+    // SAFETY: args[0] is a live LispyValue from the runtime.
+    Ok(LispyValue::bool(unsafe { heap::is_string(args[0]) }))
+}
+
+/// `(string-length s) → Int` — number of Unicode code points (LANG47).
+pub fn string_length(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("string-length", 1, args.len()));
+    }
+    let bytes = as_str_bytes("string-length", args[0])?;
+    let n = count_codepoints(bytes);
+    box_int_checked("string-length", n as i64)
+}
+
+/// `(string-ref s i) → Int` — return the i-th code point as an integer (LANG47).
+///
+/// `i` is a 0-indexed code-point position.  Returns a `TypeError` if `i` is
+/// out of bounds.
+pub fn string_ref(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("string-ref", 2, args.len()));
+    }
+    let bytes = as_str_bytes("string-ref", args[0])?;
+    let idx = as_int("string-ref", args[1])?;
+    if idx < 0 {
+        return Err(RuntimeError::TypeError(format!(
+            "string-ref: index {idx} is negative"
+        )));
+    }
+    let idx = idx as usize;
+    let cp = if let Ok(s) = std::str::from_utf8(bytes) {
+        s.chars()
+            .nth(idx)
+            .ok_or_else(|| RuntimeError::TypeError(format!(
+                "string-ref: index {idx} out of bounds (length {})",
+                s.chars().count()
+            )))?
+            as u32
+    } else {
+        // Byte-mode fallback.
+        *bytes.get(idx).ok_or_else(|| RuntimeError::TypeError(format!(
+            "string-ref: index {idx} out of bounds (byte-length {})",
+            bytes.len()
+        )))? as u32
+    };
+    Ok(LispyValue::int(cp as i64))
+}
+
+/// `(substring s start end) → String` — slice [start, end) by code points (LANG47).
+pub fn substring(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 3 {
+        return Err(arity_error("substring", 3, args.len()));
+    }
+    let bytes = as_str_bytes("substring", args[0])?;
+    let start = as_int("substring", args[1])?;
+    let end   = as_int("substring", args[2])?;
+    if start < 0 || end < start {
+        return Err(RuntimeError::TypeError(format!(
+            "substring: invalid range [{start}, {end})"
+        )));
+    }
+    let start = start as usize;
+    let end   = end   as usize;
+
+    let byte_start = byte_offset_of_nth_codepoint(bytes, start)
+        .ok_or_else(|| RuntimeError::TypeError(format!(
+            "substring: start {start} out of bounds"
+        )))?;
+    let byte_end = byte_offset_of_nth_codepoint(bytes, end)
+        .ok_or_else(|| RuntimeError::TypeError(format!(
+            "substring: end {end} out of bounds"
+        )))?;
+    Ok(heap::alloc_string(&bytes[byte_start..byte_end]))
+}
+
+/// `(string-append s1 s2) → String` — concatenate two strings (LANG47).
+pub fn string_append(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("string-append", 2, args.len()));
+    }
+    let a = as_str_bytes("string-append", args[0])?;
+    let b = as_str_bytes("string-append", args[1])?;
+    let mut result = Vec::with_capacity(a.len() + b.len());
+    result.extend_from_slice(a);
+    result.extend_from_slice(b);
+    Ok(heap::alloc_string(&result))
+}
+
+/// `(make-string n ch) → String` — build a string of `n` copies of code point `ch` (LANG47).
+pub fn make_string(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("make-string", 2, args.len()));
+    }
+    let n  = as_int("make-string", args[0])?;
+    let ch = as_int("make-string", args[1])?;
+    if n < 0 {
+        return Err(RuntimeError::TypeError(format!("make-string: length {n} is negative")));
+    }
+    let cp = char::from_u32(ch as u32).ok_or_else(|| {
+        RuntimeError::TypeError(format!("make-string: {ch} is not a valid Unicode code point"))
+    })?;
+    let mut s = String::with_capacity(n as usize * cp.len_utf8());
+    for _ in 0..n {
+        s.push(cp);
+    }
+    Ok(heap::alloc_string(s.as_bytes()))
+}
+
+/// `(string=? s1 s2) → Bool` — byte-for-byte equality (LANG47).
+pub fn string_eq_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("string=?", 2, args.len()));
+    }
+    let a = as_str_bytes("string=?", args[0])?;
+    let b = as_str_bytes("string=?", args[1])?;
+    Ok(LispyValue::bool(a == b))
+}
+
+/// `(string<? s1 s2) → Bool` — lexicographic less-than (LANG47).
+pub fn string_lt_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("string<?", 2, args.len()));
+    }
+    let a = as_str_bytes("string<?", args[0])?;
+    let b = as_str_bytes("string<?", args[1])?;
+    Ok(LispyValue::bool(a < b))
+}
+
+/// `(string>? s1 s2) → Bool` — lexicographic greater-than (LANG47).
+pub fn string_gt_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("string>?", 2, args.len()));
+    }
+    let a = as_str_bytes("string>?", args[0])?;
+    let b = as_str_bytes("string>?", args[1])?;
+    Ok(LispyValue::bool(a > b))
+}
+
+/// `(number->string n) → String` — decimal representation (LANG47).
+pub fn number_to_string(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("number->string", 1, args.len()));
+    }
+    let n = as_int("number->string", args[0])?;
+    let s = n.to_string();
+    Ok(heap::alloc_string(s.as_bytes()))
+}
+
+/// `(string->number s) → Int | #f` — parse decimal integer (LANG47).
+///
+/// Returns `#f` on parse failure rather than raising an error — this is the
+/// R7RS-compatible behaviour (`string->number` is allowed to return `#f`).
+pub fn string_to_number(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("string->number", 1, args.len()));
+    }
+    let bytes = as_str_bytes("string->number", args[0])?;
+    let s = std::str::from_utf8(bytes).unwrap_or("");
+    match s.trim().parse::<i64>() {
+        Ok(n) => box_int_checked("string->number", n),
+        Err(_) => Ok(LispyValue::FALSE),
+    }
+}
+
+/// `(string->symbol s) → Symbol` — intern the string as a symbol (LANG47).
+pub fn string_to_symbol(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("string->symbol", 1, args.len()));
+    }
+    let bytes = as_str_bytes("string->symbol", args[0])?;
+    let s = std::str::from_utf8(bytes).map_err(|_| {
+        RuntimeError::TypeError("string->symbol: string is not valid UTF-8".into())
+    })?;
+    let id = crate::intern::intern(s);
+    Ok(LispyValue::symbol(id))
+}
+
+/// `(symbol->string sym) → String` — look up the symbol's name and return a string (LANG47).
+pub fn symbol_to_string(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("symbol->string", 1, args.len()));
+    }
+    let id = args[0].as_symbol().ok_or_else(|| {
+        RuntimeError::TypeError(format!("symbol->string: expected symbol, got {}", args[0]))
+    })?;
+    let name = crate::intern::name_of(id).ok_or_else(|| {
+        RuntimeError::TypeError(format!("symbol->string: unknown symbol id {id:?}"))
+    })?;
+    Ok(heap::alloc_string(name.as_bytes()))
+}
+
+// ---------------------------------------------------------------------------
+// Character predicates (LANG47)
+//
+// In Twig, characters are represented as code-point integers (the result of
+// `string-ref`).  All character predicates accept an integer and return a
+// boolean.  Only ASCII is covered at this stage.
+// ---------------------------------------------------------------------------
+
+/// Extract a code-point integer from a `LispyValue` for char predicates.
+fn as_codepoint(name: &str, v: LispyValue) -> Result<u32, RuntimeError> {
+    let n = as_int(name, v)?;
+    if n < 0 || n > 0x10FFFF {
+        return Err(RuntimeError::TypeError(format!(
+            "{name}: {n} is not a valid Unicode code point"
+        )));
+    }
+    Ok(n as u32)
+}
+
+/// Helper: is `cp` an ASCII alphabetic code point?
+#[inline]
+fn is_alpha(cp: u32) -> bool {
+    (cp >= b'a' as u32 && cp <= b'z' as u32) || (cp >= b'A' as u32 && cp <= b'Z' as u32)
+}
+
+/// Helper: is `cp` an ASCII digit code point?
+#[inline]
+fn is_digit(cp: u32) -> bool {
+    cp >= b'0' as u32 && cp <= b'9' as u32
+}
+
+/// Helper: is `cp` an ASCII uppercase letter?
+#[inline]
+fn is_upper(cp: u32) -> bool {
+    cp >= b'A' as u32 && cp <= b'Z' as u32
+}
+
+/// Helper: is `cp` an ASCII lowercase letter?
+#[inline]
+fn is_lower(cp: u32) -> bool {
+    cp >= b'a' as u32 && cp <= b'z' as u32
+}
+
+/// `(char-alphabetic? code) → Bool` — is the code point a letter? (ASCII) (LANG47).
+pub fn char_alphabetic_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("char-alphabetic?", 1, args.len())); }
+    let cp = as_codepoint("char-alphabetic?", args[0])?;
+    Ok(LispyValue::bool(is_alpha(cp)))
+}
+
+/// `(char-numeric? code) → Bool` — is the code point an ASCII digit? (LANG47).
+pub fn char_numeric_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("char-numeric?", 1, args.len())); }
+    let cp = as_codepoint("char-numeric?", args[0])?;
+    Ok(LispyValue::bool(is_digit(cp)))
+}
+
+/// `(char-whitespace? code) → Bool` — space, tab, newline, CR, FF (LANG47).
+pub fn char_whitespace_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("char-whitespace?", 1, args.len())); }
+    let cp = as_codepoint("char-whitespace?", args[0])?;
+    // R7RS: at least #\space, #\newline, #\tab are whitespace.
+    // Common extras: CR (13), FF (12), VT (11).
+    Ok(LispyValue::bool(matches!(cp, 9 | 10 | 11 | 12 | 13 | 32)))
+}
+
+/// `(char-upper-case? code) → Bool` — is the code point an ASCII uppercase letter? (LANG47).
+pub fn char_upper_case_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("char-upper-case?", 1, args.len())); }
+    let cp = as_codepoint("char-upper-case?", args[0])?;
+    Ok(LispyValue::bool(is_upper(cp)))
+}
+
+/// `(char-lower-case? code) → Bool` — is the code point an ASCII lowercase letter? (LANG47).
+pub fn char_lower_case_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("char-lower-case?", 1, args.len())); }
+    let cp = as_codepoint("char-lower-case?", args[0])?;
+    Ok(LispyValue::bool(is_lower(cp)))
+}
+
+/// `(char->integer code) → Int` — identity in our encoding (LANG47).
+///
+/// Provided for R7RS source compatibility: in Twig's encoding, chars *are*
+/// code-point integers, so this is a no-op.
+pub fn char_to_integer(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("char->integer", 1, args.len())); }
+    let _ = as_codepoint("char->integer", args[0])?;
+    Ok(args[0])
+}
+
+/// `(integer->char n) → Int` — identity in our encoding (LANG47).
+pub fn integer_to_char(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("integer->char", 1, args.len())); }
+    let _ = as_codepoint("integer->char", args[0])?;
+    Ok(args[0])
+}
+
+/// `(char-upcase code) → Int` — ASCII uppercase (LANG47).
+pub fn char_upcase(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("char-upcase", 1, args.len())); }
+    let cp = as_codepoint("char-upcase", args[0])?;
+    let up = if is_lower(cp) { cp - 32 } else { cp };
+    Ok(LispyValue::int(up as i64))
+}
+
+/// `(char-downcase code) → Int` — ASCII lowercase (LANG47).
+pub fn char_downcase(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 { return Err(arity_error("char-downcase", 1, args.len())); }
+    let cp = as_codepoint("char-downcase", args[0])?;
+    let down = if is_upper(cp) { cp + 32 } else { cp };
+    Ok(LispyValue::int(down as i64))
+}
+
+// ---------------------------------------------------------------------------
 // I/O
 // ---------------------------------------------------------------------------
 
@@ -651,5 +1013,220 @@ mod tests {
     #[test]
     fn make_nil_rejects_args() {
         assert!(make_nil(&[i(1)]).is_err());
+    }
+
+    // ── String builtins (LANG47) ─────────────────────────────────────
+
+    /// Helper: allocate a LispyValue string from a Rust str.
+    fn s(text: &str) -> LispyValue {
+        heap::alloc_string(text.as_bytes())
+    }
+
+    #[test]
+    fn string_p_true_for_heap_string() {
+        assert_eq!(string_p(&[s("hello")]).unwrap(), LispyValue::TRUE);
+    }
+
+    #[test]
+    fn string_p_false_for_non_string() {
+        assert_eq!(string_p(&[i(0)]).unwrap(), LispyValue::FALSE);
+        assert_eq!(string_p(&[LispyValue::NIL]).unwrap(), LispyValue::FALSE);
+        assert_eq!(string_p(&[LispyValue::symbol(intern("x"))]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn string_length_ascii() {
+        assert_eq!(string_length(&[s("hello")]).unwrap(), i(5));
+        assert_eq!(string_length(&[s("")]).unwrap(), i(0));
+        assert_eq!(string_length(&[s("a")]).unwrap(), i(1));
+    }
+
+    #[test]
+    fn string_length_multibyte() {
+        // "café" = 4 code points, 5 bytes.
+        assert_eq!(string_length(&[s("café")]).unwrap(), i(4));
+    }
+
+    #[test]
+    fn string_ref_returns_codepoint() {
+        // 'h' = 104, 'e' = 101
+        assert_eq!(string_ref(&[s("hello"), i(0)]).unwrap(), i(104));
+        assert_eq!(string_ref(&[s("hello"), i(1)]).unwrap(), i(101));
+    }
+
+    #[test]
+    fn string_ref_last_char() {
+        // 'o' = 111
+        assert_eq!(string_ref(&[s("hello"), i(4)]).unwrap(), i(111));
+    }
+
+    #[test]
+    fn string_ref_out_of_bounds_errors() {
+        assert!(string_ref(&[s("hi"), i(2)]).is_err());
+        assert!(string_ref(&[s("hi"), i(-1)]).is_err());
+    }
+
+    #[test]
+    fn substring_basic() {
+        assert_eq!(
+            unsafe { heap::string_bytes(substring(&[s("hello"), i(1), i(4)]).unwrap()).unwrap() },
+            b"ell"
+        );
+    }
+
+    #[test]
+    fn substring_empty_range() {
+        let v = substring(&[s("hello"), i(2), i(2)]).unwrap();
+        assert_eq!(
+            unsafe { heap::string_bytes(v).unwrap() },
+            b""
+        );
+    }
+
+    #[test]
+    fn substring_invalid_range_errors() {
+        // end < start is an error
+        assert!(substring(&[s("hello"), i(3), i(1)]).is_err());
+        // out of bounds
+        assert!(substring(&[s("hello"), i(0), i(10)]).is_err());
+    }
+
+    #[test]
+    fn string_append_concatenates() {
+        let v = string_append(&[s("foo"), s("bar")]).unwrap();
+        assert_eq!(
+            unsafe { heap::string_bytes(v).unwrap() },
+            b"foobar"
+        );
+    }
+
+    #[test]
+    fn string_append_empty() {
+        let v = string_append(&[s(""), s("abc")]).unwrap();
+        assert_eq!(unsafe { heap::string_bytes(v).unwrap() }, b"abc");
+        let v2 = string_append(&[s("abc"), s("")]).unwrap();
+        assert_eq!(unsafe { heap::string_bytes(v2).unwrap() }, b"abc");
+    }
+
+    #[test]
+    fn make_string_builds_repeated_char() {
+        let v = make_string(&[i(3), i(b'x' as i64)]).unwrap();
+        assert_eq!(unsafe { heap::string_bytes(v).unwrap() }, b"xxx");
+    }
+
+    #[test]
+    fn make_string_zero_length() {
+        let v = make_string(&[i(0), i(b'a' as i64)]).unwrap();
+        assert_eq!(unsafe { heap::string_bytes(v).unwrap() }.len(), 0);
+    }
+
+    #[test]
+    fn string_eq_p_equal() {
+        assert_eq!(string_eq_p(&[s("abc"), s("abc")]).unwrap(), LispyValue::TRUE);
+    }
+
+    #[test]
+    fn string_eq_p_not_equal() {
+        assert_eq!(string_eq_p(&[s("abc"), s("xyz")]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn string_lt_p_ordering() {
+        assert_eq!(string_lt_p(&[s("abc"), s("abd")]).unwrap(), LispyValue::TRUE);
+        assert_eq!(string_lt_p(&[s("abd"), s("abc")]).unwrap(), LispyValue::FALSE);
+        assert_eq!(string_lt_p(&[s("abc"), s("abc")]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn string_gt_p_ordering() {
+        assert_eq!(string_gt_p(&[s("abd"), s("abc")]).unwrap(), LispyValue::TRUE);
+        assert_eq!(string_gt_p(&[s("abc"), s("abd")]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn number_to_string_positive() {
+        let v = number_to_string(&[i(42)]).unwrap();
+        assert_eq!(unsafe { heap::string_bytes(v).unwrap() }, b"42");
+    }
+
+    #[test]
+    fn number_to_string_negative() {
+        let v = number_to_string(&[i(-7)]).unwrap();
+        assert_eq!(unsafe { heap::string_bytes(v).unwrap() }, b"-7");
+    }
+
+    #[test]
+    fn string_to_number_valid() {
+        assert_eq!(string_to_number(&[s("42")]).unwrap(), i(42));
+        assert_eq!(string_to_number(&[s("-7")]).unwrap(), i(-7));
+    }
+
+    #[test]
+    fn string_to_number_invalid_returns_false() {
+        assert_eq!(string_to_number(&[s("abc")]).unwrap(), LispyValue::FALSE);
+        assert_eq!(string_to_number(&[s("")]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn string_to_symbol_and_back() {
+        let v = string_to_symbol(&[s("my-sym")]).unwrap();
+        assert!(v.is_symbol());
+        let back = symbol_to_string(&[v]).unwrap();
+        assert_eq!(
+            unsafe { heap::string_bytes(back).unwrap() },
+            b"my-sym"
+        );
+    }
+
+    #[test]
+    fn char_alphabetic_p_ascii() {
+        // 'a' = 97, 'Z' = 90, '5' = 53
+        assert_eq!(char_alphabetic_p(&[i(97)]).unwrap(), LispyValue::TRUE);  // 'a'
+        assert_eq!(char_alphabetic_p(&[i(90)]).unwrap(), LispyValue::TRUE);  // 'Z'
+        assert_eq!(char_alphabetic_p(&[i(53)]).unwrap(), LispyValue::FALSE); // '5'
+        assert_eq!(char_alphabetic_p(&[i(32)]).unwrap(), LispyValue::FALSE); // ' '
+    }
+
+    #[test]
+    fn char_numeric_p_ascii() {
+        assert_eq!(char_numeric_p(&[i(b'0' as i64)]).unwrap(), LispyValue::TRUE);
+        assert_eq!(char_numeric_p(&[i(b'9' as i64)]).unwrap(), LispyValue::TRUE);
+        assert_eq!(char_numeric_p(&[i(b'a' as i64)]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn char_whitespace_p_various() {
+        assert_eq!(char_whitespace_p(&[i(32)]).unwrap(),  LispyValue::TRUE);  // space
+        assert_eq!(char_whitespace_p(&[i(10)]).unwrap(),  LispyValue::TRUE);  // newline
+        assert_eq!(char_whitespace_p(&[i(9)]).unwrap(),   LispyValue::TRUE);  // tab
+        assert_eq!(char_whitespace_p(&[i(b'a' as i64)]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn char_upper_lower_case() {
+        assert_eq!(char_upper_case_p(&[i(b'A' as i64)]).unwrap(), LispyValue::TRUE);
+        assert_eq!(char_upper_case_p(&[i(b'a' as i64)]).unwrap(), LispyValue::FALSE);
+        assert_eq!(char_lower_case_p(&[i(b'a' as i64)]).unwrap(), LispyValue::TRUE);
+        assert_eq!(char_lower_case_p(&[i(b'A' as i64)]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn char_upcase_downcase_ascii() {
+        // 'a' (97) → 'A' (65);  'A' (65) → 'A' (65)
+        assert_eq!(char_upcase(&[i(97)]).unwrap(), i(65));
+        assert_eq!(char_upcase(&[i(65)]).unwrap(), i(65));
+        // 'A' (65) → 'a' (97);  'a' (97) → 'a' (97)
+        assert_eq!(char_downcase(&[i(65)]).unwrap(), i(97));
+        assert_eq!(char_downcase(&[i(97)]).unwrap(), i(97));
+    }
+
+    #[test]
+    fn char_to_integer_is_identity() {
+        assert_eq!(char_to_integer(&[i(65)]).unwrap(), i(65));
+    }
+
+    #[test]
+    fn integer_to_char_is_identity() {
+        assert_eq!(integer_to_char(&[i(65)]).unwrap(), i(65));
     }
 }

--- a/code/packages/rust/lispy-runtime/src/heap.rs
+++ b/code/packages/rust/lispy-runtime/src/heap.rs
@@ -68,6 +68,9 @@ pub const CLASS_CONS: u32 = 1;
 /// Class id for [`Closure`].
 pub const CLASS_CLOSURE: u32 = 2;
 
+/// Class id for [`LangString`] (LANG47).
+pub const CLASS_STRING: u32 = 3;
+
 // ---------------------------------------------------------------------------
 // ConsCell
 // ---------------------------------------------------------------------------
@@ -221,6 +224,71 @@ impl Closure {
 }
 
 // ---------------------------------------------------------------------------
+// LangString (LANG47)
+// ---------------------------------------------------------------------------
+
+/// A Lispy/Twig string — an immutable UTF-8 byte sequence managed by the
+/// same `Box::leak` allocator as cons cells and closures.
+///
+/// ## Layout
+///
+/// ```text
+/// LangString (32 bytes on 64-bit):
+///   ┌──────────────────────────────────┐
+///   │  ObjectHeader (16 bytes)         │  class_or_kind = CLASS_STRING
+///   ├──────────────────────────────────┤
+///   │  data: Box<[u8]> (16 bytes)      │  fat pointer: ptr (8) + len (8)
+///   └──────────────────────────────────┘
+/// ```
+///
+/// The `data` field stores the raw UTF-8 bytes.  Character operations such
+/// as `string-ref` iterate over the byte sequence to count code points; this
+/// is O(n) but correct.  A future optimised string type may add a code-point
+/// count alongside the bytes.
+///
+/// ## Immutability
+///
+/// Strings are never mutated after construction.  Using `Box<[u8]>` (rather
+/// than `Vec<u8>`) eliminates the unused-capacity footgun and communicates
+/// the intent.
+#[repr(C)]
+pub struct LangString {
+    /// LANG20 uniform 16-byte header.  `class_or_kind == CLASS_STRING`.
+    pub header: ObjectHeader,
+    /// The string's UTF-8 bytes.  The `Box` is a fat pointer (addr + len) so
+    /// the total struct size is 16 + 16 = 32 bytes — matching `ConsCell`.
+    pub data: Box<[u8]>,
+}
+
+impl std::fmt::Debug for LangString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Show bytes as a UTF-8 string if valid, otherwise as raw bytes.
+        match std::str::from_utf8(&self.data) {
+            Ok(s)  => write!(f, "LangString({s:?})"),
+            Err(_) => write!(f, "LangString(<{} raw bytes>)", self.data.len()),
+        }
+    }
+}
+
+// 32 bytes: 16 (ObjectHeader) + 16 (Box<[u8]> fat pointer).
+const _: () = assert!(std::mem::size_of::<LangString>() == 32);
+const _: () = assert!(std::mem::align_of::<LangString>() == 8);
+
+impl LangString {
+    /// Construct a `LangString` from a byte slice.  The bytes are copied
+    /// into a `Box<[u8]>`.  Caller must box + leak via [`alloc_string`].
+    pub fn new(bytes: &[u8]) -> LangString {
+        LangString {
+            header: ObjectHeader::new(
+                CLASS_STRING,
+                std::mem::size_of::<LangString>() as u32,
+            ),
+            data: bytes.into(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Allocator (PR 2: Box::leak; PR 4+: real GC)
 // ---------------------------------------------------------------------------
 
@@ -265,6 +333,35 @@ pub fn alloc_builtin_closure(fn_name: SymbolId) -> LispyValue {
     let clos = Box::new(Closure::new_builtin(fn_name));
     let ptr = Box::leak(clos) as *const Closure;
     // SAFETY: Box::leak'd Closure is 8-aligned (const_assert) and lives forever.
+    unsafe { LispyValue::from_heap(ptr) }
+}
+
+/// Allocate a [`LangString`] from a byte slice and return a tagged
+/// [`LispyValue`] (LANG47).
+///
+/// **PR 2 / LANG47 implementation:** `Box::leak`.  The string lives forever
+/// in the current model; when LANG16's `gc-core` lands the allocator body
+/// changes without affecting callers.
+///
+/// # Example
+///
+/// ```
+/// use lispy_runtime::heap::{alloc_string, is_string, string_bytes};
+///
+/// let v = alloc_string(b"hello");
+/// assert!(v.is_heap());
+/// // SAFETY: v was just produced by alloc_string.
+/// unsafe {
+///     assert!(is_string(v));
+///     let bytes = string_bytes(v).expect("bytes round-trip");
+///     assert_eq!(bytes, b"hello");
+/// }
+/// ```
+pub fn alloc_string(bytes: &[u8]) -> LispyValue {
+    let s = Box::new(LangString::new(bytes));
+    let ptr = Box::leak(s) as *const LangString;
+    // SAFETY: Box::leak'd LangString is 8-aligned (compile-time const_assert)
+    // and lives forever (intentional PR 2 leak).
     unsafe { LispyValue::from_heap(ptr) }
 }
 
@@ -357,6 +454,43 @@ pub unsafe fn as_closure(value: LispyValue) -> Option<&'static Closure> {
         }
         let clos = header_ptr as *const Closure;
         Some(&*clos)
+    }
+}
+
+/// `true` iff `value` is a heap-tagged [`LangString`] (LANG47).
+///
+/// # Safety
+///
+/// Same contract as [`is_cons`]: `value` must have been produced by a safe
+/// constructor of this crate (or be `is_heap()` = false, in which case this
+/// function returns `false` without dereferencing).
+pub unsafe fn is_string(value: LispyValue) -> bool {
+    if let Some(header_ptr) = value.as_heap_ptr::<ObjectHeader>() {
+        unsafe { (*header_ptr).class_or_kind == CLASS_STRING }
+    } else {
+        false
+    }
+}
+
+/// Borrow the UTF-8 bytes of a heap string.
+///
+/// Returns `None` if `value` is not a `LangString`.
+///
+/// # Safety
+///
+/// `value` must be a live heap value produced by this crate's allocators
+/// (i.e., it was returned by [`alloc_string`]).  In the current
+/// `Box::leak` model this is always satisfied for any value created during
+/// the program's lifetime.  Once LANG16 GC lands, callers must hold the
+/// value inside the GC root set for the duration of the borrow.
+pub unsafe fn string_bytes(value: LispyValue) -> Option<&'static [u8]> {
+    let header_ptr: *const ObjectHeader = value.as_heap_ptr()?;
+    unsafe {
+        if (*header_ptr).class_or_kind != CLASS_STRING {
+            return None;
+        }
+        let s = header_ptr as *const LangString;
+        Some(&(*s).data)
     }
 }
 
@@ -472,5 +606,123 @@ mod tests {
             assert!(!is_cons(clos_v));
             assert!(is_closure(clos_v));
         }
+    }
+
+    // ── LangString tests (LANG47) ─────────────────────────────────────
+
+    #[test]
+    fn lang_string_is_32_bytes() {
+        // Layout invariant: 16 (ObjectHeader) + 16 (Box<[u8]> fat ptr).
+        assert_eq!(std::mem::size_of::<LangString>(), 32);
+    }
+
+    #[test]
+    fn lang_string_is_8_aligned() {
+        assert_eq!(std::mem::align_of::<LangString>(), 8);
+    }
+
+    #[test]
+    fn lang_string_class_id_is_distinct() {
+        // CLASS_STRING must differ from the other two; GC trace
+        // dispatch keyed on class_or_kind depends on this.
+        assert_ne!(CLASS_STRING, CLASS_CONS);
+        assert_ne!(CLASS_STRING, CLASS_CLOSURE);
+    }
+
+    #[test]
+    fn alloc_string_returns_heap_tagged_value() {
+        let v = alloc_string(b"hello");
+        assert!(v.is_heap(), "a heap string must be heap-tagged");
+        // SAFETY: v came from alloc_string in this test.
+        unsafe {
+            assert!(is_string(v), "is_string should recognise the allocation");
+            let bytes = string_bytes(v).expect("bytes round-trip");
+            assert_eq!(bytes, b"hello");
+        }
+    }
+
+    #[test]
+    fn alloc_empty_string_round_trips() {
+        let v = alloc_string(b"");
+        // SAFETY: v came from alloc_string.
+        unsafe {
+            assert!(is_string(v));
+            let bytes = string_bytes(v).expect("empty string bytes");
+            assert_eq!(bytes.len(), 0);
+        }
+    }
+
+    #[test]
+    fn alloc_string_with_utf8_multibyte_round_trips() {
+        // "café" contains a 2-byte UTF-8 sequence (é = 0xC3 0xA9).
+        let s = "café";
+        let v = alloc_string(s.as_bytes());
+        // SAFETY: v came from alloc_string.
+        unsafe {
+            assert!(is_string(v));
+            let bytes = string_bytes(v).expect("multi-byte string bytes");
+            assert_eq!(bytes, s.as_bytes());
+        }
+    }
+
+    #[test]
+    fn is_string_rejects_immediates() {
+        // Immediates are never strings — the heap-tag check short-
+        // circuits the class-id read.
+        // SAFETY: passing immediates is sound (no deref for non-heap).
+        unsafe {
+            assert!(!is_string(LispyValue::int(0)));
+            assert!(!is_string(LispyValue::NIL));
+            assert!(!is_string(LispyValue::TRUE));
+            assert!(!is_string(LispyValue::FALSE));
+            assert!(!is_string(LispyValue::symbol(SymbolId(1))));
+        }
+    }
+
+    #[test]
+    fn is_string_rejects_cons_and_closure() {
+        let cons_v = alloc_cons(LispyValue::NIL, LispyValue::NIL);
+        let clos_v = alloc_closure(SymbolId(0), vec![]);
+        // SAFETY: both values came from this crate's allocators.
+        unsafe {
+            assert!(!is_string(cons_v), "cons is not a string");
+            assert!(!is_string(clos_v), "closure is not a string");
+        }
+    }
+
+    #[test]
+    fn string_bytes_returns_none_for_non_string() {
+        let cons_v = alloc_cons(LispyValue::NIL, LispyValue::NIL);
+        // SAFETY: cons_v is a valid heap value from this crate.
+        unsafe {
+            assert!(string_bytes(cons_v).is_none(), "cons has no string bytes");
+        }
+    }
+
+    #[test]
+    fn string_bytes_returns_none_for_immediate() {
+        // SAFETY: immediate values are safe to pass (no deref).
+        unsafe {
+            assert!(string_bytes(LispyValue::int(42)).is_none());
+        }
+    }
+
+    #[test]
+    fn string_class_id_is_in_header() {
+        // Directly verify the header field so the GC dispatch table
+        // can trust it without special-casing LangString.
+        let s = LangString::new(b"abc");
+        let ptr = &s as *const LangString as *const u32;
+        // SAFETY: ptr points at the first field (class_or_kind: u32).
+        let class_id = unsafe { *ptr };
+        assert_eq!(class_id, CLASS_STRING);
+    }
+
+    #[test]
+    fn alloc_multiple_strings_are_distinct_objects() {
+        // Two alloc_string calls must return different heap addresses.
+        let a = alloc_string(b"foo");
+        let b = alloc_string(b"foo");  // same bytes, different allocation
+        assert_ne!(a.bits(), b.bits(), "each alloc_string must allocate a new object");
     }
 }

--- a/code/packages/rust/lispy-runtime/src/lib.rs
+++ b/code/packages/rust/lispy-runtime/src/lib.rs
@@ -100,8 +100,9 @@ pub mod value;
 // Public re-exports — keep the headline surface easy to discover.
 pub use binding::{LispyBinding, LispyClass, LispyICEntry};
 pub use heap::{
-    alloc_builtin_closure, alloc_closure, alloc_cons, as_closure, car, cdr, is_closure, is_cons,
-    Closure, ConsCell, CLASS_CLOSURE, CLASS_CONS, CLOSURE_FLAG_BUILTIN,
+    alloc_builtin_closure, alloc_closure, alloc_cons, alloc_string, as_closure, car, cdr,
+    is_closure, is_cons, is_string, string_bytes,
+    Closure, ConsCell, LangString, CLASS_CLOSURE, CLASS_CONS, CLASS_STRING, CLOSURE_FLAG_BUILTIN,
 };
 pub use intern::{intern, name_of};
 pub use value::{LispyValue, TAG_BITS, TAG_FALSE, TAG_HEAP, TAG_INT, TAG_NIL, TAG_SYMBOL, TAG_TRUE};

--- a/code/packages/rust/twig-vm/CHANGELOG.md
+++ b/code/packages/rust/twig-vm/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog — twig-vm
 
+## [0.11.0] — 2026-05-14
+
+### Added (LANG47 — String Heap Objects and Builtins)
+
+#### `const Operand::Str` now produces a `LangString` heap value
+
+Previously, `const dest = Operand::Str("text")` interned the text as a symbol
+(the PR 5 string-as-symbol stand-in).  After LANG47, it calls
+`lispy_runtime::heap::alloc_string` and stores a real heap string.  This enables
+all the new string builtins to operate on constants produced by the compiler.
+
+The `Operand::Var` arm in `exec_const` is unchanged — it still interns as a symbol,
+which is the correct behaviour for the `string_arg` helper used by `global_set`,
+`global_get`, and `make_symbol`.
+
+#### `lispy_class_str` extended with `"string"` class
+
+The profiler and IC table now track string-type values separately from cons
+cells and closures.  `LispyClass::String` maps to the `"string"` class name.
+
+#### 18 new dispatch tests
+
+Hand-built `IIRModule` tests for every new string operation:
+`string?`, `string-length`, `string-ref`, `substring`, `string-append`,
+`string=?`, `number->string`, `string->number`, `string->symbol`,
+`symbol->string`, `char-alphabetic?`, `char-whitespace?`, `char-upcase`,
+plus `const Operand::Str` producing a heap string.
+
+---
+
 ## [0.10.0] — 2026-05-12
 
 ### Added (LANG34 — First-Class Closure Dispatch)

--- a/code/packages/rust/twig-vm/Cargo.toml
+++ b/code/packages/rust/twig-vm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "twig-vm"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
-description = "LANG26 — host/ I/O builtins (write_byte, read_byte, exit, flush_stdout) via Rust stdlib dispatch"
+description = "LANG47 — string heap objects (LangString) and string/char builtins in the dispatch loop"
 
 [dependencies]
 twig-ir-compiler  = { path = "../twig-ir-compiler" }

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -828,6 +828,7 @@ fn lispy_class_str(value: LispyValue) -> Option<&'static str> {
         LispyClass::Symbol => Some("symbol"),
         LispyClass::Cons => Some("cons"),
         LispyClass::Closure => Some("closure"),
+        LispyClass::String => Some("string"),
     }
 }
 
@@ -1169,16 +1170,17 @@ fn exec_const(instr: &IIRInstr, frame: &mut Frame) -> Result<(), RunError> {
             }
             LispyValue::symbol(id)
         }
-        // LANG32: Str is a compile-time string literal (global variable name).
-        // Intern it as a symbol — same treatment as Var string-literals above.
+        // LANG47: Str is a compile-time string literal — allocate a LangString
+        // heap object.  The old PR 5 behaviour (intern as a symbol) is no longer
+        // needed here: LANG34 removed the last user of `Operand::Str` through a
+        // `const` instruction for non-string purposes (closure fn names are now
+        // inline in `alloc_closure`'s operand list, not through a register).
+        //
+        // String-valued constants produced by the twig-ir-compiler for explicit
+        // `"hello"` literals in Twig source now produce real heap strings that
+        // `string-length`, `string-ref`, etc. can operate on.
         Operand::Str(text) => {
-            let id = intern(text);
-            if id == SymbolId::NONE {
-                return Err(RunError::Runtime(RuntimeError::TypeError(format!(
-                    "intern table exhausted: cannot intern {text:?}"
-                ))));
-            }
-            LispyValue::symbol(id)
+            lispy_runtime::heap::alloc_string(text.as_bytes())
         }
     };
     frame.set(dest.clone(), value)?;
@@ -4337,5 +4339,310 @@ mod tests {
         ";
         let result = run_source(src).unwrap();
         assert_eq!(result.as_int(), Some(15), "expected 15, got {result}");
+    }
+
+    // ── String builtins (LANG47) ────────────────────────────────────
+    //
+    // These tests hand-build IIRModules with `const dest = Operand::Str(…)`
+    // and `call_builtin "string-length" / "string-ref" / …` to exercise
+    // every string operation end-to-end through the dispatch loop.
+
+    /// Build: `const s = Operand::Str(text); r = call_builtin name s; ret r`
+    fn string_builtin_1(text: &str, builtin: &str) -> LispyValue {
+        let instrs = vec![
+            IIRInstr::new("const", Some("s".into()), vec![Operand::Str(text.into())], "string"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![Operand::Var(builtin.into()), Operand::Var("s".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        run(&module_with_main(instrs, 3)).unwrap()
+    }
+
+    /// Build: `const s = Str; const i = Int; r = call_builtin name s i; ret r`
+    fn string_builtin_str_int(text: &str, builtin: &str, n: i64) -> LispyValue {
+        let instrs = vec![
+            IIRInstr::new("const", Some("s".into()), vec![Operand::Str(text.into())], "string"),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(n)], "int"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![
+                    Operand::Var(builtin.into()),
+                    Operand::Var("s".into()),
+                    Operand::Var("i".into()),
+                ],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        run(&module_with_main(instrs, 4)).unwrap()
+    }
+
+    #[test]
+    fn string_const_operand_str_produces_heap_string() {
+        // After LANG47, `const s = Operand::Str("hello")` must produce
+        // a heap string (not an interned symbol).
+        let instrs = vec![
+            IIRInstr::new("const", Some("s".into()), vec![Operand::Str("hello".into())], "string"),
+            IIRInstr::new("ret", None, vec![Operand::Var("s".into())], "any"),
+        ];
+        let v = run(&module_with_main(instrs, 1)).unwrap();
+        assert!(v.is_heap(), "Operand::Str should produce a heap value");
+        // SAFETY: v was produced by alloc_string in exec_const.
+        unsafe {
+            assert!(lispy_runtime::is_string(v), "heap value should be a LangString");
+            let bytes = lispy_runtime::string_bytes(v).expect("string bytes");
+            assert_eq!(bytes, b"hello");
+        }
+    }
+
+    #[test]
+    fn string_p_builtin_true_for_heap_string() {
+        let v = string_builtin_1("hi", "string?");
+        assert_eq!(v, LispyValue::TRUE);
+    }
+
+    #[test]
+    fn string_p_builtin_false_for_integer() {
+        let instrs = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(42)], "int"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![Operand::Var("string?".into()), Operand::Var("n".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        let v = run(&module_with_main(instrs, 2)).unwrap();
+        assert_eq!(v, LispyValue::FALSE);
+    }
+
+    #[test]
+    fn string_length_builtin_ascii() {
+        let v = string_builtin_1("hello", "string-length");
+        assert_eq!(v.as_int(), Some(5), "\"hello\" has 5 code points");
+    }
+
+    #[test]
+    fn string_length_builtin_empty() {
+        let v = string_builtin_1("", "string-length");
+        assert_eq!(v.as_int(), Some(0));
+    }
+
+    #[test]
+    fn string_ref_builtin_returns_codepoint() {
+        // 'h' = 104
+        let v = string_builtin_str_int("hello", "string-ref", 0);
+        assert_eq!(v.as_int(), Some(104), "'h' should be code point 104");
+    }
+
+    #[test]
+    fn string_ref_builtin_last_char() {
+        // 'o' = 111
+        let v = string_builtin_str_int("hello", "string-ref", 4);
+        assert_eq!(v.as_int(), Some(111), "'o' should be code point 111");
+    }
+
+    #[test]
+    fn string_ref_builtin_out_of_bounds_errors() {
+        let instrs = vec![
+            IIRInstr::new("const", Some("s".into()), vec![Operand::Str("hi".into())], "string"),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(5)], "int"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![
+                    Operand::Var("string-ref".into()),
+                    Operand::Var("s".into()),
+                    Operand::Var("i".into()),
+                ],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        let result = run(&module_with_main(instrs, 4));
+        assert!(result.is_err(), "string-ref out-of-bounds must error");
+    }
+
+    #[test]
+    fn string_append_builtin_concatenates() {
+        let instrs = vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Str("foo".into())], "string"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Str("bar".into())], "string"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![
+                    Operand::Var("string-append".into()),
+                    Operand::Var("a".into()),
+                    Operand::Var("b".into()),
+                ],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        let v = run(&module_with_main(instrs, 4)).unwrap();
+        // SAFETY: v was produced by alloc_string.
+        unsafe {
+            let bytes = lispy_runtime::string_bytes(v).expect("appended string bytes");
+            assert_eq!(bytes, b"foobar");
+        }
+    }
+
+    #[test]
+    fn substring_builtin_slices_correctly() {
+        // "hello"[1..4) = "ell"
+        let instrs = vec![
+            IIRInstr::new("const", Some("s".into()), vec![Operand::Str("hello".into())], "string"),
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "int"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(4)], "int"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![
+                    Operand::Var("substring".into()),
+                    Operand::Var("s".into()),
+                    Operand::Var("a".into()),
+                    Operand::Var("b".into()),
+                ],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        let v = run(&module_with_main(instrs, 5)).unwrap();
+        // SAFETY: v was produced by alloc_string.
+        unsafe {
+            let bytes = lispy_runtime::string_bytes(v).expect("substring bytes");
+            assert_eq!(bytes, b"ell");
+        }
+    }
+
+    #[test]
+    fn string_eq_p_builtin_equal_strings() {
+        let instrs = vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Str("abc".into())], "string"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Str("abc".into())], "string"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![
+                    Operand::Var("string=?".into()),
+                    Operand::Var("a".into()),
+                    Operand::Var("b".into()),
+                ],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        assert_eq!(run(&module_with_main(instrs, 4)).unwrap(), LispyValue::TRUE);
+    }
+
+    #[test]
+    fn number_to_string_builtin_decimal() {
+        let instrs = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(42)], "int"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![Operand::Var("number->string".into()), Operand::Var("n".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        let v = run(&module_with_main(instrs, 3)).unwrap();
+        unsafe {
+            let bytes = lispy_runtime::string_bytes(v).expect("number->string bytes");
+            assert_eq!(bytes, b"42");
+        }
+    }
+
+    #[test]
+    fn string_to_number_builtin_parses_valid() {
+        let v = string_builtin_1("42", "string->number");
+        assert_eq!(v.as_int(), Some(42));
+    }
+
+    #[test]
+    fn string_to_number_builtin_invalid_returns_false() {
+        let v = string_builtin_1("abc", "string->number");
+        assert_eq!(v, LispyValue::FALSE);
+    }
+
+    #[test]
+    fn string_to_symbol_and_back_roundtrip() {
+        let instrs = vec![
+            IIRInstr::new("const", Some("s".into()), vec![Operand::Str("my-sym".into())], "string"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("sym".into()),
+                vec![Operand::Var("string->symbol".into()), Operand::Var("s".into())],
+                "any",
+            ),
+            IIRInstr::new(
+                "call_builtin",
+                Some("back".into()),
+                vec![Operand::Var("symbol->string".into()), Operand::Var("sym".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("back".into())], "any"),
+        ];
+        let v = run(&module_with_main(instrs, 4)).unwrap();
+        unsafe {
+            let bytes = lispy_runtime::string_bytes(v).expect("roundtrip string bytes");
+            assert_eq!(bytes, b"my-sym");
+        }
+    }
+
+    #[test]
+    fn char_alphabetic_p_builtin() {
+        // 'a' = 97
+        let instrs = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(97)], "int"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![Operand::Var("char-alphabetic?".into()), Operand::Var("n".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        assert_eq!(run(&module_with_main(instrs, 3)).unwrap(), LispyValue::TRUE);
+    }
+
+    #[test]
+    fn char_whitespace_p_builtin_space() {
+        // 32 = space
+        let instrs = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(32)], "int"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![Operand::Var("char-whitespace?".into()), Operand::Var("n".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        assert_eq!(run(&module_with_main(instrs, 3)).unwrap(), LispyValue::TRUE);
+    }
+
+    #[test]
+    fn char_upcase_builtin_lowercases_to_uppercase() {
+        // 'a' (97) → 'A' (65)
+        let instrs = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(97)], "int"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![Operand::Var("char-upcase".into()), Operand::Var("n".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+        ];
+        assert_eq!(run(&module_with_main(instrs, 3)).unwrap().as_int(), Some(65));
     }
 }

--- a/code/specs/LANG47-string-builtins.md
+++ b/code/specs/LANG47-string-builtins.md
@@ -1,0 +1,209 @@
+# LANG47 — String Heap Objects and Builtins
+
+## Motivation
+
+The Twig self-hosted compiler (TW05) manipulates source text: it reads characters,
+slices substrings, converts tokens to strings, and formats diagnostics.  Before
+LANG47, the runtime has no proper string type — string literals flow through the
+"string-as-symbol" convention (they are interned and stored as `LispyValue`
+symbols), which makes structural string operations impossible.
+
+LANG47 adds:
+
+1. A `LangString` heap object in `lispy-runtime` (alongside `ConsCell` and `Closure`).
+2. A set of `call_builtin` string operations in `twig-vm`.
+3. `Operand::Str` in a `const` instruction now produces a heap string instead of an
+   interned symbol (the old behaviour was a temporary stand-in per the
+   `string-as-symbol` comment in PR 5; LANG34 removed the last user of
+   `Operand::Str` in `const` instructions for non-string purposes).
+
+## Non-goals
+
+- A fully Unicode-aware string type.  Strings are UTF-8 byte sequences; character
+  operations work on Unicode scalar values (code points) encoded as `u32`s stored
+  in `i64` Lispy integers.
+- Mutable strings.  All string values produced by LANG47 are immutable heap objects.
+- String interning.  `LangString` is a separate type from `Symbol`; `string->symbol`
+  and `symbol->string` bridge between them.
+
+## LangString heap object
+
+Layout:
+
+```text
+LangString (32 bytes):
+  ┌──────────────────────────────────┐
+  │  ObjectHeader (16 bytes)         │  class_or_kind = CLASS_STRING = 3
+  ├──────────────────────────────────┤
+  │  data: Box<[u8]> (16 bytes)      │  fat pointer: ptr (8) + len (8)
+  └──────────────────────────────────┘
+```
+
+`Box<[u8]>` is the string's UTF-8 content.  The choice of `Box<[u8]>` rather than
+`Vec<u8>` is deliberate: strings are immutable after construction, so the unused
+capacity field of `Vec` would waste space and invite bugs.
+
+### Class id
+
+```rust
+pub const CLASS_STRING: u32 = 3;
+```
+
+Added alongside the existing `CLASS_CONS = 1` and `CLASS_CLOSURE = 2`.
+
+### Public API (in `lispy-runtime::heap`)
+
+```rust
+/// Allocate a string from UTF-8 bytes.
+pub fn alloc_string(bytes: &[u8]) -> LispyValue;
+
+/// `true` iff `v` is a heap-tagged `LangString`.
+pub fn is_string(v: LispyValue) -> bool;
+
+/// Borrow the UTF-8 bytes of a heap string.
+///
+/// # Safety
+/// `v` must satisfy `is_string(v)`.  The returned slice is valid for the
+/// lifetime of the heap (i.e. `'static` in the current Box::leak model).
+pub unsafe fn string_bytes(v: LispyValue) -> &'static [u8];
+```
+
+## `const` instruction change
+
+The `const` instruction handler in `twig-vm` previously converted `Operand::Str(text)`
+to an interned symbol (the string-as-symbol stand-in from PR 5).  LANG34 removed
+the last non-string use of `Operand::Str` in `const` instructions (closure fn names
+now live inline in `alloc_closure`'s operand list, not through a `const` register).
+
+After LANG47, `const dest = Str("hello")` produces a `LangString` heap value:
+
+```
+before: Operand::Str("hello") → LispyValue::symbol(intern("hello"))
+after:  Operand::Str("hello") → alloc_string(b"hello")
+```
+
+The `Operand::Var` arm in `const` is unchanged (it still interns as a symbol;
+it is used only by the `string_arg` helper for `global_set`, `global_get`, and
+`make_symbol` — all of which need symbol identity, not string values).
+
+## Builtins
+
+All string builtins are dispatched via `call_builtin`.  The name column shows the
+IIR builtin name (the first `Var` operand to `call_builtin`).
+
+### Type predicates
+
+| Builtin | Signature | Notes |
+|---------|-----------|-------|
+| `string?` | `(string? v) → Bool` | Returns `#t` iff `v` is a `LangString`. |
+| `symbol?` | (existing) | No change. |
+
+### Length and access
+
+| Builtin | Signature | Notes |
+|---------|-----------|-------|
+| `string-length` | `(string-length s) → Int` | Number of Unicode scalar values (code points). O(n) via UTF-8 decoding but acceptable at this stage. |
+| `string-ref` | `(string-ref s i) → Int` | The i-th code point (0-indexed). Error if `i ≥ string-length`. The result is a code point integer, not a Twig `Char` object. |
+
+### Construction
+
+| Builtin | Signature | Notes |
+|---------|-----------|-------|
+| `string-append` | `(string-append s1 s2) → String` | Concatenate two strings. |
+| `substring` | `(substring s start end) → String` | Slice by code-point index `[start, end)`. Error if indices out of range. |
+| `make-string` | `(make-string n ch) → String` | Build an n-char string filled with code point `ch`. |
+
+### Comparison
+
+| Builtin | Signature | Notes |
+|---------|-----------|-------|
+| `string=?` | `(string=? s1 s2) → Bool` | Byte-for-byte equality. |
+| `string<?` | `(string<? s1 s2) → Bool` | Lexicographic order. |
+| `string>?` | `(string>? s1 s2) → Bool` | Lexicographic order. |
+
+### Conversion
+
+| Builtin | Signature | Notes |
+|---------|-----------|-------|
+| `number->string` | `(number->string n) → String` | Decimal representation. |
+| `string->number` | `(string->number s) → Int \| #f` | Parse decimal integer; `#f` on failure. |
+| `string->symbol` | `(string->symbol s) → Symbol` | Intern the string's bytes as a symbol. |
+| `symbol->string` | `(symbol->string sym) → String` | Reverse: look up the symbol's name in the intern table and return it as a new `LangString`. |
+
+### Character predicates
+
+Characters in Twig are represented as code-point integers (the result of `string-ref`).
+
+| Builtin | Signature | Notes |
+|---------|-----------|-------|
+| `char-alphabetic?` | `(char-alphabetic? code) → Bool` | ASCII alphabetic (a-z, A-Z). Caller is responsible for passing valid code-point integers. |
+| `char-numeric?` | `(char-numeric? code) → Bool` | ASCII digits (0-9). |
+| `char-whitespace?` | `(char-whitespace? code) → Bool` | Space, tab, newline, carriage return, form feed. |
+| `char-upper-case?` | `(char-upper-case? code) → Bool` | ASCII A-Z. |
+| `char-lower-case?` | `(char-lower-case? code) → Bool` | ASCII a-z. |
+| `char->integer` | `(char->integer code) → Int` | Identity function in this encoding (chars *are* integers). Provided for R7RS source compatibility. |
+| `integer->char` | `(integer->char n) → Int` | Identity. |
+| `char-upcase` | `(char-upcase code) → Int` | ASCII upper-case conversion. |
+| `char-downcase` | `(char-downcase code) → Int` | ASCII lower-case conversion. |
+
+## Error handling
+
+String operations that receive a non-string argument return a `RunError::TypeError`.
+Out-of-bounds accesses return `RunError::MalformedInstruction`.
+
+## Relationship to refinement types (TW05)
+
+After LANG47, the compiler can express:
+
+```scheme
+(define (string-ref (s : String) (i : (Index (string-length s))) -> Int) ...)
+```
+
+The `(Index (string-length s))` refinement is a dependent predicate linking the
+index to the string's length.  The `iir-refinement-pass` (LANG42) already discharges
+static proof obligations for integer ranges.  Dependent predicates over string length
+are `Unknown` at the LANG47 stage (the solver does not yet have a model for string
+lengths), so lenient mode remains the default for string-indexed operations until
+LANG48 (flow-sensitive narrowing) adds guard-based evidence for length checks.
+
+## Tests required
+
+**`lispy-runtime`:**
+
+- `alloc_string` round-trips via `string_bytes`;
+- `alloc_string(b"hello").is_heap()` is true;
+- `is_string(alloc_string(b"x"))` is true;
+- `is_string(LispyValue::int(0))` is false;
+- `is_string(alloc_cons(NIL, NIL))` is false;
+- `is_string(alloc_closure(...))` is false;
+- empty string round-trips;
+- multi-byte UTF-8 string round-trips.
+
+**`twig-vm`:**
+
+Unit tests (hand-built IIR modules) for every builtin listed above:
+- `string?` returns `#t` for a heap string and `#f` otherwise;
+- `string-length` counts code points correctly (ASCII and multi-byte);
+- `string-ref` returns the correct code point;
+- `string-ref` out-of-bounds returns a `RunError`;
+- `substring` returns the correct slice;
+- `substring` with bad indices returns a `RunError`;
+- `string-append` concatenates two strings;
+- `string=?` compares correctly (equal and not-equal cases);
+- `string<?` orders correctly;
+- `number->string` round-trips for small positive and negative integers;
+- `string->number` parses valid and invalid inputs;
+- `string->symbol` / `symbol->string` round-trip;
+- all char predicates on ASCII corners;
+- `char-upcase` / `char-downcase` round-trip.
+
+**`const Operand::Str` change:**
+
+- A `const` instruction with `Operand::Str("hello")` stores a heap string (not a symbol).
+
+## Definition of done
+
+- `cargo test -p lispy-runtime` passes (string tests added).
+- `cargo test -p twig-vm` passes (string builtin tests added).
+- `cargo build --workspace` clean.
+- String operations available to Twig programs via `call_builtin`.


### PR DESCRIPTION
## Summary

- **`lispy-runtime` v0.3.0**: Adds `LangString` heap object (`CLASS_STRING = 3`) with `alloc_string`, `is_string`, `string_bytes`. Registers 22 string/character builtins (`string?`, `string-length`, `string-ref`, `substring`, `string-append`, `string=?`, `number->string`, `string->number`, `string->symbol`, `symbol->string`, all `char-*` predicates/converters). Updates `LispyClass`, `LangBinding::equal`, and `trace_object`.
- **`twig-vm` v0.11.0**: Changes `const Operand::Str(text)` to produce a heap string (previously interned as symbol — the PR 5 stand-in). LANG34 already removed the last non-string use of this path, making the change safe.
- **`code/specs/LANG47-string-builtins.md`**: Spec committed before implementation.

## Why this matters

TW05 (self-hosted Twig compiler) must manipulate source text: read characters, slice substrings, convert tokens. Without `string-ref`/`string-length`/`substring`, that is impossible. LANG47 unblocks the next phase of TW05 work.

## Test plan

- [x] `cargo test -p lispy-runtime` — 147 tests pass (30 new string/heap tests)
- [x] `cargo test -p twig-vm` — 157 tests pass (18 new string dispatch tests)
- [x] `cargo build -p lispy-runtime -p twig-vm -p twig-aot -p twig-ir-compiler -p iir-builtin-lowering -p iir-refinement-pass` — clean build
- [x] Security review passed — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)