### PR TITLE
ts(spice): add VCVS controlled sources

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add voltage-controlled voltage source support across DC, AC, transfer
+  function, sensitivity, Monte Carlo, and transient analyses.
 - Add AC noise analysis with resistor Johnson-Nyquist source PSDs,
   adjoint output contributions, input-referred PSD, and default log sweeps.
 - Add seeded DC Monte Carlo analysis for linear element parameters with

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8,7 +8,8 @@ export type Element =
   | Inductor
   | VoltageSource
   | CurrentSource
-  | Vccs;
+  | Vccs
+  | Vcvs;
 
 export interface Resistor {
   readonly kind: "resistor";
@@ -278,6 +279,16 @@ export interface Vccs {
   readonly transconductanceSiemens: number;
 }
 
+export interface Vcvs {
+  readonly kind: "vcvs";
+  readonly name: string;
+  readonly positive: string;
+  readonly negative: string;
+  readonly controlPositive: string;
+  readonly controlNegative: string;
+  readonly gain: number;
+}
+
 export interface DcResult {
   readonly nodeVoltages: ReadonlyMap<string, number>;
   readonly branchCurrents: ReadonlyMap<string, number>;
@@ -533,6 +544,25 @@ export function vccs(
     controlPositive,
     controlNegative,
     transconductanceSiemens,
+  };
+}
+
+export function vcvs(
+  name: string,
+  positive: string,
+  negative: string,
+  controlPositive: string,
+  controlNegative: string,
+  gain: number,
+): Vcvs {
+  return {
+    kind: "vcvs",
+    name,
+    positive,
+    negative,
+    controlPositive,
+    controlNegative,
+    gain,
   };
 }
 
@@ -1013,6 +1043,12 @@ function elementParameter(element: Element): ElementParameter | undefined {
         parameter: "transconductanceSiemens",
         nominalValue: element.transconductanceSiemens,
       };
+    case "vcvs":
+      return {
+        elementName: element.name,
+        parameter: "gain",
+        nominalValue: element.gain,
+      };
     case "capacitor":
     case "inductor":
       return undefined;
@@ -1053,6 +1089,9 @@ function circuitWithPerturbedElement(
           ...element,
           transconductanceSiemens: element.transconductanceSiemens + delta,
         });
+        break;
+      case "vcvs":
+        perturbed.add({ ...element, gain: element.gain + delta });
         break;
       case "capacitor":
       case "inductor":
@@ -1149,6 +1188,11 @@ function randomizedElement(
           distribution,
           rng,
         ),
+      };
+    case "vcvs":
+      return {
+        ...element,
+        gain: randomizedValue(element.gain, tolerance, distribution, rng),
       };
     case "capacitor":
     case "inductor":
@@ -1263,6 +1307,15 @@ function solveLinearCircuit(
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
         break;
+      case "vcvs":
+        stampVcvs(
+          element,
+          nodeIndices,
+          voltageSources,
+          nodeCount,
+          matrix,
+        );
+        break;
     }
   }
 
@@ -1337,6 +1390,15 @@ function buildSmallSignalMatrix(
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
         break;
+      case "vcvs":
+        stampVcvs(
+          element,
+          nodeIndices,
+          voltageSources,
+          nodeCount,
+          matrix,
+        );
+        break;
     }
   }
 
@@ -1374,6 +1436,7 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
       case "capacitor":
       case "inductor":
       case "vccs":
+      case "vcvs":
         break;
     }
   }
@@ -1433,6 +1496,15 @@ function buildAcMatrix(
         break;
       case "vccs":
         stampAcVccs(element, nodeIndices, matrix);
+        break;
+      case "vcvs":
+        stampAcVcvs(
+          element,
+          nodeIndices,
+          voltageSources,
+          nodeCount,
+          matrix,
+        );
         break;
     }
   }
@@ -1609,6 +1681,12 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.controlPositive);
         insertNode(names, element.controlNegative);
         break;
+      case "vcvs":
+        insertNode(names, element.positive);
+        insertNode(names, element.negative);
+        insertNode(names, element.controlPositive);
+        insertNode(names, element.controlNegative);
+        break;
     }
   }
 
@@ -1625,7 +1703,7 @@ function collectVoltageSources(
 ): Map<string, number> {
   const sources = new Map<string, number>();
   for (const element of circuit.elements()) {
-    if (element.kind === "voltage-source") {
+    if (element.kind === "voltage-source" || element.kind === "vcvs") {
       insertBranchName(sources, element.name, "duplicate voltage source name");
     } else if (element.kind === "inductor") {
       if (sources.has(element.name)) {
@@ -1642,7 +1720,7 @@ function collectVoltageSources(
 function collectAcVoltageSources(circuit: Circuit): Map<string, number> {
   const sources = new Map<string, number>();
   for (const element of circuit.elements()) {
-    if (element.kind === "voltage-source") {
+    if (element.kind === "voltage-source" || element.kind === "vcvs") {
       insertBranchName(sources, element.name, "duplicate voltage source name");
     }
   }
@@ -1661,7 +1739,8 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
       (element.kind === "resistor" ||
         element.kind === "capacitor" ||
         element.kind === "inductor" ||
-        element.kind === "vccs") &&
+        element.kind === "vccs" ||
+        element.kind === "vcvs") &&
       element.name === inputSource
     ) {
       throw invalidElement(
@@ -2152,6 +2231,52 @@ function stampVccs(
   );
 }
 
+function stampVcvs(
+  element: Vcvs,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  nodeCount: number,
+  matrix: number[][],
+): void {
+  if (!Number.isFinite(element.gain)) {
+    throw invalidElement(element.name, "gain must be finite");
+  }
+
+  const sourceIndex = voltageSources.get(element.name);
+  if (sourceIndex === undefined) {
+    throw invalidElement(element.name, "voltage source was not indexed");
+  }
+
+  const branch = nodeCount + sourceIndex;
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  const controlPositive = nodeIndex(nodeIndices, element.controlPositive);
+  const controlNegative = nodeIndex(nodeIndices, element.controlNegative);
+  stampBranchMatrix(matrix, branch, positive, negative);
+  stampControlledVoltageRow(
+    matrix,
+    branch,
+    controlPositive,
+    controlNegative,
+    element.gain,
+  );
+}
+
+function stampControlledVoltageRow(
+  matrix: number[][],
+  branch: number,
+  controlPositive: number | undefined,
+  controlNegative: number | undefined,
+  gain: number,
+): void {
+  if (controlPositive !== undefined) {
+    matrix[branch][controlPositive] -= gain;
+  }
+  if (controlNegative !== undefined) {
+    matrix[branch][controlNegative] += gain;
+  }
+}
+
 function stampTransconductance(
   matrix: number[][],
   positive: number | undefined,
@@ -2334,6 +2459,58 @@ function stampAcVccs(
     controlNegative,
     complex(element.transconductanceSiemens, 0.0),
   );
+}
+
+function stampAcVcvs(
+  element: Vcvs,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  nodeCount: number,
+  matrix: Complex[][],
+): void {
+  if (!Number.isFinite(element.gain)) {
+    throw invalidElement(element.name, "gain must be finite");
+  }
+
+  const sourceIndex = voltageSources.get(element.name);
+  if (sourceIndex === undefined) {
+    throw invalidElement(element.name, "voltage source was not indexed");
+  }
+
+  const branch = nodeCount + sourceIndex;
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  const controlPositive = nodeIndex(nodeIndices, element.controlPositive);
+  const controlNegative = nodeIndex(nodeIndices, element.controlNegative);
+  stampComplexBranchMatrix(matrix, branch, positive, negative);
+  stampComplexControlledVoltageRow(
+    matrix,
+    branch,
+    controlPositive,
+    controlNegative,
+    complex(element.gain, 0.0),
+  );
+}
+
+function stampComplexControlledVoltageRow(
+  matrix: Complex[][],
+  branch: number,
+  controlPositive: number | undefined,
+  controlNegative: number | undefined,
+  gain: Complex,
+): void {
+  if (controlPositive !== undefined) {
+    matrix[branch][controlPositive] = complexSub(
+      matrix[branch][controlPositive],
+      gain,
+    );
+  }
+  if (controlNegative !== undefined) {
+    matrix[branch][controlNegative] = complexAdd(
+      matrix[branch][controlNegative],
+      gain,
+    );
+  }
 }
 
 function stampComplexTransconductance(

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -9,6 +9,7 @@ import {
   currentSource,
   inductor,
   resistor,
+  vcvs,
   voltageSource,
 } from "../src/index.js";
 
@@ -86,6 +87,22 @@ describe("acSweep", () => {
     expect(n1).not.toBeUndefined();
     expectClose(n1!.real, 1.0);
     expectClose(n1!.imag, 0.0);
+  });
+
+  it("applies VCVS gain in AC analysis", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(vcvs("E1", "out", "0", "in", "0", 4.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const points = acSweep(circuit, 1_000.0, 1_000.0, 10);
+
+    expect(points).toHaveLength(1);
+    const out = points[0].voltage("out");
+    expect(out).not.toBeUndefined();
+    expectClose(out!.real, 4.0);
+    expectClose(out!.imag, 0.0);
+    expectClose(points[0].branchCurrent("E1")?.real, -4.0e-3);
   });
 
   it("rejects invalid frequency bounds", () => {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -9,6 +9,7 @@ import {
   inductor,
   resistor,
   vccs,
+  vcvs,
   voltageSource,
   voltageSourceWithWaveform,
 } from "../src/index.js";
@@ -88,6 +89,30 @@ describe("dcOp", () => {
     expectClose(result.voltage("out"), 1.0);
   });
 
+  it("stamps VCVS output voltage from control voltage", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vctrl", "ctrl", "0", 1.5));
+    circuit.add(vcvs("E1", "out", "0", "ctrl", "0", 2.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expectClose(result.voltage("out"), 3.0);
+    expectClose(result.branchCurrent("E1"), -3.0e-3);
+  });
+
+  it("stamps VCVS differential control polarity", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vp", "p", "0", 4.0));
+    circuit.add(voltageSource("Vn", "n", "0", 1.0));
+    circuit.add(vcvs("E1", "out", "0", "p", "n", 0.5));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expectClose(result.voltage("out"), 1.5);
+  });
+
   it("rejects non-finite VCCS transconductance", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vctrl", "ctrl", "0", 1.0));
@@ -95,6 +120,15 @@ describe("dcOp", () => {
     circuit.add(resistor("Rload", "out", "0", 1_000.0));
 
     expect(() => dcOp(circuit)).toThrowError("transconductance must be finite");
+  });
+
+  it("rejects non-finite VCVS gain", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vctrl", "ctrl", "0", 1.0));
+    circuit.add(vcvs("Ebad", "out", "0", "ctrl", "0", Number.NaN));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    expect(() => dcOp(circuit)).toThrowError("gain must be finite");
   });
 
   it("uses static source value when a waveform is present", () => {


### PR DESCRIPTION
## Summary

- add TypeScript `vcvs` elements to the SPICE engine public API
- stamp VCVS branch equations in DC/transient, small-signal transfer/sensitivity, AC, Monte Carlo, and noise-adjacent matrix paths
- cover DC gain/polarity, branch current, invalid gain, and AC controlled-voltage behavior

## Validation

- sh BUILD
- git diff --check
