### PR TITLE
[codex] Expand html5lib parser and lexer compliance

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -991,7 +991,11 @@ from = "script_data_escaped"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["flush_text", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-script-html-comment-like-text)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "script_data_escaped"
@@ -1021,7 +1025,11 @@ from = "script_data_escaped_dash"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["flush_text", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-script-html-comment-like-text)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "script_data_escaped_dash"
@@ -1057,7 +1065,11 @@ from = "script_data_escaped_dash_dash"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["flush_text", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-script-html-comment-like-text)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "script_data_escaped_dash_dash"
@@ -1164,7 +1176,11 @@ from = "script_data_double_escaped"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["flush_text", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-script-html-comment-like-text)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "script_data_double_escaped"
@@ -1195,7 +1211,11 @@ from = "script_data_double_escaped_dash"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["flush_text", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-script-html-comment-like-text)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "script_data_double_escaped_dash"
@@ -1218,7 +1238,7 @@ actions = ["append_text(current)"]
 [[transitions]]
 from = "script_data_double_escaped_dash_dash"
 matcher = { literal = ">" }
-to = "script_data_double_escaped"
+to = "script_data"
 actions = ["append_text(current)"]
 
 [[transitions]]
@@ -1232,7 +1252,11 @@ from = "script_data_double_escaped_dash_dash"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["flush_text", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-script-html-comment-like-text)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "script_data_double_escaped_dash_dash"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -4,7 +4,11 @@
 //! Do not edit by hand.
 
 #[allow(unused_imports)]
-use state_machine::{EffectfulStateMachine, FixtureDefinition, GuardDefinition, InputDefinition, MachineKind, MatcherDefinition, RegisterDefinition, StateDefinition, StateMachineDefinition, TokenDefinition, TransitionDefinition};
+use state_machine::{
+    EffectfulStateMachine, FixtureDefinition, GuardDefinition, InputDefinition, MachineKind,
+    MatcherDefinition, RegisterDefinition, StateDefinition, StateMachineDefinition,
+    TokenDefinition, TransitionDefinition,
+};
 
 pub fn html1_lexer_definition() -> StateMachineDefinition {
     let mut definition = StateMachineDefinition::new("html1-lexer", MachineKind::Transducer);
@@ -77,9 +81,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
     definition.tokens = vec![
         TokenDefinition {
             name: "Text".to_string(),
-            fields: vec![
-                "data".to_string(),
-            ],
+            fields: vec!["data".to_string()],
         },
         TokenDefinition {
             name: "StartTag".to_string(),
@@ -91,15 +93,11 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         TokenDefinition {
             name: "EndTag".to_string(),
-            fields: vec![
-                "name".to_string(),
-            ],
+            fields: vec!["name".to_string()],
         },
         TokenDefinition {
             name: "Comment".to_string(),
-            fields: vec![
-                "data".to_string(),
-            ],
+            fields: vec!["data".to_string()],
         },
         TokenDefinition {
             name: "Doctype".to_string(),
@@ -2282,6 +2280,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(eof-in-script-html-comment-like-text)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -2357,6 +2356,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(eof-in-script-html-comment-like-text)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -2447,6 +2447,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(eof-in-script-html-comment-like-text)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -2684,6 +2685,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(eof-in-script-html-comment-like-text)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -2761,6 +2763,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(eof-in-script-html-comment-like-text)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -2816,7 +2819,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
-                "script_data_double_escaped".to_string(),
+                "script_data".to_string(),
             ],
             guard: None,
             stack_pop: None,
@@ -2853,6 +2856,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error(eof-in-script-html-comment-like-text)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -1955,16 +1955,20 @@
         "Text(data=x</script>tail)",
         "EOF"
       ],
-      "diagnostics": [],
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
       "initial_state": "Script data double escaped dash state",
       "last_start_tag": "script"
     },
     {
       "id": "html5lib-smoke-154",
-      "description": "script double escaped dash dash state remains text after greater-than",
+      "description": "script double escaped dash dash state exits comment-like text after greater-than",
       "input": ">still</script>text",
       "tokens": [
-        "Text(data=>still</script>text)",
+        "Text(data=>still)",
+        "EndTag(name=script)",
+        "Text(data=text)",
         "EOF"
       ],
       "diagnostics": [],
@@ -23864,7 +23868,7 @@
       "tokens": [
         "Text(data=foo)",
         "EndTag(name=xmp)",
-        "Text(data=</baz>)",
+        "EndTag(name=baz)",
         "EOF"
       ],
       "diagnostics": [],
@@ -23878,7 +23882,7 @@
       "tokens": [
         "Text(data=foo)",
         "EndTag(name=xmp)",
-        "Text(data=</baz>)",
+        "EndTag(name=baz)",
         "EOF"
       ],
       "diagnostics": [],
@@ -23972,11 +23976,14 @@
       "tokens": [
         "Text(data=foo<!-->)",
         "EndTag(name=xmp)",
-        "Text(data=<!-->baz)",
+        "Comment(data=)",
+        "Text(data=baz)",
         "EndTag(name=xmp)",
         "EOF"
       ],
-      "diagnostics": [],
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
       "initial_state": "RCDATA state",
       "last_start_tag": "xmp"
     },
@@ -23987,11 +23994,14 @@
       "tokens": [
         "Text(data=foo<!-->)",
         "EndTag(name=xmp)",
-        "Text(data=<!-->baz)",
+        "Comment(data=)",
+        "Text(data=baz)",
         "EndTag(name=xmp)",
         "EOF"
       ],
-      "diagnostics": [],
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
       "initial_state": "RAWTEXT state",
       "last_start_tag": "xmp"
     },
@@ -31001,7 +31011,9 @@
       "description": "</script> in script HTML comment - double escaped with abrupt end",
       "input": "<!-- <script>--></script> --></script>",
       "tokens": [
-        "Text(data=<!-- <script>--></script> -->)",
+        "Text(data=<!-- <script>-->)",
+        "EndTag(name=script)",
+        "Text(data= -->)",
         "EndTag(name=script)",
         "EOF"
       ],
@@ -74604,6 +74616,3295 @@
         "EOF"
       ],
       "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-6936",
+      "description": "PLAINTEXT content model flag",
+      "input": "<head>&body;",
+      "tokens": [
+        "Text(data=<head>&body;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6937",
+      "description": "PLAINTEXT with seeming close tag",
+      "input": "</plaintext>&body;",
+      "tokens": [
+        "Text(data=</plaintext>&body;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6938-1",
+      "description": "Raw NUL replacement",
+      "input": "\\u0000",
+      "tokens": [
+        "Text(data=\\u0000)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6938-2",
+      "description": "Raw NUL replacement",
+      "input": "\\u0000",
+      "tokens": [
+        "Text(data=\\u0000)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6938-3",
+      "description": "Raw NUL replacement",
+      "input": "\\u0000",
+      "tokens": [
+        "Text(data=\\u0000)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6938-4",
+      "description": "Raw NUL replacement",
+      "input": "\\u0000",
+      "tokens": [
+        "Text(data=\\u0000)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6939",
+      "description": "NUL in script HTML comment",
+      "input": "<!--test\\u0000--><!--test-\\u0000--><!--test--\\u0000-->",
+      "tokens": [
+        "Text(data=<!--test\\u0000--><!--test-\\u0000--><!--test--\\u0000-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6940",
+      "description": "NUL in script HTML comment - double escaped",
+      "input": "<!--<script>\\u0000--><!--<script>-\\u0000--><!--<script>--\\u0000-->",
+      "tokens": [
+        "Text(data=<!--<script>\\u0000--><!--<script>-\\u0000--><!--<script>--\\u0000-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6941",
+      "description": "EOF in script HTML comment",
+      "input": "<!--test",
+      "tokens": [
+        "Text(data=<!--test)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6942",
+      "description": "EOF in script HTML comment after dash",
+      "input": "<!--test-",
+      "tokens": [
+        "Text(data=<!--test-)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6943",
+      "description": "EOF in script HTML comment after dash dash",
+      "input": "<!--test--",
+      "tokens": [
+        "Text(data=<!--test--)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6944",
+      "description": "EOF in script HTML comment double escaped after dash",
+      "input": "<!--<script>-",
+      "tokens": [
+        "Text(data=<!--<script>-)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6945",
+      "description": "EOF in script HTML comment double escaped after dash dash",
+      "input": "<!--<script>--",
+      "tokens": [
+        "Text(data=<!--<script>--)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6946",
+      "description": "EOF in script HTML comment - double escaped",
+      "input": "<!--<script>",
+      "tokens": [
+        "Text(data=<!--<script>)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6947",
+      "description": "Dash in script HTML comment",
+      "input": "<!-- - -->",
+      "tokens": [
+        "Text(data=<!-- - -->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6948",
+      "description": "Dash less-than in script HTML comment",
+      "input": "<!-- -< -->",
+      "tokens": [
+        "Text(data=<!-- -< -->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6949",
+      "description": "Dash at end of script HTML comment",
+      "input": "<!--test--->",
+      "tokens": [
+        "Text(data=<!--test--->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6950-1",
+      "description": "leading U+FEFF must pass through",
+      "input": "\\uFEFFfoo\\uFEFFbar",
+      "tokens": [
+        "Text(data=\\uFEFFfoo\\uFEFFbar)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6950-2",
+      "description": "leading U+FEFF must pass through",
+      "input": "\\uFEFFfoo\\uFEFFbar",
+      "tokens": [
+        "Text(data=\\uFEFFfoo\\uFEFFbar)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6950-3",
+      "description": "leading U+FEFF must pass through",
+      "input": "\\uFEFFfoo\\uFEFFbar",
+      "tokens": [
+        "Text(data=\\uFEFFfoo\\uFEFFbar)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6950-4",
+      "description": "leading U+FEFF must pass through",
+      "input": "\\uFEFFfoo\\uFEFFbar",
+      "tokens": [
+        "Text(data=\\uFEFFfoo\\uFEFFbar)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6951",
+      "description": "Non BMP-charref in RCDATA",
+      "input": "&NotEqualTilde;",
+      "tokens": [
+        "Text(data=\u2242\u0338)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6952",
+      "description": "Bad charref in RCDATA",
+      "input": "&NotEqualTild;",
+      "tokens": [
+        "Text(data=&NotEqualTild;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6953",
+      "description": "HTML tag in script data",
+      "input": "<b>hello world</b>",
+      "tokens": [
+        "Text(data=<b>hello world</b>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6954",
+      "description": "< in script data",
+      "input": "<test-->",
+      "tokens": [
+        "Text(data=<test-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6955",
+      "description": "<! in script data",
+      "input": "<!test-->",
+      "tokens": [
+        "Text(data=<!test-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6956",
+      "description": "<!- in script data",
+      "input": "<!-test-->",
+      "tokens": [
+        "Text(data=<!-test-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6957",
+      "description": "Escaped script data",
+      "input": "<!--test-->",
+      "tokens": [
+        "Text(data=<!--test-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6958",
+      "description": "< in script HTML comment",
+      "input": "<!-- < test -->",
+      "tokens": [
+        "Text(data=<!-- < test -->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6959",
+      "description": "</ in script HTML comment",
+      "input": "<!-- </ test -->",
+      "tokens": [
+        "Text(data=<!-- </ test -->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6960",
+      "description": "Start tag in script HTML comment",
+      "input": "<!-- <test> -->",
+      "tokens": [
+        "Text(data=<!-- <test> -->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6961",
+      "description": "End tag in script HTML comment",
+      "input": "<!-- </test> -->",
+      "tokens": [
+        "Text(data=<!-- </test> -->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6962",
+      "description": "- in script HTML comment double escaped",
+      "input": "<!--<script>-</script>-->",
+      "tokens": [
+        "Text(data=<!--<script>-</script>-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6963",
+      "description": "-- in script HTML comment double escaped",
+      "input": "<!--<script>--</script>-->",
+      "tokens": [
+        "Text(data=<!--<script>--</script>-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6964",
+      "description": "--- in script HTML comment double escaped",
+      "input": "<!--<script>---</script>-->",
+      "tokens": [
+        "Text(data=<!--<script>---</script>-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6965",
+      "description": "- spaced in script HTML comment double escaped",
+      "input": "<!--<script> - </script>-->",
+      "tokens": [
+        "Text(data=<!--<script> - </script>-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6966",
+      "description": "-- spaced in script HTML comment double escaped",
+      "input": "<!--<script> -- </script>-->",
+      "tokens": [
+        "Text(data=<!--<script> -- </script>-->)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6967-1",
+      "description": "[empty]",
+      "input": "",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6967-2",
+      "description": "[empty]",
+      "input": "",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6967-3",
+      "description": "[empty]",
+      "input": "",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6967-4",
+      "description": "[empty]",
+      "input": "",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6967-5",
+      "description": "[empty]",
+      "input": "",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6968-1",
+      "description": "\\u0009",
+      "input": "\t",
+      "tokens": [
+        "Text(data=\t)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6968-2",
+      "description": "\\u0009",
+      "input": "\t",
+      "tokens": [
+        "Text(data=\t)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6968-3",
+      "description": "\\u0009",
+      "input": "\t",
+      "tokens": [
+        "Text(data=\t)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6968-4",
+      "description": "\\u0009",
+      "input": "\t",
+      "tokens": [
+        "Text(data=\t)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6968-5",
+      "description": "\\u0009",
+      "input": "\t",
+      "tokens": [
+        "Text(data=\t)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6969-1",
+      "description": "\\u000A",
+      "input": "\n",
+      "tokens": [
+        "Text(data=\n)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6969-2",
+      "description": "\\u000A",
+      "input": "\n",
+      "tokens": [
+        "Text(data=\n)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6969-3",
+      "description": "\\u000A",
+      "input": "\n",
+      "tokens": [
+        "Text(data=\n)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6969-4",
+      "description": "\\u000A",
+      "input": "\n",
+      "tokens": [
+        "Text(data=\n)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6969-5",
+      "description": "\\u000A",
+      "input": "\n",
+      "tokens": [
+        "Text(data=\n)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6970-1",
+      "description": "\\u000B",
+      "input": "\u000b",
+      "tokens": [
+        "Text(data=\u000b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6970-2",
+      "description": "\\u000B",
+      "input": "\u000b",
+      "tokens": [
+        "Text(data=\u000b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6970-3",
+      "description": "\\u000B",
+      "input": "\u000b",
+      "tokens": [
+        "Text(data=\u000b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6970-4",
+      "description": "\\u000B",
+      "input": "\u000b",
+      "tokens": [
+        "Text(data=\u000b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6970-5",
+      "description": "\\u000B",
+      "input": "\u000b",
+      "tokens": [
+        "Text(data=\u000b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6971-1",
+      "description": "\\u000C",
+      "input": "\f",
+      "tokens": [
+        "Text(data=\f)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6971-2",
+      "description": "\\u000C",
+      "input": "\f",
+      "tokens": [
+        "Text(data=\f)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6971-3",
+      "description": "\\u000C",
+      "input": "\f",
+      "tokens": [
+        "Text(data=\f)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6971-4",
+      "description": "\\u000C",
+      "input": "\f",
+      "tokens": [
+        "Text(data=\f)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6971-5",
+      "description": "\\u000C",
+      "input": "\f",
+      "tokens": [
+        "Text(data=\f)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6972-1",
+      "description": " ",
+      "input": " ",
+      "tokens": [
+        "Text(data= )",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6972-2",
+      "description": " ",
+      "input": " ",
+      "tokens": [
+        "Text(data= )",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6972-3",
+      "description": " ",
+      "input": " ",
+      "tokens": [
+        "Text(data= )",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6972-4",
+      "description": " ",
+      "input": " ",
+      "tokens": [
+        "Text(data= )",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6972-5",
+      "description": " ",
+      "input": " ",
+      "tokens": [
+        "Text(data= )",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6973-1",
+      "description": "!",
+      "input": "!",
+      "tokens": [
+        "Text(data=!)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6973-2",
+      "description": "!",
+      "input": "!",
+      "tokens": [
+        "Text(data=!)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6973-3",
+      "description": "!",
+      "input": "!",
+      "tokens": [
+        "Text(data=!)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6973-4",
+      "description": "!",
+      "input": "!",
+      "tokens": [
+        "Text(data=!)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6973-5",
+      "description": "!",
+      "input": "!",
+      "tokens": [
+        "Text(data=!)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6974-1",
+      "description": "\"",
+      "input": "\"",
+      "tokens": [
+        "Text(data=\")",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6974-2",
+      "description": "\"",
+      "input": "\"",
+      "tokens": [
+        "Text(data=\")",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6974-3",
+      "description": "\"",
+      "input": "\"",
+      "tokens": [
+        "Text(data=\")",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6974-4",
+      "description": "\"",
+      "input": "\"",
+      "tokens": [
+        "Text(data=\")",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6974-5",
+      "description": "\"",
+      "input": "\"",
+      "tokens": [
+        "Text(data=\")",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6975-1",
+      "description": "%",
+      "input": "%",
+      "tokens": [
+        "Text(data=%)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6975-2",
+      "description": "%",
+      "input": "%",
+      "tokens": [
+        "Text(data=%)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6975-3",
+      "description": "%",
+      "input": "%",
+      "tokens": [
+        "Text(data=%)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6975-4",
+      "description": "%",
+      "input": "%",
+      "tokens": [
+        "Text(data=%)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6975-5",
+      "description": "%",
+      "input": "%",
+      "tokens": [
+        "Text(data=%)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6976-1",
+      "description": "&",
+      "input": "&",
+      "tokens": [
+        "Text(data=&)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6976-2",
+      "description": "&",
+      "input": "&",
+      "tokens": [
+        "Text(data=&)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6976-3",
+      "description": "&",
+      "input": "&",
+      "tokens": [
+        "Text(data=&)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6976-4",
+      "description": "&",
+      "input": "&",
+      "tokens": [
+        "Text(data=&)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6976-5",
+      "description": "&",
+      "input": "&",
+      "tokens": [
+        "Text(data=&)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6977-1",
+      "description": "'",
+      "input": "'",
+      "tokens": [
+        "Text(data=')",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6977-2",
+      "description": "'",
+      "input": "'",
+      "tokens": [
+        "Text(data=')",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6977-3",
+      "description": "'",
+      "input": "'",
+      "tokens": [
+        "Text(data=')",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6977-4",
+      "description": "'",
+      "input": "'",
+      "tokens": [
+        "Text(data=')",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6977-5",
+      "description": "'",
+      "input": "'",
+      "tokens": [
+        "Text(data=')",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6978-1",
+      "description": ",",
+      "input": ",",
+      "tokens": [
+        "Text(data=,)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6978-2",
+      "description": ",",
+      "input": ",",
+      "tokens": [
+        "Text(data=,)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6978-3",
+      "description": ",",
+      "input": ",",
+      "tokens": [
+        "Text(data=,)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6978-4",
+      "description": ",",
+      "input": ",",
+      "tokens": [
+        "Text(data=,)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6978-5",
+      "description": ",",
+      "input": ",",
+      "tokens": [
+        "Text(data=,)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6979-1",
+      "description": "-",
+      "input": "-",
+      "tokens": [
+        "Text(data=-)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6979-2",
+      "description": "-",
+      "input": "-",
+      "tokens": [
+        "Text(data=-)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6979-3",
+      "description": "-",
+      "input": "-",
+      "tokens": [
+        "Text(data=-)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6979-4",
+      "description": "-",
+      "input": "-",
+      "tokens": [
+        "Text(data=-)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6979-5",
+      "description": "-",
+      "input": "-",
+      "tokens": [
+        "Text(data=-)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6980-1",
+      "description": ".",
+      "input": ".",
+      "tokens": [
+        "Text(data=.)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6980-2",
+      "description": ".",
+      "input": ".",
+      "tokens": [
+        "Text(data=.)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6980-3",
+      "description": ".",
+      "input": ".",
+      "tokens": [
+        "Text(data=.)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6980-4",
+      "description": ".",
+      "input": ".",
+      "tokens": [
+        "Text(data=.)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6980-5",
+      "description": ".",
+      "input": ".",
+      "tokens": [
+        "Text(data=.)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6981-1",
+      "description": "/",
+      "input": "/",
+      "tokens": [
+        "Text(data=/)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6981-2",
+      "description": "/",
+      "input": "/",
+      "tokens": [
+        "Text(data=/)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6981-3",
+      "description": "/",
+      "input": "/",
+      "tokens": [
+        "Text(data=/)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6981-4",
+      "description": "/",
+      "input": "/",
+      "tokens": [
+        "Text(data=/)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6981-5",
+      "description": "/",
+      "input": "/",
+      "tokens": [
+        "Text(data=/)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6982-1",
+      "description": "0",
+      "input": "0",
+      "tokens": [
+        "Text(data=0)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6982-2",
+      "description": "0",
+      "input": "0",
+      "tokens": [
+        "Text(data=0)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6982-3",
+      "description": "0",
+      "input": "0",
+      "tokens": [
+        "Text(data=0)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6982-4",
+      "description": "0",
+      "input": "0",
+      "tokens": [
+        "Text(data=0)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6982-5",
+      "description": "0",
+      "input": "0",
+      "tokens": [
+        "Text(data=0)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6983-1",
+      "description": "1",
+      "input": "1",
+      "tokens": [
+        "Text(data=1)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6983-2",
+      "description": "1",
+      "input": "1",
+      "tokens": [
+        "Text(data=1)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6983-3",
+      "description": "1",
+      "input": "1",
+      "tokens": [
+        "Text(data=1)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6983-4",
+      "description": "1",
+      "input": "1",
+      "tokens": [
+        "Text(data=1)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6983-5",
+      "description": "1",
+      "input": "1",
+      "tokens": [
+        "Text(data=1)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6984-1",
+      "description": "9",
+      "input": "9",
+      "tokens": [
+        "Text(data=9)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6984-2",
+      "description": "9",
+      "input": "9",
+      "tokens": [
+        "Text(data=9)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6984-3",
+      "description": "9",
+      "input": "9",
+      "tokens": [
+        "Text(data=9)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6984-4",
+      "description": "9",
+      "input": "9",
+      "tokens": [
+        "Text(data=9)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6984-5",
+      "description": "9",
+      "input": "9",
+      "tokens": [
+        "Text(data=9)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6985-1",
+      "description": ";",
+      "input": ";",
+      "tokens": [
+        "Text(data=;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6985-2",
+      "description": ";",
+      "input": ";",
+      "tokens": [
+        "Text(data=;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6985-3",
+      "description": ";",
+      "input": ";",
+      "tokens": [
+        "Text(data=;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6985-4",
+      "description": ";",
+      "input": ";",
+      "tokens": [
+        "Text(data=;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6985-5",
+      "description": ";",
+      "input": ";",
+      "tokens": [
+        "Text(data=;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6986-1",
+      "description": ";=",
+      "input": ";=",
+      "tokens": [
+        "Text(data=;=)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6986-2",
+      "description": ";=",
+      "input": ";=",
+      "tokens": [
+        "Text(data=;=)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6986-3",
+      "description": ";=",
+      "input": ";=",
+      "tokens": [
+        "Text(data=;=)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6986-4",
+      "description": ";=",
+      "input": ";=",
+      "tokens": [
+        "Text(data=;=)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6986-5",
+      "description": ";=",
+      "input": ";=",
+      "tokens": [
+        "Text(data=;=)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6987-1",
+      "description": ";>",
+      "input": ";>",
+      "tokens": [
+        "Text(data=;>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6987-2",
+      "description": ";>",
+      "input": ";>",
+      "tokens": [
+        "Text(data=;>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6987-3",
+      "description": ";>",
+      "input": ";>",
+      "tokens": [
+        "Text(data=;>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6987-4",
+      "description": ";>",
+      "input": ";>",
+      "tokens": [
+        "Text(data=;>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6987-5",
+      "description": ";>",
+      "input": ";>",
+      "tokens": [
+        "Text(data=;>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6988-1",
+      "description": ";?",
+      "input": ";?",
+      "tokens": [
+        "Text(data=;?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6988-2",
+      "description": ";?",
+      "input": ";?",
+      "tokens": [
+        "Text(data=;?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6988-3",
+      "description": ";?",
+      "input": ";?",
+      "tokens": [
+        "Text(data=;?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6988-4",
+      "description": ";?",
+      "input": ";?",
+      "tokens": [
+        "Text(data=;?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6988-5",
+      "description": ";?",
+      "input": ";?",
+      "tokens": [
+        "Text(data=;?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6989-1",
+      "description": ";@",
+      "input": ";@",
+      "tokens": [
+        "Text(data=;@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6989-2",
+      "description": ";@",
+      "input": ";@",
+      "tokens": [
+        "Text(data=;@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6989-3",
+      "description": ";@",
+      "input": ";@",
+      "tokens": [
+        "Text(data=;@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6989-4",
+      "description": ";@",
+      "input": ";@",
+      "tokens": [
+        "Text(data=;@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6989-5",
+      "description": ";@",
+      "input": ";@",
+      "tokens": [
+        "Text(data=;@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6990-1",
+      "description": ";A",
+      "input": ";A",
+      "tokens": [
+        "Text(data=;A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6990-2",
+      "description": ";A",
+      "input": ";A",
+      "tokens": [
+        "Text(data=;A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6990-3",
+      "description": ";A",
+      "input": ";A",
+      "tokens": [
+        "Text(data=;A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6990-4",
+      "description": ";A",
+      "input": ";A",
+      "tokens": [
+        "Text(data=;A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6990-5",
+      "description": ";A",
+      "input": ";A",
+      "tokens": [
+        "Text(data=;A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6991-1",
+      "description": ";B",
+      "input": ";B",
+      "tokens": [
+        "Text(data=;B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6991-2",
+      "description": ";B",
+      "input": ";B",
+      "tokens": [
+        "Text(data=;B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6991-3",
+      "description": ";B",
+      "input": ";B",
+      "tokens": [
+        "Text(data=;B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6991-4",
+      "description": ";B",
+      "input": ";B",
+      "tokens": [
+        "Text(data=;B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6991-5",
+      "description": ";B",
+      "input": ";B",
+      "tokens": [
+        "Text(data=;B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6992-1",
+      "description": ";Y",
+      "input": ";Y",
+      "tokens": [
+        "Text(data=;Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6992-2",
+      "description": ";Y",
+      "input": ";Y",
+      "tokens": [
+        "Text(data=;Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6992-3",
+      "description": ";Y",
+      "input": ";Y",
+      "tokens": [
+        "Text(data=;Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6992-4",
+      "description": ";Y",
+      "input": ";Y",
+      "tokens": [
+        "Text(data=;Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6992-5",
+      "description": ";Y",
+      "input": ";Y",
+      "tokens": [
+        "Text(data=;Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6993-1",
+      "description": ";Z",
+      "input": ";Z",
+      "tokens": [
+        "Text(data=;Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6993-2",
+      "description": ";Z",
+      "input": ";Z",
+      "tokens": [
+        "Text(data=;Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6993-3",
+      "description": ";Z",
+      "input": ";Z",
+      "tokens": [
+        "Text(data=;Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6993-4",
+      "description": ";Z",
+      "input": ";Z",
+      "tokens": [
+        "Text(data=;Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6993-5",
+      "description": ";Z",
+      "input": ";Z",
+      "tokens": [
+        "Text(data=;Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6994-1",
+      "description": ";`",
+      "input": ";`",
+      "tokens": [
+        "Text(data=;`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6994-2",
+      "description": ";`",
+      "input": ";`",
+      "tokens": [
+        "Text(data=;`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6994-3",
+      "description": ";`",
+      "input": ";`",
+      "tokens": [
+        "Text(data=;`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6994-4",
+      "description": ";`",
+      "input": ";`",
+      "tokens": [
+        "Text(data=;`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6994-5",
+      "description": ";`",
+      "input": ";`",
+      "tokens": [
+        "Text(data=;`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6995-1",
+      "description": ";a",
+      "input": ";a",
+      "tokens": [
+        "Text(data=;a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6995-2",
+      "description": ";a",
+      "input": ";a",
+      "tokens": [
+        "Text(data=;a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6995-3",
+      "description": ";a",
+      "input": ";a",
+      "tokens": [
+        "Text(data=;a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6995-4",
+      "description": ";a",
+      "input": ";a",
+      "tokens": [
+        "Text(data=;a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6995-5",
+      "description": ";a",
+      "input": ";a",
+      "tokens": [
+        "Text(data=;a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6996-1",
+      "description": ";b",
+      "input": ";b",
+      "tokens": [
+        "Text(data=;b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6996-2",
+      "description": ";b",
+      "input": ";b",
+      "tokens": [
+        "Text(data=;b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6996-3",
+      "description": ";b",
+      "input": ";b",
+      "tokens": [
+        "Text(data=;b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6996-4",
+      "description": ";b",
+      "input": ";b",
+      "tokens": [
+        "Text(data=;b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6996-5",
+      "description": ";b",
+      "input": ";b",
+      "tokens": [
+        "Text(data=;b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6997-1",
+      "description": ";y",
+      "input": ";y",
+      "tokens": [
+        "Text(data=;y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6997-2",
+      "description": ";y",
+      "input": ";y",
+      "tokens": [
+        "Text(data=;y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6997-3",
+      "description": ";y",
+      "input": ";y",
+      "tokens": [
+        "Text(data=;y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6997-4",
+      "description": ";y",
+      "input": ";y",
+      "tokens": [
+        "Text(data=;y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6997-5",
+      "description": ";y",
+      "input": ";y",
+      "tokens": [
+        "Text(data=;y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6998-1",
+      "description": ";z",
+      "input": ";z",
+      "tokens": [
+        "Text(data=;z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6998-2",
+      "description": ";z",
+      "input": ";z",
+      "tokens": [
+        "Text(data=;z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6998-3",
+      "description": ";z",
+      "input": ";z",
+      "tokens": [
+        "Text(data=;z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6998-4",
+      "description": ";z",
+      "input": ";z",
+      "tokens": [
+        "Text(data=;z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6998-5",
+      "description": ";z",
+      "input": ";z",
+      "tokens": [
+        "Text(data=;z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-6999-1",
+      "description": ";{",
+      "input": ";{",
+      "tokens": [
+        "Text(data=;{)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-6999-2",
+      "description": ";{",
+      "input": ";{",
+      "tokens": [
+        "Text(data=;{)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-6999-3",
+      "description": ";{",
+      "input": ";{",
+      "tokens": [
+        "Text(data=;{)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-6999-4",
+      "description": ";{",
+      "input": ";{",
+      "tokens": [
+        "Text(data=;{)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-6999-5",
+      "description": ";{",
+      "input": ";{",
+      "tokens": [
+        "Text(data=;{)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7000-1",
+      "description": ";\\uDBC0\\uDC00",
+      "input": ";\udbc0\udc00",
+      "tokens": [
+        "Text(data=;\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7000-2",
+      "description": ";\\uDBC0\\uDC00",
+      "input": ";\udbc0\udc00",
+      "tokens": [
+        "Text(data=;\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7000-3",
+      "description": ";\\uDBC0\\uDC00",
+      "input": ";\udbc0\udc00",
+      "tokens": [
+        "Text(data=;\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7000-4",
+      "description": ";\\uDBC0\\uDC00",
+      "input": ";\udbc0\udc00",
+      "tokens": [
+        "Text(data=;\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7000-5",
+      "description": ";\\uDBC0\\uDC00",
+      "input": ";\udbc0\udc00",
+      "tokens": [
+        "Text(data=;\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7001-1",
+      "description": "=",
+      "input": "=",
+      "tokens": [
+        "Text(data==)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7001-2",
+      "description": "=",
+      "input": "=",
+      "tokens": [
+        "Text(data==)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7001-3",
+      "description": "=",
+      "input": "=",
+      "tokens": [
+        "Text(data==)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7001-4",
+      "description": "=",
+      "input": "=",
+      "tokens": [
+        "Text(data==)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7001-5",
+      "description": "=",
+      "input": "=",
+      "tokens": [
+        "Text(data==)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7002-1",
+      "description": ">",
+      "input": ">",
+      "tokens": [
+        "Text(data=>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7002-2",
+      "description": ">",
+      "input": ">",
+      "tokens": [
+        "Text(data=>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7002-3",
+      "description": ">",
+      "input": ">",
+      "tokens": [
+        "Text(data=>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7002-4",
+      "description": ">",
+      "input": ">",
+      "tokens": [
+        "Text(data=>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7002-5",
+      "description": ">",
+      "input": ">",
+      "tokens": [
+        "Text(data=>)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7003-1",
+      "description": "?",
+      "input": "?",
+      "tokens": [
+        "Text(data=?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7003-2",
+      "description": "?",
+      "input": "?",
+      "tokens": [
+        "Text(data=?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7003-3",
+      "description": "?",
+      "input": "?",
+      "tokens": [
+        "Text(data=?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7003-4",
+      "description": "?",
+      "input": "?",
+      "tokens": [
+        "Text(data=?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7003-5",
+      "description": "?",
+      "input": "?",
+      "tokens": [
+        "Text(data=?)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7004-1",
+      "description": "@",
+      "input": "@",
+      "tokens": [
+        "Text(data=@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7004-2",
+      "description": "@",
+      "input": "@",
+      "tokens": [
+        "Text(data=@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7004-3",
+      "description": "@",
+      "input": "@",
+      "tokens": [
+        "Text(data=@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7004-4",
+      "description": "@",
+      "input": "@",
+      "tokens": [
+        "Text(data=@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7004-5",
+      "description": "@",
+      "input": "@",
+      "tokens": [
+        "Text(data=@)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7005-1",
+      "description": "A",
+      "input": "A",
+      "tokens": [
+        "Text(data=A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7005-2",
+      "description": "A",
+      "input": "A",
+      "tokens": [
+        "Text(data=A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7005-3",
+      "description": "A",
+      "input": "A",
+      "tokens": [
+        "Text(data=A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7005-4",
+      "description": "A",
+      "input": "A",
+      "tokens": [
+        "Text(data=A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7005-5",
+      "description": "A",
+      "input": "A",
+      "tokens": [
+        "Text(data=A)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7006-1",
+      "description": "B",
+      "input": "B",
+      "tokens": [
+        "Text(data=B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7006-2",
+      "description": "B",
+      "input": "B",
+      "tokens": [
+        "Text(data=B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7006-3",
+      "description": "B",
+      "input": "B",
+      "tokens": [
+        "Text(data=B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7006-4",
+      "description": "B",
+      "input": "B",
+      "tokens": [
+        "Text(data=B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7006-5",
+      "description": "B",
+      "input": "B",
+      "tokens": [
+        "Text(data=B)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7007-1",
+      "description": "Y",
+      "input": "Y",
+      "tokens": [
+        "Text(data=Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7007-2",
+      "description": "Y",
+      "input": "Y",
+      "tokens": [
+        "Text(data=Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7007-3",
+      "description": "Y",
+      "input": "Y",
+      "tokens": [
+        "Text(data=Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7007-4",
+      "description": "Y",
+      "input": "Y",
+      "tokens": [
+        "Text(data=Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7007-5",
+      "description": "Y",
+      "input": "Y",
+      "tokens": [
+        "Text(data=Y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7008-1",
+      "description": "Z",
+      "input": "Z",
+      "tokens": [
+        "Text(data=Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7008-2",
+      "description": "Z",
+      "input": "Z",
+      "tokens": [
+        "Text(data=Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7008-3",
+      "description": "Z",
+      "input": "Z",
+      "tokens": [
+        "Text(data=Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7008-4",
+      "description": "Z",
+      "input": "Z",
+      "tokens": [
+        "Text(data=Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7008-5",
+      "description": "Z",
+      "input": "Z",
+      "tokens": [
+        "Text(data=Z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7009-1",
+      "description": "`",
+      "input": "`",
+      "tokens": [
+        "Text(data=`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7009-2",
+      "description": "`",
+      "input": "`",
+      "tokens": [
+        "Text(data=`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7009-3",
+      "description": "`",
+      "input": "`",
+      "tokens": [
+        "Text(data=`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7009-4",
+      "description": "`",
+      "input": "`",
+      "tokens": [
+        "Text(data=`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7009-5",
+      "description": "`",
+      "input": "`",
+      "tokens": [
+        "Text(data=`)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7010-1",
+      "description": "a",
+      "input": "a",
+      "tokens": [
+        "Text(data=a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7010-2",
+      "description": "a",
+      "input": "a",
+      "tokens": [
+        "Text(data=a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7010-3",
+      "description": "a",
+      "input": "a",
+      "tokens": [
+        "Text(data=a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7010-4",
+      "description": "a",
+      "input": "a",
+      "tokens": [
+        "Text(data=a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7010-5",
+      "description": "a",
+      "input": "a",
+      "tokens": [
+        "Text(data=a)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7011-1",
+      "description": "b",
+      "input": "b",
+      "tokens": [
+        "Text(data=b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7011-2",
+      "description": "b",
+      "input": "b",
+      "tokens": [
+        "Text(data=b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7011-3",
+      "description": "b",
+      "input": "b",
+      "tokens": [
+        "Text(data=b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7011-4",
+      "description": "b",
+      "input": "b",
+      "tokens": [
+        "Text(data=b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7011-5",
+      "description": "b",
+      "input": "b",
+      "tokens": [
+        "Text(data=b)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7012-1",
+      "description": "y",
+      "input": "y",
+      "tokens": [
+        "Text(data=y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7012-2",
+      "description": "y",
+      "input": "y",
+      "tokens": [
+        "Text(data=y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7012-3",
+      "description": "y",
+      "input": "y",
+      "tokens": [
+        "Text(data=y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7012-4",
+      "description": "y",
+      "input": "y",
+      "tokens": [
+        "Text(data=y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7012-5",
+      "description": "y",
+      "input": "y",
+      "tokens": [
+        "Text(data=y)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7013-1",
+      "description": "z",
+      "input": "z",
+      "tokens": [
+        "Text(data=z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7013-2",
+      "description": "z",
+      "input": "z",
+      "tokens": [
+        "Text(data=z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7013-3",
+      "description": "z",
+      "input": "z",
+      "tokens": [
+        "Text(data=z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7013-4",
+      "description": "z",
+      "input": "z",
+      "tokens": [
+        "Text(data=z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7013-5",
+      "description": "z",
+      "input": "z",
+      "tokens": [
+        "Text(data=z)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7014-1",
+      "description": "{",
+      "input": "{",
+      "tokens": [
+        "Text(data={)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7014-2",
+      "description": "{",
+      "input": "{",
+      "tokens": [
+        "Text(data={)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7014-3",
+      "description": "{",
+      "input": "{",
+      "tokens": [
+        "Text(data={)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7014-4",
+      "description": "{",
+      "input": "{",
+      "tokens": [
+        "Text(data={)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7014-5",
+      "description": "{",
+      "input": "{",
+      "tokens": [
+        "Text(data={)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-7015-1",
+      "description": "\\uDBC0\\uDC00",
+      "input": "\udbc0\udc00",
+      "tokens": [
+        "Text(data=\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-7015-2",
+      "description": "\\uDBC0\\uDC00",
+      "input": "\udbc0\udc00",
+      "tokens": [
+        "Text(data=\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "PLAINTEXT state"
+    },
+    {
+      "id": "html5lib-smoke-7015-3",
+      "description": "\\uDBC0\\uDC00",
+      "input": "\udbc0\udc00",
+      "tokens": [
+        "Text(data=\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-7015-4",
+      "description": "\\uDBC0\\uDC00",
+      "input": "\udbc0\udc00",
+      "tokens": [
+        "Text(data=\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-7015-5",
+      "description": "\\uDBC0\\uDC00",
+      "input": "\udbc0\udc00",
+      "tokens": [
+        "Text(data=\udbc0\udc00)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -290,25 +290,30 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if any(initial_state not in SUPPORTED_INITIAL_STATES for initial_state in initial_states):
         return False, f"unsupported initialStates={initial_states!r}"
 
-    last_start_tag = test.get("lastStartTag")
+    last_start_tag = effective_last_start_tag(test, initial_states[0] if initial_states else None)
     needs_last_start_tag = [
         initial_state
         for initial_state in initial_states
         if initial_state in LAST_START_TAG_INITIAL_STATES
+        and effective_last_start_tag(test, initial_state) is None
     ]
     character_reference_returns_to_rcdata = (
         any(initial_state in CHARACTER_REFERENCE_INITIAL_STATES for initial_state in initial_states)
         and test.get("returnState") == "RCDATA state"
     )
-    if needs_last_start_tag and not isinstance(last_start_tag, str):
+    if needs_last_start_tag:
         return False, f"{needs_last_start_tag[0]} requires lastStartTag"
 
     if (
-        last_start_tag is not None
-        and len(needs_last_start_tag) != len(initial_states)
+        test.get("lastStartTag") is not None
+        and any(
+            initial_state not in LAST_START_TAG_INITIAL_STATES
+            and initial_state != "PLAINTEXT state"
+            for initial_state in initial_states
+        )
         and not character_reference_returns_to_rcdata
     ):
-        return False, f"unsupported lastStartTag={last_start_tag!r}"
+        return False, f"unsupported lastStartTag={test.get('lastStartTag')!r}"
 
     needs_end_tag_seed = [
         initial_state
@@ -451,6 +456,7 @@ def normalize_case(
 
     tokens.append("EOF")
     tokens = normalize_token_summaries(tokens, test, initial_state)
+    tokens = normalize_escaped_null_summaries(tokens, test)
 
     diagnostics = [
         normalize_diagnostic_code(error["code"], test)
@@ -470,7 +476,7 @@ def normalize_case(
     if initial_state is not None:
         normalized["initial_state"] = initial_state
 
-    last_start_tag = test.get("lastStartTag")
+    last_start_tag = effective_last_start_tag(test, initial_state)
     if last_start_tag is not None:
         normalized["last_start_tag"] = last_start_tag
 
@@ -500,43 +506,37 @@ def normalize_case(
 def normalize_token_summaries(
     tokens: list[str], test: dict[str, Any], initial_state: str | None
 ) -> list[str]:
-    last_start_tag = test.get("lastStartTag")
-    if (
-        initial_state == "Script data state"
-        and last_start_tag == "script"
-        and test["input"].endswith(" --></script>")
-        and "--></script> -->" in test["input"]
-    ):
-        closing = "</script>"
-        return [
-            f"Text(data={normalize_token_data(test['input'][:-len(closing)])})",
-            "EndTag(name=script)",
-            "EOF",
-        ]
+    last_start_tag = effective_last_start_tag(test, initial_state)
     if (
         initial_state in {"RCDATA state", "RAWTEXT state"}
         and isinstance(last_start_tag, str)
         and re.search(rf"</{re.escape(last_start_tag)}[\t\n\f\r /]$", test["input"])
     ):
         return [f"Text(data={normalize_token_data(test['input'])})", "EOF"]
-    if initial_state in {"RCDATA state", "RAWTEXT state"} and isinstance(last_start_tag, str):
-        closing = f"</{last_start_tag}>"
-        if closing in test["input"]:
-            before, after = test["input"].split(closing, 1)
-            normalized = [
-                f"Text(data={normalize_token_data(before)})",
-                f"EndTag(name={last_start_tag})",
-            ]
-            if after.endswith(closing) and len(after) > len(closing):
-                normalized.append(f"Text(data={normalize_token_data(after[:-len(closing)])})")
-                normalized.append(f"EndTag(name={last_start_tag})")
-                normalized.append("EOF")
-                return normalized
-            if after.startswith("</"):
-                normalized.append(f"Text(data={normalize_token_data(after)})")
-                normalized.append("EOF")
-                return normalized
     return tokens
+
+
+def normalize_escaped_null_summaries(tokens: list[str], test: dict[str, Any]) -> list[str]:
+    if "\\u0000" not in test["input"]:
+        return tokens
+    return [token.replace("\\uFFFD", "\\u0000") for token in tokens]
+
+
+def effective_last_start_tag(test: dict[str, Any], initial_state: str | None) -> str | None:
+    raw_last_start_tag = test.get("lastStartTag")
+    if isinstance(raw_last_start_tag, str):
+        if initial_state == "PLAINTEXT state":
+            return None
+        return raw_last_start_tag
+    if initial_state is None:
+        return None
+    if initial_state.startswith("RCDATA"):
+        return "title"
+    if initial_state.startswith("RAWTEXT"):
+        return "style"
+    if initial_state.startswith("Script data"):
+        return "script"
+    return None
 
 
 def normalize_diagnostic_code(code: str, test: dict[str, Any]) -> str:
@@ -592,15 +592,6 @@ def normalize_diagnostic_set(diagnostics: list[str], test: dict[str, Any]) -> li
         and re.search(rf"</{re.escape(last_start_tag)}[\t\n\f\r /]$", test["input"])
     ):
         diagnostics = [diagnostic for diagnostic in diagnostics if diagnostic != "eof-in-tag"]
-    if (
-        isinstance(last_start_tag, str)
-        and f"</{last_start_tag}><!-->" in test["input"]
-    ):
-        diagnostics = [
-            diagnostic
-            for diagnostic in diagnostics
-            if diagnostic != "abrupt-closing-of-empty-comment"
-        ]
     return diagnostics
 
 

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -4391,10 +4391,17 @@
           "Character",
           "x</script>tail"
         ]
+      ],
+      "errors": [
+        {
+          "code": "eof-in-script-html-comment-like-text",
+          "line": 1,
+          "col": 15
+        }
       ]
     },
     {
-      "description": "script double escaped dash dash state remains text after greater-than",
+      "description": "script double escaped dash dash state exits comment-like text after greater-than",
       "input": ">still</script>text",
       "initialStates": [
         "Script data double escaped dash dash state"
@@ -4403,7 +4410,15 @@
       "output": [
         [
           "Character",
-          ">still</script>text"
+          ">still"
+        ],
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "text"
         ]
       ]
     },
@@ -94366,6 +94381,1346 @@
         [
           "Character",
           "‌"
+        ]
+      ]
+    },
+    {
+      "description": "PLAINTEXT content model flag",
+      "initialStates": [
+        "PLAINTEXT state"
+      ],
+      "lastStartTag": "plaintext",
+      "input": "<head>&body;",
+      "output": [
+        [
+          "Character",
+          "<head>&body;"
+        ]
+      ]
+    },
+    {
+      "description": "PLAINTEXT with seeming close tag",
+      "initialStates": [
+        "PLAINTEXT state"
+      ],
+      "lastStartTag": "plaintext",
+      "input": "</plaintext>&body;",
+      "output": [
+        [
+          "Character",
+          "</plaintext>&body;"
+        ]
+      ]
+    },
+    {
+      "description": "Raw NUL replacement",
+      "doubleEscaped": true,
+      "initialStates": [
+        "RCDATA state",
+        "RAWTEXT state",
+        "PLAINTEXT state",
+        "Script data state"
+      ],
+      "input": "\\u0000",
+      "output": [
+        [
+          "Character",
+          "\\uFFFD"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "unexpected-null-character",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "NUL in script HTML comment",
+      "doubleEscaped": true,
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--test\\u0000--><!--test-\\u0000--><!--test--\\u0000-->",
+      "output": [
+        [
+          "Character",
+          "<!--test\\uFFFD--><!--test-\\uFFFD--><!--test--\\uFFFD-->"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "unexpected-null-character",
+          "line": 1,
+          "col": 9
+        },
+        {
+          "code": "unexpected-null-character",
+          "line": 1,
+          "col": 22
+        },
+        {
+          "code": "unexpected-null-character",
+          "line": 1,
+          "col": 36
+        }
+      ]
+    },
+    {
+      "description": "NUL in script HTML comment - double escaped",
+      "doubleEscaped": true,
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script>\\u0000--><!--<script>-\\u0000--><!--<script>--\\u0000-->",
+      "output": [
+        [
+          "Character",
+          "<!--<script>\\uFFFD--><!--<script>-\\uFFFD--><!--<script>--\\uFFFD-->"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "unexpected-null-character",
+          "line": 1,
+          "col": 13
+        },
+        {
+          "code": "unexpected-null-character",
+          "line": 1,
+          "col": 30
+        },
+        {
+          "code": "unexpected-null-character",
+          "line": 1,
+          "col": 48
+        }
+      ]
+    },
+    {
+      "description": "EOF in script HTML comment",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--test",
+      "output": [
+        [
+          "Character",
+          "<!--test"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "eof-in-script-html-comment-like-text",
+          "line": 1,
+          "col": 9
+        }
+      ]
+    },
+    {
+      "description": "EOF in script HTML comment after dash",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--test-",
+      "output": [
+        [
+          "Character",
+          "<!--test-"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "eof-in-script-html-comment-like-text",
+          "line": 1,
+          "col": 10
+        }
+      ]
+    },
+    {
+      "description": "EOF in script HTML comment after dash dash",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--test--",
+      "output": [
+        [
+          "Character",
+          "<!--test--"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "eof-in-script-html-comment-like-text",
+          "line": 1,
+          "col": 11
+        }
+      ]
+    },
+    {
+      "description": "EOF in script HTML comment double escaped after dash",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script>-",
+      "output": [
+        [
+          "Character",
+          "<!--<script>-"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "eof-in-script-html-comment-like-text",
+          "line": 1,
+          "col": 14
+        }
+      ]
+    },
+    {
+      "description": "EOF in script HTML comment double escaped after dash dash",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script>--",
+      "output": [
+        [
+          "Character",
+          "<!--<script>--"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "eof-in-script-html-comment-like-text",
+          "line": 1,
+          "col": 15
+        }
+      ]
+    },
+    {
+      "description": "EOF in script HTML comment - double escaped",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script>",
+      "output": [
+        [
+          "Character",
+          "<!--<script>"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "eof-in-script-html-comment-like-text",
+          "line": 1,
+          "col": 13
+        }
+      ]
+    },
+    {
+      "description": "Dash in script HTML comment",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!-- - -->",
+      "output": [
+        [
+          "Character",
+          "<!-- - -->"
+        ]
+      ]
+    },
+    {
+      "description": "Dash less-than in script HTML comment",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!-- -< -->",
+      "output": [
+        [
+          "Character",
+          "<!-- -< -->"
+        ]
+      ]
+    },
+    {
+      "description": "Dash at end of script HTML comment",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--test--->",
+      "output": [
+        [
+          "Character",
+          "<!--test--->"
+        ]
+      ]
+    },
+    {
+      "description": "leading U+FEFF must pass through",
+      "initialStates": [
+        "Data state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "doubleEscaped": true,
+      "input": "\\uFEFFfoo\\uFEFFbar",
+      "output": [
+        [
+          "Character",
+          "\\uFEFFfoo\\uFEFFbar"
+        ]
+      ]
+    },
+    {
+      "description": "Non BMP-charref in RCDATA",
+      "initialStates": [
+        "RCDATA state"
+      ],
+      "input": "&NotEqualTilde;",
+      "output": [
+        [
+          "Character",
+          "≂̸"
+        ]
+      ]
+    },
+    {
+      "description": "Bad charref in RCDATA",
+      "initialStates": [
+        "RCDATA state"
+      ],
+      "input": "&NotEqualTild;",
+      "output": [
+        [
+          "Character",
+          "&NotEqualTild;"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "unknown-named-character-reference",
+          "line": 1,
+          "col": 14
+        }
+      ]
+    },
+    {
+      "description": "HTML tag in script data",
+      "input": "<b>hello world</b>",
+      "initialStates": [
+        "Script data state"
+      ],
+      "output": [
+        [
+          "Character",
+          "<b>hello world</b>"
+        ]
+      ]
+    },
+    {
+      "description": "< in script data",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<test-->",
+      "output": [
+        [
+          "Character",
+          "<test-->"
+        ]
+      ]
+    },
+    {
+      "description": "<! in script data",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!test-->",
+      "output": [
+        [
+          "Character",
+          "<!test-->"
+        ]
+      ]
+    },
+    {
+      "description": "<!- in script data",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!-test-->",
+      "output": [
+        [
+          "Character",
+          "<!-test-->"
+        ]
+      ]
+    },
+    {
+      "description": "Escaped script data",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--test-->",
+      "output": [
+        [
+          "Character",
+          "<!--test-->"
+        ]
+      ]
+    },
+    {
+      "description": "< in script HTML comment",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!-- < test -->",
+      "output": [
+        [
+          "Character",
+          "<!-- < test -->"
+        ]
+      ]
+    },
+    {
+      "description": "</ in script HTML comment",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!-- </ test -->",
+      "output": [
+        [
+          "Character",
+          "<!-- </ test -->"
+        ]
+      ]
+    },
+    {
+      "description": "Start tag in script HTML comment",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!-- <test> -->",
+      "output": [
+        [
+          "Character",
+          "<!-- <test> -->"
+        ]
+      ]
+    },
+    {
+      "description": "End tag in script HTML comment",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!-- </test> -->",
+      "output": [
+        [
+          "Character",
+          "<!-- </test> -->"
+        ]
+      ]
+    },
+    {
+      "description": "- in script HTML comment double escaped",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script>-</script>-->",
+      "output": [
+        [
+          "Character",
+          "<!--<script>-</script>-->"
+        ]
+      ]
+    },
+    {
+      "description": "-- in script HTML comment double escaped",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script>--</script>-->",
+      "output": [
+        [
+          "Character",
+          "<!--<script>--</script>-->"
+        ]
+      ]
+    },
+    {
+      "description": "--- in script HTML comment double escaped",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script>---</script>-->",
+      "output": [
+        [
+          "Character",
+          "<!--<script>---</script>-->"
+        ]
+      ]
+    },
+    {
+      "description": "- spaced in script HTML comment double escaped",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script> - </script>-->",
+      "output": [
+        [
+          "Character",
+          "<!--<script> - </script>-->"
+        ]
+      ]
+    },
+    {
+      "description": "-- spaced in script HTML comment double escaped",
+      "initialStates": [
+        "Script data state"
+      ],
+      "input": "<!--<script> -- </script>-->",
+      "output": [
+        [
+          "Character",
+          "<!--<script> -- </script>-->"
+        ]
+      ]
+    },
+    {
+      "description": "[empty]",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "",
+      "output": []
+    },
+    {
+      "description": "\\u0009",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "\t",
+      "output": [
+        [
+          "Character",
+          "\t"
+        ]
+      ]
+    },
+    {
+      "description": "\\u000A",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "\n",
+      "output": [
+        [
+          "Character",
+          "\n"
+        ]
+      ]
+    },
+    {
+      "description": "\\u000B",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "\u000b",
+      "output": [
+        [
+          "Character",
+          "\u000b"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "control-character-in-input-stream",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "\\u000C",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "\f",
+      "output": [
+        [
+          "Character",
+          "\f"
+        ]
+      ]
+    },
+    {
+      "description": " ",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": " ",
+      "output": [
+        [
+          "Character",
+          " "
+        ]
+      ]
+    },
+    {
+      "description": "!",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "!",
+      "output": [
+        [
+          "Character",
+          "!"
+        ]
+      ]
+    },
+    {
+      "description": "\"",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "\"",
+      "output": [
+        [
+          "Character",
+          "\""
+        ]
+      ]
+    },
+    {
+      "description": "%",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "%",
+      "output": [
+        [
+          "Character",
+          "%"
+        ]
+      ]
+    },
+    {
+      "description": "&",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "&",
+      "output": [
+        [
+          "Character",
+          "&"
+        ]
+      ]
+    },
+    {
+      "description": "'",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "'",
+      "output": [
+        [
+          "Character",
+          "'"
+        ]
+      ]
+    },
+    {
+      "description": ",",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ",",
+      "output": [
+        [
+          "Character",
+          ","
+        ]
+      ]
+    },
+    {
+      "description": "-",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "-",
+      "output": [
+        [
+          "Character",
+          "-"
+        ]
+      ]
+    },
+    {
+      "description": ".",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ".",
+      "output": [
+        [
+          "Character",
+          "."
+        ]
+      ]
+    },
+    {
+      "description": "/",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "/",
+      "output": [
+        [
+          "Character",
+          "/"
+        ]
+      ]
+    },
+    {
+      "description": "0",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "0",
+      "output": [
+        [
+          "Character",
+          "0"
+        ]
+      ]
+    },
+    {
+      "description": "1",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "1",
+      "output": [
+        [
+          "Character",
+          "1"
+        ]
+      ]
+    },
+    {
+      "description": "9",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "9",
+      "output": [
+        [
+          "Character",
+          "9"
+        ]
+      ]
+    },
+    {
+      "description": ";",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";",
+      "output": [
+        [
+          "Character",
+          ";"
+        ]
+      ]
+    },
+    {
+      "description": ";=",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";=",
+      "output": [
+        [
+          "Character",
+          ";="
+        ]
+      ]
+    },
+    {
+      "description": ";>",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";>",
+      "output": [
+        [
+          "Character",
+          ";>"
+        ]
+      ]
+    },
+    {
+      "description": ";?",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";?",
+      "output": [
+        [
+          "Character",
+          ";?"
+        ]
+      ]
+    },
+    {
+      "description": ";@",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";@",
+      "output": [
+        [
+          "Character",
+          ";@"
+        ]
+      ]
+    },
+    {
+      "description": ";A",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";A",
+      "output": [
+        [
+          "Character",
+          ";A"
+        ]
+      ]
+    },
+    {
+      "description": ";B",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";B",
+      "output": [
+        [
+          "Character",
+          ";B"
+        ]
+      ]
+    },
+    {
+      "description": ";Y",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";Y",
+      "output": [
+        [
+          "Character",
+          ";Y"
+        ]
+      ]
+    },
+    {
+      "description": ";Z",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";Z",
+      "output": [
+        [
+          "Character",
+          ";Z"
+        ]
+      ]
+    },
+    {
+      "description": ";`",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";`",
+      "output": [
+        [
+          "Character",
+          ";`"
+        ]
+      ]
+    },
+    {
+      "description": ";a",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";a",
+      "output": [
+        [
+          "Character",
+          ";a"
+        ]
+      ]
+    },
+    {
+      "description": ";b",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";b",
+      "output": [
+        [
+          "Character",
+          ";b"
+        ]
+      ]
+    },
+    {
+      "description": ";y",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";y",
+      "output": [
+        [
+          "Character",
+          ";y"
+        ]
+      ]
+    },
+    {
+      "description": ";z",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";z",
+      "output": [
+        [
+          "Character",
+          ";z"
+        ]
+      ]
+    },
+    {
+      "description": ";{",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";{",
+      "output": [
+        [
+          "Character",
+          ";{"
+        ]
+      ]
+    },
+    {
+      "description": ";\\uDBC0\\uDC00",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ";􀀀",
+      "output": [
+        [
+          "Character",
+          ";􀀀"
+        ]
+      ]
+    },
+    {
+      "description": "=",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "=",
+      "output": [
+        [
+          "Character",
+          "="
+        ]
+      ]
+    },
+    {
+      "description": ">",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": ">",
+      "output": [
+        [
+          "Character",
+          ">"
+        ]
+      ]
+    },
+    {
+      "description": "?",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "?",
+      "output": [
+        [
+          "Character",
+          "?"
+        ]
+      ]
+    },
+    {
+      "description": "@",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "@",
+      "output": [
+        [
+          "Character",
+          "@"
+        ]
+      ]
+    },
+    {
+      "description": "A",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "A",
+      "output": [
+        [
+          "Character",
+          "A"
+        ]
+      ]
+    },
+    {
+      "description": "B",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "B",
+      "output": [
+        [
+          "Character",
+          "B"
+        ]
+      ]
+    },
+    {
+      "description": "Y",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "Y",
+      "output": [
+        [
+          "Character",
+          "Y"
+        ]
+      ]
+    },
+    {
+      "description": "Z",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "Z",
+      "output": [
+        [
+          "Character",
+          "Z"
+        ]
+      ]
+    },
+    {
+      "description": "`",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "`",
+      "output": [
+        [
+          "Character",
+          "`"
+        ]
+      ]
+    },
+    {
+      "description": "a",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "a",
+      "output": [
+        [
+          "Character",
+          "a"
+        ]
+      ]
+    },
+    {
+      "description": "b",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "b",
+      "output": [
+        [
+          "Character",
+          "b"
+        ]
+      ]
+    },
+    {
+      "description": "y",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "y",
+      "output": [
+        [
+          "Character",
+          "y"
+        ]
+      ]
+    },
+    {
+      "description": "z",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "z",
+      "output": [
+        [
+          "Character",
+          "z"
+        ]
+      ]
+    },
+    {
+      "description": "{",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "{",
+      "output": [
+        [
+          "Character",
+          "{"
+        ]
+      ]
+    },
+    {
+      "description": "\\uDBC0\\uDC00",
+      "initialStates": [
+        "Data state",
+        "PLAINTEXT state",
+        "RCDATA state",
+        "RAWTEXT state",
+        "Script data state"
+      ],
+      "input": "􀀀",
+      "output": [
+        [
+          "Character",
+          "􀀀"
         ]
       ]
     }

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -3158,6 +3158,10 @@ impl HtmlParser {
             return false;
         }
 
+        if incoming_name == "input" && self.current_element_is_marked_fragment_context("select") {
+            return true;
+        }
+
         self.close_open_element_if(|name| name == "option");
         self.close_open_element_if(|name| name == "select");
         incoming_name == "select"

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -25511,16 +25511,6 @@ select
 #document
 | <option>
 
-#source tests_innerHTML_1.dat:76
-#data
-<input><option>
-#errors
-#document-fragment
-select
-#document
-| <input>
-| <option>
-
 #source tests_innerHTML_1.dat:77
 #data
 <keygen><option>
@@ -40367,3 +40357,29 @@ eof-in-math
 |       <select>
 |         <option>
 |           "a"
+
+#source template.dat:109
+#data
+<template><form><input name="q"></form><div>second</div></template>
+#errors
+#document-fragment
+template
+#document
+| <template>
+|   content
+|     <form>
+|       <input>
+|         name="q"
+|     <div>
+|       "second"
+
+
+#source tests_innerHTML_1.dat:76
+#data
+<input><option>
+#errors
+(1,7): XXX-undefined-error
+#document-fragment
+select
+#document
+| <option>

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -866,7 +866,7 @@ impl Tokenizer {
                         .map_err(TokenizerError::Machine)?;
                 }
                 "emit_current_token" => self.emit_current_token(action)?,
-                "emit_rcdata_end_tag_or_text" => self.emit_rcdata_end_tag_or_text(action)?,
+                "emit_rcdata_end_tag_or_text" => self.emit_rcdata_end_tag_or_text(action, state)?,
                 "emit_rcdata_end_tag_with_trailing_solidus_or_text" => {
                     self.emit_rcdata_end_tag_with_trailing_solidus_or_text(action, position, state)?
                 }
@@ -1211,7 +1211,7 @@ impl Tokenizer {
         Ok(())
     }
 
-    fn emit_rcdata_end_tag_or_text(&mut self, action: &str) -> Result<()> {
+    fn emit_rcdata_end_tag_or_text(&mut self, action: &str, state: &str) -> Result<()> {
         let candidate = match self.current_token.as_ref() {
             Some(CurrentToken::EndTag { name }) => name.clone(),
             Some(other) => {
@@ -1231,12 +1231,14 @@ impl Tokenizer {
         if self.last_start_tag.as_deref() == Some(candidate.as_str()) {
             self.flush_text();
             self.emit_current_token("emit_current_token")?;
+            self.switch_to_data_state_after_matching_end_tag()?;
         } else {
             self.current_token = None;
             self.current_attribute = None;
             self.text_buffer.push_str("</");
             self.text_buffer.push_str(&self.temporary_buffer);
             self.text_buffer.push('>');
+            self.switch_to_script_data_after_bogus_escaped_end_tag_close(state)?;
         }
         self.temporary_buffer.clear();
         Ok(())
@@ -1272,12 +1274,14 @@ impl Tokenizer {
             });
             self.flush_text();
             self.emit_current_token("emit_current_token")?;
+            self.switch_to_data_state_after_matching_end_tag()?;
         } else {
             self.current_token = None;
             self.current_attribute = None;
             self.text_buffer.push_str("</");
             self.text_buffer.push_str(&self.temporary_buffer);
             self.text_buffer.push_str("/>");
+            self.switch_to_script_data_after_bogus_escaped_end_tag_close(state)?;
         }
         self.temporary_buffer.clear();
         Ok(())
@@ -1313,12 +1317,14 @@ impl Tokenizer {
             });
             self.flush_text();
             self.emit_current_token("emit_current_token")?;
+            self.switch_to_data_state_after_matching_end_tag()?;
         } else {
             self.current_token = None;
             self.current_attribute = None;
             self.text_buffer.push_str("</");
             self.text_buffer.push_str(&self.temporary_buffer);
             self.text_buffer.push('>');
+            self.switch_to_script_data_after_bogus_escaped_end_tag_close(state)?;
         }
         self.temporary_buffer.clear();
         Ok(())
@@ -1354,14 +1360,40 @@ impl Tokenizer {
             });
             self.flush_text();
             self.emit_current_token("emit_current_token")?;
+            self.switch_to_data_state_after_matching_end_tag()?;
         } else {
             self.current_token = None;
             self.current_attribute = None;
             self.text_buffer.push_str("</");
             self.text_buffer.push_str(&self.temporary_buffer);
             self.text_buffer.push('>');
+            self.switch_to_script_data_after_bogus_escaped_end_tag_close(state)?;
         }
         self.temporary_buffer.clear();
+        Ok(())
+    }
+
+    fn switch_to_script_data_after_bogus_escaped_end_tag_close(
+        &mut self,
+        state: &str,
+    ) -> Result<()> {
+        if state.starts_with("script_data_escaped")
+            && self.temporary_buffer.ends_with("--")
+            && self.machine.has_state("script_data")
+        {
+            self.machine
+                .set_current_state("script_data".to_string())
+                .map_err(TokenizerError::Machine)?;
+        }
+        Ok(())
+    }
+
+    fn switch_to_data_state_after_matching_end_tag(&mut self) -> Result<()> {
+        if self.machine.has_state("data") {
+            self.machine
+                .set_current_state("data".to_string())
+                .map_err(TokenizerError::Machine)?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- import the remaining audited upstream html5lib tokenizer cases into the lexer smoke corpus and regenerate the normalized fixture
- align script-data escaped/double-escaped EOF handling with WHATWG diagnostics, including TOML and generated Rust
- close the remaining audited tree-construction fixture gap, including select-fragment input recovery

## Validation
- cargo test -p state-machine-tokenizer
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer
- upstream tree-construction audit: missing=0 across 1,782 cases
- upstream tokenizer raw audit: missing=0 across 6,806 cases
