### PR TITLE
rust(spice): parse CCVS netlist elements

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.3
+
+- Add SPICE `H` / CCVS controlled-source parsing, including subcircuit
+  controlling-source name remapping for expanded CCVS elements.
+
 ## 0.1.2
 
 - Add SPICE `F` / CCCS controlled-source parsing, including subcircuit

--- a/code/packages/rust/spice-netlist-parser/Cargo.toml
+++ b/code/packages/rust/spice-netlist-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spice-netlist-parser"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt};
 
 use spice_engine::{
-    Capacitor, Cccs, Circuit, CurrentSource, Element, ExpWaveform, Inductor, PulseWaveform,
+    Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, ExpWaveform, Inductor, PulseWaveform,
     PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
@@ -348,6 +348,16 @@ fn parse_element(fields: &[String]) -> Result<Element, NetlistParseError> {
                 parse_value(&fields[4])?,
             )))
         }
+        'H' => {
+            require_fields(fields, 5, "CCVS")?;
+            Ok(Element::Ccvs(Ccvs::new(
+                name,
+                &fields[1],
+                &fields[2],
+                &fields[3],
+                parse_value(&fields[4])?,
+            )))
+        }
         _ => Err(NetlistParseError::new(format!(
             "unsupported element {name:?}"
         ))),
@@ -474,7 +484,7 @@ fn map_subckt_fields(
                 mapped[index] = map_subckt_node(&fields[index], instance_name, node_map);
             }
         }
-        'F' => {
+        'F' | 'H' => {
             require_min_fields(fields, 4, "subcircuit current-controlled source")?;
             mapped[1] = map_subckt_node(&fields[1], instance_name, node_map);
             mapped[2] = map_subckt_node(&fields[2], instance_name, node_map);

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -143,6 +143,30 @@ Rload out 0 500
 }
 
 #[test]
+fn parses_ccvs_into_operating_point_circuit() {
+    let parsed = parse_netlist(
+        r#"
+Vin in 0 DC 1
+Rin in sense 1k
+Vsense sense 0 DC 0
+Hamp out 0 Vsense 1k
+Rload out 0 500
+.op
+"#,
+    )
+    .unwrap();
+
+    let Element::Ccvs(source) = &parsed.circuit.elements()[3] else {
+        panic!("expected CCVS");
+    };
+    assert_eq!(source.control_source, "Vsense");
+    assert_close(source.transresistance_ohms, 1000.0);
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    assert_close(result.voltage("out").unwrap(), 1.0);
+}
+
+#[test]
 fn parses_pwl_and_sin_source_waveforms() {
     let parsed = parse_netlist(
         r#"
@@ -281,6 +305,49 @@ Rload out 0 500
 
     let result = dc_op(&parsed.circuit).unwrap();
     assert_close(result.voltage("out").unwrap(), -1.0);
+}
+
+#[test]
+fn expands_subcircuit_ccvs_control_sources_into_engine_elements() {
+    let parsed = parse_netlist(
+        r#"
+.subckt transimpedance inp outp
+Rin inp sense 1k
+Vsense sense 0 DC 0
+Hamp outp 0 Vsense 1k
+.ends transimpedance
+Vin in 0 DC 1
+Xamp in out transimpedance
+Rload out 0 500
+.op
+"#,
+    )
+    .unwrap();
+
+    let elements = parsed.circuit.elements();
+    let names = elements
+        .iter()
+        .map(|element| match element {
+            Element::VoltageSource(source) => source.name.as_str(),
+            Element::Resistor(resistor) => resistor.name.as_str(),
+            Element::Ccvs(source) => source.name.as_str(),
+            _ => panic!("unexpected element"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        vec!["Vin", "Xamp.Rin", "Xamp.Vsense", "Xamp.Hamp", "Rload"]
+    );
+
+    let Element::Ccvs(source) = &elements[3] else {
+        panic!("expected CCVS");
+    };
+    assert_eq!(source.positive, "out");
+    assert_eq!(source.control_source, "Xamp.Vsense");
+    assert_close(source.transresistance_ohms, 1000.0);
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    assert_close(result.voltage("out").unwrap(), 1.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add Rust SPICE netlist parsing for `H` / CCVS controlled sources.
- Remap CCVS control-source references during `.subckt` expansion.
- Cover direct and expanded CCVS operating-point circuits.

## Validation

- `cargo test -p spice-netlist-parser`
- `cargo fmt -p spice-netlist-parser`
- `git diff --check`