### PR TITLE
[codex] Add Board VM I2C byte-buffer read

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -5,13 +5,13 @@ use std::slice;
 use board_vm_host::{
     AdcReadProgram, BlinkProgram, DacWriteU12Program, GpioHandleCloseProgram,
     GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
-    GpioWriteProgram, I2cOpenProgram, I2cReadU8Program, I2cWriteProgram, I2cWriteU8Program,
+    GpioWriteProgram, I2cOpenProgram, I2cReadProgram, I2cReadU8Program, I2cWriteProgram, I2cWriteU8Program,
     LedMatrixFrameProgram, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
     ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
     DAC_WRITE_U12_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
     GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN,
-    I2C_OPEN_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_WRITE_MAX_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN,
-    LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    I2C_OPEN_MODULE_LEN, I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_WRITE_MAX_MODULE_LEN,
+    I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
     TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
@@ -20,7 +20,7 @@ use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
     build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
     build_dac_write_u12_module, build_gpio_read_module, build_gpio_write_module,
-    build_hello_wire_frame, build_i2c_open_module, build_i2c_read_u8_module,
+    build_hello_wire_frame, build_i2c_open_module, build_i2c_read_module, build_i2c_read_u8_module,
     build_i2c_write_module, build_i2c_write_u8_module,
     build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
     build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
@@ -317,6 +317,21 @@ extern "C" fn session_i2c_read_u8_module(
 
     let module = build_i2c_read_u8_module_value(address, max_stack)
         .unwrap_or_else(|error| raise_core_error("i2c_read_u8_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_i2c_read_module(
+    _self_val: VALUE,
+    address_val: VALUE,
+    len_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let address = rb_u16(address_val, "address");
+    let len = rb_u8(len_val, "len");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_i2c_read_module_value(address, len, max_stack)
+        .unwrap_or_else(|error| raise_core_error("i2c_read_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1579,6 +1594,17 @@ fn build_i2c_read_u8_module_value(
     Ok(module)
 }
 
+fn build_i2c_read_module_value(
+    address: u16,
+    len: u8,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; I2C_READ_MODULE_LEN];
+    let len = build_i2c_read_module(I2cReadProgram { address, len, max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_raw_module_value(
     flags: u8,
     max_stack: u8,
@@ -1917,6 +1943,12 @@ pub extern "C" fn Init_board_vm_native() {
         "i2c_read_u8_module",
         session_i2c_read_u8_module as *const c_void,
         2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "i2c_read_module",
+        session_i2c_read_module as *const c_void,
+        3,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -500,6 +500,24 @@ module CodingAdventures
         )
       end
 
+      def i2c_read!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        address:,
+        length:,
+        max_stack: 4
+      )
+        ensure_uno_r4_wifi!
+
+        session.i2c_read(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          length: length,
+          max_stack: max_stack
+        )
+      end
+
       def store_program!(
         program_id: DEFAULT_PROGRAM_ID,
         slot: DEFAULT_EJECT_SLOT,
@@ -1181,6 +1199,22 @@ module CodingAdventures
           program_id: program_id,
           budget: budget,
           address: address,
+          max_stack: max_stack
+        )
+      end
+
+      def read(
+        address:,
+        length:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 4
+      )
+        @connection.i2c_read!(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          length: length,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -225,6 +225,10 @@ module CodingAdventures
         native_session.i2c_read_u8_module(address, max_stack)
       end
 
+      def i2c_read_module(address:, length:, max_stack: 4)
+        native_session.i2c_read_module(address, i2c_read_length_value(length), max_stack)
+      end
+
       def gpio_open_module(pin:, mode: :output, max_stack: 2)
         native_session.gpio_open_module(pin, gpio_mode(mode), max_stack)
       end
@@ -343,6 +347,18 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: i2c_read_u8_module(address: address, max_stack: max_stack)
+        )
+      end
+
+      def upload_i2c_read(
+        program_id: @program_id,
+        address:,
+        length:,
+        max_stack: 4
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: i2c_read_module(address: address, length: length, max_stack: max_stack)
         )
       end
 
@@ -761,6 +777,30 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def i2c_read(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        address:,
+        length:,
+        max_stack: 4
+      )
+        results = upload_i2c_read(
+          program_id: program_id,
+          address: address,
+          length: length,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def gpio_open(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -968,6 +1008,8 @@ module CodingAdventures
           upload_i2c_write(**i2c_write_command_options(words, command, options, require_budget: false))
         when "upload-i2c-read-u8", "upload-i2c.read_u8", "upload-i2c-read"
           upload_i2c_read_u8(**i2c_read_u8_command_options(words, command, options, require_budget: false))
+        when "upload-i2c-read-bytes", "upload-i2c.read"
+          upload_i2c_read(**i2c_read_command_options(words, command, options, require_budget: false))
         when "upload-gpio-open", "upload-gpio.open"
           upload_gpio_open(**gpio_open_command_options(words, command, options, require_budget: false))
         when "upload-gpio-handle-read", "upload-gpio.handle-read"
@@ -1012,6 +1054,8 @@ module CodingAdventures
           i2c_write(**i2c_write_command_options(words, command, options))
         when "i2c-read-u8", "i2c.read_u8", "i2c-read"
           i2c_read_u8(**i2c_read_u8_command_options(words, command, options))
+        when "i2c-read-bytes", "i2c.read"
+          i2c_read(**i2c_read_command_options(words, command, options))
         when "gpio-high", "gpio.high"
           gpio_write(**gpio_level_command_options(words, command, options, value: true))
         when "gpio-low", "gpio.low"
@@ -1304,6 +1348,22 @@ module CodingAdventures
         merged
       end
 
+      def i2c_read_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:address] = integer_argument(words.shift, "#{command} address") unless words.empty?
+        merged[:length] = i2c_read_length_value(words.shift) unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires address" unless merged.key?(:address)
+        raise ArgumentError, "#{command} requires length" unless merged.key?(:length)
+
+        merged
+      end
+
       def gpio_open_command_options(words, command, options, require_budget: true)
         merged = options.dup
         merged[:pin] = integer_argument(words.shift, "#{command} pin") unless words.empty?
@@ -1424,6 +1484,13 @@ module CodingAdventures
         end
 
         i2c_bytes_value(value)
+      end
+
+      def i2c_read_length_value(value)
+        length = byte_value(value)
+        raise ArgumentError, "I2C read length must be at most 32 bytes" if length > 32
+
+        length
       end
 
       def byte_value(value)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -42,6 +42,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "i2c.write_u8"
         assert_includes uno_r4_wifi["capabilities"], "i2c.read_u8"
         assert_includes uno_r4_wifi["capabilities"], "i2c.write"
+        assert_includes uno_r4_wifi["capabilities"], "i2c.read"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -1372,6 +1373,30 @@ module CodingAdventures
           read_result.results.map(&:command)
       end
 
+      def test_i2c_read_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        open_result = nil
+        read_result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          open_result = board.i2c.open(bus: 0, program_id: 10, budget: 24)
+          read_result = board.i2c.read(address: 0x3c, length: 3, program_id: 11, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 10, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal open_result.frames + read_result.frames, transport.frames
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          read_result.results.map(&:command)
+      end
+
       def test_store_program_dispatches_native_protocol_frame_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1860,6 +1885,40 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_i2c_read
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("i2c.read 60 3 24", program_id: 9)
+          upload = board.session.run_command("upload-i2c.read 60 3", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
+      def test_session_run_command_rejects_oversized_i2c_read_length
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: FakeWriteTransport.new
+        ) do |board|
+          error = assert_raises(ArgumentError) do
+            board.session.run_command("upload-i2c.read 60 33", program_id: 10)
+          end
+          assert_match(/I2C read length must be at most 32 bytes/, error.message)
+        end
+      end
+
       def test_board_descriptor_wraps_rust_decoded_capability_report
         decoded = {
           "kind" => "caps_report",
@@ -1996,6 +2055,10 @@ module CodingAdventures
         i2c_read_module_bytes = session.i2c_read_u8_module(0x3c, 3)
         assert_instance_of String, i2c_read_module_bytes
         assert_operator i2c_read_module_bytes.bytesize, :>, 0
+
+        i2c_read_bytes_module_bytes = session.i2c_read_module(0x3c, 3, 4)
+        assert_instance_of String, i2c_read_bytes_module_bytes
+        assert_operator i2c_read_bytes_module_bytes.bytesize, :>, 0
 
         gpio_module_bytes = session.gpio_read_module(13, 2, 2)
         assert_instance_of String, gpio_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -2,8 +2,8 @@
 
 use board_vm_ir::{
     parse_module, validate, CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
-    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ_U8, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
-    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_WRITE,
+    CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -110,6 +110,12 @@ const I2C_WRITE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "i2c.write",
+};
+const I2C_READ_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_I2C_READ,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "i2c.read",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -604,7 +610,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_AND_DAC_CAPABILITIES: [CapabilityDescriptor<'st
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
-pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 14] = [
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 15] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -618,6 +624,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor
     I2C_WRITE_U8_DESCRIPTOR,
     I2C_READ_U8_DESCRIPTOR,
     I2C_WRITE_DESCRIPTOR,
+    I2C_READ_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
@@ -676,7 +683,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDes
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<
     'static,
->; 15] = [
+>; 16] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -690,6 +697,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [Capabilit
     I2C_WRITE_U8_DESCRIPTOR,
     I2C_READ_U8_DESCRIPTOR,
     I2C_WRITE_DESCRIPTOR,
+    I2C_READ_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,8 +1,8 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ,
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
-    CAP_I2C_READ_U8, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
-    CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
+    CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
+    CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
     FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MAX_BYTE_BUFFER_LEN, MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
@@ -49,6 +49,8 @@ pub const I2C_READ_U8_CODE_LEN: usize = 7;
 pub const I2C_READ_U8_MODULE_LEN: usize = 17;
 pub const I2C_WRITE_CODE_LEN: usize = 10;
 pub const I2C_WRITE_MAX_MODULE_LEN: usize = 8 + 1 + I2C_WRITE_CODE_LEN + 1 + MAX_BYTE_BUFFER_LEN;
+pub const I2C_READ_CODE_LEN: usize = 9;
+pub const I2C_READ_MODULE_LEN: usize = 19;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -211,6 +213,13 @@ pub struct I2cWriteProgram<'a> {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct I2cReadProgram {
+    pub address: u16,
+    pub len: u8,
+    pub max_stack: u8,
+}
+
 impl I2cOpenProgram {
     pub const fn new(bus: u8) -> Self {
         Self { bus, max_stack: 2 }
@@ -241,6 +250,16 @@ impl<'a> I2cWriteProgram<'a> {
         Self {
             address,
             bytes,
+            max_stack: 4,
+        }
+    }
+}
+
+impl I2cReadProgram {
+    pub const fn new(address: u16, len: u8) -> Self {
+        Self {
+            address,
+            len,
             max_stack: 4,
         }
     }
@@ -1378,6 +1397,51 @@ pub fn write_i2c_write_module(
     Ok(offset)
 }
 
+pub fn write_i2c_read_code(program: I2cReadProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if program.len as usize > MAX_BYTE_BUFFER_LEN {
+        return Err(HostError::ProgramTooLarge);
+    }
+    if out.len() < I2C_READ_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_push_u16(out, &mut offset, program.address)?;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.len)?;
+    write_call_u8(out, &mut offset, CAP_I2C_READ)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_i2c_read_module(program: I2cReadProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if program.len as usize > MAX_BYTE_BUFFER_LEN {
+        return Err(HostError::ProgramTooLarge);
+    }
+    if out.len() < I2C_READ_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; I2C_READ_CODE_LEN];
+    let code_len = write_i2c_read_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_i2c(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_led_matrix_frame_code(
     program: LedMatrixFrameProgram,
     out: &mut [u8],
@@ -1538,8 +1602,8 @@ mod tests {
     use super::*;
     use board_vm_ir::{
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
-        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_READ_U8, CAP_I2C_WRITE,
-        CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+        CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8,
+        CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -1605,6 +1669,10 @@ mod tests {
     const I2C_WRITE_3C_DE_AD_BE_MODULE_HEX: [u8; 23] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x04, 0x00, 0x0A, 0x20, 0x13, 0x3C, 0x00, 0x16, 0x00,
         0x00, 0x03, 0x40, 0x26, 0x03, 0xDE, 0xAD, 0xBE,
+    ];
+    const I2C_READ_3C_03_MODULE_HEX: [u8; I2C_READ_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x04, 0x00, 0x09, 0x20, 0x13, 0x3C, 0x00, 0x12, 0x03,
+        0x40, 0x27, 0x50, 0x00,
     ];
     const LED_MATRIX_HEART_MODULE_HEX: [u8; LED_MATRIX_FRAME_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x12, 0x14, 0x44, 0xA4, 0x84, 0x31, 0x14,
@@ -1852,6 +1920,20 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_I2C_WRITE]);
+    }
+
+    #[test]
+    fn builds_i2c_read_module() {
+        let mut module = [0u8; I2C_READ_MODULE_LEN];
+        let len = write_i2c_read_module(I2cReadProgram::new(0x3c, 3), &mut module).unwrap();
+        assert_eq!(len, I2C_READ_MODULE_LEN);
+        assert_eq!(module, I2C_READ_3C_03_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_i2c(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_READ]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -24,6 +24,7 @@ pub const CAP_I2C_OPEN: u16 = 0x23;
 pub const CAP_I2C_WRITE_U8: u16 = 0x24;
 pub const CAP_I2C_READ_U8: u16 = 0x25;
 pub const CAP_I2C_WRITE: u16 = 0x26;
+pub const CAP_I2C_READ: u16 = 0x27;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -39,6 +40,7 @@ const CAP_I2C_OPEN_U8: u8 = CAP_I2C_OPEN as u8;
 const CAP_I2C_WRITE_U8_U8: u8 = CAP_I2C_WRITE_U8 as u8;
 const CAP_I2C_READ_U8_U8: u8 = CAP_I2C_READ_U8 as u8;
 const CAP_I2C_WRITE_CAP_U8: u8 = CAP_I2C_WRITE as u8;
+const CAP_I2C_READ_CAP_U8: u8 = CAP_I2C_READ as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -176,7 +178,9 @@ impl CapabilitySet {
             CAP_PWM_WRITE => self.pwm,
             CAP_ADC_READ => self.adc,
             CAP_DAC_WRITE_U12 => self.dac,
-            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 | CAP_I2C_WRITE => self.i2c,
+            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 | CAP_I2C_WRITE | CAP_I2C_READ => {
+                self.i2c
+            }
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -446,6 +450,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_I2C_WRITE_U8_U8) | Op::CallU16(CAP_I2C_WRITE_U8) => (3, 0),
         Op::CallU8(CAP_I2C_READ_U8_U8) | Op::CallU16(CAP_I2C_READ_U8) => (2, 1),
         Op::CallU8(CAP_I2C_WRITE_CAP_U8) | Op::CallU16(CAP_I2C_WRITE) => (3, 0),
+        Op::CallU8(CAP_I2C_READ_CAP_U8) | Op::CallU16(CAP_I2C_READ) => (3, 1),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -772,6 +777,21 @@ mod tests {
     }
 
     #[test]
+    fn validates_i2c_read_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 4,
+            code: &[0x20, 0x12, 0x3c, 0x12, 0x03, 0x40, CAP_I2C_READ as u8, 0x50],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_i2c(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_READ]);
+    }
+
+    #[test]
     fn rejects_pwm_write_without_capability() {
         let module = Module {
             flags: 0,
@@ -883,6 +903,21 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 4),
             Err(ValidateError::UnsupportedCapability(CAP_I2C_WRITE))
+        );
+    }
+
+    #[test]
+    fn rejects_i2c_read_without_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 4,
+            code: &[0x20, 0x12, 0x3c, 0x12, 0x03, 0x40, CAP_I2C_READ as u8, 0x50],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 4),
+            Err(ValidateError::UnsupportedCapability(CAP_I2C_READ))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -38,18 +38,19 @@ use board_vm_host::{
     i2c_write_module_len, write_adc_read_module, write_blink_module, write_dac_write_u12_module,
     write_gpio_handle_close_module, write_gpio_handle_read_module, write_gpio_handle_write_module,
     write_gpio_open_module, write_gpio_read_module, write_gpio_write_module, write_i2c_open_module,
-    write_i2c_read_u8_module, write_i2c_write_module, write_i2c_write_u8_module,
-    write_led_matrix_frame_module, write_module, write_pwm_write_module, write_time_now_module,
-    write_time_sleep_ms_module, AdcReadProgram, BlinkProgram, DacWriteU12Program,
-    GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram,
-    GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram, I2cReadU8Program,
-    I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram,
-    TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
-    DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
-    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
-    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
-    I2C_READ_U8_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
-    PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    write_i2c_read_module, write_i2c_read_u8_module, write_i2c_write_module,
+    write_i2c_write_u8_module, write_led_matrix_frame_module, write_module, write_pwm_write_module,
+    write_time_now_module, write_time_sleep_ms_module, AdcReadProgram, BlinkProgram,
+    DacWriteU12Program, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
+    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram,
+    I2cReadProgram, I2cReadU8Program, I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram,
+    ModuleSpec, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN,
+    BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
+    DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
+    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
+    GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN,
+    I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
+    TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -1658,6 +1659,13 @@ pub fn build_i2c_read_u8_module(
     Ok(write_i2c_read_u8_module(program, out)?)
 }
 
+pub fn build_i2c_read_module(
+    program: I2cReadProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_i2c_read_module(program, out)?)
+}
+
 pub fn build_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2451,6 +2459,31 @@ pub unsafe extern "C" fn board_vm_language_i2c_read_u8_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_i2c_read_module(
+    address: u16,
+    len: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_i2c_read_module(
+            I2cReadProgram {
+                address,
+                len,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2794,6 +2827,11 @@ pub extern "C" fn board_vm_language_i2c_read_u8_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_i2c_read_module_len() -> u64 {
+    I2C_READ_MODULE_LEN as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_led_matrix_frame_module_len() -> u64 {
     LED_MATRIX_FRAME_MODULE_LEN as u64
 }
@@ -3034,6 +3072,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"i2c.write_u8".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.read_u8".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.write".to_owned()));
+        assert!(uno.capabilities.contains(&"i2c.read".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -3896,6 +3935,25 @@ mod tests {
         };
         assert_eq!(i2c_read_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(i2c_read_status.len, I2C_READ_U8_MODULE_LEN as u64);
+
+        let mut i2c_read_bytes_module = [0u8; I2C_READ_MODULE_LEN];
+        let i2c_read_bytes_status = unsafe {
+            board_vm_language_i2c_read_module(
+                0x3c,
+                3,
+                4,
+                i2c_read_bytes_module.as_mut_ptr(),
+                i2c_read_bytes_module.len() as u64,
+            )
+        };
+        assert_eq!(
+            i2c_read_bytes_status.code,
+            BoardVmLanguageStatusCode::Ok as u32
+        );
+        assert_eq!(
+            i2c_read_bytes_status.len,
+            board_vm_language_i2c_read_module_len()
+        );
 
         let mut gpio_read_module = [0u8; GPIO_READ_MODULE_LEN];
         let gpio_read_status = unsafe {

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -2,9 +2,9 @@
 
 use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_DAC_WRITE_U12,
-    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ_U8,
-    CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS,
-    CAP_TIME_SLEEP_MS, MAX_BYTE_BUFFER_LEN,
+    CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ,
+    CAP_I2C_READ_U8, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+    CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, MAX_BYTE_BUFFER_LEN,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -137,6 +137,10 @@ pub trait BoardHal {
     }
 
     fn i2c_read_u8(&mut self, _token: u32, _address: u16) -> Result<u8, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn i2c_read(&mut self, _token: u32, _address: u16, _len: u8) -> Result<ByteBuffer, HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -591,6 +595,26 @@ where
                     })?;
                 self.push(Value::U8(byte), ip)
             }
+            CAP_I2C_READ => {
+                let len = self.pop_u8(ip)?;
+                if len as usize > MAX_BYTE_BUFFER_LEN {
+                    return Err(RuntimeError {
+                        ip,
+                        kind: RuntimeErrorKind::ByteBufferTooLarge,
+                    });
+                }
+                let address = self.pop_u16(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::I2c, ip)?;
+                let bytes = self
+                    .hal
+                    .i2c_read(token, address, len)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                self.push(Value::Bytes(bytes), ip)
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -848,6 +872,7 @@ mod tests {
         I2cWriteU8(u32, u16, u8),
         I2cWrite(u32, u16, ByteBuffer),
         I2cReadU8(u32, u16),
+        I2cRead(u32, u16, u8),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -940,6 +965,12 @@ mod tests {
         fn i2c_read_u8(&mut self, token: u32, address: u16) -> Result<u8, HalError> {
             self.events.push(Event::I2cReadU8(token, address));
             Ok(0x5a)
+        }
+
+        fn i2c_read(&mut self, token: u32, address: u16, len: u8) -> Result<ByteBuffer, HalError> {
+            self.events.push(Event::I2cRead(token, address, len));
+            ByteBuffer::from_slice(&[0xca, 0xfe, 0x42][..len as usize])
+                .map_err(|_| HalError::UnsupportedMode)
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -1198,6 +1229,27 @@ mod tests {
                     ByteBuffer::from_slice(&[0xde, 0xad, 0xbe]).unwrap()
                 )
             ]
+        );
+    }
+
+    #[test]
+    fn i2c_read_dispatches_handle_address_and_returns_bytes() {
+        let mut runtime: Runtime<FakeHal, 4, 2> = Runtime::new(FakeHal::new());
+        let open = [0x12, 1, 0x40, CAP_I2C_OPEN as u8, 0x20, 0x50];
+        let read = [0x20, 0x12, 0x3c, 0x12, 0x03, 0x40, CAP_I2C_READ as u8, 0x50];
+
+        runtime.run_code(&open, 10).unwrap();
+        let report = runtime.run_code(&read, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            report.return_value,
+            Value::Bytes(ByteBuffer::from_slice(&[0xca, 0xfe, 0x42]).unwrap())
+        );
+        assert_eq!(
+            runtime.hal().events,
+            vec![Event::I2cOpen(1), Event::I2cRead(0x1_2001, 0x3c, 3)]
         );
     }
 }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -112,7 +112,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 15] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 16] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -127,10 +127,11 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 15] = [
     "i2c.write_u8",
     "i2c.read_u8",
     "i2c.write",
+    "i2c.read",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 19] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 20] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -148,6 +149,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 19] = [
     "i2c.write_u8",
     "i2c.read_u8",
     "i2c.write",
+    "i2c.read",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -616,6 +618,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"i2c.write_u8"));
         assert!(uno.capabilities.contains(&"i2c.read_u8"));
         assert!(uno.capabilities.contains(&"i2c.write"));
+        assert!(uno.capabilities.contains(&"i2c.read"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -33,6 +33,7 @@ pub const BOARD_VM_UNO_R4_DAC_WRITE_U12_SYMBOL: &str = "board_vm_uno_r4_dac_writ
 pub const BOARD_VM_UNO_R4_I2C_WRITE_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_write_u8";
 pub const BOARD_VM_UNO_R4_I2C_WRITE_SYMBOL: &str = "board_vm_uno_r4_i2c_write";
 pub const BOARD_VM_UNO_R4_I2C_READ_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_read_u8";
+pub const BOARD_VM_UNO_R4_I2C_READ_SYMBOL: &str = "board_vm_uno_r4_i2c_read";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
@@ -293,6 +294,7 @@ mod tests {
             BOARD_VM_UNO_R4_I2C_READ_U8_SYMBOL,
             "board_vm_uno_r4_i2c_read_u8"
         );
+        assert_eq!(BOARD_VM_UNO_R4_I2C_READ_SYMBOL, "board_vm_uno_r4_i2c_read");
         assert_eq!(
             BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE,
             "src/uno_r4_wifi_pwm_bridge.cpp"

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -1,5 +1,5 @@
 use arduino_uno_r4_hal::Delay;
-use board_vm_runtime::{GpioMode, HalError, Level};
+use board_vm_runtime::{ByteBuffer, GpioMode, HalError, Level};
 use board_vm_uno_r4::UnoR4Backend;
 use embedded_hal::delay::DelayNs;
 
@@ -235,6 +235,24 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         }
     }
 
+    fn read_i2c(&mut self, bus: u8, address: u16, len: u8) -> Result<ByteBuffer, HalError> {
+        let mut bytes = [0u8; board_vm_ir::MAX_BYTE_BUFFER_LEN];
+        let mut read_len = 0;
+        if unsafe {
+            board_io_ffi::board_vm_uno_r4_i2c_read(
+                bus,
+                address,
+                bytes.as_mut_ptr(),
+                len as usize,
+                &mut read_len,
+            )
+        } {
+            ByteBuffer::from_slice(&bytes[..read_len]).map_err(|_| HalError::UnsupportedMode)
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+
     fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
         board_vm_uno_r4_usb_cdc::reboot_to_bootloader()
     }
@@ -254,5 +272,12 @@ mod board_io_ffi {
             len: usize,
         ) -> bool;
         pub fn board_vm_uno_r4_i2c_read_u8(bus: u8, address: u16, byte: *mut u8) -> bool;
+        pub fn board_vm_uno_r4_i2c_read(
+            bus: u8,
+            address: u16,
+            bytes: *mut u8,
+            len: usize,
+            read_len: *mut usize,
+        ) -> bool;
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -506,3 +506,40 @@ extern "C" bool board_vm_uno_r4_i2c_read_u8(uint8_t bus, uint16_t address, uint8
   *byte = static_cast<uint8_t>(value);
   return true;
 }
+
+extern "C" bool board_vm_uno_r4_i2c_read(uint8_t bus, uint16_t address, uint8_t *bytes, size_t len, size_t *read_len) {
+  if ((bytes == nullptr && len != 0) || read_len == nullptr || address > kI2cMax7BitAddress) {
+    return false;
+  }
+
+  I2cSlot *slot = find_i2c_slot(bus);
+  if (slot == nullptr) {
+    return false;
+  }
+
+  TwoWire *wire = slot_wire(*slot);
+  if (!slot->started) {
+    wire->begin();
+    slot->started = true;
+  }
+
+  if (len == 0) {
+    *read_len = 0;
+    return true;
+  }
+
+  if (wire->requestFrom(static_cast<uint8_t>(address), len) != len) {
+    return false;
+  }
+
+  for (size_t index = 0; index < len; ++index) {
+    int value = wire->read();
+    if (value < 0) {
+      return false;
+    }
+    bytes[index] = static_cast<uint8_t>(value);
+  }
+
+  *read_len = len;
+  return true;
+}

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -15,7 +15,7 @@ use board_vm_device::{
     BLINK_MVP_WITH_PWM_DAC_AND_LED_MATRIX_CAPABILITIES, DEFAULT_MAX_FRAME_PAYLOAD,
 };
 use board_vm_ir::CapabilitySet;
-use board_vm_runtime::{BoardHal, GpioMode, HalError, Level};
+use board_vm_runtime::{BoardHal, ByteBuffer, GpioMode, HalError, Level};
 
 pub const UNO_R4_CLOCK_HZ: u32 = 48_000_000;
 pub const UNO_R4_FLASH_BYTES: u32 = 256 * 1024;
@@ -395,6 +395,10 @@ pub trait UnoR4Backend {
         Err(HalError::UnsupportedMode)
     }
 
+    fn read_i2c(&mut self, _bus: u8, _address: u16, _len: u8) -> Result<ByteBuffer, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn supports_bootloader_reboot(&self) -> bool {
         false
     }
@@ -532,6 +536,12 @@ where
         let bus = normalize_i2c_token(self.target, token)?;
         normalize_i2c_address(address)?;
         self.backend.read_i2c_u8(bus, address)
+    }
+
+    fn i2c_read(&mut self, token: u32, address: u16, len: u8) -> Result<ByteBuffer, HalError> {
+        let bus = normalize_i2c_token(self.target, token)?;
+        normalize_i2c_address(address)?;
+        self.backend.read_i2c(bus, address, len)
     }
 
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -734,6 +744,7 @@ mod tests {
         I2cWriteU8(u8, u16, u8),
         I2cWrite(u8, u16, Vec<u8>),
         I2cReadU8(u8, u16),
+        I2cRead(u8, u16, u8),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -831,6 +842,12 @@ mod tests {
         fn read_i2c_u8(&mut self, bus: u8, address: u16) -> Result<u8, HalError> {
             self.events.push(Event::I2cReadU8(bus, address));
             Ok(0x5a)
+        }
+
+        fn read_i2c(&mut self, bus: u8, address: u16, len: u8) -> Result<ByteBuffer, HalError> {
+            self.events.push(Event::I2cRead(bus, address, len));
+            ByteBuffer::from_slice(&[0xca, 0xfe, 0x42][..len as usize])
+                .map_err(|_| HalError::UnsupportedMode)
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -939,6 +956,7 @@ mod tests {
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_I2C_WRITE));
+        assert!(UNO_R4_WIFI.capabilities.supports(board_vm_ir::CAP_I2C_READ));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -960,6 +978,9 @@ mod tests {
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_I2C_WRITE));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_READ));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -1124,6 +1145,25 @@ mod tests {
 
         assert_eq!(board.i2c_read_u8(0x1_2001, 0x3c), Err(HalError::InvalidPin));
         assert_eq!(board.i2c_read_u8(0x1_2000, 0x80), Err(HalError::InvalidPin));
+    }
+
+    #[test]
+    fn i2c_read_runs_through_bus_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(
+            board.i2c_read(0x1_2001, 0x3c, 3).unwrap(),
+            ByteBuffer::from_slice(&[0xca, 0xfe, 0x42]).unwrap()
+        );
+        assert_eq!(board.backend().events, vec![Event::I2cRead(1, 0x3c, 3)]);
+    }
+
+    #[test]
+    fn i2c_read_rejects_unknown_bus_or_address() {
+        let mut board = UnoR4Board::minima(FakeBackend::new());
+
+        assert_eq!(board.i2c_read(0x1_2001, 0x3c, 3), Err(HalError::InvalidPin));
+        assert_eq!(board.i2c_read(0x1_2000, 0x80, 3), Err(HalError::InvalidPin));
     }
 
     #[test]

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -210,6 +210,7 @@ metadata. The operation is intentionally direct and stateless, mirroring
 | `0x24` | `i2c.write_u8` | `handle`, `address: u16/u8`, `byte: u8` | `unit` |
 | `0x25` | `i2c.read_u8` | `handle`, `address: u16/u8` | `u8` |
 | `0x26` | `i2c.write` | `handle`, `address: u16/u8`, `bytes` | `unit` |
+| `0x27` | `i2c.read` | `handle`, `address: u16/u8`, `length: u8` | `bytes` |
 
 `i2c.open` opens a board-advertised I2C controller and returns a persistent bus
 handle. The handle is the lifetime anchor for transfer operations, keeping bus
@@ -219,8 +220,9 @@ identity and pin ownership out of language frontends.
 opened bus handle. `i2c.read_u8` reads one byte from that same 7-bit address and
 returns it as a scalar `u8`. These are the first concrete I2C transfer
 primitives. `i2c.write` writes a bounded VM byte buffer to the device address
-using the same handle model. Wider `i2c.read` and `i2c.transfer` operations
-should reuse the bounded byte-buffer ABI.
+using the same handle model. `i2c.read` reads a bounded byte buffer of up to the
+VM byte-buffer limit from the same handle/address pair. Wider `i2c.transfer`
+operations should reuse the bounded byte-buffer ABI.
 
 ### LED Matrix
 

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -29,7 +29,7 @@ Source snapshot:
 | PWM output | D3, D5, D6, D9, D10, D11 in the Arduino variant init path | implemented as direct write | `pwm.write` |
 | Analog input | A0-A5 | implemented as direct read | `adc.read` |
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
-| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, and byte-buffer write implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, then wider `i2c.read`, `i2c.transfer` |
+| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, and byte-buffer write/read implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, `i2c.read`, then `i2c.transfer` |
 | SPI master | MOSI D11, MISO D12, SCK D13, CS D10 | pending | `spi.open`, `spi.transfer`, `spi.close` |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
@@ -70,8 +70,9 @@ reject conflicting handles.
 4. Implement I2C and SPI as bus handles with explicit transfer boundaries;
    `i2c.open` establishes the first I2C handle tranche, while `i2c.write_u8`
    and `i2c.read_u8` prove the Rust-owned transfer path through Arduino
-   `Wire`/`Wire1`. `i2c.write` now proves the byte-buffer transfer path; wider
-   read/transfer transactions should still land as separate capability slices.
+   `Wire`/`Wire1`. `i2c.write` and `i2c.read` now prove the byte-buffer transfer
+   path; combined transfer transactions should still land as separate capability
+   slices.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 


### PR DESCRIPTION
## Summary

- Add the `i2c.read` Board VM capability for bounded byte-buffer reads.
- Wire the stack effect, host module builder, runtime dispatch, descriptors, UNO R4 target metadata, and UNO R4 firmware/backend bridge.
- Expose the capability through Ruby as `board.i2c.read(address:, length:)` while keeping the language frontend thin over the Rust-owned module builder and protocol path.

## Validation

- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- linked `uno-r4-wifi-serialusb-artifact` build/objcopy with `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, Arduino Renesas UNO core 1.5.3, and `/opt/homebrew/bin` ARM tools
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
