### PR TITLE
[codex] Add Board VM I2C byte-buffer write

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -5,12 +5,12 @@ use std::slice;
 use board_vm_host::{
     AdcReadProgram, BlinkProgram, DacWriteU12Program, GpioHandleCloseProgram,
     GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
-    GpioWriteProgram, I2cOpenProgram, I2cReadU8Program, I2cWriteU8Program,
+    GpioWriteProgram, I2cOpenProgram, I2cReadU8Program, I2cWriteProgram, I2cWriteU8Program,
     LedMatrixFrameProgram, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
     ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
     DAC_WRITE_U12_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
     GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN,
-    I2C_OPEN_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN,
+    I2C_OPEN_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_WRITE_MAX_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN,
     LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
     TIME_SLEEP_MS_MODULE_LEN,
 };
@@ -21,7 +21,7 @@ use board_vm_language_core::{
     build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
     build_dac_write_u12_module, build_gpio_read_module, build_gpio_write_module,
     build_hello_wire_frame, build_i2c_open_module, build_i2c_read_u8_module,
-    build_i2c_write_u8_module,
+    build_i2c_write_module, build_i2c_write_u8_module,
     build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
     build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
     build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
@@ -288,6 +288,22 @@ extern "C" fn session_i2c_write_u8_module(
 
     let module = build_i2c_write_u8_module_value(address, byte, max_stack)
         .unwrap_or_else(|error| raise_core_error("i2c_write_u8_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_i2c_write_module(
+    _self_val: VALUE,
+    address_val: VALUE,
+    bytes_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let address = rb_u16(address_val, "address");
+    let bytes = ruby_bridge::bytes_from_rb(bytes_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("bytes must be a Ruby binary String"));
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_i2c_write_module_value(address, &bytes, max_stack)
+        .unwrap_or_else(|error| raise_core_error("i2c_write_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1535,6 +1551,24 @@ fn build_i2c_write_u8_module_value(
     Ok(module)
 }
 
+fn build_i2c_write_module_value(
+    address: u16,
+    bytes: &[u8],
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; I2C_WRITE_MAX_MODULE_LEN];
+    let len = build_i2c_write_module(
+        I2cWriteProgram {
+            address,
+            bytes,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_i2c_read_u8_module_value(
     address: u16,
     max_stack: u8,
@@ -1870,6 +1904,12 @@ pub extern "C" fn Init_board_vm_native() {
         session_class,
         "i2c_write_u8_module",
         session_i2c_write_u8_module as *const c_void,
+        3,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "i2c_write_module",
+        session_i2c_write_module as *const c_void,
         3,
     );
     ruby_bridge::define_method_raw(

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -466,6 +466,24 @@ module CodingAdventures
         )
       end
 
+      def i2c_write!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        address:,
+        bytes:,
+        max_stack: 4
+      )
+        ensure_uno_r4_wifi!
+
+        session.i2c_write(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          bytes: bytes,
+          max_stack: max_stack
+        )
+      end
+
       def i2c_read_u8!(
         program_id: DEFAULT_PROGRAM_ID,
         budget: DEFAULT_INSTRUCTION_BUDGET,
@@ -1133,6 +1151,22 @@ module CodingAdventures
           budget: budget,
           address: address,
           byte: byte,
+          max_stack: max_stack
+        )
+      end
+
+      def write(
+        address:,
+        bytes:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 4
+      )
+        @connection.i2c_write!(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          bytes: bytes,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -217,6 +217,10 @@ module CodingAdventures
         native_session.i2c_write_u8_module(address, byte, max_stack)
       end
 
+      def i2c_write_module(address:, bytes:, max_stack: 4)
+        native_session.i2c_write_module(address, i2c_bytes_value(bytes), max_stack)
+      end
+
       def i2c_read_u8_module(address:, max_stack: 3)
         native_session.i2c_read_u8_module(address, max_stack)
       end
@@ -316,6 +320,18 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: i2c_write_u8_module(address: address, byte: byte, max_stack: max_stack)
+        )
+      end
+
+      def upload_i2c_write(
+        program_id: @program_id,
+        address:,
+        bytes:,
+        max_stack: 4
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: i2c_write_module(address: address, bytes: bytes, max_stack: max_stack)
         )
       end
 
@@ -699,6 +715,30 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def i2c_write(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        address:,
+        bytes:,
+        max_stack: 4
+      )
+        results = upload_i2c_write(
+          program_id: program_id,
+          address: address,
+          bytes: bytes,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def i2c_read_u8(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -924,6 +964,8 @@ module CodingAdventures
           upload_i2c_open(**i2c_open_command_options(words, command, options, require_budget: false))
         when "upload-i2c-write-u8", "upload-i2c.write_u8", "upload-i2c-write"
           upload_i2c_write_u8(**i2c_write_u8_command_options(words, command, options, require_budget: false))
+        when "upload-i2c-write-bytes", "upload-i2c.write"
+          upload_i2c_write(**i2c_write_command_options(words, command, options, require_budget: false))
         when "upload-i2c-read-u8", "upload-i2c.read_u8", "upload-i2c-read"
           upload_i2c_read_u8(**i2c_read_u8_command_options(words, command, options, require_budget: false))
         when "upload-gpio-open", "upload-gpio.open"
@@ -966,6 +1008,8 @@ module CodingAdventures
           i2c_open(**i2c_open_command_options(words, command, options))
         when "i2c-write-u8", "i2c.write_u8", "i2c-write"
           i2c_write_u8(**i2c_write_u8_command_options(words, command, options))
+        when "i2c-write-bytes", "i2c.write"
+          i2c_write(**i2c_write_command_options(words, command, options))
         when "i2c-read-u8", "i2c.read_u8", "i2c-read"
           i2c_read_u8(**i2c_read_u8_command_options(words, command, options))
         when "gpio-high", "gpio.high"
@@ -1230,6 +1274,22 @@ module CodingAdventures
         merged
       end
 
+      def i2c_write_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:address] = integer_argument(words.shift, "#{command} address") unless words.empty?
+        merged[:bytes] = i2c_bytes_argument(words.shift, "#{command} bytes") unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires address" unless merged.key?(:address)
+        raise ArgumentError, "#{command} requires bytes" unless merged.key?(:bytes)
+
+        merged
+      end
+
       def i2c_read_u8_command_options(words, command, options, require_budget: true)
         merged = options.dup
         merged[:address] = integer_argument(words.shift, "#{command} address") unless words.empty?
@@ -1335,6 +1395,50 @@ module CodingAdventures
         raise ArgumentError, "DAC sample must fit in u12" if sample.negative? || sample > 0x0FFF
 
         sample
+      end
+
+      def i2c_bytes_value(value)
+        case value
+        when String
+          value.b
+        when Array
+          value.map { |byte| byte_value(byte) }.pack("C*")
+        else
+          [byte_value(value)].pack("C")
+        end
+      end
+
+      def i2c_bytes_argument(value, name)
+        raise ArgumentError, "#{name} is required" if value.nil?
+
+        text = value.to_s
+        if text.start_with?("0x", "0X")
+          hex = text[2..]
+          raise ArgumentError, "#{name} hex payload must contain an even number of digits" if hex.length.odd?
+          raise ArgumentError, "#{name} hex payload must contain only hex digits" unless hex.match?(/\A[0-9a-fA-F]*\z/)
+          return [hex].pack("H*")
+        end
+
+        if text.include?(",")
+          return text.split(",").map { |byte| byte_value(byte) }.pack("C*")
+        end
+
+        i2c_bytes_value(value)
+      end
+
+      def byte_value(value)
+        byte = if value.is_a?(Integer)
+          value
+        else
+          begin
+            Integer(value, 0)
+          rescue ArgumentError
+            raise ArgumentError, "byte must be an integer: #{value.inspect}"
+          end
+        end
+        raise ArgumentError, "byte must fit in u8" if byte.negative? || byte > 0xFF
+
+        byte
       end
 
       def boot_policy_value(value)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -41,6 +41,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "i2c.open"
         assert_includes uno_r4_wifi["capabilities"], "i2c.write_u8"
         assert_includes uno_r4_wifi["capabilities"], "i2c.read_u8"
+        assert_includes uno_r4_wifi["capabilities"], "i2c.write"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -1323,6 +1324,30 @@ module CodingAdventures
           write_result.results.map(&:command)
       end
 
+      def test_i2c_write_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        open_result = nil
+        write_result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          open_result = board.i2c.open(bus: 0, program_id: 10, budget: 24)
+          write_result = board.i2c.write(address: 0x3c, bytes: [0xde, 0xad, 0xbe], program_id: 11, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 10, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal open_result.frames + write_result.frames, transport.frames
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          write_result.results.map(&:command)
+      end
+
       def test_i2c_read_u8_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1781,6 +1806,40 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_i2c_write
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("i2c.write 60 0xdeadbe 24", program_id: 9)
+          upload = board.session.run_command("upload-i2c.write 60 0xdeadbe", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
+      def test_session_run_command_rejects_invalid_i2c_write_hex_payload
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: FakeWriteTransport.new
+        ) do |board|
+          error = assert_raises(ArgumentError) do
+            board.session.run_command("upload-i2c.write 60 0xzz", program_id: 10)
+          end
+          assert_match(/hex payload must contain only hex digits/, error.message)
+        end
+      end
+
       def test_session_run_command_accepts_repl_style_i2c_read_u8
         transport = FakeWriteTransport.new
 
@@ -1929,6 +1988,10 @@ module CodingAdventures
         i2c_write_module_bytes = session.i2c_write_u8_module(0x3c, 0xa5, 4)
         assert_instance_of String, i2c_write_module_bytes
         assert_operator i2c_write_module_bytes.bytesize, :>, 0
+
+        i2c_write_bytes_module_bytes = session.i2c_write_module(0x3c, "\xDE\xAD\xBE".b, 4)
+        assert_instance_of String, i2c_write_bytes_module_bytes
+        assert_operator i2c_write_bytes_module_bytes.bytesize, :>, 0
 
         i2c_read_module_bytes = session.i2c_read_u8_module(0x3c, 3)
         assert_instance_of String, i2c_read_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -2,7 +2,7 @@
 
 use board_vm_ir::{
     parse_module, validate, CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
-    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ_U8, CAP_I2C_WRITE_U8,
+    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ_U8, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
     CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
@@ -104,6 +104,12 @@ const I2C_READ_U8_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescript
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "i2c.read_u8",
+};
+const I2C_WRITE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_I2C_WRITE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "i2c.write",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -598,7 +604,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_AND_DAC_CAPABILITIES: [CapabilityDescriptor<'st
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
-pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 13] = [
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 14] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -611,6 +617,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor
     I2C_OPEN_DESCRIPTOR,
     I2C_WRITE_U8_DESCRIPTOR,
     I2C_READ_U8_DESCRIPTOR,
+    I2C_WRITE_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
@@ -669,7 +676,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDes
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<
     'static,
->; 14] = [
+>; 15] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -682,6 +689,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [Capabilit
     I2C_OPEN_DESCRIPTOR,
     I2C_WRITE_U8_DESCRIPTOR,
     I2C_READ_U8_DESCRIPTOR,
+    I2C_WRITE_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,9 +1,9 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ,
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
-    CAP_I2C_READ_U8, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS,
-    CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
-    MODULE_MAGIC, MODULE_VERSION,
+    CAP_I2C_READ_U8, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+    CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
+    FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MAX_BYTE_BUFFER_LEN, MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -47,6 +47,8 @@ pub const I2C_WRITE_U8_CODE_LEN: usize = 8;
 pub const I2C_WRITE_U8_MODULE_LEN: usize = 18;
 pub const I2C_READ_U8_CODE_LEN: usize = 7;
 pub const I2C_READ_U8_MODULE_LEN: usize = 17;
+pub const I2C_WRITE_CODE_LEN: usize = 10;
+pub const I2C_WRITE_MAX_MODULE_LEN: usize = 8 + 1 + I2C_WRITE_CODE_LEN + 1 + MAX_BYTE_BUFFER_LEN;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -61,6 +63,7 @@ const OP_PUSH_TRUE: u8 = 0x11;
 const OP_PUSH_U8: u8 = 0x12;
 const OP_PUSH_U16: u8 = 0x13;
 const OP_PUSH_U32: u8 = 0x14;
+const OP_PUSH_BYTES: u8 = 0x16;
 const OP_DUP: u8 = 0x20;
 const OP_SWAP: u8 = 0x22;
 const OP_JUMP_S8: u8 = 0x30;
@@ -201,6 +204,13 @@ pub struct I2cReadU8Program {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct I2cWriteProgram<'a> {
+    pub address: u16,
+    pub bytes: &'a [u8],
+    pub max_stack: u8,
+}
+
 impl I2cOpenProgram {
     pub const fn new(bus: u8) -> Self {
         Self { bus, max_stack: 2 }
@@ -222,6 +232,16 @@ impl I2cReadU8Program {
         Self {
             address,
             max_stack: 3,
+        }
+    }
+}
+
+impl<'a> I2cWriteProgram<'a> {
+    pub const fn new(address: u16, bytes: &'a [u8]) -> Self {
+        Self {
+            address,
+            bytes,
+            max_stack: 4,
         }
     }
 }
@@ -1303,6 +1323,61 @@ pub fn write_i2c_read_u8_module(
     Ok(offset)
 }
 
+pub fn i2c_write_module_len(byte_len: usize) -> Result<usize, HostError> {
+    if byte_len > MAX_BYTE_BUFFER_LEN {
+        return Err(HostError::ProgramTooLarge);
+    }
+    Ok(8 + 1 + I2C_WRITE_CODE_LEN + 1 + byte_len)
+}
+
+pub fn write_i2c_write_code(
+    program: I2cWriteProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if program.bytes.len() > MAX_BYTE_BUFFER_LEN {
+        return Err(HostError::ProgramTooLarge);
+    }
+    if out.len() < I2C_WRITE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_push_u16(out, &mut offset, program.address)?;
+    write_push_bytes(out, &mut offset, 0, program.bytes.len() as u8)?;
+    write_call_u8(out, &mut offset, CAP_I2C_WRITE)?;
+    Ok(offset)
+}
+
+pub fn write_i2c_write_module(
+    program: I2cWriteProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    let required_len = i2c_write_module_len(program.bytes.len())?;
+    if out.len() < required_len {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; I2C_WRITE_CODE_LEN];
+    let code_len = write_i2c_write_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        )
+        .const_pool(program.bytes),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_i2c(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_led_matrix_frame_code(
     program: LedMatrixFrameProgram,
     out: &mut [u8],
@@ -1417,6 +1492,17 @@ fn write_push_u32(out: &mut [u8], offset: &mut usize, value: u32) -> Result<(), 
     write_slice(out, offset, &value.to_le_bytes())
 }
 
+fn write_push_bytes(
+    out: &mut [u8],
+    offset: &mut usize,
+    const_offset: u16,
+    len: u8,
+) -> Result<(), HostError> {
+    write_u8(out, offset, OP_PUSH_BYTES)?;
+    write_slice(out, offset, &const_offset.to_le_bytes())?;
+    write_u8(out, offset, len)
+}
+
 fn write_uleb128(out: &mut [u8], offset: &mut usize, mut value: u32) -> Result<(), HostError> {
     loop {
         let mut byte = (value & 0x7F) as u8;
@@ -1452,8 +1538,8 @@ mod tests {
     use super::*;
     use board_vm_ir::{
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
-        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_READ_U8, CAP_I2C_WRITE_U8,
-        CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_READ_U8, CAP_I2C_WRITE,
+        CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -1515,6 +1601,10 @@ mod tests {
     const I2C_READ_U8_3C_MODULE_HEX: [u8; I2C_READ_U8_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x03, 0x00, 0x07, 0x20, 0x13, 0x3C, 0x00, 0x40, 0x25,
         0x50, 0x00,
+    ];
+    const I2C_WRITE_3C_DE_AD_BE_MODULE_HEX: [u8; 23] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x04, 0x00, 0x0A, 0x20, 0x13, 0x3C, 0x00, 0x16, 0x00,
+        0x00, 0x03, 0x40, 0x26, 0x03, 0xDE, 0xAD, 0xBE,
     ];
     const LED_MATRIX_HEART_MODULE_HEX: [u8; LED_MATRIX_FRAME_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x12, 0x14, 0x44, 0xA4, 0x84, 0x31, 0x14,
@@ -1746,6 +1836,22 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_I2C_READ_U8]);
+    }
+
+    #[test]
+    fn builds_i2c_write_module() {
+        let payload = [0xde, 0xad, 0xbe];
+        let mut module = [0u8; I2C_WRITE_MAX_MODULE_LEN];
+        let len =
+            write_i2c_write_module(I2cWriteProgram::new(0x3c, &payload), &mut module).unwrap();
+        assert_eq!(len, I2C_WRITE_3C_DE_AD_BE_MODULE_HEX.len());
+        assert_eq!(&module[..len], I2C_WRITE_3C_DE_AD_BE_MODULE_HEX);
+
+        let parsed = parse_module(&module[..len]).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_i2c(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_WRITE]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -23,6 +23,7 @@ pub const CAP_DAC_WRITE_U12: u16 = 0x22;
 pub const CAP_I2C_OPEN: u16 = 0x23;
 pub const CAP_I2C_WRITE_U8: u16 = 0x24;
 pub const CAP_I2C_READ_U8: u16 = 0x25;
+pub const CAP_I2C_WRITE: u16 = 0x26;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -37,6 +38,7 @@ const CAP_DAC_WRITE_U12_U8: u8 = CAP_DAC_WRITE_U12 as u8;
 const CAP_I2C_OPEN_U8: u8 = CAP_I2C_OPEN as u8;
 const CAP_I2C_WRITE_U8_U8: u8 = CAP_I2C_WRITE_U8 as u8;
 const CAP_I2C_READ_U8_U8: u8 = CAP_I2C_READ_U8 as u8;
+const CAP_I2C_WRITE_CAP_U8: u8 = CAP_I2C_WRITE as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -174,7 +176,7 @@ impl CapabilitySet {
             CAP_PWM_WRITE => self.pwm,
             CAP_ADC_READ => self.adc,
             CAP_DAC_WRITE_U12 => self.dac,
-            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 => self.i2c,
+            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 | CAP_I2C_WRITE => self.i2c,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -443,6 +445,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_I2C_OPEN_U8) | Op::CallU16(CAP_I2C_OPEN) => (1, 1),
         Op::CallU8(CAP_I2C_WRITE_U8_U8) | Op::CallU16(CAP_I2C_WRITE_U8) => (3, 0),
         Op::CallU8(CAP_I2C_READ_U8_U8) | Op::CallU16(CAP_I2C_READ_U8) => (2, 1),
+        Op::CallU8(CAP_I2C_WRITE_CAP_U8) | Op::CallU16(CAP_I2C_WRITE) => (3, 0),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -744,6 +747,31 @@ mod tests {
     }
 
     #[test]
+    fn validates_i2c_write_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 4,
+            code: &[
+                0x20,
+                0x12,
+                0x3c,
+                0x16,
+                0x00,
+                0x00,
+                0x03,
+                0x40,
+                CAP_I2C_WRITE as u8,
+            ],
+            const_pool: &[0xde, 0xad, 0xbe],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_i2c(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_WRITE]);
+    }
+
+    #[test]
     fn rejects_pwm_write_without_capability() {
         let module = Module {
             flags: 0,
@@ -830,6 +858,31 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 4),
             Err(ValidateError::UnsupportedCapability(CAP_I2C_READ_U8))
+        );
+    }
+
+    #[test]
+    fn rejects_i2c_write_without_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 4,
+            code: &[
+                0x20,
+                0x12,
+                0x3c,
+                0x16,
+                0x00,
+                0x00,
+                0x03,
+                0x40,
+                CAP_I2C_WRITE as u8,
+            ],
+            const_pool: &[0xde, 0xad, 0xbe],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 4),
+            Err(ValidateError::UnsupportedCapability(CAP_I2C_WRITE))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -35,21 +35,21 @@ use board_vm_esp_rom::{
     DEFAULT_TIMEOUT_MS as ESP_DEFAULT_TIMEOUT_MS,
 };
 use board_vm_host::{
-    write_adc_read_module, write_blink_module, write_dac_write_u12_module,
+    i2c_write_module_len, write_adc_read_module, write_blink_module, write_dac_write_u12_module,
     write_gpio_handle_close_module, write_gpio_handle_read_module, write_gpio_handle_write_module,
     write_gpio_open_module, write_gpio_read_module, write_gpio_write_module, write_i2c_open_module,
-    write_i2c_read_u8_module, write_i2c_write_u8_module, write_led_matrix_frame_module,
-    write_module, write_pwm_write_module, write_time_now_module, write_time_sleep_ms_module,
-    AdcReadProgram, BlinkProgram, DacWriteU12Program, GpioHandleCloseProgram,
-    GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
-    GpioWriteProgram, HostError, HostSession, I2cOpenProgram, I2cReadU8Program, I2cWriteU8Program,
-    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
-    DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN,
-    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
-    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, I2C_READ_U8_MODULE_LEN,
-    I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
-    TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    write_i2c_read_u8_module, write_i2c_write_module, write_i2c_write_u8_module,
+    write_led_matrix_frame_module, write_module, write_pwm_write_module, write_time_now_module,
+    write_time_sleep_ms_module, AdcReadProgram, BlinkProgram, DacWriteU12Program,
+    GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram,
+    GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram, I2cReadU8Program,
+    I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram,
+    TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
+    DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
+    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
+    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
+    I2C_READ_U8_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
+    PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -1644,6 +1644,13 @@ pub fn build_i2c_write_u8_module(
     Ok(write_i2c_write_u8_module(program, out)?)
 }
 
+pub fn build_i2c_write_module(
+    program: I2cWriteProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_i2c_write_module(program, out)?)
+}
+
 pub fn build_i2c_read_u8_module(
     program: I2cReadU8Program,
     out: &mut [u8],
@@ -2400,6 +2407,33 @@ pub unsafe extern "C" fn board_vm_language_i2c_write_u8_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_i2c_write_module(
+    address: u16,
+    bytes: *const u8,
+    bytes_len: u64,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let bytes = unsafe { in_slice(bytes, bytes_len, "bytes") }?;
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_i2c_write_module(
+            I2cWriteProgram {
+                address,
+                bytes,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_i2c_read_u8_module(
     address: u16,
     max_stack: u8,
@@ -2747,6 +2781,14 @@ pub extern "C" fn board_vm_language_i2c_write_u8_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_i2c_write_module_len(byte_len: u64) -> u64 {
+    let Ok(byte_len) = usize::try_from(byte_len) else {
+        return 0;
+    };
+    i2c_write_module_len(byte_len).unwrap_or(0) as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_i2c_read_u8_module_len() -> u64 {
     I2C_READ_U8_MODULE_LEN as u64
 }
@@ -2991,6 +3033,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"i2c.open".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.write_u8".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.read_u8".to_owned()));
+        assert!(uno.capabilities.contains(&"i2c.write".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -3820,6 +3863,27 @@ mod tests {
         };
         assert_eq!(i2c_write_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(i2c_write_status.len, I2C_WRITE_U8_MODULE_LEN as u64);
+
+        let i2c_payload = [0xde, 0xad, 0xbe];
+        let mut i2c_write_bytes_module = [0u8; board_vm_host::I2C_WRITE_MAX_MODULE_LEN];
+        let i2c_write_bytes_status = unsafe {
+            board_vm_language_i2c_write_module(
+                0x3c,
+                i2c_payload.as_ptr(),
+                i2c_payload.len() as u64,
+                4,
+                i2c_write_bytes_module.as_mut_ptr(),
+                i2c_write_bytes_module.len() as u64,
+            )
+        };
+        assert_eq!(
+            i2c_write_bytes_status.code,
+            BoardVmLanguageStatusCode::Ok as u32
+        );
+        assert_eq!(
+            i2c_write_bytes_status.len,
+            board_vm_language_i2c_write_module_len(i2c_payload.len() as u64)
+        );
 
         let mut i2c_read_module = [0u8; I2C_READ_U8_MODULE_LEN];
         let i2c_read_status = unsafe {

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -3,8 +3,8 @@
 use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_DAC_WRITE_U12,
     CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ_U8,
-    CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
-    MAX_BYTE_BUFFER_LEN,
+    CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS,
+    CAP_TIME_SLEEP_MS, MAX_BYTE_BUFFER_LEN,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -129,6 +129,10 @@ pub trait BoardHal {
     }
 
     fn i2c_write_u8(&mut self, _token: u32, _address: u16, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn i2c_write(&mut self, _token: u32, _address: u16, _bytes: &[u8]) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -562,6 +566,18 @@ where
                         kind: hal_error_kind(err),
                     })
             }
+            CAP_I2C_WRITE => {
+                let bytes = self.pop_bytes(ip)?;
+                let address = self.pop_u16(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::I2c, ip)?;
+                self.hal
+                    .i2c_write(token, address, bytes.as_slice())
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })
+            }
             CAP_I2C_READ_U8 => {
                 let address = self.pop_u16(ip)?;
                 let handle = self.pop_handle(ip)?;
@@ -675,6 +691,16 @@ where
             Value::U8(value) => Ok(value as u32),
             Value::U16(value) => Ok(value as u32),
             Value::U32(value) => Ok(value),
+            _ => Err(RuntimeError {
+                ip,
+                kind: RuntimeErrorKind::TypeMismatch,
+            }),
+        }
+    }
+
+    fn pop_bytes(&mut self, ip: usize) -> Result<ByteBuffer, RuntimeError> {
+        match self.pop(ip)? {
+            Value::Bytes(value) => Ok(value),
             _ => Err(RuntimeError {
                 ip,
                 kind: RuntimeErrorKind::TypeMismatch,
@@ -820,6 +846,7 @@ mod tests {
         DacWriteU12(u16, u16),
         I2cOpen(u16),
         I2cWriteU8(u32, u16, u8),
+        I2cWrite(u32, u16, ByteBuffer),
         I2cReadU8(u32, u16),
         LedMatrixFrame([u32; 3]),
     }
@@ -898,6 +925,15 @@ mod tests {
 
         fn i2c_write_u8(&mut self, token: u32, address: u16, byte: u8) -> Result<(), HalError> {
             self.events.push(Event::I2cWriteU8(token, address, byte));
+            Ok(())
+        }
+
+        fn i2c_write(&mut self, token: u32, address: u16, bytes: &[u8]) -> Result<(), HalError> {
+            self.events.push(Event::I2cWrite(
+                token,
+                address,
+                ByteBuffer::from_slice(bytes).unwrap(),
+            ));
             Ok(())
         }
 
@@ -1123,6 +1159,45 @@ mod tests {
         assert_eq!(
             runtime.hal().events,
             vec![Event::I2cOpen(1), Event::I2cReadU8(0x1_2001, 0x3c)]
+        );
+    }
+
+    #[test]
+    fn i2c_write_dispatches_handle_address_and_bytes() {
+        let mut runtime: Runtime<FakeHal, 4, 2> = Runtime::new(FakeHal::new());
+        let open = [0x12, 1, 0x40, CAP_I2C_OPEN as u8, 0x20, 0x50];
+        let write = Module {
+            flags: board_vm_ir::FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 4,
+            code: &[
+                0x20,
+                0x12,
+                0x3c,
+                0x16,
+                0x00,
+                0x00,
+                0x03,
+                0x40,
+                CAP_I2C_WRITE as u8,
+            ],
+            const_pool: &[0xde, 0xad, 0xbe],
+        };
+
+        runtime.run_code(&open, 10).unwrap();
+        let report = runtime.run_module(&write, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            runtime.hal().events,
+            vec![
+                Event::I2cOpen(1),
+                Event::I2cWrite(
+                    0x1_2001,
+                    0x3c,
+                    ByteBuffer::from_slice(&[0xde, 0xad, 0xbe]).unwrap()
+                )
+            ]
         );
     }
 }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -112,7 +112,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 14] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 15] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -126,10 +126,11 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 14] = [
     "i2c.open",
     "i2c.write_u8",
     "i2c.read_u8",
+    "i2c.write",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 18] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 19] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -146,6 +147,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 18] = [
     "i2c.open",
     "i2c.write_u8",
     "i2c.read_u8",
+    "i2c.write",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -613,6 +615,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"i2c.open"));
         assert!(uno.capabilities.contains(&"i2c.write_u8"));
         assert!(uno.capabilities.contains(&"i2c.read_u8"));
+        assert!(uno.capabilities.contains(&"i2c.write"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -31,6 +31,7 @@ pub const BOARD_VM_UNO_R4_PWM_WRITE_SYMBOL: &str = "board_vm_uno_r4_pwm_write";
 pub const BOARD_VM_UNO_R4_ADC_READ_SYMBOL: &str = "board_vm_uno_r4_adc_read";
 pub const BOARD_VM_UNO_R4_DAC_WRITE_U12_SYMBOL: &str = "board_vm_uno_r4_dac_write_u12";
 pub const BOARD_VM_UNO_R4_I2C_WRITE_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_write_u8";
+pub const BOARD_VM_UNO_R4_I2C_WRITE_SYMBOL: &str = "board_vm_uno_r4_i2c_write";
 pub const BOARD_VM_UNO_R4_I2C_READ_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_read_u8";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
@@ -283,6 +284,10 @@ mod tests {
         assert_eq!(
             BOARD_VM_UNO_R4_I2C_WRITE_U8_SYMBOL,
             "board_vm_uno_r4_i2c_write_u8"
+        );
+        assert_eq!(
+            BOARD_VM_UNO_R4_I2C_WRITE_SYMBOL,
+            "board_vm_uno_r4_i2c_write"
         );
         assert_eq!(
             BOARD_VM_UNO_R4_I2C_READ_U8_SYMBOL,

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -216,6 +216,16 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         }
     }
 
+    fn write_i2c(&mut self, bus: u8, address: u16, bytes: &[u8]) -> Result<(), HalError> {
+        if unsafe {
+            board_io_ffi::board_vm_uno_r4_i2c_write(bus, address, bytes.as_ptr(), bytes.len())
+        } {
+            Ok(())
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+
     fn read_i2c_u8(&mut self, bus: u8, address: u16) -> Result<u8, HalError> {
         let mut byte = 0;
         if unsafe { board_io_ffi::board_vm_uno_r4_i2c_read_u8(bus, address, &mut byte) } {
@@ -237,6 +247,12 @@ mod board_io_ffi {
         pub fn board_vm_uno_r4_adc_read(pin: u8, sample: *mut u16) -> bool;
         pub fn board_vm_uno_r4_dac_write_u12(pin: u8, sample: u16) -> bool;
         pub fn board_vm_uno_r4_i2c_write_u8(bus: u8, address: u16, byte: u8) -> bool;
+        pub fn board_vm_uno_r4_i2c_write(
+            bus: u8,
+            address: u16,
+            bytes: *const u8,
+            len: usize,
+        ) -> bool;
         pub fn board_vm_uno_r4_i2c_read_u8(bus: u8, address: u16, byte: *mut u8) -> bool;
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -455,6 +455,29 @@ extern "C" bool board_vm_uno_r4_i2c_write_u8(uint8_t bus, uint16_t address, uint
   return wire->endTransmission() == END_TX_OK;
 }
 
+extern "C" bool board_vm_uno_r4_i2c_write(uint8_t bus, uint16_t address, const uint8_t *bytes, size_t len) {
+  if ((bytes == nullptr && len != 0) || address > kI2cMax7BitAddress) {
+    return false;
+  }
+
+  I2cSlot *slot = find_i2c_slot(bus);
+  if (slot == nullptr) {
+    return false;
+  }
+
+  TwoWire *wire = slot_wire(*slot);
+  if (!slot->started) {
+    wire->begin();
+    slot->started = true;
+  }
+
+  wire->beginTransmission(address);
+  if (len != 0 && wire->write(bytes, len) != len) {
+    return false;
+  }
+  return wire->endTransmission() == END_TX_OK;
+}
+
 extern "C" bool board_vm_uno_r4_i2c_read_u8(uint8_t bus, uint16_t address, uint8_t *byte) {
   if (byte == nullptr || address > kI2cMax7BitAddress) {
     return false;

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -387,6 +387,10 @@ pub trait UnoR4Backend {
         Err(HalError::UnsupportedMode)
     }
 
+    fn write_i2c(&mut self, _bus: u8, _address: u16, _bytes: &[u8]) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn read_i2c_u8(&mut self, _bus: u8, _address: u16) -> Result<u8, HalError> {
         Err(HalError::UnsupportedMode)
     }
@@ -516,6 +520,12 @@ where
         let bus = normalize_i2c_token(self.target, token)?;
         normalize_i2c_address(address)?;
         self.backend.write_i2c_u8(bus, address, byte)
+    }
+
+    fn i2c_write(&mut self, token: u32, address: u16, bytes: &[u8]) -> Result<(), HalError> {
+        let bus = normalize_i2c_token(self.target, token)?;
+        normalize_i2c_address(address)?;
+        self.backend.write_i2c(bus, address, bytes)
     }
 
     fn i2c_read_u8(&mut self, token: u32, address: u16) -> Result<u8, HalError> {
@@ -712,7 +722,7 @@ mod tests {
         0x20, 0x10, 0x40, 0x02, 0x13, 0xfa, 0x00, 0x40, 0x10, 0x30, 0xec,
     ];
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     enum Event {
         Configure(u8, GpioMode),
         Write(u8, Level),
@@ -722,6 +732,7 @@ mod tests {
         DacWriteU12(u8, u16),
         I2cOpen(u8),
         I2cWriteU8(u8, u16, u8),
+        I2cWrite(u8, u16, Vec<u8>),
         I2cReadU8(u8, u16),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
@@ -808,6 +819,12 @@ mod tests {
 
         fn write_i2c_u8(&mut self, bus: u8, address: u16, byte: u8) -> Result<(), HalError> {
             self.events.push(Event::I2cWriteU8(bus, address, byte));
+            Ok(())
+        }
+
+        fn write_i2c(&mut self, bus: u8, address: u16, bytes: &[u8]) -> Result<(), HalError> {
+            self.events
+                .push(Event::I2cWrite(bus, address, bytes.to_vec()));
             Ok(())
         }
 
@@ -919,6 +936,9 @@ mod tests {
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_I2C_READ_U8));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_WRITE));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -937,6 +957,9 @@ mod tests {
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_I2C_READ_U8));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_WRITE));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -1055,6 +1078,34 @@ mod tests {
         );
         assert_eq!(
             board.i2c_write_u8(0x1_2000, 0x80, 0xa5),
+            Err(HalError::InvalidPin)
+        );
+    }
+
+    #[test]
+    fn i2c_write_runs_through_bus_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        board
+            .i2c_write(0x1_2001, 0x3c, &[0xde, 0xad, 0xbe])
+            .unwrap();
+
+        assert_eq!(
+            board.backend().events,
+            vec![Event::I2cWrite(1, 0x3c, vec![0xde, 0xad, 0xbe])]
+        );
+    }
+
+    #[test]
+    fn i2c_write_rejects_unknown_bus_or_address() {
+        let mut board = UnoR4Board::minima(FakeBackend::new());
+
+        assert_eq!(
+            board.i2c_write(0x1_2001, 0x3c, &[0xde, 0xad, 0xbe]),
+            Err(HalError::InvalidPin)
+        );
+        assert_eq!(
+            board.i2c_write(0x1_2000, 0x80, &[0xde, 0xad, 0xbe]),
             Err(HalError::InvalidPin)
         );
     }

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -209,6 +209,7 @@ metadata. The operation is intentionally direct and stateless, mirroring
 | `0x23` | `i2c.open` | `bus: u16/u8` | `handle` |
 | `0x24` | `i2c.write_u8` | `handle`, `address: u16/u8`, `byte: u8` | `unit` |
 | `0x25` | `i2c.read_u8` | `handle`, `address: u16/u8` | `u8` |
+| `0x26` | `i2c.write` | `handle`, `address: u16/u8`, `bytes` | `unit` |
 
 `i2c.open` opens a board-advertised I2C controller and returns a persistent bus
 handle. The handle is the lifetime anchor for transfer operations, keeping bus
@@ -217,8 +218,9 @@ identity and pin ownership out of language frontends.
 `i2c.write_u8` writes a single byte to a 7-bit device address on an already
 opened bus handle. `i2c.read_u8` reads one byte from that same 7-bit address and
 returns it as a scalar `u8`. These are the first concrete I2C transfer
-primitives. Wider `i2c.write`, `i2c.read`, and `i2c.transfer` operations should
-reuse the same handle model and the bounded byte-buffer ABI.
+primitives. `i2c.write` writes a bounded VM byte buffer to the device address
+using the same handle model. Wider `i2c.read` and `i2c.transfer` operations
+should reuse the bounded byte-buffer ABI.
 
 ### LED Matrix
 

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -29,7 +29,7 @@ Source snapshot:
 | PWM output | D3, D5, D6, D9, D10, D11 in the Arduino variant init path | implemented as direct write | `pwm.write` |
 | Analog input | A0-A5 | implemented as direct read | `adc.read` |
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
-| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, and single-byte write/read implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, then wider `i2c.write`, `i2c.read`, `i2c.transfer` |
+| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, and byte-buffer write implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, then wider `i2c.read`, `i2c.transfer` |
 | SPI master | MOSI D11, MISO D12, SCK D13, CS D10 | pending | `spi.open`, `spi.transfer`, `spi.close` |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
@@ -70,9 +70,8 @@ reject conflicting handles.
 4. Implement I2C and SPI as bus handles with explicit transfer boundaries;
    `i2c.open` establishes the first I2C handle tranche, while `i2c.write_u8`
    and `i2c.read_u8` prove the Rust-owned transfer path through Arduino
-   `Wire`/`Wire1`. The byte-buffer ABI is now the shared value substrate for
-   wider write/read/transfer transactions, which should still land as separate
-   capability slices.
+   `Wire`/`Wire1`. `i2c.write` now proves the byte-buffer transfer path; wider
+   read/transfer transactions should still land as separate capability slices.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 


### PR DESCRIPTION
## Summary

Adds the Board VM `i2c.write` capability for bounded byte-buffer writes over an already-open I2C handle.

This slice wires the capability through the bytecode IR, runtime HAL, device descriptor, UNO R4 backend, linked SerialUSB firmware bridge, Rust language-core ABI, and Ruby session/connection APIs. Ruby now supports `board.i2c.write(...)`, `session.i2c_write_module(...)`, and REPL-style `i2c.write 60 0xdeadbe 24` commands.

## Validation

- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- linked `uno-r4-wifi-serialusb-artifact` build/objcopy with `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, Arduino Renesas UNO core 1.5.3, and `/opt/homebrew/bin` ARM tools
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
