### PR TITLE
python(spice): parse diode model netlists

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.4
+
+- Parse `.model <name> D(...)` cards into `ModelCard` records.
+- Parse `D` diode elements into `spice_engine.Diode` instances using `IS` and
+  `VT` model parameters.
+- Remap diode terminals during `.subckt` expansion.
+
 ## 0.1.3
 
 - Add SPICE `H` / CCVS controlled-source parsing, including subcircuit output

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -18,7 +18,8 @@ netlist.circuit.elements
 netlist.analyses
 ```
 
-This first parser slice supports `R`, `C`, `L`, `V`, `I`, and `G` elements,
-SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
+This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `G`, `E`, `F`, and
+`H` elements, `.model` cards for Shockley diode parameters (`IS`, `VT`), SPICE
+engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
 analysis cards.

--- a/code/packages/python/spice-netlist-parser/pyproject.toml
+++ b/code/packages/python/spice-netlist-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-netlist-parser"
-version = "0.1.3"
+version = "0.1.4"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -3,6 +3,7 @@
 from spice_netlist_parser.parser import (
     AcAnalysis,
     DcAnalysis,
+    ModelCard,
     NetlistParseError,
     OpAnalysis,
     ParsedNetlist,
@@ -11,11 +12,12 @@ from spice_netlist_parser.parser import (
 )
 
 parse = parse_netlist
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = [
     "AcAnalysis",
     "DcAnalysis",
+    "ModelCard",
     "NetlistParseError",
     "OpAnalysis",
     "ParsedNetlist",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -13,6 +13,7 @@ from spice_engine import (
     Capacitor,
     Circuit,
     CurrentSource,
+    Diode,
     ExpWaveform,
     Inductor,
     PulseWaveform,
@@ -65,6 +66,15 @@ type Analysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis
 
 
 @dataclass(frozen=True, slots=True)
+class ModelCard:
+    """A parsed SPICE `.model` card."""
+
+    name: str
+    kind: str
+    params: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
 class _Statement:
     line_number: int
     fields: list[str]
@@ -84,6 +94,7 @@ class ParsedNetlist:
 
     circuit: Circuit = field(default_factory=Circuit)
     analyses: list[Analysis] = field(default_factory=list)
+    models: dict[str, ModelCard] = field(default_factory=dict)
     title: str | None = None
 
     def op_cards(self) -> list[OpAnalysis]:
@@ -170,14 +181,30 @@ def parse_netlist(text: str) -> ParsedNetlist:
         )
 
     for statement in statements:
+        if statement.fields[0].lower() != ".model":
+            continue
         try:
+            model = _parse_model_card(statement.fields)
+            key = model.name.lower()
+            if key in parsed.models:
+                raise NetlistParseError(f"duplicate .model definition {model.name!r}")
+            parsed.models[key] = model
+        except NetlistParseError as exc:
+            raise NetlistParseError(f"line {statement.line_number}: {exc}") from exc
+
+    for statement in statements:
+        try:
+            if statement.fields[0].lower() == ".model":
+                continue
             if statement.fields[0].startswith("."):
                 parsed.analyses.append(_parse_directive(statement.fields))
             elif statement.fields[0].upper().startswith("X"):
-                for element in _expand_subckt_instance(statement.fields, subckts, []):
+                for element in _expand_subckt_instance(
+                    statement.fields, subckts, [], parsed.models
+                ):
                     parsed.circuit.add(element)
             else:
-                parsed.circuit.add(_parse_element(statement.fields))
+                parsed.circuit.add(_parse_element(statement.fields, parsed.models))
         except NetlistParseError as exc:
             raise NetlistParseError(f"line {statement.line_number}: {exc}") from exc
     return parsed
@@ -195,7 +222,7 @@ def parse_value(token: str) -> float:
     return float(match.group(1)) * _SUFFIXES[suffix]
 
 
-def _parse_element(fields: list[str]) -> object:
+def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
     name = fields[0]
     prefix = _element_prefix(name)
     if prefix == "R":
@@ -215,6 +242,22 @@ def _parse_element(fields: list[str]) -> object:
         _require_min_fields(fields, 4, "current source")
         current, waveform = _parse_source_value(fields[3:])
         return CurrentSource(name, fields[1], fields[2], current, waveform)
+    if prefix == "D":
+        _require_fields(fields, 4, "diode")
+        model = models.get(fields[3].lower())
+        if model is None:
+            raise NetlistParseError(f"unknown model {fields[3]!r} for diode {name!r}")
+        if model.kind != "D":
+            raise NetlistParseError(
+                f"model {model.name!r} has kind {model.kind!r}, expected 'D'"
+            )
+        return Diode(
+            name,
+            fields[1],
+            fields[2],
+            Is=model.params.get("IS", 1e-15),
+            Vt=model.params.get("VT", 0.02585),
+        )
     if prefix == "G":
         _require_fields(fields, 6, "VCCS")
         return VCCS(name, fields[1], fields[2], fields[3], fields[4], parse_value(fields[5]))
@@ -254,6 +297,7 @@ def _expand_subckt_instance(
     fields: list[str],
     subckts: dict[str, _SubcktDefinition],
     stack: list[str],
+    models: dict[str, ModelCard],
 ) -> list[object]:
     _require_min_fields(fields, 3, "subcircuit instance")
     instance_name = fields[0]
@@ -285,9 +329,9 @@ def _expand_subckt_instance(
             )
         local_fields = _map_subckt_fields(statement.fields, instance_name, node_map)
         if _element_prefix(statement.fields[0]) == "X":
-            elements.extend(_expand_subckt_instance(local_fields, subckts, next_stack))
+            elements.extend(_expand_subckt_instance(local_fields, subckts, next_stack, models))
         else:
-            elements.append(_parse_element(local_fields))
+            elements.append(_parse_element(local_fields, models))
     return elements
 
 
@@ -297,7 +341,7 @@ def _map_subckt_fields(
     name = f"{instance_name}.{fields[0]}"
     prefix = fields[0][0].upper()
     mapped = [name, *fields[1:]]
-    if prefix in {"R", "C", "L", "V", "I"}:
+    if prefix in {"R", "C", "L", "V", "I", "D"}:
         _require_min_fields(fields, 3, "subcircuit element")
         mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
         mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)
@@ -423,6 +467,42 @@ def _parse_directive(fields: list[str]) -> Analysis:
             stop_hz=parse_value(fields[4]),
         )
     raise NetlistParseError(f"unsupported directive {fields[0]!r}")
+
+
+def _parse_model_card(fields: list[str]) -> ModelCard:
+    _require_min_fields(fields, 3, ".model")
+    name = fields[1]
+    kind: str
+    params_text: str
+    joined_tail = " ".join(fields[2:]).strip()
+    inline = re.match(r"^([A-Za-z][A-Za-z0-9_]*)\s*(?:\((.*)\))?$", joined_tail)
+    if len(fields) == 3 and inline is not None:
+        kind = inline.group(1).upper()
+        params_text = inline.group(2) or ""
+    else:
+        kind = fields[2].upper()
+        params_text = " ".join(fields[3:]).strip()
+        if params_text.startswith("(") and params_text.endswith(")"):
+            params_text = params_text[1:-1]
+    return ModelCard(name=name, kind=kind, params=_parse_model_params(params_text))
+
+
+def _parse_model_params(params_text: str) -> dict[str, float]:
+    if not params_text.strip():
+        return {}
+    params: dict[str, float] = {}
+    spans: list[tuple[int, int]] = []
+    for match in re.finditer(r"([A-Za-z][A-Za-z0-9_]*)\s*=\s*([^,\s)]+)", params_text):
+        params[match.group(1).upper()] = parse_value(match.group(2))
+        spans.append(match.span())
+    cursor = 0
+    for start, end in spans:
+        if params_text[cursor:start].strip(" \t,"):
+            raise NetlistParseError(f"invalid .model parameter syntax {params_text!r}")
+        cursor = end
+    if params_text[cursor:].strip(" \t,"):
+        raise NetlistParseError(f"invalid .model parameter syntax {params_text!r}")
+    return params
 
 
 def _split_fields(line: str) -> list[str]:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -8,6 +8,7 @@ from spice_engine import (
     VCVS,
     Capacitor,
     CurrentSource,
+    Diode,
     Inductor,
     Resistor,
     VoltageSource,
@@ -17,6 +18,7 @@ from spice_engine import (
 from spice_netlist_parser import (
     AcAnalysis,
     DcAnalysis,
+    ModelCard,
     NetlistParseError,
     OpAnalysis,
     TranAnalysis,
@@ -137,6 +139,32 @@ Rload out 0 500
     result = dc_op(parsed.circuit)
     assert result.converged
     assert isclose(result.node_voltages["out"], 1.0, abs_tol=1e-9)
+
+
+def test_parse_diode_model_into_operating_point_circuit() -> None:
+    parsed = parse_netlist(
+        """
+.model fast D(IS=1e-12 VT=25m)
+V1 in 0 DC 0.7
+D1 in out fast
+Rload out 0 1k
+.op
+"""
+    )
+
+    assert parsed.models == {
+        "fast": ModelCard("fast", "D", {"IS": 1.0e-12, "VT": 25.0e-3})
+    }
+    diode = parsed.circuit.elements[1]
+    assert isinstance(diode, Diode)
+    assert diode.anode == "in"
+    assert diode.cathode == "out"
+    assert diode.Is == 1.0e-12
+    assert diode.Vt == 25.0e-3
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert 0.1 < result.node_voltages["out"] < 0.7
 
 
 def test_parse_pwl_and_sin_source_waveforms() -> None:
@@ -276,6 +304,25 @@ Rload out 0 500
     assert isclose(result.node_voltages["out"], 1.0, abs_tol=1e-9)
 
 
+def test_expands_subcircuit_diode_nodes_into_engine_elements() -> None:
+    parsed = parse_netlist(
+        """
+.model clamp D(IS=1e-12 VT=25m)
+.subckt limiter inp outp
+Dlim inp outp clamp
+.ends limiter
+Xlim in out limiter
+"""
+    )
+
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.name == "Xlim.Dlim"
+    assert diode.anode == "in"
+    assert diode.cathode == "out"
+    assert diode.Is == 1.0e-12
+
+
 def test_subcircuit_internal_nodes_are_instance_scoped() -> None:
     parsed = parse_netlist(
         """
@@ -304,10 +351,29 @@ def test_engineering_suffixes() -> None:
 
 
 def test_rejects_unsupported_element_with_line_number() -> None:
-    with pytest.raises(NetlistParseError, match="line 2: unsupported element 'D1'"):
+    with pytest.raises(NetlistParseError, match="line 2: unsupported element 'Q1'"):
         parse_netlist(
             """
-D1 a 0 diode
+Q1 c b e model
+"""
+        )
+
+
+def test_rejects_diode_with_unknown_model() -> None:
+    with pytest.raises(NetlistParseError, match="line 2: unknown model 'missing' for diode 'D1'"):
+        parse_netlist(
+            """
+D1 a 0 missing
+"""
+        )
+
+
+def test_rejects_diode_bound_to_non_diode_model() -> None:
+    with pytest.raises(NetlistParseError, match="line 3: model 'amp' has kind 'NPN'"):
+        parse_netlist(
+            """
+.model amp NPN(IS=1e-15)
+D1 a 0 amp
 """
         )
 


### PR DESCRIPTION
## Summary

- Add Python SPICE `.model <name> D(...)` parsing with `ModelCard` records.
- Parse `D` diode elements into `spice_engine.Diode` using `IS` and `VT` parameters.
- Remap diode terminals during `.subckt` expansion and cover DC operating-point execution.

## Validation

- `sh BUILD`
- `.venv/bin/ruff check .`
- `git diff --check`