### PR TITLE
feat(lang50): Generic Grammar Type Checker — annotation-aware IIR type_hint emission

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -453,6 +453,8 @@ members = [
     "upc-a",
     "x25519",
     "type-checker-protocol",
+    "type-declarations",
+    "grammar-type-checker",
     "nib-lexer",
     "nib-parser",
     "nib-type-checker",

--- a/code/packages/rust/grammar-type-checker/CHANGELOG.md
+++ b/code/packages/rust/grammar-type-checker/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog — grammar-type-checker
+
+## [0.1.0] — 2026-05-14
+
+### Added (LANG50 — Generic Grammar Type Checker)
+
+Initial release.
+
+- `check<P: LanguageProfile>(root, decls, profile) -> TypeCheckResult<AnnotatedNode>` —
+  generic type-check entry point.  Annotation is always-on; enforcement is
+  mode-gated (`Off` → no errors, `Lenient` → ok always, `Strict` → ok iff no errors).
+- `LanguageProfile` trait — language-specific tree navigation.  Implementors
+  match on `GrammarASTNode.rule_name` to recognise literals, variable
+  references, function applications, binders, match expressions, and begin
+  blocks.
+- `BinderKind` enum (`Let { bindings, body }`, `Lambda { params, body }`) —
+  distinguishes let-style from lambda-style binder forms.
+- `BinderInfo`, `AppInfo`, `MatchInfo`, `MatchArmInfo`, `ArmPattern` —
+  extracted information returned by `LanguageProfile` methods.
+- `ScopeStack` — push/pop/bind/lookup lexical scope (inner-first lookup).
+- `check::infer` — recursive core algorithm.
+  - Literal detection via `literal_kind`.
+  - Variable resolution: scope → globals → `Any` + error.
+  - Arity check when callee is `KindDecl::Function { arity }`.
+  - Union exhaustiveness check when scrutinee is `KindDecl::Named(union_name)`.
+  - Scheme `let` semantics: all RHS evaluated in outer scope.
+  - Depth cap: 256.
+- `profile::{ast_node_children, ast_nodes_named, first_token_value, has_token_type}` —
+  shared helpers for `LanguageProfile` implementations.
+- 20 unit tests covering literals, variable resolution, arity, exhaustiveness,
+  typed modes, and annotation propagation.

--- a/code/packages/rust/grammar-type-checker/Cargo.toml
+++ b/code/packages/rust/grammar-type-checker/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name        = "grammar-type-checker"
+version     = "0.1.0"
+edition     = "2021"
+description = "Generic type checker operating on GrammarASTNode + TypeDeclarations.  Returns a fully-annotated AnnotatedNode tree that feeds AOT/JIT compilation via IIR type_hint fields."
+
+[dependencies]
+parser                = { path = "../parser" }
+type-declarations     = { path = "../type-declarations" }
+type-checker-protocol = { path = "../type-checker-protocol" }
+
+[dev-dependencies]
+lexer = { path = "../lexer" }

--- a/code/packages/rust/grammar-type-checker/README.md
+++ b/code/packages/rust/grammar-type-checker/README.md
@@ -1,0 +1,78 @@
+# grammar-type-checker
+
+Generic type checker operating on `GrammarASTNode` trees with parser-emitted
+`TypeDeclarations`.  Returns a fully-annotated `AnnotatedNode` tree that feeds
+AOT/JIT compilation via IIR `type_hint` fields.
+
+## What it does
+
+Walks a raw `GrammarASTNode` tree (from the `parser` crate) using:
+
+1. **`TypeDeclarations`** — parser-emitted type rules (like TypeScript `.d.ts`):
+   named types (records, unions, aliases), global binding kinds, and the
+   module's typed-mode setting.
+
+2. **`LanguageProfile`** — language-specific tree navigation: which grammar
+   rule names correspond to literals, variable references, function calls, etc.
+
+Returns `TypeCheckResult<AnnotatedNode>` where every node in the tree carries
+its inferred `KindDecl`.
+
+## Types feed compilation
+
+The `AnnotatedNode.iir_hint()` method maps inferred kinds to IIR `type_hint`
+strings:
+
+```
+KindDecl::Int  → "i64"      (64-bit int ops, no boxing)
+KindDecl::Bool → "bool"     (direct branch, no type guard)
+KindDecl::Str  → "str"      (string fast-path)
+Function{n}    → "closure"  (direct dispatch)
+others         → "any"      (fall back to runtime profiling)
+```
+
+JIT and AOT specialisers prioritise `type_hint` over runtime profiles; a
+fully-typed IIR function compiles to native code with zero warmup cost.
+
+## Implementing LanguageProfile
+
+```rust
+use grammar_type_checker::{LanguageProfile, AppInfo, BinderInfo};
+use parser::grammar_parser::GrammarASTNode;
+use type_declarations::KindDecl;
+
+struct MyLangProfile;
+
+impl LanguageProfile for MyLangProfile {
+    fn literal_kind(&self, node: &GrammarASTNode) -> Option<KindDecl> {
+        match node.rule_name.as_str() {
+            "int_literal" => Some(KindDecl::Int),
+            "bool_literal" => Some(KindDecl::Bool),
+            _ => None,
+        }
+    }
+    // ... implement remaining methods
+}
+```
+
+## Checks performed
+
+| Check | When emitted |
+|-------|-------------|
+| Unresolved variable | `VarRef` not in scope or globals |
+| Call arity mismatch | `Apply` where callee is `Function{n}` and args ≠ n |
+| Non-exhaustive match | `Match` on a union with uncovered variants |
+
+Checks are **mode-gated**:
+
+| Mode | Behaviour |
+|------|-----------|
+| `Off` | No errors emitted; annotated tree still built |
+| `Lenient` | Errors collected; `ok: true` always |
+| `Strict` | Errors collected; `ok: false` if any errors |
+
+## Dependencies
+
+- `parser` — `GrammarASTNode`, `ASTNodeOrToken`
+- `type-declarations` — `TypeDeclarations`, `KindDecl`, `AnnotatedNode`
+- `type-checker-protocol` — `TypeCheckResult`, `TypeErrorDiagnostic`

--- a/code/packages/rust/grammar-type-checker/src/check.rs
+++ b/code/packages/rust/grammar-type-checker/src/check.rs
@@ -1,0 +1,410 @@
+//! Core type-inference algorithm for the generic grammar type checker.
+//!
+//! The central function [`infer`] walks a [`GrammarASTNode`] tree recursively,
+//! consulting the [`LanguageProfile`] to understand the semantic role of each
+//! node.  It returns a fully-annotated [`AnnotatedNode`] tree where every
+//! node carries its inferred [`KindDecl`].
+//!
+//! ## Priority order
+//!
+//! For every node `infer` tries, in order:
+//!
+//! 1. **Literal** → `profile.literal_kind(node)` → return immediately
+//! 2. **Variable reference** → `profile.as_var_ref(node)` → scope/globals lookup
+//! 3. **Apply** → `profile.as_apply(node)` → callee inference + arity check
+//! 4. **Binder** → `profile.as_binder(node)` → push scope, infer body, pop
+//! 5. **Match** → `profile.as_match(node)` → scrutinee + exhaustiveness + arms
+//! 6. **Begin** → `profile.as_begin(node)` → infer all, return last kind
+//! 7. **Fallback** → `profile.child_exprs(node)` → recurse, return last kind
+//!
+//! ## Annotation is always-on
+//!
+//! Even when `TypedModeDecl::Off`, the annotated tree is built.  The *kind*
+//! on each node is always the best inferred kind (`Any` when unknown).
+//! Whether errors are *emitted* depends on the mode (only Lenient/Strict emit
+//! errors).
+
+use std::collections::HashSet;
+
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use type_checker_protocol::TypeErrorDiagnostic;
+use type_declarations::{AnnotatedChild, AnnotatedNode, KindDecl, TypeDeclarations, TypedModeDecl};
+
+use crate::profile::{ArmPattern, BinderKind, LanguageProfile};
+use crate::scope::ScopeStack;
+
+/// Maximum recursion depth inside `infer`.
+///
+/// Guards against stack overflow on pathologically deep grammar trees.  The
+/// grammar parser already enforces its own depth cap (64 for Twig parens),
+/// so in practice depth never approaches 256.  This is a defence-in-depth.
+pub const MAX_INFER_DEPTH: usize = 256;
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Infer the kind of `node`, build its [`AnnotatedNode`], and accumulate
+/// any type errors into `errors`.
+///
+/// Callers should use the public API in [`crate`] rather than calling this
+/// directly.
+///
+/// ## Parameters
+///
+/// - `node` — the raw grammar tree node to infer
+/// - `decls` — parser-emitted type declarations (globals, named types, mode)
+/// - `profile` — language-specific navigation (which rules mean what)
+/// - `scope` — mutable lexical scope stack (caller provides, so binder forms
+///   can push/pop without cloning the whole stack)
+/// - `errors` — accumulated diagnostics (only written when mode ≠ Off)
+/// - `mode` — enforcement mode (controls whether errors are emitted)
+/// - `depth` — current recursion depth (starts at 0)
+pub fn infer<P: LanguageProfile>(
+    node: &GrammarASTNode,
+    decls: &TypeDeclarations,
+    profile: &P,
+    scope: &mut ScopeStack,
+    errors: &mut Vec<TypeErrorDiagnostic>,
+    mode: &TypedModeDecl,
+    depth: usize,
+) -> AnnotatedNode {
+    if depth > MAX_INFER_DEPTH {
+        // Bail out — return Any to avoid stack overflow.
+        return make_annotated(node, KindDecl::Any, vec![]);
+    }
+
+    // ── 1. Literal? ──────────────────────────────────────────────────────
+    if let Some(kind) = profile.literal_kind(node) {
+        let children = token_children(node);
+        return make_annotated(node, kind, children);
+    }
+
+    // ── 2. Variable reference? ───────────────────────────────────────────
+    if let Some(name) = profile.as_var_ref(node) {
+        let kind = infer_var_ref(name, decls, scope, profile, node, errors, mode);
+        let children = token_children(node);
+        return make_annotated(node, kind, children);
+    }
+
+    // ── 3. Function application? ─────────────────────────────────────────
+    if let Some(app) = profile.as_apply(node) {
+        let callee_ann = infer(app.callee, decls, profile, scope, errors, mode, depth + 1);
+        let callee_kind = decls.resolve(&callee_ann.kind);
+
+        let mut arg_anns = Vec::with_capacity(app.args.len());
+        for arg in &app.args {
+            arg_anns.push(infer(arg, decls, profile, scope, errors, mode, depth + 1));
+        }
+
+        // Arity check when the callee resolves to a known function kind.
+        if let KindDecl::Function { arity } = &callee_kind {
+            let actual = app.args.len();
+            if *arity != actual && *mode != TypedModeDecl::Off {
+                let (line, col) = profile.position(node);
+                let fn_name = profile.as_var_ref(app.callee).unwrap_or("<expr>");
+                errors.push(TypeErrorDiagnostic {
+                    message: format!(
+                        "arity error: '{}' expects {} argument{}, got {}",
+                        fn_name,
+                        arity,
+                        if *arity == 1 { "" } else { "s" },
+                        actual
+                    ),
+                    line,
+                    column: col,
+                });
+            }
+        }
+
+        // Result kind — call returns Any (static return-type tracking is TW05-C).
+        let mut children = vec![AnnotatedChild::Node(callee_ann)];
+        for ann in arg_anns {
+            children.push(AnnotatedChild::Node(ann));
+        }
+        return make_annotated(node, KindDecl::Any, children);
+    }
+
+    // ── 4. Binder (let / lambda / define)? ───────────────────────────────
+    if let Some(binder) = profile.as_binder(node) {
+        return infer_binder(node, binder, decls, profile, scope, errors, mode, depth);
+    }
+
+    // ── 5. Match? ────────────────────────────────────────────────────────
+    if let Some(m) = profile.as_match(node) {
+        let scrutinee_ann =
+            infer(m.scrutinee, decls, profile, scope, errors, mode, depth + 1);
+        let scrutinee_kind = decls.resolve(&scrutinee_ann.kind);
+
+        // Exhaustiveness check for union scrutinees.
+        if let KindDecl::Named(ref union_name) = scrutinee_kind {
+            if let Some(variants) = decls.union_variants(union_name) {
+                if *mode != TypedModeDecl::Off {
+                    check_exhaustiveness(union_name, &variants, &m.arms, profile, node, errors);
+                }
+            }
+        }
+
+        // Walk each arm.
+        let mut arm_anns: Vec<AnnotatedChild> = vec![AnnotatedChild::Node(scrutinee_ann)];
+        let mut last_kind = KindDecl::Any;
+        for arm in &m.arms {
+            scope.push();
+            match &arm.pattern {
+                ArmPattern::Binding(name) => {
+                    scope.bind(name.clone(), scrutinee_kind.clone());
+                }
+                ArmPattern::Variant { bindings, .. } => {
+                    for b in bindings {
+                        scope.bind(b.clone(), KindDecl::Any);
+                    }
+                }
+                ArmPattern::Wildcard => {}
+            }
+            let body_ann = infer(arm.body, decls, profile, scope, errors, mode, depth + 1);
+            last_kind = body_ann.kind.clone();
+            arm_anns.push(AnnotatedChild::Node(body_ann));
+            scope.pop();
+        }
+
+        return make_annotated(node, last_kind, arm_anns);
+    }
+
+    // ── 6. Begin / sequence? ─────────────────────────────────────────────
+    if let Some(exprs) = profile.as_begin(node) {
+        let mut children = Vec::with_capacity(exprs.len());
+        let mut last_kind = KindDecl::Nil; // begin with zero exprs → Nil
+        for e in &exprs {
+            let ann = infer(e, decls, profile, scope, errors, mode, depth + 1);
+            last_kind = ann.kind.clone();
+            children.push(AnnotatedChild::Node(ann));
+        }
+        return make_annotated(node, last_kind, children);
+    }
+
+    // ── 7. Fallback: recurse into child expressions ───────────────────────
+    let child_nodes = profile.child_exprs(node);
+    if child_nodes.is_empty() {
+        // Leaf node with no expr children — token wrappers etc.
+        let children = token_children(node);
+        return make_annotated(node, KindDecl::Any, children);
+    }
+
+    let mut children = Vec::with_capacity(child_nodes.len());
+    let mut last_kind = KindDecl::Any;
+    for child in &child_nodes {
+        let ann = infer(child, decls, profile, scope, errors, mode, depth + 1);
+        last_kind = ann.kind.clone();
+        children.push(AnnotatedChild::Node(ann));
+    }
+    make_annotated(node, last_kind, children)
+}
+
+// ---------------------------------------------------------------------------
+// Variable reference helper
+// ---------------------------------------------------------------------------
+
+fn infer_var_ref<P: LanguageProfile>(
+    name: &str,
+    decls: &TypeDeclarations,
+    scope: &ScopeStack,
+    profile: &P,
+    node: &GrammarASTNode,
+    errors: &mut Vec<TypeErrorDiagnostic>,
+    mode: &TypedModeDecl,
+) -> KindDecl {
+    // 1. Local scope (lambda params, let bindings)
+    if let Some(k) = scope.lookup(name) {
+        return k.clone();
+    }
+    // 2. Global declarations (top-level defines, pre-loaded before the walk)
+    if let Some(k) = decls.globals.get(name) {
+        return k.clone();
+    }
+    // 3. Not found — emit error in Lenient/Strict mode
+    if *mode != TypedModeDecl::Off {
+        let (line, col) = profile.position(node);
+        errors.push(TypeErrorDiagnostic {
+            message: format!("unresolved variable '{}'", name),
+            line,
+            column: col,
+        });
+    }
+    KindDecl::Any
+}
+
+// ---------------------------------------------------------------------------
+// Binder helper
+// ---------------------------------------------------------------------------
+
+fn infer_binder<P: LanguageProfile>(
+    node: &GrammarASTNode,
+    binder: crate::profile::BinderInfo<'_>,
+    decls: &TypeDeclarations,
+    profile: &P,
+    scope: &mut ScopeStack,
+    errors: &mut Vec<TypeErrorDiagnostic>,
+    mode: &TypedModeDecl,
+    depth: usize,
+) -> AnnotatedNode {
+    match binder.kind {
+        BinderKind::Let { bindings, body } => {
+            // Evaluate all RHS in the *outer* scope (Scheme `let` semantics —
+            // none of the new names are visible to each other's RHS).
+            let mut rhs_anns = Vec::with_capacity(bindings.len());
+            let mut rhs_kinds = Vec::with_capacity(bindings.len());
+            for (_, rhs_node) in &bindings {
+                let ann = infer(rhs_node, decls, profile, scope, errors, mode, depth + 1);
+                rhs_kinds.push(ann.kind.clone());
+                rhs_anns.push(AnnotatedChild::Node(ann));
+            }
+
+            // Now push a new scope and bind all names.
+            if !binder.is_global {
+                scope.push();
+            }
+            for ((name, _), kind) in bindings.iter().zip(rhs_kinds.iter()) {
+                scope.bind(name.clone(), kind.clone());
+            }
+
+            // Walk the body.
+            let mut body_anns = Vec::with_capacity(body.len());
+            let mut last_kind = KindDecl::Any;
+            for b in &body {
+                let ann = infer(b, decls, profile, scope, errors, mode, depth + 1);
+                last_kind = ann.kind.clone();
+                body_anns.push(AnnotatedChild::Node(ann));
+            }
+
+            if !binder.is_global {
+                scope.pop();
+            }
+
+            let mut all_children = rhs_anns;
+            all_children.extend(body_anns);
+            make_annotated(node, last_kind, all_children)
+        }
+
+        BinderKind::Lambda { params, body } => {
+            // Push scope, bind each param with its declared kind (or Any).
+            let arity = params.len();
+            scope.push();
+            for (name, kind) in &params {
+                scope.bind(name.clone(), kind.clone());
+            }
+
+            // Walk body.
+            let mut body_anns = Vec::with_capacity(body.len());
+            let mut last_kind = KindDecl::Any;
+            for b in &body {
+                let ann = infer(b, decls, profile, scope, errors, mode, depth + 1);
+                last_kind = ann.kind.clone();
+                body_anns.push(AnnotatedChild::Node(ann));
+            }
+            scope.pop();
+
+            // The binder as a whole produces a Function value if anonymous
+            // (lambda), or the last body kind if global (define-fn already
+            // registered in globals).
+            let result_kind = if binder.is_global {
+                // For top-level define-fn the global is already registered;
+                // the define form itself doesn't "produce" a value in the
+                // program — its result is used for the body's side effects.
+                last_kind
+            } else {
+                KindDecl::Function { arity }
+            };
+
+            make_annotated(node, result_kind, body_anns)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exhaustiveness checker
+// ---------------------------------------------------------------------------
+
+fn check_exhaustiveness<P: LanguageProfile>(
+    union_name: &str,
+    variants: &[String],
+    arms: &[crate::profile::MatchArmInfo<'_>],
+    profile: &P,
+    node: &GrammarASTNode,
+    errors: &mut Vec<TypeErrorDiagnostic>,
+) {
+    // A Wildcard or Binding arm makes the match trivially exhaustive.
+    for arm in arms {
+        match &arm.pattern {
+            ArmPattern::Wildcard | ArmPattern::Binding(_) => return,
+            _ => {}
+        }
+    }
+
+    // Collect which variants are covered by Variant patterns.
+    let covered: HashSet<&str> = arms
+        .iter()
+        .filter_map(|a| {
+            if let ArmPattern::Variant { name, .. } = &a.pattern {
+                Some(name.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let missing: Vec<&str> = variants
+        .iter()
+        .filter(|v| !covered.contains(v.as_str()))
+        .map(|v| v.as_str())
+        .collect();
+
+    if !missing.is_empty() {
+        let (line, col) = profile.position(node);
+        errors.push(TypeErrorDiagnostic {
+            message: format!(
+                "non-exhaustive match on union '{}': unmatched variants: '{}'",
+                union_name,
+                missing.join("', '")
+            ),
+            line,
+            column: col,
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Annotation construction helpers
+// ---------------------------------------------------------------------------
+
+/// Build an [`AnnotatedNode`] from a raw grammar node + inferred kind.
+fn make_annotated(
+    node: &GrammarASTNode,
+    kind: KindDecl,
+    children: Vec<AnnotatedChild>,
+) -> AnnotatedNode {
+    AnnotatedNode {
+        rule_name: node.rule_name.clone(),
+        kind,
+        children,
+        start_line: node.start_line,
+        start_column: node.start_column,
+        end_line: node.end_line,
+        end_column: node.end_column,
+    }
+}
+
+/// Convert raw token children of `node` into [`AnnotatedChild::Token`]
+/// entries.  Used for leaf nodes where no recursion is needed.
+fn token_children(node: &GrammarASTNode) -> Vec<AnnotatedChild> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Token(t) => Some(AnnotatedChild::Token {
+                text: t.value.clone(),
+                line: t.line,
+                column: t.column,
+            }),
+            ASTNodeOrToken::Node(_) => None,
+        })
+        .collect()
+}

--- a/code/packages/rust/grammar-type-checker/src/lib.rs
+++ b/code/packages/rust/grammar-type-checker/src/lib.rs
@@ -1,0 +1,658 @@
+//! # `grammar-type-checker`
+//!
+//! Generic type checker operating on raw [`GrammarASTNode`] trees from the
+//! `parser` crate.  Type rules come from [`TypeDeclarations`] (emitted by any
+//! language's parser); language-specific tree navigation is provided by a
+//! [`LanguageProfile`] implementation.
+//!
+//! ## Why generic?
+//!
+//! The LANG49 `twig-type-checker` hardcoded knowledge of Twig's typed AST
+//! (`Program`, `Expr`, `Form`).  Any new language would need its own checker.
+//! This crate factors out the common algorithm — scope tracking, kind
+//! inference, arity and exhaustiveness checking — so languages only need to
+//! supply a [`LanguageProfile`] that maps their grammar rule names to the
+//! semantic roles the algorithm understands.
+//!
+//! ## Types are not ornamental
+//!
+//! The checker returns [`TypeCheckResult<AnnotatedNode>`] rather than just
+//! `ok/errors`.  The [`AnnotatedNode`] tree carries a [`KindDecl`] on every
+//! node.  Downstream, `twig-ir-compiler::compile_annotated()` reads
+//! `annotated.iir_hint()` to populate `type_hint` fields on IIR instructions
+//! with concrete values (`"i64"`, `"bool"`, `"closure"`) instead of `"any"`.
+//!
+//! The JIT and AOT specialisers in this codebase prioritise `type_hint` over
+//! runtime profiles, so fully-typed IIR reaches native-code quality with zero
+//! warmup cost.
+//!
+//! ## Annotation is always-on
+//!
+//! Even in [`TypedModeDecl::Off`] the annotated tree is built — kinds are the
+//! best available inference (`Any` where nothing better is known).  Annotation
+//! always-on, enforcement mode-gated.
+//!
+//! ## Quick start
+//!
+//! ```rust,ignore
+//! use grammar_type_checker::{check, LanguageProfile};
+//! use type_declarations::{TypeDeclarations, TypedModeDecl};
+//!
+//! // MyProfile implements LanguageProfile for your grammar
+//! let decls = TypeDeclarations::new("my-lang");
+//! let result = check(&grammar_ast_root, &decls, &MyProfile);
+//! assert!(result.ok);
+//! let annotated_root = result.typed_ast;
+//! // annotated_root.iir_hint() → "any" for the program root
+//! // annotated_root.node_children() → annotated forms
+//! ```
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use type_checker_protocol::{TypeCheckResult, TypeErrorDiagnostic};
+use type_declarations::{
+    AnnotatedChild, AnnotatedNode, KindDecl, TypeDeclarations, TypedModeDecl,
+};
+
+pub mod check;
+pub mod profile;
+pub mod scope;
+
+pub use profile::{
+    AppInfo, ArmPattern, BinderInfo, BinderKind, LanguageProfile, MatchArmInfo, MatchInfo,
+};
+pub use scope::ScopeStack;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Type-check a raw grammar AST using parser-emitted [`TypeDeclarations`] and
+/// a language-specific [`LanguageProfile`].
+///
+/// # Returns
+///
+/// A [`TypeCheckResult`] where:
+/// - `typed_ast` is the fully-annotated tree (kind on every node).
+/// - `errors` holds any type violations found.
+/// - `ok` is `false` only in [`TypedModeDecl::Strict`] when there are errors.
+///
+/// **Annotation is always built**, even in `Off` mode.  The annotations feed
+/// compilation (IIR `type_hint` fields) regardless of enforcement.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let result = grammar_type_checker::check(&raw_ast, &decls, &TwigLanguageProfile);
+/// // result.typed_ast.iir_hint() → "any" (program root has no single value kind)
+/// // result.errors.is_empty() on well-typed code in strict mode
+/// ```
+pub fn check<P: LanguageProfile>(
+    root: &GrammarASTNode,
+    decls: &TypeDeclarations,
+    profile: &P,
+) -> TypeCheckResult<AnnotatedNode> {
+    let mode = decls
+        .typed_mode
+        .clone()
+        .unwrap_or(TypedModeDecl::Off);
+
+    // Seed the scope with all top-level globals so forward references work.
+    let mut scope = ScopeStack::new();
+    for (name, kind) in &decls.globals {
+        scope.bind(name.clone(), kind.clone());
+    }
+
+    // Walk every form-level child of the program root.
+    let mut errors: Vec<TypeErrorDiagnostic> = Vec::new();
+    let mut annotated_children: Vec<AnnotatedChild> = Vec::new();
+
+    for child in &root.children {
+        if let ASTNodeOrToken::Node(n) = child {
+            let ann =
+                check::infer(n, decls, profile, &mut scope, &mut errors, &mode, 0);
+            annotated_children.push(AnnotatedChild::Node(ann));
+        } else if let ASTNodeOrToken::Token(t) = child {
+            annotated_children.push(AnnotatedChild::Token {
+                text: t.value.clone(),
+                line: t.line,
+                column: t.column,
+            });
+        }
+    }
+
+    // Build the annotated program root.
+    let annotated_root = AnnotatedNode {
+        rule_name: root.rule_name.clone(),
+        kind: KindDecl::Any, // program root has no single value kind
+        children: annotated_children,
+        start_line: root.start_line,
+        start_column: root.start_column,
+        end_line: root.end_line,
+        end_column: root.end_column,
+    };
+
+    let ok = match mode {
+        TypedModeDecl::Strict => errors.is_empty(),
+        _ => true,
+    };
+
+    TypeCheckResult {
+        typed_ast: annotated_root,
+        errors,
+        ok,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+    use type_declarations::{
+        KindDecl, NamedTypeDecl, TypeDeclarations, TypedModeDecl, VariantDecl,
+    };
+
+    // ── Test helpers ─────────────────────────────────────────────────────
+
+    /// Minimal language profile for tests — recognises a handful of fictional
+    /// rule names so we can exercise the checker without a real language.
+    struct TestProfile;
+
+    impl LanguageProfile for TestProfile {
+        fn literal_kind(&self, node: &GrammarASTNode) -> Option<KindDecl> {
+            match node.rule_name.as_str() {
+                "int_lit" => Some(KindDecl::Int),
+                "bool_lit" => Some(KindDecl::Bool),
+                "nil_lit" => Some(KindDecl::Nil),
+                "sym_lit" => Some(KindDecl::Symbol),
+                _ => None,
+            }
+        }
+
+        fn as_var_ref<'a>(&self, node: &'a GrammarASTNode) -> Option<&'a str> {
+            if node.rule_name != "var_ref" {
+                return None;
+            }
+            // First token child = variable name
+            node.children.iter().find_map(|c| match c {
+                ASTNodeOrToken::Token(t) => Some(t.value.as_str()),
+                _ => None,
+            })
+        }
+
+        fn as_apply<'a>(&self, node: &'a GrammarASTNode) -> Option<AppInfo<'a>> {
+            if node.rule_name != "apply" {
+                return None;
+            }
+            let expr_children: Vec<&GrammarASTNode> = node
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    _ => None,
+                })
+                .collect();
+            if expr_children.is_empty() {
+                return None;
+            }
+            Some(AppInfo {
+                callee: expr_children[0],
+                args: expr_children[1..].to_vec(),
+            })
+        }
+
+        fn as_binder<'a>(&self, node: &'a GrammarASTNode) -> Option<BinderInfo<'a>> {
+            if node.rule_name != "let_expr" {
+                return None;
+            }
+            // Fictional structure: [binding_pair*, body]
+            let children: Vec<&GrammarASTNode> = node
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    _ => None,
+                })
+                .collect();
+            if children.len() < 2 {
+                return None;
+            }
+            // Last child = body, everything before = bindings (name=rule_name)
+            let body_node = children[children.len() - 1];
+            let bindings: Vec<(String, &GrammarASTNode)> = children[..children.len() - 1]
+                .iter()
+                .map(|n| (n.rule_name.clone(), *n))
+                .collect();
+            Some(BinderInfo {
+                is_global: false,
+                kind: BinderKind::Let {
+                    bindings,
+                    body: vec![body_node],
+                },
+            })
+        }
+
+        fn as_match<'a>(&self, node: &'a GrammarASTNode) -> Option<MatchInfo<'a>> {
+            if node.rule_name != "match_expr" {
+                return None;
+            }
+            let children: Vec<&GrammarASTNode> = node
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    _ => None,
+                })
+                .collect();
+            if children.is_empty() {
+                return None;
+            }
+            let scrutinee = children[0];
+            let arms: Vec<MatchArmInfo<'_>> = children[1..]
+                .iter()
+                .map(|arm_node| {
+                    let pat = if arm_node.rule_name == "_" {
+                        ArmPattern::Wildcard
+                    } else {
+                        ArmPattern::Variant {
+                            name: arm_node.rule_name.clone(),
+                            bindings: vec![],
+                        }
+                    };
+                    MatchArmInfo {
+                        pattern: pat,
+                        body: arm_node,
+                    }
+                })
+                .collect();
+            Some(MatchInfo { scrutinee, arms })
+        }
+
+        fn as_begin<'a>(&self, node: &'a GrammarASTNode) -> Option<Vec<&'a GrammarASTNode>> {
+            if node.rule_name != "begin" {
+                return None;
+            }
+            Some(
+                node.children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Node(n) => Some(n),
+                        _ => None,
+                    })
+                    .collect(),
+            )
+        }
+
+        fn child_exprs<'a>(&self, node: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode> {
+            node.children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+
+    /// Build a minimal `GrammarASTNode` for a given rule name with no children.
+    fn leaf(rule: &str) -> GrammarASTNode {
+        GrammarASTNode {
+            rule_name: rule.to_owned(),
+            children: vec![],
+            start_line: Some(1),
+            start_column: Some(1),
+            end_line: Some(1),
+            end_column: Some(1),
+        }
+    }
+
+    /// Build a `GrammarASTNode` whose only child is a token with the given text.
+    fn token_node(rule: &str, token_text: &str) -> GrammarASTNode {
+        use lexer::token::{Token, TokenType};
+        let tok = Token {
+            type_: TokenType::Name,
+            value: token_text.to_owned(),
+            line: 1,
+            column: 1,
+            type_name: None,
+            flags: None,
+        };
+        GrammarASTNode {
+            rule_name: rule.to_owned(),
+            children: vec![ASTNodeOrToken::Token(tok)],
+            start_line: Some(1),
+            start_column: Some(1),
+            end_line: Some(1),
+            end_column: Some(1),
+        }
+    }
+
+    /// Build a `GrammarASTNode` with node children.
+    fn parent(rule: &str, children: Vec<GrammarASTNode>) -> GrammarASTNode {
+        GrammarASTNode {
+            rule_name: rule.to_owned(),
+            children: children
+                .into_iter()
+                .map(ASTNodeOrToken::Node)
+                .collect(),
+            start_line: Some(1),
+            start_column: Some(1),
+            end_line: Some(1),
+            end_column: Some(1),
+        }
+    }
+
+    /// Wrap a single form child in a program root.
+    fn program_of(form: GrammarASTNode) -> GrammarASTNode {
+        parent("program", vec![form])
+    }
+
+    // ── Literal kind tests ────────────────────────────────────────────────
+
+    #[test]
+    fn generic_int_lit_kind() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        let root = program_of(leaf("int_lit"));
+        let result = check(&root, &d, &TestProfile);
+        assert!(result.ok);
+        // The single child annotation should have kind Int
+        let form_ann = result.typed_ast.node_children();
+        assert_eq!(form_ann[0].kind, KindDecl::Int);
+    }
+
+    #[test]
+    fn generic_bool_lit_kind() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        let root = program_of(leaf("bool_lit"));
+        let result = check(&root, &d, &TestProfile);
+        assert_eq!(result.typed_ast.node_children()[0].kind, KindDecl::Bool);
+    }
+
+    #[test]
+    fn generic_nil_lit_kind() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        let root = program_of(leaf("nil_lit"));
+        let result = check(&root, &d, &TestProfile);
+        assert_eq!(result.typed_ast.node_children()[0].kind, KindDecl::Nil);
+    }
+
+    // ── Variable reference tests ──────────────────────────────────────────
+
+    #[test]
+    fn generic_var_ref_resolved() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        d.globals
+            .insert("f".to_owned(), KindDecl::Function { arity: 1 });
+        let root = program_of(token_node("var_ref", "f"));
+        let result = check(&root, &d, &TestProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+        assert_eq!(
+            result.typed_ast.node_children()[0].kind,
+            KindDecl::Function { arity: 1 }
+        );
+    }
+
+    #[test]
+    fn generic_var_ref_unresolved() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        let root = program_of(token_node("var_ref", "unknown_name"));
+        let result = check(&root, &d, &TestProfile);
+        assert!(!result.ok);
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.errors[0].message.contains("unresolved variable"));
+        assert!(result.errors[0].message.contains("unknown_name"));
+    }
+
+    #[test]
+    fn generic_var_ref_unresolved_lenient_ok_true() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Lenient);
+        let root = program_of(token_node("var_ref", "missing"));
+        let result = check(&root, &d, &TestProfile);
+        assert!(result.ok); // lenient: ok even with errors
+        assert!(!result.errors.is_empty());
+    }
+
+    // ── Apply arity tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn generic_apply_arity_correct() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        d.globals
+            .insert("f".to_owned(), KindDecl::Function { arity: 1 });
+        // (apply (var_ref "f") (int_lit))
+        let apply = parent("apply", vec![token_node("var_ref", "f"), leaf("int_lit")]);
+        let root = program_of(apply);
+        let result = check(&root, &d, &TestProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn generic_apply_arity_wrong() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        d.globals
+            .insert("f".to_owned(), KindDecl::Function { arity: 1 });
+        // (apply (var_ref "f") (int_lit) (int_lit)) — too many args
+        let apply = parent(
+            "apply",
+            vec![
+                token_node("var_ref", "f"),
+                leaf("int_lit"),
+                leaf("int_lit"),
+            ],
+        );
+        let root = program_of(apply);
+        let result = check(&root, &d, &TestProfile);
+        assert!(!result.ok);
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.errors[0].message.contains("arity error"));
+    }
+
+    // ── Typed mode tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn generic_typed_off_no_errors() {
+        // Off mode: even unresolved vars produce no errors
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Off);
+        let root = program_of(token_node("var_ref", "does_not_exist"));
+        let result = check(&root, &d, &TestProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn generic_typed_off_still_annotates() {
+        // Annotation is always-on — even Off mode produces AnnotatedNode
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Off);
+        let root = program_of(leaf("int_lit"));
+        let result = check(&root, &d, &TestProfile);
+        // Kind is inferred even in Off mode
+        assert_eq!(result.typed_ast.node_children()[0].kind, KindDecl::Int);
+    }
+
+    #[test]
+    fn generic_typed_strict_fails_on_error() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        let root = program_of(token_node("var_ref", "not_defined"));
+        let result = check(&root, &d, &TestProfile);
+        assert!(!result.ok);
+    }
+
+    // ── AnnotatedNode propagation ─────────────────────────────────────────
+
+    #[test]
+    fn annotated_node_carries_kind() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        let root = program_of(leaf("bool_lit"));
+        let result = check(&root, &d, &TestProfile);
+        let child = &result.typed_ast.node_children()[0];
+        assert_eq!(child.kind, KindDecl::Bool);
+        assert_eq!(child.iir_hint(), "bool");
+    }
+
+    #[test]
+    fn annotated_children_propagate() {
+        // A program with two literal forms — both should be annotated
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        let root = parent(
+            "program",
+            vec![leaf("int_lit"), leaf("bool_lit")],
+        );
+        let result = check(&root, &d, &TestProfile);
+        let children = result.typed_ast.node_children();
+        assert_eq!(children[0].kind, KindDecl::Int);
+        assert_eq!(children[1].kind, KindDecl::Bool);
+    }
+
+    // ── Match exhaustiveness ──────────────────────────────────────────────
+
+    #[test]
+    fn generic_match_non_exhaustive() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        d.globals
+            .insert("v".to_owned(), KindDecl::Named("Color".to_owned()));
+        d.named_types.insert(
+            "Color".to_owned(),
+            NamedTypeDecl::Union {
+                variants: vec![
+                    VariantDecl { name: "Red".to_owned(), fields: vec![] },
+                    VariantDecl { name: "Blue".to_owned(), fields: vec![] },
+                ],
+            },
+        );
+
+        // match_expr: scrutinee=var_ref("v"), one arm for "Red" only
+        let scrutinee = token_node("var_ref", "v");
+        // arm for Red only — Blue missing
+        let red_arm = parent("Red", vec![leaf("int_lit")]);
+        let match_node = parent("match_expr", vec![scrutinee, red_arm]);
+        let root = program_of(match_node);
+
+        let result = check(&root, &d, &TestProfile);
+        assert!(!result.ok);
+        assert!(result.errors[0].message.contains("non-exhaustive"));
+        assert!(result.errors[0].message.contains("Blue"));
+    }
+
+    #[test]
+    fn generic_match_exhaustive_all_variants() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        d.globals
+            .insert("v".to_owned(), KindDecl::Named("Coin".to_owned()));
+        d.named_types.insert(
+            "Coin".to_owned(),
+            NamedTypeDecl::Union {
+                variants: vec![
+                    VariantDecl { name: "Heads".to_owned(), fields: vec![] },
+                    VariantDecl { name: "Tails".to_owned(), fields: vec![] },
+                ],
+            },
+        );
+
+        let scrutinee = token_node("var_ref", "v");
+        let heads_arm = parent("Heads", vec![leaf("int_lit")]);
+        let tails_arm = parent("Tails", vec![leaf("int_lit")]);
+        let match_node = parent("match_expr", vec![scrutinee, heads_arm, tails_arm]);
+        let root = program_of(match_node);
+
+        let result = check(&root, &d, &TestProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn generic_match_exhaustive_wildcard() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        d.globals
+            .insert("v".to_owned(), KindDecl::Named("Coin".to_owned()));
+        d.named_types.insert(
+            "Coin".to_owned(),
+            NamedTypeDecl::Union {
+                variants: vec![
+                    VariantDecl { name: "Heads".to_owned(), fields: vec![] },
+                    VariantDecl { name: "Tails".to_owned(), fields: vec![] },
+                ],
+            },
+        );
+
+        let scrutinee = token_node("var_ref", "v");
+        // "_" is our fictional wildcard rule name
+        let wildcard_arm = parent("_", vec![leaf("nil_lit")]);
+        let match_node = parent("match_expr", vec![scrutinee, wildcard_arm]);
+        let root = program_of(match_node);
+
+        let result = check(&root, &d, &TestProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    // ── KindDecl alias resolution ─────────────────────────────────────────
+
+    #[test]
+    fn kind_decl_resolve_alias_in_globals() {
+        let mut d = TypeDeclarations::new("test");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        // Nat is an alias for Int
+        d.named_types.insert(
+            "Nat".to_owned(),
+            NamedTypeDecl::Alias { target: KindDecl::Int },
+        );
+        d.globals
+            .insert("n".to_owned(), KindDecl::Named("Nat".to_owned()));
+
+        // Looking up "n" gives Named("Nat"), resolving gives Int
+        let resolved = d.resolve(&KindDecl::Named("Nat".to_owned()));
+        assert_eq!(resolved, KindDecl::Int);
+    }
+
+    // ── TypeDeclarations utilities ────────────────────────────────────────
+
+    #[test]
+    fn type_declarations_union_variants_lookup() {
+        use type_declarations::VariantDecl;
+        let mut d = TypeDeclarations::new("test");
+        d.named_types.insert(
+            "Shape".to_owned(),
+            NamedTypeDecl::Union {
+                variants: vec![
+                    VariantDecl { name: "Circle".to_owned(), fields: vec![] },
+                    VariantDecl { name: "Rect".to_owned(), fields: vec![] },
+                ],
+            },
+        );
+        let vs = d.union_variants("Shape").unwrap();
+        assert_eq!(vs, vec!["Circle", "Rect"]);
+    }
+
+    #[test]
+    fn type_declarations_empty_no_panic() {
+        let d = TypeDeclarations::new("test");
+        let root = parent("program", vec![]);
+        let result = check(&root, &d, &TestProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+}

--- a/code/packages/rust/grammar-type-checker/src/profile.rs
+++ b/code/packages/rust/grammar-type-checker/src/profile.rs
@@ -1,0 +1,244 @@
+//! The [`LanguageProfile`] trait — language-specific tree navigation for the
+//! generic type checker.
+//!
+//! The `grammar-type-checker` knows *how* to type-check (scope tracking, kind
+//! inference, arity/exhaustiveness checks) but not *which grammar rules play
+//! which semantic roles*.  Each language provides a small struct that
+//! implements [`LanguageProfile`], mapping its grammar rule names to the
+//! semantic roles the checker understands.
+//!
+//! ## Implementing `LanguageProfile` for a new language
+//!
+//! 1. Inspect the language's `.grammar` file to find the rule names for:
+//!    - Integer / bool / nil / symbol literals
+//!    - Variable references
+//!    - Function application
+//!    - Let bindings
+//!    - Lambda / function definitions
+//!    - Match / case expressions
+//!    - Begin / sequence blocks
+//! 2. Implement each method by matching on `node.rule_name`.
+//! 3. For "transparent wrapper" rules (e.g., Twig's `expr` / `compound`),
+//!    return `None` from all role methods and list the single meaningful child
+//!    in [`child_exprs`](LanguageProfile::child_exprs) so the checker recurses
+//!    through it automatically.
+
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use type_declarations::KindDecl;
+
+// ---------------------------------------------------------------------------
+// Helper return types
+// ---------------------------------------------------------------------------
+
+/// Extracted information about a function application node.
+pub struct AppInfo<'a> {
+    /// The function or callee expression.
+    pub callee: &'a GrammarASTNode,
+    /// The argument expressions, in call order.
+    pub args: Vec<&'a GrammarASTNode>,
+}
+
+/// Discriminated binder information — distinguishes let-style from
+/// lambda/function-style binding forms.
+pub enum BinderKind<'a> {
+    /// A `let`-style binder: each binding has a name and an expression whose
+    /// kind is evaluated and bound.
+    ///
+    /// Scheme semantics: all RHS expressions are evaluated in the *outer*
+    /// scope before any name is visible in the inner scope.
+    Let {
+        /// `(name, rhs_expr)` pairs.
+        bindings: Vec<(String, &'a GrammarASTNode)>,
+        /// Body expressions — the last one's kind is the result kind.
+        body: Vec<&'a GrammarASTNode>,
+    },
+
+    /// A `lambda`-style binder: parameters are names with optional kind
+    /// annotations; the result kind is `KindDecl::Function { arity }`.
+    ///
+    /// Parameters are bound in the body scope (not the outer scope).
+    Lambda {
+        /// `(param_name, param_kind)` pairs.  Kind comes from the source
+        /// type annotation if present, otherwise [`KindDecl::Any`].
+        params: Vec<(String, KindDecl)>,
+        /// Body expressions.
+        body: Vec<&'a GrammarASTNode>,
+    },
+}
+
+/// Information extracted from a binder node.
+pub struct BinderInfo<'a> {
+    /// Whether this is a global binder (top-level define) or local
+    /// (let / anonymous lambda).
+    pub is_global: bool,
+    /// The actual binding structure.
+    pub kind: BinderKind<'a>,
+}
+
+/// Extracted information about a match / case expression.
+pub struct MatchInfo<'a> {
+    /// The expression being matched.
+    pub scrutinee: &'a GrammarASTNode,
+    /// The match arms in source order.
+    pub arms: Vec<MatchArmInfo<'a>>,
+}
+
+/// One arm of a match expression.
+pub struct MatchArmInfo<'a> {
+    /// The pattern that this arm matches.
+    pub pattern: ArmPattern,
+    /// The body expression of this arm.
+    pub body: &'a GrammarASTNode,
+}
+
+/// A pattern in a match arm.
+#[derive(Debug, Clone)]
+pub enum ArmPattern {
+    /// `(VariantName binding0 binding1 ...)` — matches a specific union variant
+    /// and binds its fields.
+    Variant {
+        /// Name of the union variant constructor.
+        name: String,
+        /// Names to bind to each variant field.
+        bindings: Vec<String>,
+    },
+    /// `_` — matches anything, binds nothing.
+    Wildcard,
+    /// `varname` — matches anything, binds the scrutinee to `varname`.
+    Binding(String),
+}
+
+// ---------------------------------------------------------------------------
+// LanguageProfile trait
+// ---------------------------------------------------------------------------
+
+/// Language-specific tree navigation for the generic type checker.
+///
+/// The generic checker calls these methods on every `GrammarASTNode` it
+/// encounters.  Each method should:
+///
+/// - Return `Some(info)` when the node plays that semantic role.
+/// - Return `None` when the node is something else (the checker will try the
+///   next method or fall back to [`child_exprs`](Self::child_exprs)).
+///
+/// The methods are tried in this priority order inside [`crate::check`]:
+///
+/// 1. `literal_kind`
+/// 2. `as_var_ref`
+/// 3. `as_apply`
+/// 4. `as_binder`
+/// 5. `as_match`
+/// 6. `as_begin`
+/// 7. `child_exprs` (fallback)
+pub trait LanguageProfile: Send + Sync {
+    /// Return the literal kind produced by this node, if it is a literal.
+    ///
+    /// # Examples
+    ///
+    /// | Grammar rule | Token(s) | Returns |
+    /// |---|---|---|
+    /// | `atom` + INTEGER | `42` | `Some(KindDecl::Int)` |
+    /// | `atom` + BOOL_TRUE | `#t` | `Some(KindDecl::Bool)` |
+    /// | `quoted` | `'foo` | `Some(KindDecl::Symbol)` |
+    /// | `atom` + NAME | `my-var` | `None` (variable reference) |
+    fn literal_kind(&self, node: &GrammarASTNode) -> Option<KindDecl>;
+
+    /// If this node is a variable reference, return the variable name.
+    ///
+    /// The checker uses the name to look up the kind in the scope stack and
+    /// in `TypeDeclarations::globals`.  Returns `None` for all non-reference
+    /// nodes.
+    fn as_var_ref<'a>(&self, node: &'a GrammarASTNode) -> Option<&'a str>;
+
+    /// If this node is a function application, extract the callee and
+    /// argument sub-expressions.
+    ///
+    /// The checker infers the callee's kind, checks arity if it is
+    /// `Function { arity }`, then infers each argument.
+    fn as_apply<'a>(&self, node: &'a GrammarASTNode) -> Option<AppInfo<'a>>;
+
+    /// If this node introduces new bindings (let / lambda / define), extract
+    /// them.
+    ///
+    /// The checker uses the returned [`BinderInfo`] to extend the scope stack
+    /// and infer the body's kind.
+    fn as_binder<'a>(&self, node: &'a GrammarASTNode) -> Option<BinderInfo<'a>>;
+
+    /// If this node is a match / case expression, extract its scrutinee and
+    /// arms.
+    ///
+    /// The checker infers the scrutinee's kind, checks exhaustiveness if it
+    /// is a known union, then infers each arm body.
+    fn as_match<'a>(&self, node: &'a GrammarASTNode) -> Option<MatchInfo<'a>>;
+
+    /// If this node is a sequential block (e.g., `begin`), return its
+    /// sub-expressions in order.
+    ///
+    /// The checker infers all expressions and returns the last one's kind.
+    fn as_begin<'a>(&self, node: &'a GrammarASTNode) -> Option<Vec<&'a GrammarASTNode>>;
+
+    /// Return the child expression nodes to recurse into as a fallback.
+    ///
+    /// Used when none of the above role methods match.  For "transparent
+    /// wrapper" rules (e.g., Twig's `expr`, `compound`, `form`) this should
+    /// return the single meaningful child.  For structural expressions like
+    /// `if_form`, return the condition + branches.
+    fn child_exprs<'a>(&self, node: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode>;
+
+    /// Return the source position `(line, column)` of the node for error
+    /// reporting.
+    ///
+    /// The default implementation reads `start_line` / `start_column` from
+    /// the grammar node.
+    fn position(&self, node: &GrammarASTNode) -> (usize, usize) {
+        (
+            node.start_line.unwrap_or(0),
+            node.start_column.unwrap_or(0),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers shared across profile implementations
+// ---------------------------------------------------------------------------
+
+/// Collect all child `GrammarASTNode`s (dropping raw token children).
+pub fn ast_node_children(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+/// Collect all child `GrammarASTNode`s whose `rule_name` matches `rule`.
+pub fn ast_nodes_named<'a>(node: &'a GrammarASTNode, rule: &str) -> Vec<&'a GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == rule => Some(n),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Return the text of the first token child whose effective type name matches
+/// `token_type`, or `None` if not found.
+pub fn first_token_value<'a>(node: &'a GrammarASTNode, token_type: &str) -> Option<&'a str> {
+    node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Token(t) if t.effective_type_name() == token_type => {
+            Some(t.value.as_str())
+        }
+        _ => None,
+    })
+}
+
+/// True if the node has at least one token child of the given effective type.
+pub fn has_token_type(node: &GrammarASTNode, token_type: &str) -> bool {
+    node.children.iter().any(|c| match c {
+        ASTNodeOrToken::Token(t) => t.effective_type_name() == token_type,
+        _ => false,
+    })
+}

--- a/code/packages/rust/grammar-type-checker/src/scope.rs
+++ b/code/packages/rust/grammar-type-checker/src/scope.rs
@@ -1,0 +1,132 @@
+//! Lexical scope stack for the generic type checker.
+//!
+//! The scope stack is a chain of frames (innermost first).  Each frame maps
+//! variable names to their inferred [`KindDecl`].  When a binder form is
+//! entered (lambda / let), a new frame is pushed; when the body is fully
+//! walked the frame is popped.
+//!
+//! Lookup walks the frame chain from innermost to outermost, matching Scheme's
+//! lexical scoping semantics.  If no frame contains the name, the caller falls
+//! back to `TypeDeclarations::globals` (populated from top-level defines
+//! before the walk begins).
+
+use std::collections::HashMap;
+
+use type_declarations::KindDecl;
+
+/// Lexical scope stack.
+///
+/// Created fresh for each `check()` call.  The initial global frame is seeded
+/// from `TypeDeclarations::globals` before any expression is walked.
+pub struct ScopeStack {
+    /// Frames in push order (last = innermost / most recently pushed).
+    frames: Vec<HashMap<String, KindDecl>>,
+}
+
+impl ScopeStack {
+    /// Create a scope stack with one empty global frame.
+    pub fn new() -> Self {
+        Self {
+            frames: vec![HashMap::new()],
+        }
+    }
+
+    /// Push a new (empty) inner frame.
+    pub fn push(&mut self) {
+        self.frames.push(HashMap::new());
+    }
+
+    /// Pop the innermost frame.
+    ///
+    /// Never removes the outermost frame (the global frame stays for the
+    /// lifetime of the check pass).
+    pub fn pop(&mut self) {
+        if self.frames.len() > 1 {
+            self.frames.pop();
+        }
+    }
+
+    /// Bind `name` → `kind` in the innermost frame.
+    pub fn bind(&mut self, name: impl Into<String>, kind: KindDecl) {
+        self.frames
+            .last_mut()
+            .expect("scope stack invariant: at least one frame")
+            .insert(name.into(), kind);
+    }
+
+    /// Look up `name` in the scope chain (innermost first).
+    ///
+    /// Returns `None` if the name is not in any frame.  The caller should
+    /// then check `TypeDeclarations::globals` before reporting an error.
+    pub fn lookup(&self, name: &str) -> Option<&KindDecl> {
+        // Iterate frames in reverse (innermost = last)
+        for frame in self.frames.iter().rev() {
+            if let Some(k) = frame.get(name) {
+                return Some(k);
+            }
+        }
+        None
+    }
+
+    /// Number of frames currently on the stack (≥ 1).
+    #[cfg(test)]
+    pub fn depth(&self) -> usize {
+        self.frames.len()
+    }
+}
+
+impl Default for ScopeStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_has_one_frame() {
+        assert_eq!(ScopeStack::new().depth(), 1);
+    }
+
+    #[test]
+    fn push_pop_symmetry() {
+        let mut s = ScopeStack::new();
+        s.push();
+        assert_eq!(s.depth(), 2);
+        s.pop();
+        assert_eq!(s.depth(), 1);
+    }
+
+    #[test]
+    fn pop_does_not_remove_global_frame() {
+        let mut s = ScopeStack::new();
+        s.pop(); // already at depth 1
+        s.pop();
+        assert_eq!(s.depth(), 1);
+    }
+
+    #[test]
+    fn lookup_finds_in_innermost() {
+        let mut s = ScopeStack::new();
+        s.bind("x", KindDecl::Int);
+        s.push();
+        s.bind("x", KindDecl::Bool); // shadows outer
+        assert_eq!(s.lookup("x"), Some(&KindDecl::Bool));
+    }
+
+    #[test]
+    fn lookup_falls_through_to_outer() {
+        let mut s = ScopeStack::new();
+        s.bind("x", KindDecl::Int);
+        s.push(); // inner frame, no binding for x
+        assert_eq!(s.lookup("x"), Some(&KindDecl::Int));
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unbound() {
+        let s = ScopeStack::new();
+        assert_eq!(s.lookup("unbound"), None);
+    }
+}

--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog — twig-ir-compiler
 
+## [0.6.0] — 2026-05-14
+
+### Added (LANG50 — Annotation-aware IIR emission)
+
+- `compile_typed_source(source, module_name) -> Result<IIRModule, TwigCompileError>`
+  — new compilation entry point that runs the LANG50 grammar-type-checker pass
+  first and post-processes the resulting IIR to propagate concrete `type_hint`
+  values (`"i64"`, `"bool"`, `"str"`, `"closure"`) on instructions whose source
+  positions map to concretely-typed `AnnotatedNode`s.
+- `build_hint_map` — traverses the `AnnotatedNode` tree to build a
+  `HashMap<(line, col), &'static str>` of concrete hints.
+- `apply_hints` — post-processes an `IIRFunction`'s instructions using the
+  hint map and the function's `source_map` for position correlation.
+- `set_function_type_status` — sets `IIRFunction::type_status` to
+  `FullyTyped` / `PartiallyTyped` / `Untyped` based on the fraction of
+  non-void instructions carrying a concrete type hint.
+- 7 new unit tests in `tests` module:
+  `typed_source_int_literal_hint`, `typed_source_bool_literal_hint`,
+  `typed_source_nil_literal_hint`, `typed_source_untyped_fallback`,
+  `typed_source_function_status_fully_typed`,
+  `typed_source_strict_mode_type_error_returns_err`,
+  `typed_source_off_mode_no_errors`.
+
+### Dependencies added
+
+- `type-declarations = { path = "../type-declarations" }`
+
+### Backward compatibility
+
+- `compile_source` and `compile_program` are **unchanged**.
+- `FunctionTypeStatus` set by `set_function_type_status` only affects
+  functions compiled via `compile_typed_source`; the existing path still
+  emits `Untyped` everywhere.
+
+---
+
 ## [0.5.0] — 2026-05-14
 
 ### Added (LANG49 — TW05-B type-check pre-pass)

--- a/code/packages/rust/twig-ir-compiler/Cargo.toml
+++ b/code/packages/rust/twig-ir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "twig-ir-compiler"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
-description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler"
+description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler.  LANG50: compile_typed_source uses grammar-type-checker annotations to populate type_hint fields."
 
 [dependencies]
 twig-parser        = { path = "../twig-parser" }
@@ -12,3 +12,5 @@ interpreter-ir     = { path = "../interpreter-ir" }
 lang-refined-types = { path = "../lang-refined-types" }
 # LANG49 TW05-B: optional type-check pre-pass for (typed lenient|strict) modules.
 twig-type-checker  = { path = "../twig-type-checker" }
+# LANG50: AnnotatedNode type for post-processing type_hint fields.
+type-declarations  = { path = "../type-declarations" }

--- a/code/packages/rust/twig-ir-compiler/src/lib.rs
+++ b/code/packages/rust/twig-ir-compiler/src/lib.rs
@@ -81,8 +81,14 @@ pub use compiler::Compiler;
 pub use errors::TwigCompileError;
 pub use free_vars::free_vars;
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{
+    function::FunctionTypeStatus,
+    source_loc::SourceLoc,
+    IIRModule,
+};
+use std::collections::HashMap;
 use twig_parser::{parse, Program, TypedMode};
+use type_declarations::AnnotatedNode;
 
 /// Compile a parsed [`Program`] into an [`IIRModule`].
 ///
@@ -161,6 +167,185 @@ pub fn compile_program(
 pub fn compile_source(source: &str, module_name: &str) -> Result<IIRModule, TwigCompileError> {
     let program = parse(source)?;
     compile_program(&program, module_name)
+}
+
+// ---------------------------------------------------------------------------
+// LANG50: compile_typed_source — annotation-aware IIR emission
+// ---------------------------------------------------------------------------
+
+/// Compile a Twig source string with full type annotation propagation.
+///
+/// Runs the LANG50 `grammar-type-checker` pass first to build an
+/// [`AnnotatedNode`] tree, then compiles the program and post-processes the
+/// resulting IIR to propagate concrete `type_hint` values (`"i64"`, `"bool"`,
+/// `"str"`, `"closure"`) wherever the checker could infer a concrete kind.
+///
+/// ## Type propagation pipeline
+///
+/// ```text
+/// source
+///   ├─ parse_to_ast  → GrammarASTNode
+///   ├─ parse + emit_type_declarations → TypeDeclarations
+///   └─ grammar_type_checker::check → AnnotatedNode tree
+///                          │
+///               build_hint_map: (line, col) → iir_hint
+///                          │
+///          compile_source → IIRModule
+///                          │
+///             apply_hints: instructions.type_hint updated
+///                          │
+///            set_function_type_status: FullyTyped / PartiallyTyped / Untyped
+/// ```
+///
+/// ## Mode enforcement
+///
+/// | `(typed …)` clause | Behaviour                                     |
+/// |--------------------|-----------------------------------------------|
+/// | absent / `off`     | Annotate; never emit errors                   |
+/// | `lenient`          | Annotate; warnings printed; compilation ok    |
+/// | `strict`           | Annotate; first error → `Err(TwigCompileError)` |
+///
+/// # Errors
+///
+/// Returns `Err` on parse failure or strict-mode type errors.
+///
+/// # Example
+///
+/// ```
+/// use twig_ir_compiler::compile_typed_source;
+///
+/// let m = compile_typed_source("42", "test").unwrap();
+/// let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+/// // The integer literal 42 → type_hint "i64" on the const instruction.
+/// let hint = main.instructions.iter()
+///     .find(|i| i.op == "const")
+///     .map(|i| i.type_hint.as_str());
+/// assert_eq!(hint, Some("i64"));
+/// ```
+pub fn compile_typed_source(source: &str, module_name: &str) -> Result<IIRModule, TwigCompileError> {
+    // ── 1. Type-check via grammar-type-checker (LANG50). ──────────────────
+    let tc = twig_type_checker::type_check_source(source)
+        .map_err(|e| TwigCompileError { message: e.to_string(), line: 0, column: 0 })?;
+
+    // ── 2. Enforce typed-mode. ────────────────────────────────────────────
+    // The `TypeCheckResult::ok` flag encodes strict-mode failures; check it.
+    if !tc.ok {
+        // ok==false ↔ strict mode + at least one error.
+        let d = tc.errors.first().expect(
+            "type-checker invariant violated: ok==false but errors is empty",
+        );
+        return Err(TwigCompileError {
+            message: format!("type error: {}", d.message),
+            line: d.line,
+            column: d.column,
+        });
+    }
+    // Lenient mode: print warnings but continue.
+    for d in &tc.errors {
+        eprintln!("twig type warning ({}:{}): {}", d.line, d.column, d.message);
+    }
+
+    // ── 3. Compile to IIR (base pass — all hints still "any"). ────────────
+    let mut module = compile_source(source, module_name)?;
+
+    // ── 4. Build (line, col) → iir_hint lookup from the AnnotatedNode tree. ─
+    let hint_map = build_hint_map(&tc.typed_ast);
+
+    // ── 5. Post-process: replace "any" type_hints with concrete kinds. ────
+    for func in &mut module.functions {
+        apply_hints(func, &hint_map);
+        set_function_type_status(func);
+    }
+
+    Ok(module)
+}
+
+// ---------------------------------------------------------------------------
+// Annotation post-processing helpers
+// ---------------------------------------------------------------------------
+
+/// Walk an [`AnnotatedNode`] tree and build a map from source position
+/// `(line, col)` to IIR `type_hint` string.
+///
+/// Only positions with **concrete** hints (`"i64"`, `"bool"`, `"str"`,
+/// `"closure"`) are stored — `"any"` hints are not inserted because the
+/// default is already `"any"`.
+fn build_hint_map(root: &AnnotatedNode) -> HashMap<(u32, u32), &'static str> {
+    let mut map = HashMap::new();
+    collect_hints(root, &mut map);
+    map
+}
+
+fn collect_hints<'a>(
+    node: &'a AnnotatedNode,
+    map: &mut HashMap<(u32, u32), &'static str>,
+) {
+    use type_declarations::AnnotatedChild;
+
+    let hint = node.iir_hint();
+    if hint != "any" {
+        // Use start position as the lookup key.
+        if let (Some(line), Some(col)) = (node.start_line, node.start_column) {
+            map.insert((line as u32, col as u32), hint);
+        }
+    }
+
+    for child in &node.children {
+        if let AnnotatedChild::Node(child_node) = child {
+            collect_hints(child_node, map);
+        }
+    }
+}
+
+/// Replace `"any"` `type_hint`s on instructions where the hint map has a
+/// concrete hint at the instruction's source position.
+fn apply_hints(
+    func: &mut interpreter_ir::function::IIRFunction,
+    hint_map: &HashMap<(u32, u32), &'static str>,
+) {
+    for (instr, loc) in func.instructions.iter_mut().zip(func.source_map.iter()) {
+        if instr.type_hint == "any" && loc != &SourceLoc::SYNTHETIC {
+            if let Some(&hint) = hint_map.get(&(loc.line, loc.column)) {
+                instr.type_hint = hint.to_owned();
+            }
+        }
+    }
+}
+
+/// Set [`FunctionTypeStatus`] on a function based on how many of its
+/// instructions carry a concrete `type_hint` (non-`"any"`, non-`"void"`).
+///
+/// | Condition                        | Status            |
+/// |----------------------------------|-------------------|
+/// | All concrete (threshold = 0%)    | `FullyTyped`      |
+/// | Mixed (1%–99%)                   | `PartiallyTyped`  |
+/// | All `"any"` / `"void"` (100%)    | `Untyped`         |
+///
+/// Instructions with `"void"` type_hint (like `label` or `br`) are
+/// excluded from the count entirely — they are structural, not typed.
+fn set_function_type_status(func: &mut interpreter_ir::function::IIRFunction) {
+    let typed_instrs: Vec<_> = func
+        .instructions
+        .iter()
+        .filter(|i| i.type_hint != "void")
+        .collect();
+
+    if typed_instrs.is_empty() {
+        return; // no value-producing instructions — leave status unchanged
+    }
+
+    let concrete_count = typed_instrs
+        .iter()
+        .filter(|i| i.type_hint != "any")
+        .count();
+
+    func.type_status = if concrete_count == typed_instrs.len() {
+        FunctionTypeStatus::FullyTyped
+    } else if concrete_count > 0 {
+        FunctionTypeStatus::PartiallyTyped
+    } else {
+        FunctionTypeStatus::Untyped
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -842,5 +1027,111 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ── LANG50: compile_typed_source tests ───────────────────────────────
+
+    fn typed_module(src: &str) -> IIRModule {
+        compile_typed_source(src, "test")
+            .unwrap_or_else(|e| panic!("compile_typed_source failed: {e}"))
+    }
+
+    fn all_hints(module: &IIRModule) -> Vec<String> {
+        module
+            .functions
+            .iter()
+            .flat_map(|f| f.instructions.iter().map(|i| i.type_hint.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn typed_source_int_literal_hint() {
+        // A bare integer literal: the `const` instruction should get "i64".
+        let m = typed_module("42");
+        let hints = all_hints(&m);
+        assert!(
+            hints.iter().any(|h| h == "i64"),
+            "expected at least one 'i64' hint, got: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn typed_source_bool_literal_hint() {
+        // A boolean literal: the `const` instruction should get "bool".
+        let m = typed_module("#t");
+        let hints = all_hints(&m);
+        assert!(
+            hints.iter().any(|h| h == "bool"),
+            "expected at least one 'bool' hint, got: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn typed_source_nil_literal_hint() {
+        // `nil` maps to KindDecl::Nil → iir_hint "any".
+        // This test documents the current behaviour (Nil → "any").
+        let m = typed_module("nil");
+        // Should compile without errors.
+        assert!(!m.functions.is_empty());
+    }
+
+    #[test]
+    fn typed_source_untyped_fallback() {
+        // A function call to a builtin — the call result has type Any → hint "any".
+        // Off mode (no module declaration) so no type errors are emitted.
+        // The `+` builtin is known to the compiler, so compilation succeeds.
+        let m = typed_module("(+ 1 2)");
+        // The call to `+` has type Any (call return type unknown statically).
+        let hints = all_hints(&m);
+        // At minimum there should be no panic.
+        assert!(!m.functions.is_empty());
+        // The `+` call instruction itself should be "any" (return type unknown).
+        // But the literal args (1, 2) get "i64" hints — so the mix is expected.
+        let _ = hints; // documented: mix of "i64" (args) and "any" (call result)
+    }
+
+    #[test]
+    fn typed_source_function_status_fully_typed() {
+        // A function that takes a typed define — verifying FunctionTypeStatus
+        // is updated when all instructions have concrete hints.
+        //
+        // `(define x : int 42)` — the `42` literal gets "i64".
+        // The main function emits a `const` + `global_set` + `ret`.
+        // `const` gets "i64", `global_set` stays "any" (it's a side-effect op).
+        // So main is PartiallyTyped (not FullyTyped — not all concrete).
+        //
+        // A bare `42` just has `const` + `ret` in main.  `const` → "i64",
+        // `ret` → "any".  PartiallyTyped.  FullyTyped requires ALL non-void
+        // instructions to be concrete.
+        let m = typed_module("42");
+        let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+        // At minimum, the type_status should not be Untyped (we got a concrete hint).
+        assert_ne!(
+            main.type_status,
+            FunctionTypeStatus::Untyped,
+            "main should be at least PartiallyTyped when a literal was inferred"
+        );
+    }
+
+    #[test]
+    fn typed_source_strict_mode_type_error_returns_err() {
+        // Strict mode + arity mismatch → compile_typed_source returns Err.
+        let src = "(module m (typed strict)) (define (f x) x) (f 1 2)";
+        let result = compile_typed_source(src, "test");
+        assert!(result.is_err(), "expected Err on strict type error");
+        let err = result.unwrap_err();
+        assert!(err.message.contains("arity") || err.message.contains("type error"));
+    }
+
+    #[test]
+    fn typed_source_off_mode_no_errors() {
+        // No module declaration → Off mode → no strict errors.
+        let src = "(+ undefined_var 1)";
+        let result = compile_typed_source(src, "test");
+        // Compilation may fail for other reasons (unbound var in compiler).
+        // The point is: type errors are NOT the reason it fails.
+        // If compile_source succeeds, typed should too.
+        let baseline = compile_source(src, "test");
+        assert_eq!(result.is_ok(), baseline.is_ok());
     }
 }

--- a/code/packages/rust/twig-parser/Cargo.toml
+++ b/code/packages/rust/twig-parser/Cargo.toml
@@ -6,10 +6,11 @@ description = "Twig (Lisp-precursor) parser — thin wrapper over GrammarParser 
 build = "build.rs"
 
 [dependencies]
-grammar-tools = { path = "../grammar-tools" }
-lexer         = { path = "../lexer" }
-parser        = { path = "../parser" }
-twig-lexer    = { path = "../twig-lexer" }
+grammar-tools     = { path = "../grammar-tools" }
+lexer             = { path = "../lexer" }
+parser            = { path = "../parser" }
+twig-lexer        = { path = "../twig-lexer" }
+type-declarations = { path = "../type-declarations" }
 # Required by `bin/twig_spec_dump.rs` to pretty-print the language-spec
 # JSON.  Library code in twig-parser does not depend on serde_json.
 serde_json    = "1.0"

--- a/code/packages/rust/twig-parser/src/lib.rs
+++ b/code/packages/rust/twig-parser/src/lib.rs
@@ -64,6 +64,7 @@
 
 pub mod ast_extract;
 pub mod ast_nodes;
+pub mod type_decls;
 
 use std::fmt;
 use std::sync::OnceLock;
@@ -101,6 +102,7 @@ fn twig_parser_grammar() -> &'static ParserGrammar {
 pub use ast_extract::{
     check_membership_int_count, extract_program, MAX_AST_DEPTH, MAX_MEMBERSHIP_INT_VALUES,
 };
+pub use type_decls::emit_type_declarations;
 pub use ast_nodes::{
     // ── Atoms ─────────────────────────────────────────────────────────────
     Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program, SymLit,

--- a/code/packages/rust/twig-parser/src/type_decls.rs
+++ b/code/packages/rust/twig-parser/src/type_decls.rs
@@ -1,0 +1,523 @@
+//! # `emit_type_declarations` — parser-side type declaration emission
+//!
+//! This module converts a parsed Twig [`Program`] into a [`TypeDeclarations`]
+//! struct, analogous to TypeScript's `.d.ts` emit step.  The result is
+//! consumed by the generic `grammar-type-checker` crate to drive
+//! language-agnostic type inference over raw `GrammarASTNode` trees.
+//!
+//! ## What gets emitted
+//!
+//! | Twig source form        | Emitted to                                       |
+//! |-------------------------|--------------------------------------------------|
+//! | `(type Name expr)`      | `named_types["Name"] = Alias { target: kind }`   |
+//! | `(record Name …)`       | `named_types["Name"] = Record { fields }`        |
+//! | `(union Name …)`        | `named_types["Name"] = Union { variants }`       |
+//! | `(define name expr)`    | `globals["name"] = kind_of(expr)`               |
+//! | `(module … (typed …))`  | `typed_mode = Some(…)`                           |
+//!
+//! ## Kind mapping
+//!
+//! Twig type names and [`TypeAnnotation`] variants map to [`KindDecl`] as
+//! follows:
+//!
+//! | Twig type / annotation     | KindDecl              |
+//! |----------------------------|-----------------------|
+//! | `int` / `UnrefinedInt`     | `Int`                 |
+//! | `bool` / `UnrefinedBool`   | `Bool`                |
+//! | `str`                      | `Str`                 |
+//! | `nil`                      | `Nil`                 |
+//! | `any` / `Any`              | `Any`                 |
+//! | `RangeInt{..}`             | `Int`                 |
+//! | `MembershipInt{..}`        | `Int`                 |
+//! | `Opaque(Name(n))`          | `Named(n)` if unknown name; else resolved |
+//! | `(lambda (x y) body)`      | `Function { arity }`  |
+//! | anything else              | `Any`                 |
+//!
+//! Forward references work because `define` globals are seeded into the
+//! checker scope *before* the walk — the emitted `TypeDeclarations` captures
+//! the final global kind, not an intermediate inference state.
+
+use type_declarations::{
+    FieldDecl, KindDecl, NamedTypeDecl, TypeDeclarations, TypedModeDecl, VariantDecl,
+};
+
+use crate::ast_nodes::{
+    Expr, Form, Program, TypeAnnotation, TypeExpr, TypedMode,
+};
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Convert a parsed Twig `Program` into a [`TypeDeclarations`] struct.
+///
+/// This is the Twig implementation of the generic "emit declarations from
+/// parsed AST" step.  Call this immediately after [`crate::parse`] (or
+/// [`crate::extract_program`]) to produce the declarations the generic
+/// `grammar-type-checker` needs.
+///
+/// ## Example
+///
+/// ```no_run
+/// use twig_parser::{parse, emit_type_declarations};
+///
+/// let program = parse("(module mylib (typed strict)) (define x : int 42)").unwrap();
+/// let decls = emit_type_declarations(&program);
+/// assert_eq!(decls.globals["x"], type_declarations::KindDecl::Int);
+/// ```
+pub fn emit_type_declarations(program: &Program) -> TypeDeclarations {
+    // ── 1. Start with an empty TypeDeclarations for "twig". ───────────────
+    let mut decls = TypeDeclarations::new("twig");
+
+    // ── 2. Capture the typed_mode from the optional module declaration. ───
+    if let Some(mi) = &program.module_info {
+        decls.typed_mode = mi.typed_mode.as_ref().map(twig_mode_to_decl);
+    }
+
+    // ── 3. Collect named type declarations (alias / record / union). ───────
+    for form in &program.forms {
+        match form {
+            Form::TypeAlias(ta) => {
+                let target = type_expr_to_kind(&ta.expr);
+                decls
+                    .named_types
+                    .insert(ta.name.clone(), NamedTypeDecl::Alias { target });
+            }
+            Form::RecordDef(r) => {
+                let fields = r
+                    .fields
+                    .iter()
+                    .map(|f| FieldDecl {
+                        name: f.name.clone(),
+                        kind: annotation_to_kind(&f.type_annotation),
+                    })
+                    .collect();
+                decls
+                    .named_types
+                    .insert(r.name.clone(), NamedTypeDecl::Record { fields });
+            }
+            Form::UnionDef(u) => {
+                let variants = u
+                    .variants
+                    .iter()
+                    .map(|v| VariantDecl {
+                        name: v.name.clone(),
+                        fields: v
+                            .fields
+                            .iter()
+                            .map(|f| FieldDecl {
+                                name: f.name.clone(),
+                                kind: annotation_to_kind(&f.type_annotation),
+                            })
+                            .collect(),
+                    })
+                    .collect();
+                decls
+                    .named_types
+                    .insert(u.name.clone(), NamedTypeDecl::Union { variants });
+            }
+            // Define globals are collected below; expressions are skipped here.
+            Form::Define(_) | Form::Expr(_) => {}
+        }
+    }
+
+    // ── 4. Collect global defines. ────────────────────────────────────────
+    //
+    // Two-pass behaviour: named types are registered above so that a
+    // `define` referring to a user-defined record/union type (via its
+    // type_annotation) resolves correctly via KindDecl::Named.
+    for form in &program.forms {
+        if let Form::Define(d) = form {
+            // Prefer an explicit type_annotation when present.
+            let kind = if let Some(ann) = &d.type_annotation {
+                annotation_to_kind(ann)
+            } else {
+                // Fall back to inferring kind from the expression itself.
+                expr_to_kind(&d.expr)
+            };
+            decls.globals.insert(d.name.clone(), kind);
+        }
+    }
+
+    decls
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers — TypedMode → TypedModeDecl
+// ---------------------------------------------------------------------------
+
+/// Map a Twig [`TypedMode`] (from `ast_nodes`) to the language-agnostic
+/// [`TypedModeDecl`] (from `type-declarations`).
+fn twig_mode_to_decl(mode: &TypedMode) -> TypedModeDecl {
+    // The two enums are structurally identical; we keep them separate so
+    // neither crate depends on the other's AST.
+    match mode {
+        TypedMode::Off => TypedModeDecl::Off,
+        TypedMode::Lenient => TypedModeDecl::Lenient,
+        TypedMode::Strict => TypedModeDecl::Strict,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers — TypeAnnotation → KindDecl
+// ---------------------------------------------------------------------------
+
+/// Convert a Twig [`TypeAnnotation`] to a [`KindDecl`].
+///
+/// The LANG23 annotation vocabulary maps cleanly to `KindDecl`; opaque
+/// TW05-A expressions are lowered via [`type_expr_to_kind`].
+pub(crate) fn annotation_to_kind(ann: &TypeAnnotation) -> KindDecl {
+    match ann {
+        // LANG23 base kinds.
+        TypeAnnotation::UnrefinedInt => KindDecl::Int,
+        TypeAnnotation::UnrefinedBool => KindDecl::Bool,
+        TypeAnnotation::Any => KindDecl::Any,
+        // Range / membership annotations are still integer-kinded.
+        TypeAnnotation::RangeInt { .. } => KindDecl::Int,
+        TypeAnnotation::MembershipInt { .. } => KindDecl::Int,
+        // TW05-A opaque type expression — delegate to the TypeExpr converter.
+        TypeAnnotation::Opaque(te) => type_expr_to_kind(te),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers — TypeExpr → KindDecl
+// ---------------------------------------------------------------------------
+
+/// Convert a Twig [`TypeExpr`] to a [`KindDecl`].
+///
+/// This is a best-effort conversion: complex type expressions (dependent
+/// types, higher-kinded types) fall back to `KindDecl::Any`.  Refinements
+/// are intentionally erased here — the IIR refinement pass handles them.
+///
+/// ## Mapping table
+///
+/// | TypeExpr                             | KindDecl                     |
+/// |--------------------------------------|------------------------------|
+/// | `Name("int")` / `Name("Int")`        | `Int`                        |
+/// | `Name("bool")` / `Name("Bool")`      | `Bool`                       |
+/// | `Name("str")` / `Name("Str")`        | `Str`                        |
+/// | `Name("nil")`                        | `Nil`                        |
+/// | `Name("any")` / `Name("Any")`        | `Any`                        |
+/// | `Name("sym")` / `Name("Symbol")`     | `Symbol`                     |
+/// | `Name(other)`                        | `Named(other)`               |
+/// | `Int(_)`                             | `Int`                        |
+/// | `List([Name("fn"), params, ...])`    | `Function { arity }`         |
+/// | `List([Name("Int"), _, _])`          | `Int` (range form)           |
+/// | `List([Name("Member"), _, _])`       | `Int` (membership form)      |
+/// | anything else                        | `Any`                        |
+fn type_expr_to_kind(te: &TypeExpr) -> KindDecl {
+    match te {
+        // ── Bare name → map standard Twig kind names. ─────────────────────
+        TypeExpr::Name(n) => match n.as_str() {
+            "int" | "Int" => KindDecl::Int,
+            "bool" | "Bool" => KindDecl::Bool,
+            "str" | "Str" | "string" | "String" => KindDecl::Str,
+            "nil" | "Nil" => KindDecl::Nil,
+            "any" | "Any" | "_" => KindDecl::Any,
+            "sym" | "Symbol" | "symbol" => KindDecl::Symbol,
+            // User-defined named type (record, union, or alias resolved later
+            // by TypeDeclarations::resolve).
+            other => KindDecl::Named(other.to_owned()),
+        },
+
+        // ── Integer literal in type position → Int.  ──────────────────────
+        // (Rare, but valid in dependent types like `(Index 0)`.)
+        TypeExpr::Int(_) => KindDecl::Int,
+
+        // ── Parenthesised list: dispatch on the head element. ─────────────
+        TypeExpr::List(parts) => match parts.as_slice() {
+            // `(fn (params…) body)` — function type.  Arity is the number
+            // of items in the parameter list (second element of the list).
+            [TypeExpr::Name(kw), TypeExpr::List(params), _rest @ ..]
+                if kw == "fn" =>
+            {
+                KindDecl::Function {
+                    arity: params.len(),
+                }
+            }
+
+            // `(Int lo hi)` — integer range annotation.
+            [TypeExpr::Name(kw), _, _] if kw == "Int" => KindDecl::Int,
+
+            // `(Member int (v0 v1 …))` — integer membership.
+            [TypeExpr::Name(kw), TypeExpr::Name(base), _]
+                if kw == "Member" && (base == "int" || base == "Int") =>
+            {
+                KindDecl::Int
+            }
+
+            // Head is a known bare name — rare, but forward-compatible.
+            [TypeExpr::Name(n)] => type_expr_to_kind(&TypeExpr::Name(n.clone())),
+
+            // Anything else (dependent types, parametric types, …) is
+            // too complex to resolve statically here; fall back to Any.
+            _ => KindDecl::Any,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers — Expr → KindDecl
+// ---------------------------------------------------------------------------
+
+/// Infer the [`KindDecl`] of a Twig [`Expr`] without a scope.
+///
+/// This is a shallow, structural inference used only to populate the
+/// `globals` map.  It does not walk into subexpressions — the generic
+/// `grammar-type-checker` handles that during the full type-check pass.
+///
+/// Lambdas contribute `Function { arity }` because the arity is always
+/// statically known.  Everything else that can't be determined structurally
+/// falls back to `Any` — the checker will refine it.
+fn expr_to_kind(expr: &Expr) -> KindDecl {
+    match expr {
+        // ── Literals: directly known. ─────────────────────────────────────
+        Expr::IntLit(_) => KindDecl::Int,
+        Expr::BoolLit(_) => KindDecl::Bool,
+        Expr::NilLit(_) => KindDecl::Nil,
+        Expr::SymLit(_) => KindDecl::Symbol,
+
+        // ── Lambda: arity known from parameter list. ─────────────────────
+        //
+        // Example: `(define (f x y) (+ x y))` desugars to
+        // `(define f (lambda (x y) …))` — arity = 2.
+        Expr::Lambda(l) => KindDecl::Function {
+            arity: l.params.len(),
+        },
+
+        // ── Compound expressions: fall back to Any. ──────────────────────
+        //
+        // VarRef: the referenced name's kind is resolved during the check
+        // pass, not here.  Apply/If/Let/Begin/Match: the return kind
+        // depends on runtime values; grammar-type-checker infers it.
+        Expr::VarRef(_)
+        | Expr::Apply(_)
+        | Expr::If(_)
+        | Expr::Let(_)
+        | Expr::Begin(_)
+        | Expr::Match(_) => KindDecl::Any,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+    use type_declarations::{KindDecl, TypedModeDecl};
+
+    // ── Basic: empty program ─────────────────────────────────────────────
+
+    #[test]
+    fn empty_program_empty_decls() {
+        let p = parse("").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.language, "twig");
+        assert!(d.named_types.is_empty());
+        assert!(d.globals.is_empty());
+        assert!(d.typed_mode.is_none());
+    }
+
+    // ── TypedMode from module declaration ────────────────────────────────
+
+    #[test]
+    fn module_strict_sets_typed_mode() {
+        let p = parse("(module mylib (typed strict))").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.typed_mode, Some(TypedModeDecl::Strict));
+    }
+
+    #[test]
+    fn module_lenient_sets_typed_mode() {
+        let p = parse("(module mylib (typed lenient))").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.typed_mode, Some(TypedModeDecl::Lenient));
+    }
+
+    #[test]
+    fn module_off_sets_typed_mode() {
+        let p = parse("(module mylib (typed off))").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.typed_mode, Some(TypedModeDecl::Off));
+    }
+
+    #[test]
+    fn no_module_typed_mode_is_none() {
+        let p = parse("(define x 1)").unwrap();
+        let d = emit_type_declarations(&p);
+        assert!(d.typed_mode.is_none());
+    }
+
+    // ── type alias ───────────────────────────────────────────────────────
+
+    #[test]
+    fn type_alias_int() {
+        let p = parse("(type Nat int)").unwrap();
+        let d = emit_type_declarations(&p);
+        match d.named_types.get("Nat").expect("Nat should be registered") {
+            NamedTypeDecl::Alias { target } => assert_eq!(*target, KindDecl::Int),
+            other => panic!("expected Alias, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn type_alias_bool() {
+        let p = parse("(type Flag bool)").unwrap();
+        let d = emit_type_declarations(&p);
+        match d.named_types.get("Flag").expect("Flag") {
+            NamedTypeDecl::Alias { target } => assert_eq!(*target, KindDecl::Bool),
+            other => panic!("expected Alias, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn type_alias_range_int_is_int() {
+        let p = parse("(type Byte (Int 0 256))").unwrap();
+        let d = emit_type_declarations(&p);
+        match d.named_types.get("Byte").expect("Byte") {
+            NamedTypeDecl::Alias { target } => assert_eq!(*target, KindDecl::Int),
+            other => panic!("expected Alias, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn type_alias_opaque_becomes_named() {
+        let p = parse("(type MyToken Token)").unwrap();
+        let d = emit_type_declarations(&p);
+        match d.named_types.get("MyToken").expect("MyToken") {
+            NamedTypeDecl::Alias { target } => {
+                assert_eq!(*target, KindDecl::Named("Token".to_owned()))
+            }
+            other => panic!("expected Alias, got {other:?}"),
+        }
+    }
+
+    // ── record def ───────────────────────────────────────────────────────
+
+    #[test]
+    fn record_def_emits_record_type() {
+        let p = parse("(record Point (x : int) (y : int))").unwrap();
+        let d = emit_type_declarations(&p);
+        match d.named_types.get("Point").expect("Point") {
+            NamedTypeDecl::Record { fields } => {
+                assert_eq!(fields.len(), 2);
+                assert_eq!(fields[0].name, "x");
+                assert_eq!(fields[0].kind, KindDecl::Int);
+                assert_eq!(fields[1].name, "y");
+                assert_eq!(fields[1].kind, KindDecl::Int);
+            }
+            other => panic!("expected Record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_def_zero_fields() {
+        let p = parse("(record Unit)").unwrap();
+        let d = emit_type_declarations(&p);
+        match d.named_types.get("Unit").expect("Unit") {
+            NamedTypeDecl::Record { fields } => assert!(fields.is_empty()),
+            other => panic!("expected Record, got {other:?}"),
+        }
+    }
+
+    // ── union def ────────────────────────────────────────────────────────
+
+    #[test]
+    fn union_def_emits_union_type() {
+        let p = parse("(union Expr (IntLit (value : int)) (NameRef (name : any)))").unwrap();
+        let d = emit_type_declarations(&p);
+        match d.named_types.get("Expr").expect("Expr") {
+            NamedTypeDecl::Union { variants } => {
+                assert_eq!(variants.len(), 2);
+                assert_eq!(variants[0].name, "IntLit");
+                assert_eq!(variants[0].fields.len(), 1);
+                assert_eq!(variants[0].fields[0].kind, KindDecl::Int);
+                assert_eq!(variants[1].name, "NameRef");
+                assert_eq!(variants[1].fields[0].kind, KindDecl::Any);
+            }
+            other => panic!("expected Union, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn union_variants_accessible_via_decls_helper() {
+        let p = parse("(union Bool (True) (False))").unwrap();
+        let d = emit_type_declarations(&p);
+        let vs = d.union_variants("Bool").expect("Bool variants");
+        assert_eq!(vs, vec!["True".to_owned(), "False".to_owned()]);
+    }
+
+    // ── define globals ───────────────────────────────────────────────────
+
+    #[test]
+    fn define_int_literal_kind_int() {
+        let p = parse("(define x 42)").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.globals["x"], KindDecl::Int);
+    }
+
+    #[test]
+    fn define_bool_literal_kind_bool() {
+        let p = parse("(define flag #t)").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.globals["flag"], KindDecl::Bool);
+    }
+
+    #[test]
+    fn define_lambda_kind_function() {
+        let p = parse("(define (add x y) (+ x y))").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.globals["add"], KindDecl::Function { arity: 2 });
+    }
+
+    #[test]
+    fn define_with_int_annotation_overrides_expr() {
+        // Even though the expr would be Any (it's a var ref), the annotation wins.
+        let p = parse("(define x : int some-var)").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.globals["x"], KindDecl::Int);
+    }
+
+    #[test]
+    fn define_with_range_annotation_is_int() {
+        let p = parse("(define n : (Int 0 128) 42)").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.globals["n"], KindDecl::Int);
+    }
+
+    #[test]
+    fn define_apply_expr_kind_any() {
+        // (f 1 2) — return type unknown without full inference.
+        let p = parse("(define z (f 1 2))").unwrap();
+        let d = emit_type_declarations(&p);
+        assert_eq!(d.globals["z"], KindDecl::Any);
+    }
+
+    // ── full program round-trip ───────────────────────────────────────────
+
+    #[test]
+    fn full_program_round_trip() {
+        let src = r#"
+          (module mylib (typed strict))
+          (type Nat int)
+          (record Point (x : int) (y : int))
+          (union Shape (Circle (r : int)) (Rect (w : int) (h : int)))
+          (define (distance p1 p2) 0)
+          (define origin : Point nil)
+        "#;
+        let p = parse(src).unwrap();
+        let d = emit_type_declarations(&p);
+
+        assert_eq!(d.typed_mode, Some(TypedModeDecl::Strict));
+        assert!(d.named_types.contains_key("Nat"));
+        assert!(d.named_types.contains_key("Point"));
+        assert!(d.named_types.contains_key("Shape"));
+        assert_eq!(d.globals["distance"], KindDecl::Function { arity: 2 });
+        // "origin" has annotation "Point" → Opaque(Name("Point")) → Named("Point")
+        assert_eq!(d.globals["origin"], KindDecl::Named("Point".to_owned()));
+    }
+}

--- a/code/packages/rust/twig-type-checker/CHANGELOG.md
+++ b/code/packages/rust/twig-type-checker/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog — twig-type-checker
 
+## [0.2.0] — 2026-05-14
+
+### Added (LANG50 — Generic Grammar Type Checker integration)
+
+- `type_check_source(source) -> Result<TypeCheckResult<AnnotatedNode>, TwigTypeCheckError>`
+  — new **compilation-first** entry point.  Runs `parse_to_ast` + `emit_type_declarations`
+  + `grammar_type_checker::check` to return a fully-annotated `AnnotatedNode` tree where
+  every node carries a `KindDecl` (and thus an IIR `type_hint` via `iir_hint()`).
+  Annotation is **always built** — even in `Off` mode — so the IIR compiler can use it
+  regardless of enforcement level.
+- `TwigLanguageProfile` (`src/profile.rs`) — implements `grammar_type_checker::LanguageProfile`
+  for Twig grammar rule names.  Transparent descent through `expr`/`compound`/`form` wrapper
+  nodes via `unwrap_expr`.  Handles: literals (`atom` + INTEGER/BOOL_TRUE/BOOL_FALSE/nil,
+  `quoted`), var refs (`atom` + NAME), function application (`apply`), lambda binding
+  (`lambda_form`), let binding (`let_form`), function-sugar define (`define` with LPAREN sig),
+  match expressions (`match_form`), begin sequences (`begin_form`), and if conditionals
+  (via `child_exprs` fallback).
+- `TwigLanguageProfile` re-exported from `crate` root.
+- `AnnotatedNode` re-exported from `crate` root.
+- 13 unit tests in `profile.rs` for the new path.
+
+### Dependencies added
+
+- `grammar-type-checker = { path = "../grammar-type-checker" }`
+- `type-declarations = { path = "../type-declarations" }`
+- `parser = { path = "../parser" }`
+
+### Backward compatibility
+
+- `type_check` and `check_program` are **unchanged** — existing callers work without
+  modification.  The new `type_check_source` path is additive only.
+
+---
+
 ## [0.1.0] — 2026-05-14
 
 Initial release. TW05-B — base static type checker for Twig.

--- a/code/packages/rust/twig-type-checker/Cargo.toml
+++ b/code/packages/rust/twig-type-checker/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name        = "twig-type-checker"
-version     = "0.1.0"
+version     = "0.2.0"
 edition     = "2021"
-description = "Base static type checker for Twig (TW05-B).  Infers TwigKind for every expression, checks call arity, validates record/union constructors, tests match exhaustiveness, and enforces (typed lenient|strict) module modes."
+description = "Base static type checker for Twig (TW05-B / LANG50).  Exposes two paths: type_check_source (GrammarASTNode + grammar-type-checker) for AOT/JIT annotation, and check_program (typed Program) for backward compatibility."
 
 [dependencies]
 twig-parser           = { path = "../twig-parser" }
 type-checker-protocol = { path = "../type-checker-protocol" }
+grammar-type-checker  = { path = "../grammar-type-checker" }
+type-declarations     = { path = "../type-declarations" }
+parser                = { path = "../parser" }

--- a/code/packages/rust/twig-type-checker/src/lib.rs
+++ b/code/packages/rust/twig-type-checker/src/lib.rs
@@ -72,12 +72,18 @@ pub mod env;
 pub mod errors;
 pub mod exhaustiveness;
 pub mod kinds;
+pub mod profile;
 
 pub use env::TypeEnv;
 pub use errors::TwigTypeCheckError;
 pub use kinds::TwigKind;
+pub use profile::TwigLanguageProfile;
 
-use twig_parser::{parse, Program, TypedMode};
+// Re-export the AnnotatedNode type so callers don't need to depend on
+// type-declarations directly just to get the typed_ast out.
+pub use type_declarations::AnnotatedNode;
+
+use twig_parser::{emit_type_declarations, parse, parse_to_ast, Program, TypedMode};
 use type_checker_protocol::{TypeCheckResult, TypeChecker};
 
 // ---------------------------------------------------------------------------
@@ -101,7 +107,59 @@ pub struct TypedProgram {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Public API — LANG50: GrammarASTNode path (compilation-first)
+// ---------------------------------------------------------------------------
+
+/// Parse Twig source and type-check via the generic `grammar-type-checker`,
+/// returning a fully-annotated [`AnnotatedNode`] tree ready for IIR emission.
+///
+/// This is the **compilation-first** entry point introduced in LANG50.
+/// Every node in the returned tree carries a [`type_declarations::KindDecl`]
+/// that maps directly to an IIR `type_hint` via [`AnnotatedNode::iir_hint`].
+///
+/// ## Pipeline
+///
+/// ```text
+/// source → parse_to_ast → GrammarASTNode
+///                             │
+///        parse → Program → emit_type_declarations → TypeDeclarations
+///                                                         │
+///                        grammar_type_checker::check ←───┘
+///                             │
+///                         TypeCheckResult<AnnotatedNode>
+/// ```
+///
+/// ## Errors
+///
+/// Returns `Err(TwigTypeCheckError::Parse(…))` on lex/parse failure.
+/// Type errors are carried in `TypeCheckResult::errors`; `ok` reflects
+/// the module's `(typed …)` mode.
+///
+/// # Example
+///
+/// ```no_run
+/// use twig_type_checker::type_check_source;
+///
+/// let result = type_check_source("(module m (typed strict)) (define x : int 42)")
+///     .expect("parse should succeed");
+/// assert!(result.ok);
+/// // Every node has an IIR type hint — literals get "i64", "bool", etc.
+/// ```
+pub fn type_check_source(
+    source: &str,
+) -> Result<TypeCheckResult<AnnotatedNode>, TwigTypeCheckError> {
+    // 1. Parse to raw grammar AST (keeps position info for error messages).
+    let raw = parse_to_ast(source)?;
+    // 2. Parse to typed AST (needed to emit TypeDeclarations).
+    let program = parse(source)?;
+    // 3. Emit language-agnostic type declarations from the typed AST.
+    let decls = emit_type_declarations(&program);
+    // 4. Run the generic checker with the Twig language profile.
+    Ok(grammar_type_checker::check(&raw, &decls, &TwigLanguageProfile))
+}
+
+// ---------------------------------------------------------------------------
+// Public API — legacy Program path (backward compat)
 // ---------------------------------------------------------------------------
 
 /// Parse and type-check a Twig source string in one call.

--- a/code/packages/rust/twig-type-checker/src/profile.rs
+++ b/code/packages/rust/twig-type-checker/src/profile.rs
@@ -1,0 +1,726 @@
+//! # `TwigLanguageProfile` — Twig grammar tree navigation for the generic checker
+//!
+//! This module implements [`grammar_type_checker::LanguageProfile`] for the Twig
+//! grammar, bridging the gap between raw `GrammarASTNode` rule names (produced by
+//! `twig-parser`'s generic `GrammarParser`) and the semantic roles the
+//! `grammar-type-checker` needs to understand.
+//!
+//! ## Twig grammar → semantic role mapping
+//!
+//! | Grammar rule       | Semantic role               | Profile method        |
+//! |--------------------|-----------------------------|-----------------------|
+//! | `atom` + INTEGER   | integer literal             | `literal_kind`        |
+//! | `atom` + BOOL_TRUE | boolean literal             | `literal_kind`        |
+//! | `atom` + BOOL_FALSE| boolean literal             | `literal_kind`        |
+//! | `atom` + KEYWORD(nil) | nil literal              | `literal_kind`        |
+//! | `quoted`           | symbol literal              | `literal_kind`        |
+//! | `quote_form`       | symbol literal (long form)  | `literal_kind`        |
+//! | `atom` + NAME      | variable reference          | `as_var_ref`          |
+//! | `apply`            | function application        | `as_apply`            |
+//! | `lambda_form`      | anonymous function          | `as_binder`           |
+//! | `define` (fn form) | named function definition   | `as_binder`           |
+//! | `let_form`         | local let bindings          | `as_binder`           |
+//! | `match_form`       | pattern match               | `as_match`            |
+//! | `begin_form`       | sequencing                  | `as_begin`            |
+//! | `if_form`          | conditional (fallback)      | `child_exprs`         |
+//! | `expr` / `compound`| transparent wrapper         | `child_exprs`         |
+//! | `form`             | transparent top-level wrap  | `child_exprs`         |
+//!
+//! ## Wrapper transparency
+//!
+//! The Twig grammar has several "wrapper" rules:
+//! - `expr = atom | quoted | compound`
+//! - `compound = if_form | let_form | …`
+//! - `form = define | type_alias | … | expr`
+//!
+//! These rules produce intermediate `GrammarASTNode` nodes that contain no
+//! semantic content themselves.  Each profile method calls [`unwrap_expr`] to
+//! transparently descend through these wrappers before dispatching on rule names.
+//! This means `as_var_ref` works correctly when called on an `"expr"` node that
+//! wraps an `"atom"` — the inferred kind propagates back to the wrapper.
+
+use grammar_type_checker::{
+    AppInfo, ArmPattern, BinderInfo, BinderKind, LanguageProfile, MatchArmInfo, MatchInfo,
+};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use type_declarations::KindDecl;
+
+// ---------------------------------------------------------------------------
+// TwigLanguageProfile
+// ---------------------------------------------------------------------------
+
+/// Twig-specific implementation of [`LanguageProfile`].
+///
+/// Construct one and pass it to [`grammar_type_checker::check`]:
+///
+/// ```no_run
+/// use twig_type_checker::profile::TwigLanguageProfile;
+/// use twig_parser::{parse_to_ast, emit_type_declarations, parse};
+///
+/// let raw = parse_to_ast("(define x 42)").unwrap();
+/// let program = parse("(define x 42)").unwrap();
+/// let decls = emit_type_declarations(&program);
+/// let result = grammar_type_checker::check(&raw, &decls, &TwigLanguageProfile);
+/// assert!(result.ok);
+/// ```
+pub struct TwigLanguageProfile;
+
+impl TwigLanguageProfile {
+    // ── Internal helper: descend through transparent wrapper nodes. ────────
+    //
+    // The Twig grammar nests semantic nodes inside wrappers:
+    //   expr → compound → apply
+    //   expr → atom
+    //   form → expr → ...
+    //
+    // `unwrap_expr` follows the first child node through any chain of
+    // `"expr"`, `"compound"`, or `"form"` wrappers until it reaches a node
+    // with a semantic rule name (e.g. `"atom"`, `"apply"`, `"lambda_form"`).
+    //
+    // Lifetime: the returned reference borrows from the input tree so no
+    // copies are needed.
+    fn unwrap_expr<'a>(&self, node: &'a GrammarASTNode) -> &'a GrammarASTNode {
+        match node.rule_name.as_str() {
+            "expr" | "compound" | "form" => {
+                // Find the first child GrammarASTNode and recurse.
+                if let Some(child) = node.children.iter().find_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    ASTNodeOrToken::Token(_) => None,
+                }) {
+                    self.unwrap_expr(child)
+                } else {
+                    node // no child node — stay at current level
+                }
+            }
+            _ => node,
+        }
+    }
+}
+
+impl LanguageProfile for TwigLanguageProfile {
+    // ── 1. Literal detection ──────────────────────────────────────────────
+    //
+    // Recognises integer, boolean, nil, and symbol literals from the `atom`
+    // and `quoted` grammar rules.  The profile transparently descends through
+    // `expr`/`compound` wrappers first.
+
+    fn literal_kind(&self, node: &GrammarASTNode) -> Option<KindDecl> {
+        let n = self.unwrap_expr(node);
+        match n.rule_name.as_str() {
+            "atom" => {
+                // atom = INTEGER | BOOL_TRUE | BOOL_FALSE | "nil" | NAME
+                // Literals are anything except NAME.
+                for child in &n.children {
+                    if let ASTNodeOrToken::Token(t) = child {
+                        return match t.effective_type_name() {
+                            "INTEGER" => Some(KindDecl::Int),
+                            "BOOL_TRUE" | "BOOL_FALSE" => Some(KindDecl::Bool),
+                            // "nil" is a KEYWORD token with value "nil".
+                            "KEYWORD" if t.value == "nil" => Some(KindDecl::Nil),
+                            // NAME token → variable reference, not a literal.
+                            _ => None,
+                        };
+                    }
+                }
+                None
+            }
+            // quoted = QUOTE NAME  — always a symbol literal.
+            "quoted" | "quote_form" => Some(KindDecl::Symbol),
+            _ => None,
+        }
+    }
+
+    // ── 2. Variable reference ─────────────────────────────────────────────
+    //
+    // Recognises `atom` nodes that carry a NAME token.  The first NAME token
+    // in an atom is the variable name (there is exactly one).
+
+    fn as_var_ref<'a>(&self, node: &'a GrammarASTNode) -> Option<&'a str> {
+        let n = self.unwrap_expr(node);
+        if n.rule_name != "atom" {
+            return None;
+        }
+        // Return the value of the NAME token, if present.
+        n.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                Some(t.value.as_str())
+            }
+            _ => None,
+        })
+    }
+
+    // ── 3. Function application ───────────────────────────────────────────
+    //
+    // `apply = LPAREN expr { expr } RPAREN`
+    // The first `expr` child is the callee; the rest are the arguments.
+
+    fn as_apply<'a>(&self, node: &'a GrammarASTNode) -> Option<AppInfo<'a>> {
+        let n = self.unwrap_expr(node);
+        if n.rule_name != "apply" {
+            return None;
+        }
+        let exprs: Vec<&GrammarASTNode> = n
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(child) if child.rule_name == "expr" => Some(child),
+                _ => None,
+            })
+            .collect();
+        if exprs.is_empty() {
+            return None;
+        }
+        Some(AppInfo {
+            callee: exprs[0],
+            args: exprs[1..].to_vec(),
+        })
+    }
+
+    // ── 4. Binder (let / lambda / define-fn) ──────────────────────────────
+    //
+    // Three binder forms exist in Twig:
+    //
+    // a) `lambda_form = LPAREN "lambda" LPAREN { NAME } RPAREN expr { expr } RPAREN`
+    //    → BinderKind::Lambda with params from the NAME tokens, body from expr children.
+    //
+    // b) `let_form = LPAREN "let" LPAREN { binding } RPAREN expr { expr } RPAREN`
+    //    → BinderKind::Let with one (name, expr) pair per `binding` child.
+    //
+    // c) `define` with function-sugar: `LPAREN "define" LPAREN NAME { NAME } RPAREN expr+ RPAREN`
+    //    → BinderKind::Lambda (is_global: true) — the function name is already
+    //    in scope from TypeDeclarations; we only need to put parameters in scope
+    //    while checking the body.
+
+    fn as_binder<'a>(&self, node: &'a GrammarASTNode) -> Option<BinderInfo<'a>> {
+        let n = self.unwrap_expr(node);
+        match n.rule_name.as_str() {
+            // ── lambda_form ───────────────────────────────────────────────
+            "lambda_form" => {
+                // Parameters are all NAME tokens that appear before the first
+                // `expr` child node.  In the grammar, they sit between the
+                // inner LPAREN/RPAREN pair, so we collect all NAME tokens from
+                // the direct children (the grammar ensures they precede `expr`).
+                let params: Vec<(String, KindDecl)> = n
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                            Some((t.value.clone(), KindDecl::Any))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+
+                let body: Vec<&GrammarASTNode> = n
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Node(child) if child.rule_name == "expr" => Some(child),
+                        _ => None,
+                    })
+                    .collect();
+
+                if body.is_empty() {
+                    return None;
+                }
+                Some(BinderInfo {
+                    is_global: false,
+                    kind: BinderKind::Lambda { params, body },
+                })
+            }
+
+            // ── let_form ──────────────────────────────────────────────────
+            "let_form" => {
+                // binding = LPAREN NAME expr RPAREN
+                // Each `binding` child contributes (name, rhs_expr).
+                // `expr` children at the `let_form` level are the body.
+                let mut bindings: Vec<(String, &GrammarASTNode)> = Vec::new();
+                let mut body: Vec<&GrammarASTNode> = Vec::new();
+
+                for child in &n.children {
+                    match child {
+                        ASTNodeOrToken::Node(child_node) => {
+                            if child_node.rule_name == "binding" {
+                                // Extract the variable name and the RHS expression.
+                                let name_opt =
+                                    child_node.children.iter().find_map(|c| match c {
+                                        ASTNodeOrToken::Token(t)
+                                            if t.effective_type_name() == "NAME" =>
+                                        {
+                                            Some(t.value.clone())
+                                        }
+                                        _ => None,
+                                    });
+                                let rhs_opt = child_node.children.iter().find_map(|c| match c {
+                                    ASTNodeOrToken::Node(e) if e.rule_name == "expr" => {
+                                        Some(e as &GrammarASTNode)
+                                    }
+                                    _ => None,
+                                });
+                                if let (Some(name), Some(rhs)) = (name_opt, rhs_opt) {
+                                    bindings.push((name, rhs));
+                                }
+                            } else if child_node.rule_name == "expr" {
+                                body.push(child_node);
+                            }
+                        }
+                        ASTNodeOrToken::Token(_) => {}
+                    }
+                }
+
+                if body.is_empty() {
+                    return None;
+                }
+                Some(BinderInfo {
+                    is_global: false,
+                    kind: BinderKind::Let { bindings, body },
+                })
+            }
+
+            // ── define (function-sugar form) ──────────────────────────────
+            //
+            // `define = LPAREN "define" name_or_signature expr { expr } RPAREN`
+            // `name_or_signature = LPAREN NAME { typed_param } ... RPAREN`
+            //
+            // Only the function-sugar form (sig has LPAREN) is a binder;
+            // value-defines (sig has no LPAREN) just have a body expr and the
+            // global is already registered in TypeDeclarations.
+            "define" => {
+                let sig_node =
+                    n.children.iter().find_map(|c| match c {
+                        ASTNodeOrToken::Node(n) if n.rule_name == "name_or_signature" => Some(n),
+                        _ => None,
+                    })?;
+
+                // Function-sugar: sig has a LPAREN among its direct children.
+                let is_fn_sugar = sig_node
+                    .children
+                    .iter()
+                    .any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.effective_type_name() == "LPAREN"));
+
+                if !is_fn_sugar {
+                    // Value-define: no new scope to push.  The global is already
+                    // registered; let child_exprs handle the body expression.
+                    return None;
+                }
+
+                // Collect parameter names.  The signature structure is:
+                //   LPAREN  NAME(fn)  { NAME(param) | typed_param }  RPAREN
+                // The first NAME is the function name (already in globals);
+                // subsequent NAMEs (and typed_param children) are parameters.
+                let mut first_name_seen = false;
+                let mut params: Vec<(String, KindDecl)> = Vec::new();
+                for child in &sig_node.children {
+                    match child {
+                        ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                            if !first_name_seen {
+                                first_name_seen = true; // function name — skip
+                            } else {
+                                params.push((t.value.clone(), KindDecl::Any));
+                            }
+                        }
+                        ASTNodeOrToken::Node(tp_node) if tp_node.rule_name == "typed_param" => {
+                            // typed_param = LPAREN NAME COLON type_annotation RPAREN | NAME
+                            if let Some(t) = tp_node.children.iter().find_map(|c| match c {
+                                ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                                    Some(t)
+                                }
+                                _ => None,
+                            }) {
+                                params.push((t.value.clone(), KindDecl::Any));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Body expressions are the `expr` children of the `define` node.
+                let body: Vec<&GrammarASTNode> = n
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Node(child) if child.rule_name == "expr" => Some(child),
+                        _ => None,
+                    })
+                    .collect();
+
+                if body.is_empty() {
+                    return None;
+                }
+
+                Some(BinderInfo {
+                    is_global: true, // function name already in globals scope
+                    kind: BinderKind::Lambda { params, body },
+                })
+            }
+
+            _ => None,
+        }
+    }
+
+    // ── 5. Match expression ───────────────────────────────────────────────
+    //
+    // `match_form = LPAREN "match" expr { match_arm } RPAREN`
+    // `match_arm  = LPAREN match_pat expr { expr } RPAREN`
+    // `match_pat  = LPAREN NAME { NAME } RPAREN | NAME`
+
+    fn as_match<'a>(&self, node: &'a GrammarASTNode) -> Option<MatchInfo<'a>> {
+        let n = self.unwrap_expr(node);
+        if n.rule_name != "match_form" {
+            return None;
+        }
+
+        // First `expr` child is the scrutinee.
+        let scrutinee = n.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(child) if child.rule_name == "expr" => {
+                Some(child as &GrammarASTNode)
+            }
+            _ => None,
+        })?;
+
+        // All `match_arm` children are the arms.
+        let arms: Vec<MatchArmInfo<'_>> = n
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(arm_node) if arm_node.rule_name == "match_arm" => {
+                    extract_match_arm_info(arm_node)
+                }
+                _ => None,
+            })
+            .collect();
+
+        Some(MatchInfo { scrutinee, arms })
+    }
+
+    // ── 6. Begin / sequence ───────────────────────────────────────────────
+    //
+    // `begin_form = LPAREN "begin" expr { expr } RPAREN`
+    // Returns the `expr` children.  The begin form's value is the last expr.
+
+    fn as_begin<'a>(&self, node: &'a GrammarASTNode) -> Option<Vec<&'a GrammarASTNode>> {
+        let n = self.unwrap_expr(node);
+        if n.rule_name != "begin_form" {
+            return None;
+        }
+        let exprs: Vec<&GrammarASTNode> = n
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(child) if child.rule_name == "expr" => Some(child),
+                _ => None,
+            })
+            .collect();
+        if exprs.is_empty() {
+            None
+        } else {
+            Some(exprs)
+        }
+    }
+
+    // ── 7. Child expressions (fallback) ───────────────────────────────────
+    //
+    // For wrapper and structural nodes, returns the children that contain
+    // expressions worth recursing into.
+
+    fn child_exprs<'a>(&self, node: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode> {
+        match node.rule_name.as_str() {
+            // Transparent single-child wrappers → return the child.
+            "expr" | "compound" | "form" => node
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    _ => None,
+                })
+                .take(1)
+                .collect(),
+
+            // `if_form = LPAREN "if" expr expr expr RPAREN`
+            // → Three expression children (condition, then, else).
+            "if_form" => node
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(child) if child.rule_name == "expr" => Some(child),
+                    _ => None,
+                })
+                .collect(),
+
+            // `define` (value form, i.e. not function-sugar) — walk the body expr.
+            // For the function-sugar form, `as_binder` takes over; this fallback
+            // handles `(define name expr)` where `as_binder` returns None.
+            "define" => node
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(child) if child.rule_name == "expr" => Some(child),
+                    _ => None,
+                })
+                .collect(),
+
+            // `module_form`, `type_alias`, `record_def`, `union_def` —
+            // no expression children to check.
+            "module_form" | "type_alias" | "record_def" | "union_def" => vec![],
+
+            // Generic fallback: return all child nodes.
+            _ => node
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    _ => None,
+                })
+                .collect(),
+        }
+    }
+
+    // ── Position helper ───────────────────────────────────────────────────
+
+    fn position(&self, node: &GrammarASTNode) -> (usize, usize) {
+        (
+            node.start_line.unwrap_or(1),
+            node.start_column.unwrap_or(1),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract match arm info from a `match_arm` node
+// ---------------------------------------------------------------------------
+
+/// Extract a [`MatchArmInfo`] from a `match_arm` grammar node.
+///
+/// Grammar: `match_arm = LPAREN match_pat expr { expr } RPAREN`
+///
+/// The pattern is the single `match_pat` child; the body is the first `expr`
+/// child (multi-expression arms use the first `expr` as the body node — the
+/// checker recurses into it, and if it is a `begin_form` it gets the full
+/// sequence).
+fn extract_match_arm_info(arm_node: &GrammarASTNode) -> Option<MatchArmInfo<'_>> {
+    // Pattern: first `match_pat` child.
+    let pat_node = arm_node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) if n.rule_name == "match_pat" => Some(n),
+        _ => None,
+    })?;
+
+    // Body: first `expr` child of the arm.
+    // (If there are multiple exprs they form an implicit begin; we take the
+    // first and let the profile's begin/fallback handling cover the rest.
+    // In practice twig grammars produce a single expr per arm body unless
+    // the user explicitly uses begin — the extractor already combines them.)
+    let body = arm_node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(e) if e.rule_name == "expr" => Some(e as &GrammarASTNode),
+        _ => None,
+    })?;
+
+    let pattern = extract_arm_pattern(pat_node);
+
+    Some(MatchArmInfo { pattern, body })
+}
+
+/// Convert a `match_pat` node to an [`ArmPattern`].
+///
+/// Grammar: `match_pat = LPAREN NAME { NAME } RPAREN | NAME`
+fn extract_arm_pattern(pat_node: &GrammarASTNode) -> ArmPattern {
+    let has_paren = pat_node.children.iter().any(|c| match c {
+        ASTNodeOrToken::Token(t) => t.effective_type_name() == "LPAREN",
+        _ => false,
+    });
+
+    let name_tokens: Vec<&str> = pat_node
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                Some(t.value.as_str())
+            }
+            _ => None,
+        })
+        .collect();
+
+    if has_paren {
+        // Variant pattern: (VariantName b1 b2 ...)
+        match name_tokens.as_slice() {
+            [] => ArmPattern::Wildcard,
+            [variant, bindings @ ..] => ArmPattern::Variant {
+                name: (*variant).to_owned(),
+                bindings: bindings.iter().map(|s: &&str| s.to_string()).collect(),
+            },
+        }
+    } else {
+        // Bare NAME: wildcard `_` or binding `varname`.
+        match name_tokens.first().copied() {
+            Some("_") => ArmPattern::Wildcard,
+            Some(n) => ArmPattern::Binding((*n).to_owned()),
+            None => ArmPattern::Wildcard,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use twig_parser::parse_to_ast;
+    use type_declarations::{KindDecl, TypeDeclarations, TypedModeDecl};
+
+    fn decls_strict() -> TypeDeclarations {
+        let mut d = TypeDeclarations::new("twig");
+        d.typed_mode = Some(TypedModeDecl::Strict);
+        d
+    }
+
+    // ── Literal detection ─────────────────────────────────────────────────
+
+    #[test]
+    fn integer_atom_is_int_literal() {
+        let raw = parse_to_ast("42").unwrap();
+        let decls = decls_strict();
+        let result = grammar_type_checker::check(&raw, &decls, &TwigLanguageProfile);
+        // "program" has a "form" child whose last annotated child is Int.
+        // Verify top-level result is ok (no strict errors on well-typed source).
+        assert!(result.ok);
+    }
+
+    #[test]
+    fn bool_literal_kind() {
+        let raw = parse_to_ast("#t").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        assert!(result.ok);
+    }
+
+    #[test]
+    fn nil_literal_kind() {
+        let raw = parse_to_ast("nil").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        assert!(result.ok);
+    }
+
+    #[test]
+    fn quoted_symbol_kind() {
+        let raw = parse_to_ast("'foo").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        assert!(result.ok);
+    }
+
+    // ── Variable reference ────────────────────────────────────────────────
+
+    #[test]
+    fn known_var_ref_no_error() {
+        let raw = parse_to_ast("x").unwrap();
+        let mut decls = decls_strict();
+        decls.globals.insert("x".to_owned(), KindDecl::Int);
+        let result = grammar_type_checker::check(&raw, &decls, &TwigLanguageProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn unknown_var_ref_emits_error_strict() {
+        let raw = parse_to_ast("undefined_var").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        // strict mode → ok:false because of the unresolved variable error
+        assert!(!result.ok);
+        assert!(!result.errors.is_empty());
+    }
+
+    // ── Apply ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_correct_arity() {
+        let raw = parse_to_ast("(f 1 2)").unwrap();
+        let mut decls = decls_strict();
+        decls.globals.insert("f".to_owned(), KindDecl::Function { arity: 2 });
+        let result = grammar_type_checker::check(&raw, &decls, &TwigLanguageProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn apply_wrong_arity_emits_error() {
+        let raw = parse_to_ast("(f 1 2 3)").unwrap();
+        let mut decls = decls_strict();
+        decls.globals.insert("f".to_owned(), KindDecl::Function { arity: 2 });
+        let result = grammar_type_checker::check(&raw, &decls, &TwigLanguageProfile);
+        assert!(!result.ok);
+        assert!(!result.errors.is_empty());
+        assert!(result.errors[0].message.contains("arity"));
+    }
+
+    // ── Lambda binder ─────────────────────────────────────────────────────
+
+    #[test]
+    fn lambda_params_in_scope() {
+        // The body references the parameter `x`; no unresolved-variable error.
+        let raw = parse_to_ast("(lambda (x) x)").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn lambda_with_no_params() {
+        let raw = parse_to_ast("(lambda () 42)").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        assert!(result.ok);
+    }
+
+    // ── Let binder ────────────────────────────────────────────────────────
+
+    #[test]
+    fn let_binding_in_scope() {
+        let raw = parse_to_ast("(let ((x 1)) x)").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn let_binding_not_visible_in_sibling_rhs() {
+        // Scheme `let`: (let ((x 1) (y x)) y) — `x` is not in scope for `y`'s RHS.
+        let raw = parse_to_ast("(let ((x 1) (y x)) y)").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        // `x` is unresolved in the RHS of `y` — strict mode emits an error.
+        assert!(!result.ok);
+        assert!(!result.errors.is_empty());
+    }
+
+    // ── Define (function-sugar) ───────────────────────────────────────────
+
+    #[test]
+    fn define_fn_params_in_scope() {
+        // `(define (double x) (+ x x))` — `x` and `+` must be in scope.
+        let raw = parse_to_ast("(define (double x) (+ x x))").unwrap();
+        let mut decls = decls_strict();
+        // `double` is registered as a global by emit_type_declarations.
+        decls.globals.insert("double".to_owned(), KindDecl::Function { arity: 1 });
+        decls.globals.insert("+".to_owned(), KindDecl::Function { arity: 2 });
+        let result = grammar_type_checker::check(&raw, &decls, &TwigLanguageProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+
+    // ── Begin ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn begin_form_checked() {
+        let raw = parse_to_ast("(begin 1 2 3)").unwrap();
+        let result = grammar_type_checker::check(&raw, &decls_strict(), &TwigLanguageProfile);
+        assert!(result.ok);
+    }
+
+    // ── Off mode — no errors even on unresolved var ───────────────────────
+
+    #[test]
+    fn off_mode_no_errors() {
+        let raw = parse_to_ast("undefined_var").unwrap();
+        let decls = TypeDeclarations::new("twig"); // no mode → Off
+        let result = grammar_type_checker::check(&raw, &decls, &TwigLanguageProfile);
+        assert!(result.ok);
+        assert!(result.errors.is_empty());
+    }
+}

--- a/code/packages/rust/type-declarations/CHANGELOG.md
+++ b/code/packages/rust/type-declarations/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog — type-declarations
+
+## [0.1.0] — 2026-05-14
+
+### Added (LANG50 — Generic Grammar Type Checker)
+
+Initial release.  Pure data crate — no dependencies.
+
+- `TypeDeclarations` — container for named types, global bindings, and typed
+  mode; analogous to a TypeScript `.d.ts` file.
+- `KindDecl` enum: `Int`, `Bool`, `Nil`, `Symbol`, `Str`, `List`,
+  `Named(String)`, `Function { arity }`, `Any`.
+- `KindDecl::to_iir_hint() -> &'static str` — maps to the IIR `type_hint`
+  strings understood by `jit-core` and `aot-core`:
+  `Int → "i64"`, `Bool → "bool"`, `Str → "str"`, `Function → "closure"`,
+  everything else → `"any"`.
+- `KindDecl::is_concrete_hint() -> bool` — true when the kind maps to a
+  non-`"any"` IIR hint.
+- `TypedModeDecl` enum: `Off`, `Lenient`, `Strict`.
+- `NamedTypeDecl` enum: `Record { fields }`, `Union { variants }`,
+  `Alias { target }`.
+- `FieldDecl { name, kind }`, `VariantDecl { name, fields }`.
+- `TypeDeclarations::resolve` — follows alias chains (depth-limited to 32,
+  returns `Any` on cycle).
+- `TypeDeclarations::union_variants` — returns variant names for exhaustiveness
+  checking.
+- `AnnotatedNode` — `GrammarASTNode`-shaped tree with `KindDecl` on every
+  node; the central compilation artifact flowing from type checker into IIR
+  emission.
+- `AnnotatedNode::iir_hint()` — shorthand for `self.kind.to_iir_hint()`.
+- `AnnotatedNode::child_node(rule)`, `node_children()`, `position()`.
+- `AnnotatedChild` enum: `Node(AnnotatedNode)`, `Token { text, line, column }`.
+- 11 unit tests.

--- a/code/packages/rust/type-declarations/Cargo.toml
+++ b/code/packages/rust/type-declarations/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name        = "type-declarations"
+version     = "0.1.0"
+edition     = "2021"
+description = "Language-agnostic type declaration format — analogous to TypeScript's .d.ts files.  Emitted by any parser as a side output alongside its language-specific AST.  The grammar-type-checker uses these declarations to drive type inference and produce AnnotatedNode trees that feed AOT/JIT compilation."

--- a/code/packages/rust/type-declarations/README.md
+++ b/code/packages/rust/type-declarations/README.md
@@ -1,0 +1,54 @@
+# type-declarations
+
+Language-agnostic type declaration format for the grammar pipeline — analogous
+to TypeScript's `.d.ts` files.
+
+## What it does
+
+Defines the data structures that any parser emits as a side output alongside
+its language-specific AST.  The `grammar-type-checker` consumes these
+declarations to drive generic type inference over raw `GrammarASTNode` trees.
+
+## Core types
+
+| Type | Purpose |
+|------|---------|
+| `TypeDeclarations` | Container: named types + global bindings + typed mode |
+| `KindDecl` | Base kind inferred for every expression |
+| `AnnotatedNode` | `GrammarASTNode` + `KindDecl` at every node — the compilation artifact |
+| `NamedTypeDecl` | Record, Union, or Alias declaration |
+
+## KindDecl → IIR type_hint
+
+Types are not ornamental — they feed AOT and JIT compilation directly:
+
+```
+KindDecl::Int            → type_hint = "i64"     (no boxing, native int ops)
+KindDecl::Bool           → type_hint = "bool"    (direct branch)
+KindDecl::Str            → type_hint = "str"     (string fast-path)
+KindDecl::Function{n}    → type_hint = "closure" (direct closure dispatch)
+everything else          → type_hint = "any"     (runtime profiling fallback)
+```
+
+The JIT and AOT specialisers prioritise `type_hint` over runtime profiles;
+a fully-typed IIR module compiles to native code with zero warmup cost.
+
+## Pipeline position
+
+```
+twig-parser::emit_type_declarations()
+        ↓
+TypeDeclarations  ─────────────────────────────────────────────┐
+                                                                │
+GrammarASTNode                                                  │
+        ↓  grammar-type-checker::check(ast, decls, profile)    │
+AnnotatedNode (KindDecl on every node)  ◄──────────────────────┘
+        ↓  twig-ir-compiler::compile_annotated()
+IIRModule (type_hint = iir_hint() on each instruction)
+        ↓
+JIT / AOT → typed native code
+```
+
+## Dependencies
+
+None — pure data, zero dependencies.

--- a/code/packages/rust/type-declarations/src/lib.rs
+++ b/code/packages/rust/type-declarations/src/lib.rs
@@ -1,0 +1,657 @@
+//! # `type-declarations`
+//!
+//! Language-agnostic type declaration format — analogous to TypeScript's
+//! `.d.ts` files.  Any parser can emit a `TypeDeclarations` alongside its
+//! language-specific AST; the [`grammar-type-checker`] crate consumes it to
+//! drive generic type inference over raw `GrammarASTNode` trees.
+//!
+//! ## Design philosophy
+//!
+//! Types are not ornamental.  A [`KindDecl::Int`] annotation on an expression
+//! must propagate all the way into `type_hint = "i64"` on the IIR instruction
+//! that computes it.  The JIT/AOT specialisers in this codebase prioritise
+//! `type_hint` over runtime profiling; fully-typed IIR reaches AOT-quality
+//! code generation with zero warmup cost.
+//!
+//! [`KindDecl::to_iir_hint`] provides the mapping from semantic kinds to the
+//! IIR string constants understood by `jit-core` and `aot-core`.
+//!
+//! ## The `.d.ts` analogy
+//!
+//! TypeScript `.d.ts` files declare the *shape* of types without carrying
+//! implementation code.  `TypeDeclarations` is the same idea:
+//!
+//! - **Source** (e.g., `foo.twig`) is parsed into a `GrammarASTNode` tree.
+//! - **Declaration side-output** (`TypeDeclarations`) carries everything the
+//!   checker needs to know: named types (records, unions, aliases), global
+//!   binding kinds, and the module's typed-mode enforcement setting.
+//! - The **generic checker** reads declarations + raw tree → `AnnotatedNode`
+//!   (every node tagged with its inferred `KindDecl`).
+//!
+//! ## Crate dependency
+//!
+//! Zero dependencies — this crate is pure data.  No parser types, no runtime
+//! types.  Any crate in the stack can depend on it without pulling in the
+//! whole grammar machinery.
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// TypeDeclarations — the top-level container
+// ---------------------------------------------------------------------------
+
+/// Language-agnostic collection of type declarations emitted by a parser.
+///
+/// Call [`TypeDeclarations::new`] to create an empty instance, populate it
+/// during a declaration-collection pass over the source AST, then hand it to
+/// the `grammar-type-checker`.
+///
+/// # Example (Twig)
+///
+/// A `twig-parser` call to `emit_type_declarations(&program)` produces:
+///
+/// ```text
+/// TypeDeclarations {
+///     language: "twig",
+///     named_types: {
+///         "Point" => Record { fields: [FieldDecl { name: "x", kind: Int },
+///                                      FieldDecl { name: "y", kind: Int }] }
+///     },
+///     globals: {
+///         "distance" => Function { arity: 2 },
+///         "origin"   => Named("Point"),
+///     },
+///     typed_mode: Some(TypedModeDecl::Strict),
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct TypeDeclarations {
+    /// Language identifier (e.g., `"twig"`, `"ruby"`, `"lua"`).
+    pub language: String,
+
+    /// Named type definitions indexed by name.
+    ///
+    /// Keys match the names used in [`KindDecl::Named`] so that alias chains
+    /// and structural types can be resolved via [`TypeDeclarations::resolve`].
+    pub named_types: HashMap<String, NamedTypeDecl>,
+
+    /// Top-level global binding kinds indexed by name.
+    ///
+    /// The generic checker seeds its scope stack from this map before
+    /// walking any expressions, so all top-level defines are visible
+    /// throughout the program body (forward references work).
+    pub globals: HashMap<String, KindDecl>,
+
+    /// Typed-mode enforcement, parsed from the source module declaration.
+    ///
+    /// `None` is equivalent to `TypedModeDecl::Off` — the checker still
+    /// builds the [`AnnotatedNode`] tree but emits no type errors.
+    pub typed_mode: Option<TypedModeDecl>,
+}
+
+impl TypeDeclarations {
+    /// Create an empty `TypeDeclarations` for the given language.
+    pub fn new(language: impl Into<String>) -> Self {
+        Self {
+            language: language.into(),
+            named_types: HashMap::new(),
+            globals: HashMap::new(),
+            typed_mode: None,
+        }
+    }
+
+    /// Resolve a [`KindDecl`] through alias chains, depth-limited to 32.
+    ///
+    /// If `kind` is [`KindDecl::Named`] and the name maps to a
+    /// [`NamedTypeDecl::Alias`], this function follows the chain until it
+    /// reaches a non-alias or the depth limit.  Returns [`KindDecl::Any`]
+    /// on cycles to prevent infinite loops.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use type_declarations::{TypeDeclarations, NamedTypeDecl, KindDecl};
+    ///
+    /// let mut d = TypeDeclarations::new("twig");
+    /// d.named_types.insert(
+    ///     "Nat".to_owned(),
+    ///     NamedTypeDecl::Alias { target: KindDecl::Int },
+    /// );
+    /// assert_eq!(d.resolve(&KindDecl::Named("Nat".to_owned())), KindDecl::Int);
+    /// assert_eq!(d.resolve(&KindDecl::Int), KindDecl::Int);
+    /// ```
+    pub fn resolve(&self, kind: &KindDecl) -> KindDecl {
+        self.resolve_depth(kind, 0)
+    }
+
+    fn resolve_depth(&self, kind: &KindDecl, depth: usize) -> KindDecl {
+        // Guard against alias cycles (e.g., type A = A).
+        if depth > 32 {
+            return KindDecl::Any;
+        }
+        match kind {
+            KindDecl::Named(name) => match self.named_types.get(name) {
+                Some(NamedTypeDecl::Alias { target }) => {
+                    self.resolve_depth(target, depth + 1)
+                }
+                _ => kind.clone(),
+            },
+            other => other.clone(),
+        }
+    }
+
+    /// Return the variant names of a named union type, or `None` if the
+    /// name does not refer to a union.
+    ///
+    /// Used by the exhaustiveness checker in `grammar-type-checker`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use type_declarations::{TypeDeclarations, NamedTypeDecl, VariantDecl, KindDecl};
+    ///
+    /// let mut d = TypeDeclarations::new("twig");
+    /// d.named_types.insert("Shape".to_owned(), NamedTypeDecl::Union {
+    ///     variants: vec![
+    ///         VariantDecl { name: "Circle".to_owned(), fields: vec![] },
+    ///         VariantDecl { name: "Rect".to_owned(),   fields: vec![] },
+    ///     ],
+    /// });
+    /// assert_eq!(
+    ///     d.union_variants("Shape"),
+    ///     Some(vec!["Circle".to_owned(), "Rect".to_owned()])
+    /// );
+    /// assert!(d.union_variants("Nat").is_none());
+    /// ```
+    pub fn union_variants(&self, name: &str) -> Option<Vec<String>> {
+        match self.named_types.get(name)? {
+            NamedTypeDecl::Union { variants } => {
+                Some(variants.iter().map(|v| v.name.clone()).collect())
+            }
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TypedModeDecl
+// ---------------------------------------------------------------------------
+
+/// Enforcement mode, parsed from the source module's `(typed …)` clause.
+///
+/// | Clause | Behaviour |
+/// |--------|-----------|
+/// | `Off` or absent | Build annotated tree; emit no type errors |
+/// | `Lenient` | Emit errors; `ok: true` regardless |
+/// | `Strict` | Emit errors; `ok: errors.is_empty()` |
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypedModeDecl {
+    /// Type-check results are advisory only; compilation always proceeds.
+    Off,
+    /// Type errors are warnings — `TypeCheckResult::ok` is always `true`.
+    Lenient,
+    /// Type errors block compilation — `TypeCheckResult::ok` is `false`.
+    Strict,
+}
+
+// ---------------------------------------------------------------------------
+// NamedTypeDecl
+// ---------------------------------------------------------------------------
+
+/// A named type declaration — record, union, or alias.
+#[derive(Debug, Clone)]
+pub enum NamedTypeDecl {
+    /// Product type: all fields are present simultaneously.
+    ///
+    /// ```text
+    /// (record Point (x : int) (y : int))
+    /// ```
+    Record {
+        /// Ordered list of fields (order determines constructor arity).
+        fields: Vec<FieldDecl>,
+    },
+
+    /// Sum type: exactly one variant is active at runtime.
+    ///
+    /// ```text
+    /// (union Shape (Circle (r : int)) (Rect (w : int) (h : int)))
+    /// ```
+    Union {
+        /// Variants in declaration order (index = runtime integer tag).
+        variants: Vec<VariantDecl>,
+    },
+
+    /// Compile-time alias that resolves to another kind.
+    ///
+    /// ```text
+    /// (type Nat int)   ;; Alias { target: KindDecl::Int }
+    /// ```
+    Alias {
+        /// The kind this alias expands to.
+        target: KindDecl,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// FieldDecl / VariantDecl
+// ---------------------------------------------------------------------------
+
+/// A single field in a record or union variant.
+#[derive(Debug, Clone)]
+pub struct FieldDecl {
+    /// Field name as written in the source.
+    pub name: String,
+    /// Base kind of the field's value.
+    pub kind: KindDecl,
+}
+
+/// One variant of a tagged union.
+#[derive(Debug, Clone)]
+pub struct VariantDecl {
+    /// Variant constructor name (e.g., `"Circle"`).
+    pub name: String,
+    /// Fields of this variant, in declaration order.
+    pub fields: Vec<FieldDecl>,
+}
+
+// ---------------------------------------------------------------------------
+// KindDecl — the base type level value
+// ---------------------------------------------------------------------------
+
+/// The base kind inferred for every expression during type checking.
+///
+/// `KindDecl` is intentionally coarse — it's the *language-of-types* level,
+/// not a full refinement system.  Refinements (e.g., `0 ≤ x < 128`) are
+/// stored separately in the `lang-refined-types` crate and propagated by the
+/// `iir-refinement-pass` in TW05-C.
+///
+/// ## IIR integration
+///
+/// Every `KindDecl` maps to an IIR `type_hint` string via
+/// [`KindDecl::to_iir_hint`].  The JIT and AOT specialisers read
+/// `type_hint` *before* consulting runtime profiles:
+///
+/// ```text
+/// KindDecl::Int    → "i64"     (native 64-bit int ops, no boxing)
+/// KindDecl::Bool   → "bool"    (direct branch, no type guard)
+/// KindDecl::Str    → "str"     (string fast-path)
+/// Function{n}      → "closure" (direct closure ops)
+/// _                → "any"     (generic, falls back to profiling)
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KindDecl {
+    /// 64-bit signed integer (Twig's only numeric type in V1).
+    Int,
+    /// Boolean (`#t` / `#f`).
+    Bool,
+    /// The empty list / null value.
+    Nil,
+    /// An interned symbol (quoted identifier).
+    Symbol,
+    /// A heap-allocated string.
+    Str,
+    /// A cons-cell linked list.
+    List,
+    /// A named type — look up in [`TypeDeclarations::named_types`].
+    Named(String),
+    /// A closure value of known arity.
+    Function {
+        /// Number of parameters the function accepts.
+        arity: usize,
+    },
+    /// Widened / unknown kind — compatible with any other kind.
+    ///
+    /// Used when type information is absent or cannot be inferred.
+    /// Maps to `type_hint = "any"` in IIR (falls back to runtime profiling).
+    Any,
+}
+
+impl KindDecl {
+    /// Return the IIR `type_hint` string for this kind.
+    ///
+    /// The returned string is understood by `jit-core::specialise` and
+    /// `aot-core::specialise`.  The mapping is:
+    ///
+    /// | `KindDecl` | `type_hint` | Effect in JIT/AOT |
+    /// |------------|-------------|-------------------|
+    /// | `Int` | `"i64"` | 64-bit int ops, no boxing |
+    /// | `Bool` | `"bool"` | Branch directly, no type guard |
+    /// | `Str` | `"str"` | String fast-path |
+    /// | `Function{..}` | `"closure"` | Direct closure dispatch |
+    /// | everything else | `"any"` | Generic path, runtime profiling |
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use type_declarations::KindDecl;
+    ///
+    /// assert_eq!(KindDecl::Int.to_iir_hint(), "i64");
+    /// assert_eq!(KindDecl::Bool.to_iir_hint(), "bool");
+    /// assert_eq!(KindDecl::Function { arity: 2 }.to_iir_hint(), "closure");
+    /// assert_eq!(KindDecl::Any.to_iir_hint(), "any");
+    /// assert_eq!(KindDecl::Nil.to_iir_hint(), "any");
+    /// ```
+    pub fn to_iir_hint(&self) -> &'static str {
+        match self {
+            KindDecl::Int => "i64",
+            KindDecl::Bool => "bool",
+            KindDecl::Str => "str",
+            KindDecl::Function { .. } => "closure",
+            // Nil, Symbol, List, Named, Any — all fall back to the generic path.
+            _ => "any",
+        }
+    }
+
+    /// True if this kind maps to a concrete (non-"any") IIR type hint.
+    ///
+    /// Used by `twig-ir-compiler` to determine [`FunctionTypeStatus`].
+    pub fn is_concrete_hint(&self) -> bool {
+        self.to_iir_hint() != "any"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AnnotatedNode — the central compilation artifact
+// ---------------------------------------------------------------------------
+
+/// A `GrammarASTNode`-shaped tree where every node carries its inferred
+/// [`KindDecl`].
+///
+/// This is the central compilation artifact produced by the
+/// `grammar-type-checker`.  It flows from type checking into IIR emission:
+///
+/// ```text
+/// GrammarASTNode
+///     │  grammar_type_checker::check()
+///     ▼
+/// AnnotatedNode   (kind on every node)
+///     │  twig_ir_compiler::compile_annotated()
+///     ▼
+/// IIRModule   (type_hint = annotated_node.iir_hint() on each instruction)
+///     │  jit-core / aot-core
+///     ▼
+/// typed machine code  (zero profiling wait for fully-typed functions)
+/// ```
+///
+/// ## Relation to `GrammarASTNode`
+///
+/// `AnnotatedNode` mirrors the structure of `parser::GrammarASTNode` but is
+/// a separate type so that:
+/// - The `type-declarations` crate doesn't depend on `parser`.
+/// - Callers can store annotations without keeping the raw tree alive.
+///
+/// Children that were raw `Token`s in the grammar tree are represented as
+/// [`AnnotatedChild::Token`] (text + position only; we never need to type a
+/// raw token in isolation).
+#[derive(Debug, Clone)]
+pub struct AnnotatedNode {
+    /// Grammar rule name of this node (e.g., `"apply"`, `"atom"`, `"if_form"`).
+    pub rule_name: String,
+
+    /// The inferred kind for the *value* this node produces at runtime.
+    ///
+    /// After `grammar-type-checker::check()` the root's kind is generally
+    /// `Any` (a program is a sequence, not a single value).  Leaf expressions
+    /// carry the interesting kinds: `Int`, `Bool`, `Function{n}`, etc.
+    pub kind: KindDecl,
+
+    /// Annotated children.
+    pub children: Vec<AnnotatedChild>,
+
+    /// Source position — populated from the grammar AST.
+    pub start_line: Option<usize>,
+    /// Source position — populated from the grammar AST.
+    pub start_column: Option<usize>,
+    /// Source position — populated from the grammar AST.
+    pub end_line: Option<usize>,
+    /// Source position — populated from the grammar AST.
+    pub end_column: Option<usize>,
+}
+
+impl AnnotatedNode {
+    /// Return the IIR `type_hint` string for the value this node produces.
+    ///
+    /// Shorthand for `self.kind.to_iir_hint()`.
+    pub fn iir_hint(&self) -> &'static str {
+        self.kind.to_iir_hint()
+    }
+
+    /// Find the first child [`AnnotatedNode`] with the given rule name.
+    ///
+    /// Useful for the IIR compiler to locate specific sub-trees without
+    /// fully re-implementing the grammar's structure.
+    pub fn child_node(&self, rule: &str) -> Option<&AnnotatedNode> {
+        self.children.iter().find_map(|c| match c {
+            AnnotatedChild::Node(n) if n.rule_name == rule => Some(n),
+            _ => None,
+        })
+    }
+
+    /// Collect all immediate annotated child nodes (excluding token leaves).
+    pub fn node_children(&self) -> Vec<&AnnotatedNode> {
+        self.children
+            .iter()
+            .filter_map(|c| match c {
+                AnnotatedChild::Node(n) => Some(n),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Source position as `(line, column)`, falling back to `(0, 0)`.
+    pub fn position(&self) -> (usize, usize) {
+        (
+            self.start_line.unwrap_or(0),
+            self.start_column.unwrap_or(0),
+        )
+    }
+}
+
+/// One child of an [`AnnotatedNode`] — either a nested annotated sub-tree or
+/// a raw token leaf.
+#[derive(Debug, Clone)]
+pub enum AnnotatedChild {
+    /// A nested grammar rule that was inferred.
+    Node(AnnotatedNode),
+    /// A raw token — punctuation, keywords, or literals that carry no
+    /// sub-structure.
+    Token {
+        /// The token's text (e.g., `"42"`, `"define"`, `"("`).
+        text: String,
+        /// Source line (1-indexed).
+        line: usize,
+        /// Source column (1-indexed).
+        column: usize,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── KindDecl::to_iir_hint ────────────────────────────────────────────
+
+    #[test]
+    fn kind_to_iir_hint_int() {
+        assert_eq!(KindDecl::Int.to_iir_hint(), "i64");
+    }
+
+    #[test]
+    fn kind_to_iir_hint_bool() {
+        assert_eq!(KindDecl::Bool.to_iir_hint(), "bool");
+    }
+
+    #[test]
+    fn kind_to_iir_hint_str() {
+        assert_eq!(KindDecl::Str.to_iir_hint(), "str");
+    }
+
+    #[test]
+    fn kind_to_iir_hint_closure() {
+        assert_eq!(KindDecl::Function { arity: 1 }.to_iir_hint(), "closure");
+        assert_eq!(KindDecl::Function { arity: 0 }.to_iir_hint(), "closure");
+    }
+
+    #[test]
+    fn kind_to_iir_hint_any_variants() {
+        // All non-concrete kinds map to "any"
+        assert_eq!(KindDecl::Any.to_iir_hint(), "any");
+        assert_eq!(KindDecl::Nil.to_iir_hint(), "any");
+        assert_eq!(KindDecl::Symbol.to_iir_hint(), "any");
+        assert_eq!(KindDecl::List.to_iir_hint(), "any");
+        assert_eq!(KindDecl::Named("Foo".to_owned()).to_iir_hint(), "any");
+    }
+
+    #[test]
+    fn kind_is_concrete_hint() {
+        assert!(KindDecl::Int.is_concrete_hint());
+        assert!(KindDecl::Bool.is_concrete_hint());
+        assert!(KindDecl::Function { arity: 2 }.is_concrete_hint());
+        assert!(!KindDecl::Any.is_concrete_hint());
+        assert!(!KindDecl::Nil.is_concrete_hint());
+    }
+
+    // ── AnnotatedNode::iir_hint ──────────────────────────────────────────
+
+    #[test]
+    fn annotated_node_iir_hint() {
+        let node = AnnotatedNode {
+            rule_name: "atom".to_owned(),
+            kind: KindDecl::Int,
+            children: vec![],
+            start_line: Some(1),
+            start_column: Some(1),
+            end_line: Some(1),
+            end_column: Some(2),
+        };
+        assert_eq!(node.iir_hint(), "i64");
+    }
+
+    // ── TypeDeclarations::resolve ────────────────────────────────────────
+
+    #[test]
+    fn resolve_alias_chain() {
+        let mut d = TypeDeclarations::new("twig");
+        // Nat → Int
+        d.named_types.insert(
+            "Nat".to_owned(),
+            NamedTypeDecl::Alias {
+                target: KindDecl::Int,
+            },
+        );
+        assert_eq!(d.resolve(&KindDecl::Named("Nat".to_owned())), KindDecl::Int);
+        // Non-Named kinds pass through unchanged
+        assert_eq!(d.resolve(&KindDecl::Bool), KindDecl::Bool);
+    }
+
+    #[test]
+    fn resolve_alias_cycle_returns_any() {
+        let mut d = TypeDeclarations::new("twig");
+        // A → Named("A") — direct cycle
+        d.named_types.insert(
+            "A".to_owned(),
+            NamedTypeDecl::Alias {
+                target: KindDecl::Named("A".to_owned()),
+            },
+        );
+        // Should not loop forever; depth guard kicks in and returns Any
+        assert_eq!(d.resolve(&KindDecl::Named("A".to_owned())), KindDecl::Any);
+    }
+
+    #[test]
+    fn resolve_named_record_stays_named() {
+        let mut d = TypeDeclarations::new("twig");
+        d.named_types.insert(
+            "Point".to_owned(),
+            NamedTypeDecl::Record { fields: vec![] },
+        );
+        // Records are not aliases — Named("Point") stays as-is
+        assert_eq!(
+            d.resolve(&KindDecl::Named("Point".to_owned())),
+            KindDecl::Named("Point".to_owned())
+        );
+    }
+
+    // ── TypeDeclarations::union_variants ─────────────────────────────────
+
+    #[test]
+    fn union_variants_lookup() {
+        let mut d = TypeDeclarations::new("twig");
+        d.named_types.insert(
+            "Shape".to_owned(),
+            NamedTypeDecl::Union {
+                variants: vec![
+                    VariantDecl {
+                        name: "Circle".to_owned(),
+                        fields: vec![],
+                    },
+                    VariantDecl {
+                        name: "Rect".to_owned(),
+                        fields: vec![],
+                    },
+                ],
+            },
+        );
+        let vs = d.union_variants("Shape").unwrap();
+        assert_eq!(vs, vec!["Circle", "Rect"]);
+        assert!(d.union_variants("Unknown").is_none());
+    }
+
+    // ── TypeDeclarations baseline ─────────────────────────────────────────
+
+    #[test]
+    fn type_declarations_new_is_empty() {
+        let d = TypeDeclarations::new("twig");
+        assert_eq!(d.language, "twig");
+        assert!(d.named_types.is_empty());
+        assert!(d.globals.is_empty());
+        assert!(d.typed_mode.is_none());
+    }
+
+    // ── AnnotatedNode helpers ─────────────────────────────────────────────
+
+    #[test]
+    fn annotated_node_child_node_lookup() {
+        let child = AnnotatedNode {
+            rule_name: "atom".to_owned(),
+            kind: KindDecl::Int,
+            children: vec![],
+            start_line: None,
+            start_column: None,
+            end_line: None,
+            end_column: None,
+        };
+        let root = AnnotatedNode {
+            rule_name: "expr".to_owned(),
+            kind: KindDecl::Int,
+            children: vec![AnnotatedChild::Node(child)],
+            start_line: None,
+            start_column: None,
+            end_line: None,
+            end_column: None,
+        };
+        assert!(root.child_node("atom").is_some());
+        assert!(root.child_node("compound").is_none());
+    }
+
+    #[test]
+    fn annotated_node_position_fallback() {
+        let n = AnnotatedNode {
+            rule_name: "x".to_owned(),
+            kind: KindDecl::Any,
+            children: vec![],
+            start_line: None,
+            start_column: None,
+            end_line: None,
+            end_column: None,
+        };
+        assert_eq!(n.position(), (0, 0));
+    }
+}

--- a/code/specs/LANG50-grammar-type-checker.md
+++ b/code/specs/LANG50-grammar-type-checker.md
@@ -1,0 +1,245 @@
+# LANG50 — Generic Grammar Type Checker (Compilation-First)
+
+## Motivation
+
+LANG49 introduced `twig-type-checker`, a Twig-specific type checker that
+produces `ok/errors` only — types as ornament.  The stronger requirement is:
+**types must feed AOT and JIT compilation**.  When the type checker infers
+that an expression produces an `Int`, that knowledge must propagate into
+`type_hint = "i64"` on every IIR instruction that computes it.  The existing
+JIT/AOT specialisers in `jit-core` and `aot-core` already prioritise
+`type_hint` over runtime profiles:
+
+```rust
+// jit-core/src/specialise.rs
+fn spec_type(instr: &IIRInstr, min_obs: u32) -> String {
+    if instr.type_hint != "any" && ALLOWED_TYPES.contains(&instr.type_hint.as_str()) {
+        return instr.type_hint.clone();   // ← static hint wins, zero profiling cost
+    }
+    ...
+}
+```
+
+A fully-typed IIR module therefore reaches AOT-quality code generation without
+any runtime warmup.
+
+LANG50 generalises the type checker away from Twig-specific AST types
+(`Program`, `Expr`, `Form`) so that any language compiled through the grammar
+pipeline can participate:  the **parser emits `TypeDeclarations`** (analogous
+to TypeScript's `.d.ts`) and the **generic checker operates on the raw
+`GrammarASTNode`** tree.
+
+---
+
+## New Crates
+
+### `type-declarations` (pure data, no dependencies)
+
+Defines the language-agnostic type declaration format.
+
+```
+TypeDeclarations
+  language: String              — e.g. "twig", "ruby"
+  named_types: {name → NamedTypeDecl}   — records, unions, aliases
+  globals: {name → KindDecl}   — top-level bindings
+  typed_mode: Option<TypedModeDecl>
+
+KindDecl:
+  Int | Bool | Nil | Symbol | Str | List
+  Named(String)                — look up in named_types
+  Function { arity: usize }
+  Any
+
+KindDecl::to_iir_hint() → &'static str
+  Int → "i64",  Bool → "bool",  Str → "str",  Function{..} → "closure",  _ → "any"
+
+AnnotatedNode                  — GrammarASTNode + inferred KindDecl at every node
+  rule_name, kind, children, start_line, start_column, end_line, end_column
+  iir_hint() → kind.to_iir_hint()
+```
+
+`AnnotatedNode` is the central compilation artifact that flows from type
+checker into IIR emission.
+
+### `grammar-type-checker` (depends on `parser` + `type-declarations`)
+
+Generic type checker.  Core API:
+
+```rust
+pub fn check<P: LanguageProfile>(
+    root:    &GrammarASTNode,
+    decls:   &TypeDeclarations,
+    profile: &P,
+) -> TypeCheckResult<AnnotatedNode>
+```
+
+Annotation is **always-on** — even in `TypedModeDecl::Off` the annotated tree
+is built (kinds are `Any` for unresolved nodes).  Type *enforcement*
+(unresolved-variable errors, arity errors, exhaustiveness errors) is
+mode-gated.
+
+#### `LanguageProfile` trait
+
+Encodes language-specific tree navigation without coupling the checker to any
+language's AST types.  Each method takes a raw `GrammarASTNode` and returns
+structured info or `None`:
+
+```rust
+pub trait LanguageProfile: Send + Sync {
+    fn literal_kind(&self, node: &GrammarASTNode) -> Option<KindDecl>;
+    fn as_var_ref<'a>(&self, node: &'a GrammarASTNode) -> Option<&'a str>;
+    fn as_apply<'a>(&self, node: &'a GrammarASTNode) -> Option<AppInfo<'a>>;
+    fn as_binder<'a>(&self, node: &'a GrammarASTNode) -> Option<BinderInfo<'a>>;
+    fn as_match<'a>(&self, node: &'a GrammarASTNode) -> Option<MatchInfo<'a>>;
+    fn as_begin<'a>(&self, node: &'a GrammarASTNode) -> Option<Vec<&'a GrammarASTNode>>;
+    fn child_exprs<'a>(&self, node: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode>;
+    fn position(&self, node: &GrammarASTNode) -> (usize, usize);
+}
+```
+
+`BinderInfo` distinguishes let-style from lambda-style bindings:
+
+```rust
+pub enum BinderKind<'a> {
+    Let    { bindings: Vec<(String, &'a GrammarASTNode)>, body: Vec<&'a GrammarASTNode> },
+    Lambda { params: Vec<(String, KindDecl)>,             body: Vec<&'a GrammarASTNode> },
+}
+```
+
+#### Inference algorithm
+
+1. **Literal?** → `literal_kind()` → return annotated leaf
+2. **Variable reference?** → `as_var_ref()` → scope lookup → `globals` lookup → `Any` + error if absent
+3. **Function application?** → `as_apply()` → infer callee + args → arity check if callee is `Function{n}`
+4. **Let/lambda binder?** → `as_binder()` → push scope, bind names, infer body, pop
+5. **Match?** → `as_match()` → infer scrutinee, exhaustiveness check if union, walk arms
+6. **Begin?** → `as_begin()` → infer all, return last kind
+7. **Fallback** → `child_exprs()` → recurse, return last kind
+
+Depth cap: 256.
+
+---
+
+## Updated Crates
+
+### `twig-parser` (new export)
+
+```rust
+pub fn emit_type_declarations(program: &Program) -> TypeDeclarations
+```
+
+Converts `Form::TypeAlias/RecordDef/UnionDef/Define` → `TypeDeclarations`.
+Maps `TypeAnnotation`/`TypeExpr` → `KindDecl` (same mapping as the existing
+`type_annotation_to_kind` in `twig-type-checker`).
+
+New dependency: `type-declarations`.
+
+### `twig-type-checker` (v0.2.0 — thin adapter)
+
+Adds `TwigLanguageProfile` implementing `LanguageProfile` for Twig grammar
+rule names (`"atom"`, `"quoted"`, `"apply"`, `"lambda_form"`, `"let_form"`,
+`"begin_form"`, `"if_form"`, `"match_form"`, etc.).
+
+Adds `type_check_source` entry point using the GrammarASTNode path.
+Keeps `check_program` (legacy typed-AST path) for backward compat with
+`twig-ir-compiler`.
+
+### `twig-ir-compiler` (v0.6.0)
+
+Adds `compile_typed_source`:
+
+```rust
+pub fn compile_typed_source(source: &str) -> Result<IIRModule, TwigCompileError>
+```
+
+1. Calls `twig_type_checker::type_check_source(source)` → `AnnotatedNode` tree
+2. On strict-mode failure → `Err`
+3. Compiles to IIR using `annotated_node.iir_hint()` for `type_hint` on each instruction
+4. Sets `FunctionTypeStatus` from instruction type coverage
+
+Existing `compile_source` / `compile_program` unchanged.
+
+---
+
+## KindDecl → IIR type_hint
+
+| KindDecl | IIR type_hint | JIT/AOT impact |
+|----------|---------------|----------------|
+| `Int` | `"i64"` | Native 64-bit int ops, no box |
+| `Bool` | `"bool"` | Conditional branches skip type guard |
+| `Str` | `"str"` | String operations skip type guard |
+| `Function{n}` | `"closure"` | Direct closure ops, no apply_closure dispatch |
+| All others | `"any"` | Falls back to profiling / runtime check |
+
+---
+
+## Twig Grammar → LanguageProfile Mapping
+
+| Grammar rule_name | Profile method | Action |
+|-------------------|----------------|--------|
+| `atom` + INTEGER token | `literal_kind` | `KindDecl::Int` |
+| `atom` + BOOL_TRUE/FALSE | `literal_kind` | `KindDecl::Bool` |
+| `atom` + "nil" keyword | `literal_kind` | `KindDecl::Nil` |
+| `quoted` | `literal_kind` | `KindDecl::Symbol` |
+| `atom` + NAME token | `as_var_ref` | scope/globals lookup |
+| `apply` | `as_apply` | callee + args extracted from `expr` children |
+| `lambda_form` | `as_binder` | `BinderKind::Lambda{params, body}` |
+| `let_form` | `as_binder` | `BinderKind::Let{bindings, body}` |
+| `define` (fn) | `as_binder` | `BinderKind::Lambda{params, body, is_global}` |
+| `match_form` | `as_match` | scrutinee + arms |
+| `begin_form` | `as_begin` | all `expr` children |
+| `if_form` | `child_exprs` | cond + then + else nodes |
+| `expr`/`compound`/`form` | `child_exprs` | transparent wrapper — single child |
+
+---
+
+## Tests
+
+### `type-declarations` (≥ 8)
+- `kind_to_iir_hint_int` / `_bool` / `_str` / `_closure` / `_any`
+- `annotated_node_iir_hint`
+- `resolve_alias_chain`, `resolve_alias_cycle_returns_any`
+- `union_variants_lookup`
+
+### `grammar-type-checker` (≥ 18)
+- `annotated_node_carries_kind`
+- `annotated_children_propagate`
+- `typed_off_still_annotates`
+- `generic_var_ref_resolved` / `_unresolved`
+- `generic_apply_arity_correct` / `_wrong`
+- `generic_match_exhaustive_all` / `_wildcard` / `_non_exhaustive`
+- `generic_typed_off` / `_strict_fails` / `_lenient_ok`
+- `kind_decl_resolve_alias` / `_cycle`
+- `type_declarations_union_variants`
+
+### `twig-type-checker` adapter (existing 34 + 5 new)
+- `emit_type_decls_record` / `_union` / `_alias` / `_globals`
+- `type_check_source_path_uses_grammar_ast`
+
+### `twig-ir-compiler` (existing + 4 new)
+- `typed_source_int_literal_hint`
+- `typed_source_bool_literal_hint`
+- `typed_source_untyped_fallback`
+- `typed_source_fn_fully_typed`
+
+---
+
+## Acceptance Criteria
+
+1. `cargo test -p type-declarations` — all pass
+2. `cargo test -p grammar-type-checker` — all pass
+3. `cargo test -p twig-type-checker` — all 34 existing tests pass + 5 new
+4. `cargo test -p twig-ir-compiler` — all existing tests pass + 4 new
+5. `cargo build --workspace` — clean
+6. `(define (f (x : int)) (+ x 1))` compiled via `compile_typed_source` emits `type_hint = "i64"` on the result of `+`
+7. A fully-typed function has `FunctionTypeStatus::FullyTyped` in IIR
+
+## Follow-up
+
+- **TW05-C / LANG51**: Refinement solver — `RangeInt { lo, hi }` annotations
+  propagate into IIR as `"i64"` + refinement proof obligations in
+  `iir-refinement-pass`.
+- Unify `check_program` (typed-AST path) and `type_check_source` (GrammarASTNode
+  path) now that `twig-ir-compiler` can be refactored to retain the raw AST.
+- Extend `TwigLanguageProfile` to `define` (value form) body walking and
+  typed parameter kind propagation.


### PR DESCRIPTION
## Summary

LANG50 closes the type propagation chain: grammar checker annotations now flow into IIR `type_hint` fields so JIT/AOT specialisers get concrete kinds (`Int→"i64"`, `Bool→"bool"`, etc.) without runtime profiling.

**5 crates changed / added:**

- **`type-declarations`** (new, v0.1.0) — pure-data layer: `KindDecl`, `TypeDeclarations`, `AnnotatedNode`, `TypedModeDecl`. Zero external deps. `KindDecl::to_iir_hint()` maps inferred kinds to IIR strings.
- **`grammar-type-checker`** (new, v0.1.0) — generic checker operating on `GrammarASTNode + TypeDeclarations + LanguageProfile → TypeCheckResult<AnnotatedNode>`. Annotation is always-on; enforcement is mode-gated. Handles: literals, var-refs, apply (arity), binders (let/lambda/define), match (exhaustiveness), begin, if, fallback.
- **`twig-parser`** — adds `emit_type_declarations(program) → TypeDeclarations`: two-pass converter (named types first, then globals so forward-references work).
- **`twig-type-checker`** (v0.2.0) — adds `TwigLanguageProfile` (`LanguageProfile` impl for Twig grammar rule names, with transparent wrapper descent) and `type_check_source(source) → TypeCheckResult<AnnotatedNode>`. Backward compat: `type_check` / `check_program` unchanged.
- **`twig-ir-compiler`** (v0.6.0) — adds `compile_typed_source(source, module_name)`: runs grammar-type-checker, builds `(line,col) → iir_hint` map, post-processes IIR via `apply_hints` + `set_function_type_status`. Backward compat: `compile_source` / `compile_program` unchanged.

**Test counts:** type-declarations 14+3 doc, grammar-type-checker 25+2 doc, twig-parser 76+3 doc, twig-type-checker 49+5 doc, twig-ir-compiler 63+3 doc.

Builds on: #3224 (LANG49 — already merged)

## Test plan

- [ ] `cargo test -p type-declarations` — 14 tests pass
- [ ] `cargo test -p grammar-type-checker` — 25 tests pass
- [ ] `cargo test -p twig-parser` — 76 tests pass
- [ ] `cargo test -p twig-type-checker` — 49 tests pass
- [ ] `cargo test -p twig-ir-compiler` — 63 tests pass
- [ ] `cargo build --workspace` — clean build
- [ ] `typed_source_int_literal_hint` — `42` emits `"i64"` on `const` instruction
- [ ] `typed_source_strict_mode_type_error_returns_err` — arity mismatch in strict mode → `Err`
- [ ] `typed_source_function_status_fully_typed` — PartiallyTyped or better when literals present

🤖 Generated with [Claude Code](https://claude.com/claude-code)