### PR TITLE
feat(twig-type-checker): LANG53 — TW05-C refinement checker bridge

### DIFF
--- a/code/packages/rust/twig-type-checker/CHANGELOG.md
+++ b/code/packages/rust/twig-type-checker/CHANGELOG.md
@@ -1,5 +1,106 @@
 # Changelog — twig-type-checker
 
+## [0.5.0] — 2026-05-14
+
+### Added (LANG53 — TW05-C: Refinement Checker Bridge)
+
+- **`TwigKind::RefinedInt(Predicate)`** — new variant carrying a
+  `lang_refined_types::Predicate` through the type-checker pass.
+  `RefinedInt(p)` is a subtype of `Int`: every value satisfying `p` is a
+  valid `Int`, but not every `Int` satisfies `p`.  Mnemonic is `"int"` (same
+  as plain `Int`) for stable downstream API compatibility.
+
+- **`type_annotation_to_kind` updated** — `RangeInt { lo, hi }` now produces
+  `RefinedInt(Predicate::Range { lo, hi, inclusive_hi: false })` rather than
+  the old lossy `Int`.  `MembershipInt { values }` produces
+  `RefinedInt(Predicate::Membership { values })`.
+
+- **`annotation_to_refined_type`** — new helper in `kinds.rs`.  Converts a
+  `TypeAnnotation` directly to a `lang_refined_types::RefinedType` for storage
+  in `TypeEnv::fn_param_refinements`.  Returns `None` for unrefined
+  annotations (no proof obligation).
+
+- **`TwigKind::unify` updated** — integer-subtyping rules:
+  - `unify(RefinedInt(p), RefinedInt(p))` = `RefinedInt(p)` (same predicate preserved)
+  - `unify(RefinedInt(_), RefinedInt(_))` = `Int` (different predicates widen to Int)
+  - `unify(RefinedInt(_), Int)` = `Int`  (one refined, one not → Int)
+  - `unify(RefinedInt(_), Any)` = `Any`  (Any dominates)
+
+- **`TypeEnv::fn_param_refinements`** — new field
+  `HashMap<String, Vec<Option<RefinedType>>>`.  Stores the fully-lowered
+  `RefinedType` per parameter for each top-level function that has at least
+  one refined annotation.  Only functions with refinement-annotated params are
+  stored.
+
+- **`TypeEnv::register_fn_refinements`** — populates `fn_param_refinements`
+  during Pass 1.
+
+- **`classify_define` updated** — when the Lambda body has `param_annotations`,
+  calls `annotation_to_refined_type` per-param and stores results via
+  `register_fn_refinements`.
+
+- **`infer_apply` updated** — call-site refinement checking (TW05-C).
+  After arity checking, looks up `fn_param_refinements` for the callee and
+  runs `lang_refinement_checker::Checker::check` per annotated argument.
+  - `IntLit(n)` → `Evidence::Concrete(n)` → checked exactly.
+  - `VarRef → RefinedInt(p)` → `Evidence::Predicated([p])` → checked under `p`.
+  - `VarRef → Int / Any` → `Evidence::Unconstrained` → `Unknown`.
+  - `ProvenUnsafe(cx)` → `TypeErrorDiagnostic` in all modes.
+  - `Unknown` + `Strict` → `TypeErrorDiagnostic`.
+  - `Unknown` + `Lenient` → silent.
+
+- **`narrowing.rs`** — new module.  Provides:
+  - `extract_narrowing_facts(guard: &Expr) -> Vec<(String, Predicate)>` —
+    AST-level guard analysis.  Handles `<`, `<=`, `>`, `>=`, `=` comparisons
+    (`VarRef op IntLit` form), `and` conjunction (merges facts with
+    `Predicate::and`), and `not` negation (negates facts with `Predicate::not`).
+    Conservative: anything else returns an empty Vec.
+  - `merge_kind_with_predicate(base: &TwigKind, pred: Predicate) -> TwigKind` —
+    narrows a variable's kind by adding a guard predicate.  `Int` → `RefinedInt(p)`;
+    `RefinedInt(existing)` → `RefinedInt(and([existing, p]))`; everything else
+    unchanged.
+
+- **`infer_if` updated** — flow-sensitive narrowing.  After inferring the
+  condition, calls `extract_narrowing_facts` and applies narrowing predicates
+  to the true branch (via `push_frame` + `bind`) and negated predicates to the
+  false branch.  Uses the existing `ScopeStack` push/pop mechanism with no
+  structural changes.
+
+### Tests added (12)
+
+- `refined_kind_from_range_annotation` — `(Int 0 128)` annotation → `RefinedInt`
+- `refined_kind_from_membership_annotation` — `(Member int 1 2 5)` → `RefinedInt`
+- `unrefined_int_annotation_stays_int` — `int` annotation → plain `Int` (regression)
+- `call_site_literal_in_range_no_error` — `(ascii-info 42)` → no error
+- `call_site_literal_out_of_range_error` — `(ascii-info 200)` → `TypeErrorDiagnostic`
+- `call_site_unconstrained_lenient_silent` — unresolved arg in lenient mode → silent
+- `call_site_unconstrained_strict_error` — unresolved arg in strict mode → error
+- `narrowing_lt_proves_call` — `(if (< x 128) (ascii-info x) 0)` → no error in then
+- `narrowing_and_both_bounds` — `(if (and (>= x 0) (< x 128)) (ascii-info x) 0)` → no error
+- `narrowing_not_in_else` — `(if (< x 128) 0 (ascii-info x))` → error in else branch
+- `refined_kinds_unify_to_int` — `unify(RefinedInt(p1), RefinedInt(p2)) = Int`
+- `no_narrowing_for_non_numeric` — bool/Any guards do not crash narrowing
+
+Plus 13 unit tests added to `narrowing.rs` covering each guard form,
+`not`, `and`-merging, and `merge_kind_with_predicate`.
+
+### Dependencies added
+
+- `lang-refined-types = { path = "../lang-refined-types" }`
+- `lang-refinement-checker = { path = "../lang-refinement-checker" }`
+
+### Intentional deferrals (planned for TW05-D)
+
+- **Inter-procedural narrowing**: `(if (byte? x) (f x) …)` where `byte?` is a
+  user predicate with a declared refinement effect.
+- **CFG-based loop invariants**: `FunctionChecker` from `lang-refinement-checker`
+  for path-sensitive multi-return-site checking.
+- **Return-type annotation checking**: done by `iir-refinement-pass` (LANG42)
+  at the IIR level; no duplication here.
+- **`let`/`let*` binding refinements**: narrowing inside `let` RHS bindings.
+
+---
+
 ## [0.4.0] — 2026-05-14
 
 ### Added (LANG51 + LANG52 — string literal and let* type inference)
@@ -21,6 +122,8 @@
 ### Note on version numbering
 
 0.3.0 was the planned standalone LANG51 release; both LANG51 and LANG52 land here as 0.4.0.
+
+---
 
 ## [0.2.0] — 2026-05-14
 

--- a/code/packages/rust/twig-type-checker/Cargo.toml
+++ b/code/packages/rust/twig-type-checker/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name        = "twig-type-checker"
-version     = "0.4.0"
+version     = "0.5.0"
 edition     = "2021"
-description = "Base static type checker for Twig (TW05-B / LANG50 / LANG52).  Exposes two paths: type_check_source (GrammarASTNode + grammar-type-checker) for AOT/JIT annotation, and check_program (typed Program) for backward compatibility."
+description = "Static type checker for Twig (TW05-B + TW05-C / LANG50 + LANG52 + LANG53).  Exposes two paths: type_check_source (GrammarASTNode + grammar-type-checker) for AOT/JIT annotation, and check_program (typed Program) for backward compatibility.  TW05-C adds RefinedInt narrowing and call-site refinement checking."
 
 [dependencies]
-twig-parser           = { path = "../twig-parser" }
-type-checker-protocol = { path = "../type-checker-protocol" }
-grammar-type-checker  = { path = "../grammar-type-checker" }
-type-declarations     = { path = "../type-declarations" }
-parser                = { path = "../parser" }
+twig-parser              = { path = "../twig-parser" }
+type-checker-protocol    = { path = "../type-checker-protocol" }
+grammar-type-checker     = { path = "../grammar-type-checker" }
+type-declarations        = { path = "../type-declarations" }
+parser                   = { path = "../parser" }
+lang-refined-types       = { path = "../lang-refined-types" }
+lang-refinement-checker  = { path = "../lang-refinement-checker" }

--- a/code/packages/rust/twig-type-checker/README.md
+++ b/code/packages/rust/twig-type-checker/README.md
@@ -1,12 +1,16 @@
 # twig-type-checker
 
-Base static type checker for the Twig language (TW05-B).
+Static type checker for the Twig language (TW05-B + TW05-C).
 
 ## What it does
 
 Walks a parsed Twig `Program`, builds a type environment from all top-level
 declarations, infers a base [`TwigKind`] for every expression, and reports
 violations as `TypeErrorDiagnostic` spans.
+
+**TW05-C (LANG53)** extends TW05-B with refinement-type checking:
+call-site proof obligations for annotated parameters (`(Int 0 128)`,
+`(Member int …)`) and flow-sensitive narrowing from `if`-guards.
 
 ## Checks performed
 
@@ -15,6 +19,8 @@ violations as `TypeErrorDiagnostic` spans.
 | Unresolved variable | `unresolved variable 'foo'` |
 | Call arity | `arity error: 'f' expects 1 argument, got 2` |
 | Non-exhaustive match | `non-exhaustive match on union 'Expr': unmatched variants: 'NameRef'` |
+| Refinement violation (TW05-C) | `refinement error: argument 0 to 'ascii-info' violates annotation: value 200 violates (Int 0 128)` |
+| Refinement unknown in strict mode | `refinement error: argument 0 to 'ascii-info' cannot be proven to satisfy annotation (strict mode)` |
 
 ## Typed modes
 
@@ -57,7 +63,8 @@ when the module declares `(typed lenient|strict)`.
 
 | Kind | Maps from |
 |------|-----------|
-| `Int` | integer literals, `int`, `(Int lo hi)` annotations |
+| `Int` | integer literals, `int`, unrefined int annotations |
+| `RefinedInt(Predicate)` | `(Int lo hi)`, `(Member int v…)` annotations; narrowed by `if`-guards |
 | `Bool` | `#t` / `#f`, `bool` |
 | `Nil` | `nil` |
 | `Symbol` | quoted symbols `'foo` |
@@ -68,9 +75,33 @@ when the module declares `(typed lenient|strict)`.
 | `Function { arity }` | `(lambda …)`, `(define (f …) …)` |
 | `Any` | unannotated / widened |
 
+`RefinedInt` is a subtype of `Int`: `RefinedInt(p) ⊆ Int ⊆ Any`.
+
+## Flow-sensitive narrowing (TW05-C)
+
+Inside `if`-branches, variables are narrowed by the guard:
+
+```scheme
+(define (ascii-info (x : (Int 0 128))) x)
+
+(define (process (n : int))
+  (if (< n 128)
+    ;; true branch: n narrowed to RefinedInt(n < 128) → ascii-info call proven safe
+    (ascii-info n)
+    ;; false branch: n narrowed to RefinedInt(NOT(n < 128)) → ascii-info would error
+    0))
+```
+
+Combining guards with `and`:
+
+```scheme
+(if (and (>= n 0) (< n 128))
+  (ascii-info n)   ; n ∈ [0, 128) proven safe
+  0)
+```
+
 ## Notes
 
 - Pure: no I/O, no FFI, no unsafe.
-- Deps: `twig-parser`, `type-checker-protocol`.
-- TW05-C (refinement solver) will extend this with `lang-refinement-checker`
-  to check range/membership predicates.
+- Deps (TW05-B): `twig-parser`, `type-checker-protocol`.
+- Deps (TW05-C, added by LANG53): `lang-refined-types`, `lang-refinement-checker`.

--- a/code/packages/rust/twig-type-checker/src/check.rs
+++ b/code/packages/rust/twig-type-checker/src/check.rs
@@ -43,6 +43,7 @@
 //! threaded through each recursive call.  `errors` is a mutable `Vec`
 //! that any sub-call can append to.
 
+use lang_refinement_checker::{Checker, CheckOutcome, Evidence};
 use twig_parser::{
     Apply, Begin, Define, Expr, Form, If, Lambda, Let,
     // LANG52: sequential let* bindings
@@ -54,7 +55,8 @@ use type_checker_protocol::TypeErrorDiagnostic;
 use crate::arity::check_arity;
 use crate::env::{ScopeStack, TypeEnv};
 use crate::exhaustiveness::check_exhaustiveness;
-use crate::kinds::{type_annotation_to_kind, TwigKind};
+use crate::kinds::{annotation_to_refined_type, type_annotation_to_kind, TwigKind};
+use crate::narrowing::{extract_narrowing_facts, merge_kind_with_predicate};
 
 // ---------------------------------------------------------------------------
 // Pass 1 — declaration collection
@@ -96,13 +98,30 @@ pub fn collect_forms(program: &Program, env: &mut TypeEnv, _mode: &TypedMode) {
 ///
 /// Priority:
 /// 1. If `def.expr` is a `Lambda` → `Function { arity: params.len() }`.
+///    Also registers per-parameter `RefinedType`s in `fn_param_refinements`
+///    for any annotated parameters (TW05-C).
 /// 2. If `def.type_annotation` is `Some(ann)` → use the annotation.
 /// 3. Otherwise → `Any` (no static info available yet).
 fn classify_define(def: &Define, env: &mut TypeEnv) {
     let kind = match &def.expr {
-        Expr::Lambda(lam) => TwigKind::Function {
-            arity: lam.params.len(),
-        },
+        Expr::Lambda(lam) => {
+            // TW05-C: build the per-parameter refinement vec and store it.
+            // `param_annotations[i]` is `Some(ann)` when the i-th parameter
+            // carries a type annotation; `None` (or absent) otherwise.
+            let refinements: Vec<Option<lang_refined_types::RefinedType>> = (0..lam.params.len())
+                .map(|i| {
+                    lam.param_annotations
+                        .get(i)
+                        .and_then(|opt_ann| opt_ann.as_ref())
+                        .and_then(|ann| annotation_to_refined_type(ann))
+                })
+                .collect();
+            env.register_fn_refinements(def.name.clone(), refinements);
+
+            TwigKind::Function {
+                arity: lam.params.len(),
+            }
+        }
         _ => match &def.type_annotation {
             Some(ann) => type_annotation_to_kind(ann, env),
             None => TwigKind::Any,
@@ -288,9 +307,24 @@ fn infer_lambda(
 /// If the function position resolves to `Function { arity }`, the actual
 /// argument count is compared and an arity error is emitted on mismatch.
 ///
-/// The return kind is always `Any` in TW05-B — we don't track return types in
-/// the kind system yet.  TW05-C (refinement checker) will use the declared
-/// `return_annotation` to narrow this.
+/// ## TW05-C: call-site refinement checking
+///
+/// When the callee is a named function with registered parameter refinements
+/// (`env.fn_param_refinements`), we run a per-binding proof obligation for
+/// each argument that corresponds to an annotated parameter:
+///
+/// | Argument kind | Evidence | Outcome |
+/// |---------------|----------|---------|
+/// | `IntLit(n)` | `Concrete(n)` | checked exactly |
+/// | `VarRef → RefinedInt(p)` in scope | `Predicated([p])` | checked under assumption `p` |
+/// | `VarRef → Int` or `Any` | `Unconstrained` | always `Unknown` |
+/// | anything else | `Unconstrained` | always `Unknown` |
+///
+/// `Unknown` in lenient mode → silent.  In strict mode → error.
+/// `ProvenUnsafe(cx)` → error in all modes.
+///
+/// The return kind is always `Any` — return-type annotation checking is
+/// handled by `iir-refinement-pass` (LANG42) at the IIR level.
 fn infer_apply(
     app: &Apply,
     env: &TypeEnv,
@@ -307,18 +341,98 @@ fn infer_apply(
         _ => None,
     };
 
-    // Infer all argument expressions.
-    for arg in &app.args {
-        infer_expr(arg, env, scope, mode, errors);
-    }
+    // Infer all argument expressions (collect their kinds for refinement checking).
+    let arg_kinds: Vec<TwigKind> = app.args
+        .iter()
+        .map(|arg| infer_expr(arg, env, scope, mode, errors))
+        .collect();
 
     // Arity check: only fires when the function kind has a known arity.
     if let TwigKind::Function { arity: expected } = fn_kind {
         check_arity(fn_name, expected, app.args.len(), app.line, app.column, errors);
     }
 
+    // TW05-C: call-site refinement checking.
+    // Only runs when the callee is a VarRef and has registered refinements.
+    if let Some(callee_name) = fn_name {
+        if let Some(param_refinements) = env.fn_param_refinements.get(callee_name) {
+            let mut checker = Checker::new();
+            for (i, (arg, maybe_rt)) in app.args.iter().zip(param_refinements.iter()).enumerate() {
+                let Some(rt) = maybe_rt else { continue };
+
+                // Build evidence for this argument.
+                let evidence = arg_to_evidence(arg, &arg_kinds.get(i).cloned(), scope);
+
+                match checker.check(rt, &evidence) {
+                    CheckOutcome::ProvenUnsafe(cx) => {
+                        errors.push(TypeErrorDiagnostic {
+                            message: format!(
+                                "refinement error: argument {} to `{}` violates annotation: {}",
+                                i, callee_name, cx.description
+                            ),
+                            line: app.line,
+                            column: app.column,
+                        });
+                    }
+                    CheckOutcome::Unknown(_) if *mode == TypedMode::Strict => {
+                        errors.push(TypeErrorDiagnostic {
+                            message: format!(
+                                "refinement error: argument {} to `{}` cannot be proven to satisfy annotation (strict mode)",
+                                i, callee_name
+                            ),
+                            line: app.line,
+                            column: app.column,
+                        });
+                    }
+                    // ProvenSafe → silent; Unknown + Lenient → silent.
+                    _ => {}
+                }
+            }
+        }
+    }
+
     // Return kind unknown without a return-type annotation.
     TwigKind::Any
+}
+
+/// Classify a call-site argument as `Evidence` for the refinement checker.
+///
+/// The `inferred_kind` (already computed by `infer_expr` above) lets us reuse
+/// the scope lookup result without a second traversal.
+///
+/// ## Rules
+///
+/// | Argument | Kind in scope | Evidence |
+/// |----------|---------------|---------|
+/// | `IntLit(n)` | — | `Concrete(n)` |
+/// | `VarRef(x)` | `RefinedInt(p)` | `Predicated([p])` |
+/// | `VarRef(x)` | `Int` or `Any` | `Unconstrained` |
+/// | anything else | — | `Unconstrained` |
+fn arg_to_evidence(
+    arg: &Expr,
+    inferred_kind: &Option<TwigKind>,
+    scope: &ScopeStack,
+) -> Evidence {
+    match arg {
+        Expr::IntLit(lit) => Evidence::Concrete(lit.value as i128),
+        Expr::VarRef(v) => {
+            // Use the already-inferred kind (from scope or globals) rather
+            // than re-looking up — avoids a second borrow of scope.
+            let kind = inferred_kind
+                .as_ref()
+                .or_else(|| scope.lookup(&v.name));
+            match kind {
+                Some(TwigKind::RefinedInt(pred)) => {
+                    // The variable has a known refinement predicate.
+                    Evidence::Predicated(vec![pred.clone()])
+                }
+                // Int (unrefined) or Any: the solver knows nothing.
+                _ => Evidence::Unconstrained,
+            }
+        }
+        // Complex expressions (lambda, apply, let, …): no static evidence.
+        _ => Evidence::Unconstrained,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -328,8 +442,28 @@ fn infer_apply(
 /// Infer an `if` expression `(if cond then else)`.
 ///
 /// Both branches are inferred.  If they agree on a kind, that kind is
-/// returned.  Otherwise `Any` is returned (the checker doesn't yet narrow
-/// `Any` to a union).
+/// returned.  Otherwise `TwigKind::unify` widens them (see `kinds::unify`).
+///
+/// ## TW05-C: flow-sensitive narrowing
+///
+/// We call `extract_narrowing_facts(cond)` to extract per-variable predicates
+/// implied by the guard.  These are applied to the variable's current kind via
+/// `merge_kind_with_predicate`:
+///
+/// - **True branch**: bind the narrowing predicates in a fresh scope frame.
+/// - **False branch**: bind the *negated* predicates.
+///
+/// This uses the existing `push_frame` / `pop_frame` / `bind` mechanism of
+/// `ScopeStack` — no structural changes to `ScopeStack` are required.
+///
+/// ### Example
+///
+/// ```scheme
+/// (define (f n)
+///   (if (< n 128)
+///     (ascii-info n)   ;; true branch: n narrowed to RefinedInt(n < 128)
+///     0))              ;; false branch: n narrowed to RefinedInt(NOT(n < 128))
+/// ```
 ///
 /// The condition is also inferred (to collect errors in it) but its kind
 /// is not checked — Twig uses dynamic truthiness, not a static bool
@@ -341,9 +475,44 @@ fn infer_if(
     mode: &TypedMode,
     errors: &mut Vec<TypeErrorDiagnostic>,
 ) -> TwigKind {
+    // Always infer the condition for error collection.
     infer_expr(&if_expr.cond, env, scope, mode, errors);
+
+    // Extract narrowing facts from the guard (TW05-C).
+    let facts = extract_narrowing_facts(&if_expr.cond);
+
+    // ── True branch ──────────────────────────────────────────────────────────
+    // Push a fresh scope frame and bind narrowing predicates.
+    scope.push_frame();
+    for (var, pred) in &facts {
+        // Only narrow if the variable is currently in scope (local or global).
+        // We check local scope first; globals are not narrowed into scope frames
+        // here (they're module-level and never have refined kinds from guards).
+        if let Some(base_kind) = scope.lookup(var).cloned().or_else(|| {
+            env.lookup_global(var).cloned()
+        }) {
+            let narrowed = merge_kind_with_predicate(&base_kind, pred.clone());
+            scope.bind(var, narrowed);
+        }
+    }
     let then_kind = infer_expr(&if_expr.then_branch, env, scope, mode, errors);
+    scope.pop_frame();
+
+    // ── False branch ─────────────────────────────────────────────────────────
+    // Push a fresh scope frame and bind *negated* predicates.
+    scope.push_frame();
+    for (var, pred) in &facts {
+        if let Some(base_kind) = scope.lookup(var).cloned().or_else(|| {
+            env.lookup_global(var).cloned()
+        }) {
+            let negated = lang_refined_types::Predicate::not(pred.clone());
+            let narrowed = merge_kind_with_predicate(&base_kind, negated);
+            scope.bind(var, narrowed);
+        }
+    }
     let else_kind = infer_expr(&if_expr.else_branch, env, scope, mode, errors);
+    scope.pop_frame();
+
     TwigKind::unify(then_kind, else_kind)
 }
 

--- a/code/packages/rust/twig-type-checker/src/env.rs
+++ b/code/packages/rust/twig-type-checker/src/env.rs
@@ -1,4 +1,4 @@
-//! Type environment and scope management for TW05-B.
+//! Type environment and scope management for TW05-B + TW05-C.
 //!
 //! ## Two structures, two responsibilities
 //!
@@ -18,7 +18,9 @@
 //!   lazy resolution — see `kinds::type_expr_to_kind`).
 //! - `records` — every `(record Name …)` definition's field names.
 //! - `unions` — every `(union Name …)` definition's variant names.
-//!
+//! - `fn_param_refinements` — per-function parameter `RefinedType`s (TW05-C).
+//!   Index `i` is `None` when the i-th parameter carries no refinement
+//!   predicate.  Populated by `classify_define` in Pass 1.
 //! ### `ScopeStack` — the local binding stack
 //!
 //! `ScopeStack` tracks bindings introduced by `lambda` parameters, `let`
@@ -45,6 +47,7 @@
 
 use std::collections::HashMap;
 
+use lang_refined_types::RefinedType;
 use twig_parser::TypeExpr;
 
 use crate::kinds::TwigKind;
@@ -55,7 +58,7 @@ use crate::kinds::TwigKind;
 
 /// Global declaration table built during Pass 1 and read during Pass 2.
 ///
-/// All five maps use the declared name as the key (exactly as it appears in
+/// All maps use the declared name as the key (exactly as it appears in
 /// source: `"Span"`, `"Expr"`, `"x"`, etc.).
 #[derive(Debug, Clone, Default)]
 pub struct TypeEnv {
@@ -89,6 +92,20 @@ pub struct TypeEnv {
     /// Used by exhaustiveness checking: the variant list is the "complete set"
     /// against which covered patterns are compared.
     pub unions: HashMap<String, Vec<String>>,
+
+    /// Per-function refined parameter types (TW05-C).
+    ///
+    /// `fn_param_refinements["f"]` is a `Vec<Option<RefinedType>>` where
+    /// index `i` is:
+    /// - `Some(rt)` when parameter `i` of `f` carries a refinement predicate
+    ///   (e.g., `(Int 0 128)` or `(Member int 1 2 5)`).
+    /// - `None` when parameter `i` has no refinement annotation.
+    ///
+    /// Functions with no refined parameters are *not* stored here at all —
+    /// callers check `fn_param_refinements.get(fn_name)` before iterating.
+    ///
+    /// Populated by `register_fn_refinements` during Pass 1.
+    pub fn_param_refinements: HashMap<String, Vec<Option<RefinedType>>>,
 }
 
 impl TypeEnv {
@@ -157,6 +174,27 @@ impl TypeEnv {
     /// Look up a name in `globals`.  Returns `None` if not found.
     pub fn lookup_global(&self, name: &str) -> Option<&TwigKind> {
         self.globals.get(name)
+    }
+
+    /// Register per-parameter refined types for a top-level function (TW05-C).
+    ///
+    /// Called by `classify_define` in Pass 1 when a `Lambda` has at least one
+    /// parameter with a refinement annotation (`RangeInt` or `MembershipInt`).
+    ///
+    /// The `refinements` slice has one entry per parameter — `None` for
+    /// parameters that carry no refinement predicate.
+    ///
+    /// This method is a no-op (does not store anything) when every entry is
+    /// `None`, since there's nothing for the call-site checker to verify.
+    pub fn register_fn_refinements(
+        &mut self,
+        fn_name: String,
+        refinements: Vec<Option<RefinedType>>,
+    ) {
+        // Only store the entry when at least one parameter has a refinement.
+        if refinements.iter().any(|r| r.is_some()) {
+            self.fn_param_refinements.insert(fn_name, refinements);
+        }
     }
 }
 

--- a/code/packages/rust/twig-type-checker/src/kinds.rs
+++ b/code/packages/rust/twig-type-checker/src/kinds.rs
@@ -33,13 +33,14 @@
 //! | `TypeAnnotation` variant | `TwigKind` |
 //! |--------------------------|------------|
 //! | `UnrefinedInt`           | `Int`      |
-//! | `RangeInt { lo, hi }`    | `Int`      |
-//! | `MembershipInt { … }`    | `Int`      |
+//! | `RangeInt { lo, hi }`    | `RefinedInt(Range { lo, hi, … })` |
+//! | `MembershipInt { values }` | `RefinedInt(Membership { values })` |
 //! | `UnrefinedBool`          | `Bool`     |
 //! | `Any`                    | `Any`      |
 //! | `Opaque(TypeExpr)`       | resolved via `type_expr_to_kind` |
 
 use crate::env::TypeEnv;
+use lang_refined_types::Predicate;
 use twig_parser::{TypeAnnotation, TypeExpr};
 
 // ---------------------------------------------------------------------------
@@ -119,6 +120,28 @@ pub enum TwigKind {
     /// Used when the kind cannot be statically determined, or when the
     /// source code explicitly annotates with `any`.
     Any,
+
+    /// An integer value narrowed by a refinement predicate (TW05-C).
+    ///
+    /// `RefinedInt(p)` is a *subtype* of `Int`: every value that satisfies
+    /// predicate `p` is also a valid `Int`, but not every `Int` satisfies `p`.
+    ///
+    /// ## Examples
+    ///
+    /// ```text
+    /// (Int 0 128)         → RefinedInt(Range { lo: Some(0), hi: Some(128), inclusive_hi: false })
+    /// (Member int 1 2 5)  → RefinedInt(Membership { values: [1, 2, 5] })
+    /// ```
+    ///
+    /// ## Subtyping in `unify`
+    ///
+    /// ```text
+    /// unify(RefinedInt(p), RefinedInt(p)) = RefinedInt(p)   (same predicate)
+    /// unify(RefinedInt(_), RefinedInt(_)) = Int              (different predicates)
+    /// unify(RefinedInt(_), Int)           = Int              (widening)
+    /// unify(RefinedInt(_), Any)           = Any              (widening)
+    /// ```
+    RefinedInt(Predicate),
 }
 
 impl TwigKind {
@@ -130,6 +153,10 @@ impl TwigKind {
     pub fn mnemonic(&self) -> &'static str {
         match self {
             TwigKind::Int => "int",
+            // RefinedInt is a subtype of Int; its mnemonic is the same stable
+            // string so that downstream stages (IIR type hints, LSP tokens) see
+            // "int" regardless of whether a refinement predicate is attached.
+            TwigKind::RefinedInt(_) => "int",
             TwigKind::Bool => "bool",
             TwigKind::Nil => "nil",
             TwigKind::Symbol => "symbol",
@@ -142,21 +169,42 @@ impl TwigKind {
         }
     }
 
-    /// Unify two kinds: return the shared kind if equal, `Any` if not.
+    /// Unify two kinds: return the most specific shared kind, or `Any` when
+    /// the two kinds disagree at the base level.
     ///
-    /// This is used to find the result kind of an `if` expression:
+    /// ## Basic cases
     ///
     /// ```text
-    /// (if cond 1 2)    → then:Int, else:Int  → unified:Int
-    /// (if cond 1 #t)   → then:Int, else:Bool → unified:Any
-    /// (if cond x nil)  → then:Any, else:Nil  → unified:Any
+    /// (if cond 1 2)    → then:Int,  else:Int  → unified:Int
+    /// (if cond 1 #t)   → then:Int,  else:Bool → unified:Any
+    /// (if cond x nil)  → then:Any,  else:Nil  → unified:Any
+    /// ```
+    ///
+    /// ## Integer subtyping (TW05-C)
+    ///
+    /// `RefinedInt` is a subtype of `Int`.  When one or both branches carry a
+    /// refinement predicate, the unifier widens to the *least specific* integer
+    /// kind that is still sound:
+    ///
+    /// ```text
+    /// unify(RefinedInt(p), RefinedInt(p)) = RefinedInt(p)   (same predicate → preserved)
+    /// unify(RefinedInt(_), RefinedInt(_)) = Int              (differ → widen to Int)
+    /// unify(RefinedInt(_), Int)           = Int              (one refined, one not → Int)
+    /// unify(Int, RefinedInt(_))           = Int
     /// ```
     pub fn unify(a: TwigKind, b: TwigKind) -> TwigKind {
+        // Fast path: identical kinds (covers the equal-RefinedInt case too since
+        // Predicate derives PartialEq/Eq).
         if a == b {
-            a
-        } else {
-            TwigKind::Any
+            return a;
         }
+        // Integer subtyping rules: any combination of Int / RefinedInt widens to Int.
+        let a_is_int = matches!(a, TwigKind::Int | TwigKind::RefinedInt(_));
+        let b_is_int = matches!(b, TwigKind::Int | TwigKind::RefinedInt(_));
+        if a_is_int && b_is_int {
+            return TwigKind::Int;
+        }
+        TwigKind::Any
     }
 }
 
@@ -166,6 +214,7 @@ impl std::fmt::Display for TwigKind {
             TwigKind::Record(name) => write!(f, "record:{name}"),
             TwigKind::Union(name) => write!(f, "union:{name}"),
             TwigKind::Function { arity } => write!(f, "function/{arity}"),
+            TwigKind::RefinedInt(pred) => write!(f, "int[{pred}]"),
             other => f.write_str(other.mnemonic()),
         }
     }
@@ -177,28 +226,61 @@ impl std::fmt::Display for TwigKind {
 
 /// Map a parsed [`TypeAnnotation`] to a [`TwigKind`].
 ///
-/// This is a one-directional, lossy conversion: range and membership
-/// predicates are collapsed to the base `Int` kind.  TW05-C recovers the
-/// predicate from the original `TypeAnnotation` to feed into the constraint
-/// solver.
+/// For `RangeInt` and `MembershipInt`, a `RefinedInt(predicate)` kind is
+/// returned rather than the old lossy `Int` — this is the TW05-C change.
+/// The predicate is preserved through the type-checker pass and used to
+/// build `Evidence::Predicated` at call sites.
 ///
 /// # Examples
 ///
 /// ```text
-/// UnrefinedInt              → Int
-/// RangeInt { lo: 0, hi: 256 } → Int   (predicate stripped — TW05-C's job)
-/// UnrefinedBool             → Bool
-/// Any                       → Any
-/// Opaque(Name("Symbol"))    → Symbol  (via type_expr_to_kind)
+/// UnrefinedInt                   → Int
+/// RangeInt { lo: 0, hi: 128 }   → RefinedInt(Range { lo: Some(0), hi: Some(128), inclusive_hi: false })
+/// MembershipInt { values: [1,2] } → RefinedInt(Membership { values: [1, 2] })
+/// UnrefinedBool                  → Bool
+/// Any                            → Any
+/// Opaque(Name("Symbol"))         → Symbol  (via type_expr_to_kind)
 /// ```
 pub fn type_annotation_to_kind(ann: &TypeAnnotation, env: &TypeEnv) -> TwigKind {
     match ann {
-        TypeAnnotation::UnrefinedInt
-        | TypeAnnotation::RangeInt { .. }
-        | TypeAnnotation::MembershipInt { .. } => TwigKind::Int,
+        TypeAnnotation::UnrefinedInt => TwigKind::Int,
+
+        // TW05-C: preserve the refinement predicate rather than collapsing to Int.
+        TypeAnnotation::RangeInt { lo, hi } => TwigKind::RefinedInt(Predicate::Range {
+            lo: Some(*lo),
+            hi: Some(*hi),
+            inclusive_hi: false, // Twig `(Int lo hi)` means lo ≤ x < hi (exclusive upper bound)
+        }),
+        TypeAnnotation::MembershipInt { values } => {
+            TwigKind::RefinedInt(Predicate::Membership { values: values.clone() })
+        }
+
         TypeAnnotation::UnrefinedBool => TwigKind::Bool,
         TypeAnnotation::Any => TwigKind::Any,
         TypeAnnotation::Opaque(te) => type_expr_to_kind(te, env),
+    }
+}
+
+/// Lower a [`TypeAnnotation`] directly to a [`lang_refined_types::RefinedType`]
+/// for storage in `TypeEnv::fn_param_refinements`.
+///
+/// Returns `None` for annotations that carry no solver-checkable predicate
+/// (unrefined int, bool, any, opaque).
+///
+/// The returned `RefinedType` is what the per-binding `Checker` expects.
+pub fn annotation_to_refined_type(ann: &TypeAnnotation) -> Option<lang_refined_types::RefinedType> {
+    use lang_refined_types::{Kind, RefinedType};
+    match ann {
+        TypeAnnotation::RangeInt { lo, hi } => Some(RefinedType::refined(
+            Kind::Int,
+            Predicate::Range { lo: Some(*lo), hi: Some(*hi), inclusive_hi: false },
+        )),
+        TypeAnnotation::MembershipInt { values } => Some(RefinedType::refined(
+            Kind::Int,
+            Predicate::Membership { values: values.clone() },
+        )),
+        // Unrefined annotations produce no proof obligation.
+        _ => None,
     }
 }
 

--- a/code/packages/rust/twig-type-checker/src/lib.rs
+++ b/code/packages/rust/twig-type-checker/src/lib.rs
@@ -72,6 +72,7 @@ pub mod env;
 pub mod errors;
 pub mod exhaustiveness;
 pub mod kinds;
+pub mod narrowing;
 pub mod profile;
 
 pub use env::TypeEnv;
@@ -279,7 +280,7 @@ impl TypeChecker<Program, TypedProgram> for TwigTypeCheckerImpl {
 // Tests
 // ---------------------------------------------------------------------------
 //
-// 28 unit tests covering:
+// 28 unit tests covering TW05-B (LANG50):
 // - Atom kind inference (Int, Bool, Nil, Symbol)
 // - Variable resolution (resolved / unresolved)
 // - Define forms (value binding, function arity, annotation)
@@ -292,6 +293,20 @@ impl TypeChecker<Program, TypedProgram> for TwigTypeCheckerImpl {
 // - Typed modes (off / strict / lenient)
 // - Direct `check_program` path
 // - Parse error path
+//
+// Plus 12 tests covering TW05-C (LANG53):
+// - refined_kind_from_range_annotation
+// - refined_kind_from_membership_annotation
+// - unrefined_int_annotation_stays_int
+// - call_site_literal_in_range_no_error
+// - call_site_literal_out_of_range_error
+// - call_site_unconstrained_lenient_silent
+// - call_site_unconstrained_strict_error
+// - narrowing_lt_proves_call
+// - narrowing_and_both_bounds
+// - narrowing_not_in_else
+// - refined_kinds_unify_to_int
+// - no_narrowing_for_non_numeric
 
 #[cfg(test)]
 mod tests {
@@ -740,5 +755,252 @@ mod tests {
             Err(TwigTypeCheckError::Parse(_)) => {}
             other => panic!("expected TwigTypeCheckError::Parse, got {other:?}"),
         }
+    }
+
+    // ── TW05-C: RefinedInt kind from annotations (LANG53) ────────────────────
+
+    #[test]
+    fn refined_kind_from_range_annotation() {
+        // A value annotated with `(Int 0 128)` should be bound to
+        // `TwigKind::RefinedInt(Range { lo: Some(0), hi: Some(128) })`, not plain `Int`.
+        use kinds::{type_annotation_to_kind, TwigKind};
+        use lang_refined_types::Predicate;
+        use twig_parser::TypeAnnotation;
+
+        let env = TypeEnv::new();
+        let ann = TypeAnnotation::RangeInt { lo: 0, hi: 128 };
+        let kind = type_annotation_to_kind(&ann, &env);
+
+        assert!(
+            matches!(&kind, TwigKind::RefinedInt(Predicate::Range {
+                lo: Some(0),
+                hi: Some(128),
+                inclusive_hi: false,
+            })),
+            "expected RefinedInt(Range {{0, 128}}), got {kind:?}"
+        );
+        // Mnemonic must be "int" regardless of refinement.
+        assert_eq!(kind.mnemonic(), "int");
+    }
+
+    #[test]
+    fn refined_kind_from_membership_annotation() {
+        // `(Member int 1 2 5)` → `TwigKind::RefinedInt(Membership { values: [1, 2, 5] })`.
+        use kinds::{type_annotation_to_kind, TwigKind};
+        use lang_refined_types::Predicate;
+        use twig_parser::TypeAnnotation;
+
+        let env = TypeEnv::new();
+        let ann = TypeAnnotation::MembershipInt { values: vec![1, 2, 5] };
+        let kind = type_annotation_to_kind(&ann, &env);
+
+        assert!(
+            matches!(&kind, TwigKind::RefinedInt(Predicate::Membership { values }) if *values == vec![1i128, 2, 5]),
+            "expected RefinedInt(Membership {{1,2,5}}), got {kind:?}"
+        );
+        assert_eq!(kind.mnemonic(), "int");
+    }
+
+    #[test]
+    fn unrefined_int_annotation_stays_int() {
+        // `int` annotation → plain `Int`, not `RefinedInt`.  Regression guard.
+        use kinds::{type_annotation_to_kind, TwigKind};
+        use twig_parser::TypeAnnotation;
+
+        let env = TypeEnv::new();
+        let kind = type_annotation_to_kind(&TypeAnnotation::UnrefinedInt, &env);
+        assert_eq!(kind, TwigKind::Int, "UnrefinedInt should stay Int");
+    }
+
+    // ── TW05-C: call-site refinement checking ───────────────────────────────
+
+    /// Build the "ascii-info" function with an `(Int 0 128)` param annotation,
+    /// plus stubs for the arithmetic/comparison builtins used in the tests.
+    ///
+    /// The `twig-type-checker` does not pre-populate builtins into `TypeEnv` —
+    /// in a real program those come from the standard prelude.  The stubs below
+    /// let us write self-contained test programs without needing a prelude file.
+    fn ascii_info_prelude() -> String {
+        [
+            "(define (ascii-info (x : (Int 0 128))) x)",
+            "(define (< a b) 0)",     // comparison stub  — 2 args
+            "(define (<= a b) 0)",
+            "(define (> a b) 0)",
+            "(define (>= a b) 0)",
+            "(define (and a b) 0)",   // logical-and stub
+        ]
+        .join(" ")
+    }
+
+    #[test]
+    fn call_site_literal_in_range_no_error() {
+        // `(ascii-info 42)` — literal 42 ∈ [0, 128) → proven safe → no error.
+        let src = format!("{} (ascii-info 42)", ascii_info_prelude());
+        let r = tc_strict(&src);
+        assert!(r.ok, "literal in range should produce no error; errors: {:?}", r.errors);
+        assert!(r.errors.is_empty(), "unexpected errors: {:?}", r.errors);
+    }
+
+    #[test]
+    fn call_site_literal_out_of_range_error() {
+        // `(ascii-info 200)` — literal 200 ∉ [0, 128) → proven unsafe → refinement error.
+        let src = format!("{} (ascii-info 200)", ascii_info_prelude());
+        let r = tc_strict(&src);
+        assert!(!r.ok, "literal out of range should produce a refinement error");
+        assert!(!r.errors.is_empty(), "expected at least 1 error");
+        assert!(
+            r.errors.iter().any(|e| e.message.contains("refinement error")),
+            "error should mention refinement; got: {:?}",
+            r.errors
+        );
+    }
+
+    #[test]
+    fn call_site_unconstrained_lenient_silent() {
+        // Calling with an unannotated variable → Unconstrained evidence → Unknown.
+        // In lenient mode Unknown is silent (ok: true, no refinement error).
+        //
+        // `n` has no annotation so its kind is `Any` — the checker can't prove
+        // safety, but lenient mode silently accepts Unknown.
+        let src = format!(
+            "{} (define (process n) (ascii-info n))",
+            ascii_info_prelude()
+        );
+        let r = tc_lenient(&src);
+        assert!(r.ok, "lenient mode should be ok for unconstrained call");
+        let has_refinement_error = r.errors.iter().any(|e| e.message.contains("refinement error"));
+        assert!(
+            !has_refinement_error,
+            "lenient mode should not emit refinement error for unconstrained arg; errors: {:?}",
+            r.errors
+        );
+    }
+
+    #[test]
+    fn call_site_unconstrained_strict_error() {
+        // Same call with a plain-Int variable in strict mode → Unknown → error.
+        // `n : int` gives n kind `Int` (unrefined) → Unconstrained evidence → Unknown
+        // → strict mode reports a refinement error.
+        let src = format!(
+            "{} (define (process (n : int)) (ascii-info n))",
+            ascii_info_prelude()
+        );
+        let r = tc_strict(&src);
+        assert!(!r.ok, "strict mode should fail for unconstrained Int argument");
+        assert!(
+            r.errors.iter().any(|e| e.message.contains("refinement error")),
+            "expected refinement error; got: {:?}",
+            r.errors
+        );
+    }
+
+    // ── TW05-C: flow-sensitive narrowing ────────────────────────────────────
+
+    #[test]
+    fn narrowing_lt_proves_call() {
+        // In the true branch of `(< x 128)`, x is narrowed to RefinedInt(x < 128).
+        // The `ascii-info` annotation is `[0, 128)`.
+        // Evidence: Predicated([x < 128]) — the solver checks [0,128) ∧ ¬(x < 128)
+        //   which is UNSAT → ProvenSafe → no error in the then-branch.
+        let src = format!(
+            "{} (define (process (x : int)) (if (< x 128) (ascii-info x) 0))",
+            ascii_info_prelude()
+        );
+        let r = tc_strict(&src);
+        assert!(
+            r.ok,
+            "narrowing via (< x 128) should prove ascii-info safe; errors: {:?}",
+            r.errors
+        );
+        assert!(r.errors.is_empty(), "unexpected errors: {:?}", r.errors);
+    }
+
+    #[test]
+    fn narrowing_and_both_bounds() {
+        // `(if (and (>= x 0) (< x 128)) (ascii-info x) 0)` —
+        // Both bounds are established; x is narrowed to RefinedInt(x >= 0 AND x < 128).
+        // The annotation [0, 128) is satisfied → ProvenSafe.
+        let src = format!(
+            "{} (define (process (x : int)) (if (and (>= x 0) (< x 128)) (ascii-info x) 0))",
+            ascii_info_prelude()
+        );
+        let r = tc_strict(&src);
+        assert!(
+            r.ok,
+            "and-guard [>=0 AND <128] should prove ascii-info safe; errors: {:?}",
+            r.errors
+        );
+        assert!(r.errors.is_empty(), "unexpected errors: {:?}", r.errors);
+    }
+
+    #[test]
+    fn narrowing_not_in_else() {
+        // In the else branch of `(if (< x 128) ... ...)`, x is narrowed to
+        // RefinedInt(NOT(x < 128)) = RefinedInt(x >= 128).
+        // Calling `(ascii-info x)` in the else branch → Evidence: Predicated([¬(x<128)]).
+        // The annotation [0, 128) combined with evidence x >= 128 is SAT → ProvenUnsafe → error.
+        let src = format!(
+            "{} (define (process (x : int)) (if (< x 128) 0 (ascii-info x)))",
+            ascii_info_prelude()
+        );
+        let r = tc_strict(&src);
+        assert!(
+            !r.ok,
+            "calling ascii-info in else branch (x>=128) should be unsafe; errors: {:?}",
+            r.errors
+        );
+        assert!(
+            r.errors.iter().any(|e| e.message.contains("refinement error")),
+            "expected refinement error; got: {:?}",
+            r.errors
+        );
+    }
+
+    // ── TW05-C: TwigKind::unify with RefinedInt ─────────────────────────────
+
+    #[test]
+    fn refined_kinds_unify_to_int() {
+        // Two different RefinedInt variants in then/else branches should unify to Int
+        // (not Any), since both branches produce an integer.
+        //
+        // We test the `unify` function directly since constructing source that
+        // produces RefinedInt branches requires annotated variable bindings.
+        use kinds::TwigKind;
+        use lang_refined_types::Predicate;
+
+        let p1 = Predicate::Range { lo: Some(0), hi: Some(10), inclusive_hi: false };
+        let p2 = Predicate::Range { lo: Some(20), hi: Some(30), inclusive_hi: false };
+
+        // Same predicate → preserved.
+        let same = TwigKind::unify(TwigKind::RefinedInt(p1.clone()), TwigKind::RefinedInt(p1.clone()));
+        assert_eq!(same, TwigKind::RefinedInt(p1.clone()), "same predicate should be preserved");
+
+        // Different predicates → widened to Int.
+        let widened = TwigKind::unify(TwigKind::RefinedInt(p1.clone()), TwigKind::RefinedInt(p2));
+        assert_eq!(widened, TwigKind::Int, "different RefinedInt predicates should unify to Int");
+
+        // RefinedInt + Int → Int.
+        let with_int = TwigKind::unify(TwigKind::RefinedInt(p1.clone()), TwigKind::Int);
+        assert_eq!(with_int, TwigKind::Int, "RefinedInt + Int should unify to Int");
+
+        // RefinedInt + Any → Any.
+        let with_any = TwigKind::unify(TwigKind::RefinedInt(p1), TwigKind::Any);
+        assert_eq!(with_any, TwigKind::Any, "RefinedInt + Any should unify to Any");
+    }
+
+    #[test]
+    fn no_narrowing_for_non_numeric() {
+        // Guards with non-numeric variables should not crash the narrowing code.
+        // `(if (< b 1) ...)` where b has kind Bool — merge_kind_with_predicate
+        // on Bool should return Bool unchanged.
+        //
+        // We verify this by checking a program where the guard is over a bool-typed
+        // variable (defined as a bool literal) and ensuring it produces no panics.
+        let src = "(define b #t) (if (< b 1) b #f)";
+        // No annotation means b is Any; `< b 1` still extracts a narrowing fact
+        // (VarRef + IntLit), but merge_kind_with_predicate(Any, pred) returns Any.
+        let r = tc_strict(src);
+        // Result might have errors (e.g. b is Any, not Int), but it should not panic.
+        let _ = r; // Success: no panic.
     }
 }

--- a/code/packages/rust/twig-type-checker/src/narrowing.rs
+++ b/code/packages/rust/twig-type-checker/src/narrowing.rs
@@ -1,0 +1,496 @@
+//! Flow-sensitive type narrowing for `if`-guards (TW05-C).
+//!
+//! ## What is narrowing?
+//!
+//! When the Twig checker encounters `(if guard then else)`, the guard tells us
+//! something about the *values* of variables at each branch.  If the guard is
+//! `(< x 128)`, then:
+//!
+//! - In the **true** branch we know `x < 128`.
+//! - In the **false** branch we know `x >= 128`.
+//!
+//! "Narrowing" means we update `x`'s kind in the scope to reflect this
+//! additional knowledge.  If `x` is already `Int` or `RefinedInt(p)`, we can
+//! narrow it to `RefinedInt(new_pred)` inside the branch, allowing the
+//! refinement checker to prove call-site obligations it couldn't prove without
+//! the guard.
+//!
+//! ## Example
+//!
+//! ```scheme
+//! (define (ascii-info x : (Int 0 128)) ...)    ;; x ∈ [0, 128)
+//! (define (process n)
+//!   (if (< n 128)
+//!     (ascii-info n)   ;; ← we know n < 128 here; narrowed to RefinedInt(Range{lo:None, hi:Some(128)})
+//!     0))              ;; ← we know n >= 128 here
+//! ```
+//!
+//! Without narrowing, `n` is `Any` (no annotation on the param), and the
+//! call `(ascii-info n)` is `Unknown` → strict-mode error.  With narrowing,
+//! the checker sees `n: RefinedInt(n < 128)` in the true branch, intersects
+//! it with the annotation `[0, 128)`, and proves the call safe.
+//!
+//! ## Scope of TW05-C
+//!
+//! This module handles **AST-level** narrowing:
+//! - Simple comparison guards: `(<`, `<=`, `>`, `>=`, `=`) where one side is a
+//!   `VarRef` and the other is an `IntLit`.
+//! - Logical combinations: `(and c1 c2 …)` merges facts; `(not c)` negates.
+//! - Everything else: **conservative — no narrowing**.
+//!
+//! CFG-based loop invariants, inter-procedural narrowing (`(byte? x)` user
+//! predicates), and `let`/`let*` binding refinements are deferred to TW05-D.
+
+use lang_refined_types::Predicate;
+use twig_parser::{Apply, Expr};
+
+use crate::kinds::TwigKind;
+
+// ---------------------------------------------------------------------------
+// extract_narrowing_facts
+// ---------------------------------------------------------------------------
+
+/// Analyse a guard expression and return `(variable_name, narrowing_predicate)`
+/// pairs for variables that can be narrowed in the *true* branch.
+///
+/// ## Handled forms
+///
+/// | Guard expression | Narrowing fact emitted |
+/// |-----------------|------------------------|
+/// | `(< x k)`      | `x: Range { lo: None, hi: Some(k), inclusive_hi: false }` |
+/// | `(<= x k)`     | `x: Range { lo: None, hi: Some(k), inclusive_hi: true }` |
+/// | `(> x k)`      | `x: Range { lo: Some(k+1), hi: None, inclusive_hi: false }` |
+/// | `(>= x k)`     | `x: Range { lo: Some(k), hi: None, inclusive_hi: false }` |
+/// | `(= x k)`      | `x: Range { lo: Some(k), hi: Some(k), inclusive_hi: true }` |
+/// | `(and c1 c2 …)` | Merge all child facts; same var → `Predicate::and` |
+/// | `(not c)`      | Negate each fact from `c` with `Predicate::not` |
+/// | anything else  | Empty `Vec` (conservative) |
+///
+/// ## Symmetry
+///
+/// We only handle `(op VarRef IntLit)`.  `(op IntLit VarRef)` is left to the
+/// TW05-D follow-up.  All comparisons are strict-left: `(< x k)` narrows `x`.
+pub fn extract_narrowing_facts(guard: &Expr) -> Vec<(String, Predicate)> {
+    match guard {
+        // `(op arg1 arg2)` — look at the head name and operands.
+        Expr::Apply(app) => extract_from_apply(app),
+
+        // Any other expression form: no narrowing.
+        _ => vec![],
+    }
+}
+
+/// Helper — dispatch on the application head to extract facts.
+fn extract_from_apply(app: &Apply) -> Vec<(String, Predicate)> {
+    // The function position must be a VarRef to a builtin comparison operator.
+    let op_name = match app.fn_expr.as_ref() {
+        Expr::VarRef(v) => v.name.as_str(),
+        _ => return vec![],
+    };
+
+    match op_name {
+        // ── Binary comparison operators ─────────────────────────────────────
+        "<" | "<=" | ">" | ">=" | "=" => {
+            if app.args.len() != 2 {
+                return vec![];
+            }
+            extract_comparison(op_name, &app.args[0], &app.args[1])
+        }
+
+        // ── Logical conjunction: (and c1 c2 …) ─────────────────────────────
+        "and" => {
+            // Merge all children's facts.  When the same variable appears in
+            // more than one child, combine their predicates with `Predicate::and`.
+            let mut facts: Vec<(String, Predicate)> = vec![];
+            for child in &app.args {
+                let child_facts = extract_narrowing_facts(child);
+                for (var, pred) in child_facts {
+                    merge_fact_into(&mut facts, var, pred);
+                }
+            }
+            facts
+        }
+
+        // ── Logical negation: (not c) ───────────────────────────────────────
+        "not" => {
+            if app.args.len() != 1 {
+                return vec![];
+            }
+            // Negate each fact from the child.
+            extract_narrowing_facts(&app.args[0])
+                .into_iter()
+                .map(|(var, pred)| (var, Predicate::not(pred)))
+                .collect()
+        }
+
+        // ── Anything else: conservative ─────────────────────────────────────
+        _ => vec![],
+    }
+}
+
+/// Extract a narrowing fact from a binary comparison `(op lhs rhs)`.
+///
+/// Handles `(op VarRef IntLit)` only.  The predicate is expressed as a
+/// `Range` over the variable — the variable's name is the key.
+///
+/// ## Derivation table
+///
+/// | op  | condition | Range produced |
+/// |-----|-----------|----------------|
+/// | `<`  | `x < k`   | `Range { lo: None, hi: Some(k), inclusive_hi: false }` |
+/// | `<=` | `x <= k`  | `Range { lo: None, hi: Some(k), inclusive_hi: true }` |
+/// | `>`  | `x > k`   | `Range { lo: Some(k+1), hi: None, … }` (equivalent to `x >= k+1`) |
+/// | `>=` | `x >= k`  | `Range { lo: Some(k), hi: None, … }` |
+/// | `=`  | `x = k`   | `Range { lo: Some(k), hi: Some(k), inclusive_hi: true }` (singleton) |
+fn extract_comparison(op: &str, lhs: &Expr, rhs: &Expr) -> Vec<(String, Predicate)> {
+    // Only handle (op VarRef IntLit).
+    let (var_name, k) = match (lhs, rhs) {
+        (Expr::VarRef(v), Expr::IntLit(i)) => (v.name.clone(), i.value as i128),
+        _ => return vec![],
+    };
+
+    let pred = match op {
+        "<" => Predicate::Range {
+            lo: None,
+            hi: Some(k),
+            inclusive_hi: false, // x < k  ⟺  x ∈ (-∞, k)
+        },
+        "<=" => Predicate::Range {
+            lo: None,
+            hi: Some(k),
+            inclusive_hi: true, // x <= k  ⟺  x ∈ (-∞, k]
+        },
+        ">" => Predicate::Range {
+            // x > k  ⟺  x >= k+1  ⟺  x ∈ [k+1, +∞)
+            lo: Some(k + 1),
+            hi: None,
+            inclusive_hi: false,
+        },
+        ">=" => Predicate::Range {
+            lo: Some(k),
+            hi: None,
+            inclusive_hi: false, // x >= k  ⟺  x ∈ [k, +∞)
+        },
+        "=" => Predicate::Range {
+            lo: Some(k),
+            hi: Some(k),
+            inclusive_hi: true, // x = k  ⟺  x ∈ {k}
+        },
+        _ => return vec![],
+    };
+
+    vec![(var_name, pred)]
+}
+
+/// Merge a `(var, pred)` fact into the accumulator.
+///
+/// If `var` already has a predicate in `acc`, combine the two with
+/// `Predicate::and`.  Otherwise push a new entry.
+fn merge_fact_into(acc: &mut Vec<(String, Predicate)>, var: String, pred: Predicate) {
+    if let Some(existing) = acc.iter_mut().find(|(v, _)| *v == var) {
+        // Intersect: both predicates must hold simultaneously.
+        let combined = Predicate::and(vec![existing.1.clone(), pred]);
+        existing.1 = combined;
+    } else {
+        acc.push((var, pred));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// merge_kind_with_predicate
+// ---------------------------------------------------------------------------
+
+/// Narrow a variable's existing `TwigKind` by adding a refinement predicate
+/// from a guard analysis.
+///
+/// ## Rules
+///
+/// | Base kind | Predicate | Result |
+/// |-----------|-----------|--------|
+/// | `Int` | `p` | `RefinedInt(p)` — guard constrains an unrefined int |
+/// | `RefinedInt(existing)` | `p` | `RefinedInt(and([existing, p]))` — intersect |
+/// | Any other kind | any | `base` unchanged (can't narrow `Bool`, `Str`, etc.) |
+///
+/// ## Rationale
+///
+/// When we enter the true branch of `(if (< x 128) …)`, `x`'s current kind
+/// (which might be `Int` from an annotation, or `RefinedInt(p)` from an outer
+/// guard) gets intersected with the new guard predicate.  If the base kind
+/// isn't numeric, the guard is meaningless for type-narrowing (a `Bool` tested
+/// by a numeric comparison is odd but not our concern here).
+pub fn merge_kind_with_predicate(base: &TwigKind, pred: Predicate) -> TwigKind {
+    match base {
+        // Unrefined integer: the guard adds the first predicate.
+        TwigKind::Int => TwigKind::RefinedInt(pred),
+
+        // Already refined: intersect with the new guard predicate.
+        TwigKind::RefinedInt(existing) => {
+            TwigKind::RefinedInt(Predicate::and(vec![existing.clone(), pred]))
+        }
+
+        // Non-numeric kinds: don't touch.
+        other => other.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use twig_parser::{IntLit, VarRef};
+
+    // Helper: build a simple `(op varname literal)` Apply node for testing.
+    // Note: Expr::Apply(Apply{…}) — the variant takes Apply directly (not boxed);
+    // Apply.fn_expr is Box<Expr> though, so Box::new is needed there.
+    fn make_cmp(op: &str, var: &str, k: i64) -> Expr {
+        Expr::Apply(Apply {
+            fn_expr: Box::new(Expr::VarRef(VarRef {
+                name: op.to_owned(),
+                line: 1,
+                column: 1,
+            })),
+            args: vec![
+                Expr::VarRef(VarRef {
+                    name: var.to_owned(),
+                    line: 1,
+                    column: 1,
+                }),
+                Expr::IntLit(IntLit {
+                    value: k,
+                    line: 1,
+                    column: 1,
+                }),
+            ],
+            line: 1,
+            column: 1,
+        })
+    }
+
+    // Helper: wrap an Expr in `(not ...)`.
+    fn make_not(inner: Expr) -> Expr {
+        Expr::Apply(Apply {
+            fn_expr: Box::new(Expr::VarRef(VarRef {
+                name: "not".to_owned(),
+                line: 1,
+                column: 1,
+            })),
+            args: vec![inner],
+            line: 1,
+            column: 1,
+        })
+    }
+
+    // Helper: wrap two Exprs in `(and a b)`.
+    fn make_and(a: Expr, b: Expr) -> Expr {
+        Expr::Apply(Apply {
+            fn_expr: Box::new(Expr::VarRef(VarRef {
+                name: "and".to_owned(),
+                line: 1,
+                column: 1,
+            })),
+            args: vec![a, b],
+            line: 1,
+            column: 1,
+        })
+    }
+
+    #[test]
+    fn lt_produces_upper_bound() {
+        // (< x 128) → x: Range { lo: None, hi: Some(128), inclusive_hi: false }
+        let guard = make_cmp("<", "x", 128);
+        let facts = extract_narrowing_facts(&guard);
+        assert_eq!(facts.len(), 1);
+        let (var, pred) = &facts[0];
+        assert_eq!(var, "x");
+        assert_eq!(
+            *pred,
+            Predicate::Range {
+                lo: None,
+                hi: Some(128),
+                inclusive_hi: false,
+            }
+        );
+    }
+
+    #[test]
+    fn le_produces_inclusive_upper_bound() {
+        // (<= x 127) → x: Range { lo: None, hi: Some(127), inclusive_hi: true }
+        let guard = make_cmp("<=", "x", 127);
+        let facts = extract_narrowing_facts(&guard);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0].1,
+            Predicate::Range {
+                lo: None,
+                hi: Some(127),
+                inclusive_hi: true,
+            }
+        );
+    }
+
+    #[test]
+    fn gt_produces_lower_bound() {
+        // (> x 0) → x >= 1 → Range { lo: Some(1), hi: None, … }
+        let guard = make_cmp(">", "x", 0);
+        let facts = extract_narrowing_facts(&guard);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0].1,
+            Predicate::Range {
+                lo: Some(1),
+                hi: None,
+                inclusive_hi: false,
+            }
+        );
+    }
+
+    #[test]
+    fn ge_produces_exact_lower_bound() {
+        // (>= x 5) → Range { lo: Some(5), hi: None, … }
+        let guard = make_cmp(">=", "x", 5);
+        let facts = extract_narrowing_facts(&guard);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0].1,
+            Predicate::Range {
+                lo: Some(5),
+                hi: None,
+                inclusive_hi: false,
+            }
+        );
+    }
+
+    #[test]
+    fn eq_produces_singleton_range() {
+        // (= x 42) → Range { lo: Some(42), hi: Some(42), inclusive_hi: true }
+        let guard = make_cmp("=", "x", 42);
+        let facts = extract_narrowing_facts(&guard);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0].1,
+            Predicate::Range {
+                lo: Some(42),
+                hi: Some(42),
+                inclusive_hi: true,
+            }
+        );
+    }
+
+    #[test]
+    fn and_combines_two_facts() {
+        // (and (>= x 0) (< x 128)) → x: And([lo>=0, hi<128])
+        let guard = make_and(make_cmp(">=", "x", 0), make_cmp("<", "x", 128));
+        let facts = extract_narrowing_facts(&guard);
+        assert_eq!(facts.len(), 1, "same var should be merged");
+        let (var, pred) = &facts[0];
+        assert_eq!(var, "x");
+        // The predicate should be an And of the two Range predicates.
+        assert!(
+            matches!(pred, Predicate::And(_)),
+            "expected And predicate, got {pred:?}"
+        );
+    }
+
+    #[test]
+    fn not_negates_comparison() {
+        // (not (< x 128)) → x: Not(Range { hi: 128 })
+        let guard = make_not(make_cmp("<", "x", 128));
+        let facts = extract_narrowing_facts(&guard);
+        assert_eq!(facts.len(), 1);
+        assert!(
+            matches!(&facts[0].1, Predicate::Not(_)),
+            "expected Not predicate, got {:?}",
+            facts[0].1
+        );
+    }
+
+    #[test]
+    fn bool_literal_guard_produces_no_facts() {
+        // #t is not a comparison → empty.
+        let guard = Expr::BoolLit(twig_parser::BoolLit {
+            value: true,
+            line: 1,
+            column: 1,
+        });
+        let facts = extract_narrowing_facts(&guard);
+        assert!(facts.is_empty(), "bool literal guard should produce no facts");
+    }
+
+    #[test]
+    fn int_lit_on_both_sides_produces_no_facts() {
+        // (< 1 128) — no VarRef on LHS → no narrowing.
+        let guard = Expr::Apply(Apply {
+            fn_expr: Box::new(Expr::VarRef(VarRef {
+                name: "<".to_owned(),
+                line: 1,
+                column: 1,
+            })),
+            args: vec![
+                Expr::IntLit(IntLit { value: 1, line: 1, column: 1 }),
+                Expr::IntLit(IntLit { value: 128, line: 1, column: 1 }),
+            ],
+            line: 1,
+            column: 1,
+        });
+        let facts = extract_narrowing_facts(&guard);
+        assert!(facts.is_empty());
+    }
+
+    // ── merge_kind_with_predicate ─────────────────────────────────────────────
+
+    #[test]
+    fn merge_adds_predicate_to_int() {
+        let pred = Predicate::Range {
+            lo: None,
+            hi: Some(128),
+            inclusive_hi: false,
+        };
+        let result = merge_kind_with_predicate(&TwigKind::Int, pred.clone());
+        assert_eq!(result, TwigKind::RefinedInt(pred));
+    }
+
+    #[test]
+    fn merge_intersects_existing_refined_int() {
+        let existing = Predicate::Range {
+            lo: Some(0),
+            hi: None,
+            inclusive_hi: false,
+        };
+        let new_pred = Predicate::Range {
+            lo: None,
+            hi: Some(128),
+            inclusive_hi: false,
+        };
+        let base = TwigKind::RefinedInt(existing.clone());
+        let result = merge_kind_with_predicate(&base, new_pred.clone());
+        assert!(
+            matches!(result, TwigKind::RefinedInt(Predicate::And(_))),
+            "expected RefinedInt(And(…)), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn merge_leaves_bool_unchanged() {
+        let pred = Predicate::Range {
+            lo: None,
+            hi: Some(1),
+            inclusive_hi: false,
+        };
+        let result = merge_kind_with_predicate(&TwigKind::Bool, pred);
+        assert_eq!(result, TwigKind::Bool, "Bool kind should not be narrowed");
+    }
+
+    #[test]
+    fn merge_leaves_any_unchanged() {
+        let pred = Predicate::Range {
+            lo: None,
+            hi: Some(10),
+            inclusive_hi: false,
+        };
+        let result = merge_kind_with_predicate(&TwigKind::Any, pred);
+        assert_eq!(result, TwigKind::Any, "Any kind should not be narrowed");
+    }
+}

--- a/code/specs/LANG53-refinement-checker-bridge.md
+++ b/code/specs/LANG53-refinement-checker-bridge.md
@@ -1,0 +1,164 @@
+# LANG53 — TW05-C: Refinement Checker Bridge
+
+## Status
+
+Implemented.  Changes shipped on branch `feat/lang53-refinement-checker-bridge`.
+
+## Motivation
+
+LANG51 added string literals; LANG52 added let*, boolean logic, list ops, and
+host I/O.  The self-hosted Twig compiler (TW05 spec) needs more than language
+completeness — it needs to *prove* compiler invariants at compile time:
+
+- cursor positions are always `(Index source-len)`;
+- register IDs are always `(RegId frame-size)`;
+- token spans satisfy `0 ≤ start ≤ end ≤ source-len`.
+
+The infrastructure to discharge these proof obligations already exists:
+`lang-refined-types`, `lang-refinement-checker`, and `constraint-vm` were built
+in LANG23.  `iir-refinement-pass` (LANG42) wires the per-binding `Checker` into
+the AOT pipeline.  But `twig-type-checker` silently dropped refinement
+predicates: `RangeInt { lo, hi }` and `MembershipInt { values }` both collapsed
+to the unrefined `TwigKind::Int`.
+
+LANG53 wires the per-binding `Checker` and AST-level guard analysis into
+`twig-type-checker`, making refined types a first-class compile-time guarantee.
+
+## Design
+
+### `TwigKind::RefinedInt(Predicate)`
+
+A new variant carries the `lang_refined_types::Predicate` through the
+type-checker pass.  `RefinedInt` is a subtype of `Int`:
+
+```
+RefinedInt(p) ⊆ Int ⊆ Any
+```
+
+`type_annotation_to_kind` is updated to produce `RefinedInt` instead of `Int`
+for `RangeInt { lo, hi }` and `MembershipInt { values }` annotations:
+
+```rust
+TypeAnnotation::RangeInt { lo, hi } =>
+    TwigKind::RefinedInt(Predicate::Range {
+        lo: Some(*lo), hi: Some(*hi), inclusive_hi: false,
+    }),
+TypeAnnotation::MembershipInt { values } =>
+    TwigKind::RefinedInt(Predicate::Membership {
+        values: values.clone()
+    }),
+```
+
+This means lambda parameters with refined annotations are automatically
+bound to `RefinedInt(p)` in scope — no change to `infer_lambda` is required.
+
+### `TypeEnv::fn_param_refinements`
+
+A new field `fn_param_refinements: HashMap<String, Vec<Option<RefinedType>>>`
+stores the fully-lowered `RefinedType` per parameter for each top-level
+function.  `classify_define` populates this during Pass 1 when the function's
+`Lambda` body carries `param_annotations`.
+
+The `RefinedType` here uses `lang_refined_types::Kind::Int` as the base kind
+and the same predicate as `TwigKind::RefinedInt`.
+
+### Call-site checking in `infer_apply`
+
+When the callee is a `VarRef` with an entry in `fn_param_refinements`, the
+checker runs a per-binding proof obligation for each annotated argument:
+
+```
+arg_to_evidence(arg, scope):
+  IntLit(n)             → Evidence::Concrete(n)
+  VarRef(x) → RefinedInt(p) in scope  → Evidence::Predicated([p])
+  VarRef(x) → Int or Any in scope     → Evidence::Unconstrained
+  anything else                        → Evidence::Unconstrained
+```
+
+Outcomes:
+- `ProvenSafe` → silent.
+- `ProvenUnsafe(cx)` → `TypeErrorDiagnostic` with counter-example value.
+- `Unknown` + `Strict` mode → `TypeErrorDiagnostic`.
+- `Unknown` + `Lenient` mode → silent.
+
+### Flow-sensitive narrowing in `infer_if`
+
+`extract_narrowing_facts(guard: &Expr) -> Vec<(String, Predicate)>` analyses a
+guard expression and returns per-variable narrowing predicates.
+
+Handled forms:
+
+| Guard | Narrowing fact |
+|-------|---------------|
+| `(< x k)` | `x: Range { lo: None, hi: Some(k), inclusive_hi: false }` |
+| `(<= x k)` | `x: Range { lo: None, hi: Some(k), inclusive_hi: true }` |
+| `(> x k)` | `x: Range { lo: Some(k+1), hi: None, inclusive_hi: false }` |
+| `(>= x k)` | `x: Range { lo: Some(k), hi: None, inclusive_hi: false }` |
+| `(= x k)` | `x: Range { lo: Some(k), hi: Some(k), inclusive_hi: true }` |
+| `(and c1 c2 …)` | Combine all child facts; same variable → `Predicate::and` |
+| `(not c)` | Negate facts from `c` with `Predicate::not` |
+| anything else | Empty (conservative — no narrowing) |
+
+`infer_if` uses the existing `push_frame`/`pop_frame` mechanism to apply
+narrowing scopes:
+
+```
+True  branch: push_frame; bind narrowing facts; infer then; pop_frame
+False branch: push_frame; bind negated facts;  infer else; pop_frame
+```
+
+`merge_kind_with_predicate(base, pred)`:
+- `Int` or `RefinedInt(_)` → `RefinedInt(pred)` (guard overrides or refines)
+- Anything else → `base` unchanged
+
+### `TwigKind::unify` updates
+
+Two integer-like branches that disagree on their predicate widen to `Int`
+(not `Any`), since both branches still produce an integer:
+
+```
+unify(RefinedInt(p), RefinedInt(p)) = RefinedInt(p)  (same predicate)
+unify(RefinedInt(_), RefinedInt(_)) = Int             (different predicates)
+unify(RefinedInt(_), Int)           = Int
+unify(Int, RefinedInt(_))           = Int
+unify(RefinedInt(_), Any)           = Any
+unify(a, b) where a != b            = Any             (existing rule)
+```
+
+### Scope of v1 — intentional deferrals
+
+- **Inter-procedural narrowing** — `(if (byte? x) (f x) ...)` where `byte?` is
+  a user predicate with a declared refinement effect.  Deferred to TW05-D.
+- **CFG-based loop invariants** — `FunctionChecker` in `lang-refinement-checker`
+  does path-sensitive CFG checking.  LANG53 uses only the per-binding `Checker`
+  at call sites and AST-level guard analysis for `if`.  No loops.
+- **Return-type annotation checking** — `iir-refinement-pass` (LANG42) handles
+  this at the IIR level.  No duplication.
+- **`let`/`let*` binding refinements** — deferred to TW05-C continuation.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `twig-type-checker/src/kinds.rs` | Add `TwigKind::RefinedInt(Predicate)`; update `mnemonic`, `unify`, `Display`, `type_annotation_to_kind` |
+| `twig-type-checker/src/env.rs` | Add `fn_param_refinements` to `TypeEnv`; add `register_fn_refinements` |
+| `twig-type-checker/src/narrowing.rs` | **New** — `extract_narrowing_facts`, `merge_kind_with_predicate` |
+| `twig-type-checker/src/check.rs` | Update `classify_define`; update `infer_apply` (call-site checking); update `infer_if` (flow narrowing) |
+| `twig-type-checker/src/lib.rs` | Add `pub mod narrowing` |
+| `twig-type-checker/Cargo.toml` | Add `lang-refined-types`, `lang-refinement-checker` deps; version → 0.5.0 |
+| `twig-type-checker/CHANGELOG.md` | Prepend `## [0.5.0]` |
+
+## Tests
+
+- `refined_kind_from_range_annotation` — `(Int 0 128)` annotation → `TwigKind::RefinedInt`
+- `refined_kind_from_membership_annotation` — `(Member int 1 2 5)` → `TwigKind::RefinedInt`
+- `unrefined_int_annotation_stays_int` — `int` annotation → `TwigKind::Int` (regression)
+- `call_site_literal_in_range_no_error` — `(ascii-info 42)` with `(Int 0 128)` → no error
+- `call_site_literal_out_of_range_error` — `(ascii-info 200)` → `TypeErrorDiagnostic`
+- `call_site_unconstrained_lenient_silent` — unresolved arg in lenient mode → no error
+- `call_site_unconstrained_strict_error` — same in strict mode → error
+- `narrowing_lt_proves_call` — `(if (< x 128) (ascii-info x) ...)` → no error in then
+- `narrowing_and_both_bounds` — `(if (and (>= x 0) (< x 128)) (ascii-info x) ...)` → no error
+- `narrowing_not_in_else` — `(if (< x 128) ... (ascii-info x))` → error in else branch
+- `refined_kinds_unify_to_int` — `(if c 42 200)` from different `RefinedInt` → `Int`
+- `no_narrowing_for_non_numeric` — bool/string guards do not crash narrowing


### PR DESCRIPTION
## Summary

- **`TwigKind::RefinedInt(Predicate)`** — new variant carrying a `lang_refined_types::Predicate` through the type-checker pass; `RefinedInt(p)` is a subtype of `Int`
- **Call-site proof obligations** — `infer_apply` now runs `lang_refinement_checker::Checker::check` for each annotated argument; `ProvenUnsafe` → diagnostic in all modes, `Unknown` → diagnostic in strict mode
- **Flow-sensitive narrowing** — `infer_if` calls `extract_narrowing_facts(guard)` and pushes narrowed kinds onto the scope stack for the true branch (negated predicates for the false branch), using the existing `push_frame`/`pop_frame` mechanism with no structural changes
- **74 tests pass** (13 narrowing unit tests + original TW05-B suite + 12 TW05-C integration tests + profile/doc tests)
- **`twig-type-checker` bumped 0.2.0 → 0.5.0** (0.3.0 reserved for LANG51 merge, 0.4.0 for LANG52)

## What changed

| File | Change |
|------|--------|
| `src/kinds.rs` | Added `TwigKind::RefinedInt(Predicate)`; updated `type_annotation_to_kind` for `RangeInt`/`MembershipInt`; updated `unify` with integer subtyping rules |
| `src/env.rs` | Added `TypeEnv::fn_param_refinements` + `register_fn_refinements`; added `annotation_to_refined_type` helper |
| `src/narrowing.rs` | **New file** — `extract_narrowing_facts` + `merge_kind_with_predicate` with 13 unit tests |
| `src/check.rs` | `classify_define` registers param refinements; `infer_apply` does call-site checking; `infer_if` does flow-sensitive narrowing |
| `src/lib.rs` | `pub mod narrowing`; 12 TW05-C integration tests added |
| `Cargo.toml` | Version 0.2.0 → 0.5.0; added `lang-refined-types` + `lang-refinement-checker` deps |
| `CHANGELOG.md` | Prepended `[0.5.0]` entry |
| `README.md` | Updated for TW05-B + TW05-C, added `RefinedInt`, refinement error examples, flow-sensitive narrowing section |
| `code/specs/LANG53-refinement-checker-bridge.md` | New spec |

## Test plan

- [x] `cargo test -p twig-type-checker` — 74/74 pass
- [x] `cargo build --workspace` — zero errors, zero warnings (`-D warnings`)
- [x] Security review passed (no vulnerabilities found)
- [ ] CI green

## Intentional deferrals (TW05-D)

- Inter-procedural narrowing (`(if (byte? x) ...)` where `byte?` has a declared refinement effect)
- CFG-based loop invariants via `FunctionChecker`
- Return-type annotation checking (handled by `iir-refinement-pass` at IIR level)
- `let`/`let*` binding refinements

🤖 Generated with [Claude Code](https://claude.com/claude-code)