### PR TITLE
python(spice): parse BJT model netlists

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.5
+
+- Parse `.model <name> NPN(...)` and `.model <name> PNP(...)` cards into
+  `ModelCard` records.
+- Parse `Q` BJT elements into `spice_engine.BJT` instances using `IS`,
+  `BF`/`BETA_F`, and `VT` model parameters.
+- Remap BJT collector/base/emitter terminals during `.subckt` expansion.
+
 ## 0.1.4
 
 - Parse `.model <name> D(...)` cards into `ModelCard` records.

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -18,8 +18,8 @@ netlist.circuit.elements
 netlist.analyses
 ```
 
-This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `G`, `E`, `F`, and
-`H` elements, `.model` cards for Shockley diode parameters (`IS`, `VT`), SPICE
-engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
-`.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
-analysis cards.
+This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `G`, `E`, `F`,
+and `H` elements, `.model` cards for Shockley diode parameters (`IS`, `VT`) and
+BJT parameters (`NPN`/`PNP`, `IS`, `BF`/`BETA_F`, `VT`), SPICE engineering
+suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X`
+instance expansion, and `.op`, `.tran`, `.dc`, and `.ac` analysis cards.

--- a/code/packages/python/spice-netlist-parser/pyproject.toml
+++ b/code/packages/python/spice-netlist-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-netlist-parser"
-version = "0.1.4"
+version = "0.1.5"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -12,7 +12,7 @@ from spice_netlist_parser.parser import (
 )
 
 parse = parse_netlist
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = [
     "AcAnalysis",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass, field
 
 from spice_engine import (
+    BJT,
     CCCS,
     CCVS,
     VCCS,
@@ -258,6 +259,25 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Is=model.params.get("IS", 1e-15),
             Vt=model.params.get("VT", 0.02585),
         )
+    if prefix == "Q":
+        _require_fields(fields, 5, "BJT")
+        model = models.get(fields[4].lower())
+        if model is None:
+            raise NetlistParseError(f"unknown model {fields[4]!r} for BJT {name!r}")
+        if model.kind not in {"NPN", "PNP"}:
+            raise NetlistParseError(
+                f"model {model.name!r} has kind {model.kind!r}, expected 'NPN' or 'PNP'"
+            )
+        return BJT(
+            name,
+            fields[1],
+            fields[2],
+            fields[3],
+            polarity=model.kind,
+            Is=model.params.get("IS", 1e-14),
+            beta_f=model.params.get("BETA_F", model.params.get("BF", 100.0)),
+            Vt=model.params.get("VT", 0.02585),
+        )
     if prefix == "G":
         _require_fields(fields, 6, "VCCS")
         return VCCS(name, fields[1], fields[2], fields[3], fields[4], parse_value(fields[5]))
@@ -345,6 +365,11 @@ def _map_subckt_fields(
         _require_min_fields(fields, 3, "subcircuit element")
         mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
         mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)
+    elif prefix == "Q":
+        _require_min_fields(fields, 4, "subcircuit BJT")
+        mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
+        mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)
+        mapped[3] = _map_subckt_node(fields[3], instance_name, node_map)
     elif prefix in {"E", "G"}:
         _require_min_fields(fields, 5, "subcircuit controlled source")
         for index in range(1, 5):

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2,6 +2,7 @@ from math import isclose
 
 import pytest
 from spice_engine import (
+    BJT,
     CCCS,
     CCVS,
     VCCS,
@@ -167,6 +168,52 @@ Rload out 0 1k
     assert 0.1 < result.node_voltages["out"] < 0.7
 
 
+def test_parse_bjt_model_into_operating_point_circuit() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NPN(IS=1e-14 BF=120 VT=25m)
+Vcc vcc 0 DC 5
+Vb base 0 DC 0.7
+Rc vcc col 100
+Q1 col base 0 fast
+.op
+"""
+    )
+
+    assert parsed.models == {
+        "fast": ModelCard("fast", "NPN", {"IS": 1.0e-14, "BF": 120.0, "VT": 25.0e-3})
+    }
+    bjt = parsed.circuit.elements[3]
+    assert isinstance(bjt, BJT)
+    assert bjt.collector == "col"
+    assert bjt.base == "base"
+    assert bjt.emitter == "0"
+    assert bjt.polarity == "NPN"
+    assert bjt.Is == 1.0e-14
+    assert bjt.beta_f == 120.0
+    assert bjt.Vt == 25.0e-3
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert 0.0 < result.node_voltages["col"] < 5.0
+
+
+def test_parse_pnp_bjt_model_aliases_beta_f() -> None:
+    parsed = parse_netlist(
+        """
+.model slow PNP(IS=2e-14 BETA_F=80 VT=26m)
+Qp col base emit slow
+"""
+    )
+
+    bjt = parsed.circuit.elements[0]
+    assert isinstance(bjt, BJT)
+    assert bjt.polarity == "PNP"
+    assert bjt.Is == 2.0e-14
+    assert bjt.beta_f == 80.0
+    assert isclose(bjt.Vt, 26.0e-3)
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """
@@ -323,6 +370,31 @@ Xlim in out limiter
     assert diode.Is == 1.0e-12
 
 
+def test_expands_subcircuit_bjt_nodes_into_engine_elements() -> None:
+    parsed = parse_netlist(
+        """
+.model npn NPN(BF=50)
+.subckt follower c b e
+Qbuf c b inner npn
+Re inner e 100
+.ends follower
+Xbuf out in 0 follower
+"""
+    )
+
+    bjt = parsed.circuit.elements[0]
+    resistor = parsed.circuit.elements[1]
+    assert isinstance(bjt, BJT)
+    assert bjt.name == "Xbuf.Qbuf"
+    assert bjt.collector == "out"
+    assert bjt.base == "in"
+    assert bjt.emitter == "Xbuf.inner"
+    assert bjt.beta_f == 50.0
+    assert isinstance(resistor, Resistor)
+    assert resistor.n_plus == "Xbuf.inner"
+    assert resistor.n_minus == "0"
+
+
 def test_subcircuit_internal_nodes_are_instance_scoped() -> None:
     parsed = parse_netlist(
         """
@@ -351,10 +423,10 @@ def test_engineering_suffixes() -> None:
 
 
 def test_rejects_unsupported_element_with_line_number() -> None:
-    with pytest.raises(NetlistParseError, match="line 2: unsupported element 'Q1'"):
+    with pytest.raises(NetlistParseError, match="line 2: unsupported element 'Z1'"):
         parse_netlist(
             """
-Q1 c b e model
+Z1 c b e model
 """
         )
 
@@ -374,6 +446,25 @@ def test_rejects_diode_bound_to_non_diode_model() -> None:
             """
 .model amp NPN(IS=1e-15)
 D1 a 0 amp
+"""
+        )
+
+
+def test_rejects_bjt_with_unknown_model() -> None:
+    with pytest.raises(NetlistParseError, match="line 2: unknown model 'missing' for BJT 'Q1'"):
+        parse_netlist(
+            """
+Q1 c b e missing
+"""
+        )
+
+
+def test_rejects_bjt_bound_to_non_bjt_model() -> None:
+    with pytest.raises(NetlistParseError, match="line 3: model 'clamp' has kind 'D'"):
+        parse_netlist(
+            """
+.model clamp D(IS=1e-15)
+Q1 c b e clamp
 """
         )
 


### PR DESCRIPTION
## Summary

- Parse SPICE `Q` BJT elements bound to `.model` cards with `NPN`/`PNP` polarity.
- Map `IS`, `BF`/`BETA_F`, and `VT` model parameters into `spice_engine.BJT` instances, including subcircuit terminal remapping.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-spice-netlist-bjt-model bash BUILD`
- `.venv/bin/ruff check .`

- `git diff --check`
## Notes
- Builds on the existing Python SPICE engine BJT element; this PR only unlocks netlist parsing for it.

