### PR TITLE
typescript(spice): parse diode model netlists

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add Shockley diode elements with Newton-linearized DC operating-point support
+  and zero-bias small-signal conductance for AC/transfer analysis.
 - Add current-controlled voltage source support across DC, AC, transfer
   function, sensitivity, Monte Carlo, and transient analyses.
 - Add current-controlled current source support across DC, AC, transfer

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -8,8 +8,9 @@ sensitivity analysis, seeded DC Monte Carlo analysis, DC small-signal
 transfer-function analysis, AC small-signal frequency sweeps, and fixed-step
 AC noise analysis, and RC/RL transient analysis for linear circuits using
 modified nodal analysis (MNA). The package supports
-resistors, capacitors, inductors, independent current sources, independent
-voltage sources, voltage-controlled current sources (VCCS), PWL/SIN/PULSE/EXP
+resistors, capacitors, inductors, diodes, independent current sources,
+independent voltage sources, voltage-controlled current sources (VCCS),
+PWL/SIN/PULSE/EXP
 source waveforms for transient analysis, ground aliases, node voltages,
 voltage source branch currents, and backward-Euler reactive-element companion
 models.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8,6 +8,7 @@ export type Element =
   | Inductor
   | VoltageSource
   | CurrentSource
+  | Diode
   | Vccs
   | Vcvs
   | Cccs
@@ -269,6 +270,15 @@ export interface CurrentSource {
   readonly negative: string;
   readonly current: number;
   readonly waveform?: Waveform;
+}
+
+export interface Diode {
+  readonly kind: "diode";
+  readonly name: string;
+  readonly anode: string;
+  readonly cathode: string;
+  readonly saturationCurrent: number;
+  readonly thermalVoltage: number;
 }
 
 export interface Vccs {
@@ -545,6 +555,23 @@ export function currentSourceWithWaveform(
     negative,
     current,
     waveform,
+  };
+}
+
+export function diode(
+  name: string,
+  anode: string,
+  cathode: string,
+  saturationCurrent = 1.0e-15,
+  thermalVoltage = 0.02585,
+): Diode {
+  return {
+    kind: "diode",
+    name,
+    anode,
+    cathode,
+    saturationCurrent,
+    thermalVoltage,
   };
 }
 
@@ -1091,6 +1118,12 @@ function elementParameter(element: Element): ElementParameter | undefined {
         parameter: "current",
         nominalValue: element.current,
       };
+    case "diode":
+      return {
+        elementName: element.name,
+        parameter: "saturationCurrent",
+        nominalValue: element.saturationCurrent,
+      };
     case "vccs":
       return {
         elementName: element.name,
@@ -1149,6 +1182,12 @@ function circuitWithPerturbedElement(
         break;
       case "current-source":
         perturbed.add({ ...element, current: element.current + delta });
+        break;
+      case "diode":
+        perturbed.add({
+          ...element,
+          saturationCurrent: element.saturationCurrent + delta,
+        });
         break;
       case "vccs":
         perturbed.add({
@@ -1254,6 +1293,16 @@ function randomizedElement(
         ...element,
         current: randomizedValue(element.current, tolerance, distribution, rng),
       };
+    case "diode":
+      return {
+        ...element,
+        saturationCurrent: randomizedValue(
+          element.saturationCurrent,
+          tolerance,
+          distribution,
+          rng,
+        ),
+      };
     case "vccs":
       return {
         ...element,
@@ -1323,6 +1372,7 @@ interface InductorState {
 interface LinearSolution {
   readonly nodeVoltages: ReadonlyMap<string, number>;
   readonly branchCurrents: ReadonlyMap<string, number>;
+  readonly vector: readonly number[];
 }
 
 interface AcSolution {
@@ -1353,8 +1403,59 @@ function solveLinearCircuit(
   const matrixSize = nodeCount + branchCount;
 
   if (matrixSize === 0) {
-    return { nodeVoltages: new Map(), branchCurrents: new Map() };
+    return { nodeVoltages: new Map(), branchCurrents: new Map(), vector: [] };
   }
+
+  const hasDiode = circuit.elements().some((element) => element.kind === "diode");
+  let operatingPoint = Array.from({ length: matrixSize }, () => 0.0);
+  let solution = solveLinearCircuitAtOperatingPoint(
+    circuit,
+    capacitorStates,
+    inductorStates,
+    sourceTime,
+    nodeIndices,
+    voltageSources,
+    nodeCount,
+    matrixSize,
+    operatingPoint,
+  );
+  if (!hasDiode) {
+    return solution;
+  }
+
+  for (let iteration = 0; iteration < 80; iteration++) {
+    const delta = maxVectorDelta(solution.vector, operatingPoint);
+    operatingPoint = [...solution.vector];
+    if (delta < 1.0e-9) {
+      return solution;
+    }
+    solution = solveLinearCircuitAtOperatingPoint(
+      circuit,
+      capacitorStates,
+      inductorStates,
+      sourceTime,
+      nodeIndices,
+      voltageSources,
+      nodeCount,
+      matrixSize,
+      operatingPoint,
+    );
+  }
+
+  return solution;
+}
+
+function solveLinearCircuitAtOperatingPoint(
+  circuit: Circuit,
+  capacitorStates: readonly CapacitorState[],
+  inductorStates: readonly InductorState[],
+  sourceTime: number | undefined,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  nodeCount: number,
+  matrixSize: number,
+  operatingPoint: readonly number[],
+): LinearSolution {
 
   const matrix = Array.from({ length: matrixSize }, () =>
     Array.from({ length: matrixSize }, () => 0.0),
@@ -1393,6 +1494,9 @@ function solveLinearCircuit(
         break;
       case "current-source":
         stampCurrentSource(element, nodeIndices, rhs, sourceTime);
+        break;
+      case "diode":
+        stampDiode(element, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
@@ -1441,7 +1545,15 @@ function solveLinearCircuit(
     branchCurrents,
   );
 
-  return { nodeVoltages, branchCurrents };
+  return { nodeVoltages, branchCurrents, vector: solution };
+}
+
+function maxVectorDelta(left: readonly number[], right: readonly number[]): number {
+  let max = 0.0;
+  for (let index = 0; index < left.length; index++) {
+    max = Math.max(max, Math.abs(left[index] - right[index]));
+  }
+  return max;
 }
 
 function buildSmallSignalMatrix(
@@ -1488,6 +1600,15 @@ function buildSmallSignalMatrix(
         if (!Number.isFinite(element.current)) {
           throw invalidElement(element.name, "current must be finite");
         }
+        break;
+      case "diode":
+        validateDiode(element);
+        stampConductance(
+          matrix,
+          nodeIndex(nodeIndices, element.anode),
+          nodeIndex(nodeIndices, element.cathode),
+          element.saturationCurrent / element.thermalVoltage,
+        );
         break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
@@ -1549,6 +1670,7 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
       case "resistor":
       case "capacitor":
       case "inductor":
+      case "diode":
       case "vccs":
       case "vcvs":
       case "cccs":
@@ -1609,6 +1731,15 @@ function buildAcMatrix(
         if (!Number.isFinite(element.current)) {
           throw invalidElement(element.name, "current must be finite");
         }
+        break;
+      case "diode":
+        validateDiode(element);
+        stampComplexConductance(
+          matrix,
+          nodeIndex(nodeIndices, element.anode),
+          nodeIndex(nodeIndices, element.cathode),
+          complex(element.saturationCurrent / element.thermalVoltage, 0.0),
+        );
         break;
       case "vccs":
         stampAcVccs(element, nodeIndices, matrix);
@@ -1803,6 +1934,10 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.positive);
         insertNode(names, element.negative);
         break;
+      case "diode":
+        insertNode(names, element.anode);
+        insertNode(names, element.cathode);
+        break;
       case "vccs":
         insertNode(names, element.positive);
         insertNode(names, element.negative);
@@ -1883,6 +2018,7 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
       (element.kind === "resistor" ||
         element.kind === "capacitor" ||
         element.kind === "inductor" ||
+        element.kind === "diode" ||
         element.kind === "vccs" ||
         element.kind === "vcvs" ||
         element.kind === "cccs" ||
@@ -2121,6 +2257,34 @@ function stampConductance(
   }
 }
 
+function stampDiode(
+  element: Diode,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+  operatingPoint: readonly number[],
+): void {
+  validateDiode(element);
+  const anode = nodeIndex(nodeIndices, element.anode);
+  const cathode = nodeIndex(nodeIndices, element.cathode);
+  const voltage =
+    (anode === undefined ? 0.0 : operatingPoint[anode]) -
+    (cathode === undefined ? 0.0 : operatingPoint[cathode]);
+  const exponent = Math.max(-40.0, Math.min(40.0, voltage / element.thermalVoltage));
+  const expValue = Math.exp(exponent);
+  const current = element.saturationCurrent * (expValue - 1.0);
+  const conductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const equivalentCurrent = current - conductance * voltage;
+
+  stampConductance(matrix, anode, cathode, conductance);
+  if (anode !== undefined) {
+    rhs[anode] -= equivalentCurrent;
+  }
+  if (cathode !== undefined) {
+    rhs[cathode] += equivalentCurrent;
+  }
+}
+
 function validateReactiveElements(circuit: Circuit): void {
   for (const element of circuit.elements()) {
     if (element.kind === "capacitor") {
@@ -2128,6 +2292,15 @@ function validateReactiveElements(circuit: Circuit): void {
     } else if (element.kind === "inductor") {
       validateInductor(element);
     }
+  }
+}
+
+function validateDiode(element: Diode): void {
+  if (!Number.isFinite(element.saturationCurrent) || element.saturationCurrent <= 0.0) {
+    throw invalidElement(element.name, "saturation current must be finite and positive");
+  }
+  if (!Number.isFinite(element.thermalVoltage) || element.thermalVoltage <= 0.0) {
+    throw invalidElement(element.name, "thermal voltage must be finite and positive");
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -8,6 +8,7 @@ import {
   currentSource,
   dcOp,
   dcSweep,
+  diode,
   inductor,
   resistor,
   vccs,
@@ -142,6 +143,18 @@ describe("dcOp", () => {
     expectClose(result.branchCurrent("Vsense"), 1.0e-3);
     expectClose(result.voltage("out"), 2.0);
     expectClose(result.branchCurrent("H1"), -2.0e-3);
+  });
+
+  it("solves a forward-biased diode operating point", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 0.7));
+    circuit.add(diode("D1", "in", "out", 1.0e-12, 0.025));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expect(result.voltage("out")).toBeGreaterThan(0.1);
+    expect(result.voltage("out")).toBeLessThan(0.7);
   });
 
   it("rejects missing CCCS control sources", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.4
+
+- Add SPICE `D` diode element parsing via `.model <name> D(...)` cards with
+  `IS` and `VT` parameters, including subcircuit terminal remapping.
+
 ## 0.1.3
 
 - Add SPICE `H` / CCVS controlled-source parsing, including subcircuit

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -19,7 +19,8 @@ netlist.circuit.elements();
 netlist.analyses;
 ```
 
-This first parser slice supports `R`, `C`, `L`, `V`, `I`, and `G` elements,
+This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `G`, `E`, `F`, and `H`
+elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
 analysis cards.

--- a/code/packages/typescript/spice-netlist-parser/package.json
+++ b/code/packages/typescript/spice-netlist-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/spice-netlist-parser",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -9,6 +9,7 @@ import {
   ccvs,
   currentSource,
   currentSourceWithWaveform,
+  diode,
   dcOp,
   inductor,
   resistor,
@@ -55,10 +56,17 @@ export interface AcAnalysis {
 
 export type Analysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis;
 
+export interface ModelCard {
+  readonly name: string;
+  readonly kind: string;
+  readonly params: ReadonlyMap<string, number>;
+}
+
 export class ParsedNetlist {
   constructor(
     readonly circuit = new Circuit(),
     readonly analyses: Analysis[] = [],
+    readonly models: ReadonlyMap<string, ModelCard> = new Map(),
     readonly title?: string,
   ) {}
 
@@ -108,6 +116,7 @@ const SUFFIXES = new Map<string, number>([
 export function parseNetlist(text: string): ParsedNetlist {
   const circuit = new Circuit();
   const analyses: Analysis[] = [];
+  const models = new Map<string, ModelCard>();
   const statements: Statement[] = [];
   const subckts = new Map<string, SubcktDefinition>();
   let currentSubckt: SubcktDefinition | undefined;
@@ -180,22 +189,41 @@ export function parseNetlist(text: string): ParsedNetlist {
   }
 
   for (const statement of statements) {
+    if (statement.fields[0].toLowerCase() !== ".model") {
+      continue;
+    }
     try {
+      const model = parseModelCard(statement.fields);
+      const key = model.name.toLowerCase();
+      if (models.has(key)) {
+        throw new NetlistParseError(`duplicate .model definition ${JSON.stringify(model.name)}`);
+      }
+      models.set(key, model);
+    } catch (error) {
+      throw lineError(statement.lineNumber, error);
+    }
+  }
+
+  for (const statement of statements) {
+    try {
+      if (statement.fields[0].toLowerCase() === ".model") {
+        continue;
+      }
       if (statement.fields[0].startsWith(".")) {
         analyses.push(parseDirective(statement.fields));
       } else if (statement.fields[0].toUpperCase().startsWith("X")) {
-        for (const element of expandSubcktInstance(statement.fields, subckts, [])) {
+        for (const element of expandSubcktInstance(statement.fields, subckts, [], models)) {
           circuit.add(element);
         }
       } else {
-        circuit.add(parseElement(statement.fields));
+        circuit.add(parseElement(statement.fields, models));
       }
     } catch (error) {
       throw lineError(statement.lineNumber, error);
     }
   }
 
-  return new ParsedNetlist(circuit, analyses, title);
+  return new ParsedNetlist(circuit, analyses, models, title);
 }
 
 export const parse = parseNetlist;
@@ -213,7 +241,44 @@ export function parseValue(token: string): number {
   return Number.parseFloat(match[1]) * multiplier;
 }
 
-function parseElement(fields: readonly string[]): Element {
+function parseModelCard(fields: readonly string[]): ModelCard {
+  requireMinFields(fields, 3, ".model");
+  const tail = fields.slice(2).join(" ").trim();
+  const match = /^([A-Za-z][A-Za-z0-9_]*)(?:\s*\((.*)\)|\s+(.*))?$/.exec(tail);
+  if (match === null) {
+    throw new NetlistParseError(`invalid .model kind ${JSON.stringify(tail)}`);
+  }
+  let paramsText = (match[2] ?? match[3] ?? "").trim();
+  if (paramsText.startsWith("(") && paramsText.endsWith(")")) {
+    paramsText = paramsText.slice(1, -1);
+  }
+  return {
+    name: fields[1],
+    kind: match[1].toUpperCase(),
+    params: parseModelParams(paramsText),
+  };
+}
+
+function parseModelParams(paramsText: string): ReadonlyMap<string, number> {
+  const params = new Map<string, number>();
+  if (paramsText.trim().length === 0) {
+    return params;
+  }
+  const pattern = /([A-Za-z][A-Za-z0-9_]*)\s*=\s*([^,\s)]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(paramsText)) !== null) {
+    params.set(match[1].toUpperCase(), parseValue(match[2]));
+  }
+  const leftover = paramsText.replace(pattern, "").replace(/[,\s]/g, "");
+  if (leftover.length > 0 || params.size === 0) {
+    throw new NetlistParseError(
+      `invalid .model parameter syntax ${JSON.stringify(paramsText)}`,
+    );
+  }
+  return params;
+}
+
+function parseElement(fields: readonly string[], models: ReadonlyMap<string, ModelCard>): Element {
   const name = fields[0];
   const prefix = elementPrefix(name);
   if (prefix === "R") {
@@ -241,6 +306,27 @@ function parseElement(fields: readonly string[]): Element {
     return waveform === undefined
       ? currentSource(name, fields[1], fields[2], current)
       : currentSourceWithWaveform(name, fields[1], fields[2], current, waveform);
+  }
+  if (prefix === "D") {
+    requireFields(fields, 4, "diode");
+    const model = models.get(fields[3].toLowerCase());
+    if (model === undefined) {
+      throw new NetlistParseError(
+        `unknown model ${JSON.stringify(fields[3])} for diode ${JSON.stringify(name)}`,
+      );
+    }
+    if (model.kind !== "D") {
+      throw new NetlistParseError(
+        `model ${JSON.stringify(model.name)} has kind ${JSON.stringify(model.kind)}, expected "D"`,
+      );
+    }
+    return diode(
+      name,
+      fields[1],
+      fields[2],
+      model.params.get("IS") ?? 1.0e-15,
+      model.params.get("VT") ?? 0.02585,
+    );
   }
   if (prefix === "G") {
     requireFields(fields, 6, "VCCS");
@@ -289,6 +375,7 @@ function expandSubcktInstance(
   fields: readonly string[],
   subckts: ReadonlyMap<string, SubcktDefinition>,
   stack: readonly string[],
+  models: ReadonlyMap<string, ModelCard>,
 ): Element[] {
   requireMinFields(fields, 3, "subcircuit instance");
   const instanceName = fields[0];
@@ -325,9 +412,9 @@ function expandSubcktInstance(
     }
     const localFields = mapSubcktFields(statement.fields, instanceName, nodeMap);
     if (elementPrefix(statement.fields[0]) === "X") {
-      elements.push(...expandSubcktInstance(localFields, subckts, nextStack));
+      elements.push(...expandSubcktInstance(localFields, subckts, nextStack, models));
     } else {
-      elements.push(parseElement(localFields));
+      elements.push(parseElement(localFields, models));
     }
   }
   return elements;
@@ -340,7 +427,7 @@ function mapSubcktFields(
 ): string[] {
   const mapped = [`${instanceName}.${fields[0]}`, ...fields.slice(1)];
   const prefix = fields[0][0].toUpperCase();
-  if (["R", "C", "L", "V", "I"].includes(prefix)) {
+  if (["R", "C", "L", "V", "I", "D"].includes(prefix)) {
     requireMinFields(fields, 3, "subcircuit element");
     mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
     mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -120,6 +120,37 @@ Rload out 0 500
     expect(result.voltage("out")).toBeCloseTo(1.0, 9);
   });
 
+  it("parses diode models into operating-point circuits", () => {
+    const parsed = parseNetlist(`
+.model fast D(IS=1e-12 VT=25m)
+V1 in 0 DC 0.7
+D1 in out fast
+Rload out 0 1k
+.op
+`);
+
+    expect(parsed.models.get("fast")).toEqual({
+      name: "fast",
+      kind: "D",
+      params: new Map([
+        ["IS", 1.0e-12],
+        ["VT", 25.0e-3],
+      ]),
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "diode",
+      name: "D1",
+      anode: "in",
+      cathode: "out",
+      saturationCurrent: 1.0e-12,
+      thermalVoltage: 25.0e-3,
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("out")).toBeGreaterThan(0.1);
+    expect(result.voltage("out")).toBeLessThan(0.7);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)
@@ -253,6 +284,23 @@ Rload out 0 500
     expect(result.voltage("out")).toBeCloseTo(1.0, 9);
   });
 
+  it("expands subcircuit diode nodes into engine elements", () => {
+    const parsed = parseNetlist(`
+.model clamp D(IS=1e-12 VT=25m)
+.subckt limiter inp outp
+Dlim inp outp clamp
+.ends limiter
+Xlim in out limiter
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      name: "Xlim.Dlim",
+      anode: "in",
+      cathode: "out",
+    });
+  });
+
   it("scopes subcircuit internal nodes by instance", () => {
     const parsed = parseNetlist(`
 .subckt load in out
@@ -282,8 +330,20 @@ Xright c d load
   });
 
   it("rejects unsupported elements with line numbers", () => {
-    expect(() => parseNetlist("\nD1 a 0 diode\n")).toThrow(NetlistParseError);
-    expect(() => parseNetlist("\nD1 a 0 diode\n")).toThrow("line 2: unsupported element");
+    expect(() => parseNetlist("\nQ1 c b e model\n")).toThrow(NetlistParseError);
+    expect(() => parseNetlist("\nQ1 c b e model\n")).toThrow("line 2: unsupported element");
+  });
+
+  it("rejects unknown diode models", () => {
+    expect(() => parseNetlist("D1 a 0 missing\n")).toThrow(
+      "line 1: unknown model \"missing\" for diode \"D1\"",
+    );
+  });
+
+  it("rejects non-diode models for diode elements", () => {
+    expect(() => parseNetlist(".model amp NPN(IS=1e-12)\nD1 a 0 amp\n")).toThrow(
+      'line 2: model "amp" has kind "NPN", expected "D"',
+    );
   });
 
   it("rejects unbalanced waveform parentheses", () => {


### PR DESCRIPTION
## Summary

- Add TypeScript SPICE `.model <name> D(...)` parsing with `ModelCard` records.
- Parse `D` diode elements into `spice-engine` Shockley diode elements using `IS` and `VT` parameters.
- Remap diode terminals during `.subckt` expansion and cover DC operating-point execution.

## Validation

- `npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `git diff --check`
