### PR TITLE
rust(spice): parse diode model netlists

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add a DC modified nodal analysis solver for resistors, independent voltage
   sources, and independent current sources.
+- Add Shockley diode elements with Newton-linearized DC operating-point support
+  and zero-bias small-signal conductance for AC/transfer analysis.
 - Add voltage-controlled current sources (VCCS) for linear transconductance
   stages.
 - Add voltage-controlled voltage sources (VCVS) across DC, AC, transfer

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -19,9 +19,10 @@ The initial slices implement:
 - Backward-Euler transient analysis for linear RC/RL circuits.
 - Time-varying transient source waveforms: PWL, SIN, PULSE, and EXP.
 
-The package supports resistors, capacitors, inductors, independent current sources,
-independent voltage sources, voltage-controlled current sources, optional source
-waveforms, ground aliases, node voltages, and voltage source branch currents.
+The package supports resistors, capacitors, inductors, diodes, independent
+current sources, independent voltage sources, voltage-controlled current
+sources, optional source waveforms, ground aliases, node voltages, and voltage
+source branch currents.
 
 ```rust
 use spice_engine::{Circuit, Element, PwlWaveform, Resistor, VoltageSource, Waveform};

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -340,6 +340,7 @@ pub enum Element {
     Inductor(Inductor),
     VoltageSource(VoltageSource),
     CurrentSource(CurrentSource),
+    Diode(Diode),
     Vccs(Vccs),
     Vcvs(Vcvs),
     Cccs(Cccs),
@@ -522,6 +523,41 @@ impl CurrentSource {
             negative: negative.into(),
             current,
             waveform: Some(waveform),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Diode {
+    pub name: String,
+    pub anode: String,
+    pub cathode: String,
+    pub saturation_current: f64,
+    pub thermal_voltage: f64,
+}
+
+impl Diode {
+    pub fn new(
+        name: impl Into<String>,
+        anode: impl Into<String>,
+        cathode: impl Into<String>,
+    ) -> Self {
+        Self::with_model(name, anode, cathode, 1.0e-15, 0.02585)
+    }
+
+    pub fn with_model(
+        name: impl Into<String>,
+        anode: impl Into<String>,
+        cathode: impl Into<String>,
+        saturation_current: f64,
+        thermal_voltage: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            anode: anode.into(),
+            cathode: cathode.into(),
+            saturation_current,
+            thermal_voltage,
         }
     }
 }
@@ -1469,6 +1505,11 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
         Element::CurrentSource(source) => {
             Some((source.name.clone(), "current".to_string(), source.current))
         }
+        Element::Diode(diode) => Some((
+            diode.name.clone(),
+            "saturation_current".to_string(),
+            diode.saturation_current,
+        )),
         Element::Vccs(source) => Some((
             source.name.clone(),
             "transconductance_siemens".to_string(),
@@ -1494,6 +1535,7 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::Resistor(resistor) => resistor.resistance_ohms += delta,
         Element::VoltageSource(source) => source.voltage += delta,
         Element::CurrentSource(source) => source.current += delta,
+        Element::Diode(diode) => diode.saturation_current += delta,
         Element::Vccs(source) => source.transconductance_siemens += delta,
         Element::Vcvs(source) => source.gain += delta,
         Element::Cccs(source) => source.gain += delta,
@@ -1578,6 +1620,12 @@ fn randomized_element(
             varied.current = randomized_value(varied.current, tolerance, distribution, rng);
             Element::CurrentSource(varied)
         }
+        Element::Diode(diode) => {
+            let mut varied = diode.clone();
+            varied.saturation_current =
+                randomized_value(varied.saturation_current, tolerance, distribution, rng);
+            Element::Diode(varied)
+        }
         Element::Vccs(source) => {
             let mut varied = source.clone();
             varied.transconductance_siemens = randomized_value(
@@ -1646,6 +1694,7 @@ struct InductorState {
 struct LinearSolution {
     node_voltages: BTreeMap<String, f64>,
     branch_currents: BTreeMap<String, f64>,
+    vector: Vec<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1685,26 +1734,80 @@ fn solve_linear_circuit(
         return Ok(LinearSolution {
             node_voltages: BTreeMap::new(),
             branch_currents: BTreeMap::new(),
+            vector: Vec::new(),
         });
     }
 
+    let has_diode = circuit
+        .elements()
+        .iter()
+        .any(|element| matches!(element, Element::Diode(_)));
+    let mut operating_point = vec![0.0; matrix_size];
+    let mut solution = solve_linear_circuit_at_operating_point(
+        circuit,
+        capacitor_states,
+        inductor_states,
+        source_time,
+        &node_indices,
+        &voltage_sources,
+        node_count,
+        matrix_size,
+        &operating_point,
+    )?;
+    if !has_diode {
+        return Ok(solution);
+    }
+
+    for _ in 0..80 {
+        let delta = max_vector_delta(&solution.vector, &operating_point);
+        operating_point = solution.vector.clone();
+        if delta < 1.0e-9 {
+            return Ok(solution);
+        }
+        solution = solve_linear_circuit_at_operating_point(
+            circuit,
+            capacitor_states,
+            inductor_states,
+            source_time,
+            &node_indices,
+            &voltage_sources,
+            node_count,
+            matrix_size,
+            &operating_point,
+        )?;
+    }
+
+    Ok(solution)
+}
+
+fn solve_linear_circuit_at_operating_point(
+    circuit: &Circuit,
+    capacitor_states: &[CapacitorState],
+    inductor_states: &[InductorState],
+    source_time: Option<f64>,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    node_count: usize,
+    matrix_size: usize,
+    operating_point: &[f64],
+) -> Result<LinearSolution, SpiceError> {
     let mut matrix = vec![vec![0.0; matrix_size]; matrix_size];
     let mut rhs = vec![0.0; matrix_size];
 
     for element in circuit.elements() {
         match element {
-            Element::Resistor(resistor) => stamp_resistor(resistor, &node_indices, &mut matrix)?,
+            Element::Resistor(resistor) => stamp_resistor(resistor, node_indices, &mut matrix)?,
             Element::Capacitor(capacitor) => stamp_capacitor(
                 capacitor,
                 capacitor_states,
-                &node_indices,
+                node_indices,
                 &mut matrix,
                 &mut rhs,
             )?,
             Element::Inductor(inductor) => stamp_inductor(
                 inductor,
                 inductor_states,
-                &node_indices,
+                node_indices,
                 &voltage_sources,
                 node_count,
                 &mut matrix,
@@ -1712,7 +1815,7 @@ fn solve_linear_circuit(
             )?,
             Element::VoltageSource(source) => stamp_voltage_source(
                 source,
-                &node_indices,
+                node_indices,
                 &voltage_sources,
                 node_count,
                 source_time,
@@ -1720,23 +1823,26 @@ fn solve_linear_circuit(
                 &mut rhs,
             )?,
             Element::CurrentSource(source) => {
-                stamp_current_source(source, &node_indices, source_time, &mut rhs)?
+                stamp_current_source(source, node_indices, source_time, &mut rhs)?
             }
-            Element::Vccs(source) => stamp_vccs(source, &node_indices, &mut matrix)?,
+            Element::Diode(diode) => {
+                stamp_diode(diode, node_indices, &mut matrix, &mut rhs, operating_point)?
+            }
+            Element::Vccs(source) => stamp_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_vcvs(
                 source,
-                &node_indices,
+                node_indices,
                 &voltage_sources,
                 node_count,
                 &mut matrix,
             )?,
             Element::Cccs(source) => {
-                stamp_cccs(source, &node_indices, &voltage_sources, &mut matrix)?
+                stamp_cccs(source, node_indices, voltage_sources, &mut matrix)?
             }
             Element::Ccvs(source) => stamp_ccvs(
                 source,
-                &node_indices,
-                &voltage_sources,
+                node_indices,
+                voltage_sources,
                 node_count,
                 &mut matrix,
             )?,
@@ -1744,12 +1850,12 @@ fn solve_linear_circuit(
     }
 
     let solution = solve_linear_system(matrix, rhs)?;
-    let node_voltages = node_voltages_from_solution(&node_indices, &solution);
+    let node_voltages = node_voltages_from_solution(node_indices, &solution);
     let mut branch_currents = BTreeMap::new();
     for (source_name, branch_index) in voltage_sources {
         branch_currents.insert(
             format!("I({source_name})"),
-            solution[node_count + branch_index],
+            solution[node_count + *branch_index],
         );
     }
     insert_transient_inductor_currents(
@@ -1762,7 +1868,15 @@ fn solve_linear_circuit(
     Ok(LinearSolution {
         node_voltages,
         branch_currents,
+        vector: solution,
     })
+}
+
+fn max_vector_delta(left: &[f64], right: &[f64]) -> f64 {
+    left.iter()
+        .zip(right.iter())
+        .map(|(left, right)| (left - right).abs())
+        .fold(0.0, f64::max)
 }
 
 fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceError> {
@@ -1793,6 +1907,7 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             Element::Resistor(_)
             | Element::Capacitor(_)
             | Element::Inductor(_)
+            | Element::Diode(_)
             | Element::Vccs(_)
             | Element::Vcvs(_)
             | Element::Cccs(_)
@@ -1849,6 +1964,15 @@ fn build_ac_matrix(
                         reason: "current must be finite".to_string(),
                     });
                 }
+            }
+            Element::Diode(diode) => {
+                validate_diode(diode)?;
+                stamp_complex_conductance(
+                    &mut matrix,
+                    node_index(node_indices, &diode.anode),
+                    node_index(node_indices, &diode.cathode),
+                    Complex::new(diode.saturation_current / diode.thermal_voltage, 0.0),
+                );
             }
             Element::Vccs(source) => stamp_ac_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_ac_vcvs(
@@ -1916,6 +2040,15 @@ fn build_small_signal_matrix(
                         reason: "current must be finite".to_string(),
                     });
                 }
+            }
+            Element::Diode(diode) => {
+                validate_diode(diode)?;
+                stamp_conductance(
+                    &mut matrix,
+                    node_index(node_indices, &diode.anode),
+                    node_index(node_indices, &diode.cathode),
+                    diode.saturation_current / diode.thermal_voltage,
+                );
             }
             Element::Vccs(source) => {
                 stamp_vccs(source, node_indices, &mut matrix)?;
@@ -1996,6 +2129,10 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
             Element::CurrentSource(source) => {
                 insert_node(&mut names, &source.positive);
                 insert_node(&mut names, &source.negative);
+            }
+            Element::Diode(diode) => {
+                insert_node(&mut names, &diode.anode);
+                insert_node(&mut names, &diode.cathode);
             }
             Element::Vccs(source) => {
                 insert_node(&mut names, &source.positive);
@@ -2101,6 +2238,9 @@ fn find_input_source<'a>(
             }
             Element::Inductor(inductor) if inductor.name == input_source => {
                 return Err(input_source_type_error(input_source, "inductor"));
+            }
+            Element::Diode(diode) if diode.name == input_source => {
+                return Err(input_source_type_error(input_source, "diode"));
             }
             Element::Vccs(source) if source.name == input_source => {
                 return Err(input_source_type_error(input_source, "VCCS"));
@@ -2353,6 +2493,34 @@ fn stamp_conductance(
     }
 }
 
+fn stamp_diode(
+    diode: &Diode,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_diode(diode)?;
+    let anode = node_index(node_indices, &diode.anode);
+    let cathode = node_index(node_indices, &diode.cathode);
+    let voltage = anode.map_or(0.0, |index| operating_point[index])
+        - cathode.map_or(0.0, |index| operating_point[index]);
+    let exponent = (voltage / diode.thermal_voltage).clamp(-40.0, 40.0);
+    let exp_value = exponent.exp();
+    let current = diode.saturation_current * (exp_value - 1.0);
+    let conductance = diode.saturation_current / diode.thermal_voltage * exp_value;
+    let equivalent_current = current - conductance * voltage;
+
+    stamp_conductance(matrix, anode, cathode, conductance);
+    if let Some(index) = anode {
+        rhs[index] -= equivalent_current;
+    }
+    if let Some(index) = cathode {
+        rhs[index] += equivalent_current;
+    }
+    Ok(())
+}
+
 fn validate_reactive_elements(circuit: &Circuit) -> Result<(), SpiceError> {
     for element in circuit.elements() {
         match element {
@@ -2360,6 +2528,22 @@ fn validate_reactive_elements(circuit: &Circuit) -> Result<(), SpiceError> {
             Element::Inductor(inductor) => validate_inductor(inductor)?,
             _ => {}
         }
+    }
+    Ok(())
+}
+
+fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
+    if !diode.saturation_current.is_finite() || diode.saturation_current <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "saturation current must be finite and positive".to_string(),
+        });
+    }
+    if !diode.thermal_voltage.is_finite() || diode.thermal_voltage <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "thermal voltage must be finite and positive".to_string(),
+        });
     }
     Ok(())
 }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    dc_op, dc_sweep, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor, Resistor, SinWaveform,
-    SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
+    dc_op, dc_sweep, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, Inductor, Resistor,
+    SinWaveform, SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -142,6 +142,25 @@ fn dc_ccvs_sets_voltage_from_voltage_source_branch_current() {
     assert_close(result.branch_current("Vsense").unwrap(), 1.0e-3);
     assert_close(result.voltage("out").unwrap(), 2.0);
     assert_close(result.branch_current("H1").unwrap(), -2.0e-3);
+}
+
+#[test]
+fn dc_diode_solves_forward_biased_operating_point() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 0.7,
+    )));
+    circuit.add(Element::Diode(Diode::with_model(
+        "D1", "in", "out", 1.0e-12, 0.025,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+    let out = result.voltage("out").unwrap();
+    assert!(out > 0.1, "expected forward-biased output, got {out}");
+    assert!(out < 0.7, "expected diode drop below source, got {out}");
 }
 
 #[test]

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.4
+
+- Add SPICE `D` diode element parsing via `.model <name> D(...)` cards with
+  `IS` and `VT` parameters, including subcircuit terminal remapping.
+
 ## 0.1.3
 
 - Add SPICE `H` / CCVS controlled-source parsing, including subcircuit

--- a/code/packages/rust/spice-netlist-parser/Cargo.toml
+++ b/code/packages/rust/spice-netlist-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spice-netlist-parser"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -17,7 +17,8 @@ C1 out 0 1u
 assert_eq!(parsed.tran_cards().len(), 1);
 ```
 
-This first parser slice supports `R`, `C`, `L`, `V`, `I`, and `G` elements,
+This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `G`, `E`, `F`, and `H`
+elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
 analysis cards.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, fmt};
 
 use spice_engine::{
-    Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, ExpWaveform, Inductor, PulseWaveform,
-    PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
+    Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, ExpWaveform, Inductor,
+    PulseWaveform, PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,9 +60,17 @@ pub enum Analysis {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct ModelCard {
+    pub name: String,
+    pub kind: String,
+    pub params: HashMap<String, f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct ParsedNetlist {
     pub circuit: Circuit,
     pub analyses: Vec<Analysis>,
+    pub models: HashMap<String, ModelCard>,
     pub title: Option<String>,
 }
 
@@ -125,6 +133,7 @@ struct SubcktDefinition {
 pub fn parse_netlist(text: &str) -> Result<ParsedNetlist, NetlistParseError> {
     let mut circuit = Circuit::new();
     let mut analyses = Vec::new();
+    let mut models = HashMap::new();
     let mut statements = Vec::new();
     let mut subckts = HashMap::new();
     let mut current_subckt: Option<SubcktDefinition> = None;
@@ -204,19 +213,38 @@ pub fn parse_netlist(text: &str) -> Result<ParsedNetlist, NetlistParseError> {
         )));
     }
 
+    for statement in &statements {
+        if !statement.fields[0].eq_ignore_ascii_case(".model") {
+            continue;
+        }
+        let model = parse_model_card(&statement.fields)
+            .map_err(|err| line_error(statement.line_number, err))?;
+        let key = model.name.to_ascii_lowercase();
+        if models.contains_key(&key) {
+            return Err(line_error(
+                statement.line_number,
+                NetlistParseError::new(format!("duplicate .model definition {:?}", model.name)),
+            ));
+        }
+        models.insert(key, model);
+    }
+
     for statement in statements {
+        if statement.fields[0].eq_ignore_ascii_case(".model") {
+            continue;
+        }
         if statement.fields[0].starts_with('.') {
             let analysis = parse_directive(&statement.fields)
                 .map_err(|err| line_error(statement.line_number, err))?;
             analyses.push(analysis);
         } else if statement.fields[0].to_ascii_uppercase().starts_with('X') {
-            let elements = expand_subckt_instance(&statement.fields, &subckts, &[])
+            let elements = expand_subckt_instance(&statement.fields, &subckts, &[], &models)
                 .map_err(|err| line_error(statement.line_number, err))?;
             for element in elements {
                 circuit.add(element);
             }
         } else {
-            let element = parse_element(&statement.fields)
+            let element = parse_element(&statement.fields, &models)
                 .map_err(|err| line_error(statement.line_number, err))?;
             circuit.add(element);
         }
@@ -225,6 +253,7 @@ pub fn parse_netlist(text: &str) -> Result<ParsedNetlist, NetlistParseError> {
     Ok(ParsedNetlist {
         circuit,
         analyses,
+        models,
         title,
     })
 }
@@ -262,7 +291,77 @@ pub fn parse_value(token: &str) -> Result<f64, NetlistParseError> {
     )))
 }
 
-fn parse_element(fields: &[String]) -> Result<Element, NetlistParseError> {
+fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
+    require_min_fields(fields, 3, ".model")?;
+    let tail = fields[2..].join(" ");
+    let trimmed = tail.trim();
+    let kind_end = trimmed
+        .find(|ch: char| ch.is_whitespace() || ch == '(')
+        .unwrap_or(trimmed.len());
+    if kind_end == 0 {
+        return Err(NetlistParseError::new(format!(
+            "invalid .model kind {trimmed:?}"
+        )));
+    }
+    let kind = trimmed[..kind_end].to_ascii_uppercase();
+    let mut params_text = trimmed[kind_end..].trim();
+    if params_text.starts_with('(') && params_text.ends_with(')') {
+        params_text = &params_text[1..params_text.len() - 1];
+    }
+    Ok(ModelCard {
+        name: fields[1].clone(),
+        kind,
+        params: parse_model_params(params_text)?,
+    })
+}
+
+fn parse_model_params(params_text: &str) -> Result<HashMap<String, f64>, NetlistParseError> {
+    let mut params = HashMap::new();
+    let mut rest = params_text.trim();
+    while !rest.is_empty() {
+        rest = rest.trim_start_matches(|ch: char| ch.is_whitespace() || ch == ',');
+        if rest.is_empty() {
+            break;
+        }
+        let name_end = rest
+            .find(|ch: char| ch.is_whitespace() || ch == '=')
+            .unwrap_or(rest.len());
+        let name = &rest[..name_end];
+        if name.is_empty()
+            || !name
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        {
+            return Err(NetlistParseError::new(format!(
+                "invalid .model parameter syntax {params_text:?}"
+            )));
+        }
+        rest = rest[name_end..].trim_start();
+        if !rest.starts_with('=') {
+            return Err(NetlistParseError::new(format!(
+                "invalid .model parameter syntax {params_text:?}"
+            )));
+        }
+        rest = rest[1..].trim_start();
+        let value_end = rest
+            .find(|ch: char| ch.is_whitespace() || ch == ',')
+            .unwrap_or(rest.len());
+        let value = &rest[..value_end];
+        if value.is_empty() {
+            return Err(NetlistParseError::new(format!(
+                "invalid .model parameter syntax {params_text:?}"
+            )));
+        }
+        params.insert(name.to_ascii_uppercase(), parse_value(value)?);
+        rest = &rest[value_end..];
+    }
+    Ok(params)
+}
+
+fn parse_element(
+    fields: &[String],
+    models: &HashMap<String, ModelCard>,
+) -> Result<Element, NetlistParseError> {
     let name = &fields[0];
     let prefix = element_prefix(name)?;
 
@@ -315,6 +414,28 @@ fn parse_element(fields: &[String]) -> Result<Element, NetlistParseError> {
                 None => CurrentSource::new(name, &fields[1], &fields[2], current),
             };
             Ok(Element::CurrentSource(source))
+        }
+        'D' => {
+            require_fields(fields, 4, "diode")?;
+            let model = models.get(&fields[3].to_ascii_lowercase()).ok_or_else(|| {
+                NetlistParseError::new(format!(
+                    "unknown model {:?} for diode {:?}",
+                    fields[3], name
+                ))
+            })?;
+            if model.kind != "D" {
+                return Err(NetlistParseError::new(format!(
+                    "model {:?} has kind {:?}, expected \"D\"",
+                    model.name, model.kind
+                )));
+            }
+            Ok(Element::Diode(Diode::with_model(
+                name,
+                &fields[1],
+                &fields[2],
+                *model.params.get("IS").unwrap_or(&1.0e-15),
+                *model.params.get("VT").unwrap_or(&0.02585),
+            )))
         }
         'G' => {
             require_fields(fields, 6, "VCCS")?;
@@ -406,6 +527,7 @@ fn expand_subckt_instance(
     fields: &[String],
     subckts: &HashMap<String, SubcktDefinition>,
     stack: &[String],
+    models: &HashMap<String, ModelCard>,
 ) -> Result<Vec<Element>, NetlistParseError> {
     require_min_fields(fields, 3, "subcircuit instance")?;
     let instance_name = &fields[0];
@@ -451,9 +573,14 @@ fn expand_subckt_instance(
         }
         let local_fields = map_subckt_fields(&statement.fields, instance_name, &node_map)?;
         if element_prefix(&statement.fields[0])? == 'X' {
-            elements.extend(expand_subckt_instance(&local_fields, subckts, &next_stack)?);
+            elements.extend(expand_subckt_instance(
+                &local_fields,
+                subckts,
+                &next_stack,
+                models,
+            )?);
         } else {
-            elements.push(parse_element(&local_fields)?);
+            elements.push(parse_element(&local_fields, models)?);
         }
     }
     Ok(elements)
@@ -473,7 +600,7 @@ fn map_subckt_fields(
         .ok_or_else(|| NetlistParseError::new("element name is empty"))?
         .to_ascii_uppercase();
     match prefix {
-        'R' | 'C' | 'L' | 'V' | 'I' => {
+        'R' | 'C' | 'L' | 'V' | 'I' | 'D' => {
             require_min_fields(fields, 3, "subcircuit element")?;
             mapped[1] = map_subckt_node(&fields[1], instance_name, node_map);
             mapped[2] = map_subckt_node(&fields[2], instance_name, node_map);

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -167,6 +167,40 @@ Rload out 0 500
 }
 
 #[test]
+fn parses_diode_models_into_operating_point_circuits() {
+    let parsed = parse_netlist(
+        r#"
+.model fast D(IS=1e-12 VT=25m)
+V1 in 0 DC 0.7
+D1 in out fast
+Rload out 0 1k
+.op
+"#,
+    )
+    .unwrap();
+
+    let model = parsed.models.get("fast").unwrap();
+    assert_eq!(model.name, "fast");
+    assert_eq!(model.kind, "D");
+    assert_close(*model.params.get("IS").unwrap(), 1.0e-12);
+    assert_close(*model.params.get("VT").unwrap(), 25.0e-3);
+
+    let Element::Diode(diode) = &parsed.circuit.elements()[1] else {
+        panic!("expected diode");
+    };
+    assert_eq!(diode.name, "D1");
+    assert_eq!(diode.anode, "in");
+    assert_eq!(diode.cathode, "out");
+    assert_close(diode.saturation_current, 1.0e-12);
+    assert_close(diode.thermal_voltage, 25.0e-3);
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    let out = result.voltage("out").unwrap();
+    assert!(out > 0.1, "expected forward-biased output, got {out}");
+    assert!(out < 0.7, "expected diode drop below source, got {out}");
+}
+
+#[test]
 fn parses_pwl_and_sin_source_waveforms() {
     let parsed = parse_netlist(
         r#"
@@ -351,6 +385,27 @@ Rload out 0 500
 }
 
 #[test]
+fn expands_subcircuit_diode_nodes_into_engine_elements() {
+    let parsed = parse_netlist(
+        r#"
+.model clamp D(IS=1e-12 VT=25m)
+.subckt limiter inp outp
+Dlim inp outp clamp
+.ends limiter
+Xlim in out limiter
+"#,
+    )
+    .unwrap();
+
+    let Element::Diode(diode) = &parsed.circuit.elements()[0] else {
+        panic!("expected diode");
+    };
+    assert_eq!(diode.name, "Xlim.Dlim");
+    assert_eq!(diode.anode, "in");
+    assert_eq!(diode.cathode, "out");
+}
+
+#[test]
 fn scopes_subcircuit_internal_nodes_by_instance() {
     let parsed = parse_netlist(
         r#"
@@ -384,10 +439,28 @@ fn parses_engineering_suffixes() {
 
 #[test]
 fn rejects_unsupported_elements_with_line_numbers() {
-    let err = parse_netlist("\nD1 a 0 diode\n").unwrap_err();
+    let err = parse_netlist("\nQ1 c b e model\n").unwrap_err();
 
     assert!(err.to_string().contains("line 2: unsupported element"));
     assert_error_type(err);
+}
+
+#[test]
+fn rejects_unknown_diode_models() {
+    let err = parse_netlist("D1 a 0 missing\n").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("line 1: unknown model \"missing\" for diode \"D1\""));
+}
+
+#[test]
+fn rejects_non_diode_models_for_diode_elements() {
+    let err = parse_netlist(".model amp NPN(IS=1e-12)\nD1 a 0 amp\n").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("line 2: model \"amp\" has kind \"NPN\", expected \"D\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add Rust SPICE `.model <name> D(...)` parsing with `ModelCard` records.
- Parse `D` diode elements into `spice-engine` Shockley diode elements using `IS` and `VT` parameters.
- Remap diode terminals during `.subckt` expansion and cover DC operating-point execution.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-rust-spice-netlist-diode-model cargo test -p spice-engine -p spice-netlist-parser` in `code/packages/rust`
- `git diff --check`
