### PR TITLE
ts(spice): add CCVS controlled sources

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add current-controlled voltage source support across DC, AC, transfer
+  function, sensitivity, Monte Carlo, and transient analyses.
 - Add current-controlled current source support across DC, AC, transfer
   function, sensitivity, Monte Carlo, and transient analyses.
 - Add voltage-controlled voltage source support across DC, AC, transfer

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -10,7 +10,8 @@ export type Element =
   | CurrentSource
   | Vccs
   | Vcvs
-  | Cccs;
+  | Cccs
+  | Ccvs;
 
 export interface Resistor {
   readonly kind: "resistor";
@@ -297,6 +298,15 @@ export interface Cccs {
   readonly negative: string;
   readonly controlSource: string;
   readonly gain: number;
+}
+
+export interface Ccvs {
+  readonly kind: "ccvs";
+  readonly name: string;
+  readonly positive: string;
+  readonly negative: string;
+  readonly controlSource: string;
+  readonly transresistanceOhms: number;
 }
 
 export interface DcResult {
@@ -590,6 +600,23 @@ export function cccs(
     negative,
     controlSource,
     gain,
+  };
+}
+
+export function ccvs(
+  name: string,
+  positive: string,
+  negative: string,
+  controlSource: string,
+  transresistanceOhms: number,
+): Ccvs {
+  return {
+    kind: "ccvs",
+    name,
+    positive,
+    negative,
+    controlSource,
+    transresistanceOhms,
   };
 }
 
@@ -1082,6 +1109,12 @@ function elementParameter(element: Element): ElementParameter | undefined {
         parameter: "gain",
         nominalValue: element.gain,
       };
+    case "ccvs":
+      return {
+        elementName: element.name,
+        parameter: "transresistanceOhms",
+        nominalValue: element.transresistanceOhms,
+      };
     case "capacitor":
     case "inductor":
       return undefined;
@@ -1128,6 +1161,12 @@ function circuitWithPerturbedElement(
         break;
       case "cccs":
         perturbed.add({ ...element, gain: element.gain + delta });
+        break;
+      case "ccvs":
+        perturbed.add({
+          ...element,
+          transresistanceOhms: element.transresistanceOhms + delta,
+        });
         break;
       case "capacitor":
       case "inductor":
@@ -1234,6 +1273,16 @@ function randomizedElement(
       return {
         ...element,
         gain: randomizedValue(element.gain, tolerance, distribution, rng),
+      };
+    case "ccvs":
+      return {
+        ...element,
+        transresistanceOhms: randomizedValue(
+          element.transresistanceOhms,
+          tolerance,
+          distribution,
+          rng,
+        ),
       };
     case "capacitor":
     case "inductor":
@@ -1360,6 +1409,15 @@ function solveLinearCircuit(
       case "cccs":
         stampCccs(element, nodeIndices, voltageSources, matrix);
         break;
+      case "ccvs":
+        stampCcvs(
+          element,
+          nodeIndices,
+          voltageSources,
+          nodeCount,
+          matrix,
+        );
+        break;
     }
   }
 
@@ -1446,6 +1504,15 @@ function buildSmallSignalMatrix(
       case "cccs":
         stampCccs(element, nodeIndices, voltageSources, matrix);
         break;
+      case "ccvs":
+        stampCcvs(
+          element,
+          nodeIndices,
+          voltageSources,
+          nodeCount,
+          matrix,
+        );
+        break;
     }
   }
 
@@ -1485,6 +1552,7 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
       case "vccs":
       case "vcvs":
       case "cccs":
+      case "ccvs":
         break;
     }
   }
@@ -1556,6 +1624,15 @@ function buildAcMatrix(
         break;
       case "cccs":
         stampAcCccs(element, nodeIndices, voltageSources, matrix);
+        break;
+      case "ccvs":
+        stampAcCcvs(
+          element,
+          nodeIndices,
+          voltageSources,
+          nodeCount,
+          matrix,
+        );
         break;
     }
   }
@@ -1742,6 +1819,10 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.positive);
         insertNode(names, element.negative);
         break;
+      case "ccvs":
+        insertNode(names, element.positive);
+        insertNode(names, element.negative);
+        break;
     }
   }
 
@@ -1758,7 +1839,11 @@ function collectVoltageSources(
 ): Map<string, number> {
   const sources = new Map<string, number>();
   for (const element of circuit.elements()) {
-    if (element.kind === "voltage-source" || element.kind === "vcvs") {
+    if (
+      element.kind === "voltage-source" ||
+      element.kind === "vcvs" ||
+      element.kind === "ccvs"
+    ) {
       insertBranchName(sources, element.name, "duplicate voltage source name");
     } else if (element.kind === "inductor") {
       if (sources.has(element.name)) {
@@ -1775,7 +1860,11 @@ function collectVoltageSources(
 function collectAcVoltageSources(circuit: Circuit): Map<string, number> {
   const sources = new Map<string, number>();
   for (const element of circuit.elements()) {
-    if (element.kind === "voltage-source" || element.kind === "vcvs") {
+    if (
+      element.kind === "voltage-source" ||
+      element.kind === "vcvs" ||
+      element.kind === "ccvs"
+    ) {
       insertBranchName(sources, element.name, "duplicate voltage source name");
     }
   }
@@ -1796,7 +1885,8 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
         element.kind === "inductor" ||
         element.kind === "vccs" ||
         element.kind === "vcvs" ||
-        element.kind === "cccs") &&
+        element.kind === "cccs" ||
+        element.kind === "ccvs") &&
       element.name === inputSource
     ) {
       throw invalidElement(
@@ -2344,6 +2434,34 @@ function stampCccs(
   );
 }
 
+function stampCcvs(
+  element: Ccvs,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  nodeCount: number,
+  matrix: number[][],
+): void {
+  if (!Number.isFinite(element.transresistanceOhms)) {
+    throw invalidElement(element.name, "transresistance must be finite");
+  }
+
+  const sourceIndex = voltageSources.get(element.name);
+  if (sourceIndex === undefined) {
+    throw invalidElement(element.name, "voltage source was not indexed");
+  }
+  const controlSourceIndex = voltageSources.get(element.controlSource);
+  if (controlSourceIndex === undefined) {
+    throw invalidElement(element.name, "control source was not indexed");
+  }
+
+  const branch = nodeCount + sourceIndex;
+  const controlBranch = nodeCount + controlSourceIndex;
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  stampBranchMatrix(matrix, branch, positive, negative);
+  matrix[branch][controlBranch] -= element.transresistanceOhms;
+}
+
 function stampCurrentControlledCurrent(
   matrix: number[][],
   positive: number | undefined,
@@ -2612,6 +2730,37 @@ function stampAcCccs(
     negative,
     sourceIndex + nodeIndices.size,
     complex(element.gain, 0.0),
+  );
+}
+
+function stampAcCcvs(
+  element: Ccvs,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  nodeCount: number,
+  matrix: Complex[][],
+): void {
+  if (!Number.isFinite(element.transresistanceOhms)) {
+    throw invalidElement(element.name, "transresistance must be finite");
+  }
+
+  const sourceIndex = voltageSources.get(element.name);
+  if (sourceIndex === undefined) {
+    throw invalidElement(element.name, "voltage source was not indexed");
+  }
+  const controlSourceIndex = voltageSources.get(element.controlSource);
+  if (controlSourceIndex === undefined) {
+    throw invalidElement(element.name, "control source was not indexed");
+  }
+
+  const branch = nodeCount + sourceIndex;
+  const controlBranch = nodeCount + controlSourceIndex;
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  stampComplexBranchMatrix(matrix, branch, positive, negative);
+  matrix[branch][controlBranch] = complexSub(
+    matrix[branch][controlBranch],
+    complex(element.transresistanceOhms, 0.0),
   );
 }
 

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -5,6 +5,7 @@ import {
   acSweep,
   capacitor,
   cccs,
+  ccvs,
   complexAbs,
   complexPhase,
   currentSource,
@@ -121,6 +122,24 @@ describe("acSweep", () => {
     expect(out).not.toBeUndefined();
     expectClose(out!.real, 3.0);
     expectClose(out!.imag, 0.0);
+  });
+
+  it("applies CCVS transresistance in AC analysis", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(ccvs("H1", "out", "0", "Vsense", 3_000.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const points = acSweep(circuit, 1_000.0, 1_000.0, 10);
+
+    expect(points).toHaveLength(1);
+    const out = points[0].voltage("out");
+    expect(out).not.toBeUndefined();
+    expectClose(out!.real, 3.0);
+    expectClose(out!.imag, 0.0);
+    expectClose(points[0].branchCurrent("H1")?.real, -3.0e-3);
   });
 
   it("rejects invalid frequency bounds", () => {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -4,6 +4,7 @@ import {
   SinWaveform,
   SpiceError,
   cccs,
+  ccvs,
   currentSource,
   dcOp,
   dcSweep,
@@ -128,6 +129,21 @@ describe("dcOp", () => {
     expectClose(result.voltage("out"), 2.0);
   });
 
+  it("stamps CCVS voltage from a voltage-source branch current", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(ccvs("H1", "out", "0", "Vsense", 2_000.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expectClose(result.branchCurrent("Vsense"), 1.0e-3);
+    expectClose(result.voltage("out"), 2.0);
+    expectClose(result.branchCurrent("H1"), -2.0e-3);
+  });
+
   it("rejects missing CCCS control sources", () => {
     const circuit = new Circuit();
     circuit.add(cccs("Fbad", "0", "out", "Vmissing", 2.0));
@@ -161,6 +177,15 @@ describe("dcOp", () => {
     circuit.add(resistor("Rload", "out", "0", 1_000.0));
 
     expect(() => dcOp(circuit)).toThrowError("gain must be finite");
+  });
+
+  it("rejects non-finite CCVS transresistance", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(ccvs("Hbad", "out", "0", "Vsense", Number.NaN));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    expect(() => dcOp(circuit)).toThrowError("transresistance must be finite");
   });
 
   it("uses static source value when a waveform is present", () => {

--- a/code/packages/typescript/spice-engine/tests/mc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/mc.test.ts
@@ -3,6 +3,7 @@ import {
   Circuit,
   SpiceError,
   cccs,
+  ccvs,
   currentSource,
   mcDc,
   resistor,
@@ -115,6 +116,25 @@ describe("mcDc", () => {
 
     const result = mcDc(circuit, "out", 40, {
       seed: 11,
+      tolerance: 0.05,
+      distribution: "uniform",
+    });
+
+    expect(result.mean).toBeGreaterThan(1.8);
+    expect(result.mean).toBeLessThan(2.2);
+    expect(result.stdDev).toBeGreaterThan(0.0);
+  });
+
+  it("varies CCVS transresistance in DC Monte Carlo trials", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(ccvs("H1", "out", "0", "Vsense", 2_000.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = mcDc(circuit, "out", 40, {
+      seed: 13,
       tolerance: 0.05,
       distribution: "uniform",
     });

--- a/code/packages/typescript/spice-engine/tests/sens.test.ts
+++ b/code/packages/typescript/spice-engine/tests/sens.test.ts
@@ -4,6 +4,7 @@ import {
   SpiceError,
   SensResult,
   cccs,
+  ccvs,
   currentSource,
   resistor,
   sensDc,
@@ -110,6 +111,21 @@ describe("sensDc", () => {
     expectClose(result.nominalVoltage, 2.0);
     expectClose(entry(result, "F1", "gain").sensitivity, 1.0);
     expectClose(entry(result, "F1", "gain").relativeSensitivity, 1.0);
+  });
+
+  it("reports CCVS transresistance sensitivity", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(ccvs("H1", "out", "0", "Vsense", 2_000.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = sensDc(circuit, "out");
+
+    expectClose(result.nominalVoltage, 2.0);
+    expectClose(entry(result, "H1", "transresistanceOhms").sensitivity, 1.0e-3);
+    expectClose(entry(result, "H1", "transresistanceOhms").relativeSensitivity, 1.0);
   });
 
   it("sorts entries by absolute relative sensitivity", () => {

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -3,6 +3,7 @@ import {
   Circuit,
   capacitor,
   cccs,
+  ccvs,
   currentSource,
   inductor,
   resistor,
@@ -105,6 +106,20 @@ describe("tf", () => {
     expectClose(result.outputImpedanceOhms, 1_000.0);
   });
 
+  it("reports CCVS transresistance gain through a sensing voltage source", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 1.0));
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(ccvs("H1", "out", "0", "Vsense", 2_000.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = tf(circuit, "out", "Vin");
+
+    expectClose(result.gain(), 2.0);
+    expectClose(result.outputImpedanceOhms, 0.0);
+  });
+
   it("rejects missing output nodes", () => {
     const circuit = new Circuit();
 
@@ -139,6 +154,17 @@ describe("tf", () => {
     circuit.add(resistor("Rload", "out", "0", 1_000.0));
 
     expect(() => tf(circuit, "out", "F1")).toThrowError(
+      "input element must be an independent voltage or current source",
+    );
+  });
+
+  it("rejects CCVS elements as input sources", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(ccvs("H1", "out", "0", "Vsense", 1_000.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    expect(() => tf(circuit, "out", "H1")).toThrowError(
       "input element must be an independent voltage or current source",
     );
   });

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -9,6 +9,7 @@ import {
   capacitor,
   capacitorWithInitialVoltage,
   cccs,
+  ccvs,
   currentSourceWithWaveform,
   inductor,
   inductorWithInitialCurrent,
@@ -195,6 +196,33 @@ describe("transient", () => {
     circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
     circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
     circuit.add(cccs("F1", "0", "out", "Vsense", 2.0));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const points = transient(circuit, 0.25, 0.5);
+
+    expectClose(points[0].branchCurrent("Vsense"), 1.0e-3);
+    expectClose(points[0].voltage("out"), 2.0);
+    expectClose(points[1].voltage("out"), 2.0);
+  });
+
+  it("updates CCVS output from transient branch current", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "Vin",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [0.25, 1.0],
+          [0.5, 1.0],
+        ]),
+      ),
+    );
+    circuit.add(resistor("Rsense", "in", "sense", 1_000.0));
+    circuit.add(voltageSource("Vsense", "sense", "0", 0.0));
+    circuit.add(ccvs("H1", "out", "0", "Vsense", 2_000.0));
     circuit.add(resistor("Rload", "out", "0", 1_000.0));
 
     const points = transient(circuit, 0.25, 0.5);


### PR DESCRIPTION
## Summary

- add TypeScript `ccvs` elements for current-controlled voltage sources
- stamp CCVS branch equations from existing voltage-source branch currents through DC/transient, AC, and small-signal matrices
- cover DC, AC, transfer-function, sensitivity, Monte Carlo, transient, and validation behavior

## Validation

- sh BUILD
- git diff --check