### PR TITLE
Add UNO R4 DAC capability

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -4,10 +4,10 @@ use std::slice;
 
 use board_vm_host::{
     AdcReadProgram, BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram,
-    GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram, GpioWriteProgram,
+    DacWriteU12Program, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram, GpioWriteProgram,
     LedMatrixFrameProgram, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
-    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
+    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN,
+    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
     GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
     TIME_SLEEP_MS_MODULE_LEN,
 };
@@ -17,8 +17,9 @@ use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
     build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
     build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
-    build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
-    build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
+    build_dac_write_u12_module, build_led_matrix_frame_module, build_program_begin_wire_frame,
+    build_program_chunk_wire_frame, build_program_end_wire_frame, build_pwm_write_module,
+    build_adc_read_module, build_raw_module,
     build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
@@ -240,6 +241,21 @@ extern "C" fn session_adc_read_module(
 
     let module = build_adc_read_module_value(pin, max_stack)
         .unwrap_or_else(|error| raise_core_error("adc_read_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_dac_write_u12_module(
+    _self_val: VALUE,
+    pin_val: VALUE,
+    sample_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let pin = rb_u8(pin_val, "pin");
+    let sample = rb_u16(sample_val, "sample");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_dac_write_u12_module_value(pin, sample, max_stack)
+        .unwrap_or_else(|error| raise_core_error("dac_write_u12_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -832,6 +848,11 @@ fn language_digital_pins_to_rb(pins: &[LanguageDigitalPin]) -> VALUE {
         );
         hash_set(
             hash,
+            "supports_dac",
+            ruby_bridge::bool_to_rb(pin.supports_dac),
+        );
+        hash_set(
+            hash,
             "supports_touch",
             ruby_bridge::bool_to_rb(pin.supports_touch),
         );
@@ -1410,6 +1431,24 @@ fn build_adc_read_module_value(pin: u8, max_stack: u8) -> Result<Vec<u8>, Langua
     Ok(module)
 }
 
+fn build_dac_write_u12_module_value(
+    pin: u8,
+    sample: u16,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; DAC_WRITE_U12_MODULE_LEN];
+    let len = build_dac_write_u12_module(
+        DacWriteU12Program {
+            pin,
+            sample,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_raw_module_value(
     flags: u8,
     max_stack: u8,
@@ -1718,6 +1757,12 @@ pub extern "C" fn Init_board_vm_native() {
         "adc_read_module",
         session_adc_read_module as *const c_void,
         2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "dac_write_u12_module",
+        session_dac_write_u12_module as *const c_void,
+        3,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/capabilities.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/capabilities.rb
@@ -100,6 +100,10 @@ module CodingAdventures
         capabilities.select { |capability| capability.name.start_with?("adc.") }
       end
 
+      def dac
+        capabilities.select { |capability| capability.name.start_with?("dac.") }
+      end
+
       def program
         capabilities.select { |capability| capability.name.start_with?("program.") }
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -106,6 +106,10 @@ module CodingAdventures
         Adc.new(self)
       end
 
+      def dac
+        Dac.new(self)
+      end
+
       def eject
         Ejector.new(self)
       end
@@ -263,6 +267,28 @@ module CodingAdventures
           program_id: program_id,
           budget: budget,
           pin: pin,
+          max_stack: max_stack,
+          handshake: true,
+          query_caps: true,
+          host_nonce: host_nonce
+        )
+      end
+
+      def dac_write_u12!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        pin:,
+        sample:,
+        max_stack: 2
+      )
+        ensure_uno_r4_wifi!
+
+        session.dac_write_u12(
+          program_id: program_id,
+          budget: budget,
+          pin: pin,
+          sample: sample,
           max_stack: max_stack,
           handshake: true,
           query_caps: true,
@@ -976,6 +1002,43 @@ module CodingAdventures
           pin: pin,
           max_stack: max_stack
         )
+      end
+    end
+
+    class Dac
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def write_u12(
+        pin:,
+        sample:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        max_stack: 2
+      )
+        @connection.dac_write_u12!(
+          program_id: program_id,
+          budget: budget,
+          host_nonce: host_nonce,
+          pin: pin,
+          sample: sample,
+          max_stack: max_stack
+        )
+      end
+      alias write write_u12
+
+      def off(pin:, **options)
+        write_u12(pin: pin, sample: 0, **options)
+      end
+
+      def midpoint(pin:, **options)
+        write_u12(pin: pin, sample: 0x0800, **options)
+      end
+
+      def full(pin:, **options)
+        write_u12(pin: pin, sample: 0x0FFF, **options)
       end
     end
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -205,6 +205,10 @@ module CodingAdventures
         native_session.adc_read_module(pin, max_stack)
       end
 
+      def dac_write_u12_module(pin:, sample:, max_stack: 2)
+        native_session.dac_write_u12_module(pin, dac_sample_value(sample), max_stack)
+      end
+
       def gpio_open_module(pin:, mode: :output, max_stack: 2)
         native_session.gpio_open_module(pin, gpio_mode(mode), max_stack)
       end
@@ -265,6 +269,18 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: adc_read_module(pin: pin, max_stack: max_stack)
+        )
+      end
+
+      def upload_dac_write_u12(
+        program_id: @program_id,
+        pin:,
+        sample:,
+        max_stack: 2
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: dac_write_u12_module(pin: pin, sample: sample, max_stack: max_stack)
         )
       end
 
@@ -559,6 +575,36 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def dac_write_u12(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        pin:,
+        sample:,
+        max_stack: 2,
+        handshake: false,
+        query_caps: false,
+        host_name: @host_name,
+        host_nonce: @host_nonce
+      )
+        results = []
+        results << hello(host_name: host_name, host_nonce: host_nonce) if handshake
+        results << capabilities if query_caps
+        results.concat(
+          upload_dac_write_u12(
+            program_id: program_id,
+            pin: pin,
+            sample: sample,
+            max_stack: max_stack
+          ).results
+        )
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget
+        )
+        SessionResult.new(results: results)
+      end
+
       def gpio_open(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -756,6 +802,8 @@ module CodingAdventures
           upload_pwm_write(**pwm_write_command_options(words, command, options, require_budget: false))
         when "upload-adc-read", "upload-adc.read"
           upload_adc_read(**adc_read_command_options(words, command, options, require_budget: false))
+        when "upload-dac-write-u12", "upload-dac.write_u12", "upload-dac-write"
+          upload_dac_write_u12(**dac_write_u12_command_options(words, command, options, require_budget: false))
         when "upload-gpio-open", "upload-gpio.open"
           upload_gpio_open(**gpio_open_command_options(words, command, options, require_budget: false))
         when "upload-gpio-handle-read", "upload-gpio.handle-read"
@@ -790,6 +838,8 @@ module CodingAdventures
           pwm_write(**pwm_write_command_options(words, command, options))
         when "adc-read", "adc.read"
           adc_read(**adc_read_command_options(words, command, options))
+        when "dac-write-u12", "dac.write_u12", "dac-write"
+          dac_write_u12(**dac_write_u12_command_options(words, command, options))
         when "gpio-high", "gpio.high"
           gpio_write(**gpio_level_command_options(words, command, options, value: true))
         when "gpio-low", "gpio.low"
@@ -1006,6 +1056,22 @@ module CodingAdventures
         merged
       end
 
+      def dac_write_u12_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:pin] = integer_argument(words.shift, "#{command} pin") unless words.empty?
+        merged[:sample] = dac_sample_value(words.shift) unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires pin" unless merged.key?(:pin)
+        raise ArgumentError, "#{command} requires sample" unless merged.key?(:sample)
+
+        merged
+      end
+
       def gpio_open_command_options(words, command, options, require_budget: true)
         merged = options.dup
         merged[:pin] = integer_argument(words.shift, "#{command} pin") unless words.empty?
@@ -1082,6 +1148,21 @@ module CodingAdventures
         raise ArgumentError, "PWM duty must fit in u16" if duty.negative? || duty > 0xFFFF
 
         duty
+      end
+
+      def dac_sample_value(value)
+        sample = if value.is_a?(Integer)
+          value
+        else
+          begin
+            Integer(value, 0)
+          rescue ArgumentError
+            raise ArgumentError, "DAC sample must be an integer: #{value.inspect}"
+          end
+        end
+        raise ArgumentError, "DAC sample must fit in u12" if sample.negative? || sample > 0x0FFF
+
+        sample
       end
 
       def boot_policy_value(value)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -37,6 +37,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "led_matrix.frame"
         assert_includes uno_r4_wifi["capabilities"], "pwm.write"
         assert_includes uno_r4_wifi["capabilities"], "adc.read"
+        assert_includes uno_r4_wifi["capabilities"], "dac.write_u12"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -55,6 +56,7 @@ module CodingAdventures
         a0 = uno_r4_wifi["digital_pins"].find { |pin| pin["pin"] == 14 }
         assert_equal "A0/D14", a0["label"]
         assert a0["supports_adc"]
+        assert a0["supports_dac"]
         refute a0["supports_pwm"]
         assert_equal "esp32", esp32["family"]
         assert_equal "board-vm-esp32", esp32["runtime_id"]
@@ -1246,6 +1248,28 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_dac_write_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          result = board.dac.write(pin: 14, sample: 0x0800, program_id: 10, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 6, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal transport.frames, result.frames
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          result.results.map(&:command)
+      end
+
       def test_store_program_dispatches_native_protocol_frame_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1620,6 +1644,26 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_dac_write
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("dac-write-u12 14 0x800 24", program_id: 9)
+          upload = board.session.run_command("upload-dac-write-u12 14 2048", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
       def test_board_descriptor_wraps_rust_decoded_capability_report
         decoded = {
           "kind" => "caps_report",
@@ -1736,6 +1780,10 @@ module CodingAdventures
         adc_module_bytes = session.adc_read_module(14, 1)
         assert_instance_of String, adc_module_bytes
         assert_operator adc_module_bytes.bytesize, :>, 0
+
+        dac_module_bytes = session.dac_write_u12_module(14, 0x0800, 2)
+        assert_instance_of String, dac_module_bytes
+        assert_operator dac_module_bytes.bytesize, :>, 0
 
         gpio_module_bytes = session.gpio_read_module(13, 2, 2)
         assert_instance_of String, gpio_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 
 use board_vm_ir::{
-    parse_module, validate, CAP_ADC_READ, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ,
-    CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    parse_module, validate, CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
+    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS,
+    CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -31,6 +32,73 @@ pub const ERROR_BAD_CRC: u16 = 0x0005;
 pub const ERROR_INVALID_PROGRAM: u16 = 0x0200;
 pub const ERROR_INVALID_BYTECODE: u16 = 0x0201;
 pub const ERROR_BOARD_FAULT: u16 = 0x0400;
+
+const GPIO_OPEN_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_GPIO_OPEN,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "gpio.open",
+};
+const GPIO_WRITE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_GPIO_WRITE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "gpio.write",
+};
+const GPIO_READ_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_GPIO_READ,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "gpio.read",
+};
+const GPIO_CLOSE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_GPIO_CLOSE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "gpio.close",
+};
+const TIME_SLEEP_MS_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_TIME_SLEEP_MS,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "time.sleep_ms",
+};
+const TIME_NOW_MS_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_TIME_NOW_MS,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "time.now_ms",
+};
+const PWM_WRITE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_PWM_WRITE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "pwm.write",
+};
+const ADC_READ_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_ADC_READ,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "adc.read",
+};
+const DAC_WRITE_U12_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_DAC_WRITE_U12,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "dac.write_u12",
+};
+const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_LED_MATRIX_FRAME,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "led_matrix.frame",
+};
+const PROGRAM_RAM_EXEC_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_PROGRAM_RAM_EXEC,
+    version: 1,
+    flags: CAP_FLAG_PROTOCOL_FEATURE,
+    name: "program.ram_exec",
+};
 
 pub const BLINK_MVP_CAPABILITIES: [CapabilityDescriptor<'static>; 7] = [
     CapabilityDescriptor {
@@ -462,6 +530,107 @@ pub const BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescrip
         flags: CAP_FLAG_PROTOCOL_FEATURE,
         name: "program.ram_exec",
     },
+];
+
+pub const BLINK_MVP_WITH_DAC_CAPABILITIES: [CapabilityDescriptor<'static>; 8] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_PWM_AND_DAC_CAPABILITIES: [CapabilityDescriptor<'static>; 9] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    PWM_WRITE_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_ADC_AND_DAC_CAPABILITIES: [CapabilityDescriptor<'static>; 9] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    ADC_READ_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_PWM_ADC_AND_DAC_CAPABILITIES: [CapabilityDescriptor<'static>; 10] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    PWM_WRITE_DESCRIPTOR,
+    ADC_READ_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>; 9] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    LED_MATRIX_FRAME_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_PWM_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>; 10] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    PWM_WRITE_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    LED_MATRIX_FRAME_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_ADC_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>; 10] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    ADC_READ_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    LED_MATRIX_FRAME_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>;
+    11] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    PWM_WRITE_DESCRIPTOR,
+    ADC_READ_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    LED_MATRIX_FRAME_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,8 +1,9 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ,
-    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME,
-    CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
-    FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MODULE_MAGIC, MODULE_VERSION,
+    CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE,
+    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MODULE_MAGIC,
+    MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -38,6 +39,8 @@ pub const PWM_WRITE_CODE_LEN: usize = 8;
 pub const PWM_WRITE_MODULE_LEN: usize = 18;
 pub const ADC_READ_CODE_LEN: usize = 5;
 pub const ADC_READ_MODULE_LEN: usize = 15;
+pub const DAC_WRITE_U12_CODE_LEN: usize = 8;
+pub const DAC_WRITE_U12_MODULE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -166,6 +169,13 @@ pub struct AdcReadProgram {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DacWriteU12Program {
+    pub pin: u8,
+    pub sample: u16,
+    pub max_stack: u8,
+}
+
 impl GpioOpenProgram {
     pub const fn output(pin: u8) -> Self {
         Self {
@@ -277,6 +287,16 @@ impl PwmWriteProgram {
 impl AdcReadProgram {
     pub const fn new(pin: u8) -> Self {
         Self { pin, max_stack: 1 }
+    }
+}
+
+impl DacWriteU12Program {
+    pub const fn new(pin: u8, sample: u16) -> Self {
+        Self {
+            pin,
+            sample,
+            max_stack: 2,
+        }
     }
 }
 
@@ -1072,6 +1092,46 @@ pub fn write_adc_read_module(program: AdcReadProgram, out: &mut [u8]) -> Result<
     Ok(offset)
 }
 
+pub fn write_dac_write_u12_code(
+    program: DacWriteU12Program,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < DAC_WRITE_U12_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.pin)?;
+    write_push_u16(out, &mut offset, program.sample)?;
+    write_call_u8(out, &mut offset, CAP_DAC_WRITE_U12)?;
+    write_u8(out, &mut offset, OP_HALT)?;
+    Ok(offset)
+}
+
+pub fn write_dac_write_u12_module(
+    program: DacWriteU12Program,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < DAC_WRITE_U12_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; DAC_WRITE_U12_CODE_LEN];
+    let code_len = write_dac_write_u12_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(0, program.max_stack, &code[..code_len]),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_dac(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_led_matrix_frame_code(
     program: LedMatrixFrameProgram,
     out: &mut [u8],
@@ -1221,7 +1281,7 @@ mod tests {
     use super::*;
     use board_vm_ir::{
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
-        CAP_ADC_READ, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -1267,6 +1327,10 @@ mod tests {
     ];
     const ADC_READ_A0_MODULE_HEX: [u8; ADC_READ_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x05, 0x12, 0x0E, 0x40, 0x21, 0x50, 0x00,
+    ];
+    const DAC_WRITE_A0_MID_MODULE_HEX: [u8; DAC_WRITE_U12_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x02, 0x00, 0x08, 0x12, 0x0E, 0x13, 0x00, 0x08, 0x40,
+        0x22, 0x00, 0x00,
     ];
     const LED_MATRIX_HEART_MODULE_HEX: [u8; LED_MATRIX_FRAME_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x12, 0x14, 0x44, 0xA4, 0x84, 0x31, 0x14,
@@ -1440,6 +1504,21 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_ADC_READ]);
+    }
+
+    #[test]
+    fn builds_dac_write_u12_module() {
+        let mut module = [0u8; DAC_WRITE_U12_MODULE_LEN];
+        let len =
+            write_dac_write_u12_module(DacWriteU12Program::new(14, 0x0800), &mut module).unwrap();
+        assert_eq!(len, DAC_WRITE_U12_MODULE_LEN);
+        assert_eq!(module, DAC_WRITE_A0_MID_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_dac(), 2).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_DAC_WRITE_U12]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -18,6 +18,7 @@ pub const CAP_TIME_SLEEP_MS: u16 = 0x10;
 pub const CAP_TIME_NOW_MS: u16 = 0x11;
 pub const CAP_PWM_WRITE: u16 = 0x20;
 pub const CAP_ADC_READ: u16 = 0x21;
+pub const CAP_DAC_WRITE_U12: u16 = 0x22;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -28,6 +29,7 @@ const CAP_TIME_SLEEP_MS_U8: u8 = CAP_TIME_SLEEP_MS as u8;
 const CAP_TIME_NOW_MS_U8: u8 = CAP_TIME_NOW_MS as u8;
 const CAP_PWM_WRITE_U8: u8 = CAP_PWM_WRITE as u8;
 const CAP_ADC_READ_U8: u8 = CAP_ADC_READ as u8;
+const CAP_DAC_WRITE_U12_U8: u8 = CAP_DAC_WRITE_U12 as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -102,6 +104,7 @@ pub struct CapabilitySet {
     pub time: bool,
     pub pwm: bool,
     pub adc: bool,
+    pub dac: bool,
     pub led_matrix: bool,
 }
 
@@ -112,6 +115,7 @@ impl CapabilitySet {
             time: false,
             pwm: false,
             adc: false,
+            dac: false,
             led_matrix: false,
         }
     }
@@ -122,6 +126,7 @@ impl CapabilitySet {
             time: true,
             pwm: false,
             adc: false,
+            dac: false,
             led_matrix: false,
         }
     }
@@ -132,6 +137,10 @@ impl CapabilitySet {
 
     pub const fn with_adc(self) -> Self {
         Self { adc: true, ..self }
+    }
+
+    pub const fn with_dac(self) -> Self {
+        Self { dac: true, ..self }
     }
 
     pub const fn with_led_matrix(self) -> Self {
@@ -147,6 +156,7 @@ impl CapabilitySet {
             CAP_TIME_SLEEP_MS | CAP_TIME_NOW_MS => self.time,
             CAP_PWM_WRITE => self.pwm,
             CAP_ADC_READ => self.adc,
+            CAP_DAC_WRITE_U12 => self.dac,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -381,6 +391,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_TIME_NOW_MS_U8) | Op::CallU16(CAP_TIME_NOW_MS) => (0, 1),
         Op::CallU8(CAP_PWM_WRITE_U8) | Op::CallU16(CAP_PWM_WRITE) => (2, 0),
         Op::CallU8(CAP_ADC_READ_U8) | Op::CallU16(CAP_ADC_READ) => (1, 1),
+        Op::CallU8(CAP_DAC_WRITE_U12_U8) | Op::CallU16(CAP_DAC_WRITE_U12) => (2, 0),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -566,6 +577,21 @@ mod tests {
     }
 
     #[test]
+    fn validates_dac_write_u12_capability() {
+        let module = Module {
+            flags: 0,
+            max_stack: 2,
+            code: &[0x12, 14, 0x13, 0x00, 0x08, 0x40, CAP_DAC_WRITE_U12 as u8],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_dac(), 2).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_DAC_WRITE_U12]);
+    }
+
+    #[test]
     fn rejects_pwm_write_without_capability() {
         let module = Module {
             flags: 0,
@@ -592,6 +618,21 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 1),
             Err(ValidateError::UnsupportedCapability(CAP_ADC_READ))
+        );
+    }
+
+    #[test]
+    fn rejects_dac_write_u12_without_capability() {
+        let module = Module {
+            flags: 0,
+            max_stack: 2,
+            code: &[0x12, 14, 0x13, 0x00, 0x08, 0x40, CAP_DAC_WRITE_U12 as u8],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 2),
+            Err(ValidateError::UnsupportedCapability(CAP_DAC_WRITE_U12))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -35,18 +35,18 @@ use board_vm_esp_rom::{
     DEFAULT_TIMEOUT_MS as ESP_DEFAULT_TIMEOUT_MS,
 };
 use board_vm_host::{
-    write_adc_read_module, write_blink_module, write_gpio_handle_close_module,
-    write_gpio_handle_read_module, write_gpio_handle_write_module, write_gpio_open_module,
-    write_gpio_read_module, write_gpio_write_module, write_led_matrix_frame_module, write_module,
-    write_pwm_write_module, write_time_now_module, write_time_sleep_ms_module, AdcReadProgram,
-    BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
-    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession,
-    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
-    DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
-    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
-    GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
-    TIME_SLEEP_MS_MODULE_LEN,
+    write_adc_read_module, write_blink_module, write_dac_write_u12_module,
+    write_gpio_handle_close_module, write_gpio_handle_read_module, write_gpio_handle_write_module,
+    write_gpio_open_module, write_gpio_read_module, write_gpio_write_module,
+    write_led_matrix_frame_module, write_module, write_pwm_write_module, write_time_now_module,
+    write_time_sleep_ms_module, AdcReadProgram, BlinkProgram, DacWriteU12Program,
+    GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram,
+    GpioReadProgram, GpioWriteProgram, HostError, HostSession, LedMatrixFrameProgram, ModuleSpec,
+    PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
+    DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
+    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
+    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
+    PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -399,6 +399,7 @@ pub struct LanguageDigitalPin {
     pub supports_pulldown: bool,
     pub supports_adc: bool,
     pub supports_pwm: bool,
+    pub supports_dac: bool,
     pub supports_touch: bool,
     pub supports_interrupt: bool,
     pub boot_strap: bool,
@@ -1085,6 +1086,7 @@ fn language_digital_pin(pin: &TargetDigitalPin) -> LanguageDigitalPin {
         supports_pulldown: pin.supports_pulldown,
         supports_adc: pin.supports_adc,
         supports_pwm: pin.supports_pwm,
+        supports_dac: pin.supports_dac,
         supports_touch: pin.supports_touch,
         supports_interrupt: pin.supports_interrupt,
         boot_strap: pin.boot_strap,
@@ -1593,6 +1595,13 @@ pub fn build_adc_read_module(
     out: &mut [u8],
 ) -> Result<usize, LanguageCoreError> {
     Ok(write_adc_read_module(program, out)?)
+}
+
+pub fn build_dac_write_u12_module(
+    program: DacWriteU12Program,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_dac_write_u12_module(program, out)?)
 }
 
 pub fn build_raw_module(
@@ -2277,6 +2286,31 @@ pub unsafe extern "C" fn board_vm_language_adc_read_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_dac_write_u12_module(
+    pin: u8,
+    sample: u16,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_dac_write_u12_module(
+            DacWriteU12Program {
+                pin,
+                sample,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2592,6 +2626,11 @@ pub extern "C" fn board_vm_language_adc_read_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_dac_write_u12_module_len() -> u64 {
+    DAC_WRITE_U12_MODULE_LEN as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_led_matrix_frame_module_len() -> u64 {
     LED_MATRIX_FRAME_MODULE_LEN as u64
 }
@@ -2818,8 +2857,10 @@ mod tests {
         let uno_a0 = uno.digital_pins.iter().find(|pin| pin.pin == 14).unwrap();
         assert_eq!(uno_a0.label, "A0/D14");
         assert!(uno_a0.supports_adc);
+        assert!(uno_a0.supports_dac);
         assert!(uno.capabilities.contains(&"pwm.write".to_owned()));
         assert!(uno.capabilities.contains(&"adc.read".to_owned()));
+        assert!(uno.capabilities.contains(&"dac.write_u12".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -3611,6 +3652,19 @@ mod tests {
         };
         assert_eq!(adc_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(adc_status.len, ADC_READ_MODULE_LEN as u64);
+
+        let mut dac_module = [0u8; DAC_WRITE_U12_MODULE_LEN];
+        let dac_status = unsafe {
+            board_vm_language_dac_write_u12_module(
+                14,
+                0x0800,
+                2,
+                dac_module.as_mut_ptr(),
+                dac_module.len() as u64,
+            )
+        };
+        assert_eq!(dac_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(dac_status.len, DAC_WRITE_U12_MODULE_LEN as u64);
 
         let mut gpio_read_module = [0u8; GPIO_READ_MODULE_LEN];
         let gpio_read_status = unsafe {

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
 use board_vm_ir::{
-    decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
-    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS,
-    CAP_TIME_SLEEP_MS,
+    decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_DAC_WRITE_U12,
+    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_LED_MATRIX_FRAME,
+    CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,6 +67,10 @@ pub trait BoardHal {
     }
 
     fn adc_read(&mut self, _pin: u16) -> Result<u16, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn dac_write_u12(&mut self, _pin: u16, _sample: u16) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -425,6 +429,16 @@ where
                 })?;
                 self.push(Value::U16(sample), ip)
             }
+            CAP_DAC_WRITE_U12 => {
+                let sample = self.pop_u16(ip)?;
+                let pin = self.pop_u16(ip)?;
+                self.hal
+                    .dac_write_u12(pin, sample)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -657,6 +671,7 @@ mod tests {
         Sleep(u16),
         PwmWrite(u16, u16),
         AdcRead(u16),
+        DacWriteU12(u16, u16),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -679,6 +694,7 @@ mod tests {
             CapabilitySet::blink_mvp()
                 .with_pwm()
                 .with_adc()
+                .with_dac()
                 .with_led_matrix()
         }
 
@@ -718,6 +734,11 @@ mod tests {
         fn adc_read(&mut self, pin: u16) -> Result<u16, HalError> {
             self.events.push(Event::AdcRead(pin));
             Ok(0x03ff)
+        }
+
+        fn dac_write_u12(&mut self, pin: u16, sample: u16) -> Result<(), HalError> {
+            self.events.push(Event::DacWriteU12(pin, sample));
+            Ok(())
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -843,5 +864,25 @@ mod tests {
         assert_eq!(report.status, RunStatus::Halted);
         assert_eq!(report.return_value, Value::U16(0x03ff));
         assert_eq!(runtime.hal().events, vec![Event::AdcRead(14)]);
+    }
+
+    #[test]
+    fn dac_write_u12_dispatches_pin_and_sample() {
+        let mut runtime: Runtime<FakeHal, 4, 1> = Runtime::new(FakeHal::new());
+        let code = [
+            0x12,
+            14,
+            0x13,
+            0x00,
+            0x08,
+            0x40,
+            CAP_DAC_WRITE_U12 as u8,
+            0x00,
+        ];
+
+        let report = runtime.run_code(&code, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(runtime.hal().events, vec![Event::DacWriteU12(14, 0x0800)]);
     }
 }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -44,6 +44,7 @@ pub struct DigitalPinInfo {
     pub supports_pulldown: bool,
     pub supports_adc: bool,
     pub supports_pwm: bool,
+    pub supports_dac: bool,
     pub supports_touch: bool,
     pub supports_interrupt: bool,
     pub boot_strap: bool,
@@ -61,6 +62,7 @@ impl DigitalPinInfo {
             supports_pulldown: false,
             supports_adc: false,
             supports_pwm: false,
+            supports_dac: false,
             supports_touch: false,
             supports_interrupt: false,
             boot_strap: false,
@@ -99,7 +101,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 10] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 11] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -109,10 +111,11 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 10] = [
     "time.now_ms",
     "pwm.write",
     "adc.read",
+    "dac.write_u12",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 14] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 15] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -125,6 +128,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 14] = [
     "time.now_ms",
     "pwm.write",
     "adc.read",
+    "dac.write_u12",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -252,6 +256,7 @@ const fn uno_r4_digital_pin(pin: board_vm_uno_r4::DigitalPinDescriptor) -> Digit
         supports_pulldown: false,
         supports_adc: pin.supports_adc,
         supports_pwm: pin.supports_pwm,
+        supports_dac: pin.supports_dac,
         supports_touch: false,
         supports_interrupt: pin.supports_interrupt,
         boot_strap: false,
@@ -281,6 +286,7 @@ const fn esp32_digital_pin(pin: board_vm_esp32::DigitalPinDescriptor) -> Digital
         supports_pulldown: pin.supports_pulldown,
         supports_adc: pin.supports_adc,
         supports_pwm: pin.supports_output,
+        supports_dac: false,
         supports_touch: pin.supports_touch,
         supports_interrupt: pin.supports_input,
         boot_strap: pin.boot_strap,
@@ -310,6 +316,7 @@ const fn pico_digital_pin(pin: board_vm_pico::DigitalPinDescriptor) -> DigitalPi
         supports_pulldown: pin.supports_pulldown,
         supports_adc: pin.supports_adc,
         supports_pwm: pin.supports_pwm,
+        supports_dac: false,
         supports_touch: false,
         supports_interrupt: pin.supports_input,
         boot_strap: false,
@@ -504,6 +511,7 @@ mod tests {
         let a0 = uno.digital_pins.iter().find(|pin| pin.pin == 14).unwrap();
         assert_eq!(a0.label, "A0/D14");
         assert!(a0.supports_adc);
+        assert!(a0.supports_dac);
         assert!(!a0.supports_pwm);
 
         let pico = find_target("raspberry-pi-pico").unwrap();
@@ -529,6 +537,7 @@ mod tests {
         let uno = find_target("arduino-uno-r4-wifi").unwrap();
         assert!(uno.capabilities.contains(&"pwm.write"));
         assert!(uno.capabilities.contains(&"adc.read"));
+        assert!(uno.capabilities.contains(&"dac.write_u12"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -4,7 +4,7 @@
 // Arduino's Renesas core still owns the RA4M1 TinyUSB descriptors, IRQ
 // plumbing, FSP USB driver objects needed by `__USBStart`, and the low-level
 // GPT/AGT timer setup behind the SerialUSB firmware's PWM backend, plus the
-// FSP ADC driver used by the physical analog-read backend.
+// FSP ADC/DAC drivers used by the physical analog-read and analog-write backends.
 
 pub const ARDUINO_RENESAS_UNO_CORE_VERSION: &str = "1.5.3";
 pub const UNO_R4_WIFI_FQBN: &str = "arduino:renesas_uno:unor4wifi";
@@ -29,6 +29,7 @@ pub const ARDUINO_ARM_COMPAT_ROOT_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_COMPAT_RO
 pub const ARDUINO_USB_START_SYMBOL: &str = "_Z10__USBStartv";
 pub const BOARD_VM_UNO_R4_PWM_WRITE_SYMBOL: &str = "board_vm_uno_r4_pwm_write";
 pub const BOARD_VM_UNO_R4_ADC_READ_SYMBOL: &str = "board_vm_uno_r4_adc_read";
+pub const BOARD_VM_UNO_R4_DAC_WRITE_U12_SYMBOL: &str = "board_vm_uno_r4_dac_write_u12";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
@@ -271,6 +272,10 @@ mod tests {
             "board_vm_uno_r4_pwm_write"
         );
         assert_eq!(BOARD_VM_UNO_R4_ADC_READ_SYMBOL, "board_vm_uno_r4_adc_read");
+        assert_eq!(
+            BOARD_VM_UNO_R4_DAC_WRITE_U12_SYMBOL,
+            "board_vm_uno_r4_dac_write_u12"
+        );
         assert_eq!(
             BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE,
             "src/uno_r4_wifi_pwm_bridge.cpp"

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -163,6 +163,10 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         true
     }
 
+    fn supports_dac(&self) -> bool {
+        true
+    }
+
     fn supports_bootloader_reboot(&self) -> bool {
         true
     }
@@ -188,6 +192,14 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         }
     }
 
+    fn write_dac_u12(&mut self, pin: u8, sample: u16) -> Result<(), HalError> {
+        if unsafe { board_io_ffi::board_vm_uno_r4_dac_write_u12(pin, sample) } {
+            Ok(())
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+
     fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
         board_vm_uno_r4_usb_cdc::reboot_to_bootloader()
     }
@@ -198,5 +210,6 @@ mod board_io_ffi {
     unsafe extern "C" {
         pub fn board_vm_uno_r4_pwm_write(pin: u8, duty: u16) -> bool;
         pub fn board_vm_uno_r4_adc_read(pin: u8, sample: *mut u16) -> bool;
+        pub fn board_vm_uno_r4_dac_write_u12(pin: u8, sample: u16) -> bool;
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -13,6 +13,8 @@ namespace {
 
 constexpr uint8_t kPwmPins[] = {3, 5, 6, 9, 10, 11};
 constexpr uint8_t kAdcPins[] = {14, 15, 16, 17, 18, 19};
+constexpr uint8_t kDacPin = 14;
+constexpr uint16_t kDacU12Max = 0x0FFFu;
 constexpr size_t kOperatorNewHeapBytes = 2048;
 constexpr uint32_t kAdcRawMax = (1u << BSP_FEATURE_ADC_MAX_RESOLUTION_BITS) - 1u;
 constexpr uint32_t kAdcNormalizedMax = 65535u;
@@ -41,6 +43,10 @@ adc_extended_cfg_t g_board_vm_adc_extend = {};
 adc_cfg_t g_board_vm_adc_cfg = {};
 adc_channel_cfg_t g_board_vm_adc_channel_cfg = {};
 bool g_board_vm_adc_initialized = false;
+dac_instance_ctrl_t g_board_vm_dac_ctrl = {};
+dac_extended_cfg_t g_board_vm_dac_extend = {};
+dac_cfg_t g_board_vm_dac_cfg = {};
+bool g_board_vm_dac_opened = false;
 
 PwmSlot *find_slot(uint8_t pin) {
   for (auto &slot : g_pwm_slots) {
@@ -99,6 +105,8 @@ bool pin_cfg_matches(uint16_t cfg, PinCfgReq_t req) {
       return IS_PIN_PWM(cfg);
     case PIN_CFG_REQ_ADC:
       return IS_PIN_ANALOG(cfg);
+    case PIN_CFG_REQ_DAC:
+      return IS_PIN_DAC(cfg);
     default:
       return false;
   }
@@ -169,6 +177,17 @@ uint16_t normalize_adc_sample(uint16_t raw) {
   uint32_t scaled =
       (static_cast<uint32_t>(raw) * kAdcNormalizedMax + (kAdcRawMax / 2u)) / kAdcRawMax;
   return static_cast<uint16_t>(scaled);
+}
+
+void initialize_dac_config(uint8_t channel) {
+  g_board_vm_dac_extend.enable_charge_pump = false;
+  g_board_vm_dac_extend.output_amplifier_enabled = false;
+  g_board_vm_dac_extend.internal_output_enabled = false;
+  g_board_vm_dac_extend.data_format = DAC_DATA_FORMAT_FLUSH_RIGHT;
+
+  g_board_vm_dac_cfg.channel = channel;
+  g_board_vm_dac_cfg.ad_da_synchronized = false;
+  g_board_vm_dac_cfg.p_extend = &g_board_vm_dac_extend;
 }
 
 }  // namespace
@@ -336,4 +355,42 @@ extern "C" bool board_vm_uno_r4_adc_read(uint8_t pin, uint16_t *sample) {
 
   *sample = normalize_adc_sample(raw);
   return true;
+}
+
+extern "C" bool board_vm_uno_r4_dac_write_u12(uint8_t pin, uint16_t sample) {
+  if (pin != kDacPin || sample > kDacU12Max) {
+    return false;
+  }
+
+  auto cfg = getPinCfgs(pin, PIN_CFG_REQ_DAC);
+  if (cfg[0] == 0 || GET_CHANNEL(cfg[0]) >= DAC12_HOWMANY) {
+    return false;
+  }
+  uint8_t channel = GET_CHANNEL(cfg[0]);
+
+  fsp_err_t pin_status = R_IOPORT_PinCfg(
+      nullptr,
+      g_pin_cfg[pin].pin,
+      static_cast<uint32_t>(IOPORT_CFG_ANALOG_ENABLE | IOPORT_CFG_PERIPHERAL_PIN |
+                            IOPORT_PERIPHERAL_CAC_AD));
+  if (pin_status != FSP_SUCCESS) {
+    return false;
+  }
+
+  if (!g_board_vm_dac_opened) {
+    initialize_dac_config(channel);
+    if (R_DAC_Open(&g_board_vm_dac_ctrl, &g_board_vm_dac_cfg) != FSP_SUCCESS) {
+      return false;
+    }
+    if (R_DAC_Write(&g_board_vm_dac_ctrl, sample) != FSP_SUCCESS) {
+      return false;
+    }
+    if (R_DAC_Start(&g_board_vm_dac_ctrl) != FSP_SUCCESS) {
+      return false;
+    }
+    g_board_vm_dac_opened = true;
+    return true;
+  }
+
+  return R_DAC_Write(&g_board_vm_dac_ctrl, sample) == FSP_SUCCESS;
 }

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -2,10 +2,15 @@
 
 use board_vm_device::{
     BoardVmDevice, DeviceDescriptor, BLINK_MVP_CAPABILITIES,
-    BLINK_MVP_WITH_ADC_AND_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_ADC_CAPABILITIES,
-    BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES,
-    BLINK_MVP_WITH_PWM_AND_ADC_CAPABILITIES, BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES,
-    BLINK_MVP_WITH_PWM_CAPABILITIES, DEFAULT_MAX_FRAME_PAYLOAD,
+    BLINK_MVP_WITH_ADC_AND_DAC_CAPABILITIES, BLINK_MVP_WITH_ADC_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_ADC_CAPABILITIES, BLINK_MVP_WITH_ADC_DAC_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_DAC_AND_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_DAC_CAPABILITIES,
+    BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_PWM_ADC_AND_DAC_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_AND_ADC_CAPABILITIES, BLINK_MVP_WITH_PWM_AND_DAC_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_PWM_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_DAC_AND_LED_MATRIX_CAPABILITIES, DEFAULT_MAX_FRAME_PAYLOAD,
 };
 use board_vm_ir::CapabilitySet;
 use board_vm_runtime::{BoardHal, GpioMode, HalError, Level};
@@ -61,6 +66,7 @@ pub struct DigitalPinDescriptor {
     pub label: &'static str,
     pub supports_pwm: bool,
     pub supports_adc: bool,
+    pub supports_dac: bool,
     pub supports_interrupt: bool,
     pub notes: &'static str,
 }
@@ -71,6 +77,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D0/RX0",
         supports_pwm: false,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 0 / Serial 0 receiver",
     },
@@ -79,6 +86,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D1/TX0",
         supports_pwm: false,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 1 / Serial 0 transmitter",
     },
@@ -87,6 +95,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D2",
         supports_pwm: false,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: true,
         notes: "GPIO 2 / external interrupt",
     },
@@ -95,6 +104,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D3",
         supports_pwm: true,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: true,
         notes: "GPIO 3 / PWM / external interrupt",
     },
@@ -103,6 +113,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D4",
         supports_pwm: false,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 4 / CAN alternate function on Minima header docs",
     },
@@ -111,6 +122,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D5",
         supports_pwm: true,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 5 / PWM",
     },
@@ -119,6 +131,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D6",
         supports_pwm: true,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 6 / PWM",
     },
@@ -127,6 +140,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D7",
         supports_pwm: false,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 7",
     },
@@ -135,6 +149,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D8",
         supports_pwm: false,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 8",
     },
@@ -143,6 +158,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D9",
         supports_pwm: true,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 9 / PWM",
     },
@@ -151,6 +167,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D10/CS",
         supports_pwm: true,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 10 / PWM / SPI chip select",
     },
@@ -159,6 +176,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D11/COPI",
         supports_pwm: true,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 11 / PWM / SPI controller out",
     },
@@ -167,6 +185,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D12/CIPO",
         supports_pwm: false,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 12 / SPI controller in",
     },
@@ -175,6 +194,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "D13/SCK",
         supports_pwm: false,
         supports_adc: false,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "GPIO 13 / SPI clock / onboard LED",
     },
@@ -183,6 +203,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "A0/D14",
         supports_pwm: false,
         supports_adc: true,
+        supports_dac: true,
         supports_interrupt: false,
         notes: "Analog input A0 / DAC output / digital pin 14",
     },
@@ -191,6 +212,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "A1/D15",
         supports_pwm: false,
         supports_adc: true,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "Analog input A1 / digital pin 15",
     },
@@ -199,6 +221,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "A2/D16",
         supports_pwm: false,
         supports_adc: true,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "Analog input A2 / digital pin 16",
     },
@@ -207,6 +230,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "A3/D17",
         supports_pwm: false,
         supports_adc: true,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "Analog input A3 / digital pin 17",
     },
@@ -215,6 +239,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "A4/SDA/D18",
         supports_pwm: false,
         supports_adc: true,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "Analog input A4 / I2C SDA / digital pin 18",
     },
@@ -223,6 +248,7 @@ pub const UNO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
         label: "A5/SCL/D19",
         supports_pwm: false,
         supports_adc: true,
+        supports_dac: false,
         supports_interrupt: false,
         notes: "Analog input A5 / I2C SCL / digital pin 19",
     },
@@ -244,7 +270,7 @@ pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     onboard_led_pin: UNO_R4_ONBOARD_LED_PIN,
     supports_wifi_module: false,
     supports_led_matrix: false,
-    capabilities: CapabilitySet::blink_mvp().with_pwm().with_adc(),
+    capabilities: CapabilitySet::blink_mvp().with_pwm().with_adc().with_dac(),
     digital_pins: &UNO_R4_DIGITAL_PINS,
 };
 
@@ -267,6 +293,7 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
     capabilities: CapabilitySet::blink_mvp()
         .with_pwm()
         .with_adc()
+        .with_dac()
         .with_led_matrix(),
     digital_pins: &UNO_R4_DIGITAL_PINS,
 };
@@ -286,6 +313,10 @@ pub trait UnoR4Backend {
         false
     }
 
+    fn supports_dac(&self) -> bool {
+        false
+    }
+
     fn led_matrix_frame(&mut self, _frame: [u32; 3]) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
@@ -295,6 +326,10 @@ pub trait UnoR4Backend {
     }
 
     fn read_adc(&mut self, _pin: u8) -> Result<u16, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn write_dac_u12(&mut self, _pin: u8, _sample: u16) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -354,6 +389,7 @@ where
         let mut capabilities = self.target.capabilities;
         capabilities.pwm = self.backend.supports_pwm();
         capabilities.adc = self.backend.supports_adc();
+        capabilities.dac = self.backend.supports_dac();
         capabilities
     }
 }
@@ -404,6 +440,14 @@ where
         self.backend.read_adc(pin)
     }
 
+    fn dac_write_u12(&mut self, pin: u16, sample: u16) -> Result<(), HalError> {
+        if sample > 0x0fff {
+            return Err(HalError::UnsupportedMode);
+        }
+        let pin = normalize_dac_pin(pin)?;
+        self.backend.write_dac_u12(pin, sample)
+    }
+
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
         if !self.target.supports_led_matrix {
             return Err(HalError::UnsupportedMode);
@@ -448,6 +492,15 @@ fn normalize_adc_pin(pin: u16) -> Result<u8, HalError> {
     }
 }
 
+fn normalize_dac_pin(pin: u16) -> Result<u8, HalError> {
+    let pin = normalize_digital_pin(pin)?;
+    match digital_pin(pin) {
+        Some(descriptor) if descriptor.supports_dac => Ok(pin),
+        Some(_) => Err(HalError::UnsupportedMode),
+        None => Err(HalError::InvalidPin),
+    }
+}
+
 pub fn uno_r4_device_descriptor(
     target: &'static TargetDescriptor,
     board_nonce: u32,
@@ -466,7 +519,19 @@ fn uno_r4_device_descriptor_for_capabilities(
         board_nonce,
         max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
         supports_store_program: false,
-        capabilities: if target.supports_led_matrix && capabilities.pwm && capabilities.adc {
+        capabilities: if target.supports_led_matrix
+            && capabilities.pwm
+            && capabilities.adc
+            && capabilities.dac
+        {
+            &BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_led_matrix && capabilities.pwm && capabilities.dac {
+            &BLINK_MVP_WITH_PWM_DAC_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_led_matrix && capabilities.adc && capabilities.dac {
+            &BLINK_MVP_WITH_ADC_DAC_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_led_matrix && capabilities.dac {
+            &BLINK_MVP_WITH_DAC_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_led_matrix && capabilities.pwm && capabilities.adc {
             &BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES
         } else if target.supports_led_matrix && capabilities.pwm {
             &BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES
@@ -474,6 +539,14 @@ fn uno_r4_device_descriptor_for_capabilities(
             &BLINK_MVP_WITH_ADC_AND_LED_MATRIX_CAPABILITIES
         } else if target.supports_led_matrix {
             &BLINK_MVP_WITH_LED_MATRIX_CAPABILITIES
+        } else if capabilities.pwm && capabilities.adc && capabilities.dac {
+            &BLINK_MVP_WITH_PWM_ADC_AND_DAC_CAPABILITIES
+        } else if capabilities.pwm && capabilities.dac {
+            &BLINK_MVP_WITH_PWM_AND_DAC_CAPABILITIES
+        } else if capabilities.adc && capabilities.dac {
+            &BLINK_MVP_WITH_ADC_AND_DAC_CAPABILITIES
+        } else if capabilities.dac {
+            &BLINK_MVP_WITH_DAC_CAPABILITIES
         } else if capabilities.pwm && capabilities.adc {
             &BLINK_MVP_WITH_PWM_AND_ADC_CAPABILITIES
         } else if capabilities.pwm {
@@ -535,6 +608,7 @@ mod tests {
         Sleep(u16),
         PwmWrite(u8, u16),
         AdcRead(u8),
+        DacWriteU12(u8, u16),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -586,6 +660,10 @@ mod tests {
             true
         }
 
+        fn supports_dac(&self) -> bool {
+            true
+        }
+
         fn supports_bootloader_reboot(&self) -> bool {
             true
         }
@@ -598,6 +676,11 @@ mod tests {
         fn read_adc(&mut self, pin: u8) -> Result<u16, HalError> {
             self.events.push(Event::AdcRead(pin));
             Ok(0x02aa)
+        }
+
+        fn write_dac_u12(&mut self, pin: u8, sample: u16) -> Result<(), HalError> {
+            self.events.push(Event::DacWriteU12(pin, sample));
+            Ok(())
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -633,6 +716,7 @@ mod tests {
         let a0 = digital_pin(14).unwrap();
         assert_eq!(a0.label, "A0/D14");
         assert!(a0.supports_adc);
+        assert!(a0.supports_dac);
         assert!(!a0.supports_pwm);
         assert!(is_valid_digital_pin(19));
     }
@@ -675,18 +759,24 @@ mod tests {
         assert_eq!(descriptor.max_frame_payload, DEFAULT_MAX_FRAME_PAYLOAD);
         assert_eq!(
             descriptor.capabilities.len(),
-            BLINK_MVP_WITH_PWM_ADC_AND_LED_MATRIX_CAPABILITIES.len()
+            BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES.len()
         );
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
         assert!(UNO_R4_WIFI.capabilities.supports(board_vm_ir::CAP_ADC_READ));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_DAC_WRITE_U12));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_ADC_READ));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_DAC_WRITE_U12));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -742,6 +832,29 @@ mod tests {
 
         assert_eq!(board.adc_read(13), Err(HalError::UnsupportedMode));
         assert_eq!(board.adc_read(99), Err(HalError::InvalidPin));
+    }
+
+    #[test]
+    fn dac_write_u12_runs_through_dac_pin_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        board.dac_write_u12(14, 0x0800).unwrap();
+        assert_eq!(board.backend().events, vec![Event::DacWriteU12(14, 0x0800)]);
+    }
+
+    #[test]
+    fn dac_write_u12_rejects_non_dac_pin() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(
+            board.dac_write_u12(15, 0x0800),
+            Err(HalError::UnsupportedMode)
+        );
+        assert_eq!(
+            board.dac_write_u12(14, 0x1000),
+            Err(HalError::UnsupportedMode)
+        );
+        assert_eq!(board.dac_write_u12(99, 0x0800), Err(HalError::InvalidPin));
     }
 
     #[test]

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -186,6 +186,16 @@ needs frequency selection, ramping, or lifetime-managed timer ownership.
 `adc.read` returns a normalized 16-bit sample. Board adapters choose the
 underlying hardware resolution and scale into the portable result range.
 
+### DAC
+
+| ID | Name | Args | Returns |
+|---:|---|---|---|
+| `0x22` | `dac.write_u12` | `pin: u16/u8`, `sample: u16` | `unit` |
+
+`dac.write_u12` writes a 12-bit sample to a board DAC pin advertised by target
+metadata. The operation is intentionally direct and stateless, mirroring
+`pwm.write`; boards without a physical DAC do not advertise it.
+
 ### LED Matrix
 
 `led_matrix.*` capabilities model board-owned pixel displays such as the

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -28,7 +28,7 @@ Source snapshot:
 | LED matrix | 12x8 matrix, 96 pixels, UNO R4 WiFi only | implemented | `led_matrix.frame` |
 | PWM output | D3, D5, D6, D9, D10, D11 in the Arduino variant init path | implemented as direct write | `pwm.write` |
 | Analog input | A0-A5 | implemented as direct read | `adc.read` |
-| DAC output | A0, one 12-bit DAC channel | pending | `dac.write_u12` or `analog.write` |
+| DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
 | I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | pending | `i2c.open`, `i2c.write`, `i2c.read`, `i2c.transfer` |
 | SPI master | MOSI D11, MISO D12, SCK D13, CS D10 | pending | `spi.open`, `spi.transfer`, `spi.close` |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
@@ -64,12 +64,11 @@ reject conflicting handles.
 2. Descriptor metadata for header pins, onboard LED, LED matrix dimensions,
    PWM-capable pins, and analog-capable pins is present; keep deepening it with
    hidden pins, reserved pins, and bus pin groups.
-3. `pwm.write` and `adc.read` are the first direct analog-adjacent VM
-   operations. Add handle-oriented PWM/ADC variants only when a later streaming
-   or event tranche needs persistent resource ownership.
-4. Add DAC output on A0 as the next scalar analog capability.
-5. Implement I2C and SPI as bus handles with explicit transfer boundaries.
-6. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
+3. `pwm.write`, `adc.read`, and `dac.write_u12` are the first direct
+   analog-adjacent VM operations. Add handle-oriented variants only when a
+   later streaming or event tranche needs persistent resource ownership.
+4. Implement I2C and SPI as bus handles with explicit transfer boundaries.
+5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 
 Every tranche should include the same layers: spec entry, IR capability id,


### PR DESCRIPTION
## Summary
- add the `dac.write_u12` Board VM capability across the IR, runtime, host module builder, device descriptors, UNO R4 target metadata, and language-core native surface
- expose Ruby helpers and REPL/session commands for `board.dac.write_u12(pin:, sample:)` while keeping the frontend thin over Rust-owned module construction
- wire the UNO R4 WiFi SerialUSB firmware backend to the Renesas DAC driver for A0/D14 with pin and 12-bit sample validation
- update the Board VM bytecode and UNO R4 feature inventory specs to mark DAC as part of the VM surface

## Validation
- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core`
- `cargo test -p board-vm-uno-r4-firmware`
- linked `uno-r4-wifi-serialusb-artifact` build with `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, Arduino Renesas UNO core 1.5.3, and `/opt/homebrew/bin` ARM tools
- `bundle exec rake test` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

## Hardware Note
- The linked SerialUSB firmware image builds and objcopies with the DAC bridge included.
- Physical DAC voltage smoke is left for the next phase after flashing the new runtime onto the attached UNO R4 WiFi.
