### PR TITLE
ts(spice): parse VCVS netlist elements

### DIFF
--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.1
+
+- Add SPICE `E` / VCVS controlled-source parsing, including subcircuit node
+  remapping for expanded VCVS elements.
+
 ## 0.1.0
 
 - Add a first SPICE3 netlist parser slice for linear R/C/L circuits,

--- a/code/packages/typescript/spice-netlist-parser/package.json
+++ b/code/packages/typescript/spice-netlist-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/spice-netlist-parser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -11,6 +11,7 @@ import {
   inductor,
   resistor,
   vccs,
+  vcvs,
   voltageSource,
   voltageSourceWithWaveform,
   type Element,
@@ -243,6 +244,10 @@ function parseElement(fields: readonly string[]): Element {
     requireFields(fields, 6, "VCCS");
     return vccs(name, fields[1], fields[2], fields[3], fields[4], parseValue(fields[5]));
   }
+  if (prefix === "E") {
+    requireFields(fields, 6, "VCVS");
+    return vcvs(name, fields[1], fields[2], fields[3], fields[4], parseValue(fields[5]));
+  }
   throw new NetlistParseError(`unsupported element ${JSON.stringify(name)}`);
 }
 
@@ -329,8 +334,8 @@ function mapSubcktFields(
     requireMinFields(fields, 3, "subcircuit element");
     mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
     mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);
-  } else if (prefix === "G") {
-    requireMinFields(fields, 5, "subcircuit VCCS");
+  } else if (prefix === "E" || prefix === "G") {
+    requireMinFields(fields, 5, "subcircuit controlled source");
     for (let index = 1; index < 5; index++) {
       mapped[index] = mapSubcktNode(fields[index], instanceName, nodeMap);
     }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -59,6 +59,25 @@ G1 out 0 in 0 2m
     ]);
   });
 
+  it("parses VCVS elements into operating-point circuits", () => {
+    const parsed = parseNetlist(`
+Vctrl in 0 DC 1.5
+Eamp out 0 in 0 4
+Rload out 0 1k
+.op
+`);
+
+    const elements = parsed.circuit.elements();
+    expect(elements[1]).toMatchObject({
+      kind: "vcvs",
+      controlPositive: "in",
+      gain: 4.0,
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("out")).toBeCloseTo(6.0, 9);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)
@@ -100,6 +119,33 @@ Xdiv vin mid 0 divider
 
     const result = dcOp(parsed.circuit);
     expect(result.voltage("mid")).toBeCloseTo(5.0, 9);
+  });
+
+  it("expands subcircuit VCVS nodes into engine elements", () => {
+    const parsed = parseNetlist(`
+.subckt gain inp outp
+Ebuf outp 0 inp 0 2
+.ends gain
+V1 in 0 DC 1.25
+Xgain in out gain
+Rload out 0 1k
+.op
+`);
+
+    const elements = parsed.circuit.elements();
+    expect(elements.map((element) => element.name)).toEqual([
+      "V1",
+      "Xgain.Ebuf",
+      "Rload",
+    ]);
+    expect(elements[1]).toMatchObject({
+      kind: "vcvs",
+      positive: "out",
+      controlPositive: "in",
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("out")).toBeCloseTo(2.5, 9);
   });
 
   it("scopes subcircuit internal nodes by instance", () => {


### PR DESCRIPTION
## Summary

- add SPICE `E` / VCVS parsing to the TypeScript netlist parser
- map VCVS output and control nodes during `.subckt` expansion
- cover direct and subcircuit-expanded VCVS netlists with DC operating-point validation

## Validation

- sh BUILD
- git diff --check