### PR TITLE
ts(spice): add CCCS controlled sources

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add current-controlled current source support across DC, AC, transfer
+  function, sensitivity, Monte Carlo, and transient analyses.
 - Add voltage-controlled voltage source support across DC, AC, transfer
   function, sensitivity, Monte Carlo, and transient analyses.
 - Add AC noise analysis with resistor Johnson-Nyquist source PSDs,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -9,7 +9,8 @@ export type Element =
   | VoltageSource
   | CurrentSource
   | Vccs
-  | Vcvs;
+  | Vcvs
+  | Cccs;
 
 export interface Resistor {
   readonly kind: "resistor";
@@ -289,6 +290,15 @@ export interface Vcvs {
   readonly gain: number;
 }
 
+export interface Cccs {
+  readonly kind: "cccs";
+  readonly name: string;
+  readonly positive: string;
+  readonly negative: string;
+  readonly controlSource: string;
+  readonly gain: number;
+}
+
 export interface DcResult {
   readonly nodeVoltages: ReadonlyMap<string, number>;
   readonly branchCurrents: ReadonlyMap<string, number>;
@@ -562,6 +572,23 @@ export function vcvs(
     negative,
     controlPositive,
     controlNegative,
+    gain,
+  };
+}
+
+export function cccs(
+  name: string,
+  positive: string,
+  negative: string,
+  controlSource: string,
+  gain: number,
+): Cccs {
+  return {
+    kind: "cccs",
+    name,
+    positive,
+    negative,
+    controlSource,
     gain,
   };
 }
@@ -1049,6 +1076,12 @@ function elementParameter(element: Element): ElementParameter | undefined {
         parameter: "gain",
         nominalValue: element.gain,
       };
+    case "cccs":
+      return {
+        elementName: element.name,
+        parameter: "gain",
+        nominalValue: element.gain,
+      };
     case "capacitor":
     case "inductor":
       return undefined;
@@ -1091,6 +1124,9 @@ function circuitWithPerturbedElement(
         });
         break;
       case "vcvs":
+        perturbed.add({ ...element, gain: element.gain + delta });
+        break;
+      case "cccs":
         perturbed.add({ ...element, gain: element.gain + delta });
         break;
       case "capacitor":
@@ -1190,6 +1226,11 @@ function randomizedElement(
         ),
       };
     case "vcvs":
+      return {
+        ...element,
+        gain: randomizedValue(element.gain, tolerance, distribution, rng),
+      };
+    case "cccs":
       return {
         ...element,
         gain: randomizedValue(element.gain, tolerance, distribution, rng),
@@ -1316,6 +1357,9 @@ function solveLinearCircuit(
           matrix,
         );
         break;
+      case "cccs":
+        stampCccs(element, nodeIndices, voltageSources, matrix);
+        break;
     }
   }
 
@@ -1399,6 +1443,9 @@ function buildSmallSignalMatrix(
           matrix,
         );
         break;
+      case "cccs":
+        stampCccs(element, nodeIndices, voltageSources, matrix);
+        break;
     }
   }
 
@@ -1437,6 +1484,7 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
       case "inductor":
       case "vccs":
       case "vcvs":
+      case "cccs":
         break;
     }
   }
@@ -1505,6 +1553,9 @@ function buildAcMatrix(
           nodeCount,
           matrix,
         );
+        break;
+      case "cccs":
+        stampAcCccs(element, nodeIndices, voltageSources, matrix);
         break;
     }
   }
@@ -1687,6 +1738,10 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.controlPositive);
         insertNode(names, element.controlNegative);
         break;
+      case "cccs":
+        insertNode(names, element.positive);
+        insertNode(names, element.negative);
+        break;
     }
   }
 
@@ -1740,7 +1795,8 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
         element.kind === "capacitor" ||
         element.kind === "inductor" ||
         element.kind === "vccs" ||
-        element.kind === "vcvs") &&
+        element.kind === "vcvs" ||
+        element.kind === "cccs") &&
       element.name === inputSource
     ) {
       throw invalidElement(
@@ -2262,6 +2318,47 @@ function stampVcvs(
   );
 }
 
+function stampCccs(
+  element: Cccs,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  matrix: number[][],
+): void {
+  if (!Number.isFinite(element.gain)) {
+    throw invalidElement(element.name, "gain must be finite");
+  }
+
+  const sourceIndex = voltageSources.get(element.controlSource);
+  if (sourceIndex === undefined) {
+    throw invalidElement(element.name, "control source was not indexed");
+  }
+
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  stampCurrentControlledCurrent(
+    matrix,
+    positive,
+    negative,
+    sourceIndex + nodeIndices.size,
+    element.gain,
+  );
+}
+
+function stampCurrentControlledCurrent(
+  matrix: number[][],
+  positive: number | undefined,
+  negative: number | undefined,
+  controlBranch: number,
+  gain: number,
+): void {
+  if (positive !== undefined) {
+    matrix[positive][controlBranch] += gain;
+  }
+  if (negative !== undefined) {
+    matrix[negative][controlBranch] -= gain;
+  }
+}
+
 function stampControlledVoltageRow(
   matrix: number[][],
   branch: number,
@@ -2490,6 +2587,53 @@ function stampAcVcvs(
     controlNegative,
     complex(element.gain, 0.0),
   );
+}
+
+function stampAcCccs(
+  element: Cccs,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  matrix: Complex[][],
+): void {
+  if (!Number.isFinite(element.gain)) {
+    throw invalidElement(element.name, "gain must be finite");
+  }
+
+  const sourceIndex = voltageSources.get(element.controlSource);
+  if (sourceIndex === undefined) {
+    throw invalidElement(element.name, "control source was not indexed");
+  }
+
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  stampComplexCurrentControlledCurrent(
+    matrix,
+    positive,
+    negative,
+    sourceIndex + nodeIndices.size,
+    complex(element.gain, 0.0),
+  );
+}
+
+function stampComplexCurrentControlledCurrent(
+  matrix: Complex[][],
+  positive: number | undefined,
+  negative: number | undefined,
+  controlBranch: number,
+  gain: Complex,
+): void {
+  if (positive !== undefined) {
+    matrix[positive][controlBranch] = complexAdd(
+      matrix[positive][controlBranch],
+      gain,
+    );
+  }
+  if (negative !== undefined) {
+    matrix[negative][controlBranch] = complexSub(
+      matrix[negative][controlBranch],
+      gain,
+    );
+  }
 }
 
 function stampComplexControlledVoltageRow(

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -4,6 +4,7 @@ import {
   SpiceError,
   acSweep,
   capacitor,
+  cccs,
   complexAbs,
   complexPhase,
   currentSource,
@@ -103,6 +104,23 @@ describe("acSweep", () => {
     expectClose(out!.real, 4.0);
     expectClose(out!.imag, 0.0);
     expectClose(points[0].branchCurrent("E1")?.real, -4.0e-3);
+  });
+
+  it("applies CCCS current gain in AC analysis", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(cccs("F1", "0", "out", "Vsense", 3.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const points = acSweep(circuit, 1_000.0, 1_000.0, 10);
+
+    expect(points).toHaveLength(1);
+    const out = points[0].voltage("out");
+    expect(out).not.toBeUndefined();
+    expectClose(out!.real, 3.0);
+    expectClose(out!.imag, 0.0);
   });
 
   it("rejects invalid frequency bounds", () => {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -3,6 +3,7 @@ import {
   Circuit,
   SinWaveform,
   SpiceError,
+  cccs,
   currentSource,
   dcOp,
   dcSweep,
@@ -113,6 +114,28 @@ describe("dcOp", () => {
     expectClose(result.voltage("out"), 1.5);
   });
 
+  it("stamps CCCS current from a voltage-source branch current", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(cccs("F1", "0", "out", "Vsense", 2.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expectClose(result.branchCurrent("Vsense"), 1.0e-3);
+    expectClose(result.voltage("out"), 2.0);
+  });
+
+  it("rejects missing CCCS control sources", () => {
+    const circuit = new Circuit();
+    circuit.add(cccs("Fbad", "0", "out", "Vmissing", 2.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    expect(() => dcOp(circuit)).toThrowError("control source was not indexed");
+  });
+
   it("rejects non-finite VCCS transconductance", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vctrl", "ctrl", "0", 1.0));
@@ -126,6 +149,15 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vctrl", "ctrl", "0", 1.0));
     circuit.add(vcvs("Ebad", "out", "0", "ctrl", "0", Number.NaN));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    expect(() => dcOp(circuit)).toThrowError("gain must be finite");
+  });
+
+  it("rejects non-finite CCCS gain", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(cccs("Fbad", "0", "out", "Vsense", Number.NaN));
     circuit.add(resistor("Rload", "out", "0", 1_000.0));
 
     expect(() => dcOp(circuit)).toThrowError("gain must be finite");

--- a/code/packages/typescript/spice-engine/tests/mc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/mc.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   Circuit,
   SpiceError,
+  cccs,
   currentSource,
   mcDc,
   resistor,
@@ -101,6 +102,25 @@ describe("mcDc", () => {
 
     expect(result.mean).toBeGreaterThan(1.5);
     expect(result.mean).toBeLessThan(2.5);
+    expect(result.stdDev).toBeGreaterThan(0.0);
+  });
+
+  it("varies CCCS gain in DC Monte Carlo trials", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(cccs("F1", "0", "out", "Vsense", 2.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = mcDc(circuit, "out", 40, {
+      seed: 11,
+      tolerance: 0.05,
+      distribution: "uniform",
+    });
+
+    expect(result.mean).toBeGreaterThan(1.8);
+    expect(result.mean).toBeLessThan(2.2);
     expect(result.stdDev).toBeGreaterThan(0.0);
   });
 

--- a/code/packages/typescript/spice-engine/tests/sens.test.ts
+++ b/code/packages/typescript/spice-engine/tests/sens.test.ts
@@ -3,6 +3,7 @@ import {
   Circuit,
   SpiceError,
   SensResult,
+  cccs,
   currentSource,
   resistor,
   sensDc,
@@ -94,6 +95,21 @@ describe("sensDc", () => {
       entry(result, "Gm", "transconductanceSiemens").relativeSensitivity,
       1.0,
     );
+  });
+
+  it("reports CCCS gain sensitivity", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(cccs("F1", "0", "out", "Vsense", 2.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = sensDc(circuit, "out");
+
+    expectClose(result.nominalVoltage, 2.0);
+    expectClose(entry(result, "F1", "gain").sensitivity, 1.0);
+    expectClose(entry(result, "F1", "gain").relativeSensitivity, 1.0);
   });
 
   it("sorts entries by absolute relative sensitivity", () => {

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   Circuit,
   capacitor,
+  cccs,
   currentSource,
   inductor,
   resistor,
@@ -90,6 +91,20 @@ describe("tf", () => {
     expectClose(result.outputImpedanceOhms, 1_000.0);
   });
 
+  it("reports CCCS current gain through a sensing voltage source", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(cccs("F1", "0", "out", "Vsense", 2.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = tf(circuit, "out", "Vin");
+
+    expectClose(result.gain(), 2.0);
+    expectClose(result.outputImpedanceOhms, 1_000.0);
+  });
+
   it("rejects missing output nodes", () => {
     const circuit = new Circuit();
 
@@ -113,6 +128,17 @@ describe("tf", () => {
     circuit.add(resistor("Rload", "out", "0", 1_000.0));
 
     expect(() => tf(circuit, "out", "Gm")).toThrowError(
+      "input element must be an independent voltage or current source",
+    );
+  });
+
+  it("rejects CCCS elements as input sources", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(cccs("F1", "0", "out", "Vsense", 1.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    expect(() => tf(circuit, "out", "F1")).toThrowError(
       "input element must be an independent voltage or current source",
     );
   });

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -8,6 +8,7 @@ import {
   SpiceError,
   capacitor,
   capacitorWithInitialVoltage,
+  cccs,
   currentSourceWithWaveform,
   inductor,
   inductorWithInitialCurrent,
@@ -174,6 +175,33 @@ describe("transient", () => {
 
     expectClose(points[0].voltage("in"), 2.0);
     expectClose(points[1].voltage("in"), 0.0);
+  });
+
+  it("updates CCCS output from transient branch current", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "Vin",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [0.25, 1.0],
+          [0.5, 1.0],
+        ]),
+      ),
+    );
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(cccs("F1", "0", "out", "Vsense", 2.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const points = transient(circuit, 0.25, 0.5);
+
+    expectClose(points[0].branchCurrent("Vsense"), 1.0e-3);
+    expectClose(points[0].voltage("out"), 2.0);
+    expectClose(points[1].voltage("out"), 2.0);
   });
 
   it("repeats PULSE waveforms with edges", () => {


### PR DESCRIPTION
## Summary

- add TypeScript `cccs` elements for current-controlled current sources
- stamp CCCS gains from existing voltage-source branch currents through DC/transient, AC, and small-signal matrices
- cover DC, AC, transfer-function, sensitivity, Monte Carlo, transient, and validation behavior

## Validation

- sh BUILD
- git diff --check