### PR TITLE
rust(spice): parse CCCS netlist elements

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.2
+
+- Add SPICE `F` / CCCS controlled-source parsing, including subcircuit
+  controlling-source name remapping for expanded CCCS elements.
+
 ## 0.1.1
 
 - Add SPICE `E` / VCVS controlled-source parsing, including subcircuit node

--- a/code/packages/rust/spice-netlist-parser/Cargo.toml
+++ b/code/packages/rust/spice-netlist-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spice-netlist-parser"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, fmt};
 
 use spice_engine::{
-    Capacitor, Circuit, CurrentSource, Element, ExpWaveform, Inductor, PulseWaveform, PwlWaveform,
-    Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
+    Capacitor, Cccs, Circuit, CurrentSource, Element, ExpWaveform, Inductor, PulseWaveform,
+    PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -338,6 +338,16 @@ fn parse_element(fields: &[String]) -> Result<Element, NetlistParseError> {
                 parse_value(&fields[5])?,
             )))
         }
+        'F' => {
+            require_fields(fields, 5, "CCCS")?;
+            Ok(Element::Cccs(Cccs::new(
+                name,
+                &fields[1],
+                &fields[2],
+                &fields[3],
+                parse_value(&fields[4])?,
+            )))
+        }
         _ => Err(NetlistParseError::new(format!(
             "unsupported element {name:?}"
         ))),
@@ -464,6 +474,12 @@ fn map_subckt_fields(
                 mapped[index] = map_subckt_node(&fields[index], instance_name, node_map);
             }
         }
+        'F' => {
+            require_min_fields(fields, 4, "subcircuit current-controlled source")?;
+            mapped[1] = map_subckt_node(&fields[1], instance_name, node_map);
+            mapped[2] = map_subckt_node(&fields[2], instance_name, node_map);
+            mapped[3] = map_subckt_source_ref(&fields[3], instance_name);
+        }
         'X' => {
             for index in 1..fields.len() - 1 {
                 mapped[index] = map_subckt_node(&fields[index], instance_name, node_map);
@@ -483,6 +499,14 @@ fn map_subckt_node(node: &str, instance_name: &str, node_map: &HashMap<String, S
         .or_else(|| node_map.get(&node.to_ascii_lowercase()))
         .cloned()
         .unwrap_or_else(|| format!("{instance_name}.{node}"))
+}
+
+fn map_subckt_source_ref(source_name: &str, instance_name: &str) -> String {
+    if source_name.contains('.') {
+        source_name.to_string()
+    } else {
+        format!("{instance_name}.{source_name}")
+    }
 }
 
 fn element_prefix(name: &str) -> Result<char, NetlistParseError> {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -119,6 +119,30 @@ Rload out 0 1k
 }
 
 #[test]
+fn parses_cccs_into_operating_point_circuit() {
+    let parsed = parse_netlist(
+        r#"
+Vin in 0 DC 1
+Rin in sense 1k
+Vsense sense 0 DC 0
+Fcopy out 0 Vsense 2
+Rload out 0 500
+.op
+"#,
+    )
+    .unwrap();
+
+    let Element::Cccs(source) = &parsed.circuit.elements()[3] else {
+        panic!("expected CCCS");
+    };
+    assert_eq!(source.control_source, "Vsense");
+    assert_close(source.gain, 2.0);
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    assert_close(result.voltage("out").unwrap(), -1.0);
+}
+
+#[test]
 fn parses_pwl_and_sin_source_waveforms() {
     let parsed = parse_netlist(
         r#"
@@ -209,6 +233,54 @@ Rload out 0 1k
 
     let result = dc_op(&parsed.circuit).unwrap();
     assert_close(result.voltage("out").unwrap(), 2.5);
+}
+
+#[test]
+fn expands_subcircuit_cccs_control_sources_into_engine_elements() {
+    let parsed = parse_netlist(
+        r#"
+.subckt mirror inp outp
+Rin inp sense 1k
+Vsense sense 0 DC 0
+Fcopy outp 0 Vsense 2
+.ends mirror
+Vin in 0 DC 1
+Xmirror in out mirror
+Rload out 0 500
+.op
+"#,
+    )
+    .unwrap();
+
+    let elements = parsed.circuit.elements();
+    let names = elements
+        .iter()
+        .map(|element| match element {
+            Element::VoltageSource(source) => source.name.as_str(),
+            Element::Resistor(resistor) => resistor.name.as_str(),
+            Element::Cccs(source) => source.name.as_str(),
+            _ => panic!("unexpected element"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        vec![
+            "Vin",
+            "Xmirror.Rin",
+            "Xmirror.Vsense",
+            "Xmirror.Fcopy",
+            "Rload"
+        ]
+    );
+
+    let Element::Cccs(source) = &elements[3] else {
+        panic!("expected CCCS");
+    };
+    assert_eq!(source.positive, "out");
+    assert_eq!(source.control_source, "Xmirror.Vsense");
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    assert_close(result.voltage("out").unwrap(), -1.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- parse SPICE `F` / CCCS controlled-source elements into Rust SPICE engine circuits
- remap subcircuit-local CCCS controlling source names during expansion
- add direct and subcircuit operating-point coverage

## Tests

- `cargo test -p spice-netlist-parser && git -C /Users/adhithya/Downloads/Codex/coding-adventures-rust-spice-netlist-cccs diff --check`