### PR TITLE
[codex] Add Board VM byte buffer ABI

### DIFF
--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -1601,7 +1601,7 @@ fn write_run_report_response(
         payload_out,
     )?;
     if return_count == 1 {
-        let value = protocol_value_from_runtime(report.return_value);
+        let value = protocol_value_from_runtime(&report.return_value);
         payload_len += encode_value(&value, &mut payload_out[payload_len..])?;
     }
     write_response(
@@ -1620,17 +1620,18 @@ fn runtime_return_count(status: ProtocolRunStatus, value: RuntimeValue) -> u32 {
     }
 }
 
-fn protocol_value_from_runtime(value: RuntimeValue) -> ProtocolValue<'static> {
+fn protocol_value_from_runtime(value: &RuntimeValue) -> ProtocolValue<'_> {
     match value {
         RuntimeValue::Unit => ProtocolValue::Unit,
-        RuntimeValue::Bool(value) => ProtocolValue::Bool(value),
-        RuntimeValue::U8(value) => ProtocolValue::U8(value),
-        RuntimeValue::U16(value) => ProtocolValue::U16(value),
-        RuntimeValue::U32(value) => ProtocolValue::U32(value),
-        RuntimeValue::I16(value) => ProtocolValue::I16(value),
+        RuntimeValue::Bool(value) => ProtocolValue::Bool(*value),
+        RuntimeValue::U8(value) => ProtocolValue::U8(*value),
+        RuntimeValue::U16(value) => ProtocolValue::U16(*value),
+        RuntimeValue::U32(value) => ProtocolValue::U32(*value),
+        RuntimeValue::I16(value) => ProtocolValue::I16(*value),
         RuntimeValue::Handle(value) => {
             ProtocolValue::Handle(u16::from(value.index) | (u16::from(value.generation) << 8))
         }
+        RuntimeValue::Bytes(value) => ProtocolValue::Bytes(value.as_slice()),
     }
 }
 
@@ -1653,8 +1654,8 @@ fn crc32_ieee(bytes: &[u8]) -> u32 {
 mod tests {
     use super::*;
     use board_vm_host::{
-        write_blink_module, write_time_now_module, BlinkProgram, HostSession, TimeNowProgram,
-        DEFAULT_PROGRAM_ID,
+        write_blink_module, write_module, write_time_now_module, BlinkProgram, HostSession,
+        ModuleSpec, TimeNowProgram, DEFAULT_PROGRAM_ID,
     };
     use board_vm_ir::CapabilitySet;
     use board_vm_protocol::{
@@ -2248,6 +2249,78 @@ mod tests {
         assert_eq!(report.status, RunStatus::Halted);
         assert_eq!(report.return_count, 1);
         assert_eq!(decoder.read_value().unwrap(), Value::U32(0));
+        decoder.finish().unwrap();
+    }
+
+    #[test]
+    fn run_report_encodes_bytes_return_value() {
+        let mut device = new_device();
+        let mut session = HostSession::new();
+        let code = [0x16, 0x00, 0x00, 0x03, 0x50];
+        let const_pool = [0xCA, 0xFE, 0x42];
+        let mut module = [0u8; 32];
+        let module_len = write_module(
+            ModuleSpec::new(0, 1, &code).const_pool(&const_pool),
+            &mut module,
+        )
+        .unwrap();
+        let module = &module[..module_len];
+        let mut host_payload = [0u8; 128];
+        let mut request = [0u8; 192];
+        let mut device_payload = [0u8; 256];
+        let mut response = [0u8; 320];
+
+        let begin = session
+            .program_begin_frame(DEFAULT_PROGRAM_ID, module, &mut host_payload, &mut request)
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..begin.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let chunk = session
+            .program_chunk_frame(
+                DEFAULT_PROGRAM_ID,
+                0,
+                module,
+                &mut host_payload,
+                &mut request,
+            )
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..chunk.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let end = session
+            .program_end_frame(DEFAULT_PROGRAM_ID, &mut host_payload, &mut request)
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..end.len],
+            &mut device_payload,
+            &mut response,
+        );
+
+        let run = session
+            .run_background_frame(DEFAULT_PROGRAM_ID, 10, &mut host_payload, &mut request)
+            .unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..run.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        let (report, mut decoder) = decode_run_report_header(frame.payload).unwrap();
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.return_count, 1);
+        assert_eq!(
+            decoder.read_value().unwrap(),
+            Value::Bytes(&[0xCA, 0xFE, 0x42])
+        );
         decoder.finish().unwrap();
     }
 

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1750,7 +1750,7 @@ mod tests {
 
     #[test]
     fn writes_generic_module_from_code_and_const_pool() {
-        let code = [0x00];
+        let code = [0x16, 0x00, 0x00, 0x02, 0x50];
         let const_pool = [0xAA, 0x55];
         let mut module = [0u8; 32];
 
@@ -1765,6 +1765,7 @@ mod tests {
         assert_eq!(parsed.max_stack, 1);
         assert_eq!(parsed.code, &code);
         assert_eq!(parsed.const_pool, &const_pool);
+        validate(&parsed, CapabilitySet::empty(), 1).unwrap();
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub const MODULE_MAGIC: [u8; 4] = *b"BVM1";
 pub const MODULE_VERSION: u8 = 1;
+pub const MAX_BYTE_BUFFER_LEN: usize = 32;
 
 pub const FLAG_PROGRAM_MAY_RUN_FOREVER: u8 = 0b0000_0001;
 pub const FLAG_PROGRAM_USES_EVENTS: u8 = 0b0000_0010;
@@ -48,6 +49,7 @@ pub enum Op {
     PushU16(u16),
     PushU32(u32),
     PushI16(i16),
+    PushBytes { offset: u16, len: u8 },
     Dup,
     Drop,
     Swap,
@@ -87,6 +89,8 @@ pub enum ValidateError {
     StackOverflow(usize),
     JumpTargetOutOfBounds(usize),
     JumpTargetNotBoundary(usize),
+    ConstPoolOutOfBounds(usize),
+    ByteBufferTooLarge(usize),
     UnsupportedCapability(u16),
 }
 
@@ -189,6 +193,13 @@ pub fn decode_next(code: &[u8], ip: usize) -> Result<(Op, usize), DecodeError> {
         0x13 => Ok((Op::PushU16(read_u16(code, next)?), next + 2)),
         0x14 => Ok((Op::PushU32(read_u32(code, next)?), next + 4)),
         0x15 => Ok((Op::PushI16(read_u16(code, next)? as i16), next + 2)),
+        0x16 => Ok((
+            Op::PushBytes {
+                offset: read_u16(code, next)?,
+                len: read_u8(code, next + 2)?,
+            },
+            next + 3,
+        )),
         0x20 => Ok((Op::Dup, next)),
         0x21 => Ok((Op::Drop, next)),
         0x22 => Ok((Op::Swap, next)),
@@ -276,6 +287,7 @@ pub fn validate(
         let (op, next_ip) = decode_next(module.code, ip).map_err(ValidateError::Decode)?;
         validate_stack_effect(op, instruction_start, &mut depth, module.max_stack)?;
         validate_capability(op, board_caps)?;
+        validate_const_pool_access(module.const_pool, op, instruction_start)?;
         validate_jump_target(module.code, op, next_ip)?;
         ip = next_ip;
     }
@@ -325,6 +337,27 @@ fn validate_capability(op: Op, board_caps: CapabilitySet) -> Result<(), Validate
     } else {
         Err(ValidateError::UnsupportedCapability(capability_id))
     }
+}
+
+fn validate_const_pool_access(
+    const_pool: &[u8],
+    op: Op,
+    instruction_start: usize,
+) -> Result<(), ValidateError> {
+    let Op::PushBytes { offset, len } = op else {
+        return Ok(());
+    };
+    if len as usize > MAX_BYTE_BUFFER_LEN {
+        return Err(ValidateError::ByteBufferTooLarge(instruction_start));
+    }
+    let offset = offset as usize;
+    let end = offset
+        .checked_add(len as usize)
+        .ok_or(ValidateError::ConstPoolOutOfBounds(instruction_start))?;
+    if end > const_pool.len() {
+        return Err(ValidateError::ConstPoolOutOfBounds(instruction_start));
+    }
+    Ok(())
 }
 
 pub fn called_capability(op: Op) -> Option<u16> {
@@ -391,7 +424,8 @@ fn stack_effect(op: Op) -> (i16, i16) {
         | Op::PushU8(_)
         | Op::PushU16(_)
         | Op::PushU32(_)
-        | Op::PushI16(_) => (0, 1),
+        | Op::PushI16(_)
+        | Op::PushBytes { .. } => (0, 1),
         Op::Dup => (1, 2),
         Op::Drop => (1, 0),
         Op::Swap => (2, 2),
@@ -471,6 +505,19 @@ mod tests {
     }
 
     #[test]
+    fn decodes_push_bytes() {
+        let (op, next) = decode_next(&[0x16, 0x34, 0x12, 0x03], 0).unwrap();
+        assert_eq!(
+            op,
+            Op::PushBytes {
+                offset: 0x1234,
+                len: 3
+            }
+        );
+        assert_eq!(next, 4);
+    }
+
+    #[test]
     fn parses_blink_module() {
         let module_bytes = [
             0x42, 0x56, 0x4d, 0x31, 0x01, 0x01, 0x04, 0x00, 0x1a, 0x12, 0x0d, 0x12, 0x01, 0x40,
@@ -493,6 +540,49 @@ mod tests {
             const_pool: &[],
         };
         validate(&module, CapabilitySet::blink_mvp(), 8).unwrap();
+    }
+
+    #[test]
+    fn validates_push_bytes_const_pool_slice() {
+        let module = Module {
+            flags: 0,
+            max_stack: 1,
+            code: &[0x16, 0x01, 0x00, 0x02, 0x50],
+            const_pool: &[0xAA, 0xBE, 0xEF],
+        };
+
+        validate(&module, CapabilitySet::empty(), 8).unwrap();
+    }
+
+    #[test]
+    fn rejects_push_bytes_const_pool_out_of_bounds() {
+        let module = Module {
+            flags: 0,
+            max_stack: 1,
+            code: &[0x16, 0x02, 0x00, 0x02],
+            const_pool: &[0xAA],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::empty(), 8),
+            Err(ValidateError::ConstPoolOutOfBounds(0))
+        );
+    }
+
+    #[test]
+    fn rejects_push_bytes_larger_than_vm_buffer() {
+        let const_pool = [0u8; MAX_BYTE_BUFFER_LEN + 1];
+        let module = Module {
+            flags: 0,
+            max_stack: 1,
+            code: &[0x16, 0x00, 0x00, (MAX_BYTE_BUFFER_LEN + 1) as u8],
+            const_pool: &const_pool,
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::empty(), 8),
+            Err(ValidateError::ByteBufferTooLarge(0))
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -4049,7 +4049,7 @@ mod tests {
 
     #[test]
     fn rust_core_builds_raw_module_from_code_and_const_pool() {
-        let code = [0x00];
+        let code = [0x16, 0x00, 0x00, 0x02, 0x50];
         let const_pool = [0xAA, 0x55];
         let expected_len = raw_module_len(code.len() as u64, const_pool.len() as u64).unwrap();
         let mut module = vec![0u8; expected_len];
@@ -4059,7 +4059,10 @@ mod tests {
         assert_eq!(len, expected_len);
         assert_eq!(
             module,
-            [0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02, 0xAA, 0x55,]
+            [
+                0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x05, 0x16, 0x00, 0x00, 0x02, 0x50,
+                0x02, 0xAA, 0x55,
+            ]
         );
     }
 
@@ -4185,6 +4188,28 @@ mod tests {
                 assert_eq!(report.returns, vec![LanguageValue::U32(1234)]);
             }
             other => panic!("unexpected run response body: {other:?}"),
+        }
+
+        let run = RunReportHeader {
+            program_id: 8,
+            status: RunStatus::Halted,
+            instructions_executed: 43,
+            elapsed_ms: 9,
+            stack_depth: 0,
+            open_handles: 0,
+            return_count: 1,
+        };
+        let mut payload_len =
+            board_vm_protocol::encode_run_report_header(&run, &mut payload).unwrap();
+        payload_len +=
+            encode_value(&Value::Bytes(&[0xCA, 0xFE]), &mut payload[payload_len..]).unwrap();
+        let decoded = decode_response_fixture(MessageType::RUN_REPORT, 14, &payload[..payload_len]);
+        match decoded.body {
+            DecodedLanguageResponseBody::RunReport(report) => {
+                assert_eq!(report.program_id, 8);
+                assert_eq!(report.returns, vec![LanguageValue::Bytes(vec![0xCA, 0xFE])]);
+            }
+            other => panic!("unexpected bytes run response body: {other:?}"),
         }
     }
 

--- a/code/packages/rust/board-vm-loopback/src/lib.rs
+++ b/code/packages/rust/board-vm-loopback/src/lib.rs
@@ -508,6 +508,7 @@ impl BoardError {
                 | RuntimeErrorKind::HandleNotFound
                 | RuntimeErrorKind::ResourceBusy
                 | RuntimeErrorKind::InvalidPin
+                | RuntimeErrorKind::ByteBufferTooLarge
                 | RuntimeErrorKind::UnsupportedMode => ERROR_INVALID_PROGRAM,
                 RuntimeErrorKind::BoardFault => ERROR_BOARD_FAULT,
             },
@@ -529,6 +530,7 @@ impl BoardError {
                 | RuntimeErrorKind::HandleNotFound
                 | RuntimeErrorKind::ResourceBusy
                 | RuntimeErrorKind::InvalidPin
+                | RuntimeErrorKind::ByteBufferTooLarge
                 | RuntimeErrorKind::UnsupportedMode => "runtime rejected program",
                 RuntimeErrorKind::InvalidBytecode | RuntimeErrorKind::ValidationFailed => {
                     "invalid bytecode"

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -4,7 +4,56 @@ use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_DAC_WRITE_U12,
     CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ_U8,
     CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    MAX_BYTE_BUFFER_LEN,
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ByteBuffer {
+    len: u8,
+    bytes: [u8; MAX_BYTE_BUFFER_LEN],
+}
+
+impl ByteBuffer {
+    pub const fn empty() -> Self {
+        Self {
+            len: 0,
+            bytes: [0; MAX_BYTE_BUFFER_LEN],
+        }
+    }
+
+    pub fn from_slice(value: &[u8]) -> Result<Self, ByteBufferError> {
+        if value.len() > MAX_BYTE_BUFFER_LEN {
+            return Err(ByteBufferError);
+        }
+        let mut bytes = [0; MAX_BYTE_BUFFER_LEN];
+        bytes[..value.len()].copy_from_slice(value);
+        Ok(Self {
+            len: value.len() as u8,
+            bytes,
+        })
+    }
+
+    pub const fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes[..self.len()]
+    }
+}
+
+impl Default for ByteBuffer {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ByteBufferError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Value {
@@ -15,6 +64,7 @@ pub enum Value {
     U32(u32),
     I16(i16),
     Handle(Handle),
+    Bytes(ByteBuffer),
 }
 
 impl Default for Value {
@@ -157,6 +207,7 @@ pub enum RuntimeErrorKind {
     InvalidPin,
     UnsupportedMode,
     BoardFault,
+    ByteBufferTooLarge,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -239,7 +290,12 @@ where
             kind: RuntimeErrorKind::ValidationFailed,
         })?;
         let mut cursor = RunCursor::new();
-        self.run_code_slice(module.code, &mut cursor, instruction_budget)
+        self.run_code_slice_with_const_pool(
+            module.code,
+            module.const_pool,
+            &mut cursor,
+            instruction_budget,
+        )
     }
 
     pub fn run_code(
@@ -261,12 +317,27 @@ where
             ip: 0,
             kind: RuntimeErrorKind::ValidationFailed,
         })?;
-        self.run_code_slice(module.code, cursor, instruction_budget)
+        self.run_code_slice_with_const_pool(
+            module.code,
+            module.const_pool,
+            cursor,
+            instruction_budget,
+        )
     }
 
     pub fn run_code_slice(
         &mut self,
         code: &[u8],
+        cursor: &mut RunCursor,
+        instruction_budget: u32,
+    ) -> Result<RunReport, RuntimeError> {
+        self.run_code_slice_with_const_pool(code, &[], cursor, instruction_budget)
+    }
+
+    fn run_code_slice_with_const_pool(
+        &mut self,
+        code: &[u8],
+        const_pool: &[u8],
         cursor: &mut RunCursor,
         instruction_budget: u32,
     ) -> Result<RunReport, RuntimeError> {
@@ -304,6 +375,24 @@ where
                 Op::PushU16(value) => self.push(Value::U16(value), instruction_ip)?,
                 Op::PushU32(value) => self.push(Value::U32(value), instruction_ip)?,
                 Op::PushI16(value) => self.push(Value::I16(value), instruction_ip)?,
+                Op::PushBytes { offset, len } => {
+                    let start = offset as usize;
+                    let end = start.checked_add(len as usize).ok_or(RuntimeError {
+                        ip: instruction_ip,
+                        kind: RuntimeErrorKind::InvalidBytecode,
+                    })?;
+                    let Some(bytes) = const_pool.get(start..end) else {
+                        return Err(RuntimeError {
+                            ip: instruction_ip,
+                            kind: RuntimeErrorKind::InvalidBytecode,
+                        });
+                    };
+                    let buffer = ByteBuffer::from_slice(bytes).map_err(|_| RuntimeError {
+                        ip: instruction_ip,
+                        kind: RuntimeErrorKind::ByteBufferTooLarge,
+                    })?;
+                    self.push(Value::Bytes(buffer), instruction_ip)?;
+                }
                 Op::Dup => {
                     let value = self.peek(instruction_ip)?;
                     self.push(value, instruction_ip)?;
@@ -881,6 +970,27 @@ mod tests {
         let report = runtime.run_code(&[0x13, 0x34, 0x12, 0x50], 10).unwrap();
         assert_eq!(report.status, RunStatus::Halted);
         assert_eq!(report.return_value, Value::U16(0x1234));
+    }
+
+    #[test]
+    fn push_bytes_returns_const_pool_slice() {
+        let module = Module {
+            flags: 0,
+            max_stack: 1,
+            code: &[0x16, 0x01, 0x00, 0x03, 0x50],
+            const_pool: &[0x00, 0xCA, 0xFE, 0x42],
+        };
+        let mut runtime: Runtime<FakeHal, 4, 2> = Runtime::new(FakeHal::new());
+
+        let report = runtime.run_module(&module, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        let expected = ByteBuffer::from_slice(&[0xCA, 0xFE, 0x42]).unwrap();
+        assert_eq!(report.return_value, Value::Bytes(expected));
+        match report.return_value {
+            Value::Bytes(bytes) => assert_eq!(bytes.as_slice(), &[0xCA, 0xFE, 0x42]),
+            other => panic!("unexpected return value: {other:?}"),
+        }
     }
 
     #[test]

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -65,7 +65,10 @@ bit 2: program_requests_persistent_handles
 bits 3..7: reserved
 ```
 
-The first MVP can set `const_len = 0` and use inline immediates only.
+The constant pool stores immutable byte data used by byte-buffer immediates.
+`PUSH_BYTES` copies a checked slice from `const_pool` into a bounded VM stack
+value. The v1 portable byte-buffer maximum is 32 bytes; validators must reject
+out-of-bounds slices and larger byte buffers before execution.
 
 ## Execution Model
 
@@ -103,8 +106,10 @@ The VM value set is deliberately small:
 | `u32` | 4 bytes | counters, timestamps |
 | `i16` | 2 bytes | signed sensor values |
 | `handle` | 2 bytes | resources opened by capabilities |
+| `bytes` | 0..32 bytes | bus transfer payloads, binary results |
 
-The MVP should implement `unit`, `bool`, `u8`, `u16`, and `handle`.
+The current MVP implements the listed scalar values, `handle`, and bounded
+`bytes`.
 
 ## Core Opcodes
 
@@ -118,6 +123,7 @@ The MVP should implement `unit`, `bool`, `u8`, `u16`, and `handle`.
 | `0x13` | `PUSH_U16` | `u16_le` | `-> u16` |
 | `0x14` | `PUSH_U32` | `u32_le` | `-> u32` |
 | `0x15` | `PUSH_I16` | `i16_le` | `-> i16` |
+| `0x16` | `PUSH_BYTES` | `offset: u16_le, len: u8` | `-> bytes` |
 | `0x20` | `DUP` | none | `a -> a a` |
 | `0x21` | `DROP` | none | `a ->` |
 | `0x22` | `SWAP` | none | `a b -> b a` |
@@ -211,9 +217,8 @@ identity and pin ownership out of language frontends.
 `i2c.write_u8` writes a single byte to a 7-bit device address on an already
 opened bus handle. `i2c.read_u8` reads one byte from that same 7-bit address and
 returns it as a scalar `u8`. These are the first concrete I2C transfer
-primitives because the current VM value set has scalar integers but no
-byte-buffer value yet. Wider `i2c.write`, `i2c.read`, and `i2c.transfer`
-operations should reuse the same handle model once the byte-buffer ABI exists.
+primitives. Wider `i2c.write`, `i2c.read`, and `i2c.transfer` operations should
+reuse the same handle model and the bounded byte-buffer ABI.
 
 ### LED Matrix
 
@@ -299,6 +304,7 @@ pub enum Op {
     PushU16(u16),
     PushU32(u32),
     PushI16(i16),
+    PushBytes { offset: u16, len: u8 },
     Dup,
     Drop,
     Swap,
@@ -328,6 +334,7 @@ pub fn validate(module: &Module, caps: &CapabilitySet) -> Result<(), ValidateErr
 - Reject truncated immediates.
 - Reject jumps into the middle of an instruction.
 - Reject unknown opcodes.
+- Reject out-of-bounds and oversized constant-pool byte slices.
 - Validate stack effects for straight-line programs.
 - Validate stack effects across conditional branches.
 - Execute blink bytecode on a fake board and assert ordered GPIO operations.

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -70,8 +70,9 @@ reject conflicting handles.
 4. Implement I2C and SPI as bus handles with explicit transfer boundaries;
    `i2c.open` establishes the first I2C handle tranche, while `i2c.write_u8`
    and `i2c.read_u8` prove the Rust-owned transfer path through Arduino
-   `Wire`/`Wire1`. Byte-buffer write/read/transfer transactions follow as
-   separate slices.
+   `Wire`/`Wire1`. The byte-buffer ABI is now the shared value substrate for
+   wider write/read/transfer transactions, which should still land as separate
+   capability slices.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 


### PR DESCRIPTION
## Summary
- add a bounded 32-byte VM `bytes` value and `PUSH_BYTES` const-pool opcode
- validate const-pool byte slices before execution and encode bytes in run reports
- cover byte-buffer round trips across IR, runtime, device, host module writing, loopback error mapping, and language-core decoding
- update BVM specs to make the byte-buffer ABI the substrate for wider I2C transfers

## Validation
- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-language-core -p board-vm-loopback`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-language-core -p board-vm-loopback`
- `bundle exec rake test` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
