### PR TITLE
[codex] Add Board VM I2C transfer capability

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -5,14 +5,14 @@ use std::slice;
 use board_vm_host::{
     AdcReadProgram, BlinkProgram, DacWriteU12Program, GpioHandleCloseProgram,
     GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
-    GpioWriteProgram, I2cOpenProgram, I2cReadProgram, I2cReadU8Program, I2cWriteProgram, I2cWriteU8Program,
-    LedMatrixFrameProgram, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
-    DAC_WRITE_U12_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
-    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN,
-    I2C_OPEN_MODULE_LEN, I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_WRITE_MAX_MODULE_LEN,
-    I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
-    TIME_SLEEP_MS_MODULE_LEN,
+    GpioWriteProgram, I2cOpenProgram, I2cReadProgram, I2cReadU8Program, I2cTransferProgram,
+    I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram, PwmWriteProgram, TimeNowProgram,
+    TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN,
+    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
+    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
+    I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_TRANSFER_MAX_MODULE_LEN,
+    I2C_WRITE_MAX_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
+    PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
@@ -21,7 +21,7 @@ use board_vm_language_core::{
     build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
     build_dac_write_u12_module, build_gpio_read_module, build_gpio_write_module,
     build_hello_wire_frame, build_i2c_open_module, build_i2c_read_module, build_i2c_read_u8_module,
-    build_i2c_write_module, build_i2c_write_u8_module,
+    build_i2c_transfer_module, build_i2c_write_module, build_i2c_write_u8_module,
     build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
     build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
     build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
@@ -332,6 +332,24 @@ extern "C" fn session_i2c_read_module(
 
     let module = build_i2c_read_module_value(address, len, max_stack)
         .unwrap_or_else(|error| raise_core_error("i2c_read_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_i2c_transfer_module(
+    _self_val: VALUE,
+    address_val: VALUE,
+    write_bytes_val: VALUE,
+    read_len_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let address = rb_u16(address_val, "address");
+    let write_bytes = ruby_bridge::bytes_from_rb(write_bytes_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("write_bytes must be a Ruby binary String"));
+    let read_len = rb_u8(read_len_val, "read_len");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_i2c_transfer_module_value(address, &write_bytes, read_len, max_stack)
+        .unwrap_or_else(|error| raise_core_error("i2c_transfer_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1605,6 +1623,26 @@ fn build_i2c_read_module_value(
     Ok(module)
 }
 
+fn build_i2c_transfer_module_value(
+    address: u16,
+    write_bytes: &[u8],
+    read_len: u8,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; I2C_TRANSFER_MAX_MODULE_LEN];
+    let len = build_i2c_transfer_module(
+        I2cTransferProgram {
+            address,
+            write_bytes,
+            read_len,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_raw_module_value(
     flags: u8,
     max_stack: u8,
@@ -1949,6 +1987,12 @@ pub extern "C" fn Init_board_vm_native() {
         "i2c_read_module",
         session_i2c_read_module as *const c_void,
         3,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "i2c_transfer_module",
+        session_i2c_transfer_module as *const c_void,
+        4,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -518,6 +518,26 @@ module CodingAdventures
         )
       end
 
+      def i2c_transfer!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        address:,
+        write_bytes:,
+        read_length:,
+        max_stack: 5
+      )
+        ensure_uno_r4_wifi!
+
+        session.i2c_transfer(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          write_bytes: write_bytes,
+          read_length: read_length,
+          max_stack: max_stack
+        )
+      end
+
       def store_program!(
         program_id: DEFAULT_PROGRAM_ID,
         slot: DEFAULT_EJECT_SLOT,
@@ -1215,6 +1235,24 @@ module CodingAdventures
           budget: budget,
           address: address,
           length: length,
+          max_stack: max_stack
+        )
+      end
+
+      def transfer(
+        address:,
+        write_bytes:,
+        read_length:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 5
+      )
+        @connection.i2c_transfer!(
+          program_id: program_id,
+          budget: budget,
+          address: address,
+          write_bytes: write_bytes,
+          read_length: read_length,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -229,6 +229,15 @@ module CodingAdventures
         native_session.i2c_read_module(address, i2c_read_length_value(length), max_stack)
       end
 
+      def i2c_transfer_module(address:, write_bytes:, read_length:, max_stack: 5)
+        native_session.i2c_transfer_module(
+          address,
+          i2c_bytes_value(write_bytes),
+          i2c_read_length_value(read_length),
+          max_stack
+        )
+      end
+
       def gpio_open_module(pin:, mode: :output, max_stack: 2)
         native_session.gpio_open_module(pin, gpio_mode(mode), max_stack)
       end
@@ -359,6 +368,24 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: i2c_read_module(address: address, length: length, max_stack: max_stack)
+        )
+      end
+
+      def upload_i2c_transfer(
+        program_id: @program_id,
+        address:,
+        write_bytes:,
+        read_length:,
+        max_stack: 5
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: i2c_transfer_module(
+            address: address,
+            write_bytes: write_bytes,
+            read_length: read_length,
+            max_stack: max_stack
+          )
         )
       end
 
@@ -801,6 +828,32 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def i2c_transfer(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        address:,
+        write_bytes:,
+        read_length:,
+        max_stack: 5
+      )
+        results = upload_i2c_transfer(
+          program_id: program_id,
+          address: address,
+          write_bytes: write_bytes,
+          read_length: read_length,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def gpio_open(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -1010,6 +1063,8 @@ module CodingAdventures
           upload_i2c_read_u8(**i2c_read_u8_command_options(words, command, options, require_budget: false))
         when "upload-i2c-read-bytes", "upload-i2c.read"
           upload_i2c_read(**i2c_read_command_options(words, command, options, require_budget: false))
+        when "upload-i2c-transfer", "upload-i2c.transfer"
+          upload_i2c_transfer(**i2c_transfer_command_options(words, command, options, require_budget: false))
         when "upload-gpio-open", "upload-gpio.open"
           upload_gpio_open(**gpio_open_command_options(words, command, options, require_budget: false))
         when "upload-gpio-handle-read", "upload-gpio.handle-read"
@@ -1056,6 +1111,8 @@ module CodingAdventures
           i2c_read_u8(**i2c_read_u8_command_options(words, command, options))
         when "i2c-read-bytes", "i2c.read"
           i2c_read(**i2c_read_command_options(words, command, options))
+        when "i2c-transfer", "i2c.transfer"
+          i2c_transfer(**i2c_transfer_command_options(words, command, options))
         when "gpio-high", "gpio.high"
           gpio_write(**gpio_level_command_options(words, command, options, value: true))
         when "gpio-low", "gpio.low"
@@ -1360,6 +1417,24 @@ module CodingAdventures
         ensure_no_extra_arguments!(words, command)
         raise ArgumentError, "#{command} requires address" unless merged.key?(:address)
         raise ArgumentError, "#{command} requires length" unless merged.key?(:length)
+
+        merged
+      end
+
+      def i2c_transfer_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:address] = integer_argument(words.shift, "#{command} address") unless words.empty?
+        merged[:write_bytes] = i2c_bytes_argument(words.shift, "#{command} write bytes") unless words.empty?
+        merged[:read_length] = i2c_read_length_value(words.shift) unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires address" unless merged.key?(:address)
+        raise ArgumentError, "#{command} requires write bytes" unless merged.key?(:write_bytes)
+        raise ArgumentError, "#{command} requires read length" unless merged.key?(:read_length)
 
         merged
       end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -43,6 +43,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "i2c.read_u8"
         assert_includes uno_r4_wifi["capabilities"], "i2c.write"
         assert_includes uno_r4_wifi["capabilities"], "i2c.read"
+        assert_includes uno_r4_wifi["capabilities"], "i2c.transfer"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -1397,6 +1398,36 @@ module CodingAdventures
           read_result.results.map(&:command)
       end
 
+      def test_i2c_transfer_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        open_result = nil
+        transfer_result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          open_result = board.i2c.open(bus: 0, program_id: 10, budget: 24)
+          transfer_result = board.i2c.transfer(
+            address: 0x3c,
+            write_bytes: [0x00, 0x10],
+            read_length: 3,
+            program_id: 11,
+            budget: 24
+          )
+        end
+
+        assert_empty runner.calls
+        assert_equal 10, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal open_result.frames + transfer_result.frames, transport.frames
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          transfer_result.results.map(&:command)
+      end
+
       def test_store_program_dispatches_native_protocol_frame_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1919,6 +1950,26 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_i2c_transfer
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("i2c.transfer 60 0x0010 3 24", program_id: 9)
+          upload = board.session.run_command("upload-i2c.transfer 60 0x0010 3", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
       def test_board_descriptor_wraps_rust_decoded_capability_report
         decoded = {
           "kind" => "caps_report",
@@ -2059,6 +2110,10 @@ module CodingAdventures
         i2c_read_bytes_module_bytes = session.i2c_read_module(0x3c, 3, 4)
         assert_instance_of String, i2c_read_bytes_module_bytes
         assert_operator i2c_read_bytes_module_bytes.bytesize, :>, 0
+
+        i2c_transfer_module_bytes = session.i2c_transfer_module(0x3c, "\x00\x10".b, 3, 5)
+        assert_instance_of String, i2c_transfer_module_bytes
+        assert_operator i2c_transfer_module_bytes.bytesize, :>, 0
 
         gpio_module_bytes = session.gpio_read_module(13, 2, 2)
         assert_instance_of String, gpio_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -2,8 +2,9 @@
 
 use board_vm_ir::{
     parse_module, validate, CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
-    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_WRITE,
-    CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER,
+    CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS,
+    CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -116,6 +117,12 @@ const I2C_READ_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor 
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "i2c.read",
+};
+const I2C_TRANSFER_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_I2C_TRANSFER,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "i2c.transfer",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -610,7 +617,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_AND_DAC_CAPABILITIES: [CapabilityDescriptor<'st
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
-pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 15] = [
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor<'static>; 16] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -625,6 +632,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor
     I2C_READ_U8_DESCRIPTOR,
     I2C_WRITE_DESCRIPTOR,
     I2C_READ_DESCRIPTOR,
+    I2C_TRANSFER_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
@@ -683,7 +691,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDes
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<
     'static,
->; 16] = [
+>; 17] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -698,6 +706,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [Capabilit
     I2C_READ_U8_DESCRIPTOR,
     I2C_WRITE_DESCRIPTOR,
     I2C_READ_DESCRIPTOR,
+    I2C_TRANSFER_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,9 +1,10 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ,
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
-    CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
-    CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
-    FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MAX_BYTE_BUFFER_LEN, MODULE_MAGIC, MODULE_VERSION,
+    CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
+    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MAX_BYTE_BUFFER_LEN,
+    MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -51,6 +52,9 @@ pub const I2C_WRITE_CODE_LEN: usize = 10;
 pub const I2C_WRITE_MAX_MODULE_LEN: usize = 8 + 1 + I2C_WRITE_CODE_LEN + 1 + MAX_BYTE_BUFFER_LEN;
 pub const I2C_READ_CODE_LEN: usize = 9;
 pub const I2C_READ_MODULE_LEN: usize = 19;
+pub const I2C_TRANSFER_CODE_LEN: usize = 13;
+pub const I2C_TRANSFER_MAX_MODULE_LEN: usize =
+    8 + 1 + I2C_TRANSFER_CODE_LEN + 1 + MAX_BYTE_BUFFER_LEN;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -220,6 +224,14 @@ pub struct I2cReadProgram {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct I2cTransferProgram<'a> {
+    pub address: u16,
+    pub write_bytes: &'a [u8],
+    pub read_len: u8,
+    pub max_stack: u8,
+}
+
 impl I2cOpenProgram {
     pub const fn new(bus: u8) -> Self {
         Self { bus, max_stack: 2 }
@@ -261,6 +273,17 @@ impl I2cReadProgram {
             address,
             len,
             max_stack: 4,
+        }
+    }
+}
+
+impl<'a> I2cTransferProgram<'a> {
+    pub const fn new(address: u16, write_bytes: &'a [u8], read_len: u8) -> Self {
+        Self {
+            address,
+            write_bytes,
+            read_len,
+            max_stack: 5,
         }
     }
 }
@@ -1442,6 +1465,69 @@ pub fn write_i2c_read_module(program: I2cReadProgram, out: &mut [u8]) -> Result<
     Ok(offset)
 }
 
+pub fn i2c_transfer_module_len(write_len: usize) -> Result<usize, HostError> {
+    if write_len > MAX_BYTE_BUFFER_LEN {
+        return Err(HostError::ProgramTooLarge);
+    }
+    Ok(8 + 1 + I2C_TRANSFER_CODE_LEN + 1 + write_len)
+}
+
+pub fn write_i2c_transfer_code(
+    program: I2cTransferProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if program.write_bytes.len() > MAX_BYTE_BUFFER_LEN
+        || program.read_len as usize > MAX_BYTE_BUFFER_LEN
+    {
+        return Err(HostError::ProgramTooLarge);
+    }
+    if out.len() < I2C_TRANSFER_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_push_u16(out, &mut offset, program.address)?;
+    write_push_bytes(out, &mut offset, 0, program.write_bytes.len() as u8)?;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.read_len)?;
+    write_call_u8(out, &mut offset, CAP_I2C_TRANSFER)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_i2c_transfer_module(
+    program: I2cTransferProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if program.read_len as usize > MAX_BYTE_BUFFER_LEN {
+        return Err(HostError::ProgramTooLarge);
+    }
+    let required_len = i2c_transfer_module_len(program.write_bytes.len())?;
+    if out.len() < required_len {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; I2C_TRANSFER_CODE_LEN];
+    let code_len = write_i2c_transfer_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        )
+        .const_pool(program.write_bytes),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_i2c(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_led_matrix_frame_code(
     program: LedMatrixFrameProgram,
     out: &mut [u8],
@@ -1603,7 +1689,7 @@ mod tests {
     use board_vm_ir::{
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
         CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8,
-        CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
+        CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -1673,6 +1759,10 @@ mod tests {
     const I2C_READ_3C_03_MODULE_HEX: [u8; I2C_READ_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x04, 0x00, 0x09, 0x20, 0x13, 0x3C, 0x00, 0x12, 0x03,
         0x40, 0x27, 0x50, 0x00,
+    ];
+    const I2C_TRANSFER_3C_00_10_READ_03_MODULE_HEX: [u8; 25] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x05, 0x00, 0x0D, 0x20, 0x13, 0x3C, 0x00, 0x16, 0x00,
+        0x00, 0x02, 0x12, 0x03, 0x40, 0x28, 0x50, 0x02, 0x00, 0x10,
     ];
     const LED_MATRIX_HEART_MODULE_HEX: [u8; LED_MATRIX_FRAME_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x12, 0x14, 0x44, 0xA4, 0x84, 0x31, 0x14,
@@ -1934,6 +2024,23 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_I2C_READ]);
+    }
+
+    #[test]
+    fn builds_i2c_transfer_module() {
+        let payload = [0x00, 0x10];
+        let mut module = [0u8; I2C_TRANSFER_MAX_MODULE_LEN];
+        let len =
+            write_i2c_transfer_module(I2cTransferProgram::new(0x3c, &payload, 3), &mut module)
+                .unwrap();
+        assert_eq!(len, I2C_TRANSFER_3C_00_10_READ_03_MODULE_HEX.len());
+        assert_eq!(&module[..len], I2C_TRANSFER_3C_00_10_READ_03_MODULE_HEX);
+
+        let parsed = parse_module(&module[..len]).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_i2c(), 5).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_I2C_TRANSFER]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -25,6 +25,7 @@ pub const CAP_I2C_WRITE_U8: u16 = 0x24;
 pub const CAP_I2C_READ_U8: u16 = 0x25;
 pub const CAP_I2C_WRITE: u16 = 0x26;
 pub const CAP_I2C_READ: u16 = 0x27;
+pub const CAP_I2C_TRANSFER: u16 = 0x28;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -41,6 +42,7 @@ const CAP_I2C_WRITE_U8_U8: u8 = CAP_I2C_WRITE_U8 as u8;
 const CAP_I2C_READ_U8_U8: u8 = CAP_I2C_READ_U8 as u8;
 const CAP_I2C_WRITE_CAP_U8: u8 = CAP_I2C_WRITE as u8;
 const CAP_I2C_READ_CAP_U8: u8 = CAP_I2C_READ as u8;
+const CAP_I2C_TRANSFER_U8: u8 = CAP_I2C_TRANSFER as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -178,9 +180,8 @@ impl CapabilitySet {
             CAP_PWM_WRITE => self.pwm,
             CAP_ADC_READ => self.adc,
             CAP_DAC_WRITE_U12 => self.dac,
-            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 | CAP_I2C_WRITE | CAP_I2C_READ => {
-                self.i2c
-            }
+            CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 | CAP_I2C_WRITE | CAP_I2C_READ
+            | CAP_I2C_TRANSFER => self.i2c,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -451,6 +452,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_I2C_READ_U8_U8) | Op::CallU16(CAP_I2C_READ_U8) => (2, 1),
         Op::CallU8(CAP_I2C_WRITE_CAP_U8) | Op::CallU16(CAP_I2C_WRITE) => (3, 0),
         Op::CallU8(CAP_I2C_READ_CAP_U8) | Op::CallU16(CAP_I2C_READ) => (3, 1),
+        Op::CallU8(CAP_I2C_TRANSFER_U8) | Op::CallU16(CAP_I2C_TRANSFER) => (4, 1),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -918,6 +920,34 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 4),
             Err(ValidateError::UnsupportedCapability(CAP_I2C_READ))
+        );
+    }
+
+    #[test]
+    fn rejects_i2c_transfer_without_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 5,
+            code: &[
+                0x20,
+                0x12,
+                0x3c,
+                0x16,
+                0x00,
+                0x00,
+                0x02,
+                0x12,
+                0x03,
+                0x40,
+                CAP_I2C_TRANSFER as u8,
+                0x50,
+            ],
+            const_pool: &[0x00, 0x10],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 5),
+            Err(ValidateError::UnsupportedCapability(CAP_I2C_TRANSFER))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -35,22 +35,23 @@ use board_vm_esp_rom::{
     DEFAULT_TIMEOUT_MS as ESP_DEFAULT_TIMEOUT_MS,
 };
 use board_vm_host::{
-    i2c_write_module_len, write_adc_read_module, write_blink_module, write_dac_write_u12_module,
-    write_gpio_handle_close_module, write_gpio_handle_read_module, write_gpio_handle_write_module,
-    write_gpio_open_module, write_gpio_read_module, write_gpio_write_module, write_i2c_open_module,
-    write_i2c_read_module, write_i2c_read_u8_module, write_i2c_write_module,
+    i2c_transfer_module_len, i2c_write_module_len, write_adc_read_module, write_blink_module,
+    write_dac_write_u12_module, write_gpio_handle_close_module, write_gpio_handle_read_module,
+    write_gpio_handle_write_module, write_gpio_open_module, write_gpio_read_module,
+    write_gpio_write_module, write_i2c_open_module, write_i2c_read_module,
+    write_i2c_read_u8_module, write_i2c_transfer_module, write_i2c_write_module,
     write_i2c_write_u8_module, write_led_matrix_frame_module, write_module, write_pwm_write_module,
     write_time_now_module, write_time_sleep_ms_module, AdcReadProgram, BlinkProgram,
     DacWriteU12Program, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
     GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram,
-    I2cReadProgram, I2cReadU8Program, I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram,
-    ModuleSpec, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN,
-    BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
-    DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
-    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
-    GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN,
-    I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
-    TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    I2cReadProgram, I2cReadU8Program, I2cTransferProgram, I2cWriteProgram, I2cWriteU8Program,
+    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
+    DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN,
+    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
+    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, I2C_READ_MODULE_LEN,
+    I2C_READ_U8_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
+    PWM_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -1666,6 +1667,13 @@ pub fn build_i2c_read_module(
     Ok(write_i2c_read_module(program, out)?)
 }
 
+pub fn build_i2c_transfer_module(
+    program: I2cTransferProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_i2c_transfer_module(program, out)?)
+}
+
 pub fn build_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2484,6 +2492,35 @@ pub unsafe extern "C" fn board_vm_language_i2c_read_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_i2c_transfer_module(
+    address: u16,
+    write_bytes: *const u8,
+    write_bytes_len: u64,
+    read_len: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let write_bytes = unsafe { in_slice(write_bytes, write_bytes_len, "write_bytes") }?;
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_i2c_transfer_module(
+            I2cTransferProgram {
+                address,
+                write_bytes,
+                read_len,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_raw_module(
     flags: u8,
     max_stack: u8,
@@ -2832,6 +2869,14 @@ pub extern "C" fn board_vm_language_i2c_read_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_i2c_transfer_module_len(write_len: u64) -> u64 {
+    let Ok(write_len) = usize::try_from(write_len) else {
+        return 0;
+    };
+    i2c_transfer_module_len(write_len).unwrap_or(0) as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_led_matrix_frame_module_len() -> u64 {
     LED_MATRIX_FRAME_MODULE_LEN as u64
 }
@@ -3073,6 +3118,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"i2c.read_u8".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.write".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.read".to_owned()));
+        assert!(uno.capabilities.contains(&"i2c.transfer".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -3953,6 +3999,28 @@ mod tests {
         assert_eq!(
             i2c_read_bytes_status.len,
             board_vm_language_i2c_read_module_len()
+        );
+
+        let i2c_transfer_payload = [0x00, 0x10];
+        let mut i2c_transfer_module = [0u8; board_vm_host::I2C_TRANSFER_MAX_MODULE_LEN];
+        let i2c_transfer_status = unsafe {
+            board_vm_language_i2c_transfer_module(
+                0x3c,
+                i2c_transfer_payload.as_ptr(),
+                i2c_transfer_payload.len() as u64,
+                3,
+                5,
+                i2c_transfer_module.as_mut_ptr(),
+                i2c_transfer_module.len() as u64,
+            )
+        };
+        assert_eq!(
+            i2c_transfer_status.code,
+            BoardVmLanguageStatusCode::Ok as u32
+        );
+        assert_eq!(
+            i2c_transfer_status.len,
+            board_vm_language_i2c_transfer_module_len(i2c_transfer_payload.len() as u64)
         );
 
         let mut gpio_read_module = [0u8; GPIO_READ_MODULE_LEN];

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -3,8 +3,8 @@
 use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_DAC_WRITE_U12,
     CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ,
-    CAP_I2C_READ_U8, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
-    CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, MAX_BYTE_BUFFER_LEN,
+    CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
+    CAP_PWM_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, MAX_BYTE_BUFFER_LEN,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,6 +141,16 @@ pub trait BoardHal {
     }
 
     fn i2c_read(&mut self, _token: u32, _address: u16, _len: u8) -> Result<ByteBuffer, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn i2c_transfer(
+        &mut self,
+        _token: u32,
+        _address: u16,
+        _write_bytes: &[u8],
+        _read_len: u8,
+    ) -> Result<ByteBuffer, HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -615,6 +625,27 @@ where
                     })?;
                 self.push(Value::Bytes(bytes), ip)
             }
+            CAP_I2C_TRANSFER => {
+                let read_len = self.pop_u8(ip)?;
+                if read_len as usize > MAX_BYTE_BUFFER_LEN {
+                    return Err(RuntimeError {
+                        ip,
+                        kind: RuntimeErrorKind::ByteBufferTooLarge,
+                    });
+                }
+                let write_bytes = self.pop_bytes(ip)?;
+                let address = self.pop_u16(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::I2c, ip)?;
+                let bytes = self
+                    .hal
+                    .i2c_transfer(token, address, write_bytes.as_slice(), read_len)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                self.push(Value::Bytes(bytes), ip)
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -873,6 +904,7 @@ mod tests {
         I2cWrite(u32, u16, ByteBuffer),
         I2cReadU8(u32, u16),
         I2cRead(u32, u16, u8),
+        I2cTransfer(u32, u16, ByteBuffer, u8),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -970,6 +1002,23 @@ mod tests {
         fn i2c_read(&mut self, token: u32, address: u16, len: u8) -> Result<ByteBuffer, HalError> {
             self.events.push(Event::I2cRead(token, address, len));
             ByteBuffer::from_slice(&[0xca, 0xfe, 0x42][..len as usize])
+                .map_err(|_| HalError::UnsupportedMode)
+        }
+
+        fn i2c_transfer(
+            &mut self,
+            token: u32,
+            address: u16,
+            write_bytes: &[u8],
+            read_len: u8,
+        ) -> Result<ByteBuffer, HalError> {
+            self.events.push(Event::I2cTransfer(
+                token,
+                address,
+                ByteBuffer::from_slice(write_bytes).unwrap(),
+                read_len,
+            ));
+            ByteBuffer::from_slice(&[0x11, 0x22, 0x33][..read_len as usize])
                 .map_err(|_| HalError::UnsupportedMode)
         }
 
@@ -1250,6 +1299,53 @@ mod tests {
         assert_eq!(
             runtime.hal().events,
             vec![Event::I2cOpen(1), Event::I2cRead(0x1_2001, 0x3c, 3)]
+        );
+    }
+
+    #[test]
+    fn i2c_transfer_dispatches_handle_address_write_bytes_and_returns_bytes() {
+        let mut runtime: Runtime<FakeHal, 5, 2> = Runtime::new(FakeHal::new());
+        let open = [0x12, 1, 0x40, CAP_I2C_OPEN as u8, 0x20, 0x50];
+        let transfer = Module {
+            flags: board_vm_ir::FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 5,
+            code: &[
+                0x20,
+                0x12,
+                0x3c,
+                0x16,
+                0x00,
+                0x00,
+                0x02,
+                0x12,
+                0x03,
+                0x40,
+                CAP_I2C_TRANSFER as u8,
+                0x50,
+            ],
+            const_pool: &[0x00, 0x10],
+        };
+
+        runtime.run_code(&open, 10).unwrap();
+        let report = runtime.run_module(&transfer, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            report.return_value,
+            Value::Bytes(ByteBuffer::from_slice(&[0x11, 0x22, 0x33]).unwrap())
+        );
+        assert_eq!(
+            runtime.hal().events,
+            vec![
+                Event::I2cOpen(1),
+                Event::I2cTransfer(
+                    0x1_2001,
+                    0x3c,
+                    ByteBuffer::from_slice(&[0x00, 0x10]).unwrap(),
+                    3
+                )
+            ]
         );
     }
 }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -112,7 +112,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 16] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 17] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -128,10 +128,11 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 16] = [
     "i2c.read_u8",
     "i2c.write",
     "i2c.read",
+    "i2c.transfer",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 20] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 21] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -150,6 +151,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 20] = [
     "i2c.read_u8",
     "i2c.write",
     "i2c.read",
+    "i2c.transfer",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -619,6 +621,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"i2c.read_u8"));
         assert!(uno.capabilities.contains(&"i2c.write"));
         assert!(uno.capabilities.contains(&"i2c.read"));
+        assert!(uno.capabilities.contains(&"i2c.transfer"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -34,6 +34,7 @@ pub const BOARD_VM_UNO_R4_I2C_WRITE_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_write
 pub const BOARD_VM_UNO_R4_I2C_WRITE_SYMBOL: &str = "board_vm_uno_r4_i2c_write";
 pub const BOARD_VM_UNO_R4_I2C_READ_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_read_u8";
 pub const BOARD_VM_UNO_R4_I2C_READ_SYMBOL: &str = "board_vm_uno_r4_i2c_read";
+pub const BOARD_VM_UNO_R4_I2C_TRANSFER_SYMBOL: &str = "board_vm_uno_r4_i2c_transfer";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
@@ -295,6 +296,10 @@ mod tests {
             "board_vm_uno_r4_i2c_read_u8"
         );
         assert_eq!(BOARD_VM_UNO_R4_I2C_READ_SYMBOL, "board_vm_uno_r4_i2c_read");
+        assert_eq!(
+            BOARD_VM_UNO_R4_I2C_TRANSFER_SYMBOL,
+            "board_vm_uno_r4_i2c_transfer"
+        );
         assert_eq!(
             BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE,
             "src/uno_r4_wifi_pwm_bridge.cpp"

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -253,6 +253,32 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         }
     }
 
+    fn transfer_i2c(
+        &mut self,
+        bus: u8,
+        address: u16,
+        write_bytes: &[u8],
+        read_len: u8,
+    ) -> Result<ByteBuffer, HalError> {
+        let mut bytes = [0u8; board_vm_ir::MAX_BYTE_BUFFER_LEN];
+        let mut actual_read_len = 0;
+        if unsafe {
+            board_io_ffi::board_vm_uno_r4_i2c_transfer(
+                bus,
+                address,
+                write_bytes.as_ptr(),
+                write_bytes.len(),
+                bytes.as_mut_ptr(),
+                read_len as usize,
+                &mut actual_read_len,
+            )
+        } {
+            ByteBuffer::from_slice(&bytes[..actual_read_len]).map_err(|_| HalError::UnsupportedMode)
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+
     fn reboot_to_bootloader(&mut self) -> Result<(), HalError> {
         board_vm_uno_r4_usb_cdc::reboot_to_bootloader()
     }
@@ -278,6 +304,15 @@ mod board_io_ffi {
             bytes: *mut u8,
             len: usize,
             read_len: *mut usize,
+        ) -> bool;
+        pub fn board_vm_uno_r4_i2c_transfer(
+            bus: u8,
+            address: u16,
+            write_bytes: *const u8,
+            write_len: usize,
+            read_bytes: *mut u8,
+            read_len: usize,
+            actual_read_len: *mut usize,
         ) -> bool;
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -543,3 +543,53 @@ extern "C" bool board_vm_uno_r4_i2c_read(uint8_t bus, uint16_t address, uint8_t 
   *read_len = len;
   return true;
 }
+
+extern "C" bool board_vm_uno_r4_i2c_transfer(uint8_t bus, uint16_t address, const uint8_t *write_bytes,
+                                             size_t write_len, uint8_t *read_bytes, size_t read_len,
+                                             size_t *actual_read_len) {
+  if ((write_bytes == nullptr && write_len != 0) || (read_bytes == nullptr && read_len != 0) ||
+      actual_read_len == nullptr || address > kI2cMax7BitAddress) {
+    return false;
+  }
+
+  I2cSlot *slot = find_i2c_slot(bus);
+  if (slot == nullptr) {
+    return false;
+  }
+
+  TwoWire *wire = slot_wire(*slot);
+  if (!slot->started) {
+    wire->begin();
+    slot->started = true;
+  }
+
+  if (write_len != 0) {
+    wire->beginTransmission(address);
+    if (wire->write(write_bytes, write_len) != write_len) {
+      return false;
+    }
+    if (wire->endTransmission(read_len == 0) != END_TX_OK) {
+      return false;
+    }
+  }
+
+  if (read_len == 0) {
+    *actual_read_len = 0;
+    return true;
+  }
+
+  if (wire->requestFrom(static_cast<uint8_t>(address), read_len) != read_len) {
+    return false;
+  }
+
+  for (size_t index = 0; index < read_len; ++index) {
+    int value = wire->read();
+    if (value < 0) {
+      return false;
+    }
+    read_bytes[index] = static_cast<uint8_t>(value);
+  }
+
+  *actual_read_len = read_len;
+  return true;
+}

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -399,6 +399,16 @@ pub trait UnoR4Backend {
         Err(HalError::UnsupportedMode)
     }
 
+    fn transfer_i2c(
+        &mut self,
+        _bus: u8,
+        _address: u16,
+        _write_bytes: &[u8],
+        _read_len: u8,
+    ) -> Result<ByteBuffer, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn supports_bootloader_reboot(&self) -> bool {
         false
     }
@@ -542,6 +552,19 @@ where
         let bus = normalize_i2c_token(self.target, token)?;
         normalize_i2c_address(address)?;
         self.backend.read_i2c(bus, address, len)
+    }
+
+    fn i2c_transfer(
+        &mut self,
+        token: u32,
+        address: u16,
+        write_bytes: &[u8],
+        read_len: u8,
+    ) -> Result<ByteBuffer, HalError> {
+        let bus = normalize_i2c_token(self.target, token)?;
+        normalize_i2c_address(address)?;
+        self.backend
+            .transfer_i2c(bus, address, write_bytes, read_len)
     }
 
     fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -745,6 +768,7 @@ mod tests {
         I2cWrite(u8, u16, Vec<u8>),
         I2cReadU8(u8, u16),
         I2cRead(u8, u16, u8),
+        I2cTransfer(u8, u16, Vec<u8>, u8),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -847,6 +871,23 @@ mod tests {
         fn read_i2c(&mut self, bus: u8, address: u16, len: u8) -> Result<ByteBuffer, HalError> {
             self.events.push(Event::I2cRead(bus, address, len));
             ByteBuffer::from_slice(&[0xca, 0xfe, 0x42][..len as usize])
+                .map_err(|_| HalError::UnsupportedMode)
+        }
+
+        fn transfer_i2c(
+            &mut self,
+            bus: u8,
+            address: u16,
+            write_bytes: &[u8],
+            read_len: u8,
+        ) -> Result<ByteBuffer, HalError> {
+            self.events.push(Event::I2cTransfer(
+                bus,
+                address,
+                write_bytes.to_vec(),
+                read_len,
+            ));
+            ByteBuffer::from_slice(&[0x11, 0x22, 0x33][..read_len as usize])
                 .map_err(|_| HalError::UnsupportedMode)
         }
 
@@ -957,6 +998,9 @@ mod tests {
             .capabilities
             .supports(board_vm_ir::CAP_I2C_WRITE));
         assert!(UNO_R4_WIFI.capabilities.supports(board_vm_ir::CAP_I2C_READ));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_TRANSFER));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -981,6 +1025,9 @@ mod tests {
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_I2C_READ));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_I2C_TRANSFER));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -1164,6 +1211,36 @@ mod tests {
 
         assert_eq!(board.i2c_read(0x1_2001, 0x3c, 3), Err(HalError::InvalidPin));
         assert_eq!(board.i2c_read(0x1_2000, 0x80, 3), Err(HalError::InvalidPin));
+    }
+
+    #[test]
+    fn i2c_transfer_runs_through_bus_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(
+            board
+                .i2c_transfer(0x1_2001, 0x3c, &[0x00, 0x10], 3)
+                .unwrap(),
+            ByteBuffer::from_slice(&[0x11, 0x22, 0x33]).unwrap()
+        );
+        assert_eq!(
+            board.backend().events,
+            vec![Event::I2cTransfer(1, 0x3c, vec![0x00, 0x10], 3)]
+        );
+    }
+
+    #[test]
+    fn i2c_transfer_rejects_unknown_bus_or_address() {
+        let mut board = UnoR4Board::minima(FakeBackend::new());
+
+        assert_eq!(
+            board.i2c_transfer(0x1_2001, 0x3c, &[0x00, 0x10], 3),
+            Err(HalError::InvalidPin)
+        );
+        assert_eq!(
+            board.i2c_transfer(0x1_2000, 0x80, &[0x00, 0x10], 3),
+            Err(HalError::InvalidPin)
+        );
     }
 
     #[test]

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -211,6 +211,7 @@ metadata. The operation is intentionally direct and stateless, mirroring
 | `0x25` | `i2c.read_u8` | `handle`, `address: u16/u8` | `u8` |
 | `0x26` | `i2c.write` | `handle`, `address: u16/u8`, `bytes` | `unit` |
 | `0x27` | `i2c.read` | `handle`, `address: u16/u8`, `length: u8` | `bytes` |
+| `0x28` | `i2c.transfer` | `handle`, `address: u16/u8`, `write_bytes: bytes`, `read_length: u8` | `bytes` |
 
 `i2c.open` opens a board-advertised I2C controller and returns a persistent bus
 handle. The handle is the lifetime anchor for transfer operations, keeping bus
@@ -221,8 +222,9 @@ opened bus handle. `i2c.read_u8` reads one byte from that same 7-bit address and
 returns it as a scalar `u8`. These are the first concrete I2C transfer
 primitives. `i2c.write` writes a bounded VM byte buffer to the device address
 using the same handle model. `i2c.read` reads a bounded byte buffer of up to the
-VM byte-buffer limit from the same handle/address pair. Wider `i2c.transfer`
-operations should reuse the bounded byte-buffer ABI.
+VM byte-buffer limit from the same handle/address pair. `i2c.transfer` performs
+a bounded write-then-read transaction, preserving the bus handle and returning
+the bounded read bytes.
 
 ### LED Matrix
 

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -29,7 +29,7 @@ Source snapshot:
 | PWM output | D3, D5, D6, D9, D10, D11 in the Arduino variant init path | implemented as direct write | `pwm.write` |
 | Analog input | A0-A5 | implemented as direct read | `adc.read` |
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
-| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, and byte-buffer write/read implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, `i2c.read`, then `i2c.transfer` |
+| I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, byte-buffer write/read, and write-read transfer implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, `i2c.read`, `i2c.transfer` |
 | SPI master | MOSI D11, MISO D12, SCK D13, CS D10 | pending | `spi.open`, `spi.transfer`, `spi.close` |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
@@ -70,9 +70,8 @@ reject conflicting handles.
 4. Implement I2C and SPI as bus handles with explicit transfer boundaries;
    `i2c.open` establishes the first I2C handle tranche, while `i2c.write_u8`
    and `i2c.read_u8` prove the Rust-owned transfer path through Arduino
-   `Wire`/`Wire1`. `i2c.write` and `i2c.read` now prove the byte-buffer transfer
-   path; combined transfer transactions should still land as separate capability
-   slices.
+   `Wire`/`Wire1`. `i2c.write`, `i2c.read`, and `i2c.transfer` cover the
+   bounded byte-buffer transfer path.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 


### PR DESCRIPTION
## Summary
- add the `i2c.transfer` VM capability for combined I2C write/read transactions over byte buffers
- wire host module generation, runtime dispatch, UNO R4 metadata/backends, device descriptors, and Ruby session/connection helpers
- add UNO R4 SerialUSB firmware bridge support with repeated-start behavior when a read follows a write
- update the bytecode/spec inventory docs for the new capability

## Validation
- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- linked `uno-r4-wifi-serialusb-artifact` build/objcopy with `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, Arduino Renesas UNO core 1.5.3, and `/opt/homebrew/bin` ARM tools
- `bundle exec ruby -c lib/coding_adventures/board_vm/session.rb`
- `bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb`
- `bundle exec rake test` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- build-tool target/language detection with `-diff-base origin/main`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`