### PR TITLE
[codex] Add Board VM SPI transfer capability

### DIFF
--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -134,6 +134,7 @@ def test_known_targets_are_exposed_from_rust_registry():
     assert "transport.bluetooth_le" in uno_r4_wifi.capabilities
     assert "pwm.write" in uno_r4_wifi.capabilities
     assert "spi.open" in uno_r4_wifi.capabilities
+    assert "spi.transfer" in uno_r4_wifi.capabilities
     assert uno_r4_wifi.wireless_transports == ["wifi", "bluetooth_le"]
     assert uno_r4_wifi.supports_wifi is True
     assert uno_r4_wifi.supports_bluetooth is True

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -7,13 +7,14 @@ use board_vm_host::{
     GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
     GpioWriteProgram, I2cOpenProgram, I2cReadProgram, I2cReadU8Program, I2cTransferProgram,
     I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram, PwmWriteProgram, SpiOpenProgram,
-    TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
+    SpiTransferProgram, TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
     DAC_WRITE_U12_MODULE_LEN,
     GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
     GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
     I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_TRANSFER_MAX_MODULE_LEN,
     I2C_WRITE_MAX_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
-    PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, SPI_TRANSFER_MAX_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
@@ -26,7 +27,7 @@ use board_vm_language_core::{
     build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
     build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
     build_run_background_wire_frame, build_run_wire_frame, build_spi_open_module,
-    build_stop_wire_frame,
+    build_spi_transfer_module, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, connection_transport_name, decode_wire_response,
@@ -289,6 +290,24 @@ extern "C" fn session_spi_open_module(
 
     let module = build_spi_open_module_value(bus, max_stack)
         .unwrap_or_else(|error| raise_core_error("spi_open_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_spi_transfer_module(
+    _self_val: VALUE,
+    cs_pin_val: VALUE,
+    write_bytes_val: VALUE,
+    read_len_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let cs_pin = rb_u16(cs_pin_val, "cs_pin");
+    let write_bytes = ruby_bridge::bytes_from_rb(write_bytes_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("write_bytes must be a Ruby binary String"));
+    let read_len = rb_u8(read_len_val, "read_len");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_spi_transfer_module_value(cs_pin, &write_bytes, read_len, max_stack)
+        .unwrap_or_else(|error| raise_core_error("spi_transfer_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1606,6 +1625,26 @@ fn build_spi_open_module_value(bus: u8, max_stack: u8) -> Result<Vec<u8>, Langua
     Ok(module)
 }
 
+fn build_spi_transfer_module_value(
+    cs_pin: u16,
+    write_bytes: &[u8],
+    read_len: u8,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; SPI_TRANSFER_MAX_MODULE_LEN];
+    let len = build_spi_transfer_module(
+        SpiTransferProgram {
+            cs_pin,
+            write_bytes,
+            read_len,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_i2c_write_u8_module_value(
     address: u16,
     byte: u8,
@@ -2009,6 +2048,12 @@ pub extern "C" fn Init_board_vm_native() {
         "spi_open_module",
         session_spi_open_module as *const c_void,
         2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "spi_transfer_module",
+        session_spi_transfer_module as *const c_void,
+        4,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -472,6 +472,26 @@ module CodingAdventures
         )
       end
 
+      def spi_transfer!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        cs_pin:,
+        write_bytes:,
+        read_length:,
+        max_stack: 5
+      )
+        ensure_uno_r4_wifi!
+
+        session.spi_transfer(
+          program_id: program_id,
+          budget: budget,
+          cs_pin: cs_pin,
+          write_bytes: write_bytes,
+          read_length: read_length,
+          max_stack: max_stack
+        )
+      end
+
       def i2c_write_u8!(
         program_id: DEFAULT_PROGRAM_ID,
         budget: DEFAULT_INSTRUCTION_BUDGET,
@@ -1299,6 +1319,24 @@ module CodingAdventures
           budget: budget,
           host_nonce: host_nonce,
           bus: bus,
+          max_stack: max_stack
+        )
+      end
+
+      def transfer(
+        cs_pin:,
+        write_bytes:,
+        read_length:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 5
+      )
+        @connection.spi_transfer!(
+          program_id: program_id,
+          budget: budget,
+          cs_pin: cs_pin,
+          write_bytes: write_bytes,
+          read_length: read_length,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -217,6 +217,15 @@ module CodingAdventures
         native_session.spi_open_module(bus, max_stack)
       end
 
+      def spi_transfer_module(cs_pin:, write_bytes:, read_length:, max_stack: 5)
+        native_session.spi_transfer_module(
+          cs_pin,
+          i2c_bytes_value(write_bytes),
+          i2c_read_length_value(read_length),
+          max_stack
+        )
+      end
+
       def i2c_write_u8_module(address:, byte:, max_stack: 4)
         native_session.i2c_write_u8_module(address, byte, max_stack)
       end
@@ -336,6 +345,24 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: spi_open_module(bus: bus, max_stack: max_stack)
+        )
+      end
+
+      def upload_spi_transfer(
+        program_id: @program_id,
+        cs_pin:,
+        write_bytes:,
+        read_length:,
+        max_stack: 5
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: spi_transfer_module(
+            cs_pin: cs_pin,
+            write_bytes: write_bytes,
+            read_length: read_length,
+            max_stack: max_stack
+          )
         )
       end
 
@@ -773,6 +800,32 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def spi_transfer(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        cs_pin:,
+        write_bytes:,
+        read_length:,
+        max_stack: 5
+      )
+        results = upload_spi_transfer(
+          program_id: program_id,
+          cs_pin: cs_pin,
+          write_bytes: write_bytes,
+          read_length: read_length,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def i2c_write_u8(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -1096,6 +1149,8 @@ module CodingAdventures
           upload_i2c_open(**i2c_open_command_options(words, command, options, require_budget: false))
         when "upload-spi-open", "upload-spi.open"
           upload_spi_open(**spi_open_command_options(words, command, options, require_budget: false))
+        when "upload-spi-transfer", "upload-spi.transfer"
+          upload_spi_transfer(**spi_transfer_command_options(words, command, options, require_budget: false))
         when "upload-i2c-write-u8", "upload-i2c.write_u8", "upload-i2c-write"
           upload_i2c_write_u8(**i2c_write_u8_command_options(words, command, options, require_budget: false))
         when "upload-i2c-write-bytes", "upload-i2c.write"
@@ -1146,6 +1201,8 @@ module CodingAdventures
           i2c_open(**i2c_open_command_options(words, command, options))
         when "spi-open", "spi.open"
           spi_open(**spi_open_command_options(words, command, options))
+        when "spi-transfer", "spi.transfer"
+          spi_transfer(**spi_transfer_command_options(words, command, options))
         when "i2c-write-u8", "i2c.write_u8", "i2c-write"
           i2c_write_u8(**i2c_write_u8_command_options(words, command, options))
         when "i2c-write-bytes", "i2c.write"
@@ -1478,6 +1535,24 @@ module CodingAdventures
 
         ensure_no_extra_arguments!(words, command)
         raise ArgumentError, "#{command} requires address" unless merged.key?(:address)
+        raise ArgumentError, "#{command} requires write bytes" unless merged.key?(:write_bytes)
+        raise ArgumentError, "#{command} requires read length" unless merged.key?(:read_length)
+
+        merged
+      end
+
+      def spi_transfer_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:cs_pin] = integer_argument(words.shift, "#{command} chip select pin") unless words.empty?
+        merged[:write_bytes] = i2c_bytes_argument(words.shift, "#{command} write bytes") unless words.empty?
+        merged[:read_length] = i2c_read_length_value(words.shift) unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires chip select pin" unless merged.key?(:cs_pin)
         raise ArgumentError, "#{command} requires write bytes" unless merged.key?(:write_bytes)
         raise ArgumentError, "#{command} requires read length" unless merged.key?(:read_length)
 

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -45,6 +45,7 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "i2c.read"
         assert_includes uno_r4_wifi["capabilities"], "i2c.transfer"
         assert_includes uno_r4_wifi["capabilities"], "spi.open"
+        assert_includes uno_r4_wifi["capabilities"], "spi.transfer"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -1328,6 +1329,38 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_spi_transfer_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        open_result = nil
+        transfer_result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          open_result = board.spi.open(bus: 0, program_id: 10, budget: 24)
+          transfer_result = board.spi.transfer(
+            cs_pin: 10,
+            write_bytes: [0x9f],
+            read_length: 3,
+            program_id: 11,
+            budget: 24
+          )
+        end
+
+        assert_empty runner.calls
+        assert_equal 10, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal open_result.frames + transfer_result.frames, transport.frames
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          open_result.results.map(&:command)
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          transfer_result.results.map(&:command)
+      end
+
       def test_i2c_write_u8_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1888,6 +1921,29 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_spi_transfer
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          open = board.session.run_command("spi-open 0 24", program_id: 8)
+          result = board.session.run_command("spi-transfer 10 0x9f 3 24", program_id: 9)
+          upload = board.session.run_command("upload-spi-transfer 10 0x9f 3", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            open.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal open.frames + result.frames + upload.frames, transport.frames
+        end
+      end
+
       def test_session_run_command_accepts_repl_style_i2c_write_u8
         transport = FakeWriteTransport.new
 
@@ -2144,6 +2200,10 @@ module CodingAdventures
         spi_module_bytes = session.spi_open_module(0, 2)
         assert_instance_of String, spi_module_bytes
         assert_operator spi_module_bytes.bytesize, :>, 0
+
+        spi_transfer_module_bytes = session.spi_transfer_module(10, "\x9F".b, 3, 5)
+        assert_instance_of String, spi_transfer_module_bytes
+        assert_operator spi_transfer_module_bytes.bytesize, :>, 0
 
         i2c_write_module_bytes = session.i2c_write_u8_module(0x3c, 0xa5, 4)
         assert_instance_of String, i2c_write_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -4,7 +4,7 @@ use board_vm_ir::{
     parse_module, validate, CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
     CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER,
     CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_SPI_OPEN,
-    CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    CAP_SPI_TRANSFER, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -129,6 +129,12 @@ const SPI_OPEN_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor 
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "spi.open",
+};
+const SPI_TRANSFER_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_SPI_TRANSFER,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "spi.transfer",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -642,7 +648,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_AND_I2C_CAPABILITIES: [CapabilityDescriptor
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
-pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_SPI_CAPABILITIES: [CapabilityDescriptor<'static>; 17] = [
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_SPI_CAPABILITIES: [CapabilityDescriptor<'static>; 18] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -659,6 +665,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_SPI_CAPABILITIES: [CapabilityDescri
     I2C_READ_DESCRIPTOR,
     I2C_TRANSFER_DESCRIPTOR,
     SPI_OPEN_DESCRIPTOR,
+    SPI_TRANSFER_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
@@ -739,7 +746,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_LED_MATRIX_CAPABILITIES: [Capabilit
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<
     'static,
->; 18] = [
+>; 19] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -756,6 +763,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_AND_LED_MATRIX_CAPABILITIES: [Capab
     I2C_READ_DESCRIPTOR,
     I2C_TRANSFER_DESCRIPTOR,
     SPI_OPEN_DESCRIPTOR,
+    SPI_TRANSFER_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -2,9 +2,9 @@ use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ,
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
     CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
-    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_SPI_OPEN, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
-    FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MAX_BYTE_BUFFER_LEN,
-    MODULE_MAGIC, MODULE_VERSION,
+    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_SPI_OPEN, CAP_SPI_TRANSFER, CAP_TIME_NOW_MS,
+    CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+    MAX_BYTE_BUFFER_LEN, MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -57,6 +57,9 @@ pub const I2C_TRANSFER_MAX_MODULE_LEN: usize =
     8 + 1 + I2C_TRANSFER_CODE_LEN + 1 + MAX_BYTE_BUFFER_LEN;
 pub const SPI_OPEN_CODE_LEN: usize = 6;
 pub const SPI_OPEN_MODULE_LEN: usize = 16;
+pub const SPI_TRANSFER_CODE_LEN: usize = 13;
+pub const SPI_TRANSFER_MAX_MODULE_LEN: usize =
+    8 + 1 + SPI_TRANSFER_CODE_LEN + 1 + MAX_BYTE_BUFFER_LEN;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -240,6 +243,14 @@ pub struct I2cTransferProgram<'a> {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpiTransferProgram<'a> {
+    pub cs_pin: u16,
+    pub write_bytes: &'a [u8],
+    pub read_len: u8,
+    pub max_stack: u8,
+}
+
 impl I2cOpenProgram {
     pub const fn new(bus: u8) -> Self {
         Self { bus, max_stack: 2 }
@@ -295,6 +306,17 @@ impl<'a> I2cTransferProgram<'a> {
     pub const fn new(address: u16, write_bytes: &'a [u8], read_len: u8) -> Self {
         Self {
             address,
+            write_bytes,
+            read_len,
+            max_stack: 5,
+        }
+    }
+}
+
+impl<'a> SpiTransferProgram<'a> {
+    pub const fn new(cs_pin: u16, write_bytes: &'a [u8], read_len: u8) -> Self {
+        Self {
+            cs_pin,
             write_bytes,
             read_len,
             max_stack: 5,
@@ -1326,6 +1348,69 @@ pub fn write_spi_open_module(program: SpiOpenProgram, out: &mut [u8]) -> Result<
     Ok(offset)
 }
 
+pub fn spi_transfer_module_len(write_len: usize) -> Result<usize, HostError> {
+    if write_len > MAX_BYTE_BUFFER_LEN {
+        return Err(HostError::ProgramTooLarge);
+    }
+    Ok(8 + 1 + SPI_TRANSFER_CODE_LEN + 1 + write_len)
+}
+
+pub fn write_spi_transfer_code(
+    program: SpiTransferProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if program.write_bytes.len() > MAX_BYTE_BUFFER_LEN
+        || program.read_len as usize > MAX_BYTE_BUFFER_LEN
+    {
+        return Err(HostError::ProgramTooLarge);
+    }
+    if out.len() < SPI_TRANSFER_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_push_u16(out, &mut offset, program.cs_pin)?;
+    write_push_bytes(out, &mut offset, 0, program.write_bytes.len() as u8)?;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.read_len)?;
+    write_call_u8(out, &mut offset, CAP_SPI_TRANSFER)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_spi_transfer_module(
+    program: SpiTransferProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if program.read_len as usize > MAX_BYTE_BUFFER_LEN {
+        return Err(HostError::ProgramTooLarge);
+    }
+    let required_len = spi_transfer_module_len(program.write_bytes.len())?;
+    if out.len() < required_len {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; SPI_TRANSFER_CODE_LEN];
+    let code_len = write_spi_transfer_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        )
+        .const_pool(program.write_bytes),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_spi(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn write_i2c_write_u8_code(
     program: I2cWriteU8Program,
     out: &mut [u8],
@@ -1797,6 +1882,10 @@ mod tests {
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x02, 0x00, 0x06, 0x12, 0x00, 0x40, 0x29, 0x20, 0x50,
         0x00,
     ];
+    const SPI_TRANSFER_CS10_9F_READ_03_MODULE_HEX: [u8; 24] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x05, 0x00, 0x0D, 0x20, 0x13, 0x0A, 0x00, 0x16, 0x00,
+        0x00, 0x01, 0x12, 0x03, 0x40, 0x2A, 0x50, 0x01, 0x9F,
+    ];
     const I2C_WRITE_U8_3C_A5_MODULE_HEX: [u8; I2C_WRITE_U8_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x04, 0x00, 0x08, 0x20, 0x13, 0x3C, 0x00, 0x12, 0xA5,
         0x40, 0x24, 0x00,
@@ -2032,6 +2121,22 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_SPI_OPEN]);
+    }
+
+    #[test]
+    fn builds_spi_transfer_module() {
+        let payload = [0x9f];
+        let mut module = [0u8; SPI_TRANSFER_MAX_MODULE_LEN];
+        let len = write_spi_transfer_module(SpiTransferProgram::new(10, &payload, 3), &mut module)
+            .unwrap();
+        assert_eq!(len, SPI_TRANSFER_CS10_9F_READ_03_MODULE_HEX.len());
+        assert_eq!(&module[..len], SPI_TRANSFER_CS10_9F_READ_03_MODULE_HEX);
+
+        let parsed = parse_module(&module[..len]).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_spi(), 5).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_SPI_TRANSFER]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -27,6 +27,7 @@ pub const CAP_I2C_WRITE: u16 = 0x26;
 pub const CAP_I2C_READ: u16 = 0x27;
 pub const CAP_I2C_TRANSFER: u16 = 0x28;
 pub const CAP_SPI_OPEN: u16 = 0x29;
+pub const CAP_SPI_TRANSFER: u16 = 0x2A;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -45,6 +46,7 @@ const CAP_I2C_WRITE_CAP_U8: u8 = CAP_I2C_WRITE as u8;
 const CAP_I2C_READ_CAP_U8: u8 = CAP_I2C_READ as u8;
 const CAP_I2C_TRANSFER_U8: u8 = CAP_I2C_TRANSFER as u8;
 const CAP_SPI_OPEN_U8: u8 = CAP_SPI_OPEN as u8;
+const CAP_SPI_TRANSFER_U8: u8 = CAP_SPI_TRANSFER as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -191,7 +193,7 @@ impl CapabilitySet {
             CAP_DAC_WRITE_U12 => self.dac,
             CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 | CAP_I2C_WRITE | CAP_I2C_READ
             | CAP_I2C_TRANSFER => self.i2c,
-            CAP_SPI_OPEN => self.spi,
+            CAP_SPI_OPEN | CAP_SPI_TRANSFER => self.spi,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -464,6 +466,7 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_I2C_READ_CAP_U8) | Op::CallU16(CAP_I2C_READ) => (3, 1),
         Op::CallU8(CAP_I2C_TRANSFER_U8) | Op::CallU16(CAP_I2C_TRANSFER) => (4, 1),
         Op::CallU8(CAP_SPI_OPEN_U8) | Op::CallU16(CAP_SPI_OPEN) => (1, 1),
+        Op::CallU8(CAP_SPI_TRANSFER_U8) | Op::CallU16(CAP_SPI_TRANSFER) => (4, 1),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -820,6 +823,35 @@ mod tests {
     }
 
     #[test]
+    fn validates_spi_transfer_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 5,
+            code: &[
+                0x20,
+                0x13,
+                0x0a,
+                0x00,
+                0x16,
+                0x00,
+                0x00,
+                0x01,
+                0x12,
+                0x03,
+                0x40,
+                CAP_SPI_TRANSFER as u8,
+                0x50,
+            ],
+            const_pool: &[0x9f],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_spi(), 5).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_SPI_TRANSFER]);
+    }
+
+    #[test]
     fn rejects_pwm_write_without_capability() {
         let module = Module {
             flags: 0,
@@ -891,6 +923,35 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 2),
             Err(ValidateError::UnsupportedCapability(CAP_SPI_OPEN))
+        );
+    }
+
+    #[test]
+    fn rejects_spi_transfer_without_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 5,
+            code: &[
+                0x20,
+                0x13,
+                0x0a,
+                0x00,
+                0x16,
+                0x00,
+                0x00,
+                0x01,
+                0x12,
+                0x03,
+                0x40,
+                CAP_SPI_TRANSFER as u8,
+                0x50,
+            ],
+            const_pool: &[0x9f],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 5),
+            Err(ValidateError::UnsupportedCapability(CAP_SPI_TRANSFER))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -35,18 +35,19 @@ use board_vm_esp_rom::{
     DEFAULT_TIMEOUT_MS as ESP_DEFAULT_TIMEOUT_MS,
 };
 use board_vm_host::{
-    i2c_transfer_module_len, i2c_write_module_len, write_adc_read_module, write_blink_module,
-    write_dac_write_u12_module, write_gpio_handle_close_module, write_gpio_handle_read_module,
-    write_gpio_handle_write_module, write_gpio_open_module, write_gpio_read_module,
-    write_gpio_write_module, write_i2c_open_module, write_i2c_read_module,
+    i2c_transfer_module_len, i2c_write_module_len, spi_transfer_module_len, write_adc_read_module,
+    write_blink_module, write_dac_write_u12_module, write_gpio_handle_close_module,
+    write_gpio_handle_read_module, write_gpio_handle_write_module, write_gpio_open_module,
+    write_gpio_read_module, write_gpio_write_module, write_i2c_open_module, write_i2c_read_module,
     write_i2c_read_u8_module, write_i2c_transfer_module, write_i2c_write_module,
     write_i2c_write_u8_module, write_led_matrix_frame_module, write_module, write_pwm_write_module,
-    write_spi_open_module, write_time_now_module, write_time_sleep_ms_module, AdcReadProgram,
-    BlinkProgram, DacWriteU12Program, GpioHandleCloseProgram, GpioHandleReadProgram,
-    GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError,
-    HostSession, I2cOpenProgram, I2cReadProgram, I2cReadU8Program, I2cTransferProgram,
-    I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram,
-    SpiOpenProgram, TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
+    write_spi_open_module, write_spi_transfer_module, write_time_now_module,
+    write_time_sleep_ms_module, AdcReadProgram, BlinkProgram, DacWriteU12Program,
+    GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram,
+    GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram, I2cReadProgram,
+    I2cReadU8Program, I2cTransferProgram, I2cWriteProgram, I2cWriteU8Program,
+    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, SpiOpenProgram, SpiTransferProgram,
+    TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
     DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
     GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
     GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
@@ -1672,6 +1673,13 @@ pub fn build_spi_open_module(
     Ok(write_spi_open_module(program, out)?)
 }
 
+pub fn build_spi_transfer_module(
+    program: SpiTransferProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_spi_transfer_module(program, out)?)
+}
+
 pub fn build_i2c_write_u8_module(
     program: I2cWriteU8Program,
     out: &mut [u8],
@@ -2448,6 +2456,35 @@ pub unsafe extern "C" fn board_vm_language_spi_open_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_spi_transfer_module(
+    cs_pin: u16,
+    write_bytes: *const u8,
+    write_bytes_len: u64,
+    read_len: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let write_bytes = unsafe { in_slice(write_bytes, write_bytes_len, "write_bytes") }?;
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_spi_transfer_module(
+            SpiTransferProgram {
+                cs_pin,
+                write_bytes,
+                read_len,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_i2c_write_u8_module(
     address: u16,
     byte: u8,
@@ -2901,6 +2938,14 @@ pub extern "C" fn board_vm_language_spi_open_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_spi_transfer_module_len(write_len: u64) -> u64 {
+    let Ok(write_len) = usize::try_from(write_len) else {
+        return 0;
+    };
+    spi_transfer_module_len(write_len).unwrap_or(0) as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_i2c_write_u8_module_len() -> u64 {
     I2C_WRITE_U8_MODULE_LEN as u64
 }
@@ -3181,6 +3226,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"i2c.read".to_owned()));
         assert!(uno.capabilities.contains(&"i2c.transfer".to_owned()));
         assert!(uno.capabilities.contains(&"spi.open".to_owned()));
+        assert!(uno.capabilities.contains(&"spi.transfer".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -4009,6 +4055,28 @@ mod tests {
         };
         assert_eq!(spi_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(spi_status.len, SPI_OPEN_MODULE_LEN as u64);
+
+        let spi_transfer_payload = [0x9f];
+        let mut spi_transfer_module = [0u8; board_vm_host::SPI_TRANSFER_MAX_MODULE_LEN];
+        let spi_transfer_status = unsafe {
+            board_vm_language_spi_transfer_module(
+                10,
+                spi_transfer_payload.as_ptr(),
+                spi_transfer_payload.len() as u64,
+                3,
+                5,
+                spi_transfer_module.as_mut_ptr(),
+                spi_transfer_module.len() as u64,
+            )
+        };
+        assert_eq!(
+            spi_transfer_status.code,
+            BoardVmLanguageStatusCode::Ok as u32
+        );
+        assert_eq!(
+            spi_transfer_status.len,
+            board_vm_language_spi_transfer_module_len(spi_transfer_payload.len() as u64)
+        );
 
         let mut i2c_write_module = [0u8; I2C_WRITE_U8_MODULE_LEN];
         let i2c_write_status = unsafe {

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -4,7 +4,8 @@ use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_DAC_WRITE_U12,
     CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ,
     CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
-    CAP_PWM_WRITE, CAP_SPI_OPEN, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, MAX_BYTE_BUFFER_LEN,
+    CAP_PWM_WRITE, CAP_SPI_OPEN, CAP_SPI_TRANSFER, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    MAX_BYTE_BUFFER_LEN,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -155,6 +156,16 @@ pub trait BoardHal {
     }
 
     fn spi_open(&mut self, _bus: u16) -> Result<u32, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn spi_transfer(
+        &mut self,
+        _token: u32,
+        _cs_pin: u16,
+        _write_bytes: &[u8],
+        _read_len: u8,
+    ) -> Result<ByteBuffer, HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -660,6 +671,27 @@ where
                 let handle = self.alloc_handle(HandleKind::Spi, token, ip)?;
                 self.push(Value::Handle(handle), ip)
             }
+            CAP_SPI_TRANSFER => {
+                let read_len = self.pop_u8(ip)?;
+                if read_len as usize > MAX_BYTE_BUFFER_LEN {
+                    return Err(RuntimeError {
+                        ip,
+                        kind: RuntimeErrorKind::ByteBufferTooLarge,
+                    });
+                }
+                let write_bytes = self.pop_bytes(ip)?;
+                let cs_pin = self.pop_u16(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::Spi, ip)?;
+                let bytes = self
+                    .hal
+                    .spi_transfer(token, cs_pin, write_bytes.as_slice(), read_len)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                self.push(Value::Bytes(bytes), ip)
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -920,6 +952,7 @@ mod tests {
         I2cRead(u32, u16, u8),
         I2cTransfer(u32, u16, ByteBuffer, u8),
         SpiOpen(u16),
+        SpiTransfer(u32, u16, ByteBuffer, u8),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -1041,6 +1074,27 @@ mod tests {
         fn spi_open(&mut self, bus: u16) -> Result<u32, HalError> {
             self.events.push(Event::SpiOpen(bus));
             Ok(0x2_2000 | bus as u32)
+        }
+
+        fn spi_transfer(
+            &mut self,
+            token: u32,
+            cs_pin: u16,
+            write_bytes: &[u8],
+            read_len: u8,
+        ) -> Result<ByteBuffer, HalError> {
+            self.events.push(Event::SpiTransfer(
+                token,
+                cs_pin,
+                ByteBuffer::from_slice(write_bytes).unwrap(),
+                read_len,
+            ));
+            let mut response = [0u8; MAX_BYTE_BUFFER_LEN];
+            response[0] = 0x9f;
+            response[1] = 0x01;
+            response[2] = 0x02;
+            ByteBuffer::from_slice(&response[..read_len as usize])
+                .map_err(|_| HalError::UnsupportedMode)
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -1245,6 +1299,49 @@ mod tests {
         );
         assert_eq!(report.open_handles, 1);
         assert_eq!(runtime.hal().events, vec![Event::SpiOpen(0)]);
+    }
+
+    #[test]
+    fn spi_transfer_dispatches_handle_cs_pin_write_bytes_and_returns_bytes() {
+        let mut runtime: Runtime<FakeHal, 5, 2> = Runtime::new(FakeHal::new());
+        let open = [0x12, 0, 0x40, CAP_SPI_OPEN as u8, 0x20, 0x50];
+        let transfer = Module {
+            flags: board_vm_ir::FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 5,
+            code: &[
+                0x20,
+                0x13,
+                0x0a,
+                0x00,
+                0x16,
+                0x00,
+                0x00,
+                0x01,
+                0x12,
+                0x03,
+                0x40,
+                CAP_SPI_TRANSFER as u8,
+                0x50,
+            ],
+            const_pool: &[0x9f],
+        };
+
+        runtime.run_code(&open, 10).unwrap();
+        let report = runtime.run_module(&transfer, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            report.return_value,
+            Value::Bytes(ByteBuffer::from_slice(&[0x9f, 0x01, 0x02]).unwrap())
+        );
+        assert_eq!(
+            runtime.hal().events,
+            vec![
+                Event::SpiOpen(0),
+                Event::SpiTransfer(0x2_2000, 10, ByteBuffer::from_slice(&[0x9f]).unwrap(), 3)
+            ]
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -124,7 +124,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 18] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 19] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -142,10 +142,11 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 18] = [
     "i2c.read",
     "i2c.transfer",
     "spi.open",
+    "spi.transfer",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 22] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 23] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -166,6 +167,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 22] = [
     "i2c.read",
     "i2c.transfer",
     "spi.open",
+    "spi.transfer",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -686,6 +688,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"i2c.read"));
         assert!(uno.capabilities.contains(&"i2c.transfer"));
         assert!(uno.capabilities.contains(&"spi.open"));
+        assert!(uno.capabilities.contains(&"spi.transfer"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -35,6 +35,7 @@ pub const BOARD_VM_UNO_R4_I2C_WRITE_SYMBOL: &str = "board_vm_uno_r4_i2c_write";
 pub const BOARD_VM_UNO_R4_I2C_READ_U8_SYMBOL: &str = "board_vm_uno_r4_i2c_read_u8";
 pub const BOARD_VM_UNO_R4_I2C_READ_SYMBOL: &str = "board_vm_uno_r4_i2c_read";
 pub const BOARD_VM_UNO_R4_I2C_TRANSFER_SYMBOL: &str = "board_vm_uno_r4_i2c_transfer";
+pub const BOARD_VM_UNO_R4_SPI_TRANSFER_SYMBOL: &str = "board_vm_uno_r4_spi_transfer";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
@@ -94,6 +95,7 @@ pub const ARDUINO_USB_LINK_SOURCES: &[ArduinoLinkSource] = &[
     ArduinoLinkSource::cxx("cores/arduino/FspTimer.cpp"),
     ArduinoLinkSource::cxx("cores/arduino/pwm.cpp"),
     ArduinoLinkSource::cxx("libraries/Wire/Wire.cpp"),
+    ArduinoLinkSource::cxx("libraries/SPI/SPI.cpp"),
     ArduinoLinkSource::cxx("cores/arduino/usb/USB.cpp"),
     ArduinoLinkSource::static_archive(UNO_R4_WIFI_FSP_ARCHIVE),
 ];
@@ -107,6 +109,7 @@ pub const ARDUINO_USB_LINK_INCLUDE_DIRS: &[&str] = &[
     "cores/arduino/api/deprecated",
     "cores/arduino/api/deprecated-avr-comp",
     "libraries/Wire",
+    "libraries/SPI",
     "variants/UNOWIFIR4",
     "variants/UNOWIFIR4/includes/ra/fsp/inc",
     "variants/UNOWIFIR4/includes/ra/fsp/inc/api",
@@ -237,6 +240,7 @@ mod tests {
         assert!(contains_source("cores/arduino/FspTimer.cpp"));
         assert!(contains_source("cores/arduino/pwm.cpp"));
         assert!(contains_source("libraries/Wire/Wire.cpp"));
+        assert!(contains_source("libraries/SPI/SPI.cpp"));
         assert!(contains_source("cores/arduino/tinyusb/tusb.c"));
         assert!(contains_source(
             "cores/arduino/tinyusb/class/cdc/cdc_device.c"
@@ -250,6 +254,7 @@ mod tests {
     fn link_manifest_carries_arduino_flags_needed_by_tinyusb() {
         assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"cores/arduino/tinyusb"));
         assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"cores/arduino/api/deprecated"));
+        assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"libraries/SPI"));
         assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"variants/UNOWIFIR4"));
         assert!(ARDUINO_USB_LINK_DEFINES.contains(&"ARDUINO_UNOWIFIR4"));
         assert!(ARDUINO_USB_LINK_DEFINES.contains(&"ARDUINO_ARCH_RENESAS_UNO"));
@@ -299,6 +304,10 @@ mod tests {
         assert_eq!(
             BOARD_VM_UNO_R4_I2C_TRANSFER_SYMBOL,
             "board_vm_uno_r4_i2c_transfer"
+        );
+        assert_eq!(
+            BOARD_VM_UNO_R4_SPI_TRANSFER_SYMBOL,
+            "board_vm_uno_r4_spi_transfer"
         );
         assert_eq!(
             BOARD_VM_UNO_R4_PWM_BRIDGE_SOURCE,

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -216,6 +216,32 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
         Ok(0x13_0000 | bus as u32)
     }
 
+    fn transfer_spi(
+        &mut self,
+        bus: u8,
+        cs_pin: u8,
+        write_bytes: &[u8],
+        read_len: u8,
+    ) -> Result<ByteBuffer, HalError> {
+        let mut bytes = [0u8; board_vm_ir::MAX_BYTE_BUFFER_LEN];
+        let mut actual_read_len = 0;
+        if unsafe {
+            board_io_ffi::board_vm_uno_r4_spi_transfer(
+                bus,
+                cs_pin,
+                write_bytes.as_ptr(),
+                write_bytes.len(),
+                bytes.as_mut_ptr(),
+                read_len as usize,
+                &mut actual_read_len,
+            )
+        } {
+            ByteBuffer::from_slice(&bytes[..actual_read_len]).map_err(|_| HalError::UnsupportedMode)
+        } else {
+            Err(HalError::UnsupportedMode)
+        }
+    }
+
     fn write_i2c_u8(&mut self, bus: u8, address: u16, byte: u8) -> Result<(), HalError> {
         if unsafe { board_io_ffi::board_vm_uno_r4_i2c_write_u8(bus, address, byte) } {
             Ok(())
@@ -316,6 +342,15 @@ mod board_io_ffi {
         pub fn board_vm_uno_r4_i2c_transfer(
             bus: u8,
             address: u16,
+            write_bytes: *const u8,
+            write_len: usize,
+            read_bytes: *mut u8,
+            read_len: usize,
+            actual_read_len: *mut usize,
+        ) -> bool;
+        pub fn board_vm_uno_r4_spi_transfer(
+            bus: u8,
+            cs_pin: u8,
             write_bytes: *const u8,
             write_len: usize,
             read_bytes: *mut u8,

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_pwm_bridge.cpp
@@ -4,6 +4,7 @@
 #include <new>
 
 #include "Arduino.h"
+#include "SPI.h"
 #include "Wire.h"
 #include "hal_data.h"
 #include "pwm.h"
@@ -21,6 +22,7 @@ constexpr uint32_t kAdcRawMax = (1u << BSP_FEATURE_ADC_MAX_RESOLUTION_BITS) - 1u
 constexpr uint32_t kAdcNormalizedMax = 65535u;
 constexpr uint32_t kAdcScanPollLimit = 100000u;
 constexpr uint16_t kI2cMax7BitAddress = 0x7Fu;
+constexpr uint8_t kHeaderSpiBus = 0;
 
 struct PwmSlot {
   uint8_t pin;
@@ -241,6 +243,14 @@ void operator delete[](void *, size_t) noexcept {}
 
 // Wire.cpp uses micros() only as a transaction timeout clock in this firmware.
 unsigned long micros() {
+  static unsigned long ticks = 0;
+  return ++ticks;
+}
+
+// SPI.cpp uses millis() only for SCI-mode transfer timeouts. The UNO R4 WiFi
+// header SPI bus is forced to the native SPI peripheral, but provide a bounded
+// monotonic clock so the Arduino SPI object links without the full core time.cpp.
+unsigned long millis() {
   static unsigned long ticks = 0;
   return ++ticks;
 }
@@ -590,6 +600,43 @@ extern "C" bool board_vm_uno_r4_i2c_transfer(uint8_t bus, uint16_t address, cons
     read_bytes[index] = static_cast<uint8_t>(value);
   }
 
+  *actual_read_len = read_len;
+  return true;
+}
+
+extern "C" bool board_vm_uno_r4_spi_transfer(uint8_t bus, uint8_t cs_pin, const uint8_t *write_bytes,
+                                             size_t write_len, uint8_t *read_bytes, size_t read_len,
+                                             size_t *actual_read_len) {
+  if (bus != kHeaderSpiBus || (write_bytes == nullptr && write_len != 0) ||
+      (read_bytes == nullptr && read_len != 0) || actual_read_len == nullptr || cs_pin >= PINCOUNT_fn()) {
+    return false;
+  }
+
+  if (R_IOPORT_PinCfg(nullptr, g_pin_cfg[cs_pin].pin, IOPORT_CFG_PORT_DIRECTION_OUTPUT) != FSP_SUCCESS ||
+      R_IOPORT_PinWrite(nullptr, g_pin_cfg[cs_pin].pin, BSP_IO_LEVEL_HIGH) != FSP_SUCCESS) {
+    return false;
+  }
+
+  SPI.begin();
+  SPI.beginTransaction(SPISettings(1000000, MSBFIRST, SPI_MODE0));
+  if (R_IOPORT_PinWrite(nullptr, g_pin_cfg[cs_pin].pin, BSP_IO_LEVEL_LOW) != FSP_SUCCESS) {
+    SPI.endTransaction();
+    return false;
+  }
+
+  for (size_t index = 0; index < write_len; ++index) {
+    static_cast<void>(SPI.transfer(write_bytes[index]));
+  }
+
+  for (size_t index = 0; index < read_len; ++index) {
+    read_bytes[index] = SPI.transfer(0x00);
+  }
+
+  bool cs_high = R_IOPORT_PinWrite(nullptr, g_pin_cfg[cs_pin].pin, BSP_IO_LEVEL_HIGH) == FSP_SUCCESS;
+  SPI.endTransaction();
+  if (!cs_high) {
+    return false;
+  }
   *actual_read_len = read_len;
   return true;
 }

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -422,6 +422,16 @@ pub trait UnoR4Backend {
         Err(HalError::UnsupportedMode)
     }
 
+    fn transfer_spi(
+        &mut self,
+        _bus: u8,
+        _cs_pin: u8,
+        _write_bytes: &[u8],
+        _read_len: u8,
+    ) -> Result<ByteBuffer, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn write_i2c_u8(&mut self, _bus: u8, _address: u16, _byte: u8) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
@@ -575,6 +585,19 @@ where
         self.backend.open_spi(bus)
     }
 
+    fn spi_transfer(
+        &mut self,
+        token: u32,
+        cs_pin: u16,
+        write_bytes: &[u8],
+        read_len: u8,
+    ) -> Result<ByteBuffer, HalError> {
+        let bus = normalize_spi_token(self.target, token)?;
+        let cs_pin = normalize_digital_pin(cs_pin)?;
+        self.backend
+            .transfer_spi(bus, cs_pin, write_bytes, read_len)
+    }
+
     fn i2c_write_u8(&mut self, token: u32, address: u16, byte: u8) -> Result<(), HalError> {
         let bus = normalize_i2c_token(self.target, token)?;
         normalize_i2c_address(address)?;
@@ -696,6 +719,11 @@ fn normalize_spi_bus(target: &TargetDescriptor, bus: u16) -> Result<u8, HalError
     }
 }
 
+fn normalize_spi_token(target: &TargetDescriptor, token: u32) -> Result<u8, HalError> {
+    let bus = u16::try_from(token & 0xff).map_err(|_| HalError::InvalidPin)?;
+    normalize_spi_bus(target, bus)
+}
+
 fn normalize_i2c_address(address: u16) -> Result<(), HalError> {
     if address <= 0x7f {
         Ok(())
@@ -815,6 +843,7 @@ extern crate std;
 mod tests {
     use super::*;
     use board_vm_host::{write_blink_module, BlinkProgram, HostSession, DEFAULT_PROGRAM_ID};
+    use board_vm_ir::MAX_BYTE_BUFFER_LEN;
     use board_vm_protocol::{
         decode_caps_report_header, decode_frame, decode_hello_ack, decode_run_report_header,
         MessageType, RunStatus as ProtocolRunStatus,
@@ -843,6 +872,7 @@ mod tests {
         I2cRead(u8, u16, u8),
         I2cTransfer(u8, u16, Vec<u8>, u8),
         SpiOpen(u8),
+        SpiTransfer(u8, u8, Vec<u8>, u8),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -933,6 +963,27 @@ mod tests {
         fn open_spi(&mut self, bus: u8) -> Result<u32, HalError> {
             self.events.push(Event::SpiOpen(bus));
             Ok(0x2_2000 | bus as u32)
+        }
+
+        fn transfer_spi(
+            &mut self,
+            bus: u8,
+            cs_pin: u8,
+            write_bytes: &[u8],
+            read_len: u8,
+        ) -> Result<ByteBuffer, HalError> {
+            self.events.push(Event::SpiTransfer(
+                bus,
+                cs_pin,
+                write_bytes.to_vec(),
+                read_len,
+            ));
+            let mut response = [0u8; MAX_BYTE_BUFFER_LEN];
+            response[0] = 0x9f;
+            response[1] = 0x01;
+            response[2] = 0x02;
+            ByteBuffer::from_slice(&response[..read_len as usize])
+                .map_err(|_| HalError::UnsupportedMode)
         }
 
         fn write_i2c_u8(&mut self, bus: u8, address: u16, byte: u8) -> Result<(), HalError> {
@@ -1096,6 +1147,9 @@ mod tests {
             .capabilities
             .supports(board_vm_ir::CAP_I2C_TRANSFER));
         assert!(UNO_R4_WIFI.capabilities.supports(board_vm_ir::CAP_SPI_OPEN));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_SPI_TRANSFER));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -1126,6 +1180,9 @@ mod tests {
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_SPI_OPEN));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_SPI_TRANSFER));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -1236,6 +1293,34 @@ mod tests {
 
         assert_eq!(board.spi_open(1), Err(HalError::InvalidPin));
         assert_eq!(board.spi_open(99), Err(HalError::InvalidPin));
+    }
+
+    #[test]
+    fn spi_transfer_runs_through_bus_metadata_and_chip_select_pin() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(
+            board.spi_transfer(0x2_2000, 10, &[0x9f], 3).unwrap(),
+            ByteBuffer::from_slice(&[0x9f, 0x01, 0x02]).unwrap()
+        );
+        assert_eq!(
+            board.backend().events,
+            vec![Event::SpiTransfer(0, 10, vec![0x9f], 3)]
+        );
+    }
+
+    #[test]
+    fn spi_transfer_rejects_unknown_bus_or_chip_select_pin() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(
+            board.spi_transfer(0x2_2001, 10, &[0x9f], 3),
+            Err(HalError::InvalidPin)
+        );
+        assert_eq!(
+            board.spi_transfer(0x2_2000, 99, &[0x9f], 3),
+            Err(HalError::InvalidPin)
+        );
     }
 
     #[test]

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -213,6 +213,7 @@ metadata. The operation is intentionally direct and stateless, mirroring
 | `0x27` | `i2c.read` | `handle`, `address: u16/u8`, `length: u8` | `bytes` |
 | `0x28` | `i2c.transfer` | `handle`, `address: u16/u8`, `write_bytes: bytes`, `read_length: u8` | `bytes` |
 | `0x29` | `spi.open` | `bus: u16/u8` | `handle` |
+| `0x2A` | `spi.transfer` | `handle`, `cs_pin: u16/u8`, `write_bytes: bytes`, `read_length: u8` | `bytes` |
 
 `i2c.open` opens a board-advertised I2C controller and returns a persistent bus
 handle. The handle is the lifetime anchor for transfer operations, keeping bus
@@ -232,8 +233,13 @@ the bounded read bytes.
 `spi.open` opens a board-advertised SPI controller and returns a persistent bus
 handle. Target metadata owns the controller name and header pins such as COPI,
 CIPO, SCK, and the conventional chip-select pin; language frontends pass only
-the bus id. Follow-on SPI transfer capabilities should use the returned handle
-instead of repeating pin or bus metadata in each command.
+the bus id. `spi.transfer` uses the returned handle and an explicit chip-select
+pin to wrap one bounded transaction. The VM writes `write_bytes` while chip
+select is asserted, then clocks `read_length` bytes with zero-valued dummy writes
+and returns those bounded read bytes. `spi.transfer` therefore covers write-only
+transactions with `read_length = 0`, read-only transactions with an empty write
+buffer, and register-style write-then-read exchanges without repeating SPI bus
+metadata in language frontends.
 
 ### LED Matrix
 

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -30,7 +30,7 @@ Source snapshot:
 | Analog input | A0-A5 | implemented as direct read | `adc.read` |
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
 | I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, byte-buffer write/read, and write-read transfer implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, `i2c.read`, `i2c.transfer` |
-| SPI master | COPI D11, CIPO D12, SCK D13, conventional CS D10 | bus metadata and handle open implemented | `spi.open`; transfer/read/write capabilities follow |
+| SPI master | COPI D11, CIPO D12, SCK D13, conventional CS D10 | bus metadata, handle open, and bounded write-then-read transfer implemented | `spi.open`, `spi.transfer`; convenience read/write commands follow |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
 | RTC | one RTC instance in the core | pending | `rtc.now`, `rtc.set`, alarms/events later |
@@ -72,8 +72,8 @@ reject conflicting handles.
    and `i2c.read_u8` prove the Rust-owned transfer path through Arduino
    `Wire`/`Wire1`. `i2c.write`, `i2c.read`, and `i2c.transfer` cover the
    bounded byte-buffer transfer path. `spi.open` establishes the SPI handle
-   tranche over Rust-owned UNO R4 bus metadata; SPI transfer commands should
-   layer on that handle.
+   tranche over Rust-owned UNO R4 bus metadata; `spi.transfer` layers a bounded
+   chip-select-scoped write-then-read transaction on that handle.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 


### PR DESCRIPTION
## Summary
- add the `spi.transfer` Board VM capability across IR validation, host module builders, runtime dispatch, device descriptors, and UNO R4 target metadata
- wire UNO R4 SPI transfer through the SerialUSB firmware backend using an explicit chip-select pin and bounded write-then-read byte buffers
- expose the capability through Rust language-core and the Ruby native/session/connection APIs, with Ruby/Python target metadata coverage

## Validation
- `cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- linked `uno-r4-wifi-serialusb-artifact` build/objcopy with `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, Arduino Renesas UNO core 1.5.3, and `/opt/homebrew/bin` ARM tools
- `bundle exec ruby -c lib/coding_adventures/board_vm/session.rb`
- `bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb`
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

## Hardware note
Physical SPI smoke still needs an external SPI peripheral wired to the UNO R4 header; this slice proves the VM/runtime/firmware path links and exposes the capability without bypassing the VM.