### PR TITLE
python(spice): parse CCVS netlist elements

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.3
+
+- Add SPICE `H` / CCVS controlled-source parsing, including subcircuit output
+  node remapping and local controlling source-name remapping.
+
 ## 0.1.2
 
 - Add SPICE `F` / CCCS controlled-source parsing, including subcircuit output

--- a/code/packages/python/spice-netlist-parser/pyproject.toml
+++ b/code/packages/python/spice-netlist-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-netlist-parser"
-version = "0.1.2"
+version = "0.1.3"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -11,7 +11,7 @@ from spice_netlist_parser.parser import (
 )
 
 parse = parse_netlist
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     "AcAnalysis",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 
 from spice_engine import (
     CCCS,
+    CCVS,
     VCCS,
     VCVS,
     Capacitor,
@@ -223,6 +224,9 @@ def _parse_element(fields: list[str]) -> object:
     if prefix == "F":
         _require_fields(fields, 5, "CCCS")
         return CCCS(name, fields[1], fields[2], fields[3], parse_value(fields[4]))
+    if prefix == "H":
+        _require_fields(fields, 5, "CCVS")
+        return CCVS(name, fields[1], fields[2], fields[3], parse_value(fields[4]))
     raise NetlistParseError(f"unsupported element {name!r}")
 
 
@@ -301,7 +305,7 @@ def _map_subckt_fields(
         _require_min_fields(fields, 5, "subcircuit controlled source")
         for index in range(1, 5):
             mapped[index] = _map_subckt_node(fields[index], instance_name, node_map)
-    elif prefix == "F":
+    elif prefix in {"F", "H"}:
         _require_min_fields(fields, 4, "subcircuit current-controlled source")
         mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
         mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3,6 +3,7 @@ from math import isclose
 import pytest
 from spice_engine import (
     CCCS,
+    CCVS,
     VCCS,
     VCVS,
     Capacitor,
@@ -117,6 +118,27 @@ Rload out 0 500
     assert isclose(result.node_voltages["out"], 1.0, abs_tol=1e-9)
 
 
+def test_parse_ccvs_into_operating_point_circuit() -> None:
+    parsed = parse_netlist(
+        """
+Vin in 0 DC 1
+Rin in mid 1k
+Vsense mid 0 0
+Hamp out 0 Vsense 1k
+Rload out 0 500
+.op
+"""
+    )
+
+    assert isinstance(parsed.circuit.elements[3], CCVS)
+    assert parsed.circuit.elements[3].ctrl_source == "Vsense"
+    assert parsed.circuit.elements[3].transresistance == 1000.0
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert isclose(result.node_voltages["out"], 1.0, abs_tol=1e-9)
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """
@@ -216,6 +238,38 @@ Rload out 0 500
     assert isinstance(cccs, CCCS)
     assert cccs.n_plus == "out"
     assert cccs.ctrl_source == "Xmirror.Vsense"
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert isclose(result.node_voltages["out"], 1.0, abs_tol=1e-9)
+
+
+def test_expands_subcircuit_ccvs_control_source_into_engine_elements() -> None:
+    parsed = parse_netlist(
+        """
+.subckt transimpedance inp outp
+Rin inp mid 1k
+Vsense mid 0 0
+Hamp outp 0 Vsense 1k
+.ends transimpedance
+Vin in 0 DC 1
+Xamp in out transimpedance
+Rload out 0 500
+.op
+"""
+    )
+
+    assert [element.name for element in parsed.circuit.elements] == [
+        "Vin",
+        "Xamp.Rin",
+        "Xamp.Vsense",
+        "Xamp.Hamp",
+        "Rload",
+    ]
+    ccvs = parsed.circuit.elements[3]
+    assert isinstance(ccvs, CCVS)
+    assert ccvs.n_plus == "out"
+    assert ccvs.ctrl_source == "Xamp.Vsense"
 
     result = dc_op(parsed.circuit)
     assert result.converged


### PR DESCRIPTION
## Summary

- parse SPICE `H` / CCVS controlled-source elements into Python SPICE engine circuits
- remap subcircuit-local CCVS controlling source names during expansion
- add direct and subcircuit operating-point coverage

## Tests

- `sh BUILD && git -C /Users/adhithya/Downloads/Codex/coding-adventures-python-spice-netlist-ccvs diff --check`