### PR TITLE
[codex] Add UNO R4 I2C byte write capability

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -3,23 +3,24 @@ use std::ptr;
 use std::slice;
 
 use board_vm_host::{
-    AdcReadProgram, BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram,
-    DacWriteU12Program, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram, GpioWriteProgram,
-    I2cOpenProgram, LedMatrixFrameProgram, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN,
-    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
-    GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
-    TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    AdcReadProgram, BlinkProgram, DacWriteU12Program, GpioHandleCloseProgram,
+    GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
+    GpioWriteProgram, I2cOpenProgram, I2cWriteU8Program, LedMatrixFrameProgram, PwmWriteProgram,
+    TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
+    DAC_WRITE_U12_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
+    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN,
+    I2C_OPEN_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
+    PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
     bluetooth_endpoint_candidates_from_devices, bluetooth_transact_wire_frame, board_family_name,
     build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
     build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
-    build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
-    build_dac_write_u12_module, build_i2c_open_module, build_led_matrix_frame_module, build_program_begin_wire_frame,
-    build_program_chunk_wire_frame, build_program_end_wire_frame, build_pwm_write_module,
-    build_adc_read_module, build_raw_module,
+    build_dac_write_u12_module, build_gpio_read_module, build_gpio_write_module,
+    build_hello_wire_frame, build_i2c_open_module, build_i2c_write_u8_module,
+    build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
+    build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
     build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
@@ -269,6 +270,21 @@ extern "C" fn session_i2c_open_module(
 
     let module = build_i2c_open_module_value(bus, max_stack)
         .unwrap_or_else(|error| raise_core_error("i2c_open_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_i2c_write_u8_module(
+    _self_val: VALUE,
+    address_val: VALUE,
+    byte_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let address = rb_u16(address_val, "address");
+    let byte = rb_u8(byte_val, "byte");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_i2c_write_u8_module_value(address, byte, max_stack)
+        .unwrap_or_else(|error| raise_core_error("i2c_write_u8_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1485,6 +1501,24 @@ fn build_i2c_open_module_value(bus: u8, max_stack: u8) -> Result<Vec<u8>, Langua
     Ok(module)
 }
 
+fn build_i2c_write_u8_module_value(
+    address: u16,
+    byte: u8,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; I2C_WRITE_U8_MODULE_LEN];
+    let len = build_i2c_write_u8_module(
+        I2cWriteU8Program {
+            address,
+            byte,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_raw_module_value(
     flags: u8,
     max_stack: u8,
@@ -1805,6 +1839,12 @@ pub extern "C" fn Init_board_vm_native() {
         "i2c_open_module",
         session_i2c_open_module as *const c_void,
         2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "i2c_write_u8_module",
+        session_i2c_write_u8_module as *const c_void,
+        3,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -448,6 +448,24 @@ module CodingAdventures
         )
       end
 
+      def i2c_write_u8!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        address:,
+        byte:,
+        max_stack: 4
+      )
+        ensure_uno_r4_wifi!
+
+        session.i2c_write_u8(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          byte: byte,
+          max_stack: max_stack
+        )
+      end
+
       def store_program!(
         program_id: DEFAULT_PROGRAM_ID,
         slot: DEFAULT_EJECT_SLOT,
@@ -1083,6 +1101,22 @@ module CodingAdventures
           budget: budget,
           host_nonce: host_nonce,
           bus: bus,
+          max_stack: max_stack
+        )
+      end
+
+      def write_u8(
+        address:,
+        byte:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 4
+      )
+        @connection.i2c_write_u8!(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          byte: byte,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -213,6 +213,10 @@ module CodingAdventures
         native_session.i2c_open_module(bus, max_stack)
       end
 
+      def i2c_write_u8_module(address:, byte:, max_stack: 4)
+        native_session.i2c_write_u8_module(address, byte, max_stack)
+      end
+
       def gpio_open_module(pin:, mode: :output, max_stack: 2)
         native_session.gpio_open_module(pin, gpio_mode(mode), max_stack)
       end
@@ -296,6 +300,18 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: i2c_open_module(bus: bus, max_stack: max_stack)
+        )
+      end
+
+      def upload_i2c_write_u8(
+        program_id: @program_id,
+        address:,
+        byte:,
+        max_stack: 4
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: i2c_write_u8_module(address: address, byte: byte, max_stack: max_stack)
         )
       end
 
@@ -644,6 +660,30 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def i2c_write_u8(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        address:,
+        byte:,
+        max_stack: 4
+      )
+        results = upload_i2c_write_u8(
+          program_id: program_id,
+          address: address,
+          byte: byte,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def gpio_open(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -845,6 +885,8 @@ module CodingAdventures
           upload_dac_write_u12(**dac_write_u12_command_options(words, command, options, require_budget: false))
         when "upload-i2c-open", "upload-i2c.open"
           upload_i2c_open(**i2c_open_command_options(words, command, options, require_budget: false))
+        when "upload-i2c-write-u8", "upload-i2c.write_u8", "upload-i2c-write"
+          upload_i2c_write_u8(**i2c_write_u8_command_options(words, command, options, require_budget: false))
         when "upload-gpio-open", "upload-gpio.open"
           upload_gpio_open(**gpio_open_command_options(words, command, options, require_budget: false))
         when "upload-gpio-handle-read", "upload-gpio.handle-read"
@@ -883,6 +925,8 @@ module CodingAdventures
           dac_write_u12(**dac_write_u12_command_options(words, command, options))
         when "i2c-open", "i2c.open"
           i2c_open(**i2c_open_command_options(words, command, options))
+        when "i2c-write-u8", "i2c.write_u8", "i2c-write"
+          i2c_write_u8(**i2c_write_u8_command_options(words, command, options))
         when "gpio-high", "gpio.high"
           gpio_write(**gpio_level_command_options(words, command, options, value: true))
         when "gpio-low", "gpio.low"
@@ -1125,6 +1169,22 @@ module CodingAdventures
 
         ensure_no_extra_arguments!(words, command)
         raise ArgumentError, "#{command} requires bus" unless merged.key?(:bus)
+
+        merged
+      end
+
+      def i2c_write_u8_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:address] = integer_argument(words.shift, "#{command} address") unless words.empty?
+        merged[:byte] = integer_argument(words.shift, "#{command} byte") unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires address" unless merged.key?(:address)
+        raise ArgumentError, "#{command} requires byte" unless merged.key?(:byte)
 
         merged
       end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -39,6 +39,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "adc.read"
         assert_includes uno_r4_wifi["capabilities"], "dac.write_u12"
         assert_includes uno_r4_wifi["capabilities"], "i2c.open"
+        assert_includes uno_r4_wifi["capabilities"], "i2c.write_u8"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -1297,6 +1298,30 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_i2c_write_u8_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        open_result = nil
+        write_result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          open_result = board.i2c.open(bus: 0, program_id: 10, budget: 24)
+          write_result = board.i2c.write_u8(address: 0x3c, byte: 0xa5, program_id: 11, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 10, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal open_result.frames + write_result.frames, transport.frames
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          write_result.results.map(&:command)
+      end
+
       def test_store_program_dispatches_native_protocol_frame_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1711,6 +1736,26 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_i2c_write_u8
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("i2c-write-u8 60 165 24", program_id: 9)
+          upload = board.session.run_command("upload-i2c-write-u8 60 165", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
       def test_board_descriptor_wraps_rust_decoded_capability_report
         decoded = {
           "kind" => "caps_report",
@@ -1835,6 +1880,10 @@ module CodingAdventures
         i2c_module_bytes = session.i2c_open_module(0, 2)
         assert_instance_of String, i2c_module_bytes
         assert_operator i2c_module_bytes.bytesize, :>, 0
+
+        i2c_write_module_bytes = session.i2c_write_u8_module(0x3c, 0xa5, 4)
+        assert_instance_of String, i2c_write_module_bytes
+        assert_operator i2c_write_module_bytes.bytesize, :>, 0
 
         gpio_module_bytes = session.gpio_read_module(13, 2, 2)
         assert_instance_of String, gpio_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -2,8 +2,8 @@
 
 use board_vm_ir::{
     parse_module, validate, CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
-    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
-    CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
+    CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -92,6 +92,12 @@ const I2C_OPEN_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor 
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "i2c.open",
+};
+const I2C_WRITE_U8_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_I2C_WRITE_U8,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "i2c.write_u8",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -586,7 +592,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_AND_DAC_CAPABILITIES: [CapabilityDescriptor<'st
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
-pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 11] = [
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 12] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -597,6 +603,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor
     ADC_READ_DESCRIPTOR,
     DAC_WRITE_U12_DESCRIPTOR,
     I2C_OPEN_DESCRIPTOR,
+    I2C_WRITE_U8_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
@@ -655,7 +662,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDes
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<
     'static,
->; 12] = [
+>; 13] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -666,6 +673,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [Capabilit
     ADC_READ_DESCRIPTOR,
     DAC_WRITE_U12_DESCRIPTOR,
     I2C_OPEN_DESCRIPTOR,
+    I2C_WRITE_U8_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,7 +1,7 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ,
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
-    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
     FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MODULE_MAGIC,
     MODULE_VERSION,
 };
@@ -43,6 +43,8 @@ pub const DAC_WRITE_U12_CODE_LEN: usize = 8;
 pub const DAC_WRITE_U12_MODULE_LEN: usize = 18;
 pub const I2C_OPEN_CODE_LEN: usize = 6;
 pub const I2C_OPEN_MODULE_LEN: usize = 16;
+pub const I2C_WRITE_U8_CODE_LEN: usize = 8;
+pub const I2C_WRITE_U8_MODULE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -184,9 +186,26 @@ pub struct I2cOpenProgram {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct I2cWriteU8Program {
+    pub address: u16,
+    pub byte: u8,
+    pub max_stack: u8,
+}
+
 impl I2cOpenProgram {
     pub const fn new(bus: u8) -> Self {
         Self { bus, max_stack: 2 }
+    }
+}
+
+impl I2cWriteU8Program {
+    pub const fn new(address: u16, byte: u8) -> Self {
+        Self {
+            address,
+            byte,
+            max_stack: 4,
+        }
     }
 }
 
@@ -1180,6 +1199,50 @@ pub fn write_i2c_open_module(program: I2cOpenProgram, out: &mut [u8]) -> Result<
     Ok(offset)
 }
 
+pub fn write_i2c_write_u8_code(
+    program: I2cWriteU8Program,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < I2C_WRITE_U8_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_push_u16(out, &mut offset, program.address)?;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.byte)?;
+    write_call_u8(out, &mut offset, CAP_I2C_WRITE_U8)?;
+    Ok(offset)
+}
+
+pub fn write_i2c_write_u8_module(
+    program: I2cWriteU8Program,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < I2C_WRITE_U8_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; I2C_WRITE_U8_CODE_LEN];
+    let code_len = write_i2c_write_u8_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_i2c(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_led_matrix_frame_code(
     program: LedMatrixFrameProgram,
     out: &mut [u8],
@@ -1329,7 +1392,8 @@ mod tests {
     use super::*;
     use board_vm_ir::{
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
-        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
+        CAP_PWM_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -1383,6 +1447,10 @@ mod tests {
     const I2C_OPEN_BUS0_MODULE_HEX: [u8; I2C_OPEN_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x02, 0x00, 0x06, 0x12, 0x00, 0x40, 0x23, 0x20, 0x50,
         0x00,
+    ];
+    const I2C_WRITE_U8_3C_A5_MODULE_HEX: [u8; I2C_WRITE_U8_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x04, 0x00, 0x08, 0x20, 0x13, 0x3C, 0x00, 0x12, 0xA5,
+        0x40, 0x24, 0x00,
     ];
     const LED_MATRIX_HEART_MODULE_HEX: [u8; LED_MATRIX_FRAME_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x12, 0x14, 0x44, 0xA4, 0x84, 0x31, 0x14,
@@ -1585,6 +1653,21 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_I2C_OPEN]);
+    }
+
+    #[test]
+    fn builds_i2c_write_u8_module() {
+        let mut module = [0u8; I2C_WRITE_U8_MODULE_LEN];
+        let len =
+            write_i2c_write_u8_module(I2cWriteU8Program::new(0x3c, 0xa5), &mut module).unwrap();
+        assert_eq!(len, I2C_WRITE_U8_MODULE_LEN);
+        assert_eq!(module, I2C_WRITE_U8_3C_A5_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_i2c(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_WRITE_U8]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -20,6 +20,7 @@ pub const CAP_PWM_WRITE: u16 = 0x20;
 pub const CAP_ADC_READ: u16 = 0x21;
 pub const CAP_DAC_WRITE_U12: u16 = 0x22;
 pub const CAP_I2C_OPEN: u16 = 0x23;
+pub const CAP_I2C_WRITE_U8: u16 = 0x24;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -32,6 +33,7 @@ const CAP_PWM_WRITE_U8: u8 = CAP_PWM_WRITE as u8;
 const CAP_ADC_READ_U8: u8 = CAP_ADC_READ as u8;
 const CAP_DAC_WRITE_U12_U8: u8 = CAP_DAC_WRITE_U12 as u8;
 const CAP_I2C_OPEN_U8: u8 = CAP_I2C_OPEN as u8;
+const CAP_I2C_WRITE_U8_U8: u8 = CAP_I2C_WRITE_U8 as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -166,7 +168,7 @@ impl CapabilitySet {
             CAP_PWM_WRITE => self.pwm,
             CAP_ADC_READ => self.adc,
             CAP_DAC_WRITE_U12 => self.dac,
-            CAP_I2C_OPEN => self.i2c,
+            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 => self.i2c,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -403,6 +405,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_ADC_READ_U8) | Op::CallU16(CAP_ADC_READ) => (1, 1),
         Op::CallU8(CAP_DAC_WRITE_U12_U8) | Op::CallU16(CAP_DAC_WRITE_U12) => (2, 0),
         Op::CallU8(CAP_I2C_OPEN_U8) | Op::CallU16(CAP_I2C_OPEN) => (1, 1),
+        Op::CallU8(CAP_I2C_WRITE_U8_U8) | Op::CallU16(CAP_I2C_WRITE_U8) => (3, 0),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -618,6 +621,21 @@ mod tests {
     }
 
     #[test]
+    fn validates_i2c_write_u8_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 4,
+            code: &[0x20, 0x12, 0x3c, 0x12, 0xa5, 0x40, CAP_I2C_WRITE_U8 as u8],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_i2c(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_WRITE_U8]);
+    }
+
+    #[test]
     fn rejects_pwm_write_without_capability() {
         let module = Module {
             flags: 0,
@@ -674,6 +692,21 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 2),
             Err(ValidateError::UnsupportedCapability(CAP_I2C_OPEN))
+        );
+    }
+
+    #[test]
+    fn rejects_i2c_write_u8_without_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 4,
+            code: &[0x20, 0x12, 0x3c, 0x12, 0xa5, 0x40, CAP_I2C_WRITE_U8 as u8],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 4),
+            Err(ValidateError::UnsupportedCapability(CAP_I2C_WRITE_U8))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -38,16 +38,17 @@ use board_vm_host::{
     write_adc_read_module, write_blink_module, write_dac_write_u12_module,
     write_gpio_handle_close_module, write_gpio_handle_read_module, write_gpio_handle_write_module,
     write_gpio_open_module, write_gpio_read_module, write_gpio_write_module, write_i2c_open_module,
-    write_led_matrix_frame_module, write_module, write_pwm_write_module, write_time_now_module,
-    write_time_sleep_ms_module, AdcReadProgram, BlinkProgram, DacWriteU12Program,
-    GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram,
-    GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram,
-    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
-    DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN,
-    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
-    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
-    PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    write_i2c_write_u8_module, write_led_matrix_frame_module, write_module, write_pwm_write_module,
+    write_time_now_module, write_time_sleep_ms_module, AdcReadProgram, BlinkProgram,
+    DacWriteU12Program, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
+    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram,
+    I2cWriteU8Program, LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, TimeNowProgram,
+    TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN,
+    DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
+    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
+    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
+    I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
+    TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -1635,6 +1636,13 @@ pub fn build_i2c_open_module(
     Ok(write_i2c_open_module(program, out)?)
 }
 
+pub fn build_i2c_write_u8_module(
+    program: I2cWriteU8Program,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_i2c_write_u8_module(program, out)?)
+}
+
 pub fn build_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2359,6 +2367,31 @@ pub unsafe extern "C" fn board_vm_language_i2c_open_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_i2c_write_u8_module(
+    address: u16,
+    byte: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_i2c_write_u8_module(
+            I2cWriteU8Program {
+                address,
+                byte,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2684,6 +2717,11 @@ pub extern "C" fn board_vm_language_i2c_open_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_i2c_write_u8_module_len() -> u64 {
+    I2C_WRITE_U8_MODULE_LEN as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_led_matrix_frame_module_len() -> u64 {
     LED_MATRIX_FRAME_MODULE_LEN as u64
 }
@@ -2921,6 +2959,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"adc.read".to_owned()));
         assert!(uno.capabilities.contains(&"dac.write_u12".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.open".to_owned()));
+        assert!(uno.capabilities.contains(&"i2c.write_u8".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -3737,6 +3776,19 @@ mod tests {
         };
         assert_eq!(i2c_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(i2c_status.len, I2C_OPEN_MODULE_LEN as u64);
+
+        let mut i2c_write_module = [0u8; I2C_WRITE_U8_MODULE_LEN];
+        let i2c_write_status = unsafe {
+            board_vm_language_i2c_write_u8_module(
+                0x3c,
+                0xa5,
+                4,
+                i2c_write_module.as_mut_ptr(),
+                i2c_write_module.len() as u64,
+            )
+        };
+        assert_eq!(i2c_write_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(i2c_write_status.len, I2C_WRITE_U8_MODULE_LEN as u64);
 
         let mut gpio_read_module = [0u8; GPIO_READ_MODULE_LEN];
         let gpio_read_status = unsafe {

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -2,7 +2,7 @@
 
 use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_DAC_WRITE_U12,
-    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
+    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_WRITE_U8,
     CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 
@@ -75,6 +75,10 @@ pub trait BoardHal {
     }
 
     fn i2c_open(&mut self, _bus: u16) -> Result<u32, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn i2c_write_u8(&mut self, _token: u32, _address: u16, _byte: u8) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -453,6 +457,18 @@ where
                 let handle = self.alloc_handle(HandleKind::I2c, token, ip)?;
                 self.push(Value::Handle(handle), ip)
             }
+            CAP_I2C_WRITE_U8 => {
+                let byte = self.pop_u8(ip)?;
+                let address = self.pop_u16(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::I2c, ip)?;
+                self.hal
+                    .i2c_write_u8(token, address, byte)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -531,6 +547,16 @@ where
         match self.pop(ip)? {
             Value::U8(value) => Ok(value as u16),
             Value::U16(value) => Ok(value),
+            _ => Err(RuntimeError {
+                ip,
+                kind: RuntimeErrorKind::TypeMismatch,
+            }),
+        }
+    }
+
+    fn pop_u8(&mut self, ip: usize) -> Result<u8, RuntimeError> {
+        match self.pop(ip)? {
+            Value::U8(value) => Ok(value),
             _ => Err(RuntimeError {
                 ip,
                 kind: RuntimeErrorKind::TypeMismatch,
@@ -687,6 +713,7 @@ mod tests {
         AdcRead(u16),
         DacWriteU12(u16, u16),
         I2cOpen(u16),
+        I2cWriteU8(u32, u16, u8),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -760,6 +787,11 @@ mod tests {
         fn i2c_open(&mut self, bus: u16) -> Result<u32, HalError> {
             self.events.push(Event::I2cOpen(bus));
             Ok(0x1_2000 | bus as u32)
+        }
+
+        fn i2c_write_u8(&mut self, token: u32, address: u16, byte: u8) -> Result<(), HalError> {
+            self.events.push(Event::I2cWriteU8(token, address, byte));
+            Ok(())
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -924,5 +956,22 @@ mod tests {
         );
         assert_eq!(report.open_handles, 1);
         assert_eq!(runtime.hal().events, vec![Event::I2cOpen(0)]);
+    }
+
+    #[test]
+    fn i2c_write_u8_dispatches_handle_address_and_byte() {
+        let mut runtime: Runtime<FakeHal, 4, 2> = Runtime::new(FakeHal::new());
+        let open = [0x12, 1, 0x40, CAP_I2C_OPEN as u8, 0x20, 0x50];
+        let write = [0x20, 0x12, 0x3c, 0x12, 0xa5, 0x40, CAP_I2C_WRITE_U8 as u8];
+
+        runtime.run_code(&open, 10).unwrap();
+        let report = runtime.run_code(&write, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            runtime.hal().events,
+            vec![Event::I2cOpen(1), Event::I2cWriteU8(0x1_2001, 0x3c, 0xa5)]
+        );
     }
 }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -112,7 +112,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 12] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 13] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -124,10 +124,11 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 12] = [
     "adc.read",
     "dac.write_u12",
     "i2c.open",
+    "i2c.write_u8",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 16] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 17] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -142,6 +143,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 16] = [
     "adc.read",
     "dac.write_u12",
     "i2c.open",
+    "i2c.write_u8",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -607,6 +609,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"adc.read"));
         assert!(uno.capabilities.contains(&"dac.write_u12"));
         assert!(uno.capabilities.contains(&"i2c.open"));
+        assert!(uno.capabilities.contains(&"i2c.write_u8"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -30,6 +30,7 @@ pub const ARDUINO_USB_START_SYMBOL: &str = "_Z10__USBStartv";
 pub const BOARD_VM_UNO_R4_PWM_WRITE_SYMBOL: &str = "board_vm_uno_r4_pwm_write";
 pub const BOARD_VM_UNO_R4_ADC_READ_SYMBOL: &str = "board_vm_uno_r4_adc_read";
 pub const BOARD_VM_UNO_R4_DAC_WRITE_U12_SYMBOL: &str = "board_vm_uno_r4_dac_write_u12";
+pub const BOARD_VM_UNO_R4_I2C_WRITE_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_write_u8";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
@@ -88,19 +89,20 @@ pub const ARDUINO_USB_LINK_SOURCES: &[ArduinoLinkSource] = &[
     ArduinoLinkSource::cxx("cores/arduino/IRQManager.cpp"),
     ArduinoLinkSource::cxx("cores/arduino/FspTimer.cpp"),
     ArduinoLinkSource::cxx("cores/arduino/pwm.cpp"),
+    ArduinoLinkSource::cxx("libraries/Wire/Wire.cpp"),
     ArduinoLinkSource::cxx("cores/arduino/usb/USB.cpp"),
     ArduinoLinkSource::static_archive(UNO_R4_WIFI_FSP_ARCHIVE),
 ];
 
 pub const ARDUINO_USB_LINK_INCLUDE_DIRS: &[&str] = &[
     "cores/arduino",
-    "cores/arduino/api",
     "cores/arduino/tinyusb",
     "cores/arduino/tinyusb/common",
     "cores/arduino/tinyusb/device",
     "cores/arduino/usb",
     "cores/arduino/api/deprecated",
     "cores/arduino/api/deprecated-avr-comp",
+    "libraries/Wire",
     "variants/UNOWIFIR4",
     "variants/UNOWIFIR4/includes/ra/fsp/inc",
     "variants/UNOWIFIR4/includes/ra/fsp/inc/api",
@@ -230,6 +232,7 @@ mod tests {
         assert!(contains_source("cores/arduino/IRQManager.cpp"));
         assert!(contains_source("cores/arduino/FspTimer.cpp"));
         assert!(contains_source("cores/arduino/pwm.cpp"));
+        assert!(contains_source("libraries/Wire/Wire.cpp"));
         assert!(contains_source("cores/arduino/tinyusb/tusb.c"));
         assert!(contains_source(
             "cores/arduino/tinyusb/class/cdc/cdc_device.c"
@@ -275,6 +278,10 @@ mod tests {
         assert_eq!(
             BOARD_VM_UNO_R4_DAC_WRITE_U12_SYMBOL,
             "board_vm_uno_r4_dac_write_u12"
+        );
+        assert_eq!(
+            BOARD_VM_UNO_R4_I2C_WRITE_U8_SYMBOL,
+            "board_vm_uno_r4_i2c_write_u8"
         );
         assert_eq!(
             BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE,

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -208,6 +208,14 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         Ok(0x12_0000 | bus as u32)
     }
 
+    fn write_i2c_u8(&mut self, bus: u8, address: u16, byte: u8) -> Result<(), HalError> {
+        if unsafe { board_io_ffi::board_vm_uno_r4_i2c_write_u8(bus, address, byte) } {
+            Ok(())
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+
     fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
         board_vm_uno_r4_usb_cdc::reboot_to_bootloader()
     }
@@ -219,5 +227,6 @@ mod board_io_ffi {
         pub fn board_vm_uno_r4_pwm_write(pin: u8, duty: u16) -> bool;
         pub fn board_vm_uno_r4_adc_read(pin: u8, sample: *mut u16) -> bool;
         pub fn board_vm_uno_r4_dac_write_u12(pin: u8, sample: u16) -> bool;
+        pub fn board_vm_uno_r4_i2c_write_u8(bus: u8, address: u16, byte: u8) -> bool;
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -4,6 +4,7 @@
 #include <new>
 
 #include "Arduino.h"
+#include "Wire.h"
 #include "hal_data.h"
 #include "pwm.h"
 #include "pinmux.inc"
@@ -19,11 +20,21 @@ constexpr size_t kOperatorNewHeapBytes = 2048;
 constexpr uint32_t kAdcRawMax = (1u << BSP_FEATURE_ADC_MAX_RESOLUTION_BITS) - 1u;
 constexpr uint32_t kAdcNormalizedMax = 65535u;
 constexpr uint32_t kAdcScanPollLimit = 100000u;
+constexpr uint16_t kI2cMax7BitAddress = 0x7Fu;
 
 struct PwmSlot {
   uint8_t pin;
   alignas(PwmOut) uint8_t storage[sizeof(PwmOut)];
   PwmOut *pwm;
+  bool started;
+};
+
+struct I2cSlot {
+  uint8_t bus;
+  uint8_t scl_pin;
+  uint8_t sda_pin;
+  alignas(TwoWire) uint8_t storage[sizeof(TwoWire)];
+  TwoWire *wire;
   bool started;
 };
 
@@ -36,6 +47,10 @@ PwmSlot g_pwm_slots[] = {
   {9, {}, nullptr, false},
   {10, {}, nullptr, false},
   {11, {}, nullptr, false},
+};
+I2cSlot g_i2c_slots[] = {
+  {0, WIRE_SCL_PIN, WIRE_SDA_PIN, {}, nullptr, false},
+  {1, WIRE1_SCL_PIN, WIRE1_SDA_PIN, {}, nullptr, false},
 };
 bool g_pwm_channels_reserved = false;
 adc_instance_ctrl_t g_board_vm_adc_ctrl = {};
@@ -51,6 +66,15 @@ bool g_board_vm_dac_opened = false;
 PwmSlot *find_slot(uint8_t pin) {
   for (auto &slot : g_pwm_slots) {
     if (slot.pin == pin) {
+      return &slot;
+    }
+  }
+  return nullptr;
+}
+
+I2cSlot *find_i2c_slot(uint8_t bus) {
+  for (auto &slot : g_i2c_slots) {
+    if (slot.bus == bus) {
       return &slot;
     }
   }
@@ -97,6 +121,13 @@ PwmOut *slot_pwm(PwmSlot &slot) {
     slot.pwm = new (slot.storage) PwmOut(slot.pin);
   }
   return slot.pwm;
+}
+
+TwoWire *slot_wire(I2cSlot &slot) {
+  if (slot.wire == nullptr) {
+    slot.wire = new (slot.storage) TwoWire(slot.scl_pin, slot.sda_pin);
+  }
+  return slot.wire;
 }
 
 bool pin_cfg_matches(uint16_t cfg, PinCfgReq_t req) {
@@ -207,6 +238,12 @@ void operator delete[](void *) noexcept {}
 void operator delete(void *, size_t) noexcept {}
 
 void operator delete[](void *, size_t) noexcept {}
+
+// Wire.cpp uses micros() only as a transaction timeout clock in this firmware.
+unsigned long micros() {
+  static unsigned long ticks = 0;
+  return ++ticks;
+}
 
 extern "C" const PinMuxCfg_t g_pin_cfg[] = {
   {BSP_IO_PORT_03_PIN_01, P301}, /* (0) D0 */
@@ -393,4 +430,27 @@ extern "C" bool board_vm_uno_r4_dac_write_u12(uint8_t pin, uint16_t sample) {
   }
 
   return R_DAC_Write(&g_board_vm_dac_ctrl, sample) == FSP_SUCCESS;
+}
+
+extern "C" bool board_vm_uno_r4_i2c_write_u8(uint8_t bus, uint16_t address, uint8_t byte) {
+  if (address > kI2cMax7BitAddress) {
+    return false;
+  }
+
+  I2cSlot *slot = find_i2c_slot(bus);
+  if (slot == nullptr) {
+    return false;
+  }
+
+  TwoWire *wire = slot_wire(*slot);
+  if (!slot->started) {
+    wire->begin();
+    slot->started = true;
+  }
+
+  wire->beginTransmission(address);
+  if (wire->write(byte) != 1) {
+    return false;
+  }
+  return wire->endTransmission() == END_TX_OK;
 }

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -383,6 +383,10 @@ pub trait UnoR4Backend {
         Err(HalError::UnsupportedMode)
     }
 
+    fn write_i2c_u8(&mut self, _bus: u8, _address: u16, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn supports_bootloader_reboot(&self) -> bool {
         false
     }
@@ -504,6 +508,12 @@ where
         self.backend.open_i2c(bus)
     }
 
+    fn i2c_write_u8(&mut self, token: u32, address: u16, byte: u8) -> Result<(), HalError> {
+        let bus = normalize_i2c_token(self.target, token)?;
+        normalize_i2c_address(address)?;
+        self.backend.write_i2c_u8(bus, address, byte)
+    }
+
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
         if !self.target.supports_led_matrix {
             return Err(HalError::UnsupportedMode);
@@ -565,6 +575,19 @@ fn normalize_i2c_bus(target: &TargetDescriptor, bus: u16) -> Result<u8, HalError
         .any(|descriptor| descriptor.bus == bus)
     {
         Ok(bus)
+    } else {
+        Err(HalError::InvalidPin)
+    }
+}
+
+fn normalize_i2c_token(target: &TargetDescriptor, token: u32) -> Result<u8, HalError> {
+    let bus = u16::try_from(token & 0xff).map_err(|_| HalError::InvalidPin)?;
+    normalize_i2c_bus(target, bus)
+}
+
+fn normalize_i2c_address(address: u16) -> Result<(), HalError> {
+    if address <= 0x7f {
+        Ok(())
     } else {
         Err(HalError::InvalidPin)
     }
@@ -688,6 +711,7 @@ mod tests {
         AdcRead(u8),
         DacWriteU12(u8, u16),
         I2cOpen(u8),
+        I2cWriteU8(u8, u16, u8),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -769,6 +793,11 @@ mod tests {
         fn open_i2c(&mut self, bus: u8) -> Result<u32, HalError> {
             self.events.push(Event::I2cOpen(bus));
             Ok(0x1_2000 | bus as u32)
+        }
+
+        fn write_i2c_u8(&mut self, bus: u8, address: u16, byte: u8) -> Result<(), HalError> {
+            self.events.push(Event::I2cWriteU8(bus, address, byte));
+            Ok(())
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -868,6 +897,9 @@ mod tests {
             .capabilities
             .supports(board_vm_ir::CAP_DAC_WRITE_U12));
         assert!(UNO_R4_WIFI.capabilities.supports(board_vm_ir::CAP_I2C_OPEN));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_WRITE_U8));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -880,6 +912,9 @@ mod tests {
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_I2C_OPEN));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_WRITE_U8));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -974,6 +1009,32 @@ mod tests {
 
         assert_eq!(board.i2c_open(1), Err(HalError::InvalidPin));
         assert_eq!(board.i2c_open(99), Err(HalError::InvalidPin));
+    }
+
+    #[test]
+    fn i2c_write_u8_runs_through_bus_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        board.i2c_write_u8(0x1_2001, 0x3c, 0xa5).unwrap();
+
+        assert_eq!(
+            board.backend().events,
+            vec![Event::I2cWriteU8(1, 0x3c, 0xa5)]
+        );
+    }
+
+    #[test]
+    fn i2c_write_u8_rejects_unknown_bus_or_address() {
+        let mut board = UnoR4Board::minima(FakeBackend::new());
+
+        assert_eq!(
+            board.i2c_write_u8(0x1_2001, 0x3c, 0xa5),
+            Err(HalError::InvalidPin)
+        );
+        assert_eq!(
+            board.i2c_write_u8(0x1_2000, 0x80, 0xa5),
+            Err(HalError::InvalidPin)
+        );
     }
 
     #[test]

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -201,11 +201,17 @@ metadata. The operation is intentionally direct and stateless, mirroring
 | ID | Name | Args | Returns |
 |---:|---|---|---|
 | `0x23` | `i2c.open` | `bus: u16/u8` | `handle` |
+| `0x24` | `i2c.write_u8` | `handle`, `address: u16/u8`, `byte: u8` | `unit` |
 
 `i2c.open` opens a board-advertised I2C controller and returns a persistent bus
-handle. The handle is the lifetime anchor for later `i2c.write`, `i2c.read`,
-and `i2c.transfer` operations, keeping bus identity and pin ownership out of
-language frontends.
+handle. The handle is the lifetime anchor for transfer operations, keeping bus
+identity and pin ownership out of language frontends.
+
+`i2c.write_u8` writes a single byte to a 7-bit device address on an already
+opened bus handle. It is the first concrete I2C transfer primitive because the
+current VM value set has scalar integers but no byte-buffer value yet. Wider
+`i2c.write`, `i2c.read`, and `i2c.transfer` operations should reuse the same
+handle model once the byte-buffer ABI exists.
 
 ### LED Matrix
 

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -29,7 +29,7 @@ Source snapshot:
 | PWM output | D3, D5, D6, D9, D10, D11 in the Arduino variant init path | implemented as direct write | `pwm.write` |
 | Analog input | A0-A5 | implemented as direct read | `adc.read` |
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
-| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata and handle open implemented | `i2c.open`, then `i2c.write`, `i2c.read`, `i2c.transfer` |
+| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, and single-byte write implemented | `i2c.open`, `i2c.write_u8`, then wider `i2c.write`, `i2c.read`, `i2c.transfer` |
 | SPI master | MOSI D11, MISO D12, SCK D13, CS D10 | pending | `spi.open`, `spi.transfer`, `spi.close` |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
@@ -68,8 +68,9 @@ reject conflicting handles.
    analog-adjacent VM operations. Add handle-oriented variants only when a
    later streaming or event tranche needs persistent resource ownership.
 4. Implement I2C and SPI as bus handles with explicit transfer boundaries;
-   `i2c.open` establishes the first I2C handle tranche, with write/read/transfer
-   transactions following as separate slices.
+   `i2c.open` establishes the first I2C handle tranche, and `i2c.write_u8`
+   proves the Rust-owned transfer path through Arduino `Wire`/`Wire1`.
+   Byte-buffer write/read/transfer transactions follow as separate slices.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 


### PR DESCRIPTION
## Summary

- Adds the portable `i2c.write_u8` bytecode capability over an existing persistent I2C handle.
- Wires the capability through the runtime HAL, UNO R4 target descriptor/backend, host module builder, Rust language core ABI, and Ruby session/connection helpers.
- Links the UNO R4 SerialUSB firmware against Arduino `Wire`/`Wire1` so the physical backend can send one-byte I2C writes on board-owned bus metadata.
- Updates the Board VM bytecode and UNO R4 feature-inventory specs to describe this scalar I2C transfer slice.

## Validation

- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `cargo test -p board-vm-uno-r4-firmware` in `code/packages/rust`
- `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1 cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" --arm-toolchain-bin /opt/homebrew/bin --arm-compat-root "$HOME/Library/Arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4"`
- `bundle exec rake test` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
