### PR TITLE
ts(spice): parse CCCS netlist elements

### DIFF
--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.2
+
+- Add SPICE `F` / CCCS controlled-source parsing, including subcircuit
+  controlling-source name remapping for expanded CCCS elements.
+
 ## 0.1.1
 
 - Add SPICE `E` / VCVS controlled-source parsing, including subcircuit node

--- a/code/packages/typescript/spice-netlist-parser/package.json
+++ b/code/packages/typescript/spice-netlist-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/spice-netlist-parser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -5,6 +5,7 @@ import {
   PwlWaveform,
   SinWaveform,
   capacitor,
+  cccs,
   currentSource,
   currentSourceWithWaveform,
   dcOp,
@@ -248,6 +249,10 @@ function parseElement(fields: readonly string[]): Element {
     requireFields(fields, 6, "VCVS");
     return vcvs(name, fields[1], fields[2], fields[3], fields[4], parseValue(fields[5]));
   }
+  if (prefix === "F") {
+    requireFields(fields, 5, "CCCS");
+    return cccs(name, fields[1], fields[2], fields[3], parseValue(fields[4]));
+  }
   throw new NetlistParseError(`unsupported element ${JSON.stringify(name)}`);
 }
 
@@ -339,6 +344,11 @@ function mapSubcktFields(
     for (let index = 1; index < 5; index++) {
       mapped[index] = mapSubcktNode(fields[index], instanceName, nodeMap);
     }
+  } else if (prefix === "F") {
+    requireMinFields(fields, 4, "subcircuit current-controlled source");
+    mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
+    mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);
+    mapped[3] = mapSubcktSourceRef(fields[3], instanceName);
   } else if (prefix === "X") {
     for (let index = 1; index < fields.length - 1; index++) {
       mapped[index] = mapSubcktNode(fields[index], instanceName, nodeMap);
@@ -356,6 +366,10 @@ function mapSubcktNode(
     return node;
   }
   return nodeMap.get(node) ?? nodeMap.get(node.toLowerCase()) ?? `${instanceName}.${node}`;
+}
+
+function mapSubcktSourceRef(sourceName: string, instanceName: string): string {
+  return sourceName.includes(".") ? sourceName : `${instanceName}.${sourceName}`;
 }
 
 function elementPrefix(name: string): string {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -78,6 +78,27 @@ Rload out 0 1k
     expect(result.voltage("out")).toBeCloseTo(6.0, 9);
   });
 
+  it("parses CCCS elements into operating-point circuits", () => {
+    const parsed = parseNetlist(`
+Vin in 0 DC 1
+Rin in sense 1k
+Vsense sense 0 DC 0
+Fcopy out 0 Vsense 2
+Rload out 0 500
+.op
+`);
+
+    const elements = parsed.circuit.elements();
+    expect(elements[3]).toMatchObject({
+      kind: "cccs",
+      controlSource: "Vsense",
+      gain: 2.0,
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("out")).toBeCloseTo(-1.0, 9);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)
@@ -146,6 +167,37 @@ Rload out 0 1k
 
     const result = dcOp(parsed.circuit);
     expect(result.voltage("out")).toBeCloseTo(2.5, 9);
+  });
+
+  it("expands subcircuit CCCS control sources into engine elements", () => {
+    const parsed = parseNetlist(`
+.subckt mirror inp outp
+Rin inp sense 1k
+Vsense sense 0 DC 0
+Fcopy outp 0 Vsense 2
+.ends mirror
+Vin in 0 DC 1
+Xmirror in out mirror
+Rload out 0 500
+.op
+`);
+
+    const elements = parsed.circuit.elements();
+    expect(elements.map((element) => element.name)).toEqual([
+      "Vin",
+      "Xmirror.Rin",
+      "Xmirror.Vsense",
+      "Xmirror.Fcopy",
+      "Rload",
+    ]);
+    expect(elements[3]).toMatchObject({
+      kind: "cccs",
+      positive: "out",
+      controlSource: "Xmirror.Vsense",
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("out")).toBeCloseTo(-1.0, 9);
   });
 
   it("scopes subcircuit internal nodes by instance", () => {


### PR DESCRIPTION
## Summary

- parse SPICE `F` / CCCS controlled-source elements into TypeScript SPICE engine circuits
- remap subcircuit-local CCCS controlling source names during expansion
- add direct and subcircuit operating-point coverage

## Tests

- `sh BUILD && git -C /Users/adhithya/Downloads/Codex/coding-adventures-ts-spice-netlist-cccs diff --check`