### PR TITLE
LANG51 + LANG52: string literals and stdlib completeness for self-hosting

### DIFF
--- a/code/grammars/twig.grammar
+++ b/code/grammars/twig.grammar
@@ -148,6 +148,7 @@ quoted = QUOTE NAME ;
 # form is wrapped in its own non-terminal for clarity.
 compound = if_form
          | let_form
+         | let_star_form
          | begin_form
          | lambda_form
          | quote_form
@@ -160,6 +161,15 @@ if_form     = LPAREN "if"     expr expr expr RPAREN ;
 # Bindings are mutually independent (Scheme ``let``, not ``let*``).
 let_form    = LPAREN "let" LPAREN { binding } RPAREN expr { expr } RPAREN ;
 binding     = LPAREN NAME expr RPAREN ;
+
+# (let* ((x e1) (y e2) ...) body+)                                 — LANG52
+# Sequential bindings: each RHS is evaluated in a scope that includes all
+# prior bindings.  ``(let* ((a 1) (b (+ a 1))) b)`` → 2.
+# ``let*`` is listed AFTER ``let`` so that the ``(`` dispatch reaches ``let``
+# before ``let*``; in practice both start with LPAREN ``"let"``/``"let*"``
+# and PEG commit as soon as the keyword token differs, so order only matters
+# for the documented PEG preference rule.
+let_star_form = LPAREN "let*" LPAREN { binding } RPAREN expr { expr } RPAREN ;
 
 # (begin e1 e2 ...) — sequencing, returns the value of the last expr.
 begin_form  = LPAREN "begin" expr { expr } RPAREN ;

--- a/code/grammars/twig.tokens
+++ b/code/grammars/twig.tokens
@@ -141,6 +141,11 @@ keywords:
   union
   # (match expr arm ...) — pattern matching expression
   match
+  # LANG52 — sequential let bindings.  ``let*`` is promoted to a keyword
+  # so the grammar's ``"let*"`` literal match wins over the NAME pattern.
+  # (The ``*`` character is legal inside a Twig identifier — see the NAME
+  # regex — so ``let*`` would otherwise lex as a plain NAME token.)
+  let*
 
 # ---------------------------------------------------------------------------
 # Skip patterns — consumed silently, never reach the parser

--- a/code/packages/rust/lispy-runtime/CHANGELOG.md
+++ b/code/packages/rust/lispy-runtime/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog — lispy-runtime
 
+## [0.4.0] — 2026-05-14
+
+### Added — LANG52 stdlib completeness for self-hosting
+
+#### Extended comparisons
+
+- **`le` (`<=`)** — integer less-than-or-equal.
+- **`ge` (`>=`)** — integer greater-than-or-equal.
+
+#### Extended integer arithmetic
+
+- **`quotient`** — truncating integer division (Scheme `quotient`; sign matches sign of the
+  mathematical quotient, truncating toward zero).
+- **`remainder`** — remainder after `quotient`; sign matches the *dividend* (same as Rust/C `%`).
+- **`modulo`** — Scheme-style floor-division remainder; sign matches the *divisor*.
+  For example: `(modulo -13 4)` → 3, `(modulo 13 -4)` → -3.
+
+#### Logic
+
+- **`not`** — logical negation.  Returns `#t` iff the argument is `#f` or `nil`; `#f` otherwise.
+  Notably `(not 0)` → `#f` — zero is truthy in Scheme.
+- **`boolean?`** — type predicate; `#t` for `#t` and `#f`, `#f` for everything else.
+- **`equal?`** — structural equality across all value kinds:
+  - Immediates (int, bool, nil, symbol): bitwise comparison.
+  - Cons cells: recursive structural comparison on car/cdr.
+  - Strings: byte-for-byte comparison.
+  - Closures: identity (`eq?` semantics for opaque values).
+
+#### List operations
+
+- **`list`** — build a proper list from positional arguments.  `(list)` → `nil`.
+- **`list?`** — proper-list predicate (nil-terminated check; iterative, no stack overflow).
+- **`length`** — number of elements in a proper list; errors on improper/dotted lists.
+- **`append`** — concatenate two proper lists; `lst1` elements are freshly consed onto `lst2`.
+- **`reverse`** — return `lst` with elements in reverse order.
+- **`list-ref`** — `(list-ref lst i)` — 0-indexed element access; out-of-bounds error.
+- **`assoc`** — `(assoc key alist)` — find the first pair in `alist` whose `car` is `equal?`
+  to `key`; returns the pair, or `#f` if not found.
+
+#### Symbol operations
+
+- **`symbol-append`** — `(symbol-append sym1 sym2)` — intern the concatenation of both
+  symbols' names as a new symbol.  Useful for macro-generated identifiers.
+
+### Implementation notes
+
+- **`values_equal` helper** — private function in `builtins.rs` that implements the same
+  structural equality as `LispyBinding::equal` in `binding.rs`, without creating a circular
+  dependency (binding imports builtins; builtins cannot import binding).
+- All list operations use **iterative loops** (not recursion) to avoid stack overflow on long
+  lists.  The `unsafe` blocks are bounded by the same invariant as the existing cons/car/cdr
+  builtins: values enter through the BuiltinRegistry, so heap tags reflect real allocations.
+
 ## [0.3.0] — 2026-05-14
 
 ### Added — LANG47 string heap objects and builtins

--- a/code/packages/rust/lispy-runtime/Cargo.toml
+++ b/code/packages/rust/lispy-runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lispy-runtime"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "LANG20 PRs 2 + 5 + LANG47 — LispyBinding: shared LangBinding implementation for Lisp/Scheme/Twig/Clojure (tagged-i64 values, cons cells, closures, LangString heap objects, full string builtin set)"
+description = "LANG20 PRs 2 + 5 + LANG47 + LANG52 — LispyBinding: shared LangBinding implementation for Lisp/Scheme/Twig/Clojure (tagged-i64 values, cons cells, closures, LangString heap objects, full string + stdlib builtin set)"
 
 [dependencies]
 lang-runtime-core = { path = "../lang-runtime-core" }

--- a/code/packages/rust/lispy-runtime/src/binding.rs
+++ b/code/packages/rust/lispy-runtime/src/binding.rs
@@ -374,6 +374,27 @@ impl LangBinding for LispyBinding {
             "integer->char"    => Some(builtins::integer_to_char),
             "char-upcase"      => Some(builtins::char_upcase),
             "char-downcase"    => Some(builtins::char_downcase),
+            // ── Extended comparisons (LANG52) ───────────────────────────
+            "<="  => Some(builtins::le),
+            ">="  => Some(builtins::ge),
+            // ── Extended arithmetic (LANG52) ────────────────────────────
+            "quotient"   => Some(builtins::quotient),
+            "remainder"  => Some(builtins::remainder),
+            "modulo"     => Some(builtins::modulo),
+            // ── Logic (LANG52) ──────────────────────────────────────────
+            "not"      => Some(builtins::not),
+            "boolean?" => Some(builtins::boolean_p),
+            "equal?"   => Some(builtins::equal_p),
+            // ── List operations (LANG52) ────────────────────────────────
+            "list"       => Some(builtins::list),
+            "list?"      => Some(builtins::list_p),
+            "length"     => Some(builtins::length),
+            "append"     => Some(builtins::append),
+            "reverse"    => Some(builtins::reverse),
+            "list-ref"   => Some(builtins::list_ref),
+            "assoc"      => Some(builtins::assoc),
+            // ── Symbol operations (LANG52) ──────────────────────────────
+            "symbol-append" => Some(builtins::symbol_append),
             _ => None,
         }
     }

--- a/code/packages/rust/lispy-runtime/src/builtins.rs
+++ b/code/packages/rust/lispy-runtime/src/builtins.rs
@@ -200,6 +200,116 @@ pub fn gt(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
     Ok(LispyValue::bool(a > b))
 }
 
+/// `(<= a b)` — integer less-than-or-equal (LANG52).
+pub fn le(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("<=", 2, args.len()));
+    }
+    let a = as_int("<=", args[0])?;
+    let b = as_int("<=", args[1])?;
+    Ok(LispyValue::bool(a <= b))
+}
+
+/// `(>= a b)` — integer greater-than-or-equal (LANG52).
+pub fn ge(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error(">=", 2, args.len()));
+    }
+    let a = as_int(">=", args[0])?;
+    let b = as_int(">=", args[1])?;
+    Ok(LispyValue::bool(a >= b))
+}
+
+// ---------------------------------------------------------------------------
+// Extended integer arithmetic (LANG52)
+// ---------------------------------------------------------------------------
+//
+// Scheme distinguishes three integer division operations with different
+// sign conventions for the result:
+//
+//   `quotient`  — truncates toward zero (same as C's `/`).
+//   `remainder` — remainder after `quotient`; sign matches the *dividend*.
+//   `modulo`    — remainder after floor division; sign matches the *divisor*.
+//
+// Truth table for negative inputs (Scheme reference):
+//
+//   | a  | b  | quotient | remainder | modulo |
+//   |----|----|----------|-----------|--------|
+//   | 13 |  4 |  3       |  1        |  1     |
+//   |-13 |  4 | -3       | -1        |  3     |
+//   | 13 | -4 | -3       |  1        | -3     |
+//   |-13 | -4 |  3       | -1        | -1     |
+//
+// Rust's `%` operator has `remainder` semantics (sign matches dividend),
+// so `remainder` maps directly to `checked_rem`, and `modulo` adds one
+// adjustment step: if the Rust remainder is non-zero *and* its sign
+// differs from the divisor's sign, add the divisor.
+
+/// `(quotient a b)` — truncating integer division (LANG52).
+///
+/// `(quotient 13 4)` → 3;  `(quotient -13 4)` → -3.
+/// Errors on division by zero or signed-overflow (INT_MIN / -1).
+pub fn quotient(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("quotient", 2, args.len()));
+    }
+    let a = as_int("quotient", args[0])?;
+    let b = as_int("quotient", args[1])?;
+    if b == 0 {
+        return Err(RuntimeError::TypeError("quotient: division by zero".into()));
+    }
+    let q = a.checked_div(b).ok_or_else(|| {
+        RuntimeError::TypeError("quotient: integer overflow".into())
+    })?;
+    box_int_checked("quotient", q)
+}
+
+/// `(remainder a b)` — remainder after `quotient`; sign matches dividend (LANG52).
+///
+/// `(remainder 13 4)` → 1;  `(remainder -13 4)` → -1.
+pub fn remainder(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("remainder", 2, args.len()));
+    }
+    let a = as_int("remainder", args[0])?;
+    let b = as_int("remainder", args[1])?;
+    if b == 0 {
+        return Err(RuntimeError::TypeError("remainder: division by zero".into()));
+    }
+    let r = a.checked_rem(b).ok_or_else(|| {
+        RuntimeError::TypeError("remainder: integer overflow".into())
+    })?;
+    box_int_checked("remainder", r)
+}
+
+/// `(modulo a b)` — Scheme-style floor-division remainder; sign matches divisor (LANG52).
+///
+/// `(modulo -13 4)` → 3;  `(modulo 13 -4)` → -3.
+pub fn modulo(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("modulo", 2, args.len()));
+    }
+    let a = as_int("modulo", args[0])?;
+    let b = as_int("modulo", args[1])?;
+    if b == 0 {
+        return Err(RuntimeError::TypeError("modulo: division by zero".into()));
+    }
+    // Rust's `%` gives remainder (sign matches dividend).  One adjustment
+    // step converts it to Scheme's modulo (sign matches divisor): if the
+    // remainder is nonzero and its sign differs from the divisor's, add b.
+    let r = a.checked_rem(b).ok_or_else(|| {
+        RuntimeError::TypeError("modulo: integer overflow".into())
+    })?;
+    let m = if r != 0 && (r < 0) != (b < 0) {
+        r.checked_add(b).ok_or_else(|| {
+            RuntimeError::TypeError("modulo: integer overflow".into())
+        })?
+    } else {
+        r
+    };
+    box_int_checked("modulo", m)
+}
+
 // ---------------------------------------------------------------------------
 // Cons cells
 // ---------------------------------------------------------------------------
@@ -273,6 +383,367 @@ pub fn symbol_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
         return Err(arity_error("symbol?", 1, args.len()));
     }
     Ok(LispyValue::bool(args[0].is_symbol()))
+}
+
+/// `(boolean? x)` — true iff `x` is `#t` or `#f` (LANG52).
+pub fn boolean_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("boolean?", 1, args.len()));
+    }
+    Ok(LispyValue::bool(args[0].is_bool()))
+}
+
+// ---------------------------------------------------------------------------
+// Logic (LANG52)
+// ---------------------------------------------------------------------------
+//
+// `not` is a straightforward predicate: only `#f` and `nil` are falsy in
+// Scheme (and Twig inherits that rule — every other value, including `0`,
+// is truthy).
+//
+// `and` / `or` are special forms handled by the *compiler* as short-circuit
+// lowerings — they never appear here as builtins.  Only `not` needs to live
+// in the runtime because it has no compile-time short-circuit behaviour; it
+// is a plain 1-argument function.
+//
+// `equal?` provides structural equality across all value kinds:
+//   * immediates    — bitwise comparison (int, bool, nil, symbol)
+//   * cons cells    — recursive structural comparison
+//   * strings       — byte-for-byte comparison
+//   * closures      — identity (eq? semantics for opaque values)
+//
+// `equal?` is placed here rather than in binding.rs to avoid a circular
+// dependency: binding.rs imports builtins; builtins cannot import binding.
+// The implementation is a private `values_equal` helper that mirrors
+// `LispyBinding::equal` exactly.
+
+/// Structural equality used by `equal?` and `assoc`.
+///
+/// Private helper — not a builtin entry point.  Mirrors
+/// [`crate::binding::LispyBinding::equal`] without the circular dep.
+///
+/// # Safety / DoS hardening
+///
+/// Uses an **explicit work-stack** (iterative, not recursive) to avoid Rust
+/// call-stack overflow on arbitrarily-deep nested lists.  A depth cap of
+/// 4096 pairs prevents adversarial input from growing the work-stack without
+/// bound while still handling any practically reasonable data structure.  On
+/// hitting the cap the function returns `false` (safe-conservative).
+fn values_equal(a: LispyValue, b: LispyValue) -> bool {
+    /// Maximum number of pair comparisons before we give up.
+    ///
+    /// A deeply-nested list `(cons 1 (cons 1 … nil))` with 4 096 levels
+    /// requires exactly 4 096 work-stack entries.  Real Twig data
+    /// structures are well below this limit; the cap is a DoS guard, not
+    /// a semantic limit on `equal?`.
+    const MAX_PAIRS: usize = 4096;
+
+    // The work-stack holds pairs of values that must themselves be equal
+    // for the overall comparison to be `true`.  We pop one pair per
+    // iteration, check for fast-path equality, and push sub-pairs for
+    // cons cells.
+    let mut work: Vec<(LispyValue, LispyValue)> = Vec::with_capacity(16);
+    work.push((a, b));
+
+    while let Some((a, b)) = work.pop() {
+        // Fast path: bitwise equality covers all immediates (int, bool,
+        // nil, symbol) and pointer-equal heap objects.
+        if a.bits() == b.bits() {
+            continue;
+        }
+
+        // Depth / DoS guard.
+        if work.len() >= MAX_PAIRS {
+            return false;
+        }
+
+        // SAFETY: values in the work-stack originate from the runtime's
+        // value space — heap tags always reflect real, live allocations.
+        unsafe {
+            if heap::is_cons(a) && heap::is_cons(b) {
+                // Structural: push both car/car and cdr/cdr pairs.
+                let ca = heap::car(a); let da = heap::cdr(a);
+                let cb = heap::car(b); let db = heap::cdr(b);
+                match (ca, da, cb, db) {
+                    (Some(ca), Some(da), Some(cb), Some(db)) => {
+                        work.push((ca, cb));
+                        work.push((da, db));
+                        continue;
+                    }
+                    _ => return false,
+                }
+            }
+            if heap::is_string(a) && heap::is_string(b) {
+                // Byte-for-byte string equality.
+                let ab = heap::string_bytes(a).unwrap_or(&[]);
+                let bb = heap::string_bytes(b).unwrap_or(&[]);
+                if ab == bb { continue; } else { return false; }
+            }
+        }
+        // Different types — not equal.
+        return false;
+    }
+    // All pairs in the work-stack compared equal.
+    true
+}
+
+/// `(not x)` — logical negation; returns `#t` iff `x` is falsy (LANG52).
+///
+/// Scheme falsy values: `#f` and `nil`.  Everything else — including `0`
+/// and the empty string — is truthy.
+pub fn not(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("not", 1, args.len()));
+    }
+    Ok(LispyValue::bool(!args[0].is_truthy()))
+}
+
+/// `(equal? a b)` — structural equality (LANG52).
+///
+/// Integers, booleans, nil, and symbols compare by value.  Cons cells
+/// recurse on car/cdr.  Strings compare byte-for-byte.  Closures compare
+/// by identity (pointer equality, matching R7RS for opaque values).
+pub fn equal_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("equal?", 2, args.len()));
+    }
+    Ok(LispyValue::bool(values_equal(args[0], args[1])))
+}
+
+// ---------------------------------------------------------------------------
+// List operations (LANG52)
+// ---------------------------------------------------------------------------
+//
+// These operations build on the cons-cell primitives (`cons`, `car`, `cdr`)
+// already in this file.  Higher-order operations (`map`, `filter`,
+// `fold-left`) require calling back into the VM interpreter and are deferred
+// to LANG53 or a stdlib.tw once the self-hosted compiler exists.
+//
+// | Builtin     | Arity | Description                                      |
+// |-------------|------:|--------------------------------------------------|
+// | `list`      | n-ary | Build a proper list from positional args         |
+// | `list?`     |     1 | Proper-list predicate (nil-terminated)           |
+// | `length`    |     1 | Number of elements in a proper list              |
+// | `append`    |     2 | Concatenate two proper lists                     |
+// | `reverse`   |     1 | Reverse a proper list                            |
+// | `list-ref`  |     2 | 0-indexed element access                         |
+// | `assoc`     |     2 | Alist lookup; uses `equal?` for key comparison   |
+
+/// `(list a b c ...)` — construct a proper list from positional args (LANG52).
+///
+/// `(list 1 2 3)` → `(1 2 3)` (= `(cons 1 (cons 2 (cons 3 nil)))`).
+/// `(list)` → `nil`.
+pub fn list(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    // Build the list from the right so each `alloc_cons` prepends one cell.
+    let mut result = LispyValue::NIL;
+    for a in args.iter().rev() {
+        result = heap::alloc_cons(*a, result);
+    }
+    Ok(result)
+}
+
+/// `(list? x)` — `#t` iff `x` is a proper (nil-terminated) list (LANG52).
+///
+/// `(list? nil)` → `#t`.  `(list? (cons 1 2))` → `#f` (improper list).
+/// Uses an iterative walk to avoid stack overflow on long lists.
+pub fn list_p(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("list?", 1, args.len()));
+    }
+    let mut cur = args[0];
+    loop {
+        if cur.is_nil() {
+            return Ok(LispyValue::TRUE);
+        }
+        // SAFETY: see `car`.
+        if !unsafe { heap::is_cons(cur) } {
+            return Ok(LispyValue::FALSE);
+        }
+        cur = unsafe { heap::cdr(cur) }.unwrap_or(LispyValue::NIL);
+    }
+}
+
+/// `(length lst)` — number of elements in proper list `lst` (LANG52).
+///
+/// Errors if `lst` is not a proper list (e.g. a dotted pair or non-list).
+pub fn length(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("length", 1, args.len()));
+    }
+    let mut cur = args[0];
+    let mut n: i64 = 0;
+    loop {
+        if cur.is_nil() {
+            return box_int_checked("length", n);
+        }
+        // SAFETY: see `car`.
+        if !unsafe { heap::is_cons(cur) } {
+            return Err(RuntimeError::TypeError(
+                "length: not a proper list".into(),
+            ));
+        }
+        cur = unsafe { heap::cdr(cur) }.unwrap_or(LispyValue::NIL);
+        n += 1;
+    }
+}
+
+/// `(append lst1 lst2)` — concatenate two proper lists (LANG52).
+///
+/// The result shares the structure of `lst2`; `lst1` elements are copied
+/// (each gets a fresh cons cell).  Errors if `lst1` is not a proper list.
+pub fn append(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("append", 2, args.len()));
+    }
+    // Collect the elements of lst1 into a Vec so we can prepend them to
+    // lst2 in reverse order.
+    let mut items: Vec<LispyValue> = Vec::new();
+    let mut cur = args[0];
+    loop {
+        if cur.is_nil() {
+            break;
+        }
+        // SAFETY: see `car`.
+        if !unsafe { heap::is_cons(cur) } {
+            return Err(RuntimeError::TypeError(
+                "append: first argument is not a proper list".into(),
+            ));
+        }
+        unsafe {
+            items.push(heap::car(cur).unwrap_or(LispyValue::NIL));
+            cur = heap::cdr(cur).unwrap_or(LispyValue::NIL);
+        }
+    }
+    let mut result = args[1];
+    for item in items.iter().rev() {
+        result = heap::alloc_cons(*item, result);
+    }
+    Ok(result)
+}
+
+/// `(reverse lst)` — return `lst` with elements in reverse order (LANG52).
+///
+/// `(reverse '(1 2 3))` → `(3 2 1)`.  Errors if `lst` is not a proper list.
+pub fn reverse(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 1 {
+        return Err(arity_error("reverse", 1, args.len()));
+    }
+    let mut result = LispyValue::NIL;
+    let mut cur = args[0];
+    loop {
+        if cur.is_nil() {
+            return Ok(result);
+        }
+        // SAFETY: see `car`.
+        if !unsafe { heap::is_cons(cur) } {
+            return Err(RuntimeError::TypeError(
+                "reverse: not a proper list".into(),
+            ));
+        }
+        unsafe {
+            result = heap::alloc_cons(heap::car(cur).unwrap_or(LispyValue::NIL), result);
+            cur = heap::cdr(cur).unwrap_or(LispyValue::NIL);
+        }
+    }
+}
+
+/// `(list-ref lst i)` — return the element at 0-based index `i` (LANG52).
+///
+/// `(list-ref '(a b c) 1)` → `b`.  Errors if `i` is out of bounds.
+pub fn list_ref(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("list-ref", 2, args.len()));
+    }
+    let idx = as_int("list-ref", args[1])?;
+    if idx < 0 {
+        return Err(RuntimeError::TypeError(format!(
+            "list-ref: index {idx} is negative"
+        )));
+    }
+    let mut cur = args[0];
+    let mut remaining = idx;
+    loop {
+        // SAFETY: see `car`.
+        if !unsafe { heap::is_cons(cur) } {
+            return Err(RuntimeError::TypeError(format!(
+                "list-ref: index {idx} out of bounds"
+            )));
+        }
+        if remaining == 0 {
+            return Ok(unsafe { heap::car(cur) }.unwrap_or(LispyValue::NIL));
+        }
+        cur = unsafe { heap::cdr(cur) }.unwrap_or(LispyValue::NIL);
+        remaining -= 1;
+    }
+}
+
+/// `(assoc key alist)` — find the first pair in `alist` whose car is
+/// `equal?` to `key`; return the pair, or `#f` if not found (LANG52).
+///
+/// `(assoc 2 '((1 . a) (2 . b) (3 . c)))` → `(2 . b)`.
+pub fn assoc(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("assoc", 2, args.len()));
+    }
+    let key = args[0];
+    let mut cur = args[1];
+    loop {
+        if cur.is_nil() {
+            return Ok(LispyValue::FALSE);
+        }
+        // SAFETY: see `car`.
+        if !unsafe { heap::is_cons(cur) } {
+            return Err(RuntimeError::TypeError(
+                "assoc: second argument is not a proper list".into(),
+            ));
+        }
+        let pair = unsafe { heap::car(cur) }.unwrap_or(LispyValue::NIL);
+        // Each element of the alist must itself be a pair.
+        if unsafe { heap::is_cons(pair) } {
+            let pair_key = unsafe { heap::car(pair) }.unwrap_or(LispyValue::NIL);
+            if values_equal(key, pair_key) {
+                return Ok(pair);
+            }
+        }
+        cur = unsafe { heap::cdr(cur) }.unwrap_or(LispyValue::NIL);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol operations (LANG52)
+// ---------------------------------------------------------------------------
+
+/// `(symbol-append sym1 sym2)` — intern the concatenation of both symbols'
+/// names as a new symbol (LANG52).
+///
+/// `(symbol-append 'foo 'bar)` → `foobar` (as a symbol).
+/// Useful in macro-expansion contexts where generated symbol names are
+/// built from component names.
+pub fn symbol_append(args: &[LispyValue]) -> Result<LispyValue, RuntimeError> {
+    if args.len() != 2 {
+        return Err(arity_error("symbol-append", 2, args.len()));
+    }
+    let id1 = args[0].as_symbol().ok_or_else(|| {
+        RuntimeError::TypeError(format!(
+            "symbol-append: first arg must be a symbol, got {}",
+            args[0]
+        ))
+    })?;
+    let id2 = args[1].as_symbol().ok_or_else(|| {
+        RuntimeError::TypeError(format!(
+            "symbol-append: second arg must be a symbol, got {}",
+            args[1]
+        ))
+    })?;
+    let name1 = crate::intern::name_of(id1).ok_or_else(|| {
+        RuntimeError::TypeError(format!("symbol-append: unknown symbol id {id1:?}"))
+    })?;
+    let name2 = crate::intern::name_of(id2).ok_or_else(|| {
+        RuntimeError::TypeError(format!("symbol-append: unknown symbol id {id2:?}"))
+    })?;
+    let combined = format!("{name1}{name2}");
+    let id = crate::intern::intern(&combined);
+    Ok(LispyValue::symbol(id))
 }
 
 // ---------------------------------------------------------------------------
@@ -1228,5 +1699,281 @@ mod tests {
     #[test]
     fn integer_to_char_is_identity() {
         assert_eq!(integer_to_char(&[i(65)]).unwrap(), i(65));
+    }
+
+    // ── Extended comparisons (LANG52) ────────────────────────────────
+
+    #[test]
+    fn le_basic() {
+        assert_eq!(le(&[i(1), i(2)]).unwrap(), LispyValue::TRUE);   // 1 ≤ 2
+        assert_eq!(le(&[i(2), i(2)]).unwrap(), LispyValue::TRUE);   // 2 ≤ 2
+        assert_eq!(le(&[i(3), i(2)]).unwrap(), LispyValue::FALSE);  // 3 ≤ 2 false
+    }
+
+    #[test]
+    fn ge_basic() {
+        assert_eq!(ge(&[i(2), i(1)]).unwrap(), LispyValue::TRUE);   // 2 ≥ 1
+        assert_eq!(ge(&[i(2), i(2)]).unwrap(), LispyValue::TRUE);   // 2 ≥ 2
+        assert_eq!(ge(&[i(1), i(2)]).unwrap(), LispyValue::FALSE);  // 1 ≥ 2 false
+    }
+
+    #[test]
+    fn le_ge_reject_wrong_arity() {
+        assert!(le(&[i(1)]).is_err());
+        assert!(ge(&[i(1), i(2), i(3)]).is_err());
+    }
+
+    // ── Extended arithmetic (LANG52) ─────────────────────────────────
+
+    #[test]
+    fn quotient_basic() {
+        // Same as truncating division.
+        assert_eq!(quotient(&[i(13), i(4)]).unwrap(), i(3));
+        assert_eq!(quotient(&[i(-13), i(4)]).unwrap(), i(-3));
+        assert_eq!(quotient(&[i(13), i(-4)]).unwrap(), i(-3));
+        assert_eq!(quotient(&[i(-13), i(-4)]).unwrap(), i(3));
+    }
+
+    #[test]
+    fn quotient_by_zero_errors() {
+        assert!(quotient(&[i(7), i(0)]).is_err());
+    }
+
+    #[test]
+    fn remainder_basic() {
+        // Sign matches dividend.
+        assert_eq!(remainder(&[i(13), i(4)]).unwrap(), i(1));
+        assert_eq!(remainder(&[i(-13), i(4)]).unwrap(), i(-1));
+        assert_eq!(remainder(&[i(13), i(-4)]).unwrap(), i(1));
+        assert_eq!(remainder(&[i(-13), i(-4)]).unwrap(), i(-1));
+    }
+
+    #[test]
+    fn remainder_by_zero_errors() {
+        assert!(remainder(&[i(5), i(0)]).is_err());
+    }
+
+    #[test]
+    fn modulo_basic() {
+        // Sign matches divisor (Scheme rule).
+        assert_eq!(modulo(&[i(13), i(4)]).unwrap(), i(1));
+        assert_eq!(modulo(&[i(-13), i(4)]).unwrap(), i(3));
+        assert_eq!(modulo(&[i(13), i(-4)]).unwrap(), i(-3));
+        assert_eq!(modulo(&[i(-13), i(-4)]).unwrap(), i(-1));
+    }
+
+    #[test]
+    fn modulo_by_zero_errors() {
+        assert!(modulo(&[i(7), i(0)]).is_err());
+    }
+
+    // ── Logic (LANG52) ────────────────────────────────────────────────
+
+    #[test]
+    fn boolean_p_true_for_bools() {
+        assert_eq!(boolean_p(&[LispyValue::TRUE]).unwrap(), LispyValue::TRUE);
+        assert_eq!(boolean_p(&[LispyValue::FALSE]).unwrap(), LispyValue::TRUE);
+        assert_eq!(boolean_p(&[LispyValue::NIL]).unwrap(), LispyValue::FALSE);
+        assert_eq!(boolean_p(&[i(0)]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn not_returns_logical_inverse() {
+        // Falsy inputs → #t
+        assert_eq!(not(&[LispyValue::FALSE]).unwrap(), LispyValue::TRUE);
+        assert_eq!(not(&[LispyValue::NIL]).unwrap(), LispyValue::TRUE);
+        // Truthy inputs → #f  (0 is truthy in Scheme!)
+        assert_eq!(not(&[LispyValue::TRUE]).unwrap(), LispyValue::FALSE);
+        assert_eq!(not(&[i(0)]).unwrap(), LispyValue::FALSE);
+        assert_eq!(not(&[i(42)]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn not_rejects_wrong_arity() {
+        assert!(not(&[]).is_err());
+        assert!(not(&[LispyValue::TRUE, LispyValue::FALSE]).is_err());
+    }
+
+    #[test]
+    fn equal_p_integers_by_value() {
+        assert_eq!(equal_p(&[i(7), i(7)]).unwrap(), LispyValue::TRUE);
+        assert_eq!(equal_p(&[i(7), i(8)]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn equal_p_strings_by_content() {
+        let s = |t: &str| heap::alloc_string(t.as_bytes());
+        assert_eq!(equal_p(&[s("abc"), s("abc")]).unwrap(), LispyValue::TRUE);
+        assert_eq!(equal_p(&[s("abc"), s("xyz")]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn equal_p_lists_structurally() {
+        // Two distinct allocations of (1 . 2) are equal?.
+        let a = heap::alloc_cons(i(1), i(2));
+        let b = heap::alloc_cons(i(1), i(2));
+        assert_eq!(equal_p(&[a, b]).unwrap(), LispyValue::TRUE);
+        // (1 2) vs (1 3) — differ in second element.
+        let xs = heap::alloc_cons(i(1), heap::alloc_cons(i(2), LispyValue::NIL));
+        let ys = heap::alloc_cons(i(1), heap::alloc_cons(i(3), LispyValue::NIL));
+        assert_eq!(equal_p(&[xs, ys]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn equal_p_symbols_by_identity() {
+        let id_a = intern("alpha");
+        let id_b = intern("beta");
+        let sa = LispyValue::symbol(id_a);
+        let sb = LispyValue::symbol(id_b);
+        assert_eq!(equal_p(&[sa, sa]).unwrap(), LispyValue::TRUE);
+        assert_eq!(equal_p(&[sa, sb]).unwrap(), LispyValue::FALSE);
+    }
+
+    // ── List operations (LANG52) ──────────────────────────────────────
+
+    #[test]
+    fn list_builds_proper_list() {
+        // (list 1 2 3) → (1 2 3)
+        let v = list(&[i(1), i(2), i(3)]).unwrap();
+        assert_eq!(unsafe { heap::car(v) }.unwrap(), i(1));
+        let tl = unsafe { heap::cdr(v) }.unwrap();
+        assert_eq!(unsafe { heap::car(tl) }.unwrap(), i(2));
+        let ttl = unsafe { heap::cdr(tl) }.unwrap();
+        assert_eq!(unsafe { heap::car(ttl) }.unwrap(), i(3));
+        assert!(unsafe { heap::cdr(ttl) }.unwrap().is_nil());
+    }
+
+    #[test]
+    fn list_empty_is_nil() {
+        assert_eq!(list(&[]).unwrap(), LispyValue::NIL);
+    }
+
+    #[test]
+    fn list_p_proper_list_is_true() {
+        let lst = list(&[i(1), i(2), i(3)]).unwrap();
+        assert_eq!(list_p(&[lst]).unwrap(), LispyValue::TRUE);
+        assert_eq!(list_p(&[LispyValue::NIL]).unwrap(), LispyValue::TRUE);
+    }
+
+    #[test]
+    fn list_p_dotted_pair_is_false() {
+        let pair = heap::alloc_cons(i(1), i(2)); // (1 . 2) — cdr is not nil
+        assert_eq!(list_p(&[pair]).unwrap(), LispyValue::FALSE);
+        assert_eq!(list_p(&[i(42)]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn length_of_proper_list() {
+        let lst = list(&[i(10), i(20), i(30)]).unwrap();
+        assert_eq!(length(&[lst]).unwrap(), i(3));
+        assert_eq!(length(&[LispyValue::NIL]).unwrap(), i(0));
+    }
+
+    #[test]
+    fn length_of_non_list_errors() {
+        let dotted = heap::alloc_cons(i(1), i(2));
+        assert!(length(&[dotted]).is_err());
+    }
+
+    #[test]
+    fn append_two_lists() {
+        let a = list(&[i(1), i(2)]).unwrap();
+        let b = list(&[i(3), i(4)]).unwrap();
+        let result = append(&[a, b]).unwrap();
+        assert_eq!(length(&[result]).unwrap(), i(4));
+        assert_eq!(list_ref(&[result, i(0)]).unwrap(), i(1));
+        assert_eq!(list_ref(&[result, i(3)]).unwrap(), i(4));
+    }
+
+    #[test]
+    fn append_empty_first() {
+        let b = list(&[i(1), i(2)]).unwrap();
+        let result = append(&[LispyValue::NIL, b]).unwrap();
+        assert_eq!(length(&[result]).unwrap(), i(2));
+    }
+
+    #[test]
+    fn reverse_reverses() {
+        let lst = list(&[i(1), i(2), i(3)]).unwrap();
+        let rev = reverse(&[lst]).unwrap();
+        assert_eq!(list_ref(&[rev, i(0)]).unwrap(), i(3));
+        assert_eq!(list_ref(&[rev, i(1)]).unwrap(), i(2));
+        assert_eq!(list_ref(&[rev, i(2)]).unwrap(), i(1));
+    }
+
+    #[test]
+    fn reverse_empty_is_nil() {
+        assert_eq!(reverse(&[LispyValue::NIL]).unwrap(), LispyValue::NIL);
+    }
+
+    #[test]
+    fn list_ref_indexes_correctly() {
+        let lst = list(&[i(10), i(20), i(30)]).unwrap();
+        assert_eq!(list_ref(&[lst, i(0)]).unwrap(), i(10));
+        assert_eq!(list_ref(&[lst, i(1)]).unwrap(), i(20));
+        assert_eq!(list_ref(&[lst, i(2)]).unwrap(), i(30));
+    }
+
+    #[test]
+    fn list_ref_out_of_bounds_errors() {
+        let lst = list(&[i(1)]).unwrap();
+        assert!(list_ref(&[lst, i(1)]).is_err());
+        assert!(list_ref(&[lst, i(-1)]).is_err());
+    }
+
+    #[test]
+    fn assoc_finds_key() {
+        // Build ((1 . a) (2 . b) (3 . c))
+        let sym_a = LispyValue::symbol(intern("a"));
+        let sym_b = LispyValue::symbol(intern("b"));
+        let sym_c = LispyValue::symbol(intern("c"));
+        let alist = list(&[
+            heap::alloc_cons(i(1), sym_a),
+            heap::alloc_cons(i(2), sym_b),
+            heap::alloc_cons(i(3), sym_c),
+        ]).unwrap();
+        let found = assoc(&[i(2), alist]).unwrap();
+        assert!(unsafe { heap::is_cons(found) });
+        assert_eq!(unsafe { heap::car(found) }.unwrap(), i(2));
+        assert_eq!(unsafe { heap::cdr(found) }.unwrap(), sym_b);
+    }
+
+    #[test]
+    fn assoc_not_found_returns_false() {
+        let pair = heap::alloc_cons(i(1), LispyValue::symbol(intern("x")));
+        let alist = list(&[pair]).unwrap();
+        assert_eq!(assoc(&[i(99), alist]).unwrap(), LispyValue::FALSE);
+    }
+
+    #[test]
+    fn assoc_empty_alist_returns_false() {
+        assert_eq!(assoc(&[i(1), LispyValue::NIL]).unwrap(), LispyValue::FALSE);
+    }
+
+    // ── Symbol operations (LANG52) ────────────────────────────────────
+
+    #[test]
+    fn symbol_append_combines_names() {
+        let foo = LispyValue::symbol(intern("foo"));
+        let bar = LispyValue::symbol(intern("bar"));
+        let result = symbol_append(&[foo, bar]).unwrap();
+        assert!(result.is_symbol());
+        let id = result.as_symbol().unwrap();
+        let name = crate::intern::name_of(id).unwrap();
+        assert_eq!(name, "foobar");
+    }
+
+    #[test]
+    fn symbol_append_rejects_non_symbol() {
+        let foo = LispyValue::symbol(intern("foo"));
+        assert!(symbol_append(&[foo, i(1)]).is_err());
+        assert!(symbol_append(&[i(1), foo]).is_err());
+    }
+
+    #[test]
+    fn symbol_append_rejects_wrong_arity() {
+        let foo = LispyValue::symbol(intern("foo"));
+        assert!(symbol_append(&[foo]).is_err());
+        assert!(symbol_append(&[]).is_err());
     }
 }

--- a/code/packages/rust/twig-folding-ranges/src/lib.rs
+++ b/code/packages/rust/twig-folding-ranges/src/lib.rs
@@ -66,7 +66,7 @@
 use std::fmt;
 
 use twig_parser::{
-    parse, Apply, Begin, Expr, Form, If, Lambda, Let, Program, TwigParseError,
+    parse, Apply, Begin, Expr, Form, If, Lambda, Let, LetStar, Program, TwigParseError,
 };
 
 // ---------------------------------------------------------------------------
@@ -186,6 +186,18 @@ fn descend_expr(out: &mut Vec<FoldingRange>, expr: &Expr) {
                 descend_expr(out, e);
             }
         }
+        // LANG52 — let* with sequential bindings; fold identical to let.
+        Expr::LetStar(LetStar { bindings, body, line, .. }) => {
+            let start = u32_of(*line);
+            let end = max_line_in_bindings(bindings).max(max_line_in_exprs(body));
+            push_if_multiline(out, start, end);
+            for (_n, e) in bindings {
+                descend_expr(out, e);
+            }
+            for e in body {
+                descend_expr(out, e);
+            }
+        }
         Expr::Begin(Begin { exprs, line, .. }) => {
             let start = u32_of(*line);
             let end = max_line_in_exprs(exprs);
@@ -252,6 +264,10 @@ fn max_line_in_expr(expr: &Expr) -> u32 {
             .max(max_line_in_expr(then_branch))
             .max(max_line_in_expr(else_branch)),
         Expr::Let(Let { bindings, body, line, .. }) => u32_of(*line)
+            .max(max_line_in_bindings(bindings))
+            .max(max_line_in_exprs(body)),
+        // LANG52 — let* max-line identical to let.
+        Expr::LetStar(LetStar { bindings, body, line, .. }) => u32_of(*line)
             .max(max_line_in_bindings(bindings))
             .max(max_line_in_exprs(body)),
         Expr::Begin(Begin { exprs, line, .. }) => u32_of(*line).max(max_line_in_exprs(exprs)),

--- a/code/packages/rust/twig-formatter/src/lib.rs
+++ b/code/packages/rust/twig-formatter/src/lib.rs
@@ -102,8 +102,8 @@ use format_doc::{
     LayoutOptions,
 };
 use twig_parser::{
-    parse, Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program,
-    StrLit, SymLit, TwigParseError, TypeAnnotation, TypeExpr, VarRef,
+    parse, Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, LetStar, NilLit,
+    Program, StrLit, SymLit, TwigParseError, TypeAnnotation, TypeExpr, VarRef,
 };
 
 // ---------------------------------------------------------------------------
@@ -363,6 +363,9 @@ fn expr_to_doc(expr: &Expr) -> Doc {
         Expr::VarRef(VarRef { name, .. }) => text(name.clone()),
         Expr::If(i) => if_to_doc(i),
         Expr::Let(l) => let_to_doc(l),
+        // LANG52 — let* with sequential bindings; same layout as let
+        // but opens with `(let* ` to preserve the sequential semantics.
+        Expr::LetStar(l) => let_star_to_doc(l),
         Expr::Begin(b) => begin_to_doc(b),
         Expr::Lambda(l) => lambda_to_doc(l),
         Expr::Apply(a) => apply_to_doc(a),
@@ -457,6 +460,39 @@ fn let_to_doc(l: &Let) -> Doc {
     }
     group(concat([
         text("(let "),
+        bindings_doc,
+        indent(concat(body_parts), 1),
+        text(")"),
+    ]))
+}
+
+/// Format `(let* ((x e1) (y e2)) body)` — layout identical to `let_to_doc`
+/// but uses `"(let* "` so sequential binding semantics are preserved.
+fn let_star_to_doc(l: &LetStar) -> Doc {
+    let bindings_doc = if l.bindings.is_empty() {
+        text("()")
+    } else {
+        let mut binding_parts: Vec<Doc> = Vec::with_capacity(l.bindings.len() * 2 - 1);
+        for (i, (name, expr)) in l.bindings.iter().enumerate() {
+            if i > 0 {
+                binding_parts.push(line());
+            }
+            binding_parts.push(group(concat([
+                text("("),
+                text(name.clone()),
+                indent(concat([line(), expr_to_doc(expr)]), 1),
+                text(")"),
+            ])));
+        }
+        concat([text("("), group(concat(binding_parts)), text(")")])
+    };
+    let mut body_parts: Vec<Doc> = Vec::with_capacity(l.body.len() * 2);
+    for e in &l.body {
+        body_parts.push(line());
+        body_parts.push(expr_to_doc(e));
+    }
+    group(concat([
+        text("(let* "),
         bindings_doc,
         indent(concat(body_parts), 1),
         text(")"),
@@ -636,6 +672,12 @@ mod tests {
                 column: 0,
             }),
             Expr::Let(l) => Expr::Let(Let {
+                bindings: l.bindings.iter().map(|(n, e)| (n.clone(), strip_expr(e))).collect(),
+                body: l.body.iter().map(strip_expr).collect(),
+                line: 0,
+                column: 0,
+            }),
+            Expr::LetStar(l) => Expr::LetStar(LetStar {
                 bindings: l.bindings.iter().map(|(n, e)| (n.clone(), strip_expr(e))).collect(),
                 body: l.body.iter().map(strip_expr).collect(),
                 line: 0,

--- a/code/packages/rust/twig-hover/src/lib.rs
+++ b/code/packages/rust/twig-hover/src/lib.rs
@@ -54,7 +54,8 @@ use std::fmt;
 
 use twig_document_symbols::{symbols_for_program, DocumentSymbol, SymbolKind};
 use twig_parser::{
-    parse, Apply, Begin, BoolLit, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program, StrLit,
+    parse, Apply, Begin, BoolLit, Expr, Form, If, IntLit, Lambda, Let, LetStar, NilLit, Program,
+    StrLit,
     SymLit, TwigParseError, VarRef,
 };
 
@@ -409,6 +410,17 @@ fn visit_expr(
         }
         Expr::Let(Let { bindings, body, line: l, column: c }) => {
             try_keyword(found, line, column, u32_of(*l), u32_of(*c).saturating_add(1), "let");
+            for (_n, e) in bindings {
+                visit_expr(e, line, column, symbols, found);
+            }
+            for e in body {
+                visit_expr(e, line, column, symbols, found);
+            }
+        }
+        // LANG52 — let* with sequential bindings; surface as the "let*" keyword
+        // and recurse into each binding RHS and each body expression.
+        Expr::LetStar(LetStar { bindings, body, line: l, column: c }) => {
+            try_keyword(found, line, column, u32_of(*l), u32_of(*c).saturating_add(1), "let*");
             for (_n, e) in bindings {
                 visit_expr(e, line, column, symbols, found);
             }

--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,19 +1,45 @@
 # Changelog — twig-ir-compiler
 
-## [0.7.0] — 2026-05-14
+## [0.8.0] — 2026-05-14
 
-### Added (LANG51 — String literals)
+### Added (LANG52 — stdlib completeness + LANG51 string literals)
 
-- `Expr::StrLit` arm in `compile_expr_inner` — lowers a double-quoted string
-  literal to `const(Operand::Str(value))` with `type_hint = "str"`.
-  The VM's `exec_const` already handles `Operand::Str` by calling
-  `lispy_runtime::heap::alloc_string` (no VM changes needed — infrastructure
-  was present from LANG47).
-- `StrLit` added to the `use twig_parser::{ … }` import list.
-- `Expr::StrLit` added to `free_vars.rs` as a leaf (no captured variables).
-- 9 new unit tests covering: basic string, empty string, escaped quote,
-  newline escape, all basic escapes, `type_hint = "str"`, string as argument,
-  `compile_typed_source` round-trip, string in lambda closure.
+#### LANG51: string literal lowering
+
+- **`Expr::StrLit` → `const(Operand::Str(value)) : "str"`** — string literals compile to a
+  `const` instruction with `Operand::Str` payload and `type_hint = "str"`.  The VM's
+  `exec_const` handler (introduced in LANG47) materialises this as a `LangString` heap object.
+- `Expr::StrLit` added to the leaf-atom arm of `free_vars.rs` (never a free variable).
+
+#### LANG52: `let*` sequential bindings
+
+- **`Expr::LetStar` → `compile_let_star`** — sequential bindings: each RHS is compiled in a
+  scope extended by all prior names.  Each binding gets a fresh register allocated via
+  `_move`; the body is compiled after all bindings are live.
+- **`free_vars.rs` Expr::LetStar walk** — incremental bound-set extension mirrors the
+  compiler's sequential scoping exactly (each name bound before the next RHS).
+
+#### LANG52: `and` / `or` special forms (short-circuit)
+
+- **`(and e₁ e₂ …)`** — intercepted in `compile_apply` before the builtin-resolution path.
+  Lowered to: evaluate `e₁`, branch on `jmp_if_false`, evaluate tail with
+  recursive `compile_and`, merge into shared result register via `_move`.
+  `(and)` → `#t`; `(and e)` → `e`.
+- **`(or e₁ e₂ …)`** — similar pattern.  `(or)` → `#f`; `(or e)` → `e`.
+- Neither `and` nor `or` is in the `BUILTINS` constant — they never reach the
+  `resolve_builtin` path.
+
+#### LANG52: expanded BUILTINS constant
+
+Added to the `BUILTINS: &[&str]` array (used for higher-order closure wrapping):
+`<=`, `>=`, `modulo`, `remainder`, `quotient`, `not`, `boolean?`, `equal?`,
+`list`, `list?`, `length`, `append`, `reverse`, `list-ref`, `assoc`,
+`symbol-append`, `host/write_string`, `host/read_line`, `host/read_file`.
+
+## [0.7.0] — 2026-05-14 (LANG51 — string literal lowering, included here)
+
+*Note: 0.7.0 was the planned standalone LANG51 release; changes are rolled into 0.8.0
+above since LANG52 depends on LANG51 and both land together.*
 
 ## [0.6.0] — 2026-05-14
 

--- a/code/packages/rust/twig-ir-compiler/Cargo.toml
+++ b/code/packages/rust/twig-ir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "twig-ir-compiler"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
-description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler.  LANG50: compile_typed_source uses grammar-type-checker annotations to populate type_hint fields."
+description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler.  LANG52: let*, and/or special forms, expanded builtin set."
 
 [dependencies]
 twig-parser        = { path = "../twig-parser" }

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -75,7 +75,10 @@ use interpreter_ir::{
 use lang_refined_types::{Kind, Predicate, RefinedType};
 
 use twig_parser::{
-    Apply, Begin, BoolLit, Expr, Form, If, IntLit, Lambda, Let, Match, MatchPat, NilLit, Program,
+    Apply, Begin, BoolLit, Expr, Form, If, IntLit, Lambda, Let,
+    // LANG52: sequential let* bindings
+    LetStar,
+    Match, MatchPat, NilLit, Program,
     RecordDef, StrLit, SymLit, TypeAnnotation, UnionDef, VarRef,
 };
 
@@ -146,14 +149,26 @@ pub const MAX_COMPILE_DEPTH: usize = 256;
 // ---------------------------------------------------------------------------
 
 const BUILTINS: &[&str] = &[
-    // Arithmetic / comparison
+    // Arithmetic / comparison (TW00 core)
     "+", "-", "*", "/", "=", "<", ">",
+    // LANG52: extended comparisons and arithmetic
+    "<=", ">=", "modulo", "remainder", "quotient",
     // Cons cells
     "cons", "car", "cdr",
-    // Predicates
+    // Predicates (TW00 core)
     "null?", "pair?", "number?", "symbol?",
+    // LANG52: boolean and type predicates
+    "not", "boolean?",
+    // LANG52: structural equality
+    "equal?",
+    // LANG52: list stdlib
+    "list", "length", "append", "reverse", "list-ref", "assoc", "list?",
+    // LANG52: symbol utilities
+    "symbol-append",
     // I/O
     "print",
+    // Host I/O (LANG52) — these dispatch via call_builtin to exec_host_call
+    "host/write_string", "host/read_line", "host/read_file",
 ];
 
 fn is_builtin(name: &str) -> bool {
@@ -695,6 +710,9 @@ impl Compiler {
 
             Expr::Let(l) => self.compile_let(l, ctx),
 
+            // LANG52: sequential let* — compile via compile_let_star.
+            Expr::LetStar(l) => self.compile_let_star(l, ctx),
+
             Expr::Lambda(l) => self.compile_anonymous_lambda(l, ctx),
 
             Expr::Apply(a) => self.compile_apply(a, ctx),
@@ -863,8 +881,194 @@ impl Compiler {
         Ok(last)
     }
 
+    /// LANG52: compile `(let* ((x e1) (y e2) ...) body+)`.
+    ///
+    /// Unlike `compile_let`, each binding's RHS is compiled AFTER the previous
+    /// binding is added to locals — so each name is in scope for all subsequent
+    /// RHSs.  This is Scheme `let*` semantics.
+    ///
+    /// ```text
+    /// ; (let* ((a 1) (b (+ a 1))) b)
+    /// const  %n0  = 1              ; compile a=1 in outer scope
+    /// _move  a    ← %n0           ; bind 'a' into locals (now in scope)
+    /// call_builtin +, a, 1 → %n1  ; compile b=(+ a 1) — 'a' is visible
+    /// _move  b    ← %n1           ; bind 'b' into locals
+    /// ret    b
+    /// ```
+    fn compile_let_star(&mut self, expr: &LetStar, ctx: &mut FnCtx) -> Result<String, TwigCompileError> {
+        let loc = SourceLoc::new(expr.line, expr.column);
+        let mut added: Vec<String> = Vec::new();
+
+        for (name, rhs) in &expr.bindings {
+            // Compile the RHS in the current scope (which already includes
+            // all prior let* bindings).
+            let v = self.compile_expr(rhs, ctx)?;
+
+            // Bind the name into locals BEFORE compiling the next binding.
+            if ctx.locals.insert(name.clone()) {
+                added.push(name.clone());
+            }
+            ctx.emit(IIRInstr::new(
+                "call_builtin",
+                Some(name.clone()),
+                vec![Operand::Var("_move".into()), Operand::Var(v)],
+                "any",
+            ), loc);
+        }
+
+        // Compile body — parser-enforced at least one expression.
+        let mut last: Option<String> = None;
+        for e in &expr.body {
+            last = Some(self.compile_expr(e, ctx)?);
+        }
+        let last = last.expect("parser rejects empty let* body");
+
+        // Remove bindings so they don't leak into enclosing scope peers.
+        for n in added {
+            ctx.locals.remove(&n);
+        }
+        Ok(last)
+    }
+
+    // ── LANG52: and / or compile-time special forms ───────────────────────────
+
+    /// Compile `(and args…)` with short-circuit semantics.
+    ///
+    /// Expansion rules (PEG-style, applied left-to-right):
+    ///   `(and)`         → emit `const #t`, return the register
+    ///   `(and e)`       → compile e, return its register
+    ///   `(and e1 e2 …)` → compile e1; if truthy, evaluate `(and e2 …)`; else `#f`
+    ///
+    /// The result register holds the value of the last evaluated sub-expression,
+    /// or `#f` if any sub-expression was falsy.  This matches Scheme semantics.
+    ///
+    /// IIR pattern (mirrors `compile_if`):
+    ///   `jmp_if_false cond, else_label`
+    ///   then-path: compile rest, _move into dest, jmp end
+    ///   else-path: label else_label; const #f, _move into dest
+    ///   label end_label
+    fn compile_and(&mut self, args: &[Expr], ctx: &mut FnCtx, loc: SourceLoc) -> Result<String, TwigCompileError> {
+        match args {
+            [] => {
+                // (and) → #t
+                let v = ctx.fresh_var("and");
+                ctx.emit(IIRInstr::new("const", Some(v.clone()), vec![Operand::Bool(true)], "any"), loc);
+                Ok(v)
+            }
+            [e] => {
+                // (and e) → e
+                self.compile_expr(e, ctx)
+            }
+            [first, rest @ ..] => {
+                // (and e1 e2 …) → if e1 then (and e2 …) else #f
+                let cond = self.compile_expr(first, ctx)?;
+                let dest = ctx.fresh_var("and");
+                let else_label = ctx.fresh_label("and_else");
+                let end_label  = ctx.fresh_label("and_end");
+
+                // jmp_if_false cond → else_label
+                ctx.emit(IIRInstr::new("jmp_if_false", None,
+                    vec![Operand::Var(cond), Operand::Var(else_label.clone())],
+                    "void"), loc);
+
+                // Then path: compile rest, copy to dest, jump to end.
+                let then_val = self.compile_and(rest, ctx, loc)?;
+                ctx.emit(IIRInstr::new("call_builtin", Some(dest.clone()),
+                    vec![Operand::Var("_move".into()), Operand::Var(then_val)], "any"), loc);
+                ctx.emit(IIRInstr::new("jmp", None, vec![Operand::Var(end_label.clone())], "void"), loc);
+
+                // Else path: dest ← #f
+                ctx.emit(IIRInstr::new("label", None, vec![Operand::Var(else_label)], "void"), loc);
+                let false_tmp = ctx.fresh_var("f");
+                ctx.emit(IIRInstr::new("const", Some(false_tmp.clone()), vec![Operand::Bool(false)], "any"), loc);
+                ctx.emit(IIRInstr::new("call_builtin", Some(dest.clone()),
+                    vec![Operand::Var("_move".into()), Operand::Var(false_tmp)], "any"), loc);
+
+                ctx.emit(IIRInstr::new("label", None, vec![Operand::Var(end_label)], "void"), loc);
+                Ok(dest)
+            }
+        }
+    }
+
+    /// Compile `(or args…)` with short-circuit semantics.
+    ///
+    /// Expansion rules:
+    ///   `(or)`          → emit `const #f`, return the register
+    ///   `(or e)`        → compile e, return its register
+    ///   `(or e1 e2 …)`  → evaluate e1; if truthy return it, else `(or e2 …)`
+    ///
+    /// The result register holds the first truthy value, or the value of the
+    /// last sub-expression if all were falsy.  This matches Scheme semantics.
+    fn compile_or(&mut self, args: &[Expr], ctx: &mut FnCtx, loc: SourceLoc) -> Result<String, TwigCompileError> {
+        match args {
+            [] => {
+                // (or) → #f
+                let v = ctx.fresh_var("or");
+                ctx.emit(IIRInstr::new("const", Some(v.clone()), vec![Operand::Bool(false)], "any"), loc);
+                Ok(v)
+            }
+            [e] => {
+                // (or e) → e
+                self.compile_expr(e, ctx)
+            }
+            [first, rest @ ..] => {
+                // (or e1 e2 …): if e1 is truthy return e1, else (or e2 …)
+                let cond = self.compile_expr(first, ctx)?;
+                let dest = ctx.fresh_var("or");
+                let falsy_label = ctx.fresh_label("or_falsy");
+                let end_label   = ctx.fresh_label("or_end");
+
+                // jmp_if_false cond → falsy_label (i.e. if cond is FALSE, skip)
+                ctx.emit(IIRInstr::new("jmp_if_false", None,
+                    vec![Operand::Var(cond.clone()), Operand::Var(falsy_label.clone())],
+                    "void"), loc);
+
+                // Truthy path: dest ← cond, jump to end.
+                ctx.emit(IIRInstr::new("call_builtin", Some(dest.clone()),
+                    vec![Operand::Var("_move".into()), Operand::Var(cond)], "any"), loc);
+                ctx.emit(IIRInstr::new("jmp", None, vec![Operand::Var(end_label.clone())], "void"), loc);
+
+                // Falsy path: evaluate rest.
+                ctx.emit(IIRInstr::new("label", None, vec![Operand::Var(falsy_label)], "void"), loc);
+                let rest_val = self.compile_or(rest, ctx, loc)?;
+                ctx.emit(IIRInstr::new("call_builtin", Some(dest.clone()),
+                    vec![Operand::Var("_move".into()), Operand::Var(rest_val)], "any"), loc);
+
+                ctx.emit(IIRInstr::new("label", None, vec![Operand::Var(end_label)], "void"), loc);
+                Ok(dest)
+            }
+        }
+    }
+
     fn compile_apply(&mut self, expr: &Apply, ctx: &mut FnCtx) -> Result<String, TwigCompileError> {
         let loc = SourceLoc::new(expr.line, expr.column);
+        // ── LANG52: `and` / `or` short-circuit special forms ─────────────────
+        //
+        // `and` and `or` require short-circuit evaluation — the second argument
+        // must NOT be evaluated when the first is sufficient.  We intercept them
+        // at the apply site and lower them inline to `if` chains.  They do NOT
+        // appear in BUILTINS and never reach the runtime.
+        //
+        // | Expression      | Expansion                         |
+        // |-----------------|-----------------------------------|
+        // | (and)           | #t                                |
+        // | (and e)         | e                                 |
+        // | (and e1 e2 …)   | (if e1 (and e2 …) #f)            |
+        // | (or)            | #f                                |
+        // | (or e)          | e                                 |
+        // | (or e1 e2 …)    | emit cond-reg; if cond-reg return |
+        //
+        // The expansions are done recursively by re-entering compile_apply
+        // so the depth counter naturally bounds them.
+        if let Expr::VarRef(v) = expr.fn_expr.as_ref() {
+            if v.name == "and" {
+                return self.compile_and(&expr.args, ctx, loc);
+            }
+            if v.name == "or" {
+                return self.compile_or(&expr.args, ctx, loc);
+            }
+        }
+
         // Direct call: fn is a VarRef whose name is a top-level
         // function or a builtin.  We materialise this decision at
         // compile time so the hot path stays a single `call`.

--- a/code/packages/rust/twig-ir-compiler/src/free_vars.rs
+++ b/code/packages/rust/twig-ir-compiler/src/free_vars.rs
@@ -20,7 +20,10 @@
 
 use std::collections::HashSet;
 
-use twig_parser::{Apply, Begin, Expr, If, Lambda, Let};
+use twig_parser::{Apply, Begin, Expr, If, Lambda, Let,
+    // LANG52: sequential let* bindings
+    LetStar,
+};
 
 /// Maximum AST depth the walker will descend before bailing out.
 ///
@@ -113,6 +116,26 @@ fn walk(
             }
             let mut added: Vec<String> = Vec::new();
             for (n, _) in bindings {
+                if bound.insert(n.clone()) {
+                    added.push(n.clone());
+                }
+            }
+            for e in body {
+                walk(e, bound, globals, found, seen, depth);
+            }
+            for n in added {
+                bound.remove(&n);
+            }
+        }
+
+        // LANG52: let* — each RHS is in scope of all prior bindings, so we
+        // bind incrementally as we walk.
+        Expr::LetStar(LetStar { bindings, body, .. }) => {
+            let mut added: Vec<String> = Vec::new();
+            for (n, rhs) in bindings {
+                // The RHS is walked BEFORE the name is bound — same as the
+                // compiler: each binding sees all *prior* names, but not itself.
+                walk(rhs, bound, globals, found, seen, depth);
                 if bound.insert(n.clone()) {
                     added.push(n.clone());
                 }

--- a/code/packages/rust/twig-parser/CHANGELOG.md
+++ b/code/packages/rust/twig-parser/CHANGELOG.md
@@ -1,26 +1,39 @@
 # Changelog — twig-parser
 
-## [0.5.0] — 2026-05-14 — LANG51 string literals
+## [0.6.0] — 2026-05-14 — LANG51 string literals + LANG52 let*
 
 ### Added
 
-- `StrLit { value: String, line, column }` AST node — represents a
-  double-quoted string literal such as `"hello"` or `"say \"hi\"\n"`.
-- `Expr::StrLit(StrLit)` variant — added between `SymLit` and `VarRef` so that
-  match exhaustiveness checks catch all Expr variants immediately.
-- `Expr::pos()` arm for `StrLit`.
+#### LANG51: `StrLit` AST node and STRING grammar rule
+
+- **`pub struct StrLit { value: String, line, column }`** — new AST node representing a
+  string literal.  The `value` field contains the decoded string content (escape sequences
+  already processed by the GrammarLexer before the token reaches the extractor).
+- **`Expr::StrLit(StrLit)`** — new variant in the `Expr` enum; `Expr::pos()` covers it.
+- **Grammar**: `atom = STRING | INTEGER | ...` — the STRING token (regex `/"([^"\]|\.)*"/`)
+  precedes INTEGER so the lexer matches double-quoted strings first.
+- **`extract_atom`**: `"STRING"` case calls `tok.value.clone()` directly; the GrammarLexer's
+  `process_escapes` already strips surrounding quotes and decodes `
+`, `	`, `\`, `\"`.
+- **`type_decls.rs`**: `Expr::StrLit(_) => KindDecl::Str` — string literals have kind `Str`.
 - `lib.rs` re-exports `StrLit`.
-- `extract_atom` handles `"STRING"` token type.  The GrammarLexer pre-decodes
-  escape sequences and strips surrounding quotes before the token reaches the
-  parser, so `extract_atom` uses `tok.value` directly as the decoded content.
-- `expr_to_kind` in `type_decls.rs` returns `KindDecl::Str` for `Expr::StrLit`.
-- `twig.grammar` atom rule: `atom = STRING | INTEGER | BOOL_TRUE | BOOL_FALSE | "nil" | NAME ;`
-- `twig.tokens`: `STRING = /"([^"\\]|\\.)*"/` added before `INTEGER`.
 
-### Changed
+#### LANG52: `LetStar` AST node and `let*` grammar rule
 
-- Removed draft `decode_string_escapes` helper from `ast_extract.rs` (the
-  GrammarLexer's `process_escapes` already handles the same escapes).
+- **`pub struct LetStar { bindings: Vec<(String, Expr)>, body: Vec<Expr>, line, column }`** —
+  sequential `let*` bindings; each binding's RHS is evaluated in a scope extended by all
+  prior binding names (unlike `let` where all RHS expressions see only the outer scope).
+- **`Expr::LetStar(LetStar)`** — new variant; `Expr::pos()` covers it.
+- **Grammar**: `let_star_form` rule added to `compound`; `let*` promoted to a keyword so the
+  lexer wins over the `NAME` pattern (asterisk is valid in a NAME).
+- **`extract_let_star`**: walks child nodes; requires at least one body expression.
+- **`type_decls.rs`**: `Expr::LetStar(_)` added to the `Any` fallback arm.
+- `lib.rs` re-exports `LetStar`.
+
+### Note on version numbering
+
+0.5.0 was the planned standalone LANG51 release; both LANG51 and LANG52 land here as 0.6.0
+since LANG52 depends on LANG51 and they ship together.
 
 ## [0.4.0] — 2026-05-14 — LANG48 TW05-A typed syntax
 

--- a/code/packages/rust/twig-parser/Cargo.toml
+++ b/code/packages/rust/twig-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-parser"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Twig (Lisp-precursor) parser — thin wrapper over GrammarParser plus a typed-AST extractor; grammar is build-time-compiled to Rust via grammar_tools::codegen"
 build = "build.rs"

--- a/code/packages/rust/twig-parser/src/ast_extract.rs
+++ b/code/packages/rust/twig-parser/src/ast_extract.rs
@@ -44,7 +44,10 @@ use lexer::token::Token;
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 
 use crate::ast_nodes::{
-    Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, Match, MatchArm, MatchPat,
+    Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let,
+    // LANG52: sequential let* bindings
+    LetStar,
+    Match, MatchArm, MatchPat,
     ModuleInfo, NilLit, Program, RecordDef, RecordField, SymLit, TypeAlias, TypeAnnotation,
     TypeExpr, TypedMode, UnionDef, UnionVariant, VarRef,
 };
@@ -1183,9 +1186,11 @@ fn extract_compound(node: &GrammarASTNode, depth: usize) -> Result<Expr, TwigPar
             column,
         })?;
     match inner.rule_name.as_str() {
-        "if_form"     => Ok(Expr::If(extract_if(inner, depth + 1)?)),
-        "let_form"    => Ok(Expr::Let(extract_let(inner, depth + 1)?)),
-        "begin_form"  => Ok(Expr::Begin(extract_begin(inner, depth + 1)?)),
+        "if_form"        => Ok(Expr::If(extract_if(inner, depth + 1)?)),
+        "let_form"       => Ok(Expr::Let(extract_let(inner, depth + 1)?)),
+        // LANG52: let* form — sequential bindings
+        "let_star_form"  => Ok(Expr::LetStar(extract_let_star(inner, depth + 1)?)),
+        "begin_form"     => Ok(Expr::Begin(extract_begin(inner, depth + 1)?)),
         "lambda_form" => Ok(Expr::Lambda(extract_lambda(inner, depth + 1)?)),
         "quote_form"  => Ok(Expr::SymLit(extract_quote_form(inner)?)),
         "match_form"  => Ok(Expr::Match(extract_match(inner, depth + 1)?)),
@@ -1238,6 +1243,33 @@ fn extract_let(node: &GrammarASTNode, depth: usize) -> Result<Let, TwigParseErro
         });
     }
     Ok(Let { bindings, body, line, column })
+}
+
+/// LANG52: extract `(let* ((x e1) (y e2) ...) body+)`.
+///
+/// The shape is identical to `(let ...)` — same grammar rule structure,
+/// same `binding` children, same `expr` body children.  The semantic
+/// difference (sequential vs. parallel binding) is handled by the
+/// IR compiler, not the extractor.
+fn extract_let_star(node: &GrammarASTNode, depth: usize) -> Result<LetStar, TwigParseError> {
+    let (line, column) = pos(node);
+    let mut bindings: Vec<(String, Expr)> = Vec::new();
+    let mut body: Vec<Expr> = Vec::new();
+    for child in ast_children(node) {
+        match child.rule_name.as_str() {
+            "binding" => bindings.push(extract_binding(child, depth + 1)?),
+            "expr" => body.push(extract_expr(child, depth + 1)?),
+            _ => {}
+        }
+    }
+    if body.is_empty() {
+        return Err(TwigParseError {
+            message: "(let* (...) ...) needs at least one body expression".into(),
+            line,
+            column,
+        });
+    }
+    Ok(LetStar { bindings, body, line, column })
 }
 
 fn extract_binding(

--- a/code/packages/rust/twig-parser/src/ast_nodes.rs
+++ b/code/packages/rust/twig-parser/src/ast_nodes.rs
@@ -467,6 +467,20 @@ pub struct Let {
     pub column: usize,
 }
 
+/// `(let* ((x e1) (y e2) ...) body+)` — LANG52 sequential bindings.
+///
+/// Each RHS is evaluated in a scope that includes all *prior* bindings.
+/// This is Scheme `let*`, not plain `let`.
+///
+/// Example: `(let* ((a 1) (b (+ a 1))) b)` → 2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LetStar {
+    pub bindings: Vec<(String, Expr)>,
+    pub body: Vec<Expr>,
+    pub line: usize,
+    pub column: usize,
+}
+
 /// `(begin e1 e2 ...)` — sequencing.  Returns the value of the final expression.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Begin {
@@ -553,6 +567,8 @@ pub enum Expr {
     VarRef(VarRef),
     If(If),
     Let(Let),
+    /// `(let* ((x e1) (y (+ x 1)) …) body+)` — sequential bindings (LANG52).
+    LetStar(LetStar),
     Begin(Begin),
     Lambda(Lambda),
     Apply(Apply),
@@ -572,6 +588,7 @@ impl Expr {
             Expr::VarRef(v) => (v.line, v.column),
             Expr::If(i) => (i.line, i.column),
             Expr::Let(l) => (l.line, l.column),
+            Expr::LetStar(l) => (l.line, l.column),
             Expr::Begin(b) => (b.line, b.column),
             Expr::Lambda(l) => (l.line, l.column),
             Expr::Apply(a) => (a.line, a.column),

--- a/code/packages/rust/twig-parser/src/lib.rs
+++ b/code/packages/rust/twig-parser/src/lib.rs
@@ -105,7 +105,10 @@ pub use ast_extract::{
 pub use type_decls::emit_type_declarations;
 pub use ast_nodes::{
     // ── Atoms ─────────────────────────────────────────────────────────────
-    Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program,
+    Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let,
+    // LANG52: sequential let* bindings
+    LetStar,
+    NilLit, Program,
     // LANG51: string literal AST node
     StrLit, SymLit,
     TypeAnnotation, VarRef,

--- a/code/packages/rust/twig-parser/src/type_decls.rs
+++ b/code/packages/rust/twig-parser/src/type_decls.rs
@@ -297,6 +297,8 @@ fn expr_to_kind(expr: &Expr) -> KindDecl {
         | Expr::Apply(_)
         | Expr::If(_)
         | Expr::Let(_)
+        // LANG52: let* has the same fallback as let — runtime-dependent.
+        | Expr::LetStar(_)
         | Expr::Begin(_)
         | Expr::Match(_) => KindDecl::Any,
     }

--- a/code/packages/rust/twig-semantic-tokens/src/lib.rs
+++ b/code/packages/rust/twig-semantic-tokens/src/lib.rs
@@ -67,8 +67,8 @@
 use std::fmt;
 
 use twig_parser::{
-    parse, Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program,
-    StrLit, SymLit, TwigParseError, VarRef,
+    parse, Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, LetStar, NilLit,
+    Program, StrLit, SymLit, TwigParseError, VarRef,
 };
 
 // ---------------------------------------------------------------------------
@@ -285,6 +285,21 @@ fn emit_expr(out: &mut Vec<SemanticToken>, expr: &Expr) {
             // accuracy.  Most consumers will instead rely on the
             // VarRef colouring for the binding's body usages, which
             // we DO emit accurately.
+            for (_name, expr) in bindings {
+                emit_expr(out, expr);
+            }
+            for e in body {
+                emit_expr(out, e);
+            }
+            let _ = (l, c);
+        }
+        // LANG52 — let* with sequential bindings.  Emit "let*" as a keyword,
+        // then recurse into binding RHS expressions and body.  Same position
+        // caveat as Let: binding names are emitted with column 0 sentinel.
+        Expr::LetStar(LetStar { bindings, body, line, column }) => {
+            let l = u32_of(*line);
+            let c = u32_of(*column);
+            push_keyword(out, l, c.saturating_add(1), "let*");
             for (_name, expr) in bindings {
                 emit_expr(out, expr);
             }

--- a/code/packages/rust/twig-type-checker/CHANGELOG.md
+++ b/code/packages/rust/twig-type-checker/CHANGELOG.md
@@ -1,12 +1,26 @@
 # Changelog — twig-type-checker
 
-## [0.3.0] — 2026-05-14
+## [0.4.0] — 2026-05-14
 
-### Added (LANG51 — String literals)
+### Added (LANG51 + LANG52 — string literal and let* type inference)
 
-- `literal_kind` in `profile.rs`: `"STRING"` token → `Some(KindDecl::Str)`.
-  The comment on the `atom` grammar rule has been updated to include `STRING`.
-- `infer_expr` in `check.rs`: `Expr::StrLit` arm → `TwigKind::Str`.
+#### LANG51: `TwigKind::Str` for string literals
+
+- **`infer_expr` `Expr::StrLit` arm** — returns `TwigKind::Str`.  String literals propagate
+  their type through the entire inference pass.
+- **`profile.rs` `literal_kind`** — `"STRING"` token maps to `Some(KindDecl::Str)`, enabling
+  the grammar-type-checker profile to classify string literal tokens as `Str`.
+
+#### LANG52: `let*` sequential binding inference
+
+- **`infer_let_star`** — new helper function; pushes a new scope frame, then for each
+  binding: infers the RHS type, binds the name in the current scope (so subsequent
+  bindings see it), and infers the body.  Returns the type of the last body expression.
+- **`Expr::LetStar` arm** — dispatches to `infer_let_star`.
+
+### Note on version numbering
+
+0.3.0 was the planned standalone LANG51 release; both LANG51 and LANG52 land here as 0.4.0.
 
 ## [0.2.0] — 2026-05-14
 

--- a/code/packages/rust/twig-type-checker/Cargo.toml
+++ b/code/packages/rust/twig-type-checker/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name        = "twig-type-checker"
-version     = "0.3.0"
+version     = "0.4.0"
 edition     = "2021"
-description = "Base static type checker for Twig (TW05-B / LANG50).  Exposes two paths: type_check_source (GrammarASTNode + grammar-type-checker) for AOT/JIT annotation, and check_program (typed Program) for backward compatibility."
+description = "Base static type checker for Twig (TW05-B / LANG50 / LANG52).  Exposes two paths: type_check_source (GrammarASTNode + grammar-type-checker) for AOT/JIT annotation, and check_program (typed Program) for backward compatibility."
 
 [dependencies]
 twig-parser           = { path = "../twig-parser" }

--- a/code/packages/rust/twig-type-checker/src/check.rs
+++ b/code/packages/rust/twig-type-checker/src/check.rs
@@ -44,7 +44,10 @@
 //! that any sub-call can append to.
 
 use twig_parser::{
-    Apply, Begin, Define, Expr, Form, If, Lambda, Let, Match, MatchPat, Program, TypedMode,
+    Apply, Begin, Define, Expr, Form, If, Lambda, Let,
+    // LANG52: sequential let* bindings
+    LetStar,
+    Match, MatchPat, Program, TypedMode,
 };
 use type_checker_protocol::TypeErrorDiagnostic;
 
@@ -177,6 +180,13 @@ pub fn infer_expr(
 
         // ── Let binding ─────────────────────────────────────────────────────
         Expr::Let(let_expr) => infer_let(let_expr, env, scope, mode, errors),
+
+        // ── Sequential let* binding (LANG52) ─────────────────────────────────
+        //
+        // For type checking purposes, let* behaves like a chain of nested lets.
+        // We walk each binding's RHS in the scope that includes all prior
+        // bindings, then walk the body in the full accumulated scope.
+        Expr::LetStar(let_star) => infer_let_star(let_star, env, scope, mode, errors),
 
         // ── Sequencing ──────────────────────────────────────────────────────
         Expr::Begin(begin) => infer_begin(begin, env, scope, mode, errors),
@@ -387,6 +397,40 @@ fn infer_let(
     // Step 5: pop frame.
     scope.pop_frame();
 
+    last_kind
+}
+
+// ---------------------------------------------------------------------------
+// LetStar (LANG52)
+// ---------------------------------------------------------------------------
+
+/// Infer a `(let* ((x e1) (y e2) …) body+)` expression.
+///
+/// Unlike `infer_let`, each binding's RHS is evaluated in the scope that
+/// includes all *prior* bindings.  Modelled as a single push-frame followed
+/// by incremental binding additions.
+fn infer_let_star(
+    let_star: &LetStar,
+    env: &TypeEnv,
+    scope: &mut ScopeStack,
+    mode: &TypedMode,
+    errors: &mut Vec<TypeErrorDiagnostic>,
+) -> TwigKind {
+    scope.push_frame();
+
+    // Evaluate each RHS in the accumulated scope, then immediately bind.
+    for (name, rhs) in &let_star.bindings {
+        let kind = infer_expr(rhs, env, scope, mode, errors);
+        scope.bind(name, kind);
+    }
+
+    // Infer body.
+    let mut last_kind = TwigKind::Any;
+    for e in &let_star.body {
+        last_kind = infer_expr(e, env, scope, mode, errors);
+    }
+
+    scope.pop_frame();
     last_kind
 }
 

--- a/code/packages/rust/twig-vm/CHANGELOG.md
+++ b/code/packages/rust/twig-vm/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — twig-vm
 
+## [0.12.0] — 2026-05-14
+
+### Added (LANG52 — Host I/O stdlib)
+
+Three new `host/<capability>` arms in `exec_host_call` bridge Twig programs to OS-level I/O:
+
+#### `host/write_string` (IIR: `call_builtin "host/write_string" <string_reg>`)
+
+Write the UTF-8 bytes of a `LangString` heap value to stdout.  The argument must be a string
+value (class tag `CLASS_STRING = 3`).  This is the idiomatic way for Twig programs to print
+string data; `host/write_byte` remains available for byte-level I/O.
+
+#### `host/read_line` (IIR: `call_builtin "host/read_line" → dest`)
+
+Read one line from stdin (using `BufRead::read_line`).  The trailing `\n` (and `\r\n` on
+Windows) is stripped before the content is allocated as a heap string and stored in `dest`.
+Returns an empty heap string on EOF.
+
+#### `host/read_file` (IIR: `call_builtin "host/read_file" <path_reg> → dest`)
+
+Read the entire contents of the file at the path given by the string argument.  The contents
+are returned as a heap string.  OS errors propagate as `RunError::HostIo`.
+
+#### `host_arg_string` helper
+
+New private helper function mirroring `host_arg_int` for string arguments.  Extracts the
+`&'static [u8]` byte slice from a `LangString` heap object at a given argument position in
+an IIR instruction.  Returns `RunError::HostArgType` on type mismatch.
+
 ## [0.11.0] — 2026-05-14
 
 ### Added (LANG47 — String Heap Objects and Builtins)

--- a/code/packages/rust/twig-vm/Cargo.toml
+++ b/code/packages/rust/twig-vm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "twig-vm"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
-description = "LANG47 — string heap objects (LangString) and string/char builtins in the dispatch loop"
+description = "LANG47 + LANG52 — string heap objects (LangString), string/char builtins, host I/O (write_string, read_line, read_file) in the dispatch loop"
 
 [dependencies]
 twig-ir-compiler  = { path = "../twig-ir-compiler" }

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -1884,10 +1884,139 @@ fn exec_host_call(
             Ok(())
         }
 
+        // ── host/write_string (LANG52) ────────────────────────────────
+        //
+        // Write the UTF-8 bytes of a heap string to stdout.  The single
+        // argument must be a `LangString` heap object produced by
+        // `alloc_string` (i.e. a value whose class tag is CLASS_STRING).
+        //
+        // IIR: call_builtin "host/write_string" <string_reg>
+        //
+        // This is the idiomatic way to print string values from Twig
+        // code; `host/write_byte` writes individual bytes and is useful
+        // for protocol-level I/O.
+        "write_string" => {
+            let bytes = host_arg_string(name, instr, frame, 1)?;
+            use std::io::Write as _;
+            std::io::stdout()
+                .write_all(bytes)
+                .map_err(|e| RunError::HostIo(e.to_string()))?;
+            // void — no dest
+            Ok(())
+        }
+
+        // ── host/read_line (LANG52) ───────────────────────────────────
+        //
+        // Read one line from stdin, stripping the trailing `\n` (and
+        // `\r\n` on Windows).  Returns the content as a heap string.
+        // Returns an empty string on EOF.
+        //
+        // IIR: call_builtin "host/read_line" → dest
+        //
+        // Security: capped at 1 MiB per line to prevent adversarial
+        // input from causing unbounded memory growth (DoS).  Lines that
+        // exceed the cap return a HostIo error rather than truncating
+        // silently (truncation would produce a different semantic result,
+        // which is harder to reason about).
+        "read_line" => {
+            use std::io::{BufRead as _, Read as _};
+            /// Maximum bytes we will read for a single line.
+            const MAX_LINE_BYTES: u64 = 1 * 1024 * 1024; // 1 MiB
+            let mut line = String::new();
+            let stdin = std::io::stdin();
+            let mut limited = stdin.lock().take(MAX_LINE_BYTES + 1);
+            limited
+                .read_line(&mut line)
+                .map_err(|e| RunError::HostIo(e.to_string()))?;
+            // Reject lines that hit or exceed the cap.
+            if line.len() as u64 > MAX_LINE_BYTES {
+                return Err(RunError::HostIo(
+                    "host/read_line: line exceeds 1 MiB limit".into(),
+                ));
+            }
+            // Strip trailing newline / CRLF.
+            if line.ends_with('\n') {
+                line.pop();
+                if line.ends_with('\r') {
+                    line.pop();
+                }
+            }
+            let val = lispy_runtime::heap::alloc_string(line.as_bytes());
+            if let Some(d) = &instr.dest {
+                frame.set(d.clone(), val)?;
+            }
+            Ok(())
+        }
+
+        // ── host/read_file (LANG52) ───────────────────────────────────
+        //
+        // Read the entire contents of the file at the path given by the
+        // argument string.  Returns the file contents as a heap string.
+        // Propagates OS errors as `RunError::HostIo`.
+        //
+        // IIR: call_builtin "host/read_file" <path_reg> → dest
+        //
+        // Security hardening:
+        //
+        // 1. **Size cap** — files larger than 64 MiB return a HostIo
+        //    error.  `std::fs::read` on an unbounded file (or a synthetic
+        //    "infinite" file like `/dev/zero`) would otherwise OOM the
+        //    process.
+        //
+        // 2. **Error message** — the path is NOT included in the public
+        //    error string to prevent filesystem enumeration via
+        //    OS-error side channels ("permission denied" vs "not found").
+        //    The path is Debug-printed only at the `RunError::HostIo`
+        //    level, which the host can choose to log or suppress.
+        //
+        // Note: path-traversal sandboxing (restricting which directories
+        // are accessible) is a host-level concern.  The VM's caller is
+        // responsible for not passing untrusted Twig programs to VMs
+        // with ambient filesystem access.
+        "read_file" => {
+            /// Maximum bytes we will read from a single file.
+            ///
+            /// The cap is enforced via `Read::take()` on the open file handle
+            /// (NOT via a `metadata()` pre-check).  `metadata()` reports
+            /// `len() == 0` for special files such as FIFOs, named pipes, and
+            /// `/proc` virtual files, which would bypass a metadata-based
+            /// guard entirely.  `take()` limits the actual bytes transferred
+            /// regardless of file type.
+            const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
+            let path_bytes = host_arg_string(name, instr, frame, 1)?;
+            let path_str = std::str::from_utf8(path_bytes)
+                .map_err(|_| RunError::HostIo(
+                    "host/read_file: path argument is not valid UTF-8".into(),
+                ))?;
+            // Open the file, then read through a `take()` adapter that limits
+            // how many bytes are transferred.  We request one byte beyond the
+            // cap so we can distinguish "exactly at the limit" from "over".
+            use std::io::Read as _;
+            let f = std::fs::File::open(path_str)
+                .map_err(|e| RunError::HostIo(format!("host/read_file: {e}")))?;
+            let mut buf = Vec::with_capacity(
+                (MAX_FILE_BYTES as usize).min(256 * 1024) // 256 KiB initial
+            );
+            f.take(MAX_FILE_BYTES + 1)
+                .read_to_end(&mut buf)
+                .map_err(|e| RunError::HostIo(format!("host/read_file: {e}")))?;
+            // If we read more bytes than the cap, the file was too large.
+            if buf.len() as u64 > MAX_FILE_BYTES {
+                return Err(RunError::HostIo(format!(
+                    "host/read_file: file exceeds {MAX_FILE_BYTES}-byte limit",
+                )));
+            }
+            let val = lispy_runtime::heap::alloc_string(&buf);
+            if let Some(d) = &instr.dest {
+                frame.set(d.clone(), val)?;
+            }
+            Ok(())
+        }
+
         // ── Unknown host/ capability ──────────────────────────────────
         //
         // Any unrecognised `host/<name>` is an error.  Future
-        // capabilities (e.g. `host/read_line`, `host/open_file`) will
+        // capabilities (e.g. `host/open_file`, `host/write_file`) will
         // be added here alongside their backend lowering rules.
         cap => {
             Err(RunError::UnknownBuiltin(format!("host/{cap}")))
@@ -1917,6 +2046,36 @@ fn host_arg_int(
         function: host_fn.to_string(),
         received: format!("{val}"),
     })
+}
+
+/// Extract the heap-string bytes at argument position `pos` (1-based).
+///
+/// Used by `host/write_string`, `host/read_file`, and any future
+/// host call that takes a string argument.  Returns a `HostArgType`
+/// error if the value is not a `LangString` heap object.
+///
+/// The returned slice is `'static` because `alloc_string` uses
+/// `Box::leak` — all heap strings live for the process lifetime.
+fn host_arg_string(
+    host_fn: &str,
+    instr: &IIRInstr,
+    frame: &Frame,
+    pos: usize,
+) -> Result<&'static [u8], RunError> {
+    let src = instr.srcs.get(pos)
+        .ok_or_else(|| RunError::MalformedInstruction(
+            format!("host/{host_fn}: missing argument at position {pos}"),
+        ))?;
+    let frame_ref = frame;
+    let val = operand_to_value(src, &|n| frame_ref.get(n))
+        .map_err(RunError::OperandConversion)?;
+    // SAFETY: values in the dispatch loop come from the VM's value space —
+    // heap tags always reflect real, live allocations.
+    unsafe { lispy_runtime::heap::string_bytes(val) }
+        .ok_or_else(|| RunError::HostArgType {
+            function: host_fn.to_string(),
+            received: format!("{val}"),
+        })
 }
 
 // ---------------------------------------------------------------------------

--- a/code/specs/LANG52-stdlib-completeness.md
+++ b/code/specs/LANG52-stdlib-completeness.md
@@ -1,0 +1,196 @@
+# LANG52 — Standard Library Completeness for Self-Hosting
+
+## Motivation
+
+LANG51 unblocked string literals.  The remaining self-hosting blockers are:
+
+1. **`let*`** — sequential bindings where later RHSs can reference earlier names.
+   The compiler's self-contained passes all use this pattern.
+
+2. **Boolean logic** — `not`, `and`, `or`.  Every conditional chain in the
+   compiler needs these.
+
+3. **Missing comparisons** — `<=`, `>=` for range checks; `equal?` for
+   structural equality (comparing tokens, strings, symbols).
+
+4. **Arithmetic** — `modulo`, `remainder`, `quotient` for column arithmetic and
+   alignment math.
+
+5. **List stdlib** — `list`, `length`, `append`, `reverse`, `list-ref`, `assoc`,
+   `list?`, `symbol-append`.  The compiler builds and traverses lists for the
+   parameter tables, env frames, and output IIR.
+
+6. **Host I/O** — `host/write_string`, `host/read_line`, `host/read_file` to read
+   Twig source files and emit output.
+
+---
+
+## A. `let*` — Sequential bindings
+
+### Syntax
+
+```scheme
+(let* ((a 1)
+       (b (+ a 1))
+       (c (+ b 1)))
+  c)   ; ⇒ 3
+```
+
+### Grammar
+
+`twig.tokens` — add `let*` to the keywords list.
+
+`twig.grammar` — add `let_star_form` beside `let_form`:
+
+```
+form = define | type_alias | record_def | union_def | expr ;
+compound = if_form | let_form | let_star_form | begin_form | lambda_form
+         | quote_form | match_form | apply ;
+let_star_form = LPAREN "let*" LPAREN { binding } RPAREN expr { expr } RPAREN ;
+```
+
+### AST
+
+`LetStar` is identical in shape to `Let` — same fields, different struct name.
+`Expr::LetStar(LetStar)`.
+
+### IIR lowering
+
+`compile_let_star`: unlike `compile_let`, each binding's RHS is compiled AFTER
+the previous binding's name is added to locals.  This gives each binding access
+to all earlier bindings.
+
+```
+; (let* ((a 1) (b (+ a 1)))  …)
+const a = 1                ; compile a=1 in outer scope
+_move a ← a               ; bind 'a' into locals
+add b, a, 1               ; compile b=(+ a 1) WITH 'a' in scope
+_move b ← b               ; bind 'b' into locals
+```
+
+---
+
+## B. Boolean logic
+
+### `not` — runtime builtin
+
+```scheme
+(not #f) → #t
+(not #t) → #f
+(not nil) → #t     ; nil is falsy
+(not 42) → #f     ; everything else is truthy
+```
+
+Implementation: `lispy-runtime/src/builtins.rs`.  Single arg; returns
+`LispyValue::TRUE` iff arg is falsy (`NIL` or `FALSE`).
+
+### `and` / `or` — compiler special forms
+
+Handled in `compile_apply` before the builtin lookup, because short-circuit
+evaluation is required — the second operand must not be evaluated if the first
+is sufficient.
+
+| Call | Expansion |
+|------|-----------|
+| `(and)` | `#t` |
+| `(and e)` | `e` |
+| `(and e1 e2 …)` | `(if e1 (and e2 …) #f)` |
+| `(or)` | `#f` |
+| `(or e)` | `e` |
+| `(or e1 e2 …)` | `(let* ((t e1)) (if t t (or e2 …)))` — standard `or` macro expansion |
+
+`and` and `or` are NOT in the BUILTINS list — they are intercepted at the
+apply site in `compile_apply` and lowered inline.  This keeps them off the
+runtime dispatch path entirely.
+
+---
+
+## C. Comparison and arithmetic builtins
+
+All added to `lispy-runtime/src/builtins.rs`, registered in `binding.rs`, and
+listed in the BUILTINS const in `twig-ir-compiler/src/compiler.rs`.
+
+| Builtin | Args | Returns |
+|---------|------|---------|
+| `<=` | `(a b)` | `#t` if a ≤ b |
+| `>=` | `(a b)` | `#t` if a ≥ b |
+| `modulo` | `(a b)` | a mod b, result sign matches divisor (Scheme) |
+| `remainder` | `(a b)` | a rem b, result sign matches dividend (C `%`) |
+| `quotient` | `(a b)` | truncating integer division |
+| `not` | `(a)` | logical negation |
+| `boolean?` | `(a)` | `#t` if arg is `#t` or `#f` |
+| `equal?` | `(a b)` | structural equality: int by value, bool by value, string by content, symbol by id, cons cells recursively |
+
+---
+
+## D. List builtins
+
+| Builtin | Description |
+|---------|-------------|
+| `list` | `(list a b c)` → `(cons a (cons b (cons c nil)))` |
+| `length` | Length of proper list |
+| `append` | Concatenate two proper lists |
+| `reverse` | Reverse a proper list |
+| `list-ref` | `(list-ref lst i)` — 0-indexed element access |
+| `assoc` | `(assoc key alist)` — uses `equal?` for comparison |
+| `list?` | `#t` if proper list (nil-terminated) |
+| `symbol-append` | `(symbol-append sym1 sym2)` — concatenate symbol names |
+
+All added to `lispy-runtime/src/builtins.rs`, `binding.rs`, and BUILTINS.
+
+---
+
+## E. Host I/O
+
+All added to `twig-vm/src/dispatch.rs` in `exec_host_call`.
+
+| Builtin | Args | Returns | Description |
+|---------|------|---------|-------------|
+| `host/write_string` | `(str)` | void | Write UTF-8 bytes to stdout |
+| `host/read_line` | none | heap string | Read one line from stdin, strip `\n` |
+| `host/read_file` | `(path)` | heap string | Read entire file at path; `RunError::HostIo` on failure |
+
+A new helper `host_arg_string(host_fn, instr, frame, pos)` extracts a
+`LangString` heap object from an argument, mirroring `host_arg_int`.
+
+---
+
+## Files changed
+
+| File | What changes |
+|------|--------------|
+| `code/grammars/twig.tokens` | Add `let*` to keywords |
+| `code/grammars/twig.grammar` | Add `let_star_form`, update `compound` rule |
+| `twig-parser/src/ast_nodes.rs` | `LetStar` struct + `Expr::LetStar` |
+| `twig-parser/src/ast_extract.rs` | `extract_let_star`, dispatch in `extract_compound` |
+| `twig-parser/src/lib.rs` | Re-export `LetStar` |
+| `twig-parser/src/type_decls.rs` | `expr_to_kind` for `LetStar` → `Any` |
+| `twig-type-checker/src/check.rs` | `infer_expr` arm for `LetStar` |
+| `twig-ir-compiler/src/compiler.rs` | `compile_let_star`, `and`/`or` special cases, update BUILTINS |
+| `twig-ir-compiler/src/free_vars.rs` | `free_vars` for `LetStar` |
+| `lispy-runtime/src/builtins.rs` | `<=`, `>=`, `modulo`, `remainder`, `quotient`, `not`, `boolean?`, `equal?`, list ops, `symbol-append` |
+| `lispy-runtime/src/binding.rs` | Register all new builtins |
+| `twig-vm/src/dispatch.rs` | `host/write_string`, `host/read_line`, `host/read_file`, `host_arg_string` |
+
+---
+
+## Version bumps
+
+| Crate | From | To |
+|-------|------|----|
+| `twig-parser` | 0.4.0 | 0.5.0 |
+| `twig-ir-compiler` | 0.6.0 | 0.7.0 |
+| `twig-type-checker` | 0.2.0 | 0.3.0 |
+| `lispy-runtime` | current | +minor |
+| `twig-vm` | current | +minor |
+
+(On this branch — main has not merged LANG51 yet, so starting from pre-LANG51 versions.)
+
+---
+
+## After LANG52
+
+Remaining blockers for self-hosting (reduced set):
+- **LANG53**: Multi-file module driver — Twig-callable `(import "path/to/file.tw")` resolver
+- **LANG54**: Flow-sensitive type narrowing (`<`, `<=`, `=` guards)
+- **Higher-order list ops** — `map`/`filter`/`fold-*` require VM callback — stdlib.tw


### PR DESCRIPTION
## Summary

This PR implements LANG51 (string literals end-to-end) and LANG52 (stdlib completeness for self-hosting), the two largest blockers before a self-hosted Twig compiler is possible.

**Note: this branch includes all LANG51 changes.** PR #3242 holds the standalone LANG51 commit; this branch depends on LANG51 at every layer (parser StrLit, type checker TwigKind::Str, IR compiler StrLit arm). Version numbers skip the planned LANG51 minor bump (e.g. twig-parser 0.4.0 → 0.6.0 instead of 0.5.0 → 0.6.0). When #3242 merges, this branch rebases cleanly.

### LANG51 — String literals (layers: grammar → parser → type-checker → IR compiler → VM)

- `twig.tokens`: `STRING = /"([^"\\]|\\.)*"/` before `INTEGER`
- `twig.grammar`: `atom = STRING | INTEGER | ...`
- `twig-parser` v0.6.0: `StrLit` AST node; `extract_atom` uses `tok.value` (already decoded by `GrammarLexer::process_escapes`)
- `twig-type-checker` v0.4.0: `Expr::StrLit` → `TwigKind::Str`; `"STRING"` → `KindDecl::Str` in profile
- `twig-ir-compiler` v0.8.0: `Expr::StrLit` emits `const(Operand::Str(value)) : "str"`
- `twig-vm` v0.12.0: `exec_const` materialises `Operand::Str` as a `CLASS_STRING` heap object

### LANG52 — Stdlib completeness

- `let*` sequential bindings (grammar + parser `LetStar` + type-checker `infer_let_star` + IR compiler `compile_let_star`)
- `and`/`or` short-circuit special forms (compiler-lowered, no new opcodes)
- **lispy-runtime v0.4.0** new builtins: `<=`, `>=`, `quotient`, `remainder`, `modulo`, `not`, `boolean?`, `equal?`, `list`, `list?`, `length`, `append`, `reverse`, `list-ref`, `assoc`, `symbol-append`
- **host I/O**: `host/write_string`, `host/read_line` (1 MiB cap), `host/read_file` (64 MiB cap)

### Security hardening applied during review

- `values_equal` (structural equality): iterative work-stack with `MAX_PAIRS=4096` instead of recursion — prevents stack-overflow DoS on deeply-nested adversarial input
- `host/read_file`: uses `File::take(MAX_FILE_BYTES + 1)` on the open handle rather than `metadata().len()` pre-check — FIFOs, named pipes, `/proc` entries, and `/dev/stdin` all report `len() == 0`; `take()` enforces the cap regardless of file type and closes the TOCTOU race window
- `host/read_line`: `take(MAX_LINE_BYTES + 1)` prevents unbounded memory growth
- Error messages in `read_file` omit the file path to prevent filesystem enumeration

## Test plan

- [ ] `cargo test -p twig-parser -- string` — StrLit parsing
- [ ] `cargo test -p twig-parser -- let_star` — LetStar parsing
- [ ] `cargo test -p twig-ir-compiler -- string_literal` — StrLit lowering
- [ ] `cargo test -p twig-ir-compiler -- let_star` — let* compilation
- [ ] `cargo test -p lispy-runtime` — 181+ tests covering all new builtins
- [ ] `cargo test -p twig-vm -- string_literal` — round-trip VM tests
- [ ] `cargo test -p twig-vm -- host_` — host I/O tests
- [ ] `cargo build --workspace` — full workspace clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)