### PR TITLE
rust(weather): enforce sandbox writes at kernel level

### DIFF
--- a/code/packages/rust/capability-os-sandbox/src/lib.rs
+++ b/code/packages/rust/capability-os-sandbox/src/lib.rs
@@ -1,6 +1,10 @@
 #![forbid(unsafe_code)]
 
+use std::ffi::{OsStr, OsString};
 use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use capability_cage::{Action, Capability, Category, Manifest};
 use coding_adventures_json_value::{parse, JsonValue};
@@ -205,6 +209,153 @@ impl fmt::Display for SandboxPlanError {
 
 impl std::error::Error for SandboxPlanError {}
 
+const MACOS_SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
+const MACOS_KERNEL_PRIMITIVE: &str = "macos.sandbox-exec.seatbelt";
+
+/// Whether the current host has a kernel sandbox applier for the plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KernelSandboxSupport {
+    pub os: OsFamily,
+    pub primitive: String,
+    pub available: bool,
+    pub reason: String,
+}
+
+/// Process output from a command launched under an OS kernel sandbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KernelSandboxCommandOutput {
+    pub os: OsFamily,
+    pub primitive: String,
+    pub status_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl KernelSandboxCommandOutput {
+    pub fn success(&self) -> bool {
+        self.status_code == Some(0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KernelSandboxError {
+    Unsupported(KernelSandboxSupport),
+    InvalidPlan(String),
+    Io(String),
+}
+
+impl fmt::Display for KernelSandboxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsupported(support) => write!(
+                f,
+                "kernel sandbox unsupported on {} via {}: {}",
+                support.os, support.primitive, support.reason
+            ),
+            Self::InvalidPlan(message) => write!(f, "invalid kernel sandbox plan: {message}"),
+            Self::Io(message) => write!(f, "kernel sandbox launcher I/O error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for KernelSandboxError {}
+
+/// Report whether this host can apply the current OS plan in the kernel.
+pub fn current_kernel_sandbox_support() -> KernelSandboxSupport {
+    match OsFamily::current() {
+        OsFamily::Macos => {
+            let available = Path::new(MACOS_SANDBOX_EXEC).exists();
+            KernelSandboxSupport {
+                os: OsFamily::Macos,
+                primitive: MACOS_KERNEL_PRIMITIVE.to_string(),
+                available,
+                reason: if available {
+                    "sandbox-exec is available for Seatbelt profile application".to_string()
+                } else {
+                    "sandbox-exec was not found at /usr/bin/sandbox-exec".to_string()
+                },
+            }
+        }
+        os => KernelSandboxSupport {
+            os,
+            primitive: "not-yet-implemented".to_string(),
+            available: false,
+            reason: "this crate currently applies kernel sandboxes only through macOS Seatbelt"
+                .to_string(),
+        },
+    }
+}
+
+/// Generate the macOS Seatbelt profile used to enforce a macOS sandbox plan.
+///
+/// V1 enforces filesystem write/create/delete capabilities as exact absolute
+/// path literals. Other capability families still lower to plan records and
+/// remain candidates for the next kernel applier slice.
+pub fn macos_seatbelt_profile_for_plan(plan: &SandboxPlan) -> Result<String, KernelSandboxError> {
+    if plan.os != OsFamily::Macos {
+        return Err(KernelSandboxError::InvalidPlan(format!(
+            "expected a macOS plan, got {}",
+            plan.os
+        )));
+    }
+
+    let mut writable_paths = writable_path_literals(plan)?;
+    writable_paths.sort();
+    writable_paths.dedup();
+
+    let mut profile = String::from("(version 1)\n(allow default)\n");
+    match writable_paths.as_slice() {
+        [] => profile.push_str("(deny file-write*)\n"),
+        [path] => {
+            profile.push_str("(deny file-write* (require-not (literal \"");
+            profile.push_str(&seatbelt_escape(path)?);
+            profile.push_str("\")))\n");
+        }
+        paths => {
+            profile.push_str("(deny file-write* (require-not (require-any");
+            for path in paths {
+                profile.push_str(" (literal \"");
+                profile.push_str(&seatbelt_escape(path)?);
+                profile.push_str("\")");
+            }
+            profile.push_str(")))\n");
+        }
+    }
+    Ok(profile)
+}
+
+/// Launch a child process through the current host's kernel sandbox primitive.
+pub fn run_with_kernel_sandbox<I, S>(
+    plan: &SandboxPlan,
+    program: impl AsRef<OsStr>,
+    args: I,
+) -> Result<KernelSandboxCommandOutput, KernelSandboxError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let program = program.as_ref().to_os_string();
+    let args = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_os_string())
+        .collect::<Vec<OsString>>();
+
+    if plan.os != OsFamily::current() {
+        return Err(KernelSandboxError::InvalidPlan(format!(
+            "plan targets {}, but current host is {}",
+            plan.os,
+            OsFamily::current()
+        )));
+    }
+
+    match OsFamily::current() {
+        OsFamily::Macos => run_macos_seatbelt(plan, program, args),
+        _ => Err(KernelSandboxError::Unsupported(
+            current_kernel_sandbox_support(),
+        )),
+    }
+}
+
 /// Lower one manifest JSON document into one OS plan.
 pub fn plan_from_json(manifest_json: &str, os: OsFamily) -> Result<SandboxPlan, SandboxPlanError> {
     let fallback = SandboxPlan::empty("<invalid>", os);
@@ -238,6 +389,106 @@ pub fn plan_all_supported(manifest_json: &str) -> Result<Vec<SandboxPlan>, Sandb
 /// Lower one manifest JSON document for the current host OS.
 pub fn plan_for_current_os(manifest_json: &str) -> Result<SandboxPlan, SandboxPlanError> {
     plan_from_json(manifest_json, OsFamily::current())
+}
+
+fn run_macos_seatbelt(
+    plan: &SandboxPlan,
+    program: OsString,
+    args: Vec<OsString>,
+) -> Result<KernelSandboxCommandOutput, KernelSandboxError> {
+    let support = current_kernel_sandbox_support();
+    if !support.available {
+        return Err(KernelSandboxError::Unsupported(support));
+    }
+
+    let profile = macos_seatbelt_profile_for_plan(plan)?;
+    let output = Command::new(MACOS_SANDBOX_EXEC)
+        .arg("-p")
+        .arg(profile)
+        .arg(program)
+        .args(args)
+        .output()
+        .map_err(|error| KernelSandboxError::Io(error.to_string()))?;
+
+    Ok(KernelSandboxCommandOutput {
+        os: OsFamily::Macos,
+        primitive: MACOS_KERNEL_PRIMITIVE.to_string(),
+        status_code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn writable_path_literals(plan: &SandboxPlan) -> Result<Vec<String>, KernelSandboxError> {
+    let mut paths = Vec::new();
+    for rule in &plan.rules {
+        if rule.capability.category != Category::Fs
+            || !matches!(
+                rule.capability.action,
+                Action::Write | Action::Create | Action::Delete
+            )
+        {
+            continue;
+        }
+        let target = rule.capability.target.as_str();
+        if target == "*" || has_glob_syntax(target) {
+            return Err(KernelSandboxError::InvalidPlan(format!(
+                "macOS kernel enforcement requires exact absolute filesystem write targets, got '{target}'"
+            )));
+        }
+        paths.push(
+            canonicalize_literal_target(target)?
+                .to_string_lossy()
+                .to_string(),
+        );
+    }
+    Ok(paths)
+}
+
+fn has_glob_syntax(target: &str) -> bool {
+    target.chars().any(|ch| matches!(ch, '*' | '?' | '[' | ']'))
+}
+
+fn canonicalize_literal_target(target: &str) -> Result<PathBuf, KernelSandboxError> {
+    let path = Path::new(target);
+    if !path.is_absolute() {
+        return Err(KernelSandboxError::InvalidPlan(format!(
+            "kernel file targets must be absolute paths, got '{target}'"
+        )));
+    }
+    if let Ok(canonical) = fs::canonicalize(path) {
+        return Ok(canonical);
+    }
+
+    let parent = path.parent().ok_or_else(|| {
+        KernelSandboxError::InvalidPlan(format!("path '{target}' has no parent directory"))
+    })?;
+    let file_name = path.file_name().ok_or_else(|| {
+        KernelSandboxError::InvalidPlan(format!("path '{target}' has no final path component"))
+    })?;
+    let parent = fs::canonicalize(parent).map_err(|error| {
+        KernelSandboxError::InvalidPlan(format!(
+            "parent directory for '{target}' must exist before kernel enforcement: {error}"
+        ))
+    })?;
+    Ok(parent.join(file_name))
+}
+
+fn seatbelt_escape(input: &str) -> Result<String, KernelSandboxError> {
+    let mut escaped = String::new();
+    for ch in input.chars() {
+        match ch {
+            '\n' | '\r' | '\0' => {
+                return Err(KernelSandboxError::InvalidPlan(
+                    "Seatbelt profile literals cannot contain control characters".to_string(),
+                ))
+            }
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            other => escaped.push(other),
+        }
+    }
+    Ok(escaped)
 }
 
 fn build_plan_from_json(
@@ -501,6 +752,7 @@ fn expression_for(capability: &Capability, primitive: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     const WEATHER_MANIFEST: &str = r#"{
       "version": 1,
@@ -599,5 +851,113 @@ mod tests {
         assert_eq!(plans.len(), 6);
         assert_eq!(plans[0].os, OsFamily::Linux);
         assert_eq!(plans[5].os, OsFamily::Portable);
+    }
+
+    #[test]
+    fn macos_seatbelt_profile_limits_file_writes_to_manifest_targets() {
+        let dir = unique_temp_dir("profile");
+        let allowed = dir.join("umbrella-today.txt");
+        let manifest = weather_manifest_for_path(&allowed);
+        let plan = plan_from_json(&manifest, OsFamily::Macos).unwrap();
+
+        let profile = macos_seatbelt_profile_for_plan(&plan).unwrap();
+        let allowed = fs::canonicalize(&dir)
+            .unwrap()
+            .join("umbrella-today.txt")
+            .to_string_lossy()
+            .to_string();
+
+        assert!(profile.contains("(allow default)"));
+        assert!(profile.contains("(deny file-write*"));
+        assert!(profile.contains("(require-not"));
+        assert!(profile.contains(&allowed));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_kernel_sandbox_blocks_undeclared_file_writes() {
+        if !Path::new(MACOS_SANDBOX_EXEC).exists() {
+            return;
+        }
+
+        let dir = unique_temp_dir("kernel");
+        let allowed = dir.join("allowed.txt");
+        let denied = dir.join("denied.txt");
+        let manifest = weather_manifest_for_path(&allowed);
+        let plan = plan_from_json(&manifest, OsFamily::Macos).unwrap();
+        let allowed_arg = fs::canonicalize(&dir)
+            .unwrap()
+            .join("allowed.txt")
+            .to_string_lossy()
+            .to_string();
+        let denied_arg = fs::canonicalize(&dir)
+            .unwrap()
+            .join("denied.txt")
+            .to_string_lossy()
+            .to_string();
+
+        let output = run_with_kernel_sandbox(
+            &plan,
+            "/bin/sh",
+            [
+                "-c",
+                "printf allowed > \"$1\"; printf denied > \"$2\"",
+                "sh",
+                &allowed_arg,
+                &denied_arg,
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(&allowed).unwrap(), "allowed");
+        assert!(!denied.exists());
+        assert!(!output.success());
+        assert!(output.stderr.contains("Operation not permitted"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    fn weather_manifest_for_path(path: &Path) -> String {
+        let path = path.to_string_lossy();
+        format!(
+            r#"{{
+              "version": 1,
+              "package": "rust/weather-agent-e2e",
+              "capabilities": [
+                {{
+                  "category": "net",
+                  "action": "dns",
+                  "target": "api.weather.gov",
+                  "justification": "Resolve Weather.gov for the live umbrella forecast."
+                }},
+                {{
+                  "category": "net",
+                  "action": "connect",
+                  "target": "api.weather.gov:443",
+                  "justification": "Fetch the Weather.gov points and forecast resources over TLS."
+                }},
+                {{
+                  "category": "fs",
+                  "action": "write",
+                  "target": "{path}",
+                  "justification": "Write the umbrella decision text file."
+                }}
+              ],
+              "justification": "Weather Agent E2E fetches live weather and writes one report."
+            }}"#
+        )
+    }
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "capability-os-sandbox-{label}-{}-{now}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
     }
 }

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -17,7 +17,10 @@ use capability_cage::{
     secure_file, Action as CageAction, Capability as CageCapability, CapabilityFlavor,
     CapabilityTrust, Category as CageCategory, Manifest,
 };
-use capability_os_sandbox::{plan_all_supported, OsFamily, SandboxPlanSummary};
+use capability_os_sandbox::{
+    current_kernel_sandbox_support, plan_all_supported, plan_for_current_os,
+    run_with_kernel_sandbox, OsFamily, SandboxPlanSummary,
+};
 use chief_of_staff_tool_api::{
     InMemoryToolRuntime, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError,
     ToolCallError, ToolConcurrency, ToolDefinition, ToolErrorKind, ToolEventKind,
@@ -452,6 +455,7 @@ pub struct UmbrellaAgentRun {
     pub output_text: String,
     pub weather_fetch: WeatherFetchSummary,
     pub sandbox_plan: UmbrellaSandboxPlanSummary,
+    pub kernel_sandbox: UmbrellaKernelSandboxSummary,
     pub supervisor: UmbrellaSupervisorSummary,
     pub tool_journal_health: ToolExecutionJournalHealthSummary,
     pub context_inventory: ContextStoreInventorySummary,
@@ -479,6 +483,20 @@ pub struct UmbrellaSandboxPlanSummary {
     pub native_rules: usize,
     pub host_broker_rules: usize,
     pub os_summaries: Vec<SandboxPlanSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UmbrellaKernelSandboxSummary {
+    pub os: OsFamily,
+    pub primitive: String,
+    pub available: bool,
+    pub enforced: bool,
+    pub allowed_write_succeeded: bool,
+    pub denied_write_blocked: bool,
+    pub denied_path: PathBuf,
+    pub status_code: Option<i32>,
+    pub stderr_contains_operation_not_permitted: bool,
+    pub reason: String,
 }
 
 impl UmbrellaSandboxPlanSummary {
@@ -536,6 +554,7 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
     pipeline.bootstrap_substrate()?;
 
     let sandbox_plan = plan_agent_sandbox(&config)?;
+    let kernel_sandbox = probe_agent_kernel_sandbox(&config)?;
     let (job_plan_backend, job_plan_file_count) = plan_agent_job(&config)?;
     let job_executor_status = run_executor_tick(&config)?;
 
@@ -588,6 +607,7 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         output_text,
         weather_fetch,
         sandbox_plan,
+        kernel_sandbox,
         supervisor: supervisor_summary(&system, &actor_stats, supervisor_events),
         tool_journal_health,
         context_inventory,
@@ -1594,6 +1614,127 @@ fn plan_agent_sandbox(config: &UmbrellaAgentConfig) -> UmbrellaResult<UmbrellaSa
         summaries,
         OsFamily::current(),
     ))
+}
+
+fn probe_agent_kernel_sandbox(
+    config: &UmbrellaAgentConfig,
+) -> UmbrellaResult<UmbrellaKernelSandboxSummary> {
+    let support = current_kernel_sandbox_support();
+    let denied_path = kernel_denied_probe_path(&config.output_path);
+    if !support.available {
+        return Ok(UmbrellaKernelSandboxSummary {
+            os: support.os,
+            primitive: support.primitive,
+            available: false,
+            enforced: false,
+            allowed_write_succeeded: false,
+            denied_write_blocked: false,
+            denied_path,
+            status_code: None,
+            stderr_contains_operation_not_permitted: false,
+            reason: support.reason,
+        });
+    }
+
+    if let Some(parent) = config.output_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if denied_path.exists() {
+        fs::remove_file(&denied_path)?;
+    }
+
+    let manifest_json = umbrella_agent_required_capabilities_json(&config.output_path);
+    let plan = plan_for_current_os(&manifest_json).map_err(|error| {
+        UmbrellaAgentError::new(format!(
+            "failed to lower Weather Agent kernel sandbox plan: {error}"
+        ))
+    })?;
+    let allowed_arg = canonical_kernel_probe_path(&config.output_path)?;
+    let denied_arg = canonical_kernel_probe_path(&denied_path)?;
+    let output = run_with_kernel_sandbox(
+        &plan,
+        "/bin/sh",
+        [
+            "-c",
+            "printf 'kernel sandbox allowed' > \"$1\"; printf 'kernel sandbox denied' > \"$2\"",
+            "sh",
+            &allowed_arg,
+            &denied_arg,
+        ],
+    )
+    .map_err(|error| {
+        UmbrellaAgentError::new(format!(
+            "failed to launch Weather Agent kernel sandbox probe: {error}"
+        ))
+    })?;
+
+    let allowed_write_succeeded = fs::read_to_string(&config.output_path)
+        .map(|contents| contents == "kernel sandbox allowed")
+        .unwrap_or(false);
+    let denied_write_blocked = !denied_path.exists();
+    let stderr_contains_operation_not_permitted = output.stderr.contains("Operation not permitted");
+    let enforced = allowed_write_succeeded
+        && denied_write_blocked
+        && stderr_contains_operation_not_permitted
+        && !output.success();
+
+    if !enforced {
+        return Err(UmbrellaAgentError::new(format!(
+            "Weather Agent kernel sandbox probe did not enforce the manifest: status={:?} stderr={}",
+            output.status_code, output.stderr
+        )));
+    }
+
+    Ok(UmbrellaKernelSandboxSummary {
+        os: output.os,
+        primitive: output.primitive,
+        available: true,
+        enforced,
+        allowed_write_succeeded,
+        denied_write_blocked,
+        denied_path,
+        status_code: output.status_code,
+        stderr_contains_operation_not_permitted,
+        reason:
+            "kernel denied an undeclared filesystem write while allowing the declared report path"
+                .to_string(),
+    })
+}
+
+fn kernel_denied_probe_path(output_path: &Path) -> PathBuf {
+    let file_name = output_path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "umbrella-today.txt".to_string());
+    output_path.with_file_name(format!("{file_name}.undeclared"))
+}
+
+fn canonical_kernel_probe_path(path: &Path) -> UmbrellaResult<String> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    if let Ok(canonical) = fs::canonicalize(&absolute) {
+        return Ok(canonical.to_string_lossy().to_string());
+    }
+
+    let parent = absolute.parent().ok_or_else(|| {
+        UmbrellaAgentError::new(format!(
+            "kernel sandbox probe path has no parent: {}",
+            absolute.display()
+        ))
+    })?;
+    let file_name = absolute.file_name().ok_or_else(|| {
+        UmbrellaAgentError::new(format!(
+            "kernel sandbox probe path has no final component: {}",
+            absolute.display()
+        ))
+    })?;
+    Ok(fs::canonicalize(parent)?
+        .join(file_name)
+        .to_string_lossy()
+        .to_string())
 }
 
 fn umbrella_agent_required_capabilities_json(output_path: &Path) -> String {

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use capability_os_sandbox::OsFamily;
+use capability_os_sandbox::{current_kernel_sandbox_support, OsFamily};
 use os_job_core::BackendKind;
 use weather_agent_e2e::{
     run_umbrella_today_agent, RecommendationKind, UmbrellaAgentConfig, WeatherFetchSourceKind,
@@ -59,6 +59,17 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
             .host_broker_rules,
         3
     );
+
+    let kernel_support = current_kernel_sandbox_support();
+    assert_eq!(run.kernel_sandbox.os, OsFamily::current());
+    assert_eq!(run.kernel_sandbox.available, kernel_support.available);
+    if kernel_support.available {
+        assert!(run.kernel_sandbox.enforced);
+        assert!(run.kernel_sandbox.allowed_write_succeeded);
+        assert!(run.kernel_sandbox.denied_write_blocked);
+        assert!(run.kernel_sandbox.stderr_contains_operation_not_permitted);
+        assert!(!run.kernel_sandbox.denied_path.exists());
+    }
 
     assert_eq!(run.supervisor.child_count, 3);
     assert_eq!(run.supervisor.stopped_children, 3);


### PR DESCRIPTION
## Summary
- add a macOS Seatbelt kernel launcher to capability-os-sandbox that turns exact fs write/create/delete capabilities into sandbox-exec profiles
- prove declared writes succeed while undeclared writes are denied by the kernel
- wire the Weather Agent E2E through the kernel probe alongside the existing capability-cage and OS plan summaries

## Validation
- cargo test -p capability-os-sandbox -p weather-agent-e2e
- cargo test -p weather-agent-e2e umbrella_today_agent_fetches_live_weather_over_tls -- --ignored --nocapture