### PR TITLE
rust(spice): add CCVS controlled sources

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -10,6 +10,8 @@
   function, sensitivity, Monte Carlo, and transient analyses.
 - Add current-controlled current sources (CCCS) across DC, AC, transfer
   function, sensitivity, Monte Carlo, and transient analyses.
+- Add current-controlled voltage sources (CCVS) across DC, AC, transfer
+  function, sensitivity, Monte Carlo, and transient analyses.
 - Add DC source sweeps for independent voltage and current sources.
 - Add DC sensitivity analysis for resistor and independent source parameters.
 - Add seeded DC Monte Carlo analysis for linear element parameters with

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -343,6 +343,7 @@ pub enum Element {
     Vccs(Vccs),
     Vcvs(Vcvs),
     Cccs(Cccs),
+    Ccvs(Ccvs),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -608,6 +609,33 @@ impl Cccs {
             negative: negative.into(),
             control_source: control_source.into(),
             gain,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ccvs {
+    pub name: String,
+    pub positive: String,
+    pub negative: String,
+    pub control_source: String,
+    pub transresistance_ohms: f64,
+}
+
+impl Ccvs {
+    pub fn new(
+        name: impl Into<String>,
+        positive: impl Into<String>,
+        negative: impl Into<String>,
+        control_source: impl Into<String>,
+        transresistance_ohms: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            positive: positive.into(),
+            negative: negative.into(),
+            control_source: control_source.into(),
+            transresistance_ohms,
         }
     }
 }
@@ -1448,6 +1476,11 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
         )),
         Element::Vcvs(source) => Some((source.name.clone(), "gain".to_string(), source.gain)),
         Element::Cccs(source) => Some((source.name.clone(), "gain".to_string(), source.gain)),
+        Element::Ccvs(source) => Some((
+            source.name.clone(),
+            "transresistance_ohms".to_string(),
+            source.transresistance_ohms,
+        )),
         Element::Capacitor(_) | Element::Inductor(_) => None,
     }
 }
@@ -1464,6 +1497,7 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::Vccs(source) => source.transconductance_siemens += delta,
         Element::Vcvs(source) => source.gain += delta,
         Element::Cccs(source) => source.gain += delta,
+        Element::Ccvs(source) => source.transresistance_ohms += delta,
         Element::Capacitor(_) | Element::Inductor(_) => {}
     }
 }
@@ -1563,6 +1597,12 @@ fn randomized_element(
             let mut varied = source.clone();
             varied.gain = randomized_value(varied.gain, tolerance, distribution, rng);
             Element::Cccs(varied)
+        }
+        Element::Ccvs(source) => {
+            let mut varied = source.clone();
+            varied.transresistance_ohms =
+                randomized_value(varied.transresistance_ohms, tolerance, distribution, rng);
+            Element::Ccvs(varied)
         }
         Element::Capacitor(_) | Element::Inductor(_) => element.clone(),
     }
@@ -1693,6 +1733,13 @@ fn solve_linear_circuit(
             Element::Cccs(source) => {
                 stamp_cccs(source, &node_indices, &voltage_sources, &mut matrix)?
             }
+            Element::Ccvs(source) => stamp_ccvs(
+                source,
+                &node_indices,
+                &voltage_sources,
+                node_count,
+                &mut matrix,
+            )?,
         }
     }
 
@@ -1748,7 +1795,8 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             | Element::Inductor(_)
             | Element::Vccs(_)
             | Element::Vcvs(_)
-            | Element::Cccs(_) => {}
+            | Element::Cccs(_)
+            | Element::Ccvs(_) => {}
         }
     }
 
@@ -1813,6 +1861,13 @@ fn build_ac_matrix(
             Element::Cccs(source) => {
                 stamp_ac_cccs(source, node_indices, voltage_sources, &mut matrix)?
             }
+            Element::Ccvs(source) => stamp_ac_ccvs(
+                source,
+                node_indices,
+                voltage_sources,
+                node_count,
+                &mut matrix,
+            )?,
         }
     }
 
@@ -1876,6 +1931,15 @@ fn build_small_signal_matrix(
             }
             Element::Cccs(source) => {
                 stamp_cccs(source, node_indices, voltage_sources, &mut matrix)?;
+            }
+            Element::Ccvs(source) => {
+                stamp_ccvs(
+                    source,
+                    node_indices,
+                    voltage_sources,
+                    node_count,
+                    &mut matrix,
+                )?;
             }
         }
     }
@@ -1949,6 +2013,10 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &source.positive);
                 insert_node(&mut names, &source.negative);
             }
+            Element::Ccvs(source) => {
+                insert_node(&mut names, &source.positive);
+                insert_node(&mut names, &source.negative);
+            }
         }
     }
     names
@@ -1969,6 +2037,9 @@ fn collect_voltage_sources(
                 insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
             }
             Element::Vcvs(source) => {
+                insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
+            }
+            Element::Ccvs(source) => {
                 insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
             }
             Element::Inductor(inductor) => {
@@ -1999,6 +2070,9 @@ fn collect_ac_voltage_sources(circuit: &Circuit) -> Result<BTreeMap<String, usiz
                 insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
             }
             Element::Vcvs(source) => {
+                insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
+            }
+            Element::Ccvs(source) => {
                 insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
             }
             _ => {}
@@ -2036,6 +2110,9 @@ fn find_input_source<'a>(
             }
             Element::Cccs(source) if source.name == input_source => {
                 return Err(input_source_type_error(input_source, "CCCS"));
+            }
+            Element::Ccvs(source) if source.name == input_source => {
+                return Err(input_source_type_error(input_source, "CCVS"));
             }
             _ => {}
         }
@@ -2623,6 +2700,42 @@ fn stamp_cccs(
     Ok(())
 }
 
+fn stamp_ccvs(
+    source: &Ccvs,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    node_count: usize,
+    matrix: &mut [Vec<f64>],
+) -> Result<(), SpiceError> {
+    if !source.transresistance_ohms.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "transresistance must be finite".to_string(),
+        });
+    }
+
+    let Some(source_index) = voltage_sources.get(&source.name) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "voltage source was not indexed".to_string(),
+        });
+    };
+    let Some(control_index) = voltage_sources.get(&source.control_source) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "control source was not indexed".to_string(),
+        });
+    };
+
+    let branch = node_count + source_index;
+    let control_branch = node_count + control_index;
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    stamp_branch_matrix(matrix, branch, positive, negative);
+    matrix[branch][control_branch] -= source.transresistance_ohms;
+    Ok(())
+}
+
 fn stamp_current_controlled_current(
     matrix: &mut [Vec<f64>],
     positive: Option<usize>,
@@ -2914,6 +3027,42 @@ fn stamp_ac_cccs(
         node_indices.len() + source_index,
         Complex::new(source.gain, 0.0),
     );
+    Ok(())
+}
+
+fn stamp_ac_ccvs(
+    source: &Ccvs,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    node_count: usize,
+    matrix: &mut [Vec<Complex>],
+) -> Result<(), SpiceError> {
+    if !source.transresistance_ohms.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "transresistance must be finite".to_string(),
+        });
+    }
+
+    let Some(source_index) = voltage_sources.get(&source.name) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "voltage source was not indexed".to_string(),
+        });
+    };
+    let Some(control_index) = voltage_sources.get(&source.control_source) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "control source was not indexed".to_string(),
+        });
+    };
+
+    let branch = node_count + source_index;
+    let control_branch = node_count + control_index;
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    stamp_complex_branch_matrix(matrix, branch, positive, negative);
+    matrix[branch][control_branch] -= Complex::new(source.transresistance_ohms, 0.0);
     Ok(())
 }
 

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    ac_sweep, Capacitor, Cccs, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError,
-    Vcvs, VoltageSource,
+    ac_sweep, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor, Resistor,
+    SpiceError, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -144,6 +144,34 @@ fn ac_cccs_applies_current_gain_from_sensed_branch_current() {
     let out = points[0].voltage("out").unwrap();
     assert_close(out.real, 3.0);
     assert_close(out.imag, 0.0);
+}
+
+#[test]
+fn ac_ccvs_applies_transresistance_from_sensed_branch_current() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "H1", "out", "0", "Vsense", 3_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let points = ac_sweep(&circuit, 1_000.0, 1_000.0, 10).unwrap();
+
+    assert_eq!(points.len(), 1);
+    let out = points[0].voltage("out").unwrap();
+    assert_close(out.real, 3.0);
+    assert_close(out.imag, 0.0);
+    assert_close(points[0].branch_current("H1").unwrap().real, -3.0e-3);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,5 +1,5 @@
 use spice_engine::{
-    dc_op, dc_sweep, Cccs, Circuit, CurrentSource, Element, Inductor, Resistor, SinWaveform,
+    dc_op, dc_sweep, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor, Resistor, SinWaveform,
     SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
@@ -116,6 +116,32 @@ fn dc_cccs_injects_current_from_voltage_source_branch_current() {
 
     assert_close(result.branch_current("Vsense").unwrap(), 1.0e-3);
     assert_close(result.voltage("out").unwrap(), 2.0);
+}
+
+#[test]
+fn dc_ccvs_sets_voltage_from_voltage_source_branch_current() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "H1", "out", "0", "Vsense", 2_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert_close(result.branch_current("Vsense").unwrap(), 1.0e-3);
+    assert_close(result.voltage("out").unwrap(), 2.0);
+    assert_close(result.branch_current("H1").unwrap(), -2.0e-3);
 }
 
 #[test]
@@ -329,6 +355,29 @@ fn dc_rejects_non_finite_cccs_gain() {
 }
 
 #[test]
+fn dc_rejects_non_finite_ccvs_transresistance() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "Hbad",
+        "out",
+        "0",
+        "Vsense",
+        f64::NAN,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    assert!(matches!(
+        dc_op(&circuit),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Hbad"
+    ));
+}
+
+#[test]
 fn dc_rejects_missing_cccs_control_source() {
     let mut circuit = Circuit::new();
     circuit.add(Element::Cccs(Cccs::new(
@@ -341,6 +390,22 @@ fn dc_rejects_missing_cccs_control_source() {
     assert!(matches!(
         dc_op(&circuit),
         Err(SpiceError::InvalidElement { name, .. }) if name == "Fbad"
+    ));
+}
+
+#[test]
+fn dc_rejects_missing_ccvs_control_source() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "Hbad", "out", "0", "Vmissing", 2_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    assert!(matches!(
+        dc_op(&circuit),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Hbad"
     ));
 }
 

--- a/code/packages/rust/spice-engine/tests/mc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/mc_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    mc_dc, Cccs, Circuit, CurrentSource, Element, McDistribution, McOptions, Resistor, SpiceError,
-    Vccs, Vcvs, VoltageSource,
+    mc_dc, Cccs, Ccvs, Circuit, CurrentSource, Element, McDistribution, McOptions, Resistor,
+    SpiceError, Vccs, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -217,6 +217,42 @@ fn mc_dc_varies_cccs_gain() {
             tolerance: 0.05,
             distribution: McDistribution::Uniform,
             seed: Some(13),
+        },
+    )
+    .unwrap();
+
+    assert!(result.mean > 1.8, "mean was {}", result.mean);
+    assert!(result.mean < 2.2, "mean was {}", result.mean);
+    assert!(result.std_dev > 0.0, "std_dev was {}", result.std_dev);
+}
+
+#[test]
+fn mc_dc_varies_ccvs_transresistance() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "H1", "out", "0", "Vsense", 2_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = mc_dc(
+        &circuit,
+        "out",
+        40,
+        McOptions {
+            tolerance: 0.05,
+            distribution: McDistribution::Uniform,
+            seed: Some(15),
         },
     )
     .unwrap();

--- a/code/packages/rust/spice-engine/tests/sens_tests.rs
+++ b/code/packages/rust/spice-engine/tests/sens_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    sens_dc, Cccs, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, Vccs, Vcvs,
-    VoltageSource,
+    sens_dc, Cccs, Ccvs, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, Vccs,
+    Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -149,6 +149,38 @@ fn sens_dc_reports_cccs_gain_sensitivity() {
     assert_close(result.nominal_voltage, 2.0);
     assert_close(entry(&result, "F1", "gain").sensitivity, 1.0);
     assert_close(entry(&result, "F1", "gain").relative_sensitivity, 1.0);
+}
+
+#[test]
+fn sens_dc_reports_ccvs_transresistance_sensitivity() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "H1", "out", "0", "Vsense", 2_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = sens_dc(&circuit, "out").unwrap();
+
+    assert_close(result.nominal_voltage, 2.0);
+    assert_close(
+        entry(&result, "H1", "transresistance_ohms").sensitivity,
+        1.0e-3,
+    );
+    assert_close(
+        entry(&result, "H1", "transresistance_ohms").relative_sensitivity,
+        1.0,
+    );
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    tf, Capacitor, Cccs, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError, TfResult,
-    Vccs, Vcvs, VoltageSource,
+    tf, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError,
+    TfResult, Vccs, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -138,6 +138,31 @@ fn tf_cccs_stage_reports_current_gain() {
 }
 
 #[test]
+fn tf_ccvs_stage_reports_transresistance_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "H1", "out", "0", "Vsense", 2_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = tf(&circuit, "out", "Vin").unwrap();
+
+    assert_close(result.gain(), 2.0);
+    assert_close(result.output_impedance_ohms, 0.0);
+}
+
+#[test]
 fn tf_capacitor_is_open_and_inductor_is_short_at_dc_small_signal() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -210,5 +235,24 @@ fn tf_rejects_cccs_as_input_source() {
     assert!(matches!(
         tf(&circuit, "out", "F1"),
         Err(SpiceError::InvalidElement { name, .. }) if name == "F1"
+    ));
+}
+
+#[test]
+fn tf_rejects_ccvs_as_input_source() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "H1", "out", "0", "Vsense", 1_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    assert!(matches!(
+        tf(&circuit, "out", "H1"),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "H1"
     ));
 }

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1,5 +1,5 @@
 use spice_engine::{
-    transient, Capacitor, Cccs, Circuit, CurrentSource, Element, ExpWaveform, Inductor,
+    transient, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, ExpWaveform, Inductor,
     PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, VoltageSource, Waveform,
 };
 
@@ -192,6 +192,36 @@ fn transient_cccs_updates_from_sensed_branch_current() {
         "Vsense", "sense", "0", 0.0,
     )));
     circuit.add(Element::Cccs(Cccs::new("F1", "0", "out", "Vsense", 2.0)));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let points = transient(&circuit, 0.25, 0.5).unwrap();
+
+    assert_close(points[0].branch_current("Vsense").unwrap(), 1.0e-3);
+    assert_close(points[0].voltage("out").unwrap(), 2.0);
+    assert_close(points[1].voltage("out").unwrap(), 2.0);
+}
+
+#[test]
+fn transient_ccvs_updates_from_sensed_branch_current() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+        "Vin",
+        "in",
+        "0",
+        0.0,
+        Waveform::Pwl(PwlWaveform::new(vec![(0.0, 0.0), (0.25, 1.0), (0.5, 1.0)])),
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsense", "in", "sense", 1_000.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vsense", "sense", "0", 0.0,
+    )));
+    circuit.add(Element::Ccvs(Ccvs::new(
+        "H1", "out", "0", "Vsense", 2_000.0,
+    )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
     )));


### PR DESCRIPTION
## Summary

- add Rust `Ccvs` elements for current-controlled voltage sources
- stamp CCVS branch equations from existing voltage-source branch currents through DC/transient, AC, and small-signal matrices
- cover DC, AC, transfer-function, sensitivity, Monte Carlo, transient, and validation behavior

## Validation

- cargo fmt -p spice-engine
- sh BUILD
- git diff --check