### PR TITLE
rust(weather): enforce sandbox network ports

### DIFF
--- a/code/packages/rust/capability-os-sandbox/src/lib.rs
+++ b/code/packages/rust/capability-os-sandbox/src/lib.rs
@@ -211,6 +211,7 @@ impl std::error::Error for SandboxPlanError {}
 
 const MACOS_SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
 const MACOS_KERNEL_PRIMITIVE: &str = "macos.sandbox-exec.seatbelt";
+const MACOS_MDNSRESPONDER_SOCKET: &str = "/private/var/run/mDNSResponder";
 
 /// Whether the current host has a kernel sandbox applier for the plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -289,8 +290,9 @@ pub fn current_kernel_sandbox_support() -> KernelSandboxSupport {
 /// Generate the macOS Seatbelt profile used to enforce a macOS sandbox plan.
 ///
 /// V1 enforces filesystem write/create/delete capabilities as exact absolute
-/// path literals. Other capability families still lower to plan records and
-/// remain candidates for the next kernel applier slice.
+/// path literals and outbound network capabilities as resolver-socket plus
+/// TCP-port policy. macOS Seatbelt cannot target arbitrary remote hostnames,
+/// so host-exact checks remain paired with TLS/application validation.
 pub fn macos_seatbelt_profile_for_plan(plan: &SandboxPlan) -> Result<String, KernelSandboxError> {
     if plan.os != OsFamily::Macos {
         return Err(KernelSandboxError::InvalidPlan(format!(
@@ -319,6 +321,24 @@ pub fn macos_seatbelt_profile_for_plan(plan: &SandboxPlan) -> Result<String, Ker
                 profile.push_str("\")");
             }
             profile.push_str(")))\n");
+        }
+    }
+    match macos_network_policy(plan)? {
+        MacosNetworkPolicy::Unrestricted => {}
+        MacosNetworkPolicy::DenyAll => profile.push_str("(deny network-outbound)\n"),
+        MacosNetworkPolicy::Restricted(filters) => {
+            if filters.len() == 1 {
+                profile.push_str("(deny network-outbound (require-not ");
+                profile.push_str(&filters[0]);
+                profile.push_str("))\n");
+            } else {
+                profile.push_str("(deny network-outbound\n  (require-not\n    (require-any");
+                for filter in filters {
+                    profile.push_str("\n      ");
+                    profile.push_str(&filter);
+                }
+                profile.push_str(")))\n");
+            }
         }
     }
     Ok(profile)
@@ -443,6 +463,64 @@ fn writable_path_literals(plan: &SandboxPlan) -> Result<Vec<String>, KernelSandb
         );
     }
     Ok(paths)
+}
+
+enum MacosNetworkPolicy {
+    Unrestricted,
+    Restricted(Vec<String>),
+    DenyAll,
+}
+
+fn macos_network_policy(plan: &SandboxPlan) -> Result<MacosNetworkPolicy, KernelSandboxError> {
+    let mut filters = Vec::new();
+    for rule in &plan.rules {
+        if rule.capability.category != Category::Net {
+            continue;
+        }
+        match rule.capability.action {
+            Action::Dns => filters.push(format!(
+                "(literal \"{}\")",
+                seatbelt_escape(MACOS_MDNSRESPONDER_SOCKET)?
+            )),
+            Action::Connect => {
+                let target = rule.capability.target.as_str();
+                if target == "*" {
+                    return Ok(MacosNetworkPolicy::Unrestricted);
+                }
+                let port = network_target_port(target)?;
+                filters.push(format!("(remote tcp \"*:{port}\")"));
+            }
+            Action::Listen => {}
+            other => {
+                return Err(KernelSandboxError::InvalidPlan(format!(
+                    "unsupported macOS network action '{other}'"
+                )))
+            }
+        }
+    }
+
+    filters.sort();
+    filters.dedup();
+
+    if filters.is_empty() {
+        Ok(MacosNetworkPolicy::DenyAll)
+    } else {
+        Ok(MacosNetworkPolicy::Restricted(filters))
+    }
+}
+
+fn network_target_port(target: &str) -> Result<u16, KernelSandboxError> {
+    let port = target
+        .rsplit_once(':')
+        .map(|(_, port)| port)
+        .ok_or_else(|| {
+            KernelSandboxError::InvalidPlan(format!(
+                "macOS network kernel enforcement requires host:port targets, got '{target}'"
+            ))
+        })?;
+    port.parse::<u16>().map_err(|error| {
+        KernelSandboxError::InvalidPlan(format!("invalid network port in '{target}': {error}"))
+    })
 }
 
 fn has_glob_syntax(target: &str) -> bool {
@@ -606,6 +684,16 @@ fn lower_linux(capability: &Capability) -> (&'static str, SandboxCoverage, &'sta
 
 fn lower_macos(capability: &Capability) -> (&'static str, SandboxCoverage, &'static str) {
     match capability.category {
+        Category::Net if capability.action == Action::Dns => (
+            "macos.seatbelt.profile",
+            SandboxCoverage::Direct,
+            "Seatbelt can gate resolver socket access; hostname policy is paired with TLS/application checks",
+        ),
+        Category::Net => (
+            "macos.seatbelt.profile",
+            SandboxCoverage::Direct,
+            "Seatbelt can constrain outbound sockets by protocol and port; arbitrary remote hostnames are not kernel-matchable",
+        ),
         Category::Env => (
             "macos.posix_spawn.env_allowlist",
             SandboxCoverage::LaunchTime,
@@ -752,6 +840,7 @@ fn expression_for(capability: &Capability, primitive: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::TcpListener;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const WEATHER_MANIFEST: &str = r#"{
@@ -869,6 +958,9 @@ mod tests {
 
         assert!(profile.contains("(allow default)"));
         assert!(profile.contains("(deny file-write*"));
+        assert!(profile.contains("(deny network-outbound"));
+        assert!(profile.contains("(literal \"/private/var/run/mDNSResponder\")"));
+        assert!(profile.contains("(remote tcp \"*:443\")"));
         assert!(profile.contains("(require-not"));
         assert!(profile.contains(&allowed));
         fs::remove_dir_all(dir).ok();
@@ -917,6 +1009,42 @@ mod tests {
         fs::remove_dir_all(dir).ok();
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_kernel_sandbox_blocks_undeclared_network_ports() {
+        if !Path::new(MACOS_SANDBOX_EXEC).exists() {
+            return;
+        }
+
+        let allowed_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let denied_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let allowed_port = allowed_listener.local_addr().unwrap().port();
+        let denied_port = denied_listener.local_addr().unwrap().port();
+        let manifest = network_manifest_for_port(allowed_port);
+        let plan = plan_from_json(&manifest, OsFamily::Macos).unwrap();
+        let allowed_port = allowed_port.to_string();
+        let denied_port = denied_port.to_string();
+
+        let output = run_with_kernel_sandbox(
+            &plan,
+            "/bin/sh",
+            [
+                "-c",
+                "/usr/bin/nc -z -G 1 localhost \"$1\"; /usr/bin/nc -z -G 1 localhost \"$2\"",
+                "sh",
+                &allowed_port,
+                &denied_port,
+            ],
+        )
+        .unwrap();
+
+        assert!(!output.success());
+        assert!(output
+            .stderr
+            .contains(&format!("localhost port {allowed_port}")));
+        assert!(output.stderr.contains("succeeded"));
+    }
+
     fn weather_manifest_for_path(path: &Path) -> String {
         let path = path.to_string_lossy();
         format!(
@@ -944,6 +1072,24 @@ mod tests {
                 }}
               ],
               "justification": "Weather Agent E2E fetches live weather and writes one report."
+            }}"#
+        )
+    }
+
+    fn network_manifest_for_port(port: u16) -> String {
+        format!(
+            r#"{{
+              "version": 1,
+              "package": "rust/network-probe",
+              "capabilities": [
+                {{
+                  "category": "net",
+                  "action": "connect",
+                  "target": "localhost:{port}",
+                  "justification": "Connect to the declared local TCP test port."
+                }}
+              ],
+              "justification": "Network probe validates Seatbelt outbound port enforcement."
             }}"#
         )
     }

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::fmt;
 use std::fs;
 use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -19,7 +20,7 @@ use capability_cage::{
 };
 use capability_os_sandbox::{
     current_kernel_sandbox_support, plan_all_supported, plan_for_current_os,
-    run_with_kernel_sandbox, OsFamily, SandboxPlanSummary,
+    run_with_kernel_sandbox, OsFamily, SandboxPlan, SandboxPlanSummary,
 };
 use chief_of_staff_tool_api::{
     InMemoryToolRuntime, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError,
@@ -493,7 +494,12 @@ pub struct UmbrellaKernelSandboxSummary {
     pub enforced: bool,
     pub allowed_write_succeeded: bool,
     pub denied_write_blocked: bool,
+    pub network_outbound_enforced: bool,
+    pub network_denied_outbound_blocked: bool,
+    pub weather_https_allowed: bool,
+    pub host_exact_kernel_enforced: bool,
     pub denied_path: PathBuf,
+    pub denied_network_target: String,
     pub status_code: Option<i32>,
     pub stderr_contains_operation_not_permitted: bool,
     pub reason: String,
@@ -1621,6 +1627,7 @@ fn probe_agent_kernel_sandbox(
 ) -> UmbrellaResult<UmbrellaKernelSandboxSummary> {
     let support = current_kernel_sandbox_support();
     let denied_path = kernel_denied_probe_path(&config.output_path);
+    let denied_network_target = "localhost:<ephemeral-undeclared-port>".to_string();
     if !support.available {
         return Ok(UmbrellaKernelSandboxSummary {
             os: support.os,
@@ -1629,7 +1636,12 @@ fn probe_agent_kernel_sandbox(
             enforced: false,
             allowed_write_succeeded: false,
             denied_write_blocked: false,
+            network_outbound_enforced: false,
+            network_denied_outbound_blocked: false,
+            weather_https_allowed: false,
+            host_exact_kernel_enforced: false,
             denied_path,
+            denied_network_target,
             status_code: None,
             stderr_contains_operation_not_permitted: false,
             reason: support.reason,
@@ -1672,9 +1684,12 @@ fn probe_agent_kernel_sandbox(
         .map(|contents| contents == "kernel sandbox allowed")
         .unwrap_or(false);
     let denied_write_blocked = !denied_path.exists();
+    let network_denied = probe_denied_kernel_network_target(&plan)?;
+    let weather_https_allowed = probe_weather_https_kernel_target(config, &plan)?;
     let stderr_contains_operation_not_permitted = output.stderr.contains("Operation not permitted");
     let enforced = allowed_write_succeeded
         && denied_write_blocked
+        && network_denied.blocked
         && stderr_contains_operation_not_permitted
         && !output.success();
 
@@ -1692,13 +1707,59 @@ fn probe_agent_kernel_sandbox(
         enforced,
         allowed_write_succeeded,
         denied_write_blocked,
+        network_outbound_enforced: network_denied.blocked,
+        network_denied_outbound_blocked: network_denied.blocked,
+        weather_https_allowed,
+        host_exact_kernel_enforced: false,
         denied_path,
+        denied_network_target: network_denied.target,
         status_code: output.status_code,
         stderr_contains_operation_not_permitted,
-        reason:
-            "kernel denied an undeclared filesystem write while allowing the declared report path"
-                .to_string(),
+        reason: "kernel denied undeclared filesystem writes and undeclared outbound TCP ports; macOS Seatbelt constrains Weather.gov to TCP 443 while TLS/application checks retain host identity".to_string(),
     })
+}
+
+struct NetworkProbeSummary {
+    target: String,
+    blocked: bool,
+}
+
+fn probe_denied_kernel_network_target(plan: &SandboxPlan) -> UmbrellaResult<NetworkProbeSummary> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port().to_string();
+    let output =
+        run_with_kernel_sandbox(plan, "/usr/bin/nc", ["-z", "-G", "1", "localhost", &port])
+            .map_err(|error| {
+                UmbrellaAgentError::new(format!(
+                    "failed to launch Weather Agent kernel network deny probe: {error}"
+                ))
+            })?;
+
+    Ok(NetworkProbeSummary {
+        target: format!("localhost:{port}"),
+        blocked: !output.success(),
+    })
+}
+
+fn probe_weather_https_kernel_target(
+    config: &UmbrellaAgentConfig,
+    plan: &SandboxPlan,
+) -> UmbrellaResult<bool> {
+    if !matches!(config.weather_source, WeatherSource::LiveNws { .. }) {
+        return Ok(false);
+    }
+
+    let output = run_with_kernel_sandbox(
+        plan,
+        "/usr/bin/curl",
+        ["-I", "--max-time", "8", "https://api.weather.gov"],
+    )
+    .map_err(|error| {
+        UmbrellaAgentError::new(format!(
+            "failed to launch Weather Agent kernel Weather.gov allow probe: {error}"
+        ))
+    })?;
+    Ok(output.success())
 }
 
 fn kernel_denied_probe_path(output_path: &Path) -> PathBuf {

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -67,6 +67,14 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
         assert!(run.kernel_sandbox.enforced);
         assert!(run.kernel_sandbox.allowed_write_succeeded);
         assert!(run.kernel_sandbox.denied_write_blocked);
+        assert!(run.kernel_sandbox.network_outbound_enforced);
+        assert!(run.kernel_sandbox.network_denied_outbound_blocked);
+        assert!(run
+            .kernel_sandbox
+            .denied_network_target
+            .starts_with("localhost:"));
+        assert!(!run.kernel_sandbox.weather_https_allowed);
+        assert!(!run.kernel_sandbox.host_exact_kernel_enforced);
         assert!(run.kernel_sandbox.stderr_contains_operation_not_permitted);
         assert!(!run.kernel_sandbox.denied_path.exists());
     }
@@ -168,5 +176,11 @@ fn umbrella_today_agent_fetches_live_weather_over_tls() {
         .starts_with("https://api.weather.gov/"));
     assert!(run.output_text.contains("location=Seattle"));
     assert!(run.output_text.contains("decision="));
+    if current_kernel_sandbox_support().available {
+        assert!(run.kernel_sandbox.network_outbound_enforced);
+        assert!(run.kernel_sandbox.network_denied_outbound_blocked);
+        assert!(run.kernel_sandbox.weather_https_allowed);
+        assert!(!run.kernel_sandbox.host_exact_kernel_enforced);
+    }
     assert!(output_path.exists());
 }


### PR DESCRIPTION
## Summary
- extend the macOS Seatbelt kernel profile generator to restrict outbound network access from required capabilities
- allow resolver-socket access and declared TCP ports, while denying undeclared outbound TCP ports
- surface the Weather Agent kernel summary for denied network probes and live Weather.gov HTTPS allow probes

## Notes
- macOS Seatbelt can enforce protocol/port policy, but not arbitrary remote hostnames; host identity remains enforced by the capability/runtime/TLS layer.

## Validation
- cargo test -p capability-os-sandbox -p weather-agent-e2e
- cargo test -p weather-agent-e2e umbrella_today_agent_fetches_live_weather_over_tls -- --ignored --nocapture