### PR TITLE
rust(spice): add VCVS controlled sources

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -6,6 +6,8 @@
   sources, and independent current sources.
 - Add voltage-controlled current sources (VCCS) for linear transconductance
   stages.
+- Add voltage-controlled voltage sources (VCVS) across DC, AC, transfer
+  function, sensitivity, Monte Carlo, and transient analyses.
 - Add DC source sweeps for independent voltage and current sources.
 - Add DC sensitivity analysis for resistor and independent source parameters.
 - Add seeded DC Monte Carlo analysis for linear element parameters with

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -341,6 +341,7 @@ pub enum Element {
     VoltageSource(VoltageSource),
     CurrentSource(CurrentSource),
     Vccs(Vccs),
+    Vcvs(Vcvs),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -549,6 +550,36 @@ impl Vccs {
             control_positive: control_positive.into(),
             control_negative: control_negative.into(),
             transconductance_siemens,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Vcvs {
+    pub name: String,
+    pub positive: String,
+    pub negative: String,
+    pub control_positive: String,
+    pub control_negative: String,
+    pub gain: f64,
+}
+
+impl Vcvs {
+    pub fn new(
+        name: impl Into<String>,
+        positive: impl Into<String>,
+        negative: impl Into<String>,
+        control_positive: impl Into<String>,
+        control_negative: impl Into<String>,
+        gain: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            positive: positive.into(),
+            negative: negative.into(),
+            control_positive: control_positive.into(),
+            control_negative: control_negative.into(),
+            gain,
         }
     }
 }
@@ -1387,6 +1418,7 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
             "transconductance_siemens".to_string(),
             source.transconductance_siemens,
         )),
+        Element::Vcvs(source) => Some((source.name.clone(), "gain".to_string(), source.gain)),
         Element::Capacitor(_) | Element::Inductor(_) => None,
     }
 }
@@ -1401,6 +1433,7 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::VoltageSource(source) => source.voltage += delta,
         Element::CurrentSource(source) => source.current += delta,
         Element::Vccs(source) => source.transconductance_siemens += delta,
+        Element::Vcvs(source) => source.gain += delta,
         Element::Capacitor(_) | Element::Inductor(_) => {}
     }
 }
@@ -1490,6 +1523,11 @@ fn randomized_element(
                 rng,
             );
             Element::Vccs(varied)
+        }
+        Element::Vcvs(source) => {
+            let mut varied = source.clone();
+            varied.gain = randomized_value(varied.gain, tolerance, distribution, rng);
+            Element::Vcvs(varied)
         }
         Element::Capacitor(_) | Element::Inductor(_) => element.clone(),
     }
@@ -1610,6 +1648,13 @@ fn solve_linear_circuit(
                 stamp_current_source(source, &node_indices, source_time, &mut rhs)?
             }
             Element::Vccs(source) => stamp_vccs(source, &node_indices, &mut matrix)?,
+            Element::Vcvs(source) => stamp_vcvs(
+                source,
+                &node_indices,
+                &voltage_sources,
+                node_count,
+                &mut matrix,
+            )?,
         }
     }
 
@@ -1663,7 +1708,8 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             Element::Resistor(_)
             | Element::Capacitor(_)
             | Element::Inductor(_)
-            | Element::Vccs(_) => {}
+            | Element::Vccs(_)
+            | Element::Vcvs(_) => {}
         }
     }
 
@@ -1718,6 +1764,13 @@ fn build_ac_matrix(
                 }
             }
             Element::Vccs(source) => stamp_ac_vccs(source, node_indices, &mut matrix)?,
+            Element::Vcvs(source) => stamp_ac_vcvs(
+                source,
+                node_indices,
+                voltage_sources,
+                node_count,
+                &mut matrix,
+            )?,
         }
     }
 
@@ -1769,6 +1822,15 @@ fn build_small_signal_matrix(
             }
             Element::Vccs(source) => {
                 stamp_vccs(source, node_indices, &mut matrix)?;
+            }
+            Element::Vcvs(source) => {
+                stamp_vcvs(
+                    source,
+                    node_indices,
+                    voltage_sources,
+                    node_count,
+                    &mut matrix,
+                )?;
             }
         }
     }
@@ -1832,6 +1894,12 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &source.control_positive);
                 insert_node(&mut names, &source.control_negative);
             }
+            Element::Vcvs(source) => {
+                insert_node(&mut names, &source.positive);
+                insert_node(&mut names, &source.negative);
+                insert_node(&mut names, &source.control_positive);
+                insert_node(&mut names, &source.control_negative);
+            }
         }
     }
     names
@@ -1849,6 +1917,9 @@ fn collect_voltage_sources(
     for element in circuit.elements() {
         match element {
             Element::VoltageSource(source) => {
+                insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
+            }
+            Element::Vcvs(source) => {
                 insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
             }
             Element::Inductor(inductor) => {
@@ -1874,8 +1945,14 @@ fn collect_voltage_sources(
 fn collect_ac_voltage_sources(circuit: &Circuit) -> Result<BTreeMap<String, usize>, SpiceError> {
     let mut sources = BTreeMap::new();
     for element in circuit.elements() {
-        if let Element::VoltageSource(source) = element {
-            insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
+        match element {
+            Element::VoltageSource(source) => {
+                insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
+            }
+            Element::Vcvs(source) => {
+                insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
+            }
+            _ => {}
         }
     }
     Ok(sources)
@@ -1904,6 +1981,9 @@ fn find_input_source<'a>(
             }
             Element::Vccs(source) if source.name == input_source => {
                 return Err(input_source_type_error(input_source, "VCCS"));
+            }
+            Element::Vcvs(source) if source.name == input_source => {
+                return Err(input_source_type_error(input_source, "VCVS"));
             }
             _ => {}
         }
@@ -2422,6 +2502,58 @@ fn stamp_vccs(
     Ok(())
 }
 
+fn stamp_vcvs(
+    source: &Vcvs,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    node_count: usize,
+    matrix: &mut [Vec<f64>],
+) -> Result<(), SpiceError> {
+    if !source.gain.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "gain must be finite".to_string(),
+        });
+    }
+
+    let Some(source_index) = voltage_sources.get(&source.name) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "voltage source was not indexed".to_string(),
+        });
+    };
+
+    let branch = node_count + source_index;
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    let control_positive = node_index(node_indices, &source.control_positive);
+    let control_negative = node_index(node_indices, &source.control_negative);
+    stamp_branch_matrix(matrix, branch, positive, negative);
+    stamp_controlled_voltage_row(
+        matrix,
+        branch,
+        control_positive,
+        control_negative,
+        source.gain,
+    );
+    Ok(())
+}
+
+fn stamp_controlled_voltage_row(
+    matrix: &mut [Vec<f64>],
+    branch: usize,
+    control_positive: Option<usize>,
+    control_negative: Option<usize>,
+    gain: f64,
+) {
+    if let Some(cp) = control_positive {
+        matrix[branch][cp] -= gain;
+    }
+    if let Some(cn) = control_negative {
+        matrix[branch][cn] += gain;
+    }
+}
+
 fn stamp_transconductance(
     matrix: &mut [Vec<f64>],
     positive: Option<usize>,
@@ -2615,6 +2747,58 @@ fn stamp_ac_vccs(
         Complex::new(source.transconductance_siemens, 0.0),
     );
     Ok(())
+}
+
+fn stamp_ac_vcvs(
+    source: &Vcvs,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    node_count: usize,
+    matrix: &mut [Vec<Complex>],
+) -> Result<(), SpiceError> {
+    if !source.gain.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "gain must be finite".to_string(),
+        });
+    }
+
+    let Some(source_index) = voltage_sources.get(&source.name) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "voltage source was not indexed".to_string(),
+        });
+    };
+
+    let branch = node_count + source_index;
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    let control_positive = node_index(node_indices, &source.control_positive);
+    let control_negative = node_index(node_indices, &source.control_negative);
+    stamp_complex_branch_matrix(matrix, branch, positive, negative);
+    stamp_complex_controlled_voltage_row(
+        matrix,
+        branch,
+        control_positive,
+        control_negative,
+        Complex::new(source.gain, 0.0),
+    );
+    Ok(())
+}
+
+fn stamp_complex_controlled_voltage_row(
+    matrix: &mut [Vec<Complex>],
+    branch: usize,
+    control_positive: Option<usize>,
+    control_negative: Option<usize>,
+    gain: Complex,
+) {
+    if let Some(cp) = control_positive {
+        matrix[branch][cp] -= gain;
+    }
+    if let Some(cn) = control_negative {
+        matrix[branch][cn] += gain;
+    }
 }
 
 fn stamp_complex_transconductance(

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,5 +1,5 @@
 use spice_engine::{
-    ac_sweep, Capacitor, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError,
+    ac_sweep, Capacitor, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, Vcvs,
     VoltageSource,
 };
 
@@ -99,6 +99,26 @@ fn ac_current_source_injects_real_phasor_current() {
     let n1 = points[0].voltage("n1").unwrap();
     assert_close(n1.real, 1.0);
     assert_close(n1.imag, 0.0);
+}
+
+#[test]
+fn ac_vcvs_applies_controlled_voltage_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Vcvs(Vcvs::new("E1", "out", "0", "in", "0", 4.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let points = ac_sweep(&circuit, 1_000.0, 1_000.0, 10).unwrap();
+
+    assert_eq!(points.len(), 1);
+    let out = points[0].voltage("out").unwrap();
+    assert_close(out.real, 4.0);
+    assert_close(out.imag, 0.0);
+    assert_close(points[0].branch_current("E1").unwrap().real, -4.0e-3);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
     dc_op, dc_sweep, Circuit, CurrentSource, Element, Inductor, Resistor, SinWaveform, SpiceError,
-    Vccs, VoltageSource, Waveform,
+    Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -57,6 +57,42 @@ fn dc_vccs_injects_current_from_control_voltage() {
     let result = dc_op(&circuit).unwrap();
 
     assert_close(result.voltage("out").unwrap(), 2.0);
+}
+
+#[test]
+fn dc_vcvs_sets_output_from_control_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vctrl", "ctrl", "0", 1.5,
+    )));
+    circuit.add(Element::Vcvs(Vcvs::new("E1", "out", "0", "ctrl", "0", 2.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert_close(result.voltage("out").unwrap(), 3.0);
+    assert_close(result.branch_current("E1").unwrap(), -3.0e-3);
+}
+
+#[test]
+fn dc_vcvs_respects_differential_control_polarity() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vp", "p", "0", 4.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vn", "n", "0", 1.0,
+    )));
+    circuit.add(Element::Vcvs(Vcvs::new("E1", "out", "0", "p", "n", 0.5)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert_close(result.voltage("out").unwrap(), 1.5);
 }
 
 #[test]
@@ -219,6 +255,30 @@ fn dc_rejects_non_finite_vccs_transconductance() {
     assert!(matches!(
         dc_op(&circuit),
         Err(SpiceError::InvalidElement { name, .. }) if name == "Gbad"
+    ));
+}
+
+#[test]
+fn dc_rejects_non_finite_vcvs_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vctrl", "ctrl", "0", 1.0,
+    )));
+    circuit.add(Element::Vcvs(Vcvs::new(
+        "Ebad",
+        "out",
+        "0",
+        "ctrl",
+        "0",
+        f64::NAN,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    assert!(matches!(
+        dc_op(&circuit),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Ebad"
     ));
 }
 

--- a/code/packages/rust/spice-engine/tests/mc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/mc_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
     mc_dc, Circuit, CurrentSource, Element, McDistribution, McOptions, Resistor, SpiceError, Vccs,
-    VoltageSource,
+    Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -161,6 +161,34 @@ fn mc_dc_varies_current_source_and_vccs_parameters() {
 
     assert!(result.mean > 1.5, "mean was {}", result.mean);
     assert!(result.mean < 2.5, "mean was {}", result.mean);
+    assert!(result.std_dev > 0.0, "std_dev was {}", result.std_dev);
+}
+
+#[test]
+fn mc_dc_varies_vcvs_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Vcvs(Vcvs::new("E1", "out", "0", "in", "0", 2.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = mc_dc(
+        &circuit,
+        "out",
+        40,
+        McOptions {
+            tolerance: 0.05,
+            distribution: McDistribution::Uniform,
+            seed: Some(11),
+        },
+    )
+    .unwrap();
+
+    assert!(result.mean > 1.8, "mean was {}", result.mean);
+    assert!(result.mean < 2.2, "mean was {}", result.mean);
     assert!(result.std_dev > 0.0, "std_dev was {}", result.std_dev);
 }
 

--- a/code/packages/rust/spice-engine/tests/sens_tests.rs
+++ b/code/packages/rust/spice-engine/tests/sens_tests.rs
@@ -1,5 +1,6 @@
 use spice_engine::{
-    sens_dc, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, Vccs, VoltageSource,
+    sens_dc, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, Vccs, Vcvs,
+    VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -106,6 +107,24 @@ fn sens_dc_reports_vccs_transconductance_sensitivity() {
         entry(&result, "Gm", "transconductance_siemens").relative_sensitivity,
         1.0,
     );
+}
+
+#[test]
+fn sens_dc_reports_vcvs_gain_sensitivity() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Vcvs(Vcvs::new("E1", "out", "0", "in", "0", 3.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = sens_dc(&circuit, "out").unwrap();
+
+    assert_close(result.nominal_voltage, 3.0);
+    assert_close(entry(&result, "E1", "gain").sensitivity, 1.0);
+    assert_close(entry(&result, "E1", "gain").relative_sensitivity, 1.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
     tf, Capacitor, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, TfResult, Vccs,
-    VoltageSource,
+    Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -93,6 +93,24 @@ fn tf_vccs_stage_reports_transconductance_gain() {
 
     assert_close(result.gain(), 2.0);
     assert_close(result.output_impedance_ohms, 1_000.0);
+    assert!(result.input_impedance_ohms.is_infinite());
+}
+
+#[test]
+fn tf_vcvs_stage_reports_voltage_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Vcvs(Vcvs::new("E1", "out", "0", "in", "0", 4.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = tf(&circuit, "out", "Vin").unwrap();
+
+    assert_close(result.gain(), 4.0);
+    assert_close(result.output_impedance_ohms, 0.0);
     assert!(result.input_impedance_ohms.is_infinite());
 }
 


### PR DESCRIPTION
## Summary

- add Rust `Vcvs` elements and branch-equation stamping for controlled voltage sources
- wire VCVS through DC/transient, AC, transfer-function, sensitivity, and Monte Carlo paths
- cover DC gain/polarity, AC gain, TF gain, sensitivity, Monte Carlo variation, and invalid gain errors

## Validation

- cargo fmt -p spice-engine
- sh BUILD
- git diff --check