### PR TITLE
Add Rust capability sandbox planning primitives

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -297,6 +297,7 @@ members = [
     "windows-job-backend-task-xml",
     "os-job-core",
     "os-job-runtime",
+    "operation-primitives",
     "event-loop",
     "hyperloglog",
     "hash-functions",
@@ -617,5 +618,6 @@ members = [
     "zigbee-zdo",
     "zwave-command-classes",
     "capability-cage",
+    "capability-os-sandbox",
     "iir-to-jvm-class-file",
 ]

--- a/code/packages/rust/capability-os-sandbox/BUILD
+++ b/code/packages/rust/capability-os-sandbox/BUILD
@@ -1,0 +1,1 @@
+cargo test -p capability-os-sandbox -- --nocapture

--- a/code/packages/rust/capability-os-sandbox/CHANGELOG.md
+++ b/code/packages/rust/capability-os-sandbox/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [0.1.0] - 2026-05-14
+
+### Added
+
+- Added manifest-to-sandbox lowering for Linux, macOS, Windows, FreeBSD,
+  OpenBSD, and portable host-broker plans.
+- Added coverage labels for direct OS enforcement, brokered mediation,
+  launch-time setup, and advisory narrowing.

--- a/code/packages/rust/capability-os-sandbox/Cargo.toml
+++ b/code/packages/rust/capability-os-sandbox/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "capability-os-sandbox"
+version = "0.1.0"
+edition = "2021"
+description = "Lower required_capabilities.json manifests into OS-specific sandbox primitive plans"
+
+[dependencies]
+capability-cage = { path = "../capability-cage" }
+coding-adventures-json-value = { path = "../json-value" }
+operation-primitives = { path = "../operation-primitives" }

--- a/code/packages/rust/capability-os-sandbox/README.md
+++ b/code/packages/rust/capability-os-sandbox/README.md
@@ -1,0 +1,17 @@
+# capability-os-sandbox
+
+`capability-os-sandbox` lowers `required_capabilities.json` manifests into
+reviewable OS sandbox primitive plans.
+
+The manifest remains the source of truth. This crate translates each declared
+capability into a platform-specific defense-in-depth rule and labels the rule's
+coverage:
+
+- `direct`: an OS primitive can enforce the boundary.
+- `brokered`: a host broker must mediate the operation.
+- `launch_time`: the boundary is applied when the process is spawned.
+- `advisory`: the OS primitive narrows the class of behavior but not the exact
+  target.
+
+Supported planning targets are Linux, macOS, Windows, FreeBSD, OpenBSD, and a
+portable host-broker fallback.

--- a/code/packages/rust/capability-os-sandbox/required_capabilities.json
+++ b/code/packages/rust/capability-os-sandbox/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/capability-os-sandbox",
+  "capabilities": [],
+  "justification": "Pure manifest lowering. The crate translates caller-provided JSON strings into sandbox plans without reading files, opening sockets, spawning processes, or touching environment variables."
+}

--- a/code/packages/rust/capability-os-sandbox/src/lib.rs
+++ b/code/packages/rust/capability-os-sandbox/src/lib.rs
@@ -1,0 +1,603 @@
+#![forbid(unsafe_code)]
+
+use std::fmt;
+
+use capability_cage::{Action, Capability, Category, Manifest};
+use coding_adventures_json_value::{parse, JsonValue};
+use operation_primitives::{start_new, OperationError};
+
+/// Host operating system family for sandbox lowering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OsFamily {
+    Linux,
+    Macos,
+    Windows,
+    FreeBsd,
+    OpenBsd,
+    Portable,
+}
+
+impl OsFamily {
+    pub fn current() -> Self {
+        if cfg!(target_os = "linux") {
+            Self::Linux
+        } else if cfg!(target_os = "macos") {
+            Self::Macos
+        } else if cfg!(target_os = "windows") {
+            Self::Windows
+        } else if cfg!(target_os = "freebsd") {
+            Self::FreeBsd
+        } else if cfg!(target_os = "openbsd") {
+            Self::OpenBsd
+        } else {
+            Self::Portable
+        }
+    }
+
+    pub fn all_supported() -> [Self; 6] {
+        [
+            Self::Linux,
+            Self::Macos,
+            Self::Windows,
+            Self::FreeBsd,
+            Self::OpenBsd,
+            Self::Portable,
+        ]
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Linux => "linux",
+            Self::Macos => "macos",
+            Self::Windows => "windows",
+            Self::FreeBsd => "freebsd",
+            Self::OpenBsd => "openbsd",
+            Self::Portable => "portable",
+        }
+    }
+}
+
+impl fmt::Display for OsFamily {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// How strong the lowered primitive is for the manifest target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SandboxCoverage {
+    Direct,
+    Brokered,
+    LaunchTime,
+    Advisory,
+}
+
+impl SandboxCoverage {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Direct => "direct",
+            Self::Brokered => "brokered",
+            Self::LaunchTime => "launch_time",
+            Self::Advisory => "advisory",
+        }
+    }
+}
+
+impl fmt::Display for SandboxCoverage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One OS-level primitive selected for one capability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxRule {
+    pub capability: Capability,
+    pub os: OsFamily,
+    pub primitive: String,
+    pub expression: String,
+    pub coverage: SandboxCoverage,
+    pub note: String,
+}
+
+impl SandboxRule {
+    pub fn capability_key(&self) -> String {
+        format!(
+            "{}:{}:{}",
+            self.capability.category, self.capability.action, self.capability.target
+        )
+    }
+
+    pub fn is_native(&self) -> bool {
+        self.coverage != SandboxCoverage::Brokered || !self.primitive.contains("host_broker")
+    }
+}
+
+/// Full lowering plan for one OS.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxPlan {
+    pub package: String,
+    pub os: OsFamily,
+    pub rules: Vec<SandboxRule>,
+}
+
+impl SandboxPlan {
+    pub fn empty(package: impl Into<String>, os: OsFamily) -> Self {
+        Self {
+            package: package.into(),
+            os,
+            rules: Vec::new(),
+        }
+    }
+
+    pub fn summary(&self) -> SandboxPlanSummary {
+        let mut summary = SandboxPlanSummary {
+            package: self.package.clone(),
+            os: self.os,
+            total_rules: self.rules.len(),
+            ..SandboxPlanSummary::default()
+        };
+        for rule in &self.rules {
+            match rule.coverage {
+                SandboxCoverage::Direct => summary.direct_rules += 1,
+                SandboxCoverage::Brokered => summary.brokered_rules += 1,
+                SandboxCoverage::LaunchTime => summary.launch_time_rules += 1,
+                SandboxCoverage::Advisory => summary.advisory_rules += 1,
+            }
+            if rule.primitive.contains("host_broker") {
+                summary.host_broker_rules += 1;
+            } else {
+                summary.native_rules += 1;
+            }
+        }
+        summary
+    }
+
+    pub fn has_primitive(&self, primitive: &str) -> bool {
+        self.rules.iter().any(|rule| rule.primitive == primitive)
+    }
+}
+
+/// Payload-light summary for end-to-end tests and audit records.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxPlanSummary {
+    pub package: String,
+    pub os: OsFamily,
+    pub total_rules: usize,
+    pub direct_rules: usize,
+    pub brokered_rules: usize,
+    pub launch_time_rules: usize,
+    pub advisory_rules: usize,
+    pub native_rules: usize,
+    pub host_broker_rules: usize,
+}
+
+impl Default for SandboxPlanSummary {
+    fn default() -> Self {
+        Self {
+            package: String::new(),
+            os: OsFamily::Portable,
+            total_rules: 0,
+            direct_rules: 0,
+            brokered_rules: 0,
+            launch_time_rules: 0,
+            advisory_rules: 0,
+            native_rules: 0,
+            host_broker_rules: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxPlanError {
+    Manifest(String),
+    Operation(OperationError),
+}
+
+impl fmt::Display for SandboxPlanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Manifest(message) => write!(f, "sandbox manifest error: {message}"),
+            Self::Operation(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for SandboxPlanError {}
+
+/// Lower one manifest JSON document into one OS plan.
+pub fn plan_from_json(manifest_json: &str, os: OsFamily) -> Result<SandboxPlan, SandboxPlanError> {
+    let fallback = SandboxPlan::empty("<invalid>", os);
+    start_new(
+        "capability-os-sandbox.plan_from_json",
+        fallback,
+        |op, rf| {
+            op.add_property("os", os.as_str());
+            match build_plan_from_json(manifest_json, os) {
+                Ok(plan) => {
+                    op.add_property("package", &plan.package);
+                    op.add_property("rules", plan.rules.len());
+                    rf.succeed(plan)
+                }
+                Err(error) => rf.fail(SandboxPlan::empty("<invalid>", os), error.to_string()),
+            }
+        },
+    )
+    .get_result()
+    .map_err(SandboxPlanError::Operation)
+}
+
+/// Lower one manifest JSON document for every supported OS family.
+pub fn plan_all_supported(manifest_json: &str) -> Result<Vec<SandboxPlan>, SandboxPlanError> {
+    OsFamily::all_supported()
+        .into_iter()
+        .map(|os| plan_from_json(manifest_json, os))
+        .collect()
+}
+
+/// Lower one manifest JSON document for the current host OS.
+pub fn plan_for_current_os(manifest_json: &str) -> Result<SandboxPlan, SandboxPlanError> {
+    plan_from_json(manifest_json, OsFamily::current())
+}
+
+fn build_plan_from_json(
+    manifest_json: &str,
+    os: OsFamily,
+) -> Result<SandboxPlan, SandboxPlanError> {
+    let package = manifest_package(manifest_json)?;
+    let manifest = Manifest::load_from_str(manifest_json)
+        .map_err(|error| SandboxPlanError::Manifest(error.to_string()))?;
+    let rules = manifest
+        .capabilities()
+        .iter()
+        .map(|capability| lower_capability(capability, os))
+        .collect();
+    Ok(SandboxPlan { package, os, rules })
+}
+
+fn manifest_package(manifest_json: &str) -> Result<String, SandboxPlanError> {
+    let root =
+        parse(manifest_json).map_err(|error| SandboxPlanError::Manifest(error.to_string()))?;
+    let object = match root {
+        JsonValue::Object(pairs) => pairs,
+        _ => {
+            return Err(SandboxPlanError::Manifest(
+                "top-level manifest value must be an object".to_string(),
+            ))
+        }
+    };
+    object
+        .iter()
+        .find_map(|(key, value)| {
+            if key == "package" {
+                match value {
+                    JsonValue::String(package) => Some(package.clone()),
+                    _ => Some(String::new()),
+                }
+            } else {
+                None
+            }
+        })
+        .filter(|package| !package.is_empty())
+        .ok_or_else(|| {
+            SandboxPlanError::Manifest("manifest package field must be a string".to_string())
+        })
+}
+
+fn lower_capability(capability: &Capability, os: OsFamily) -> SandboxRule {
+    let (primitive, coverage, note) = match os {
+        OsFamily::Linux => lower_linux(capability),
+        OsFamily::Macos => lower_macos(capability),
+        OsFamily::Windows => lower_windows(capability),
+        OsFamily::FreeBsd => lower_freebsd(capability),
+        OsFamily::OpenBsd => lower_openbsd(capability),
+        OsFamily::Portable => lower_portable(capability),
+    };
+    SandboxRule {
+        capability: capability.clone(),
+        os,
+        primitive: primitive.to_string(),
+        expression: expression_for(capability, primitive),
+        coverage,
+        note: note.to_string(),
+    }
+}
+
+fn lower_linux(capability: &Capability) -> (&'static str, SandboxCoverage, &'static str) {
+    match capability.category {
+        Category::Fs if capability.target == "*" => (
+            "linux.mount_namespace",
+            SandboxCoverage::Advisory,
+            "wildcard filesystem grants need a narrowed root or a host broker to become target-exact",
+        ),
+        Category::Fs => (
+            "linux.landlock.path_beneath",
+            SandboxCoverage::Direct,
+            "Landlock can restrict file actions to declared paths after process start",
+        ),
+        Category::Net if capability.action == Action::Dns => (
+            "linux.seccomp.brokered_resolver",
+            SandboxCoverage::Brokered,
+            "hostname resolution needs a broker when the manifest target is a DNS name",
+        ),
+        Category::Net => (
+            "linux.cgroup_bpf.sock_addr",
+            SandboxCoverage::Direct,
+            "cgroup socket-address filters can restrict connect/listen targets",
+        ),
+        Category::Proc => (
+            "linux.seccomp.process_syscalls",
+            SandboxCoverage::Direct,
+            "seccomp plus pid/user namespaces bound process creation and signalling",
+        ),
+        Category::Env => (
+            "linux.execve.env_allowlist",
+            SandboxCoverage::LaunchTime,
+            "environment capabilities are enforced by constructing the child env block",
+        ),
+        Category::Ffi => (
+            "linux.mount_namespace.library_view",
+            SandboxCoverage::Direct,
+            "library loading is reduced to the visible filesystem and executable mappings",
+        ),
+        Category::Time => (
+            "linux.seccomp.clock_syscalls",
+            SandboxCoverage::Advisory,
+            "time reads can be syscall-shaped but not meaningfully target-scoped",
+        ),
+        Category::Stdin | Category::Stdout => (
+            "linux.fd_table",
+            SandboxCoverage::LaunchTime,
+            "stdio authority is selected by the file descriptors inherited at spawn",
+        ),
+    }
+}
+
+fn lower_macos(capability: &Capability) -> (&'static str, SandboxCoverage, &'static str) {
+    match capability.category {
+        Category::Env => (
+            "macos.posix_spawn.env_allowlist",
+            SandboxCoverage::LaunchTime,
+            "environment authority is selected when spawning the child",
+        ),
+        Category::Stdin | Category::Stdout => (
+            "macos.posix_spawn.file_actions",
+            SandboxCoverage::LaunchTime,
+            "stdio authority is selected through inherited descriptors",
+        ),
+        Category::Time => (
+            "macos.seatbelt.profile",
+            SandboxCoverage::Advisory,
+            "Seatbelt profiles help shape system access but do not target-scope time reads",
+        ),
+        _ => (
+            "macos.seatbelt.profile",
+            SandboxCoverage::Direct,
+            "Seatbelt/App Sandbox profiles carry filesystem, network, process, and mapping policy",
+        ),
+    }
+}
+
+fn lower_windows(capability: &Capability) -> (&'static str, SandboxCoverage, &'static str) {
+    match capability.category {
+        Category::Fs => (
+            "windows.appcontainer.acl",
+            SandboxCoverage::Direct,
+            "AppContainer identity plus ACLs can restrict file object access",
+        ),
+        Category::Net => (
+            "windows.appcontainer.network_capability",
+            SandboxCoverage::Direct,
+            "AppContainer network capabilities and firewall policy shape socket authority",
+        ),
+        Category::Proc => (
+            "windows.job_object.restricted_token",
+            SandboxCoverage::Direct,
+            "restricted tokens and job objects constrain child processes and signalling",
+        ),
+        Category::Env => (
+            "windows.createprocess.environment_block",
+            SandboxCoverage::LaunchTime,
+            "the child environment block is built from the manifest allowlist",
+        ),
+        Category::Ffi => (
+            "windows.process_mitigation.dll_policy",
+            SandboxCoverage::Advisory,
+            "DLL loading needs search-path and mitigation policy plus broker review",
+        ),
+        Category::Time => (
+            "windows.restricted_token",
+            SandboxCoverage::Advisory,
+            "time reads are not target-scoped by Windows sandbox primitives",
+        ),
+        Category::Stdin | Category::Stdout => (
+            "windows.handle_inheritance",
+            SandboxCoverage::LaunchTime,
+            "stdio authority is selected by inheritable handles at spawn",
+        ),
+    }
+}
+
+fn lower_freebsd(capability: &Capability) -> (&'static str, SandboxCoverage, &'static str) {
+    match capability.category {
+        Category::Fs | Category::Ffi => (
+            "freebsd.capsicum.cap_rights",
+            SandboxCoverage::Direct,
+            "Capsicum preopens handles and limits rights before capability mode",
+        ),
+        Category::Net if capability.action == Action::Dns => (
+            "freebsd.host_broker.resolver",
+            SandboxCoverage::Brokered,
+            "DNS names require a resolver broker when using Capsicum capability mode",
+        ),
+        Category::Net => (
+            "freebsd.jail.vnet_firewall",
+            SandboxCoverage::Direct,
+            "jails with VNET/firewall rules shape socket authority",
+        ),
+        Category::Proc => (
+            "freebsd.jail.rctl",
+            SandboxCoverage::Direct,
+            "jail and rctl policy constrain process authority",
+        ),
+        Category::Env => (
+            "freebsd.posix_spawn.env_allowlist",
+            SandboxCoverage::LaunchTime,
+            "the child environment is built from the manifest allowlist",
+        ),
+        Category::Time => (
+            "freebsd.capsicum.capability_mode",
+            SandboxCoverage::Advisory,
+            "capability mode narrows global access but not target-scoped time reads",
+        ),
+        Category::Stdin | Category::Stdout => (
+            "freebsd.capsicum.fd_rights",
+            SandboxCoverage::LaunchTime,
+            "stdio authority is selected by inherited descriptors and Capsicum rights",
+        ),
+    }
+}
+
+fn lower_openbsd(capability: &Capability) -> (&'static str, SandboxCoverage, &'static str) {
+    match capability.category {
+        Category::Fs | Category::Ffi => (
+            "openbsd.unveil",
+            SandboxCoverage::Direct,
+            "unveil can restrict visible filesystem paths and rights",
+        ),
+        Category::Env => (
+            "openbsd.execve.env_allowlist",
+            SandboxCoverage::LaunchTime,
+            "the child environment is built from the manifest allowlist",
+        ),
+        Category::Stdin | Category::Stdout => (
+            "openbsd.fd_inheritance",
+            SandboxCoverage::LaunchTime,
+            "stdio authority is selected by inherited descriptors",
+        ),
+        _ => (
+            "openbsd.pledge",
+            SandboxCoverage::Advisory,
+            "pledge narrows syscall classes but does not target-scope hosts or PIDs",
+        ),
+    }
+}
+
+fn lower_portable(_capability: &Capability) -> (&'static str, SandboxCoverage, &'static str) {
+    (
+        "host_broker.json_rpc",
+        SandboxCoverage::Brokered,
+        "portable defense-in-depth routes the operation through a manifest-checking host broker",
+    )
+}
+
+fn expression_for(capability: &Capability, primitive: &str) -> String {
+    format!(
+        "{} allow {}:{} target={}",
+        primitive, capability.category, capability.action, capability.target
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WEATHER_MANIFEST: &str = r#"{
+      "version": 1,
+      "package": "rust/weather-agent-e2e",
+      "capabilities": [
+        {
+          "category": "net",
+          "action": "dns",
+          "target": "api.weather.gov",
+          "justification": "Resolve Weather.gov for the live umbrella forecast."
+        },
+        {
+          "category": "net",
+          "action": "connect",
+          "target": "api.weather.gov:443",
+          "justification": "Fetch the Weather.gov points and forecast resources over TLS."
+        },
+        {
+          "category": "fs",
+          "action": "write",
+          "target": "/tmp/umbrella-today.txt",
+          "justification": "Write the umbrella decision text file."
+        }
+      ],
+      "justification": "Weather Agent E2E fetches live weather and writes one report."
+    }"#;
+
+    #[test]
+    fn empty_manifest_lowers_to_empty_plan() {
+        let plan = plan_from_json(
+            r#"{
+              "version": 1,
+              "package": "rust/pure",
+              "capabilities": [],
+              "justification": "Pure computation."
+            }"#,
+            OsFamily::Linux,
+        )
+        .unwrap();
+
+        assert_eq!(plan.package, "rust/pure");
+        assert_eq!(plan.rules.len(), 0);
+        assert_eq!(plan.summary().total_rules, 0);
+    }
+
+    #[test]
+    fn weather_manifest_lowers_to_linux_primitives() {
+        let plan = plan_from_json(WEATHER_MANIFEST, OsFamily::Linux).unwrap();
+
+        assert!(plan.has_primitive("linux.landlock.path_beneath"));
+        assert!(plan.has_primitive("linux.cgroup_bpf.sock_addr"));
+        assert!(plan.has_primitive("linux.seccomp.brokered_resolver"));
+        assert_eq!(plan.summary().total_rules, 3);
+        assert_eq!(plan.summary().direct_rules, 2);
+        assert_eq!(plan.summary().brokered_rules, 1);
+    }
+
+    #[test]
+    fn weather_manifest_lowers_to_macos_windows_and_portable() {
+        let macos = plan_from_json(WEATHER_MANIFEST, OsFamily::Macos).unwrap();
+        assert!(macos.has_primitive("macos.seatbelt.profile"));
+
+        let windows = plan_from_json(WEATHER_MANIFEST, OsFamily::Windows).unwrap();
+        assert!(windows.has_primitive("windows.appcontainer.network_capability"));
+        assert!(windows.has_primitive("windows.appcontainer.acl"));
+
+        let portable = plan_from_json(WEATHER_MANIFEST, OsFamily::Portable).unwrap();
+        assert_eq!(portable.summary().brokered_rules, 3);
+        assert_eq!(portable.summary().host_broker_rules, 3);
+    }
+
+    #[test]
+    fn invalid_manifest_reports_operation_error_with_context() {
+        let error = plan_from_json(
+            r#"{"version":1,"package":"rust/bad","capabilities":"oops"}"#,
+            OsFamily::Linux,
+        )
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("capabilities must be an array"));
+        match error {
+            SandboxPlanError::Operation(operation) => {
+                assert_eq!(
+                    operation.properties.get("os").map(String::as_str),
+                    Some("linux")
+                );
+            }
+            other => panic!("expected operation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_supported_plans_cover_six_os_families() {
+        let plans = plan_all_supported(WEATHER_MANIFEST).unwrap();
+        assert_eq!(plans.len(), 6);
+        assert_eq!(plans[0].os, OsFamily::Linux);
+        assert_eq!(plans[5].os, OsFamily::Portable);
+    }
+}

--- a/code/packages/rust/operation-primitives/BUILD
+++ b/code/packages/rust/operation-primitives/BUILD
@@ -1,0 +1,1 @@
+cargo test -p operation-primitives -- --nocapture

--- a/code/packages/rust/operation-primitives/CHANGELOG.md
+++ b/code/packages/rust/operation-primitives/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - 2026-05-14
+
+### Added
+
+- Added Rust operation envelope primitives: `OperationResult`, `ResultFactory`,
+  `OperationScope`, `OperationOutcome`, `OperationError`, and `start_new`.
+- Added panic capture with optional rethrow through `panic_on_unexpected`.

--- a/code/packages/rust/operation-primitives/Cargo.toml
+++ b/code/packages/rust/operation-primitives/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "operation-primitives"
+version = "0.1.0"
+edition = "2021"
+description = "Rust operation envelope primitives for generated capability cages"
+
+[dependencies]

--- a/code/packages/rust/operation-primitives/README.md
+++ b/code/packages/rust/operation-primitives/README.md
@@ -1,0 +1,13 @@
+# operation-primitives
+
+Rust port of the operation envelope generated for Go capability-cage packages.
+
+The crate provides:
+
+- `OperationResult<T>`: success, expected failure, or unexpected failure plus a value.
+- `ResultFactory<T>`: helpers for producing operation results inside callbacks.
+- `Operation<T, F>`: named callback wrapper with a property bag and panic capture.
+- `start_new(...)`: constructor matching the Go `StartNew` shape.
+
+Use this crate when a package wants one uniform envelope for capability checks,
+host calls, sandbox planning, or generated code.

--- a/code/packages/rust/operation-primitives/required_capabilities.json
+++ b/code/packages/rust/operation-primitives/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/operation-primitives",
+  "capabilities": [],
+  "justification": "Pure operation envelope types. This crate performs no filesystem, network, process, environment, or stdio access."
+}

--- a/code/packages/rust/operation-primitives/src/lib.rs
+++ b/code/packages/rust/operation-primitives/src/lib.rs
@@ -1,0 +1,341 @@
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+
+/// Three-state result produced by an operation callback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationResult<T> {
+    pub did_succeed: bool,
+    pub did_fail_unexpectedly: bool,
+    pub return_value: T,
+    pub error: Option<String>,
+}
+
+impl<T> OperationResult<T> {
+    pub fn success(value: T) -> Self {
+        Self {
+            did_succeed: true,
+            did_fail_unexpectedly: false,
+            return_value: value,
+            error: None,
+        }
+    }
+
+    pub fn expected_failure(value: T, error: impl Into<String>) -> Self {
+        Self {
+            did_succeed: false,
+            did_fail_unexpectedly: false,
+            return_value: value,
+            error: Some(error.into()),
+        }
+    }
+
+    pub fn unexpected_failure(value: T, error: impl Into<String>) -> Self {
+        Self {
+            did_succeed: false,
+            did_fail_unexpectedly: true,
+            return_value: value,
+            error: Some(error.into()),
+        }
+    }
+
+    pub fn from_parts(
+        did_succeed: bool,
+        did_fail_unexpectedly: bool,
+        value: T,
+        error: Option<String>,
+    ) -> Self {
+        Self {
+            did_succeed,
+            did_fail_unexpectedly,
+            return_value: value,
+            error,
+        }
+    }
+}
+
+/// Creates [`OperationResult`] values inside callbacks.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResultFactory<T> {
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> ResultFactory<T> {
+    pub fn new() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn generate(
+        &self,
+        did_succeed: bool,
+        did_fail_unexpectedly: bool,
+        value: T,
+    ) -> OperationResult<T> {
+        OperationResult::from_parts(did_succeed, did_fail_unexpectedly, value, None)
+    }
+
+    pub fn succeed(&self, value: T) -> OperationResult<T> {
+        OperationResult::success(value)
+    }
+
+    pub fn fail(&self, value: T, error: impl Into<String>) -> OperationResult<T> {
+        OperationResult::expected_failure(value, error)
+    }
+
+    pub fn fail_unexpectedly(&self, value: T, error: impl Into<String>) -> OperationResult<T> {
+        OperationResult::unexpected_failure(value, error)
+    }
+}
+
+/// Mutable callback context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationScope {
+    name: String,
+    property_bag: BTreeMap<String, String>,
+}
+
+impl OperationScope {
+    fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            property_bag: BTreeMap::new(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn add_property(&mut self, name: impl Into<String>, value: impl ToString) {
+        self.property_bag.insert(name.into(), value.to_string());
+    }
+
+    pub fn properties(&self) -> &BTreeMap<String, String> {
+        &self.property_bag
+    }
+}
+
+/// Error kind for operation failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationErrorKind {
+    Expected,
+    Unexpected,
+}
+
+/// Error returned when an operation does not succeed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationError {
+    pub name: String,
+    pub kind: OperationErrorKind,
+    pub message: String,
+    pub properties: BTreeMap<String, String>,
+}
+
+impl OperationError {
+    pub fn is_expected(&self) -> bool {
+        self.kind == OperationErrorKind::Expected
+    }
+
+    pub fn is_unexpected(&self) -> bool {
+        self.kind == OperationErrorKind::Unexpected
+    }
+}
+
+impl fmt::Display for OperationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            OperationErrorKind::Expected => {
+                write!(f, "operation {:?} failed: {}", self.name, self.message)
+            }
+            OperationErrorKind::Unexpected => write!(
+                f,
+                "operation {:?} failed unexpectedly: {}",
+                self.name, self.message
+            ),
+        }
+    }
+}
+
+impl std::error::Error for OperationError {}
+
+/// Outcome preserving Go-style `(value, error)` semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationOutcome<T> {
+    pub value: T,
+    pub error: Option<OperationError>,
+}
+
+impl<T> OperationOutcome<T> {
+    pub fn into_result(self) -> Result<T, OperationError> {
+        match self.error {
+            Some(error) => Err(error),
+            None => Ok(self.value),
+        }
+    }
+}
+
+/// A named unit of work.
+pub struct Operation<T, F>
+where
+    F: FnOnce(&mut OperationScope, &ResultFactory<T>) -> OperationResult<T>,
+{
+    name: String,
+    fallback: T,
+    callback: Option<F>,
+    re_panic: bool,
+}
+
+impl<T, F> Operation<T, F>
+where
+    F: FnOnce(&mut OperationScope, &ResultFactory<T>) -> OperationResult<T>,
+{
+    pub fn panic_on_unexpected(mut self) -> Self {
+        self.re_panic = true;
+        self
+    }
+
+    pub fn get_outcome(mut self) -> OperationOutcome<T> {
+        let name = self.name.clone();
+        let mut scope = OperationScope::new(name.clone());
+        let rf = ResultFactory::<T>::new();
+        let callback = self
+            .callback
+            .take()
+            .expect("operation callback should be present exactly once");
+
+        let result = catch_unwind(AssertUnwindSafe(|| callback(&mut scope, &rf)));
+        let properties = scope.property_bag;
+
+        let operation_result = match result {
+            Ok(operation_result) => operation_result,
+            Err(panic_value) => {
+                if self.re_panic {
+                    resume_unwind(panic_value);
+                }
+                OperationResult::unexpected_failure(
+                    self.fallback,
+                    "callback panicked before producing an operation result",
+                )
+            }
+        };
+
+        if operation_result.did_succeed {
+            return OperationOutcome {
+                value: operation_result.return_value,
+                error: None,
+            };
+        }
+
+        let kind = if operation_result.did_fail_unexpectedly {
+            OperationErrorKind::Unexpected
+        } else {
+            OperationErrorKind::Expected
+        };
+        let message = operation_result.error.unwrap_or_else(|| match kind {
+            OperationErrorKind::Expected => "operation failed".to_string(),
+            OperationErrorKind::Unexpected => "operation failed unexpectedly".to_string(),
+        });
+
+        OperationOutcome {
+            value: operation_result.return_value,
+            error: Some(OperationError {
+                name,
+                kind,
+                message,
+                properties,
+            }),
+        }
+    }
+
+    pub fn get_result(self) -> Result<T, OperationError> {
+        self.get_outcome().into_result()
+    }
+}
+
+/// Create an operation without executing it.
+pub fn start_new<T, F>(name: impl Into<String>, fallback: T, callback: F) -> Operation<T, F>
+where
+    F: FnOnce(&mut OperationScope, &ResultFactory<T>) -> OperationResult<T>,
+{
+    Operation {
+        name: name.into(),
+        fallback,
+        callback: Some(callback),
+        re_panic: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_operation_returns_value() {
+        let value = start_new("math.add", 0, |op, rf| {
+            op.add_property("lhs", 2);
+            op.add_property("rhs", 3);
+            rf.succeed(5)
+        })
+        .get_result()
+        .unwrap();
+
+        assert_eq!(value, 5);
+    }
+
+    #[test]
+    fn expected_failure_preserves_fallback_value_and_properties() {
+        let outcome = start_new("fs.read", Vec::<u8>::new(), |op, rf| {
+            op.add_property("path", "/etc/passwd");
+            rf.fail(Vec::new(), "capability denied")
+        })
+        .get_outcome();
+
+        assert_eq!(outcome.value, Vec::<u8>::new());
+        let error = outcome.error.expect("expected failure should carry error");
+        assert!(error.is_expected());
+        assert_eq!(error.message, "capability denied");
+        assert_eq!(
+            error.properties.get("path").map(String::as_str),
+            Some("/etc/passwd")
+        );
+    }
+
+    #[test]
+    fn unexpected_failure_can_be_returned_without_panic() {
+        let error = start_new("planner.lower", "fallback".to_string(), |_op, rf| {
+            rf.fail_unexpectedly("fallback".to_string(), "internal invariant broke")
+        })
+        .get_result()
+        .unwrap_err();
+
+        assert!(error.is_unexpected());
+        assert_eq!(error.message, "internal invariant broke");
+    }
+
+    #[test]
+    fn panic_becomes_unexpected_failure_by_default() {
+        let outcome = start_new("panic.catcher", 42, |_op, _rf| -> OperationResult<i32> {
+            panic!("boom")
+        })
+        .get_outcome();
+
+        assert_eq!(outcome.value, 42);
+        let error = outcome.error.expect("panic should become error");
+        assert!(error.is_unexpected());
+        assert!(error.message.contains("panicked"));
+    }
+
+    #[test]
+    #[should_panic(expected = "boom")]
+    fn panic_on_unexpected_rethrows_callback_panic() {
+        let _ = start_new("panic.rethrow", 0, |_op, _rf| -> OperationResult<i32> {
+            panic!("boom")
+        })
+        .panic_on_unexpected()
+        .get_result();
+    }
+}

--- a/code/packages/rust/weather-agent-e2e/CHANGELOG.md
+++ b/code/packages/rust/weather-agent-e2e/CHANGELOG.md
@@ -12,3 +12,6 @@ All notable changes to this package will be documented in this file.
 - Added a live Weather.gov HTTPS mode through `tls-platform` + `http1`, plus a
   supervisor restart proof that kills and recreates a weather child before the
   pipeline tick.
+- Added an end-to-end sandbox-plan proof that lowers the Weather Agent
+  capability manifest into OS-specific defense-in-depth primitives for Linux,
+  macOS, Windows, FreeBSD, OpenBSD, and the portable host broker.

--- a/code/packages/rust/weather-agent-e2e/Cargo.toml
+++ b/code/packages/rust/weather-agent-e2e/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 actor = { path = "../actor" }
 artifact-store = { path = "../artifact-store" }
+capability-os-sandbox = { path = "../capability-os-sandbox" }
 capability-cage = { path = "../capability-cage" }
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding-adventures-json-value = { path = "../json-value" }

--- a/code/packages/rust/weather-agent-e2e/README.md
+++ b/code/packages/rust/weather-agent-e2e/README.md
@@ -11,7 +11,9 @@ one pipeline.
 
 The primary tests write a real `umbrella-today.txt` file through the capability
 cage, assert that the supervised agent says to bring an umbrella for the rainy
-fixture, and prove the supervisor recreates a killed child before the next tick.
+fixture, prove the supervisor recreates a killed child before the next tick, and
+lower the Weather Agent capability manifest into Linux, macOS, Windows, FreeBSD,
+OpenBSD, and portable host-broker sandbox primitive plans.
 
 Run the live HTTPS smoke manually when network access is acceptable:
 

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -17,6 +17,7 @@ use capability_cage::{
     secure_file, Action as CageAction, Capability as CageCapability, CapabilityFlavor,
     CapabilityTrust, Category as CageCategory, Manifest,
 };
+use capability_os_sandbox::{plan_all_supported, OsFamily, SandboxPlanSummary};
 use chief_of_staff_tool_api::{
     InMemoryToolRuntime, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError,
     ToolCallError, ToolConcurrency, ToolDefinition, ToolErrorKind, ToolEventKind,
@@ -450,6 +451,7 @@ pub struct UmbrellaAgentRun {
     pub output_path: PathBuf,
     pub output_text: String,
     pub weather_fetch: WeatherFetchSummary,
+    pub sandbox_plan: UmbrellaSandboxPlanSummary,
     pub supervisor: UmbrellaSupervisorSummary,
     pub tool_journal_health: ToolExecutionJournalHealthSummary,
     pub context_inventory: ContextStoreInventorySummary,
@@ -463,10 +465,77 @@ pub struct UmbrellaAgentRun {
     pub actor_channel_messages: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UmbrellaSandboxPlanSummary {
+    pub package: String,
+    pub plan_count: usize,
+    pub current_os: OsFamily,
+    pub current_os_rules: usize,
+    pub total_rules: usize,
+    pub direct_rules: usize,
+    pub brokered_rules: usize,
+    pub launch_time_rules: usize,
+    pub advisory_rules: usize,
+    pub native_rules: usize,
+    pub host_broker_rules: usize,
+    pub os_summaries: Vec<SandboxPlanSummary>,
+}
+
+impl UmbrellaSandboxPlanSummary {
+    fn from_summaries(os_summaries: Vec<SandboxPlanSummary>, current_os: OsFamily) -> Self {
+        let package = os_summaries
+            .first()
+            .map(|summary| summary.package.clone())
+            .unwrap_or_default();
+        let current_os_rules = os_summaries
+            .iter()
+            .find(|summary| summary.os == current_os)
+            .map(|summary| summary.total_rules)
+            .unwrap_or_default();
+        Self {
+            package,
+            plan_count: os_summaries.len(),
+            current_os,
+            current_os_rules,
+            total_rules: os_summaries.iter().map(|summary| summary.total_rules).sum(),
+            direct_rules: os_summaries
+                .iter()
+                .map(|summary| summary.direct_rules)
+                .sum(),
+            brokered_rules: os_summaries
+                .iter()
+                .map(|summary| summary.brokered_rules)
+                .sum(),
+            launch_time_rules: os_summaries
+                .iter()
+                .map(|summary| summary.launch_time_rules)
+                .sum(),
+            advisory_rules: os_summaries
+                .iter()
+                .map(|summary| summary.advisory_rules)
+                .sum(),
+            native_rules: os_summaries
+                .iter()
+                .map(|summary| summary.native_rules)
+                .sum(),
+            host_broker_rules: os_summaries
+                .iter()
+                .map(|summary| summary.host_broker_rules)
+                .sum(),
+            os_summaries,
+        }
+    }
+
+    pub fn summary_for_os(&self, os: OsFamily) -> Option<&SandboxPlanSummary> {
+        self.os_summaries.iter().find(|summary| summary.os == os)
+    }
+}
+
 pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<UmbrellaAgentRun> {
     let pipeline = Arc::new(UmbrellaPipeline::new(config.clone())?);
     pipeline.bootstrap_substrate()?;
 
+    let sandbox_plan = plan_agent_sandbox(&config)?;
     let (job_plan_backend, job_plan_file_count) = plan_agent_job(&config)?;
     let job_executor_status = run_executor_tick(&config)?;
 
@@ -518,6 +587,7 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         output_path: config.output_path,
         output_text,
         weather_fetch,
+        sandbox_plan,
         supervisor: supervisor_summary(&system, &actor_stats, supervisor_events),
         tool_journal_health,
         context_inventory,
@@ -1510,6 +1580,67 @@ fn recommendation_schema() -> JsonSchema {
         ],
         allow_unknown_fields: false,
     }
+}
+
+fn plan_agent_sandbox(config: &UmbrellaAgentConfig) -> UmbrellaResult<UmbrellaSandboxPlanSummary> {
+    let manifest_json = umbrella_agent_required_capabilities_json(&config.output_path);
+    let plans = plan_all_supported(&manifest_json).map_err(|error| {
+        UmbrellaAgentError::new(format!(
+            "failed to lower Weather Agent sandbox plan: {error}"
+        ))
+    })?;
+    let summaries = plans.into_iter().map(|plan| plan.summary()).collect();
+    Ok(UmbrellaSandboxPlanSummary::from_summaries(
+        summaries,
+        OsFamily::current(),
+    ))
+}
+
+fn umbrella_agent_required_capabilities_json(output_path: &Path) -> String {
+    let output_path = json_escape(&output_path.to_string_lossy());
+    format!(
+        r#"{{
+  "version": 1,
+  "package": "rust/weather-agent-e2e",
+  "capabilities": [
+    {{
+      "category": "net",
+      "action": "dns",
+      "target": "api.weather.gov",
+      "justification": "Resolve Weather.gov for the live umbrella-today weather fetch."
+    }},
+    {{
+      "category": "net",
+      "action": "connect",
+      "target": "api.weather.gov:443",
+      "justification": "Fetch Weather.gov points and forecast resources over TLS."
+    }},
+    {{
+      "category": "fs",
+      "action": "write",
+      "target": "{output_path}",
+      "justification": "Write the umbrella-today decision text file."
+    }}
+  ],
+  "justification": "Weather Agent E2E fetches Seattle weather and writes the umbrella decision."
+}}"#
+    )
+}
+
+fn json_escape(input: &str) -> String {
+    let mut escaped = String::new();
+    for ch in input.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            ch if ch.is_control() => escaped.push_str(&format!("\\u{:04x}", ch as u32)),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 fn plan_agent_job(config: &UmbrellaAgentConfig) -> UmbrellaResult<(BackendKind, usize)> {

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use capability_os_sandbox::OsFamily;
 use os_job_core::BackendKind;
 use weather_agent_e2e::{
     run_umbrella_today_agent, RecommendationKind, UmbrellaAgentConfig, WeatherFetchSourceKind,
@@ -35,6 +36,29 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
     assert_eq!(run.weather_fetch.https_requests, 0);
     assert_eq!(run.weather_fetch.tls_handshakes, 0);
     assert_eq!(run.weather_fetch.http_statuses, vec![200]);
+
+    assert_eq!(run.sandbox_plan.package, "rust/weather-agent-e2e");
+    assert_eq!(run.sandbox_plan.plan_count, 6);
+    assert_eq!(run.sandbox_plan.total_rules, 18);
+    assert_eq!(run.sandbox_plan.current_os, OsFamily::current());
+    assert_eq!(run.sandbox_plan.current_os_rules, 3);
+    assert!(run.sandbox_plan.direct_rules >= 8);
+    assert!(run.sandbox_plan.brokered_rules >= 4);
+    assert!(run.sandbox_plan.native_rules >= 12);
+    assert_eq!(
+        run.sandbox_plan
+            .summary_for_os(OsFamily::Linux)
+            .expect("linux plan should be present")
+            .total_rules,
+        3
+    );
+    assert_eq!(
+        run.sandbox_plan
+            .summary_for_os(OsFamily::Portable)
+            .expect("portable plan should be present")
+            .host_broker_rules,
+        3
+    );
 
     assert_eq!(run.supervisor.child_count, 3);
     assert_eq!(run.supervisor.stopped_children, 3);


### PR DESCRIPTION
## Summary
- add operation-primitives, a Rust port of the Go OperationResult / ResultFactory / StartNew envelope with panic capture and Go-style value-plus-error outcomes
- add capability-os-sandbox, which lowers required_capabilities.json manifests into Linux, macOS, Windows, FreeBSD, OpenBSD, and portable host-broker sandbox primitive plans
- wire Weather Agent E2E to build a capability manifest for Weather.gov DNS/connect plus report write, lower it across OS families, and assert the sandbox summaries in the umbrella integration test

## Validation
- cargo fmt -p operation-primitives -p capability-os-sandbox -p weather-agent-e2e
- cargo test -p operation-primitives -p capability-os-sandbox -p weather-agent-e2e
- cargo test -p weather-agent-e2e umbrella_today_agent_fetches_live_weather_over_tls -- --ignored --nocapture
- cargo fmt -p capability-os-sandbox && cargo test -p capability-os-sandbox -p weather-agent-e2e
- git diff --check
- verified no generated code/packages/rust/Cargo.lock remains
