### PR TITLE
typescript(spice): parse CCVS netlist elements

### DIFF
--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.3
+
+- Add SPICE `H` / CCVS controlled-source parsing, including subcircuit
+  controlling-source name remapping for expanded CCVS elements.
+
 ## 0.1.2
 
 - Add SPICE `F` / CCCS controlled-source parsing, including subcircuit

--- a/code/packages/typescript/spice-netlist-parser/package.json
+++ b/code/packages/typescript/spice-netlist-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/spice-netlist-parser",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -6,6 +6,7 @@ import {
   SinWaveform,
   capacitor,
   cccs,
+  ccvs,
   currentSource,
   currentSourceWithWaveform,
   dcOp,
@@ -253,6 +254,10 @@ function parseElement(fields: readonly string[]): Element {
     requireFields(fields, 5, "CCCS");
     return cccs(name, fields[1], fields[2], fields[3], parseValue(fields[4]));
   }
+  if (prefix === "H") {
+    requireFields(fields, 5, "CCVS");
+    return ccvs(name, fields[1], fields[2], fields[3], parseValue(fields[4]));
+  }
   throw new NetlistParseError(`unsupported element ${JSON.stringify(name)}`);
 }
 
@@ -344,7 +349,7 @@ function mapSubcktFields(
     for (let index = 1; index < 5; index++) {
       mapped[index] = mapSubcktNode(fields[index], instanceName, nodeMap);
     }
-  } else if (prefix === "F") {
+  } else if (prefix === "F" || prefix === "H") {
     requireMinFields(fields, 4, "subcircuit current-controlled source");
     mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
     mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -99,6 +99,27 @@ Rload out 0 500
     expect(result.voltage("out")).toBeCloseTo(-1.0, 9);
   });
 
+  it("parses CCVS elements into operating-point circuits", () => {
+    const parsed = parseNetlist(`
+Vin in 0 DC 1
+Rin in sense 1k
+Vsense sense 0 DC 0
+Hamp out 0 Vsense 1k
+Rload out 0 500
+.op
+`);
+
+    const elements = parsed.circuit.elements();
+    expect(elements[3]).toMatchObject({
+      kind: "ccvs",
+      controlSource: "Vsense",
+      transresistanceOhms: 1000.0,
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("out")).toBeCloseTo(1.0, 9);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)
@@ -198,6 +219,38 @@ Rload out 0 500
 
     const result = dcOp(parsed.circuit);
     expect(result.voltage("out")).toBeCloseTo(-1.0, 9);
+  });
+
+  it("expands subcircuit CCVS control sources into engine elements", () => {
+    const parsed = parseNetlist(`
+.subckt transimpedance inp outp
+Rin inp sense 1k
+Vsense sense 0 DC 0
+Hamp outp 0 Vsense 1k
+.ends transimpedance
+Vin in 0 DC 1
+Xamp in out transimpedance
+Rload out 0 500
+.op
+`);
+
+    const elements = parsed.circuit.elements();
+    expect(elements.map((element) => element.name)).toEqual([
+      "Vin",
+      "Xamp.Rin",
+      "Xamp.Vsense",
+      "Xamp.Hamp",
+      "Rload",
+    ]);
+    expect(elements[3]).toMatchObject({
+      kind: "ccvs",
+      positive: "out",
+      controlSource: "Xamp.Vsense",
+      transresistanceOhms: 1000.0,
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("out")).toBeCloseTo(1.0, 9);
   });
 
   it("scopes subcircuit internal nodes by instance", () => {


### PR DESCRIPTION
## Summary

- Add TypeScript SPICE netlist parsing for `H` / CCVS controlled sources.
- Remap CCVS control-source references during `.subckt` expansion.
- Cover direct and expanded CCVS operating-point circuits.

## Validation

- `sh BUILD`
- `git diff --check`