### PR TITLE
[codex] Add UNO R4 I2C byte read capability

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -5,12 +5,14 @@ use std::slice;
 use board_vm_host::{
     AdcReadProgram, BlinkProgram, DacWriteU12Program, GpioHandleCloseProgram,
     GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
-    GpioWriteProgram, I2cOpenProgram, I2cWriteU8Program, LedMatrixFrameProgram, PwmWriteProgram,
-    TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
+    GpioWriteProgram, I2cOpenProgram, I2cReadU8Program, I2cWriteU8Program,
+    LedMatrixFrameProgram, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
     DAC_WRITE_U12_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
     GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN,
-    I2C_OPEN_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
-    PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    I2C_OPEN_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN,
+    LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
@@ -18,7 +20,8 @@ use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
     build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
     build_dac_write_u12_module, build_gpio_read_module, build_gpio_write_module,
-    build_hello_wire_frame, build_i2c_open_module, build_i2c_write_u8_module,
+    build_hello_wire_frame, build_i2c_open_module, build_i2c_read_u8_module,
+    build_i2c_write_u8_module,
     build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
     build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
     build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
@@ -285,6 +288,19 @@ extern "C" fn session_i2c_write_u8_module(
 
     let module = build_i2c_write_u8_module_value(address, byte, max_stack)
         .unwrap_or_else(|error| raise_core_error("i2c_write_u8_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_i2c_read_u8_module(
+    _self_val: VALUE,
+    address_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let address = rb_u16(address_val, "address");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_i2c_read_u8_module_value(address, max_stack)
+        .unwrap_or_else(|error| raise_core_error("i2c_read_u8_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1519,6 +1535,16 @@ fn build_i2c_write_u8_module_value(
     Ok(module)
 }
 
+fn build_i2c_read_u8_module_value(
+    address: u16,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; I2C_READ_U8_MODULE_LEN];
+    let len = build_i2c_read_u8_module(I2cReadU8Program { address, max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_raw_module_value(
     flags: u8,
     max_stack: u8,
@@ -1845,6 +1871,12 @@ pub extern "C" fn Init_board_vm_native() {
         "i2c_write_u8_module",
         session_i2c_write_u8_module as *const c_void,
         3,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "i2c_read_u8_module",
+        session_i2c_read_u8_module as *const c_void,
+        2,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -466,6 +466,22 @@ module CodingAdventures
         )
       end
 
+      def i2c_read_u8!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        address:,
+        max_stack: 3
+      )
+        ensure_uno_r4_wifi!
+
+        session.i2c_read_u8(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          max_stack: max_stack
+        )
+      end
+
       def store_program!(
         program_id: DEFAULT_PROGRAM_ID,
         slot: DEFAULT_EJECT_SLOT,
@@ -1117,6 +1133,20 @@ module CodingAdventures
           budget: budget,
           address: address,
           byte: byte,
+          max_stack: max_stack
+        )
+      end
+
+      def read_u8(
+        address:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 3
+      )
+        @connection.i2c_read_u8!(
+          program_id: program_id,
+          budget: budget,
+          address: address,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -217,6 +217,10 @@ module CodingAdventures
         native_session.i2c_write_u8_module(address, byte, max_stack)
       end
 
+      def i2c_read_u8_module(address:, max_stack: 3)
+        native_session.i2c_read_u8_module(address, max_stack)
+      end
+
       def gpio_open_module(pin:, mode: :output, max_stack: 2)
         native_session.gpio_open_module(pin, gpio_mode(mode), max_stack)
       end
@@ -312,6 +316,17 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: i2c_write_u8_module(address: address, byte: byte, max_stack: max_stack)
+        )
+      end
+
+      def upload_i2c_read_u8(
+        program_id: @program_id,
+        address:,
+        max_stack: 3
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: i2c_read_u8_module(address: address, max_stack: max_stack)
         )
       end
 
@@ -684,6 +699,28 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def i2c_read_u8(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        address:,
+        max_stack: 3
+      )
+        results = upload_i2c_read_u8(
+          program_id: program_id,
+          address: address,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def gpio_open(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -887,6 +924,8 @@ module CodingAdventures
           upload_i2c_open(**i2c_open_command_options(words, command, options, require_budget: false))
         when "upload-i2c-write-u8", "upload-i2c.write_u8", "upload-i2c-write"
           upload_i2c_write_u8(**i2c_write_u8_command_options(words, command, options, require_budget: false))
+        when "upload-i2c-read-u8", "upload-i2c.read_u8", "upload-i2c-read"
+          upload_i2c_read_u8(**i2c_read_u8_command_options(words, command, options, require_budget: false))
         when "upload-gpio-open", "upload-gpio.open"
           upload_gpio_open(**gpio_open_command_options(words, command, options, require_budget: false))
         when "upload-gpio-handle-read", "upload-gpio.handle-read"
@@ -927,6 +966,8 @@ module CodingAdventures
           i2c_open(**i2c_open_command_options(words, command, options))
         when "i2c-write-u8", "i2c.write_u8", "i2c-write"
           i2c_write_u8(**i2c_write_u8_command_options(words, command, options))
+        when "i2c-read-u8", "i2c.read_u8", "i2c-read"
+          i2c_read_u8(**i2c_read_u8_command_options(words, command, options))
         when "gpio-high", "gpio.high"
           gpio_write(**gpio_level_command_options(words, command, options, value: true))
         when "gpio-low", "gpio.low"
@@ -1185,6 +1226,20 @@ module CodingAdventures
         ensure_no_extra_arguments!(words, command)
         raise ArgumentError, "#{command} requires address" unless merged.key?(:address)
         raise ArgumentError, "#{command} requires byte" unless merged.key?(:byte)
+
+        merged
+      end
+
+      def i2c_read_u8_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:address] = integer_argument(words.shift, "#{command} address") unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires address" unless merged.key?(:address)
 
         merged
       end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -40,6 +40,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "dac.write_u12"
         assert_includes uno_r4_wifi["capabilities"], "i2c.open"
         assert_includes uno_r4_wifi["capabilities"], "i2c.write_u8"
+        assert_includes uno_r4_wifi["capabilities"], "i2c.read_u8"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -1322,6 +1323,30 @@ module CodingAdventures
           write_result.results.map(&:command)
       end
 
+      def test_i2c_read_u8_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        open_result = nil
+        read_result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          open_result = board.i2c.open(bus: 0, program_id: 10, budget: 24)
+          read_result = board.i2c.read_u8(address: 0x3c, program_id: 11, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 10, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal open_result.frames + read_result.frames, transport.frames
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          read_result.results.map(&:command)
+      end
+
       def test_store_program_dispatches_native_protocol_frame_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1756,6 +1781,26 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_i2c_read_u8
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("i2c-read-u8 60 24", program_id: 9)
+          upload = board.session.run_command("upload-i2c-read-u8 60", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
       def test_board_descriptor_wraps_rust_decoded_capability_report
         decoded = {
           "kind" => "caps_report",
@@ -1884,6 +1929,10 @@ module CodingAdventures
         i2c_write_module_bytes = session.i2c_write_u8_module(0x3c, 0xa5, 4)
         assert_instance_of String, i2c_write_module_bytes
         assert_operator i2c_write_module_bytes.bytesize, :>, 0
+
+        i2c_read_module_bytes = session.i2c_read_u8_module(0x3c, 3)
+        assert_instance_of String, i2c_read_module_bytes
+        assert_operator i2c_read_module_bytes.bytesize, :>, 0
 
         gpio_module_bytes = session.gpio_read_module(13, 2, 2)
         assert_instance_of String, gpio_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -2,8 +2,8 @@
 
 use board_vm_ir::{
     parse_module, validate, CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
-    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
-    CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ_U8, CAP_I2C_WRITE_U8,
+    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -98,6 +98,12 @@ const I2C_WRITE_U8_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescrip
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "i2c.write_u8",
+};
+const I2C_READ_U8_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_I2C_READ_U8,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "i2c.read_u8",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -592,7 +598,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_AND_DAC_CAPABILITIES: [CapabilityDescriptor<'st
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
-pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 12] = [
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 13] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -604,6 +610,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor
     DAC_WRITE_U12_DESCRIPTOR,
     I2C_OPEN_DESCRIPTOR,
     I2C_WRITE_U8_DESCRIPTOR,
+    I2C_READ_U8_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
@@ -662,7 +669,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDes
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<
     'static,
->; 13] = [
+>; 14] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -674,6 +681,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [Capabilit
     DAC_WRITE_U12_DESCRIPTOR,
     I2C_OPEN_DESCRIPTOR,
     I2C_WRITE_U8_DESCRIPTOR,
+    I2C_READ_U8_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,9 +1,9 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ,
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
-    CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
-    FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MODULE_MAGIC,
-    MODULE_VERSION,
+    CAP_I2C_READ_U8, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS,
+    CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+    MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -45,6 +45,8 @@ pub const I2C_OPEN_CODE_LEN: usize = 6;
 pub const I2C_OPEN_MODULE_LEN: usize = 16;
 pub const I2C_WRITE_U8_CODE_LEN: usize = 8;
 pub const I2C_WRITE_U8_MODULE_LEN: usize = 18;
+pub const I2C_READ_U8_CODE_LEN: usize = 7;
+pub const I2C_READ_U8_MODULE_LEN: usize = 17;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -193,6 +195,12 @@ pub struct I2cWriteU8Program {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct I2cReadU8Program {
+    pub address: u16,
+    pub max_stack: u8,
+}
+
 impl I2cOpenProgram {
     pub const fn new(bus: u8) -> Self {
         Self { bus, max_stack: 2 }
@@ -205,6 +213,15 @@ impl I2cWriteU8Program {
             address,
             byte,
             max_stack: 4,
+        }
+    }
+}
+
+impl I2cReadU8Program {
+    pub const fn new(address: u16) -> Self {
+        Self {
+            address,
+            max_stack: 3,
         }
     }
 }
@@ -1243,6 +1260,49 @@ pub fn write_i2c_write_u8_module(
     Ok(offset)
 }
 
+pub fn write_i2c_read_u8_code(
+    program: I2cReadU8Program,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < I2C_READ_U8_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_push_u16(out, &mut offset, program.address)?;
+    write_call_u8(out, &mut offset, CAP_I2C_READ_U8)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_i2c_read_u8_module(
+    program: I2cReadU8Program,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < I2C_READ_U8_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; I2C_READ_U8_CODE_LEN];
+    let code_len = write_i2c_read_u8_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_i2c(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_led_matrix_frame_code(
     program: LedMatrixFrameProgram,
     out: &mut [u8],
@@ -1392,8 +1452,8 @@ mod tests {
     use super::*;
     use board_vm_ir::{
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
-        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
-        CAP_PWM_WRITE,
+        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_READ_U8, CAP_I2C_WRITE_U8,
+        CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -1451,6 +1511,10 @@ mod tests {
     const I2C_WRITE_U8_3C_A5_MODULE_HEX: [u8; I2C_WRITE_U8_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x04, 0x00, 0x08, 0x20, 0x13, 0x3C, 0x00, 0x12, 0xA5,
         0x40, 0x24, 0x00,
+    ];
+    const I2C_READ_U8_3C_MODULE_HEX: [u8; I2C_READ_U8_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x03, 0x00, 0x07, 0x20, 0x13, 0x3C, 0x00, 0x40, 0x25,
+        0x50, 0x00,
     ];
     const LED_MATRIX_HEART_MODULE_HEX: [u8; LED_MATRIX_FRAME_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x12, 0x14, 0x44, 0xA4, 0x84, 0x31, 0x14,
@@ -1668,6 +1732,20 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_I2C_WRITE_U8]);
+    }
+
+    #[test]
+    fn builds_i2c_read_u8_module() {
+        let mut module = [0u8; I2C_READ_U8_MODULE_LEN];
+        let len = write_i2c_read_u8_module(I2cReadU8Program::new(0x3c), &mut module).unwrap();
+        assert_eq!(len, I2C_READ_U8_MODULE_LEN);
+        assert_eq!(module, I2C_READ_U8_3C_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_i2c(), 3).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_READ_U8]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -21,6 +21,7 @@ pub const CAP_ADC_READ: u16 = 0x21;
 pub const CAP_DAC_WRITE_U12: u16 = 0x22;
 pub const CAP_I2C_OPEN: u16 = 0x23;
 pub const CAP_I2C_WRITE_U8: u16 = 0x24;
+pub const CAP_I2C_READ_U8: u16 = 0x25;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -34,6 +35,7 @@ const CAP_ADC_READ_U8: u8 = CAP_ADC_READ as u8;
 const CAP_DAC_WRITE_U12_U8: u8 = CAP_DAC_WRITE_U12 as u8;
 const CAP_I2C_OPEN_U8: u8 = CAP_I2C_OPEN as u8;
 const CAP_I2C_WRITE_U8_U8: u8 = CAP_I2C_WRITE_U8 as u8;
+const CAP_I2C_READ_U8_U8: u8 = CAP_I2C_READ_U8 as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -168,7 +170,7 @@ impl CapabilitySet {
             CAP_PWM_WRITE => self.pwm,
             CAP_ADC_READ => self.adc,
             CAP_DAC_WRITE_U12 => self.dac,
-            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 => self.i2c,
+            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 => self.i2c,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -406,6 +408,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_DAC_WRITE_U12_U8) | Op::CallU16(CAP_DAC_WRITE_U12) => (2, 0),
         Op::CallU8(CAP_I2C_OPEN_U8) | Op::CallU16(CAP_I2C_OPEN) => (1, 1),
         Op::CallU8(CAP_I2C_WRITE_U8_U8) | Op::CallU16(CAP_I2C_WRITE_U8) => (3, 0),
+        Op::CallU8(CAP_I2C_READ_U8_U8) | Op::CallU16(CAP_I2C_READ_U8) => (2, 1),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -636,6 +639,21 @@ mod tests {
     }
 
     #[test]
+    fn validates_i2c_read_u8_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 3,
+            code: &[0x20, 0x12, 0x3c, 0x40, CAP_I2C_READ_U8 as u8, 0x50],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_i2c(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_READ_U8]);
+    }
+
+    #[test]
     fn rejects_pwm_write_without_capability() {
         let module = Module {
             flags: 0,
@@ -707,6 +725,21 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 4),
             Err(ValidateError::UnsupportedCapability(CAP_I2C_WRITE_U8))
+        );
+    }
+
+    #[test]
+    fn rejects_i2c_read_u8_without_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 3,
+            code: &[0x20, 0x12, 0x3c, 0x40, CAP_I2C_READ_U8 as u8, 0x50],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 4),
+            Err(ValidateError::UnsupportedCapability(CAP_I2C_READ_U8))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -38,15 +38,16 @@ use board_vm_host::{
     write_adc_read_module, write_blink_module, write_dac_write_u12_module,
     write_gpio_handle_close_module, write_gpio_handle_read_module, write_gpio_handle_write_module,
     write_gpio_open_module, write_gpio_read_module, write_gpio_write_module, write_i2c_open_module,
-    write_i2c_write_u8_module, write_led_matrix_frame_module, write_module, write_pwm_write_module,
-    write_time_now_module, write_time_sleep_ms_module, AdcReadProgram, BlinkProgram,
-    DacWriteU12Program, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
-    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram,
-    I2cWriteU8Program, LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, TimeNowProgram,
-    TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN,
-    DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
-    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
-    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
+    write_i2c_read_u8_module, write_i2c_write_u8_module, write_led_matrix_frame_module,
+    write_module, write_pwm_write_module, write_time_now_module, write_time_sleep_ms_module,
+    AdcReadProgram, BlinkProgram, DacWriteU12Program, GpioHandleCloseProgram,
+    GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
+    GpioWriteProgram, HostError, HostSession, I2cOpenProgram, I2cReadU8Program, I2cWriteU8Program,
+    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
+    DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN,
+    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
+    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, I2C_READ_U8_MODULE_LEN,
     I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
     TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
@@ -1643,6 +1644,13 @@ pub fn build_i2c_write_u8_module(
     Ok(write_i2c_write_u8_module(program, out)?)
 }
 
+pub fn build_i2c_read_u8_module(
+    program: I2cReadU8Program,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_i2c_read_u8_module(program, out)?)
+}
+
 pub fn build_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2392,6 +2400,23 @@ pub unsafe extern "C" fn board_vm_language_i2c_write_u8_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_i2c_read_u8_module(
+    address: u16,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_i2c_read_u8_module(I2cReadU8Program { address, max_stack }, module_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2722,6 +2747,11 @@ pub extern "C" fn board_vm_language_i2c_write_u8_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_i2c_read_u8_module_len() -> u64 {
+    I2C_READ_U8_MODULE_LEN as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_led_matrix_frame_module_len() -> u64 {
     LED_MATRIX_FRAME_MODULE_LEN as u64
 }
@@ -2960,6 +2990,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"dac.write_u12".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.open".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.write_u8".to_owned()));
+        assert!(uno.capabilities.contains(&"i2c.read_u8".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -3789,6 +3820,18 @@ mod tests {
         };
         assert_eq!(i2c_write_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(i2c_write_status.len, I2C_WRITE_U8_MODULE_LEN as u64);
+
+        let mut i2c_read_module = [0u8; I2C_READ_U8_MODULE_LEN];
+        let i2c_read_status = unsafe {
+            board_vm_language_i2c_read_u8_module(
+                0x3c,
+                3,
+                i2c_read_module.as_mut_ptr(),
+                i2c_read_module.len() as u64,
+            )
+        };
+        assert_eq!(i2c_read_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(i2c_read_status.len, I2C_READ_U8_MODULE_LEN as u64);
 
         let mut gpio_read_module = [0u8; GPIO_READ_MODULE_LEN];
         let gpio_read_status = unsafe {

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -2,8 +2,8 @@
 
 use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_DAC_WRITE_U12,
-    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_WRITE_U8,
-    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ_U8,
+    CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,6 +79,10 @@ pub trait BoardHal {
     }
 
     fn i2c_write_u8(&mut self, _token: u32, _address: u16, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn i2c_read_u8(&mut self, _token: u32, _address: u16) -> Result<u8, HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -469,6 +473,19 @@ where
                         kind: hal_error_kind(err),
                     })
             }
+            CAP_I2C_READ_U8 => {
+                let address = self.pop_u16(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::I2c, ip)?;
+                let byte = self
+                    .hal
+                    .i2c_read_u8(token, address)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                self.push(Value::U8(byte), ip)
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -714,6 +731,7 @@ mod tests {
         DacWriteU12(u16, u16),
         I2cOpen(u16),
         I2cWriteU8(u32, u16, u8),
+        I2cReadU8(u32, u16),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -792,6 +810,11 @@ mod tests {
         fn i2c_write_u8(&mut self, token: u32, address: u16, byte: u8) -> Result<(), HalError> {
             self.events.push(Event::I2cWriteU8(token, address, byte));
             Ok(())
+        }
+
+        fn i2c_read_u8(&mut self, token: u32, address: u16) -> Result<u8, HalError> {
+            self.events.push(Event::I2cReadU8(token, address));
+            Ok(0x5a)
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -972,6 +995,24 @@ mod tests {
         assert_eq!(
             runtime.hal().events,
             vec![Event::I2cOpen(1), Event::I2cWriteU8(0x1_2001, 0x3c, 0xa5)]
+        );
+    }
+
+    #[test]
+    fn i2c_read_u8_dispatches_handle_address_and_returns_byte() {
+        let mut runtime: Runtime<FakeHal, 4, 2> = Runtime::new(FakeHal::new());
+        let open = [0x12, 1, 0x40, CAP_I2C_OPEN as u8, 0x20, 0x50];
+        let read = [0x20, 0x12, 0x3c, 0x40, CAP_I2C_READ_U8 as u8, 0x50];
+
+        runtime.run_code(&open, 10).unwrap();
+        let report = runtime.run_code(&read, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.return_value, Value::U8(0x5a));
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            runtime.hal().events,
+            vec![Event::I2cOpen(1), Event::I2cReadU8(0x1_2001, 0x3c)]
         );
     }
 }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -112,7 +112,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 13] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 14] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -125,10 +125,11 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 13] = [
     "dac.write_u12",
     "i2c.open",
     "i2c.write_u8",
+    "i2c.read_u8",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 17] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 18] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -144,6 +145,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 17] = [
     "dac.write_u12",
     "i2c.open",
     "i2c.write_u8",
+    "i2c.read_u8",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -610,6 +612,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"dac.write_u12"));
         assert!(uno.capabilities.contains(&"i2c.open"));
         assert!(uno.capabilities.contains(&"i2c.write_u8"));
+        assert!(uno.capabilities.contains(&"i2c.read_u8"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -31,6 +31,7 @@ pub const BOARD_VM_UNO_R4_PWM_WRITE_SYMBOL: &str = "board_vm_uno_r4_pwm_write";
 pub const BOARD_VM_UNO_R4_ADC_READ_SYMBOL: &str = "board_vm_uno_r4_adc_read";
 pub const BOARD_VM_UNO_R4_DAC_WRITE_U12_SYMBOL: &str = "board_vm_uno_r4_dac_write_u12";
 pub const BOARD_VM_UNO_R4_I2C_WRITE_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_write_u8";
+pub const BOARD_VM_UNO_R4_I2C_READ_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_read_u8";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
@@ -282,6 +283,10 @@ mod tests {
         assert_eq!(
             BOARD_VM_UNO_R4_I2C_WRITE_U8_SYMBOL,
             "board_vm_uno_r4_i2c_write_u8"
+        );
+        assert_eq!(
+            BOARD_VM_UNO_R4_I2C_READ_U8_SYMBOL,
+            "board_vm_uno_r4_i2c_read_u8"
         );
         assert_eq!(
             BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE,

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -216,6 +216,15 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         }
     }
 
+    fn read_i2c_u8(&mut self, bus: u8, address: u16) -> Result<u8, HalError> {
+        let mut byte = 0;
+        if unsafe { board_io_ffi::board_vm_uno_r4_i2c_read_u8(bus, address, &mut byte) } {
+            Ok(byte)
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+
     fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
         board_vm_uno_r4_usb_cdc::reboot_to_bootloader()
     }
@@ -228,5 +237,6 @@ mod board_io_ffi {
         pub fn board_vm_uno_r4_adc_read(pin: u8, sample: *mut u16) -> bool;
         pub fn board_vm_uno_r4_dac_write_u12(pin: u8, sample: u16) -> bool;
         pub fn board_vm_uno_r4_i2c_write_u8(bus: u8, address: u16, byte: u8) -> bool;
+        pub fn board_vm_uno_r4_i2c_read_u8(bus: u8, address: u16, byte: *mut u8) -> bool;
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -454,3 +454,32 @@ extern "C" bool board_vm_uno_r4_i2c_write_u8(uint8_t bus, uint16_t address, uint
   }
   return wire->endTransmission() == END_TX_OK;
 }
+
+extern "C" bool board_vm_uno_r4_i2c_read_u8(uint8_t bus, uint16_t address, uint8_t *byte) {
+  if (byte == nullptr || address > kI2cMax7BitAddress) {
+    return false;
+  }
+
+  I2cSlot *slot = find_i2c_slot(bus);
+  if (slot == nullptr) {
+    return false;
+  }
+
+  TwoWire *wire = slot_wire(*slot);
+  if (!slot->started) {
+    wire->begin();
+    slot->started = true;
+  }
+
+  if (wire->requestFrom(static_cast<uint8_t>(address), static_cast<size_t>(1)) != 1) {
+    return false;
+  }
+
+  int value = wire->read();
+  if (value < 0) {
+    return false;
+  }
+
+  *byte = static_cast<uint8_t>(value);
+  return true;
+}

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -387,6 +387,10 @@ pub trait UnoR4Backend {
         Err(HalError::UnsupportedMode)
     }
 
+    fn read_i2c_u8(&mut self, _bus: u8, _address: u16) -> Result<u8, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn supports_bootloader_reboot(&self) -> bool {
         false
     }
@@ -512,6 +516,12 @@ where
         let bus = normalize_i2c_token(self.target, token)?;
         normalize_i2c_address(address)?;
         self.backend.write_i2c_u8(bus, address, byte)
+    }
+
+    fn i2c_read_u8(&mut self, token: u32, address: u16) -> Result<u8, HalError> {
+        let bus = normalize_i2c_token(self.target, token)?;
+        normalize_i2c_address(address)?;
+        self.backend.read_i2c_u8(bus, address)
     }
 
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -712,6 +722,7 @@ mod tests {
         DacWriteU12(u8, u16),
         I2cOpen(u8),
         I2cWriteU8(u8, u16, u8),
+        I2cReadU8(u8, u16),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -798,6 +809,11 @@ mod tests {
         fn write_i2c_u8(&mut self, bus: u8, address: u16, byte: u8) -> Result<(), HalError> {
             self.events.push(Event::I2cWriteU8(bus, address, byte));
             Ok(())
+        }
+
+        fn read_i2c_u8(&mut self, bus: u8, address: u16) -> Result<u8, HalError> {
+            self.events.push(Event::I2cReadU8(bus, address));
+            Ok(0x5a)
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -900,6 +916,9 @@ mod tests {
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_I2C_WRITE_U8));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_READ_U8));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -915,6 +934,9 @@ mod tests {
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_I2C_WRITE_U8));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_READ_U8));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -1035,6 +1057,22 @@ mod tests {
             board.i2c_write_u8(0x1_2000, 0x80, 0xa5),
             Err(HalError::InvalidPin)
         );
+    }
+
+    #[test]
+    fn i2c_read_u8_runs_through_bus_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(board.i2c_read_u8(0x1_2001, 0x3c).unwrap(), 0x5a);
+        assert_eq!(board.backend().events, vec![Event::I2cReadU8(1, 0x3c)]);
+    }
+
+    #[test]
+    fn i2c_read_u8_rejects_unknown_bus_or_address() {
+        let mut board = UnoR4Board::minima(FakeBackend::new());
+
+        assert_eq!(board.i2c_read_u8(0x1_2001, 0x3c), Err(HalError::InvalidPin));
+        assert_eq!(board.i2c_read_u8(0x1_2000, 0x80), Err(HalError::InvalidPin));
     }
 
     #[test]

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -202,16 +202,18 @@ metadata. The operation is intentionally direct and stateless, mirroring
 |---:|---|---|---|
 | `0x23` | `i2c.open` | `bus: u16/u8` | `handle` |
 | `0x24` | `i2c.write_u8` | `handle`, `address: u16/u8`, `byte: u8` | `unit` |
+| `0x25` | `i2c.read_u8` | `handle`, `address: u16/u8` | `u8` |
 
 `i2c.open` opens a board-advertised I2C controller and returns a persistent bus
 handle. The handle is the lifetime anchor for transfer operations, keeping bus
 identity and pin ownership out of language frontends.
 
 `i2c.write_u8` writes a single byte to a 7-bit device address on an already
-opened bus handle. It is the first concrete I2C transfer primitive because the
-current VM value set has scalar integers but no byte-buffer value yet. Wider
-`i2c.write`, `i2c.read`, and `i2c.transfer` operations should reuse the same
-handle model once the byte-buffer ABI exists.
+opened bus handle. `i2c.read_u8` reads one byte from that same 7-bit address and
+returns it as a scalar `u8`. These are the first concrete I2C transfer
+primitives because the current VM value set has scalar integers but no
+byte-buffer value yet. Wider `i2c.write`, `i2c.read`, and `i2c.transfer`
+operations should reuse the same handle model once the byte-buffer ABI exists.
 
 ### LED Matrix
 

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -29,7 +29,7 @@ Source snapshot:
 | PWM output | D3, D5, D6, D9, D10, D11 in the Arduino variant init path | implemented as direct write | `pwm.write` |
 | Analog input | A0-A5 | implemented as direct read | `adc.read` |
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
-| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, and single-byte write implemented | `i2c.open`, `i2c.write_u8`, then wider `i2c.write`, `i2c.read`, `i2c.transfer` |
+| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, and single-byte write/read implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, then wider `i2c.write`, `i2c.read`, `i2c.transfer` |
 | SPI master | MOSI D11, MISO D12, SCK D13, CS D10 | pending | `spi.open`, `spi.transfer`, `spi.close` |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
@@ -68,9 +68,10 @@ reject conflicting handles.
    analog-adjacent VM operations. Add handle-oriented variants only when a
    later streaming or event tranche needs persistent resource ownership.
 4. Implement I2C and SPI as bus handles with explicit transfer boundaries;
-   `i2c.open` establishes the first I2C handle tranche, and `i2c.write_u8`
-   proves the Rust-owned transfer path through Arduino `Wire`/`Wire1`.
-   Byte-buffer write/read/transfer transactions follow as separate slices.
+   `i2c.open` establishes the first I2C handle tranche, while `i2c.write_u8`
+   and `i2c.read_u8` prove the Rust-owned transfer path through Arduino
+   `Wire`/`Wire1`. Byte-buffer write/read/transfer transactions follow as
+   separate slices.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 


### PR DESCRIPTION
## Summary
- Adds portable `i2c.read_u8` capability id `0x25` across the bytecode IR, runtime HAL, UNO R4 target descriptors, and device capability reports.
- Wires UNO R4 SerialUSB firmware through Arduino `Wire`/`Wire1` for scalar one-byte reads using the existing persistent I2C handle model.
- Exposes the read module/action through Rust language-core and Ruby, including REPL aliases like `i2c-read-u8` and `upload-i2c-read-u8`.

## Validation
- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core`
- `cargo test -p board-vm-uno-r4-firmware`
- `bundle exec ruby -c lib/coding_adventures/board_vm/session.rb && bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb`
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- linked `uno-r4-wifi-serialusb-artifact` build with `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, Arduino Renesas UNO core 1.5.3, and `/opt/homebrew/bin` ARM tools
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

## Notes
- This intentionally keeps the slice scalar-only. Wider `i2c.write`, `i2c.read`, and `i2c.transfer` should land after the byte-buffer ABI is introduced.