### PR TITLE
ts(spice): add BJT model netlists

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add Ebers-Moll-style BJT elements with Newton-linearized DC operating-point
+  support and zero-bias small-signal conductance/transconductance for AC and
+  transfer analysis.
 - Add Shockley diode elements with Newton-linearized DC operating-point support
   and zero-bias small-signal conductance for AC/transfer analysis.
 - Add current-controlled voltage source support across DC, AC, transfer

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -8,7 +8,7 @@ sensitivity analysis, seeded DC Monte Carlo analysis, DC small-signal
 transfer-function analysis, AC small-signal frequency sweeps, and fixed-step
 AC noise analysis, and RC/RL transient analysis for linear circuits using
 modified nodal analysis (MNA). The package supports
-resistors, capacitors, inductors, diodes, independent current sources,
+resistors, capacitors, inductors, diodes, BJTs, independent current sources,
 independent voltage sources, voltage-controlled current sources (VCCS),
 PWL/SIN/PULSE/EXP
 source waveforms for transient analysis, ground aliases, node voltages,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -9,6 +9,7 @@ export type Element =
   | VoltageSource
   | CurrentSource
   | Diode
+  | Bjt
   | Vccs
   | Vcvs
   | Cccs
@@ -278,6 +279,20 @@ export interface Diode {
   readonly anode: string;
   readonly cathode: string;
   readonly saturationCurrent: number;
+  readonly thermalVoltage: number;
+}
+
+export type BjtPolarity = "NPN" | "PNP";
+
+export interface Bjt {
+  readonly kind: "bjt";
+  readonly name: string;
+  readonly collector: string;
+  readonly base: string;
+  readonly emitter: string;
+  readonly polarity: BjtPolarity;
+  readonly saturationCurrent: number;
+  readonly forwardBeta: number;
   readonly thermalVoltage: number;
 }
 
@@ -571,6 +586,29 @@ export function diode(
     anode,
     cathode,
     saturationCurrent,
+    thermalVoltage,
+  };
+}
+
+export function bjt(
+  name: string,
+  collector: string,
+  base: string,
+  emitter: string,
+  polarity: BjtPolarity = "NPN",
+  saturationCurrent = 1.0e-14,
+  forwardBeta = 100.0,
+  thermalVoltage = 0.02585,
+): Bjt {
+  return {
+    kind: "bjt",
+    name,
+    collector,
+    base,
+    emitter,
+    polarity,
+    saturationCurrent,
+    forwardBeta,
     thermalVoltage,
   };
 }
@@ -1124,6 +1162,12 @@ function elementParameter(element: Element): ElementParameter | undefined {
         parameter: "saturationCurrent",
         nominalValue: element.saturationCurrent,
       };
+    case "bjt":
+      return {
+        elementName: element.name,
+        parameter: "saturationCurrent",
+        nominalValue: element.saturationCurrent,
+      };
     case "vccs":
       return {
         elementName: element.name,
@@ -1184,6 +1228,12 @@ function circuitWithPerturbedElement(
         perturbed.add({ ...element, current: element.current + delta });
         break;
       case "diode":
+        perturbed.add({
+          ...element,
+          saturationCurrent: element.saturationCurrent + delta,
+        });
+        break;
+      case "bjt":
         perturbed.add({
           ...element,
           saturationCurrent: element.saturationCurrent + delta,
@@ -1303,6 +1353,16 @@ function randomizedElement(
           rng,
         ),
       };
+    case "bjt":
+      return {
+        ...element,
+        saturationCurrent: randomizedValue(
+          element.saturationCurrent,
+          tolerance,
+          distribution,
+          rng,
+        ),
+      };
     case "vccs":
       return {
         ...element,
@@ -1406,7 +1466,9 @@ function solveLinearCircuit(
     return { nodeVoltages: new Map(), branchCurrents: new Map(), vector: [] };
   }
 
-  const hasDiode = circuit.elements().some((element) => element.kind === "diode");
+  const hasNonlinearElement = circuit
+    .elements()
+    .some((element) => element.kind === "diode" || element.kind === "bjt");
   let operatingPoint = Array.from({ length: matrixSize }, () => 0.0);
   let solution = solveLinearCircuitAtOperatingPoint(
     circuit,
@@ -1419,7 +1481,7 @@ function solveLinearCircuit(
     matrixSize,
     operatingPoint,
   );
-  if (!hasDiode) {
+  if (!hasNonlinearElement) {
     return solution;
   }
 
@@ -1497,6 +1559,9 @@ function solveLinearCircuitAtOperatingPoint(
         break;
       case "diode":
         stampDiode(element, nodeIndices, matrix, rhs, operatingPoint);
+        break;
+      case "bjt":
+        stampBjt(element, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
@@ -1610,6 +1675,9 @@ function buildSmallSignalMatrix(
           element.saturationCurrent / element.thermalVoltage,
         );
         break;
+      case "bjt":
+        stampBjtSmallSignal(element, nodeIndices, matrix);
+        break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
         break;
@@ -1671,6 +1739,7 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
       case "capacitor":
       case "inductor":
       case "diode":
+      case "bjt":
       case "vccs":
       case "vcvs":
       case "cccs":
@@ -1740,6 +1809,9 @@ function buildAcMatrix(
           nodeIndex(nodeIndices, element.cathode),
           complex(element.saturationCurrent / element.thermalVoltage, 0.0),
         );
+        break;
+      case "bjt":
+        stampAcBjtSmallSignal(element, nodeIndices, matrix);
         break;
       case "vccs":
         stampAcVccs(element, nodeIndices, matrix);
@@ -1938,6 +2010,11 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.anode);
         insertNode(names, element.cathode);
         break;
+      case "bjt":
+        insertNode(names, element.collector);
+        insertNode(names, element.base);
+        insertNode(names, element.emitter);
+        break;
       case "vccs":
         insertNode(names, element.positive);
         insertNode(names, element.negative);
@@ -2019,6 +2096,7 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
         element.kind === "capacitor" ||
         element.kind === "inductor" ||
         element.kind === "diode" ||
+        element.kind === "bjt" ||
         element.kind === "vccs" ||
         element.kind === "vcvs" ||
         element.kind === "cccs" ||
@@ -2285,6 +2363,62 @@ function stampDiode(
   }
 }
 
+function stampBjt(
+  element: Bjt,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+  operatingPoint: readonly number[],
+): void {
+  validateBjt(element);
+  const collector = nodeIndex(nodeIndices, element.collector);
+  const base = nodeIndex(nodeIndices, element.base);
+  const emitter = nodeIndex(nodeIndices, element.emitter);
+  const baseVoltage = base === undefined ? 0.0 : operatingPoint[base];
+  const emitterVoltage = emitter === undefined ? 0.0 : operatingPoint[emitter];
+
+  const junctionVoltage =
+    element.polarity === "NPN"
+      ? baseVoltage - emitterVoltage
+      : emitterVoltage - baseVoltage;
+  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / element.thermalVoltage));
+  const expValue = Math.exp(exponent);
+  const collectorCurrent = element.saturationCurrent * (expValue - 1.0);
+  const transconductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const junctionConductance = transconductance / element.forwardBeta;
+  const baseCurrent = collectorCurrent / element.forwardBeta;
+  const equivalentCollectorCurrent =
+    collectorCurrent - transconductance * junctionVoltage;
+  const equivalentBaseCurrent =
+    baseCurrent - junctionConductance * junctionVoltage;
+
+  if (element.polarity === "NPN") {
+    stampConductance(matrix, base, emitter, junctionConductance);
+    stampTransconductance(matrix, collector, emitter, base, emitter, transconductance);
+    stampCurrentSourceEquivalent(rhs, base, emitter, equivalentBaseCurrent);
+    stampCurrentSourceEquivalent(rhs, collector, emitter, equivalentCollectorCurrent);
+  } else {
+    stampConductance(matrix, emitter, base, junctionConductance);
+    stampTransconductance(matrix, emitter, collector, emitter, base, transconductance);
+    stampCurrentSourceEquivalent(rhs, emitter, base, equivalentBaseCurrent);
+    stampCurrentSourceEquivalent(rhs, emitter, collector, equivalentCollectorCurrent);
+  }
+}
+
+function stampCurrentSourceEquivalent(
+  rhs: number[],
+  positive: number | undefined,
+  negative: number | undefined,
+  current: number,
+): void {
+  if (positive !== undefined) {
+    rhs[positive] -= current;
+  }
+  if (negative !== undefined) {
+    rhs[negative] += current;
+  }
+}
+
 function validateReactiveElements(circuit: Circuit): void {
   for (const element of circuit.elements()) {
     if (element.kind === "capacitor") {
@@ -2298,6 +2432,21 @@ function validateReactiveElements(circuit: Circuit): void {
 function validateDiode(element: Diode): void {
   if (!Number.isFinite(element.saturationCurrent) || element.saturationCurrent <= 0.0) {
     throw invalidElement(element.name, "saturation current must be finite and positive");
+  }
+  if (!Number.isFinite(element.thermalVoltage) || element.thermalVoltage <= 0.0) {
+    throw invalidElement(element.name, "thermal voltage must be finite and positive");
+  }
+}
+
+function validateBjt(element: Bjt): void {
+  if (element.polarity !== "NPN" && element.polarity !== "PNP") {
+    throw invalidElement(element.name, "BJT polarity must be NPN or PNP");
+  }
+  if (!Number.isFinite(element.saturationCurrent) || element.saturationCurrent <= 0.0) {
+    throw invalidElement(element.name, "saturation current must be finite and positive");
+  }
+  if (!Number.isFinite(element.forwardBeta) || element.forwardBeta <= 0.0) {
+    throw invalidElement(element.name, "forward beta must be finite and positive");
   }
   if (!Number.isFinite(element.thermalVoltage) || element.thermalVoltage <= 0.0) {
     throw invalidElement(element.name, "thermal voltage must be finite and positive");
@@ -2687,6 +2836,26 @@ function stampTransconductance(
   }
 }
 
+function stampBjtSmallSignal(
+  element: Bjt,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+): void {
+  validateBjt(element);
+  const collector = nodeIndex(nodeIndices, element.collector);
+  const base = nodeIndex(nodeIndices, element.base);
+  const emitter = nodeIndex(nodeIndices, element.emitter);
+  const transconductance = element.saturationCurrent / element.thermalVoltage;
+  const junctionConductance = transconductance / element.forwardBeta;
+  if (element.polarity === "NPN") {
+    stampConductance(matrix, base, emitter, junctionConductance);
+    stampTransconductance(matrix, collector, emitter, base, emitter, transconductance);
+  } else {
+    stampConductance(matrix, emitter, base, junctionConductance);
+    stampTransconductance(matrix, emitter, collector, emitter, base, transconductance);
+  }
+}
+
 function stampAcResistor(
   element: Resistor,
   nodeIndices: ReadonlyMap<string, number>,
@@ -3009,6 +3178,50 @@ function stampComplexTransconductance(
     matrix[negative][controlNegative] = complexAdd(
       matrix[negative][controlNegative],
       transconductance,
+    );
+  }
+}
+
+function stampAcBjtSmallSignal(
+  element: Bjt,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: Complex[][],
+): void {
+  validateBjt(element);
+  const collector = nodeIndex(nodeIndices, element.collector);
+  const base = nodeIndex(nodeIndices, element.base);
+  const emitter = nodeIndex(nodeIndices, element.emitter);
+  const transconductance = element.saturationCurrent / element.thermalVoltage;
+  const junctionConductance = transconductance / element.forwardBeta;
+  if (element.polarity === "NPN") {
+    stampComplexConductance(
+      matrix,
+      base,
+      emitter,
+      complex(junctionConductance, 0.0),
+    );
+    stampComplexTransconductance(
+      matrix,
+      collector,
+      emitter,
+      base,
+      emitter,
+      complex(transconductance, 0.0),
+    );
+  } else {
+    stampComplexConductance(
+      matrix,
+      emitter,
+      base,
+      complex(junctionConductance, 0.0),
+    );
+    stampComplexTransconductance(
+      matrix,
+      emitter,
+      collector,
+      emitter,
+      base,
+      complex(transconductance, 0.0),
     );
   }
 }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -3,6 +3,7 @@ import {
   Circuit,
   SinWaveform,
   SpiceError,
+  bjt,
   cccs,
   ccvs,
   currentSource,
@@ -155,6 +156,29 @@ describe("dcOp", () => {
 
     expect(result.voltage("out")).toBeGreaterThan(0.1);
     expect(result.voltage("out")).toBeLessThan(0.7);
+  });
+
+  it("solves an NPN BJT operating point", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+    circuit.add(voltageSource("Vb", "base", "0", 0.7));
+    circuit.add(resistor("Rc", "vcc", "collector", 100.0));
+    circuit.add(bjt("Q1", "collector", "base", "0", "NPN", 1.0e-14, 120.0, 0.02585));
+
+    const result = dcOp(circuit);
+
+    expect(result.voltage("collector")).toBeGreaterThan(0.0);
+    expect(result.voltage("collector")).toBeLessThan(5.0);
+  });
+
+  it("rejects invalid BJT model parameters", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+    circuit.add(voltageSource("Vb", "base", "0", 0.7));
+    circuit.add(resistor("Rc", "vcc", "collector", 100.0));
+    circuit.add(bjt("Qbad", "collector", "base", "0", "NPN", 1.0e-14, 0.0, 0.02585));
+
+    expect(() => dcOp(circuit)).toThrowError("forward beta must be finite and positive");
   });
 
   it("rejects missing CCCS control sources", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.5
+
+- Add SPICE `Q` BJT element parsing via `.model <name> NPN(...)` and
+  `.model <name> PNP(...)` cards with `IS`, `BF` / `BETA_F`, and `VT`
+  parameters, including subcircuit collector/base/emitter remapping.
+
 ## 0.1.4
 
 - Add SPICE `D` diode element parsing via `.model <name> D(...)` cards with

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -19,8 +19,10 @@ netlist.circuit.elements();
 netlist.analyses;
 ```
 
-This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `G`, `E`, `F`, and `H`
+This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `G`, `E`, `F`, and `H`
 elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
+`.model <name> NPN(...)` / `.model <name> PNP(...)` BJT cards with `IS`,
+`BF` / `BETA_F`, and `VT` parameters,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
 analysis cards.

--- a/code/packages/typescript/spice-netlist-parser/package-lock.json
+++ b/code/packages/typescript/spice-netlist-parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/spice-netlist-parser",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/spice-netlist-parser",
-      "version": "0.1.0",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/spice-engine": "file:../spice-engine"

--- a/code/packages/typescript/spice-netlist-parser/package.json
+++ b/code/packages/typescript/spice-netlist-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/spice-netlist-parser",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -4,6 +4,7 @@ import {
   PulseWaveform,
   PwlWaveform,
   SinWaveform,
+  bjt,
   capacitor,
   cccs,
   ccvs,
@@ -328,6 +329,30 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("VT") ?? 0.02585,
     );
   }
+  if (prefix === "Q") {
+    requireFields(fields, 5, "BJT");
+    const model = models.get(fields[4].toLowerCase());
+    if (model === undefined) {
+      throw new NetlistParseError(
+        `unknown model ${JSON.stringify(fields[4])} for BJT ${JSON.stringify(name)}`,
+      );
+    }
+    if (model.kind !== "NPN" && model.kind !== "PNP") {
+      throw new NetlistParseError(
+        `model ${JSON.stringify(model.name)} has kind ${JSON.stringify(model.kind)}, expected "NPN" or "PNP"`,
+      );
+    }
+    return bjt(
+      name,
+      fields[1],
+      fields[2],
+      fields[3],
+      model.kind,
+      model.params.get("IS") ?? 1.0e-14,
+      model.params.get("BF") ?? model.params.get("BETA_F") ?? 100.0,
+      model.params.get("VT") ?? 0.02585,
+    );
+  }
   if (prefix === "G") {
     requireFields(fields, 6, "VCCS");
     return vccs(name, fields[1], fields[2], fields[3], fields[4], parseValue(fields[5]));
@@ -431,6 +456,11 @@ function mapSubcktFields(
     requireMinFields(fields, 3, "subcircuit element");
     mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
     mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);
+  } else if (prefix === "Q") {
+    requireMinFields(fields, 4, "subcircuit BJT");
+    mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
+    mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);
+    mapped[3] = mapSubcktNode(fields[3], instanceName, nodeMap);
   } else if (prefix === "E" || prefix === "G") {
     requireMinFields(fields, 5, "subcircuit controlled source");
     for (let index = 1; index < 5; index++) {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -151,6 +151,63 @@ Rload out 0 1k
     expect(result.voltage("out")).toBeLessThan(0.7);
   });
 
+  it("parses BJT models into operating-point circuits", () => {
+    const parsed = parseNetlist(`
+.model fast NPN(IS=1e-14 BF=120 VT=25m)
+Vcc vcc 0 DC 5
+Vb base 0 DC 0.7
+Rc vcc col 100
+Q1 col base 0 fast
+.op
+`);
+
+    expect(parsed.models.get("fast")).toEqual({
+      name: "fast",
+      kind: "NPN",
+      params: new Map([
+        ["IS", 1.0e-14],
+        ["BF", 120.0],
+        ["VT", 25.0e-3],
+      ]),
+    });
+    expect(parsed.circuit.elements()[3]).toMatchObject({
+      kind: "bjt",
+      name: "Q1",
+      collector: "col",
+      base: "base",
+      emitter: "0",
+      polarity: "NPN",
+      saturationCurrent: 1.0e-14,
+      forwardBeta: 120.0,
+      thermalVoltage: 25.0e-3,
+    });
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("col")).toBeGreaterThan(0.0);
+    expect(result.voltage("col")).toBeLessThan(5.0);
+  });
+
+  it("parses PNP BJT model aliases", () => {
+    const parsed = parseNetlist(`
+.model slow PNP(IS=2e-14 BETA_F=80 VT=26m)
+Q2 out base emit slow
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      name: "Q2",
+      polarity: "PNP",
+      saturationCurrent: 2.0e-14,
+      forwardBeta: 80.0,
+    });
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("bjt");
+    if (element.kind !== "bjt") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.thermalVoltage).toBeCloseTo(26.0e-3, 12);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)
@@ -301,6 +358,25 @@ Xlim in out limiter
     });
   });
 
+  it("expands subcircuit BJT nodes into engine elements", () => {
+    const parsed = parseNetlist(`
+.model fast NPN(IS=1e-14 BF=120)
+.subckt stage c b e
+Qamp c b e fast
+.ends stage
+Xstage out in 0 stage
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      name: "Xstage.Qamp",
+      collector: "out",
+      base: "in",
+      emitter: "0",
+      polarity: "NPN",
+    });
+  });
+
   it("scopes subcircuit internal nodes by instance", () => {
     const parsed = parseNetlist(`
 .subckt load in out
@@ -330,8 +406,8 @@ Xright c d load
   });
 
   it("rejects unsupported elements with line numbers", () => {
-    expect(() => parseNetlist("\nQ1 c b e model\n")).toThrow(NetlistParseError);
-    expect(() => parseNetlist("\nQ1 c b e model\n")).toThrow("line 2: unsupported element");
+    expect(() => parseNetlist("\nZ1 c b e model\n")).toThrow(NetlistParseError);
+    expect(() => parseNetlist("\nZ1 c b e model\n")).toThrow("line 2: unsupported element");
   });
 
   it("rejects unknown diode models", () => {
@@ -343,6 +419,18 @@ Xright c d load
   it("rejects non-diode models for diode elements", () => {
     expect(() => parseNetlist(".model amp NPN(IS=1e-12)\nD1 a 0 amp\n")).toThrow(
       'line 2: model "amp" has kind "NPN", expected "D"',
+    );
+  });
+
+  it("rejects unknown BJT models", () => {
+    expect(() => parseNetlist("Q1 c b e missing\n")).toThrow(
+      'line 1: unknown model "missing" for BJT "Q1"',
+    );
+  });
+
+  it("rejects non-BJT models for BJT elements", () => {
+    expect(() => parseNetlist(".model clamp D(IS=1e-12)\nQ1 c b e clamp\n")).toThrow(
+      'line 2: model "clamp" has kind "D", expected "NPN" or "PNP"',
     );
   });
 


### PR DESCRIPTION
## Summary
- add TypeScript SPICE engine BJT elements with nonlinear DC and small-signal AC/TF support
- parse SPICE Q devices from NPN/PNP .model cards with IS, BF/BETA_F, and VT parameters
- remap BJT collector/base/emitter terminals during .subckt expansion

## Validation
- npm run build && npm test (code/packages/typescript/spice-engine)
- npm run build && npm test (code/packages/typescript/spice-netlist-parser)
- git diff --check