### PR TITLE
feat(lang-refinement-protocol): LANG54 — generic refinement-type checker protocol

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -591,6 +591,7 @@ members = [
     "twig-ir-compiler",
     "lang-refined-types",
     "lang-refinement-checker",
+    "lang-refinement-protocol",
     "lang-runtime-core",
     "lispy-runtime",
     "twig-vm",

--- a/code/packages/rust/lang-refinement-protocol/CHANGELOG.md
+++ b/code/packages/rust/lang-refinement-protocol/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog — lang-refinement-protocol
+
+## [0.1.0] — 2026-05-14
+
+Initial release. LANG54 — Generic Refinement-Type Checker Protocol.
+
+### Added
+
+- **`RefinementBridge` trait** — three-method trait Language X implements to
+  get call-site refinement checking and flow-sensitive narrowing for free:
+  - `evidence_for(expr, inferred_kind) -> Evidence` — classify a call-site
+    argument as `Concrete`, `Predicated`, or `Unconstrained`.
+  - `narrowing_facts(guard) -> Vec<(String, Predicate)>` — extract per-variable
+    predicates implied by a guard expression being true.
+  - `narrow_kind(base, pred) -> Kind` — merge a base kind with a narrowing
+    predicate (e.g., `Int + (x < 128)` → `RefinedInt(x < 128)`).
+
+- **`check_call_site_refinements`** generic free function — drives
+  `lang_refinement_checker::Checker::check` per annotated parameter at a
+  function call site:
+  - `ProvenUnsafe(cx)` → `RefinementDiagnostic` (error in all modes).
+  - `Unknown` + `Strict` → `RefinementDiagnostic`.
+  - `Unknown` + `Lenient` → silent.
+  - `ProvenSafe` → silent.
+
+- **`compute_if_narrowing`** generic free function — computes `NarrowedBindings<K>`
+  for both branches of an `if`-expression:
+  - Calls `bridge.narrowing_facts(guard)` to extract facts.
+  - Looks up each variable via the provided `scope_lookup` closure.
+  - `true_branch`: `bridge.narrow_kind(base, pred)` for each fact.
+  - `false_branch`: `bridge.narrow_kind(base, Predicate::not(pred))`.
+  - Variables not in scope are silently skipped (conservative: no narrowing).
+
+- **`NarrowedBindings<K>`** — returned by `compute_if_narrowing`:
+  - `true_branch: Vec<(String, K)>`
+  - `false_branch: Vec<(String, K)>`
+
+- **`RefinementDiagnostic`** — error/warning from refinement checking:
+  - `message: String`, `line: usize`, `column: usize`.
+
+- **`RefinementMode`** — `Lenient` | `Strict`, controls `Unknown` handling.
+
+- **Re-exports** from `lang-refinement-checker`: `Evidence`, `CheckOutcome`,
+  `CounterExample`, `Checker`, `Obligation`, `check_all`.
+
+- **Re-exports** from `lang-refined-types`: `Predicate`, `RefinedType`,
+  `Kind as RefKind`.
+
+### Language X adoption cost
+
+~70 lines total:
+- Implement `RefinementBridge` (~50 lines: 3 methods).
+- Wire `check_call_site_refinements` into apply handler (~10 lines).
+- Wire `compute_if_narrowing` into if-expression handler (~10 lines).
+
+### Tests
+
+14 unit tests with a `MockBridge` (`MockExpr` + `MockKind`) covering:
+- Call-site: concrete in range, concrete out of range, unconstrained lenient,
+  unconstrained strict, no annotation, no param_refinements, predicated safe,
+  predicated unsafe.
+- Narrowing: true + false branches extracted, no facts → empty, variable not
+  in scope skipped, false branch is negated predicate, `and` guard produces
+  two facts, non-numeric kind unchanged.

--- a/code/packages/rust/lang-refinement-protocol/Cargo.toml
+++ b/code/packages/rust/lang-refinement-protocol/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name        = "lang-refinement-protocol"
+version     = "0.1.0"
+edition     = "2021"
+description = "LANG54 — Generic protocol for wiring lang-refinement-checker into any language's type-checker. Exposes RefinementBridge trait, check_call_site_refinements(), and compute_if_narrowing() so a new language gets call-site proof obligations and flow-sensitive narrowing by implementing three bridge methods."
+
+[dependencies]
+lang-refined-types      = { path = "../lang-refined-types" }
+lang-refinement-checker = { path = "../lang-refinement-checker" }

--- a/code/packages/rust/lang-refinement-protocol/README.md
+++ b/code/packages/rust/lang-refinement-protocol/README.md
@@ -1,0 +1,138 @@
+# lang-refinement-protocol
+
+Generic protocol for wiring the refinement-type solver into any language's
+type checker (LANG54).
+
+## What it does
+
+Extracts the 150-line language-specific glue from `twig-type-checker` into two
+generic free functions backed by a three-method trait.  Any language type
+checker that implements `RefinementBridge` gets call-site proof obligations and
+flow-sensitive narrowing for free.
+
+## Quick start
+
+### 1. Implement `RefinementBridge` for your language
+
+```rust
+use lang_refinement_protocol::{Evidence, Predicate, RefinementBridge};
+
+struct MyBridge;
+
+impl RefinementBridge for MyBridge {
+    type Expr = MyExpr;
+    type Kind = MyKind;
+
+    fn evidence_for(&self, expr: &MyExpr, kind: Option<&MyKind>) -> Evidence {
+        match expr {
+            MyExpr::IntLit(n) => Evidence::Concrete(*n as i128),
+            MyExpr::Var(_) => match kind {
+                Some(MyKind::RefinedInt(p)) => Evidence::Predicated(vec![p.clone()]),
+                _ => Evidence::Unconstrained,
+            },
+            _ => Evidence::Unconstrained,
+        }
+    }
+
+    fn narrowing_facts(&self, guard: &MyExpr) -> Vec<(String, Predicate)> {
+        // analyse (< x 128), (>= x 0), (and …), (not …) here
+        vec![]
+    }
+
+    fn narrow_kind(&self, base: &MyKind, pred: Predicate) -> MyKind {
+        match base {
+            MyKind::Int => MyKind::RefinedInt(pred),
+            MyKind::RefinedInt(existing) => {
+                MyKind::RefinedInt(Predicate::and(vec![existing.clone(), pred]))
+            }
+            other => other.clone(),
+        }
+    }
+}
+```
+
+### 2. Wire into your function-application handler
+
+```rust
+use lang_refinement_protocol::{check_call_site_refinements, RefinementMode};
+
+let diags = check_call_site_refinements(
+    &MyBridge,
+    callee_name,
+    call_line, call_column,
+    &arg_exprs,        // &[MyExpr]
+    &arg_kinds,        // &[MyKind]
+    &param_refinements, // &[Option<RefinedType>]
+    RefinementMode::Strict,
+);
+for d in diags {
+    errors.push(MyError { msg: d.message, line: d.line, col: d.column });
+}
+```
+
+### 3. Wire into your if-expression handler
+
+```rust
+use lang_refinement_protocol::compute_if_narrowing;
+
+let narrowed = compute_if_narrowing(
+    &MyBridge,
+    &guard_expr,
+    |var| scope.lookup(var).cloned(),
+);
+
+// True branch
+scope.push_frame();
+for (var, kind) in narrowed.true_branch { scope.bind(&var, kind); }
+let then_kind = infer(then_branch);
+scope.pop_frame();
+
+// False branch
+scope.push_frame();
+for (var, kind) in narrowed.false_branch { scope.bind(&var, kind); }
+let else_kind = infer(else_branch);
+scope.pop_frame();
+```
+
+## API
+
+### `RefinementBridge` trait
+
+| Method | Description |
+|---|---|
+| `evidence_for(expr, kind)` | Classify a call-site arg as `Evidence` |
+| `narrowing_facts(guard)` | Extract `(var, predicate)` pairs from a guard expression |
+| `narrow_kind(base, pred)` | Merge a base kind with a narrowing predicate |
+
+### `check_call_site_refinements`
+
+Generic free function.  Drives `Checker::check` per annotated argument.
+Returns `Vec<RefinementDiagnostic>`.
+
+### `compute_if_narrowing`
+
+Generic free function.  Computes `NarrowedBindings<K>` for the true and
+false branches of an `if`-expression.
+
+### `RefinementMode`
+
+```rust
+pub enum RefinementMode { Lenient, Strict }
+```
+
+`Strict` → `Unknown` outcomes are errors.  `Lenient` → `Unknown` is silent.
+
+## Reference implementation
+
+`twig-type-checker/src/bridge.rs` contains `TwigRefinementBridge` — the
+complete, commented reference implementation for the Twig language.
+
+## Pipeline position
+
+```
+lang-refined-types
+    │
+lang-refinement-protocol   ← this crate
+    │
+language type-checker (Language X implements RefinementBridge)
+```

--- a/code/packages/rust/lang-refinement-protocol/src/lib.rs
+++ b/code/packages/rust/lang-refinement-protocol/src/lib.rs
@@ -1,0 +1,911 @@
+//! # `lang-refinement-protocol` — LANG54
+//!
+//! Generic protocol for wiring the refinement-type solver into any language's
+//! type checker.  Before LANG54, the 150-line glue between a type checker and
+//! `lang-refinement-checker` had to be copy-pasted and adapted for every new
+//! language.  LANG54 extracts that glue into two generic free functions backed
+//! by a three-method trait.
+//!
+//! ## What Language X gets by implementing `RefinementBridge`
+//!
+//! | Feature | Code in Language X |
+//! |---|---|
+//! | Call-site proof obligations | `check_call_site_refinements(…)` |
+//! | Flow-sensitive narrowing from `if` guards | `compute_if_narrowing(…)` |
+//! | All solver infrastructure | provided by `lang-refinement-checker` |
+//!
+//! ## Architecture
+//!
+//! ```text
+//!  ┌────────────────────────────────────────────────────────────┐
+//!  │ Language X type checker                                    │
+//!  │                                                            │
+//!  │  impl RefinementBridge for LangXBridge {                  │
+//!  │      type Expr = LangXExpr;                               │
+//!  │      type Kind = LangXKind;                               │
+//!  │      fn evidence_for(…)  → Evidence   // 5–10 lines       │
+//!  │      fn narrowing_facts(…) → Vec<…>  // 10–30 lines       │
+//!  │      fn narrow_kind(…)   → LangXKind // 5–10 lines        │
+//!  │  }                                                         │
+//!  │                                                            │
+//!  │  infer_apply: check_call_site_refinements(&bridge, …)     │
+//!  │  infer_if:    compute_if_narrowing(&bridge, …)            │
+//!  └───────────────────────────┬────────────────────────────────┘
+//!                              │ uses
+//!  ┌───────────────────────────▼────────────────────────────────┐
+//!  │ lang-refinement-protocol (this crate)                      │
+//!  │   RefinementBridge trait                                   │
+//!  │   check_call_site_refinements()  generic free fn           │
+//!  │   compute_if_narrowing()         generic free fn           │
+//!  └───────────────────────────┬────────────────────────────────┘
+//!                              │ uses
+//!  ┌───────────────────────────▼────────────────────────────────┐
+//!  │ lang-refinement-checker                                    │
+//!  │   Checker::check(annotation, evidence) → CheckOutcome     │
+//!  └───────────────────────────┬────────────────────────────────┘
+//!                              │ uses
+//!  ┌───────────────────────────▼────────────────────────────────┐
+//!  │ constraint-vm → constraint-engine → SAT / LIA tactics      │
+//!  └────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Minimal example — implementing the bridge for a new language
+//!
+//! ```rust,ignore
+//! use lang_refinement_protocol::{
+//!     RefinementBridge, RefinementDiagnostic, RefinementMode,
+//!     NarrowedBindings, Evidence, Predicate, RefinedType,
+//!     check_call_site_refinements, compute_if_narrowing,
+//! };
+//!
+//! // Language X's types.
+//! enum LangXExpr { IntLit(i64), Var(String), Other }
+//! #[derive(Clone)] enum LangXKind { Int, RefinedInt(Predicate), Bool }
+//!
+//! struct LangXBridge;
+//!
+//! impl RefinementBridge for LangXBridge {
+//!     type Expr = LangXExpr;
+//!     type Kind = LangXKind;
+//!
+//!     fn evidence_for(&self, expr: &LangXExpr, _kind: Option<&LangXKind>) -> Evidence {
+//!         match expr {
+//!             LangXExpr::IntLit(n) => Evidence::Concrete(*n as i128),
+//!             _ => Evidence::Unconstrained,
+//!         }
+//!     }
+//!
+//!     fn narrowing_facts(&self, _guard: &LangXExpr) -> Vec<(String, Predicate)> {
+//!         vec![]   // implement guard analysis here
+//!     }
+//!
+//!     fn narrow_kind(&self, base: &LangXKind, pred: Predicate) -> LangXKind {
+//!         match base {
+//!             LangXKind::Int => LangXKind::RefinedInt(pred),
+//!             LangXKind::RefinedInt(existing) => {
+//!                 LangXKind::RefinedInt(Predicate::and(vec![existing.clone(), pred]))
+//!             }
+//!             other => other.clone(),
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ## Quick start — call-site checking
+//!
+//! ```rust,ignore
+//! // In your type checker's function-application handler:
+//! let diags = check_call_site_refinements(
+//!     &LangXBridge,
+//!     callee_name,      // &str
+//!     call_site_line,   // usize
+//!     call_site_column, // usize
+//!     &arg_exprs,       // &[LangXExpr]
+//!     &arg_kinds,       // &[LangXKind]
+//!     param_refinements, // &[Option<RefinedType>]
+//!     RefinementMode::Strict,
+//! );
+//! for d in diags {
+//!     your_error_list.push((d.message, d.line, d.column));
+//! }
+//! ```
+//!
+//! ## Quick start — flow-sensitive narrowing
+//!
+//! ```rust,ignore
+//! // In your type checker's if-expression handler:
+//! let narrowed = compute_if_narrowing(
+//!     &LangXBridge,
+//!     &guard_expr,
+//!     |var| your_scope.lookup(var).cloned(),
+//! );
+//! // Apply true_branch bindings, infer then-body, restore.
+//! // Apply false_branch bindings, infer else-body, restore.
+//! ```
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+// ---------------------------------------------------------------------------
+// Re-exports — Language X only needs this one dep in Cargo.toml
+// ---------------------------------------------------------------------------
+
+pub use lang_refined_types::{Kind as RefKind, Predicate, RefinedType};
+pub use lang_refinement_checker::{
+    check_all, CheckOutcome, Checker, CounterExample, Evidence, Obligation,
+};
+
+// ---------------------------------------------------------------------------
+// RefinementMode — how Unknown outcomes are treated
+// ---------------------------------------------------------------------------
+
+/// Whether `Unknown` proof obligations produce diagnostics.
+///
+/// The solver returns `Unknown` when it cannot determine at compile time
+/// whether an annotation holds (e.g., the argument comes from user input).
+/// The configured mode decides whether that counts as an error.
+///
+/// ```text
+/// Outcome        Lenient       Strict
+/// ──────────────────────────────────
+/// ProvenSafe     silent        silent
+/// ProvenUnsafe   error         error
+/// Unknown        silent        error
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefinementMode {
+    /// `Unknown` outcomes are silent; only `ProvenUnsafe` is an error.
+    ///
+    /// Appropriate for early development where not every call site can be
+    /// statically proven — the compiler warns but does not reject.
+    Lenient,
+    /// Both `Unknown` and `ProvenUnsafe` outcomes are errors.
+    ///
+    /// Appropriate for production builds and fully-annotated modules where
+    /// every refinement obligation must be statically discharged.
+    Strict,
+}
+
+// ---------------------------------------------------------------------------
+// RefinementDiagnostic — an error/warning from refinement checking
+// ---------------------------------------------------------------------------
+
+/// A diagnostic produced by the refinement checker at a specific source location.
+///
+/// Carries enough information for the caller to synthesise a `TypeErrorDiagnostic`
+/// or equivalent error struct in its own type system.
+///
+/// # Diagnostic messages
+///
+/// - `ProvenUnsafe`: `"refinement error: argument N to `f` violates annotation: …"`
+/// - `Unknown` + `Strict`: `"refinement error: argument N to `f` cannot be proven to satisfy annotation (strict mode)"`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefinementDiagnostic {
+    /// Human-readable error message.  Suitable for display to the user.
+    pub message: String,
+    /// Source line of the call site (1-indexed).
+    pub line: usize,
+    /// Source column of the call site (1-indexed).
+    pub column: usize,
+}
+
+// ---------------------------------------------------------------------------
+// NarrowedBindings — output of compute_if_narrowing
+// ---------------------------------------------------------------------------
+
+/// The narrowed variable bindings for the two branches of an `if` expression.
+///
+/// After calling [`compute_if_narrowing`], the caller applies these bindings
+/// to its scope before inferring each branch, then restores the scope after.
+///
+/// # Usage pattern
+///
+/// ```rust,ignore
+/// let narrowed = compute_if_narrowing(&bridge, guard, |v| scope.lookup(v).cloned());
+///
+/// // True branch
+/// scope.push_frame();
+/// for (var, kind) in narrowed.true_branch { scope.bind(&var, kind); }
+/// let then_kind = infer_expr(then_branch, …);
+/// scope.pop_frame();
+///
+/// // False branch
+/// scope.push_frame();
+/// for (var, kind) in narrowed.false_branch { scope.bind(&var, kind); }
+/// let else_kind = infer_expr(else_branch, …);
+/// scope.pop_frame();
+/// ```
+#[derive(Debug, Clone)]
+pub struct NarrowedBindings<K> {
+    /// `(variable_name, narrowed_kind)` bindings for the true (then) branch.
+    ///
+    /// Each variable's kind is narrowed by the guard predicate — e.g., a
+    /// variable `x : Int` narrows to `x : RefinedInt(x < 128)` inside the
+    /// true branch of `(if (< x 128) …)`.
+    pub true_branch: Vec<(String, K)>,
+
+    /// `(variable_name, narrowed_kind)` bindings for the false (else) branch.
+    ///
+    /// Each variable's kind is narrowed by the **negation** of the guard
+    /// predicate — e.g., `x` narrows to `RefinedInt(NOT(x < 128))` inside
+    /// the false branch of `(if (< x 128) …)`.
+    pub false_branch: Vec<(String, K)>,
+}
+
+// ---------------------------------------------------------------------------
+// RefinementBridge — the three-method trait Language X implements
+// ---------------------------------------------------------------------------
+
+/// The bridge between a language's type checker and the generic refinement logic.
+///
+/// Implement this trait once for a language to get
+/// [`check_call_site_refinements`] and [`compute_if_narrowing`] for free.
+///
+/// ## Type parameters
+///
+/// - `Expr` — the language's AST expression type.  Passed at call sites (for
+///   evidence classification) and at guard positions (for narrowing facts).
+/// - `Kind` — the language's kind/type representation returned by the type
+///   checker.  Must implement `Clone` so narrowed bindings can be stored.
+///
+/// ## Implementing the three methods
+///
+/// ### `evidence_for`
+///
+/// Classify a call-site argument as `Evidence` for the refinement solver.
+/// The three cases a typical implementation handles:
+///
+/// | Argument | Evidence |
+/// |----------|---------|
+/// | Integer literal `n` | `Concrete(n)` |
+/// | Variable `x` with refined integer kind | `Predicated([predicate])` |
+/// | Anything else | `Unconstrained` |
+///
+/// ### `narrowing_facts`
+///
+/// Analyse a guard expression and return `(variable, predicate)` pairs that
+/// hold when the guard is true.  A conservative implementation returns `[]`
+/// for guards it cannot analyse — the worst case is missed optimisation, not
+/// unsoundness.
+///
+/// Typical patterns to handle:
+/// - `(< x k)` → `[("x", Range { hi: Some(k) })]`
+/// - `(>= x k)` → `[("x", Range { lo: Some(k) })]`
+/// - `(= x k)` → `[("x", Range { lo: k, hi: k, inclusive_hi: true })]`
+/// - `(and c1 c2)` → merge facts from `c1` and `c2`
+/// - `(not c)` → negate facts from `c`
+///
+/// ### `narrow_kind`
+///
+/// Merge a base kind with a narrowing predicate, returning the narrowed kind.
+/// Typical rules:
+/// - `Int + p` → `RefinedInt(p)`
+/// - `RefinedInt(q) + p` → `RefinedInt(and([q, p]))`
+/// - Any non-numeric kind → return unchanged
+pub trait RefinementBridge {
+    /// The language's AST expression type at call sites and guard positions.
+    type Expr;
+
+    /// The language's kind/type representation (result of type inference).
+    ///
+    /// Must implement `Clone` so narrowed bindings can be collected into
+    /// [`NarrowedBindings`].
+    type Kind: Clone;
+
+    /// Classify a call-site argument expression as `Evidence` for the solver.
+    ///
+    /// # Parameters
+    ///
+    /// - `expr` — the argument AST node from the call site.
+    /// - `inferred_kind` — the kind the type checker already computed for
+    ///   this expression.  Pass `None` if you have not pre-computed it;
+    ///   the bridge may fall back to `Unconstrained` in that case.
+    ///   Passing the pre-computed kind avoids a second traversal.
+    fn evidence_for(&self, expr: &Self::Expr, inferred_kind: Option<&Self::Kind>) -> Evidence;
+
+    /// Extract narrowing facts from a guard expression.
+    ///
+    /// Returns `(variable_name, predicate)` pairs meaning "if this guard
+    /// expression evaluates to true, the named variable satisfies this
+    /// predicate."
+    ///
+    /// Return an empty `Vec` for guards that cannot be analysed — conservative
+    /// behaviour (no narrowing applied) is always safe.
+    fn narrowing_facts(&self, guard: &Self::Expr) -> Vec<(String, Predicate)>;
+
+    /// Narrow a variable's kind by adding a guard predicate.
+    ///
+    /// Called once for each `(variable, predicate)` pair returned by
+    /// [`narrowing_facts`]:
+    ///
+    /// - For the **true branch**: called with the predicate as-is.
+    /// - For the **false branch**: called with `Predicate::not(predicate)`.
+    ///
+    /// A typical implementation for a kind system with `Int` and
+    /// `RefinedInt(Predicate)`:
+    ///
+    /// ```rust,ignore
+    /// fn narrow_kind(&self, base: &MyKind, pred: Predicate) -> MyKind {
+    ///     match base {
+    ///         MyKind::Int => MyKind::RefinedInt(pred),
+    ///         MyKind::RefinedInt(existing) => {
+    ///             MyKind::RefinedInt(Predicate::and(vec![existing.clone(), pred]))
+    ///         }
+    ///         other => other.clone(),   // non-numeric: no narrowing
+    ///     }
+    /// }
+    /// ```
+    fn narrow_kind(&self, base: &Self::Kind, pred: Predicate) -> Self::Kind;
+}
+
+// ---------------------------------------------------------------------------
+// check_call_site_refinements — generic call-site proof obligation checker
+// ---------------------------------------------------------------------------
+
+/// Check refinement annotations at a function call site.
+///
+/// This is the primary entry point for integrating the refinement solver into
+/// a type checker's function-application handler.
+///
+/// ## Algorithm
+///
+/// For each `(arg_expr, arg_kind, maybe_refinement)` triple:
+///
+/// 1. If `maybe_refinement` is `None`, skip this argument (no annotation).
+/// 2. Call `bridge.evidence_for(arg_expr, Some(arg_kind))` to classify
+///    the argument as `Concrete`, `Predicated`, or `Unconstrained`.
+/// 3. Run `Checker::check(refinement, evidence)`.
+/// 4. Map the three outcomes to diagnostics based on `mode`:
+///    - `ProvenSafe` → silent.
+///    - `ProvenUnsafe(cx)` → `RefinementDiagnostic` always.
+///    - `Unknown` + `Lenient` → silent.
+///    - `Unknown` + `Strict` → `RefinementDiagnostic`.
+///
+/// ## Parameters
+///
+/// - `bridge` — the language-specific `RefinementBridge` implementation.
+/// - `callee_name` — name of the function being called (used in error messages).
+/// - `call_site_line` / `call_site_column` — source location of the call
+///   (used in `RefinementDiagnostic`).
+/// - `arg_exprs` — the argument AST nodes from the call site.
+/// - `arg_kinds` — the inferred kinds for each argument (may be shorter than
+///   `arg_exprs`; missing entries are treated as `None` → `Unconstrained`).
+/// - `param_refinements` — the registered `RefinedType` per parameter (indexed
+///   by parameter position).  `None` at position `i` means no annotation.
+/// - `mode` — `Lenient` or `Strict` (controls handling of `Unknown`).
+///
+/// ## Returns
+///
+/// A `Vec<RefinementDiagnostic>` — empty if no violations are found.
+///
+/// # Example — wiring into `infer_apply`
+///
+/// ```rust,ignore
+/// let diags = check_call_site_refinements(
+///     &MyBridge,
+///     callee_name,
+///     app.line,
+///     app.column,
+///     &app.args,
+///     &arg_kinds,
+///     param_refinements,
+///     mode.into(),
+/// );
+/// for d in diags {
+///     errors.push(TypeErrorDiagnostic { message: d.message, line: d.line, column: d.column });
+/// }
+/// ```
+pub fn check_call_site_refinements<B>(
+    bridge: &B,
+    callee_name: &str,
+    call_site_line: usize,
+    call_site_column: usize,
+    arg_exprs: &[B::Expr],
+    arg_kinds: &[B::Kind],
+    param_refinements: &[Option<RefinedType>],
+    mode: RefinementMode,
+) -> Vec<RefinementDiagnostic>
+where
+    B: RefinementBridge,
+{
+    let mut checker = Checker::new();
+    let mut diagnostics = Vec::new();
+
+    // Walk over argument positions up to the length of param_refinements.
+    // Extra arguments beyond param_refinements (shouldn't happen after arity
+    // checking, but be defensive) are silently ignored.
+    let n = param_refinements.len().min(arg_exprs.len());
+
+    for i in 0..n {
+        // Skip positions with no annotation — no obligation to discharge.
+        let Some(rt) = &param_refinements[i] else {
+            continue;
+        };
+
+        let arg_expr = &arg_exprs[i];
+        let arg_kind = arg_kinds.get(i);
+
+        // Classify the argument as Evidence.
+        // `arg_kind` is passed so the bridge can check for `RefinedInt(p)` etc.
+        // without doing a second scope lookup.
+        let evidence = bridge.evidence_for(arg_expr, arg_kind);
+
+        // Run the proof obligation.
+        match checker.check(rt, &evidence) {
+            CheckOutcome::ProvenSafe => {
+                // Annotation holds for all values consistent with evidence.
+                // Silent — this is the happy path.
+            }
+
+            CheckOutcome::ProvenUnsafe(cx) => {
+                // Solver found a concrete counter-example violating the annotation.
+                // This is a definite compile-time bug — error in all modes.
+                diagnostics.push(RefinementDiagnostic {
+                    message: format!(
+                        "refinement error: argument {} to `{}` violates annotation: {}",
+                        i, callee_name, cx.description
+                    ),
+                    line: call_site_line,
+                    column: call_site_column,
+                });
+            }
+
+            CheckOutcome::Unknown(_) if mode == RefinementMode::Strict => {
+                // Solver could not determine the outcome and we are in strict
+                // mode — treat as an error.
+                diagnostics.push(RefinementDiagnostic {
+                    message: format!(
+                        "refinement error: argument {} to `{}` cannot be proven \
+                         to satisfy annotation (strict mode)",
+                        i, callee_name
+                    ),
+                    line: call_site_line,
+                    column: call_site_column,
+                });
+            }
+
+            CheckOutcome::Unknown(_) => {
+                // Lenient mode: solver gave up, emit runtime check (caller's
+                // responsibility), proceed silently at compile time.
+            }
+        }
+    }
+
+    diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// compute_if_narrowing — generic flow-sensitive narrowing for if-expressions
+// ---------------------------------------------------------------------------
+
+/// Compute narrowed variable bindings for both branches of an `if` expression.
+///
+/// Call this in your type checker's `if`-expression handler to get the
+/// narrowed kind for each variable in the true and false branches.
+///
+/// ## Algorithm
+///
+/// 1. Call `bridge.narrowing_facts(guard)` to extract `(variable, predicate)`
+///    pairs implied by the guard being true.
+/// 2. For each pair, call `scope_lookup(variable)` to find the variable's
+///    current kind.  Variables not in scope are skipped.
+/// 3. For the **true branch**: narrow each variable's kind via
+///    `bridge.narrow_kind(current_kind, predicate)`.
+/// 4. For the **false branch**: narrow via
+///    `bridge.narrow_kind(current_kind, Predicate::not(predicate))`.
+///
+/// ## Parameters
+///
+/// - `bridge` — the language-specific `RefinementBridge` implementation.
+/// - `guard` — the condition expression of the `if`.
+/// - `scope_lookup` — a closure that looks up a variable's current kind in
+///   the type checker's scope.  Return `None` for variables not in scope.
+///
+/// ## Returns
+///
+/// [`NarrowedBindings`] containing the `(variable_name, narrowed_kind)` pairs
+/// for each branch.  Apply these to your scope *after* pushing a frame and
+/// *before* inferring the branch body.  Restore by popping the frame.
+///
+/// ## Conservative behaviour
+///
+/// If `bridge.narrowing_facts(guard)` returns `[]` (the guard implies nothing
+/// useful), both branches in the returned `NarrowedBindings` will be empty
+/// and no narrowing is applied.  This is always safe: the branches are
+/// checked with unnarrowed kinds.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // In your if-expression handler:
+/// let narrowed = compute_if_narrowing(
+///     &MyBridge,
+///     &if_expr.cond,
+///     |var| scope.lookup(var).cloned().or_else(|| globals.get(var).cloned()),
+/// );
+///
+/// // True branch
+/// scope.push_frame();
+/// for (var, kind) in narrowed.true_branch {
+///     scope.bind(&var, kind);
+/// }
+/// let then_kind = infer_expr(&if_expr.then_branch, …);
+/// scope.pop_frame();
+///
+/// // False branch
+/// scope.push_frame();
+/// for (var, kind) in narrowed.false_branch {
+///     scope.bind(&var, kind);
+/// }
+/// let else_kind = infer_expr(&if_expr.else_branch, …);
+/// scope.pop_frame();
+/// ```
+pub fn compute_if_narrowing<B, F>(
+    bridge: &B,
+    guard: &B::Expr,
+    scope_lookup: F,
+) -> NarrowedBindings<B::Kind>
+where
+    B: RefinementBridge,
+    F: Fn(&str) -> Option<B::Kind>,
+{
+    let facts = bridge.narrowing_facts(guard);
+
+    let mut true_branch = Vec::new();
+    let mut false_branch = Vec::new();
+
+    for (var, pred) in facts {
+        // Only narrow variables that are currently in scope.
+        // Variables not found are silently skipped — conservative is safe.
+        let Some(base_kind) = scope_lookup(&var) else {
+            continue;
+        };
+
+        // True branch: narrow by the guard predicate as-is.
+        let narrowed_true = bridge.narrow_kind(&base_kind, pred.clone());
+        true_branch.push((var.clone(), narrowed_true));
+
+        // False branch: narrow by the logical negation of the guard predicate.
+        // For example, a guard `(< x 128)` means `x < 128` is false in the
+        // else branch, so we add `NOT(x < 128)` ≡ `x ≥ 128`.
+        let negated_pred = Predicate::not(pred);
+        let narrowed_false = bridge.narrow_kind(&base_kind, negated_pred);
+        false_branch.push((var, narrowed_false));
+    }
+
+    NarrowedBindings { true_branch, false_branch }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lang_refined_types::{Kind as RefKind, Predicate, RefinedType};
+
+    // ─── Mock bridge ─────────────────────────────────────────────────────────
+    //
+    // A minimal, self-contained bridge used only in tests.
+    // MockExpr and MockKind are simple enough to cover all Evidence paths.
+
+    /// Minimal expression type for tests.
+    #[derive(Debug, Clone)]
+    #[allow(dead_code)]
+    enum MockExpr {
+        /// An integer literal.
+        IntLit(i64),
+        /// A variable reference.
+        Var(String),
+        /// A simple `(< var literal)` guard.
+        LtGuard { var: String, bound: i64 },
+        /// A `(and guard1 guard2)` conjunction.
+        AndGuard(Box<MockExpr>, Box<MockExpr>),
+        /// Any other expression — yields no narrowing facts and Unconstrained evidence.
+        Other,
+    }
+
+    /// Minimal kind type for tests.
+    #[derive(Debug, Clone, PartialEq)]
+    enum MockKind {
+        Int,
+        /// Integer with a refinement predicate.
+        RefinedInt(Predicate),
+        Bool,
+    }
+
+    /// The mock bridge:
+    /// - `IntLit(n)` → `Concrete(n)`
+    /// - `Var(_)` with `RefinedInt(p)` kind → `Predicated([p])`
+    /// - anything else → `Unconstrained`
+    /// - `LtGuard { var, bound }` → one narrowing fact: `var ∈ (-∞, bound)`
+    /// - `AndGuard(l, r)` → merged facts from both children
+    struct MockBridge;
+
+    impl RefinementBridge for MockBridge {
+        type Expr = MockExpr;
+        type Kind = MockKind;
+
+        fn evidence_for(&self, expr: &MockExpr, inferred_kind: Option<&MockKind>) -> Evidence {
+            match expr {
+                MockExpr::IntLit(n) => Evidence::Concrete(*n as i128),
+                MockExpr::Var(_) => match inferred_kind {
+                    Some(MockKind::RefinedInt(p)) => Evidence::Predicated(vec![p.clone()]),
+                    _ => Evidence::Unconstrained,
+                },
+                _ => Evidence::Unconstrained,
+            }
+        }
+
+        fn narrowing_facts(&self, guard: &MockExpr) -> Vec<(String, Predicate)> {
+            match guard {
+                MockExpr::LtGuard { var, bound } => {
+                    // Guard `var < bound` → predicate: Range { hi: Some(bound), exclusive }
+                    vec![(
+                        var.clone(),
+                        Predicate::Range {
+                            lo: None,
+                            hi: Some(*bound as i128),
+                            inclusive_hi: false,
+                        },
+                    )]
+                }
+                MockExpr::AndGuard(l, r) => {
+                    // Merge facts from both children.
+                    let mut facts = self.narrowing_facts(l);
+                    facts.extend(self.narrowing_facts(r));
+                    facts
+                }
+                _ => vec![],
+            }
+        }
+
+        fn narrow_kind(&self, base: &MockKind, pred: Predicate) -> MockKind {
+            match base {
+                MockKind::Int => MockKind::RefinedInt(pred),
+                MockKind::RefinedInt(existing) => {
+                    MockKind::RefinedInt(Predicate::and(vec![existing.clone(), pred]))
+                }
+                // Bool cannot be narrowed by integer predicates.
+                other => other.clone(),
+            }
+        }
+    }
+
+    // ─── Helper — build a [0, 128) range annotation ──────────────────────────
+
+    fn ascii_annotation() -> RefinedType {
+        RefinedType::refined(
+            RefKind::Int,
+            Predicate::Range { lo: Some(0), hi: Some(128), inclusive_hi: false },
+        )
+    }
+
+    // ─── check_call_site_refinements — concrete evidence ─────────────────────
+
+    #[test]
+    fn check_call_site_concrete_in_range_no_diagnostic() {
+        // Literal 42 satisfies [0, 128).
+        let diags = check_call_site_refinements(
+            &MockBridge,
+            "ascii-info",
+            10,
+            5,
+            &[MockExpr::IntLit(42)],
+            &[MockKind::Int],
+            &[Some(ascii_annotation())],
+            RefinementMode::Strict,
+        );
+        assert!(diags.is_empty(), "42 is in [0,128); expected no diagnostic");
+    }
+
+    #[test]
+    fn check_call_site_concrete_out_of_range_is_diagnostic() {
+        // Literal 200 violates [0, 128).
+        let diags = check_call_site_refinements(
+            &MockBridge,
+            "ascii-info",
+            10,
+            5,
+            &[MockExpr::IntLit(200)],
+            &[MockKind::Int],
+            &[Some(ascii_annotation())],
+            RefinementMode::Strict,
+        );
+        assert_eq!(diags.len(), 1, "200 is outside [0,128); expected 1 diagnostic");
+        assert!(diags[0].message.contains("ascii-info"));
+        assert!(diags[0].message.contains("violates"));
+        assert_eq!(diags[0].line, 10);
+        assert_eq!(diags[0].column, 5);
+    }
+
+    // ─── check_call_site_refinements — unconstrained evidence ────────────────
+
+    #[test]
+    fn check_call_site_unconstrained_lenient_is_silent() {
+        // Unknown source in lenient mode → no diagnostic.
+        let diags = check_call_site_refinements(
+            &MockBridge,
+            "ascii-info",
+            1, 1,
+            &[MockExpr::Var("x".into())],
+            &[MockKind::Int],   // Int (unrefined) → Unconstrained
+            &[Some(ascii_annotation())],
+            RefinementMode::Lenient,
+        );
+        assert!(diags.is_empty(), "unconstrained in lenient mode should be silent");
+    }
+
+    #[test]
+    fn check_call_site_unconstrained_strict_is_diagnostic() {
+        // Unknown source in strict mode → diagnostic.
+        let diags = check_call_site_refinements(
+            &MockBridge,
+            "ascii-info",
+            1, 1,
+            &[MockExpr::Var("x".into())],
+            &[MockKind::Int],   // Int → Unconstrained
+            &[Some(ascii_annotation())],
+            RefinementMode::Strict,
+        );
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("strict mode"));
+    }
+
+    // ─── check_call_site_refinements — no annotation registered ─────────────
+
+    #[test]
+    fn check_call_site_no_annotation_is_silent() {
+        // param_refinements[0] = None → no obligation, no diagnostic.
+        let diags = check_call_site_refinements(
+            &MockBridge,
+            "f",
+            1, 1,
+            &[MockExpr::IntLit(200)],
+            &[MockKind::Int],
+            &[None],
+            RefinementMode::Strict,
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn check_call_site_empty_param_refinements_is_silent() {
+        // No registered refinements for any param.
+        let diags = check_call_site_refinements(
+            &MockBridge,
+            "g",
+            1, 1,
+            &[MockExpr::IntLit(999)],
+            &[MockKind::Int],
+            &[],  // no param_refinements at all
+            RefinementMode::Strict,
+        );
+        assert!(diags.is_empty());
+    }
+
+    // ─── check_call_site_refinements — predicated evidence ──────────────────
+
+    #[test]
+    fn check_call_site_predicated_proven_safe_is_silent() {
+        // Variable x has RefinedInt(x ∈ [0, 50)) → safe for [0, 128) annotation.
+        let narrow_pred = Predicate::Range { lo: Some(0), hi: Some(50), inclusive_hi: false };
+        let diags = check_call_site_refinements(
+            &MockBridge,
+            "ascii-info",
+            5, 10,
+            &[MockExpr::Var("x".into())],
+            &[MockKind::RefinedInt(narrow_pred)],
+            &[Some(ascii_annotation())],
+            RefinementMode::Strict,
+        );
+        assert!(diags.is_empty(), "[0,50) ⊆ [0,128); expected no diagnostic");
+    }
+
+    #[test]
+    fn check_call_site_predicated_proven_unsafe_is_diagnostic() {
+        // Variable y has RefinedInt(y ∈ [100, 200)) — overlaps OUTSIDE [0,128).
+        let wide_pred = Predicate::Range { lo: Some(100), hi: Some(200), inclusive_hi: false };
+        let diags = check_call_site_refinements(
+            &MockBridge,
+            "ascii-info",
+            7, 3,
+            &[MockExpr::Var("y".into())],
+            &[MockKind::RefinedInt(wide_pred)],
+            &[Some(ascii_annotation())],
+            RefinementMode::Lenient,
+        );
+        assert_eq!(diags.len(), 1, "y ∈ [100,200) can violate [0,128)");
+    }
+
+    // ─── compute_if_narrowing ─────────────────────────────────────────────────
+
+    #[test]
+    fn compute_if_narrowing_extracts_true_and_false_branches() {
+        // Guard: `x < 128`.  Variable x is Int in scope.
+        let guard = MockExpr::LtGuard { var: "x".into(), bound: 128 };
+        let scope = |var: &str| {
+            if var == "x" { Some(MockKind::Int) } else { None }
+        };
+
+        let nb = compute_if_narrowing(&MockBridge, &guard, scope);
+
+        assert_eq!(nb.true_branch.len(), 1);
+        assert_eq!(nb.true_branch[0].0, "x");
+        // True branch: x narrowed to RefinedInt(x < 128).
+        assert!(matches!(nb.true_branch[0].1, MockKind::RefinedInt(_)));
+
+        assert_eq!(nb.false_branch.len(), 1);
+        assert_eq!(nb.false_branch[0].0, "x");
+        // False branch: x narrowed to RefinedInt(NOT(x < 128)).
+        assert!(matches!(nb.false_branch[0].1, MockKind::RefinedInt(_)));
+    }
+
+    #[test]
+    fn compute_if_narrowing_no_facts_yields_empty() {
+        // Other expression → no narrowing facts.
+        let guard = MockExpr::Other;
+        let nb = compute_if_narrowing(&MockBridge, &guard, |_| Some(MockKind::Int));
+        assert!(nb.true_branch.is_empty());
+        assert!(nb.false_branch.is_empty());
+    }
+
+    #[test]
+    fn compute_if_narrowing_variable_not_in_scope_is_skipped() {
+        // Guard references `x`, but scope has no `x` → nothing narrowed.
+        let guard = MockExpr::LtGuard { var: "x".into(), bound: 128 };
+        let nb = compute_if_narrowing(&MockBridge, &guard, |_| None);
+        assert!(nb.true_branch.is_empty());
+        assert!(nb.false_branch.is_empty());
+    }
+
+    #[test]
+    fn narrowed_bindings_false_branch_is_negated_predicate() {
+        // Narrow `x : Int` with guard `x < 10`.
+        // True branch: x ∈ (-∞, 10) [exclusive].
+        // False branch: x ∈ NOT(-∞, 10) — some negated predicate.
+        let guard = MockExpr::LtGuard { var: "x".into(), bound: 10 };
+        let nb = compute_if_narrowing(&MockBridge, &guard, |var| {
+            if var == "x" { Some(MockKind::Int) } else { None }
+        });
+
+        // True: RefinedInt with Range predicate.
+        if let MockKind::RefinedInt(Predicate::Range { hi: Some(10), inclusive_hi: false, .. }) =
+            &nb.true_branch[0].1
+        {
+            // ok
+        } else {
+            panic!("expected true branch to carry Range(hi=10) predicate; got {:?}", nb.true_branch[0].1);
+        }
+
+        // False: RefinedInt with Not(Range).
+        assert!(matches!(&nb.false_branch[0].1, MockKind::RefinedInt(Predicate::Not(_))),
+            "false branch should carry Not(…) predicate; got {:?}", nb.false_branch[0].1);
+    }
+
+    #[test]
+    fn compute_if_narrowing_and_guard_produces_two_facts() {
+        // Guard: (and (x < 128) (x < 64)) → two overlapping facts for x.
+        // Both have the same variable, so two entries in true_branch.
+        let guard = MockExpr::AndGuard(
+            Box::new(MockExpr::LtGuard { var: "x".into(), bound: 128 }),
+            Box::new(MockExpr::LtGuard { var: "x".into(), bound: 64 }),
+        );
+        let nb = compute_if_narrowing(&MockBridge, &guard, |var| {
+            if var == "x" { Some(MockKind::Int) } else { None }
+        });
+        // Two facts → two entries (we don't merge same-variable facts in the protocol).
+        assert_eq!(nb.true_branch.len(), 2);
+        assert_eq!(nb.false_branch.len(), 2);
+    }
+
+    #[test]
+    fn narrow_kind_bool_is_unchanged() {
+        // Non-numeric kinds should pass through unchanged.
+        let bridge = MockBridge;
+        let pred = Predicate::Range { lo: Some(0), hi: Some(1), inclusive_hi: true };
+        let narrowed = bridge.narrow_kind(&MockKind::Bool, pred);
+        assert_eq!(narrowed, MockKind::Bool);
+    }
+}

--- a/code/packages/rust/twig-type-checker/CHANGELOG.md
+++ b/code/packages/rust/twig-type-checker/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog — twig-type-checker
 
+## [0.6.0] — 2026-05-14
+
+### Changed (LANG54 — Generic Refinement Protocol adoption)
+
+- **`src/bridge.rs`** — new module.  Exports `TwigRefinementBridge`, which
+  implements `lang_refinement_protocol::RefinementBridge` for Twig's `Expr`
+  AST and `TwigKind` type system:
+  - `evidence_for` — `IntLit → Concrete`, `VarRef+RefinedInt → Predicated`,
+    everything else → `Unconstrained`.
+  - `narrowing_facts` — delegates to `narrowing::extract_narrowing_facts`
+    (unchanged from LANG53).
+  - `narrow_kind` — delegates to `narrowing::merge_kind_with_predicate`
+    (unchanged from LANG53).
+
+- **`check.rs` `infer_apply`** — the 40-line manual `Checker::check` loop
+  replaced with a single call to `check_call_site_refinements` from
+  `lang-refinement-protocol`.  Behaviour is identical; the loop now lives
+  in the generic crate and is shared with other languages.
+
+- **`check.rs` `infer_if`** — the 35-line manual narrowing block replaced
+  with a call to `compute_if_narrowing` from `lang-refinement-protocol`.
+  Scope push/pop and branch inference are unchanged; only the predicate
+  extraction + kind-narrowing computation is delegated.
+
+- **`arg_to_evidence` helper removed** — this private function has been
+  absorbed into `TwigRefinementBridge::evidence_for`.  No public API change.
+
+- **`Cargo.toml`** — `lang-refinement-checker` dep replaced by
+  `lang-refinement-protocol` (which re-exports `Evidence`, `Checker`,
+  `CheckOutcome`, etc.).  `lang-refined-types` kept for `TwigKind::RefinedInt`.
+
+### Tests added (10)
+
+10 new tests in `bridge::tests` covering `TwigRefinementBridge` specifically:
+`evidence_int_lit_is_concrete`, `evidence_var_ref_with_refined_kind_is_predicated`,
+`evidence_var_ref_with_plain_int_is_unconstrained`, `evidence_bool_lit_is_unconstrained`,
+`narrow_int_produces_refined_int`, `narrow_refined_int_intersects_predicates`,
+`narrow_bool_is_unchanged`, `check_call_site_int_lit_in_range_no_diagnostic`,
+`check_call_site_int_lit_out_of_range_is_diagnostic`,
+`compute_if_narrowing_narrows_variable`.
+
+All 74 LANG53 tests continue to pass (84 total).
+
+### Backward compatibility
+
+No public API changes.  `type_check`, `type_check_source`, `check_program`,
+`TwigKind`, `TypeEnv` are all unchanged.  `TwigRefinementBridge` is new public
+API (additive).
+
+---
+
 ## [0.5.0] — 2026-05-14
 
 ### Added (LANG53 — TW05-C: Refinement Checker Bridge)

--- a/code/packages/rust/twig-type-checker/Cargo.toml
+++ b/code/packages/rust/twig-type-checker/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name        = "twig-type-checker"
-version     = "0.5.0"
+version     = "0.6.0"
 edition     = "2021"
-description = "Static type checker for Twig (TW05-B + TW05-C / LANG50 + LANG52 + LANG53).  Exposes two paths: type_check_source (GrammarASTNode + grammar-type-checker) for AOT/JIT annotation, and check_program (typed Program) for backward compatibility.  TW05-C adds RefinedInt narrowing and call-site refinement checking."
+description = "Static type checker for Twig (TW05-B + TW05-C / LANG50 + LANG52 + LANG53 + LANG54).  Exposes two paths: type_check_source (GrammarASTNode + grammar-type-checker) for AOT/JIT annotation, and check_program (typed Program) for backward compatibility.  TW05-C adds RefinedInt narrowing and call-site refinement checking.  LANG54 refactors the refinement integration to use lang-refinement-protocol, exposing TwigRefinementBridge as an example implementation."
 
 [dependencies]
-twig-parser              = { path = "../twig-parser" }
-type-checker-protocol    = { path = "../type-checker-protocol" }
-grammar-type-checker     = { path = "../grammar-type-checker" }
-type-declarations        = { path = "../type-declarations" }
-parser                   = { path = "../parser" }
-lang-refined-types       = { path = "../lang-refined-types" }
-lang-refinement-checker  = { path = "../lang-refinement-checker" }
+twig-parser               = { path = "../twig-parser" }
+type-checker-protocol     = { path = "../type-checker-protocol" }
+grammar-type-checker      = { path = "../grammar-type-checker" }
+type-declarations         = { path = "../type-declarations" }
+parser                    = { path = "../parser" }
+lang-refined-types        = { path = "../lang-refined-types" }
+lang-refinement-protocol  = { path = "../lang-refinement-protocol" }

--- a/code/packages/rust/twig-type-checker/src/bridge.rs
+++ b/code/packages/rust/twig-type-checker/src/bridge.rs
@@ -1,0 +1,311 @@
+//! # Twig `RefinementBridge` implementation (LANG54)
+//!
+//! `TwigRefinementBridge` connects the generic
+//! [`lang_refinement_protocol::RefinementBridge`] trait to Twig's concrete
+//! AST and kind types.  It is the *only* place where Twig-specific knowledge
+//! lives — the generic [`check_call_site_refinements`] and
+//! [`compute_if_narrowing`] functions do the rest.
+//!
+//! ## Implementing the three methods
+//!
+//! ### `evidence_for` — mapping Twig expressions to proof-obligation evidence
+//!
+//! | Twig expression | Evidence |
+//! |---|---|
+//! | `Expr::IntLit(n)` | `Concrete(n)` — exact solver check |
+//! | `Expr::VarRef` with `TwigKind::RefinedInt(p)` in scope | `Predicated([p])` |
+//! | anything else | `Unconstrained` — solver cannot determine outcome |
+//!
+//! ### `narrowing_facts` — delegating to `narrowing::extract_narrowing_facts`
+//!
+//! Re-uses the existing `src/narrowing.rs` guard-analysis logic (unchanged
+//! from LANG53).  The bridge is the thin adapter that plugs it in.
+//!
+//! ### `narrow_kind` — delegating to `narrowing::merge_kind_with_predicate`
+//!
+//! Re-uses the existing `src/narrowing.rs` kind-merging logic (unchanged
+//! from LANG53).
+//!
+//! ## Usage in `check.rs`
+//!
+//! ```rust,ignore
+//! // In infer_apply:
+//! let diags = check_call_site_refinements(
+//!     &TwigRefinementBridge,
+//!     callee_name, app.line, app.column,
+//!     &app.args, &arg_kinds, param_refinements, mode.into(),
+//! );
+//!
+//! // In infer_if:
+//! let narrowed = compute_if_narrowing(
+//!     &TwigRefinementBridge,
+//!     &if_expr.cond,
+//!     |var| scope.lookup(var).cloned().or_else(|| env.lookup_global(var).cloned()),
+//! );
+//! ```
+
+use lang_refinement_protocol::{Evidence, Predicate, RefinementBridge};
+use twig_parser::Expr;
+
+use crate::kinds::TwigKind;
+use crate::narrowing::{extract_narrowing_facts, merge_kind_with_predicate};
+
+/// The `RefinementBridge` implementation for the Twig type system.
+///
+/// Bridges [`lang_refinement_protocol`]'s generic checker functions to Twig's
+/// [`Expr`] AST and [`TwigKind`] type system.
+///
+/// This struct is zero-sized (no fields) — construct with `TwigRefinementBridge`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use twig_type_checker::bridge::TwigRefinementBridge;
+/// use lang_refinement_protocol::{check_call_site_refinements, RefinementMode};
+///
+/// let diags = check_call_site_refinements(
+///     &TwigRefinementBridge,
+///     "ascii-info",   // callee name
+///     10, 5,          // line, column
+///     &arg_exprs,
+///     &arg_kinds,
+///     &param_refinements,
+///     RefinementMode::Strict,
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TwigRefinementBridge;
+
+impl RefinementBridge for TwigRefinementBridge {
+    /// Twig's AST expression node — parsed from source by `twig-parser`.
+    type Expr = Expr;
+
+    /// Twig's kind system — the static type inferred for each expression.
+    ///
+    /// `RefinedInt(p)` is the key variant: it carries the narrowing predicate
+    /// gathered from guard analysis or parameter annotations.
+    type Kind = TwigKind;
+
+    /// Classify a call-site argument as refinement `Evidence`.
+    ///
+    /// ## Classification rules (in order)
+    ///
+    /// 1. **`IntLit(n)`** → `Concrete(n as i128)`.
+    ///    The literal value is known exactly at compile time — the solver can
+    ///    evaluate the annotation predicate without any constraint programs.
+    ///
+    /// 2. **`VarRef` with `RefinedInt(p)` kind** → `Predicated([p])`.
+    ///    The variable has been narrowed by a guard (or has a refined annotation
+    ///    from its binding site).  The solver checks whether every value
+    ///    satisfying `p` also satisfies the callee's annotation.
+    ///
+    /// 3. **`VarRef` with `Int` / `Any` kind** → `Unconstrained`.
+    ///    The type checker knows the variable is an integer but has no further
+    ///    bounds.  The solver cannot determine the outcome — emit a runtime
+    ///    check (lenient) or an error (strict).
+    ///
+    /// 4. **Anything else** → `Unconstrained`.
+    ///    Complex expressions (lambdas, applies, lets, …) are not analysed;
+    ///    conservatively Unconstrained.
+    fn evidence_for(&self, expr: &Expr, inferred_kind: Option<&TwigKind>) -> Evidence {
+        match expr {
+            // ── Integer literal: the value is known exactly ───────────────────
+            Expr::IntLit(lit) => Evidence::Concrete(lit.value as i128),
+
+            // ── Variable reference: check if the inferred kind carries a pred ─
+            Expr::VarRef(_) => match inferred_kind {
+                Some(TwigKind::RefinedInt(pred)) => {
+                    // The variable's kind has been narrowed to a specific
+                    // integer predicate — pass that as Predicated evidence.
+                    Evidence::Predicated(vec![pred.clone()])
+                }
+                // Int (unrefined) or Any: the solver knows the value is an
+                // integer but has no further constraint on it.
+                _ => Evidence::Unconstrained,
+            },
+
+            // ── All other expressions: no static evidence ─────────────────────
+            //
+            // Lambda, Apply, Let, LetStar, Begin, Match, StrLit, BoolLit,
+            // NilLit, SymLit — none of these have a compile-time integer value
+            // the solver can use.  Fall through to Unconstrained.
+            _ => Evidence::Unconstrained,
+        }
+    }
+
+    /// Extract narrowing facts from a Twig guard expression.
+    ///
+    /// Delegates entirely to [`extract_narrowing_facts`] from `narrowing.rs`
+    /// (LANG53).  The bridge is the thin adapter connecting the generic
+    /// protocol to the existing guard-analysis implementation.
+    ///
+    /// Handles:
+    /// - `(< x k)`, `(<= x k)`, `(> x k)`, `(>= x k)`, `(= x k)` with
+    ///   `VarRef op IntLit` form.
+    /// - `(and c1 c2 …)` — conjunction, merging facts.
+    /// - `(not c)` — negation.
+    /// - Everything else → empty (conservative; no narrowing applied).
+    fn narrowing_facts(&self, guard: &Expr) -> Vec<(String, Predicate)> {
+        extract_narrowing_facts(guard)
+    }
+
+    /// Narrow a `TwigKind` by intersecting it with a guard predicate.
+    ///
+    /// Delegates to [`merge_kind_with_predicate`] from `narrowing.rs` (LANG53).
+    ///
+    /// | Base kind | Result |
+    /// |---|---|
+    /// | `Int` | `RefinedInt(pred)` — add first refinement |
+    /// | `RefinedInt(existing)` | `RefinedInt(and([existing, pred]))` — intersect |
+    /// | Any other kind | unchanged — non-integer kinds are not narrowed |
+    fn narrow_kind(&self, base: &TwigKind, pred: Predicate) -> TwigKind {
+        merge_kind_with_predicate(base, pred)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — TwigRefinementBridge specifically
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use lang_refined_types::{Predicate, RefinedType, Kind as RefKind};
+    use lang_refinement_protocol::{
+        check_call_site_refinements, compute_if_narrowing, RefinementMode,
+    };
+    use twig_parser::{IntLit, VarRef};
+
+    use super::*;
+
+    // ─── evidence_for ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn evidence_int_lit_is_concrete() {
+        let bridge = TwigRefinementBridge;
+        let lit = Expr::IntLit(IntLit { value: 42, line: 1, column: 1 });
+        assert!(matches!(bridge.evidence_for(&lit, None), Evidence::Concrete(42)));
+    }
+
+    #[test]
+    fn evidence_var_ref_with_refined_kind_is_predicated() {
+        let bridge = TwigRefinementBridge;
+        let pred = Predicate::Range { lo: Some(0), hi: Some(50), inclusive_hi: false };
+        let var = Expr::VarRef(VarRef { name: "x".into(), line: 1, column: 1 });
+        let kind = TwigKind::RefinedInt(pred.clone());
+        let ev = bridge.evidence_for(&var, Some(&kind));
+        assert!(matches!(ev, Evidence::Predicated(_)));
+    }
+
+    #[test]
+    fn evidence_var_ref_with_plain_int_is_unconstrained() {
+        let bridge = TwigRefinementBridge;
+        let var = Expr::VarRef(VarRef { name: "n".into(), line: 1, column: 1 });
+        let ev = bridge.evidence_for(&var, Some(&TwigKind::Int));
+        assert!(matches!(ev, Evidence::Unconstrained));
+    }
+
+    #[test]
+    fn evidence_bool_lit_is_unconstrained() {
+        use twig_parser::BoolLit;
+        let bridge = TwigRefinementBridge;
+        let b = Expr::BoolLit(BoolLit { value: true, line: 1, column: 1 });
+        assert!(matches!(bridge.evidence_for(&b, None), Evidence::Unconstrained));
+    }
+
+    // ─── narrow_kind ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn narrow_int_produces_refined_int() {
+        let bridge = TwigRefinementBridge;
+        let pred = Predicate::Range { lo: None, hi: Some(128), inclusive_hi: false };
+        let narrowed = bridge.narrow_kind(&TwigKind::Int, pred);
+        assert!(matches!(narrowed, TwigKind::RefinedInt(_)));
+    }
+
+    #[test]
+    fn narrow_refined_int_intersects_predicates() {
+        let bridge = TwigRefinementBridge;
+        let existing = Predicate::Range { lo: Some(0), hi: None, inclusive_hi: false };
+        let new_pred = Predicate::Range { lo: None, hi: Some(128), inclusive_hi: false };
+        let narrowed = bridge.narrow_kind(&TwigKind::RefinedInt(existing), new_pred);
+        // Should be RefinedInt(And([…]))
+        assert!(matches!(narrowed, TwigKind::RefinedInt(Predicate::And(_))));
+    }
+
+    #[test]
+    fn narrow_bool_is_unchanged() {
+        let bridge = TwigRefinementBridge;
+        let pred = Predicate::Range { lo: Some(0), hi: Some(1), inclusive_hi: true };
+        let narrowed = bridge.narrow_kind(&TwigKind::Bool, pred);
+        assert_eq!(narrowed, TwigKind::Bool);
+    }
+
+    // ─── Integration via generic functions ───────────────────────────────────
+
+    #[test]
+    fn check_call_site_int_lit_in_range_no_diagnostic() {
+        let ann = RefinedType::refined(
+            RefKind::Int,
+            Predicate::Range { lo: Some(0), hi: Some(128), inclusive_hi: false },
+        );
+        let lit = Expr::IntLit(IntLit { value: 42, line: 1, column: 1 });
+        let diags = check_call_site_refinements(
+            &TwigRefinementBridge,
+            "ascii-info",
+            1, 1,
+            &[lit],
+            &[TwigKind::Int],
+            &[Some(ann)],
+            RefinementMode::Strict,
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn check_call_site_int_lit_out_of_range_is_diagnostic() {
+        let ann = RefinedType::refined(
+            RefKind::Int,
+            Predicate::Range { lo: Some(0), hi: Some(128), inclusive_hi: false },
+        );
+        let lit = Expr::IntLit(IntLit { value: 200, line: 3, column: 5 });
+        let diags = check_call_site_refinements(
+            &TwigRefinementBridge,
+            "ascii-info",
+            3, 5,
+            &[lit],
+            &[TwigKind::Int],
+            &[Some(ann)],
+            RefinementMode::Strict,
+        );
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("ascii-info"));
+        assert_eq!(diags[0].line, 3);
+    }
+
+    #[test]
+    fn compute_if_narrowing_narrows_variable() {
+        use twig_parser::{Apply, VarRef as VR, IntLit as IL};
+        // Build a guard: (< x 128) — Apply with fn_expr=VarRef("<"), args=[VarRef("x"), IntLit(128)]
+        let guard = Expr::Apply(Apply {
+            fn_expr: Box::new(Expr::VarRef(VR { name: "<".into(), line: 1, column: 1 })),
+            args: vec![
+                Expr::VarRef(VR { name: "x".into(), line: 1, column: 3 }),
+                Expr::IntLit(IL { value: 128, line: 1, column: 5 }),
+            ],
+            line: 1,
+            column: 1,
+        });
+        let nb = compute_if_narrowing(
+            &TwigRefinementBridge,
+            &guard,
+            |var| if var == "x" { Some(TwigKind::Int) } else { None },
+        );
+        // True branch: x narrowed to RefinedInt.
+        assert_eq!(nb.true_branch.len(), 1);
+        assert_eq!(nb.true_branch[0].0, "x");
+        assert!(matches!(nb.true_branch[0].1, TwigKind::RefinedInt(_)));
+        // False branch: x narrowed to RefinedInt(negated).
+        assert_eq!(nb.false_branch.len(), 1);
+        assert!(matches!(nb.false_branch[0].1, TwigKind::RefinedInt(_)));
+    }
+}

--- a/code/packages/rust/twig-type-checker/src/check.rs
+++ b/code/packages/rust/twig-type-checker/src/check.rs
@@ -43,7 +43,9 @@
 //! threaded through each recursive call.  `errors` is a mutable `Vec`
 //! that any sub-call can append to.
 
-use lang_refinement_checker::{Checker, CheckOutcome, Evidence};
+use lang_refinement_protocol::{
+    check_call_site_refinements, compute_if_narrowing, RefinementMode,
+};
 use twig_parser::{
     Apply, Begin, Define, Expr, Form, If, Lambda, Let,
     // LANG52: sequential let* bindings
@@ -53,10 +55,10 @@ use twig_parser::{
 use type_checker_protocol::TypeErrorDiagnostic;
 
 use crate::arity::check_arity;
+use crate::bridge::TwigRefinementBridge;
 use crate::env::{ScopeStack, TypeEnv};
 use crate::exhaustiveness::check_exhaustiveness;
 use crate::kinds::{annotation_to_refined_type, type_annotation_to_kind, TwigKind};
-use crate::narrowing::{extract_narrowing_facts, merge_kind_with_predicate};
 
 // ---------------------------------------------------------------------------
 // Pass 1 — declaration collection
@@ -352,87 +354,43 @@ fn infer_apply(
         check_arity(fn_name, expected, app.args.len(), app.line, app.column, errors);
     }
 
-    // TW05-C: call-site refinement checking.
-    // Only runs when the callee is a VarRef and has registered refinements.
+    // TW05-C / LANG54: call-site refinement checking via the generic protocol.
+    // Only runs when the callee is a VarRef with registered param refinements.
     if let Some(callee_name) = fn_name {
         if let Some(param_refinements) = env.fn_param_refinements.get(callee_name) {
-            let mut checker = Checker::new();
-            for (i, (arg, maybe_rt)) in app.args.iter().zip(param_refinements.iter()).enumerate() {
-                let Some(rt) = maybe_rt else { continue };
+            // Map TypedMode → RefinementMode for the protocol.
+            let ref_mode = match mode {
+                TypedMode::Strict  => RefinementMode::Strict,
+                // Lenient and Off both use Lenient — Off never reaches here
+                // (check_program returns early), but be defensive.
+                _ => RefinementMode::Lenient,
+            };
 
-                // Build evidence for this argument.
-                let evidence = arg_to_evidence(arg, &arg_kinds.get(i).cloned(), scope);
-
-                match checker.check(rt, &evidence) {
-                    CheckOutcome::ProvenUnsafe(cx) => {
-                        errors.push(TypeErrorDiagnostic {
-                            message: format!(
-                                "refinement error: argument {} to `{}` violates annotation: {}",
-                                i, callee_name, cx.description
-                            ),
-                            line: app.line,
-                            column: app.column,
-                        });
-                    }
-                    CheckOutcome::Unknown(_) if *mode == TypedMode::Strict => {
-                        errors.push(TypeErrorDiagnostic {
-                            message: format!(
-                                "refinement error: argument {} to `{}` cannot be proven to satisfy annotation (strict mode)",
-                                i, callee_name
-                            ),
-                            line: app.line,
-                            column: app.column,
-                        });
-                    }
-                    // ProvenSafe → silent; Unknown + Lenient → silent.
-                    _ => {}
-                }
+            // Delegate to the generic free function via TwigRefinementBridge.
+            // All evidence classification, Checker invocation, and outcome
+            // handling is now in lang-refinement-protocol.
+            let diags = check_call_site_refinements(
+                &TwigRefinementBridge,
+                callee_name,
+                app.line,
+                app.column,
+                &app.args,
+                &arg_kinds,
+                param_refinements,
+                ref_mode,
+            );
+            for d in diags {
+                errors.push(TypeErrorDiagnostic {
+                    message: d.message,
+                    line: d.line,
+                    column: d.column,
+                });
             }
         }
     }
 
     // Return kind unknown without a return-type annotation.
     TwigKind::Any
-}
-
-/// Classify a call-site argument as `Evidence` for the refinement checker.
-///
-/// The `inferred_kind` (already computed by `infer_expr` above) lets us reuse
-/// the scope lookup result without a second traversal.
-///
-/// ## Rules
-///
-/// | Argument | Kind in scope | Evidence |
-/// |----------|---------------|---------|
-/// | `IntLit(n)` | — | `Concrete(n)` |
-/// | `VarRef(x)` | `RefinedInt(p)` | `Predicated([p])` |
-/// | `VarRef(x)` | `Int` or `Any` | `Unconstrained` |
-/// | anything else | — | `Unconstrained` |
-fn arg_to_evidence(
-    arg: &Expr,
-    inferred_kind: &Option<TwigKind>,
-    scope: &ScopeStack,
-) -> Evidence {
-    match arg {
-        Expr::IntLit(lit) => Evidence::Concrete(lit.value as i128),
-        Expr::VarRef(v) => {
-            // Use the already-inferred kind (from scope or globals) rather
-            // than re-looking up — avoids a second borrow of scope.
-            let kind = inferred_kind
-                .as_ref()
-                .or_else(|| scope.lookup(&v.name));
-            match kind {
-                Some(TwigKind::RefinedInt(pred)) => {
-                    // The variable has a known refinement predicate.
-                    Evidence::Predicated(vec![pred.clone()])
-                }
-                // Int (unrefined) or Any: the solver knows nothing.
-                _ => Evidence::Unconstrained,
-            }
-        }
-        // Complex expressions (lambda, apply, let, …): no static evidence.
-        _ => Evidence::Unconstrained,
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -444,17 +402,19 @@ fn arg_to_evidence(
 /// Both branches are inferred.  If they agree on a kind, that kind is
 /// returned.  Otherwise `TwigKind::unify` widens them (see `kinds::unify`).
 ///
-/// ## TW05-C: flow-sensitive narrowing
+/// ## TW05-C / LANG54: flow-sensitive narrowing via the generic protocol
 ///
-/// We call `extract_narrowing_facts(cond)` to extract per-variable predicates
-/// implied by the guard.  These are applied to the variable's current kind via
-/// `merge_kind_with_predicate`:
+/// We call [`compute_if_narrowing`] (from `lang-refinement-protocol`) with
+/// [`TwigRefinementBridge`].  The generic function:
 ///
-/// - **True branch**: bind the narrowing predicates in a fresh scope frame.
-/// - **False branch**: bind the *negated* predicates.
+/// 1. Calls `bridge.narrowing_facts(cond)` → per-variable predicates implied
+///    by the guard being true.
+/// 2. Looks up each variable's current kind via the provided `scope_lookup`
+///    closure.
+/// 3. Returns [`NarrowedBindings`] with `true_branch` and `false_branch`
+///    binding lists.
 ///
-/// This uses the existing `push_frame` / `pop_frame` / `bind` mechanism of
-/// `ScopeStack` — no structural changes to `ScopeStack` are required.
+/// We then push a scope frame, apply the bindings, infer the branch, and pop.
 ///
 /// ### Example
 ///
@@ -478,37 +438,31 @@ fn infer_if(
     // Always infer the condition for error collection.
     infer_expr(&if_expr.cond, env, scope, mode, errors);
 
-    // Extract narrowing facts from the guard (TW05-C).
-    let facts = extract_narrowing_facts(&if_expr.cond);
+    // LANG54: delegate narrowing computation to the generic protocol.
+    // `compute_if_narrowing` calls TwigRefinementBridge::narrowing_facts and
+    // TwigRefinementBridge::narrow_kind internally — no Twig-specific logic here.
+    let narrowed = compute_if_narrowing(
+        &TwigRefinementBridge,
+        &if_expr.cond,
+        // Scope lookup: local scope first, then module globals.
+        // Globals are typically not refined kinds (module-level names are always
+        // Function / Any / Int etc., never narrowed by a guard), but we include
+        // them here for completeness.
+        |var| scope.lookup(var).cloned().or_else(|| env.lookup_global(var).cloned()),
+    );
 
     // ── True branch ──────────────────────────────────────────────────────────
-    // Push a fresh scope frame and bind narrowing predicates.
     scope.push_frame();
-    for (var, pred) in &facts {
-        // Only narrow if the variable is currently in scope (local or global).
-        // We check local scope first; globals are not narrowed into scope frames
-        // here (they're module-level and never have refined kinds from guards).
-        if let Some(base_kind) = scope.lookup(var).cloned().or_else(|| {
-            env.lookup_global(var).cloned()
-        }) {
-            let narrowed = merge_kind_with_predicate(&base_kind, pred.clone());
-            scope.bind(var, narrowed);
-        }
+    for (var, kind) in narrowed.true_branch {
+        scope.bind(&var, kind);
     }
     let then_kind = infer_expr(&if_expr.then_branch, env, scope, mode, errors);
     scope.pop_frame();
 
     // ── False branch ─────────────────────────────────────────────────────────
-    // Push a fresh scope frame and bind *negated* predicates.
     scope.push_frame();
-    for (var, pred) in &facts {
-        if let Some(base_kind) = scope.lookup(var).cloned().or_else(|| {
-            env.lookup_global(var).cloned()
-        }) {
-            let negated = lang_refined_types::Predicate::not(pred.clone());
-            let narrowed = merge_kind_with_predicate(&base_kind, negated);
-            scope.bind(var, narrowed);
-        }
+    for (var, kind) in narrowed.false_branch {
+        scope.bind(&var, kind);
     }
     let else_kind = infer_expr(&if_expr.else_branch, env, scope, mode, errors);
     scope.pop_frame();

--- a/code/packages/rust/twig-type-checker/src/lib.rs
+++ b/code/packages/rust/twig-type-checker/src/lib.rs
@@ -67,6 +67,9 @@
 #![warn(rust_2018_idioms)]
 
 pub mod arity;
+/// LANG54: `TwigRefinementBridge` — implements `lang_refinement_protocol::RefinementBridge`
+/// for Twig's `Expr` AST and `TwigKind` type system.
+pub mod bridge;
 pub mod check;
 pub mod env;
 pub mod errors;

--- a/code/specs/LANG54-refinement-protocol.md
+++ b/code/specs/LANG54-refinement-protocol.md
@@ -1,0 +1,292 @@
+# LANG54 — Generic Refinement-Type Checker Protocol
+
+**Status:** planned  
+**Branch:** `feat/lang54-refinement-protocol`  
+**Depends on:** LANG53 (twig-type-checker v0.5.0), LANG23 (lang-refinement-checker)
+
+---
+
+## Motivation
+
+LANG53 wired `lang-refinement-checker` into `twig-type-checker` with ~150 lines
+of Twig-specific glue.  The pattern is valuable — call-site proof obligations,
+flow-sensitive narrowing from `if`-guards — but it cannot be reused by other
+language frontends (Nib, future Twig-derivative languages, etc.) without copying
+and adapting those 150 lines.
+
+LANG54 extracts the reusable core into a new `lang-refinement-protocol` crate
+so that Language X gets call-site checking and flow-sensitive narrowing by
+implementing three bridge methods.
+
+---
+
+## New crate: `lang-refinement-protocol`
+
+### Public API
+
+#### `RefinementBridge` trait
+
+The single trait a language must implement.  It is generic over the language's
+expression (`Expr`) and kind (`Kind`) types.
+
+```rust
+pub trait RefinementBridge {
+    /// The language's AST expression type at call sites and guard positions.
+    type Expr;
+    /// The language's kind/type representation (result of type inference).
+    type Kind: Clone;
+
+    /// Classify a call-site argument expression as `Evidence` for the solver.
+    ///
+    /// `expr` — the argument AST node.  
+    /// `inferred_kind` — the kind already computed for this expression (avoids
+    ///   a second traversal).  `None` when the caller did not pre-compute it.
+    fn evidence_for(&self, expr: &Self::Expr, inferred_kind: Option<&Self::Kind>) -> Evidence;
+
+    /// Extract narrowing facts from a guard expression.
+    ///
+    /// Returns `(variable_name, predicate)` pairs: "if this guard is true,
+    /// `variable_name` satisfies `predicate`."  Returns `[]` when the guard
+    /// implies nothing useful (conservative: no narrowing).
+    fn narrowing_facts(&self, guard: &Self::Expr) -> Vec<(String, Predicate)>;
+
+    /// Narrow a variable's kind by adding a guard predicate.
+    ///
+    /// - `Int + p` → `RefinedInt(p)`    (add refinement)
+    /// - `RefinedInt(q) + p` → `RefinedInt(and(q, p))`  (intersect)
+    /// - `Bool / Str / …` → unchanged   (non-numeric kinds)
+    fn narrow_kind(&self, base: &Self::Kind, pred: Predicate) -> Self::Kind;
+}
+```
+
+#### `check_call_site_refinements` — generic call-site checker
+
+```rust
+pub fn check_call_site_refinements<B>(
+    bridge: &B,
+    callee_name: &str,
+    call_site_line: usize,
+    call_site_column: usize,
+    arg_exprs: &[B::Expr],
+    arg_kinds: &[B::Kind],
+    param_refinements: &[Option<RefinedType>],
+    mode: RefinementMode,
+) -> Vec<RefinementDiagnostic>
+where
+    B: RefinementBridge;
+```
+
+Drives `Checker::check` for each annotated argument:
+
+| argument | evidence | outcome |
+|---|---|---|
+| `evidence_for(arg)` = `Concrete(n)` | `Concrete(n)` | exact check |
+| `evidence_for(arg)` = `Predicated(ps)` | `Predicated(ps)` | entailment check |
+| `evidence_for(arg)` = `Unconstrained` | `Unconstrained` | `Unknown` |
+| `ProvenUnsafe(cx)` | → `RefinementDiagnostic` always |
+| `Unknown` + `Strict` | → `RefinementDiagnostic` |
+| `Unknown` + `Lenient` | → silent |
+| `ProvenSafe` | → silent |
+
+#### `NarrowedBindings<K>` + `compute_if_narrowing` — generic narrowing
+
+```rust
+pub struct NarrowedBindings<K> {
+    /// (variable, narrowed-kind) bindings for the true branch.
+    pub true_branch: Vec<(String, K)>,
+    /// (variable, narrowed-kind) bindings for the false branch.
+    pub false_branch: Vec<(String, K)>,
+}
+
+pub fn compute_if_narrowing<B>(
+    bridge: &B,
+    guard: &B::Expr,
+    scope_lookup: impl Fn(&str) -> Option<B::Kind>,
+) -> NarrowedBindings<B::Kind>
+where
+    B: RefinementBridge;
+```
+
+Calls `bridge.narrowing_facts(guard)`, looks up each variable in the provided
+scope, and delegates to `bridge.narrow_kind` for true-branch narrowing and
+`bridge.narrow_kind(base, Predicate::not(pred))` for false-branch narrowing.
+
+#### Supporting types
+
+```rust
+/// An error or warning produced by the refinement checker at a specific source location.
+pub struct RefinementDiagnostic {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+/// Whether `Unknown` outcomes produce diagnostics (Strict) or are silent (Lenient).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefinementMode { Lenient, Strict }
+```
+
+#### Re-exports
+
+From `lang-refinement-checker`:
+- `Evidence`, `CheckOutcome`, `CounterExample`, `Checker`, `Obligation`, `check_all`
+
+From `lang-refined-types`:
+- `Predicate`, `RefinedType`, `Kind` as `RefKind`
+
+This means a language only needs `lang-refinement-protocol` in its Cargo.toml.
+
+---
+
+## Refactored crate: `twig-type-checker` → v0.6.0
+
+### New file: `src/bridge.rs`
+
+`TwigRefinementBridge` implementing `RefinementBridge`:
+
+```rust
+pub struct TwigRefinementBridge;
+
+impl RefinementBridge for TwigRefinementBridge {
+    type Expr = twig_parser::Expr;
+    type Kind = TwigKind;
+
+    fn evidence_for(&self, expr: &Expr, inferred_kind: Option<&TwigKind>) -> Evidence {
+        match expr {
+            Expr::IntLit(lit) => Evidence::Concrete(lit.value as i128),
+            Expr::VarRef(_) => match inferred_kind {
+                Some(TwigKind::RefinedInt(p)) => Evidence::Predicated(vec![p.clone()]),
+                _ => Evidence::Unconstrained,
+            },
+            _ => Evidence::Unconstrained,
+        }
+    }
+
+    fn narrowing_facts(&self, guard: &Expr) -> Vec<(String, Predicate)> {
+        extract_narrowing_facts(guard)   // existing narrowing.rs function
+    }
+
+    fn narrow_kind(&self, base: &TwigKind, pred: Predicate) -> TwigKind {
+        merge_kind_with_predicate(base, pred)  // existing narrowing.rs function
+    }
+}
+```
+
+### Updated `src/check.rs`
+
+`infer_apply` — replace the 40-line manual loop with:
+```rust
+let diags = check_call_site_refinements(
+    &TwigRefinementBridge,
+    callee_name,
+    app.line,
+    app.column,
+    &app.args,
+    &arg_kinds,
+    param_refinements,
+    mode.into(),
+);
+for d in diags {
+    errors.push(TypeErrorDiagnostic { message: d.message, line: d.line, column: d.column });
+}
+```
+
+`infer_if` — replace the 30-line manual narrowing block with:
+```rust
+let narrowed = compute_if_narrowing(
+    &TwigRefinementBridge,
+    &if_expr.cond,
+    |var| scope.lookup(var).cloned().or_else(|| env.lookup_global(var).cloned()),
+);
+scope.push_frame();
+for (var, kind) in narrowed.true_branch { scope.bind(&var, kind); }
+let then_kind = infer_expr(&if_expr.then_branch, env, scope, mode, errors);
+scope.pop_frame();
+
+scope.push_frame();
+for (var, kind) in narrowed.false_branch { scope.bind(&var, kind); }
+let else_kind = infer_expr(&if_expr.else_branch, env, scope, mode, errors);
+scope.pop_frame();
+```
+
+### Dependency changes
+
+`twig-type-checker/Cargo.toml`:
+- **Add**: `lang-refinement-protocol = { path = "../lang-refinement-protocol" }`
+- **Remove**: `lang-refinement-checker` (re-exported through protocol)
+- **Keep**: `lang-refined-types` (for `RefinedType`/`Predicate` in TwigKind + bridge)
+
+---
+
+## Adoption guide for Language X
+
+To add refinement checking to Language X:
+
+1. **Add dep**: `lang-refinement-protocol = { path = "../lang-refinement-protocol" }`
+
+2. **Implement bridge** (~50 lines):
+   ```rust
+   pub struct LangXBridge;
+   impl RefinementBridge for LangXBridge {
+       type Expr = LangXExpr;
+       type Kind = LangXKind;
+       fn evidence_for(&self, expr: &LangXExpr, kind: Option<&LangXKind>) -> Evidence { ... }
+       fn narrowing_facts(&self, guard: &LangXExpr) -> Vec<(String, Predicate)> { ... }
+       fn narrow_kind(&self, base: &LangXKind, pred: Predicate) -> LangXKind { ... }
+   }
+   ```
+
+3. **Call-site checking** (~10 lines in your apply/call handler):
+   ```rust
+   let diags = check_call_site_refinements(&LangXBridge, callee, line, col,
+       args, kinds, param_refinements, mode);
+   ```
+
+4. **Flow narrowing** (~10 lines in your if/cond handler):
+   ```rust
+   let narrowed = compute_if_narrowing(&LangXBridge, guard, |v| scope.lookup(v));
+   // apply narrowed.true_branch / narrowed.false_branch to your scope frames
+   ```
+
+Total: ~70 lines of language-specific code for full refinement checking.
+
+---
+
+## Tests
+
+### `lang-refinement-protocol` (≥ 10 unit tests, mock bridge)
+
+1. `check_call_site_concrete_in_range` → no diagnostics
+2. `check_call_site_concrete_out_of_range` → diagnostic
+3. `check_call_site_unconstrained_lenient` → no diagnostics
+4. `check_call_site_unconstrained_strict` → diagnostic
+5. `check_call_site_no_refinements` → no diagnostics (empty param_refinements)
+6. `check_call_site_predicated_proven_safe` → no diagnostics
+7. `check_call_site_predicated_proven_unsafe` → diagnostic
+8. `compute_if_narrowing_extracts_true_and_false_branches`
+9. `compute_if_narrowing_no_facts_yields_empty`
+10. `compute_if_narrowing_variable_not_in_scope_skipped`
+11. `narrowed_bindings_false_branch_is_negated`
+
+### `twig-type-checker` regression (all 74 existing tests must still pass)
+
+---
+
+## Version bumps
+
+| Crate | Old | New | Reason |
+|---|---|---|---|
+| `lang-refinement-protocol` | — | 0.1.0 | New crate |
+| `twig-type-checker` | 0.5.0 | 0.6.0 | Refactored to use protocol; behaviour identical |
+
+---
+
+## Commit sequence
+
+1. `docs(specs)`: `LANG54-refinement-protocol.md`
+2. `feat(lang-refinement-protocol)`: `RefinementBridge` trait + supporting types
+3. `feat(lang-refinement-protocol)`: `check_call_site_refinements` free function
+4. `feat(lang-refinement-protocol)`: `compute_if_narrowing` + `NarrowedBindings`
+5. `test(lang-refinement-protocol)`: 11 unit tests with mock bridge
+6. `feat(twig-type-checker)`: `TwigRefinementBridge` + refactored check.rs
+7. `docs`: CHANGELOG + README updates


### PR DESCRIPTION
## Summary

- **New crate `lang-refinement-protocol` v0.1.0** — generic protocol so any language type checker can get call-site refinement checking and flow-sensitive narrowing by implementing 3 bridge methods (~50 lines)
- **New `RefinementBridge` trait** with `evidence_for`, `narrowing_facts`, `narrow_kind` — the only language-specific code a new language needs to write
- **`check_call_site_refinements()`** and **`compute_if_narrowing()`** generic free functions that drive the `lang-refinement-checker` solver, fully reusable across languages
- **`twig-type-checker` v0.6.0** refactored to use the protocol via `TwigRefinementBridge` — behaviour identical, 40-line manual loop replaced, 35-line manual narrowing block replaced

## What this unblocks

Language X (e.g. Nib, future languages) can now get refinement checking in **~70 lines** instead of copying 150+ lines of Twig-specific code:
1. Implement `RefinementBridge` (3 methods, ~50 lines)
2. Call `check_call_site_refinements` in your apply handler (~10 lines)
3. Call `compute_if_narrowing` in your if-expression handler (~10 lines)

## Tests

- 14 new unit tests in `lang-refinement-protocol` (mock bridge covering all Evidence paths + both narrowing directions)
- 10 new integration tests in `twig-type-checker/bridge.rs`
- All 74 LANG53 regression tests continue to pass (84 total in twig-type-checker)
- 98 total tests across both crates

## Test plan

- [ ] `cargo test -p lang-refinement-protocol` — 14 pass
- [ ] `cargo test -p twig-type-checker` — 84 pass
- [ ] All existing LANG53 narrowing + call-site tests pass (regression)
- [ ] No public API changes to `type_check`, `check_program`, `TwigKind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)