### PR TITLE
python(spice): parse VCVS netlist elements

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.1
+
+- Add SPICE `E` / VCVS controlled-source parsing, including subcircuit node
+  remapping for expanded VCVS elements.
+
 ## 0.1.0
 
 - Add a first SPICE3 netlist parser slice for linear R/C/L circuits,

--- a/code/packages/python/spice-netlist-parser/pyproject.toml
+++ b/code/packages/python/spice-netlist-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-netlist-parser"
-version = "0.1.0"
+version = "0.1.1"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -11,7 +11,7 @@ from spice_netlist_parser.parser import (
 )
 
 parse = parse_netlist
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "AcAnalysis",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 
 from spice_engine import (
     VCCS,
+    VCVS,
     Capacitor,
     Circuit,
     CurrentSource,
@@ -215,6 +216,9 @@ def _parse_element(fields: list[str]) -> object:
     if prefix == "G":
         _require_fields(fields, 6, "VCCS")
         return VCCS(name, fields[1], fields[2], fields[3], fields[4], parse_value(fields[5]))
+    if prefix == "E":
+        _require_fields(fields, 6, "VCVS")
+        return VCVS(name, fields[1], fields[2], fields[3], fields[4], parse_value(fields[5]))
     raise NetlistParseError(f"unsupported element {name!r}")
 
 
@@ -289,8 +293,8 @@ def _map_subckt_fields(
         _require_min_fields(fields, 3, "subcircuit element")
         mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
         mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)
-    elif prefix == "G":
-        _require_min_fields(fields, 5, "subcircuit VCCS")
+    elif prefix in {"E", "G"}:
+        _require_min_fields(fields, 5, "subcircuit controlled source")
         for index in range(1, 5):
             mapped[index] = _map_subckt_node(fields[index], instance_name, node_map)
     elif prefix == "X":

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1,7 +1,16 @@
 from math import isclose
 
 import pytest
-from spice_engine import VCCS, Capacitor, CurrentSource, Inductor, Resistor, VoltageSource, dc_op
+from spice_engine import (
+    VCCS,
+    VCVS,
+    Capacitor,
+    CurrentSource,
+    Inductor,
+    Resistor,
+    VoltageSource,
+    dc_op,
+)
 
 from spice_netlist_parser import (
     AcAnalysis,
@@ -67,6 +76,25 @@ G1 out 0 in 0 2m
     ]
 
 
+def test_parse_vcvs_into_operating_point_circuit() -> None:
+    parsed = parse_netlist(
+        """
+Vctrl in 0 DC 1.5
+Eamp out 0 in 0 4
+Rload out 0 1k
+.op
+"""
+    )
+
+    assert isinstance(parsed.circuit.elements[1], VCVS)
+    assert parsed.circuit.elements[1].ctrl_plus == "in"
+    assert parsed.circuit.elements[1].gain == 4.0
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert isclose(result.node_voltages["out"], 6.0, abs_tol=1e-9)
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """
@@ -110,6 +138,34 @@ Xdiv vin mid 0 divider
     result = dc_op(parsed.circuit)
     assert result.converged
     assert isclose(result.node_voltages["mid"], 5.0, abs_tol=1e-9)
+
+
+def test_expands_subcircuit_vcvs_nodes_into_engine_elements() -> None:
+    parsed = parse_netlist(
+        """
+.subckt gain inp outp
+Ebuf outp 0 inp 0 2
+.ends gain
+V1 in 0 DC 1.25
+Xgain in out gain
+Rload out 0 1k
+.op
+"""
+    )
+
+    assert [element.name for element in parsed.circuit.elements] == [
+        "V1",
+        "Xgain.Ebuf",
+        "Rload",
+    ]
+    vcvs = parsed.circuit.elements[1]
+    assert isinstance(vcvs, VCVS)
+    assert vcvs.n_plus == "out"
+    assert vcvs.ctrl_plus == "in"
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert isclose(result.node_voltages["out"], 2.5, abs_tol=1e-9)
 
 
 def test_subcircuit_internal_nodes_are_instance_scoped() -> None:


### PR DESCRIPTION
## Summary

- add SPICE `E` / VCVS parsing to the Python netlist parser
- map VCVS output and control nodes during `.subckt` expansion
- cover direct and subcircuit-expanded VCVS netlists with DC operating-point validation

## Validation

- sh BUILD
- git diff --check