### PR TITLE
rust(spice): add CCCS controlled sources

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -8,6 +8,8 @@
   stages.
 - Add voltage-controlled voltage sources (VCVS) across DC, AC, transfer
   function, sensitivity, Monte Carlo, and transient analyses.
+- Add current-controlled current sources (CCCS) across DC, AC, transfer
+  function, sensitivity, Monte Carlo, and transient analyses.
 - Add DC source sweeps for independent voltage and current sources.
 - Add DC sensitivity analysis for resistor and independent source parameters.
 - Add seeded DC Monte Carlo analysis for linear element parameters with

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -342,6 +342,7 @@ pub enum Element {
     CurrentSource(CurrentSource),
     Vccs(Vccs),
     Vcvs(Vcvs),
+    Cccs(Cccs),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -579,6 +580,33 @@ impl Vcvs {
             negative: negative.into(),
             control_positive: control_positive.into(),
             control_negative: control_negative.into(),
+            gain,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cccs {
+    pub name: String,
+    pub positive: String,
+    pub negative: String,
+    pub control_source: String,
+    pub gain: f64,
+}
+
+impl Cccs {
+    pub fn new(
+        name: impl Into<String>,
+        positive: impl Into<String>,
+        negative: impl Into<String>,
+        control_source: impl Into<String>,
+        gain: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            positive: positive.into(),
+            negative: negative.into(),
+            control_source: control_source.into(),
             gain,
         }
     }
@@ -1419,6 +1447,7 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
             source.transconductance_siemens,
         )),
         Element::Vcvs(source) => Some((source.name.clone(), "gain".to_string(), source.gain)),
+        Element::Cccs(source) => Some((source.name.clone(), "gain".to_string(), source.gain)),
         Element::Capacitor(_) | Element::Inductor(_) => None,
     }
 }
@@ -1434,6 +1463,7 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::CurrentSource(source) => source.current += delta,
         Element::Vccs(source) => source.transconductance_siemens += delta,
         Element::Vcvs(source) => source.gain += delta,
+        Element::Cccs(source) => source.gain += delta,
         Element::Capacitor(_) | Element::Inductor(_) => {}
     }
 }
@@ -1528,6 +1558,11 @@ fn randomized_element(
             let mut varied = source.clone();
             varied.gain = randomized_value(varied.gain, tolerance, distribution, rng);
             Element::Vcvs(varied)
+        }
+        Element::Cccs(source) => {
+            let mut varied = source.clone();
+            varied.gain = randomized_value(varied.gain, tolerance, distribution, rng);
+            Element::Cccs(varied)
         }
         Element::Capacitor(_) | Element::Inductor(_) => element.clone(),
     }
@@ -1655,6 +1690,9 @@ fn solve_linear_circuit(
                 node_count,
                 &mut matrix,
             )?,
+            Element::Cccs(source) => {
+                stamp_cccs(source, &node_indices, &voltage_sources, &mut matrix)?
+            }
         }
     }
 
@@ -1709,7 +1747,8 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             | Element::Capacitor(_)
             | Element::Inductor(_)
             | Element::Vccs(_)
-            | Element::Vcvs(_) => {}
+            | Element::Vcvs(_)
+            | Element::Cccs(_) => {}
         }
     }
 
@@ -1771,6 +1810,9 @@ fn build_ac_matrix(
                 node_count,
                 &mut matrix,
             )?,
+            Element::Cccs(source) => {
+                stamp_ac_cccs(source, node_indices, voltage_sources, &mut matrix)?
+            }
         }
     }
 
@@ -1831,6 +1873,9 @@ fn build_small_signal_matrix(
                     node_count,
                     &mut matrix,
                 )?;
+            }
+            Element::Cccs(source) => {
+                stamp_cccs(source, node_indices, voltage_sources, &mut matrix)?;
             }
         }
     }
@@ -1899,6 +1944,10 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &source.negative);
                 insert_node(&mut names, &source.control_positive);
                 insert_node(&mut names, &source.control_negative);
+            }
+            Element::Cccs(source) => {
+                insert_node(&mut names, &source.positive);
+                insert_node(&mut names, &source.negative);
             }
         }
     }
@@ -1984,6 +2033,9 @@ fn find_input_source<'a>(
             }
             Element::Vcvs(source) if source.name == input_source => {
                 return Err(input_source_type_error(input_source, "VCVS"));
+            }
+            Element::Cccs(source) if source.name == input_source => {
+                return Err(input_source_type_error(input_source, "CCCS"));
             }
             _ => {}
         }
@@ -2539,6 +2591,53 @@ fn stamp_vcvs(
     Ok(())
 }
 
+fn stamp_cccs(
+    source: &Cccs,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+) -> Result<(), SpiceError> {
+    if !source.gain.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "gain must be finite".to_string(),
+        });
+    }
+
+    let Some(source_index) = voltage_sources.get(&source.control_source) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "control source was not indexed".to_string(),
+        });
+    };
+
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    stamp_current_controlled_current(
+        matrix,
+        positive,
+        negative,
+        node_indices.len() + source_index,
+        source.gain,
+    );
+    Ok(())
+}
+
+fn stamp_current_controlled_current(
+    matrix: &mut [Vec<f64>],
+    positive: Option<usize>,
+    negative: Option<usize>,
+    control_branch: usize,
+    gain: f64,
+) {
+    if let Some(i) = positive {
+        matrix[i][control_branch] += gain;
+    }
+    if let Some(j) = negative {
+        matrix[j][control_branch] -= gain;
+    }
+}
+
 fn stamp_controlled_voltage_row(
     matrix: &mut [Vec<f64>],
     branch: usize,
@@ -2784,6 +2883,53 @@ fn stamp_ac_vcvs(
         Complex::new(source.gain, 0.0),
     );
     Ok(())
+}
+
+fn stamp_ac_cccs(
+    source: &Cccs,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    matrix: &mut [Vec<Complex>],
+) -> Result<(), SpiceError> {
+    if !source.gain.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "gain must be finite".to_string(),
+        });
+    }
+
+    let Some(source_index) = voltage_sources.get(&source.control_source) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "control source was not indexed".to_string(),
+        });
+    };
+
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    stamp_complex_current_controlled_current(
+        matrix,
+        positive,
+        negative,
+        node_indices.len() + source_index,
+        Complex::new(source.gain, 0.0),
+    );
+    Ok(())
+}
+
+fn stamp_complex_current_controlled_current(
+    matrix: &mut [Vec<Complex>],
+    positive: Option<usize>,
+    negative: Option<usize>,
+    control_branch: usize,
+    gain: Complex,
+) {
+    if let Some(i) = positive {
+        matrix[i][control_branch] += gain;
+    }
+    if let Some(j) = negative {
+        matrix[j][control_branch] -= gain;
+    }
 }
 
 fn stamp_complex_controlled_voltage_row(

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    ac_sweep, Capacitor, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, Vcvs,
-    VoltageSource,
+    ac_sweep, Capacitor, Cccs, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError,
+    Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -119,6 +119,31 @@ fn ac_vcvs_applies_controlled_voltage_gain() {
     assert_close(out.real, 4.0);
     assert_close(out.imag, 0.0);
     assert_close(points[0].branch_current("E1").unwrap().real, -4.0e-3);
+}
+
+#[test]
+fn ac_cccs_applies_current_gain_from_sensed_branch_current() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Cccs(Cccs::new("F1", "0", "out", "Vsense", 3.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let points = ac_sweep(&circuit, 1_000.0, 1_000.0, 10).unwrap();
+
+    assert_eq!(points.len(), 1);
+    let out = points[0].voltage("out").unwrap();
+    assert_close(out.real, 3.0);
+    assert_close(out.imag, 0.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    dc_op, dc_sweep, Circuit, CurrentSource, Element, Inductor, Resistor, SinWaveform, SpiceError,
-    Vccs, Vcvs, VoltageSource, Waveform,
+    dc_op, dc_sweep, Cccs, Circuit, CurrentSource, Element, Inductor, Resistor, SinWaveform,
+    SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -93,6 +93,29 @@ fn dc_vcvs_respects_differential_control_polarity() {
     let result = dc_op(&circuit).unwrap();
 
     assert_close(result.voltage("out").unwrap(), 1.5);
+}
+
+#[test]
+fn dc_cccs_injects_current_from_voltage_source_branch_current() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Cccs(Cccs::new("F1", "0", "out", "Vsense", 2.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert_close(result.branch_current("Vsense").unwrap(), 1.0e-3);
+    assert_close(result.voltage("out").unwrap(), 2.0);
 }
 
 #[test]
@@ -279,6 +302,45 @@ fn dc_rejects_non_finite_vcvs_gain() {
     assert!(matches!(
         dc_op(&circuit),
         Err(SpiceError::InvalidElement { name, .. }) if name == "Ebad"
+    ));
+}
+
+#[test]
+fn dc_rejects_non_finite_cccs_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Cccs(Cccs::new(
+        "Fbad",
+        "0",
+        "out",
+        "Vsense",
+        f64::NAN,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    assert!(matches!(
+        dc_op(&circuit),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Fbad"
+    ));
+}
+
+#[test]
+fn dc_rejects_missing_cccs_control_source() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Cccs(Cccs::new(
+        "Fbad", "0", "out", "Vmissing", 2.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    assert!(matches!(
+        dc_op(&circuit),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Fbad"
     ));
 }
 

--- a/code/packages/rust/spice-engine/tests/mc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/mc_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    mc_dc, Circuit, CurrentSource, Element, McDistribution, McOptions, Resistor, SpiceError, Vccs,
-    Vcvs, VoltageSource,
+    mc_dc, Cccs, Circuit, CurrentSource, Element, McDistribution, McOptions, Resistor, SpiceError,
+    Vccs, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -183,6 +183,40 @@ fn mc_dc_varies_vcvs_gain() {
             tolerance: 0.05,
             distribution: McDistribution::Uniform,
             seed: Some(11),
+        },
+    )
+    .unwrap();
+
+    assert!(result.mean > 1.8, "mean was {}", result.mean);
+    assert!(result.mean < 2.2, "mean was {}", result.mean);
+    assert!(result.std_dev > 0.0, "std_dev was {}", result.std_dev);
+}
+
+#[test]
+fn mc_dc_varies_cccs_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Cccs(Cccs::new("F1", "0", "out", "Vsense", 2.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = mc_dc(
+        &circuit,
+        "out",
+        40,
+        McOptions {
+            tolerance: 0.05,
+            distribution: McDistribution::Uniform,
+            seed: Some(13),
         },
     )
     .unwrap();

--- a/code/packages/rust/spice-engine/tests/sens_tests.rs
+++ b/code/packages/rust/spice-engine/tests/sens_tests.rs
@@ -1,5 +1,5 @@
 use spice_engine::{
-    sens_dc, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, Vccs, Vcvs,
+    sens_dc, Cccs, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, Vccs, Vcvs,
     VoltageSource,
 };
 
@@ -125,6 +125,30 @@ fn sens_dc_reports_vcvs_gain_sensitivity() {
     assert_close(result.nominal_voltage, 3.0);
     assert_close(entry(&result, "E1", "gain").sensitivity, 1.0);
     assert_close(entry(&result, "E1", "gain").relative_sensitivity, 1.0);
+}
+
+#[test]
+fn sens_dc_reports_cccs_gain_sensitivity() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Cccs(Cccs::new("F1", "0", "out", "Vsense", 2.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = sens_dc(&circuit, "out").unwrap();
+
+    assert_close(result.nominal_voltage, 2.0);
+    assert_close(entry(&result, "F1", "gain").sensitivity, 1.0);
+    assert_close(entry(&result, "F1", "gain").relative_sensitivity, 1.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    tf, Capacitor, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, TfResult, Vccs,
-    Vcvs, VoltageSource,
+    tf, Capacitor, Cccs, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, TfResult,
+    Vccs, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -115,6 +115,29 @@ fn tf_vcvs_stage_reports_voltage_gain() {
 }
 
 #[test]
+fn tf_cccs_stage_reports_current_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Cccs(Cccs::new("F1", "0", "out", "Vsense", 2.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = tf(&circuit, "out", "Vin").unwrap();
+
+    assert_close(result.gain(), 2.0);
+    assert_close(result.output_impedance_ohms, 1_000.0);
+}
+
+#[test]
 fn tf_capacitor_is_open_and_inductor_is_short_at_dc_small_signal() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -170,5 +193,22 @@ fn tf_rejects_vccs_as_input_source() {
     assert!(matches!(
         tf(&circuit, "out", "Gm"),
         Err(SpiceError::InvalidElement { name, .. }) if name == "Gm"
+    ));
+}
+
+#[test]
+fn tf_rejects_cccs_as_input_source() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Cccs(Cccs::new("F1", "0", "out", "Vsense", 1.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    assert!(matches!(
+        tf(&circuit, "out", "F1"),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "F1"
     ));
 }

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    transient, Capacitor, Circuit, CurrentSource, Element, ExpWaveform, Inductor, PulseWaveform,
-    PwlWaveform, Resistor, SinWaveform, SpiceError, VoltageSource, Waveform,
+    transient, Capacitor, Cccs, Circuit, CurrentSource, Element, ExpWaveform, Inductor,
+    PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -173,6 +173,34 @@ fn transient_voltage_source_uses_sin_waveform() {
 
     assert_close(points[0].voltage("in").unwrap(), 2.0);
     assert_close(points[1].voltage("in").unwrap(), 0.0);
+}
+
+#[test]
+fn transient_cccs_updates_from_sensed_branch_current() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+        "Vin",
+        "in",
+        "0",
+        0.0,
+        Waveform::Pwl(PwlWaveform::new(vec![(0.0, 0.0), (0.25, 1.0), (0.5, 1.0)])),
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Cccs(Cccs::new("F1", "0", "out", "Vsense", 2.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let points = transient(&circuit, 0.25, 0.5).unwrap();
+
+    assert_close(points[0].branch_current("Vsense").unwrap(), 1.0e-3);
+    assert_close(points[0].voltage("out").unwrap(), 2.0);
+    assert_close(points[1].voltage("out").unwrap(), 2.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add Rust `Cccs` elements for current-controlled current sources
- stamp CCCS gains from existing voltage-source branch currents through DC/transient, AC, and small-signal matrices
- cover DC, AC, transfer-function, sensitivity, Monte Carlo, transient, and validation behavior

## Validation

- cargo fmt -p spice-engine
- sh BUILD
- git diff --check