### PR TITLE
rust(spice): parse VCVS netlist elements

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.1
+
+- Add SPICE `E` / VCVS controlled-source parsing, including subcircuit node
+  remapping for expanded VCVS elements.
+
 ## 0.1.0
 
 - Add a first SPICE3 netlist parser slice for linear R/C/L circuits,

--- a/code/packages/rust/spice-netlist-parser/Cargo.toml
+++ b/code/packages/rust/spice-netlist-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spice-netlist-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt};
 
 use spice_engine::{
     Capacitor, Circuit, CurrentSource, Element, ExpWaveform, Inductor, PulseWaveform, PwlWaveform,
-    Resistor, SinWaveform, Vccs, VoltageSource, Waveform,
+    Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -327,6 +327,17 @@ fn parse_element(fields: &[String]) -> Result<Element, NetlistParseError> {
                 parse_value(&fields[5])?,
             )))
         }
+        'E' => {
+            require_fields(fields, 6, "VCVS")?;
+            Ok(Element::Vcvs(Vcvs::new(
+                name,
+                &fields[1],
+                &fields[2],
+                &fields[3],
+                &fields[4],
+                parse_value(&fields[5])?,
+            )))
+        }
         _ => Err(NetlistParseError::new(format!(
             "unsupported element {name:?}"
         ))),
@@ -447,8 +458,8 @@ fn map_subckt_fields(
             mapped[1] = map_subckt_node(&fields[1], instance_name, node_map);
             mapped[2] = map_subckt_node(&fields[2], instance_name, node_map);
         }
-        'G' => {
-            require_min_fields(fields, 5, "subcircuit VCCS")?;
+        'E' | 'G' => {
+            require_min_fields(fields, 5, "subcircuit controlled source")?;
             for index in 1..5 {
                 mapped[index] = map_subckt_node(&fields[index], instance_name, node_map);
             }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -97,6 +97,28 @@ G1 out 0 in 0 2m
 }
 
 #[test]
+fn parses_vcvs_into_operating_point_circuit() {
+    let parsed = parse_netlist(
+        r#"
+Vctrl in 0 DC 1.5
+Eamp out 0 in 0 4
+Rload out 0 1k
+.op
+"#,
+    )
+    .unwrap();
+
+    let Element::Vcvs(source) = &parsed.circuit.elements()[1] else {
+        panic!("expected VCVS");
+    };
+    assert_eq!(source.control_positive, "in");
+    assert_close(source.gain, 4.0);
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    assert_close(result.voltage("out").unwrap(), 6.0);
+}
+
+#[test]
 fn parses_pwl_and_sin_source_waveforms() {
     let parsed = parse_netlist(
         r#"
@@ -150,6 +172,43 @@ Xdiv vin mid 0 divider
 
     let result = dc_op(&parsed.circuit).unwrap();
     assert_close(result.voltage("mid").unwrap(), 5.0);
+}
+
+#[test]
+fn expands_subcircuit_vcvs_nodes_into_engine_elements() {
+    let parsed = parse_netlist(
+        r#"
+.subckt gain inp outp
+Ebuf outp 0 inp 0 2
+.ends gain
+V1 in 0 DC 1.25
+Xgain in out gain
+Rload out 0 1k
+.op
+"#,
+    )
+    .unwrap();
+
+    let elements = parsed.circuit.elements();
+    let names = elements
+        .iter()
+        .map(|element| match element {
+            Element::VoltageSource(source) => source.name.as_str(),
+            Element::Vcvs(source) => source.name.as_str(),
+            Element::Resistor(resistor) => resistor.name.as_str(),
+            _ => panic!("unexpected element"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["V1", "Xgain.Ebuf", "Rload"]);
+
+    let Element::Vcvs(source) = &elements[1] else {
+        panic!("expected VCVS");
+    };
+    assert_eq!(source.positive, "out");
+    assert_eq!(source.control_positive, "in");
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    assert_close(result.voltage("out").unwrap(), 2.5);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add SPICE `E` / VCVS parsing to the Rust netlist parser
- map VCVS output and control nodes during `.subckt` expansion
- cover direct and subcircuit-expanded VCVS netlists with DC operating-point validation

## Validation

- cargo fmt -p spice-netlist-parser
- sh BUILD
- git diff --check