### PR TITLE
python(spice): parse CCCS netlist elements

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.2
+
+- Add SPICE `F` / CCCS controlled-source parsing, including subcircuit output
+  node remapping and local controlling source-name remapping.
+
 ## 0.1.1
 
 - Add SPICE `E` / VCVS controlled-source parsing, including subcircuit node

--- a/code/packages/python/spice-netlist-parser/pyproject.toml
+++ b/code/packages/python/spice-netlist-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-netlist-parser"
-version = "0.1.1"
+version = "0.1.2"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -11,7 +11,7 @@ from spice_netlist_parser.parser import (
 )
 
 parse = parse_netlist
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     "AcAnalysis",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass, field
 
 from spice_engine import (
+    CCCS,
     VCCS,
     VCVS,
     Capacitor,
@@ -219,6 +220,9 @@ def _parse_element(fields: list[str]) -> object:
     if prefix == "E":
         _require_fields(fields, 6, "VCVS")
         return VCVS(name, fields[1], fields[2], fields[3], fields[4], parse_value(fields[5]))
+    if prefix == "F":
+        _require_fields(fields, 5, "CCCS")
+        return CCCS(name, fields[1], fields[2], fields[3], parse_value(fields[4]))
     raise NetlistParseError(f"unsupported element {name!r}")
 
 
@@ -297,11 +301,22 @@ def _map_subckt_fields(
         _require_min_fields(fields, 5, "subcircuit controlled source")
         for index in range(1, 5):
             mapped[index] = _map_subckt_node(fields[index], instance_name, node_map)
+    elif prefix == "F":
+        _require_min_fields(fields, 4, "subcircuit current-controlled source")
+        mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
+        mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)
+        mapped[3] = _map_subckt_source_ref(fields[3], instance_name)
     elif prefix == "X":
         mapped[1:-1] = [
             _map_subckt_node(node, instance_name, node_map) for node in fields[1:-1]
         ]
     return mapped
+
+
+def _map_subckt_source_ref(source: str, instance_name: str) -> str:
+    if "." in source:
+        return source
+    return f"{instance_name}.{source}"
 
 
 def _map_subckt_node(node: str, instance_name: str, node_map: dict[str, str]) -> str:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2,6 +2,7 @@ from math import isclose
 
 import pytest
 from spice_engine import (
+    CCCS,
     VCCS,
     VCVS,
     Capacitor,
@@ -95,6 +96,27 @@ Rload out 0 1k
     assert isclose(result.node_voltages["out"], 6.0, abs_tol=1e-9)
 
 
+def test_parse_cccs_into_operating_point_circuit() -> None:
+    parsed = parse_netlist(
+        """
+Vin in 0 DC 1
+Rin in mid 1k
+Vsense mid 0 0
+Fcopy out 0 Vsense 2
+Rload out 0 500
+.op
+"""
+    )
+
+    assert isinstance(parsed.circuit.elements[3], CCCS)
+    assert parsed.circuit.elements[3].ctrl_source == "Vsense"
+    assert parsed.circuit.elements[3].beta == 2.0
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert isclose(result.node_voltages["out"], 1.0, abs_tol=1e-9)
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """
@@ -166,6 +188,38 @@ Rload out 0 1k
     result = dc_op(parsed.circuit)
     assert result.converged
     assert isclose(result.node_voltages["out"], 2.5, abs_tol=1e-9)
+
+
+def test_expands_subcircuit_cccs_nodes_and_control_source_into_engine_elements() -> None:
+    parsed = parse_netlist(
+        """
+.subckt mirror inp outp
+Rin inp mid 1k
+Vsense mid 0 0
+Fcopy outp 0 Vsense 2
+.ends mirror
+Vin in 0 DC 1
+Xmirror in out mirror
+Rload out 0 500
+.op
+"""
+    )
+
+    assert [element.name for element in parsed.circuit.elements] == [
+        "Vin",
+        "Xmirror.Rin",
+        "Xmirror.Vsense",
+        "Xmirror.Fcopy",
+        "Rload",
+    ]
+    cccs = parsed.circuit.elements[3]
+    assert isinstance(cccs, CCCS)
+    assert cccs.n_plus == "out"
+    assert cccs.ctrl_source == "Xmirror.Vsense"
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert isclose(result.node_voltages["out"], 1.0, abs_tol=1e-9)
 
 
 def test_subcircuit_internal_nodes_are_instance_scoped() -> None:


### PR DESCRIPTION
## Summary

- add SPICE `F` / CCCS parsing to the Python netlist parser
- map CCCS output nodes and local controlling voltage-source names during `.subckt` expansion
- cover direct and subcircuit-expanded CCCS netlists with DC operating-point validation

## Validation

- sh BUILD
- git diff --check