### PR TITLE
[codex] Add Board VM SPI read/write convenience wrappers

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -7,14 +7,14 @@ use board_vm_host::{
     GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram, GpioReadProgram,
     GpioWriteProgram, I2cOpenProgram, I2cReadProgram, I2cReadU8Program, I2cTransferProgram,
     I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram, PwmWriteProgram, SpiOpenProgram,
-    SpiTransferProgram, TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
-    DAC_WRITE_U12_MODULE_LEN,
+    SpiReadProgram, SpiTransferProgram, SpiWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN,
     GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
     GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
     I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_TRANSFER_MAX_MODULE_LEN,
     I2C_WRITE_MAX_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
-    PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, SPI_TRANSFER_MAX_MODULE_LEN, TIME_NOW_MODULE_LEN,
-    TIME_SLEEP_MS_MODULE_LEN,
+    PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, SPI_READ_MODULE_LEN, SPI_TRANSFER_MAX_MODULE_LEN,
+    SPI_WRITE_MAX_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
@@ -27,7 +27,7 @@ use board_vm_language_core::{
     build_led_matrix_frame_module, build_program_begin_wire_frame, build_program_chunk_wire_frame,
     build_program_end_wire_frame, build_pwm_write_module, build_adc_read_module, build_raw_module,
     build_run_background_wire_frame, build_run_wire_frame, build_spi_open_module,
-    build_spi_transfer_module, build_stop_wire_frame,
+    build_spi_read_module, build_spi_transfer_module, build_spi_write_module, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, connection_transport_name, decode_wire_response,
@@ -308,6 +308,37 @@ extern "C" fn session_spi_transfer_module(
 
     let module = build_spi_transfer_module_value(cs_pin, &write_bytes, read_len, max_stack)
         .unwrap_or_else(|error| raise_core_error("spi_transfer_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_spi_write_module(
+    _self_val: VALUE,
+    cs_pin_val: VALUE,
+    bytes_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let cs_pin = rb_u16(cs_pin_val, "cs_pin");
+    let bytes = ruby_bridge::bytes_from_rb(bytes_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("bytes must be a Ruby binary String"));
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_spi_write_module_value(cs_pin, &bytes, max_stack)
+        .unwrap_or_else(|error| raise_core_error("spi_write_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_spi_read_module(
+    _self_val: VALUE,
+    cs_pin_val: VALUE,
+    len_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let cs_pin = rb_u16(cs_pin_val, "cs_pin");
+    let len = rb_u8(len_val, "len");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_spi_read_module_value(cs_pin, len, max_stack)
+        .unwrap_or_else(|error| raise_core_error("spi_read_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1645,6 +1676,42 @@ fn build_spi_transfer_module_value(
     Ok(module)
 }
 
+fn build_spi_write_module_value(
+    cs_pin: u16,
+    bytes: &[u8],
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; SPI_WRITE_MAX_MODULE_LEN];
+    let len = build_spi_write_module(
+        SpiWriteProgram {
+            cs_pin,
+            bytes,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_spi_read_module_value(
+    cs_pin: u16,
+    read_len: u8,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; SPI_READ_MODULE_LEN];
+    let len = build_spi_read_module(
+        SpiReadProgram {
+            cs_pin,
+            len: read_len,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_i2c_write_u8_module_value(
     address: u16,
     byte: u8,
@@ -2054,6 +2121,18 @@ pub extern "C" fn Init_board_vm_native() {
         "spi_transfer_module",
         session_spi_transfer_module as *const c_void,
         4,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "spi_write_module",
+        session_spi_write_module as *const c_void,
+        3,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "spi_read_module",
+        session_spi_read_module as *const c_void,
+        3,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -492,6 +492,42 @@ module CodingAdventures
         )
       end
 
+      def spi_write!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        cs_pin:,
+        bytes:,
+        max_stack: 5
+      )
+        ensure_uno_r4_wifi!
+
+        session.spi_write(
+          program_id: program_id,
+          budget: budget,
+          cs_pin: cs_pin,
+          bytes: bytes,
+          max_stack: max_stack
+        )
+      end
+
+      def spi_read!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        cs_pin:,
+        length:,
+        max_stack: 5
+      )
+        ensure_uno_r4_wifi!
+
+        session.spi_read(
+          program_id: program_id,
+          budget: budget,
+          cs_pin: cs_pin,
+          length: length,
+          max_stack: max_stack
+        )
+      end
+
       def i2c_write_u8!(
         program_id: DEFAULT_PROGRAM_ID,
         budget: DEFAULT_INSTRUCTION_BUDGET,
@@ -1337,6 +1373,38 @@ module CodingAdventures
           cs_pin: cs_pin,
           write_bytes: write_bytes,
           read_length: read_length,
+          max_stack: max_stack
+        )
+      end
+
+      def write(
+        cs_pin:,
+        bytes:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 5
+      )
+        @connection.spi_write!(
+          program_id: program_id,
+          budget: budget,
+          cs_pin: cs_pin,
+          bytes: bytes,
+          max_stack: max_stack
+        )
+      end
+
+      def read(
+        cs_pin:,
+        length:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 5
+      )
+        @connection.spi_read!(
+          program_id: program_id,
+          budget: budget,
+          cs_pin: cs_pin,
+          length: length,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -220,10 +220,18 @@ module CodingAdventures
       def spi_transfer_module(cs_pin:, write_bytes:, read_length:, max_stack: 5)
         native_session.spi_transfer_module(
           cs_pin,
-          i2c_bytes_value(write_bytes),
-          i2c_read_length_value(read_length),
+          spi_bytes_value(write_bytes),
+          spi_read_length_value(read_length),
           max_stack
         )
+      end
+
+      def spi_write_module(cs_pin:, bytes:, max_stack: 5)
+        native_session.spi_write_module(cs_pin, spi_bytes_value(bytes), max_stack)
+      end
+
+      def spi_read_module(cs_pin:, length:, max_stack: 5)
+        native_session.spi_read_module(cs_pin, spi_read_length_value(length), max_stack)
       end
 
       def i2c_write_u8_module(address:, byte:, max_stack: 4)
@@ -363,6 +371,30 @@ module CodingAdventures
             read_length: read_length,
             max_stack: max_stack
           )
+        )
+      end
+
+      def upload_spi_write(
+        program_id: @program_id,
+        cs_pin:,
+        bytes:,
+        max_stack: 5
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: spi_write_module(cs_pin: cs_pin, bytes: bytes, max_stack: max_stack)
+        )
+      end
+
+      def upload_spi_read(
+        program_id: @program_id,
+        cs_pin:,
+        length:,
+        max_stack: 5
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: spi_read_module(cs_pin: cs_pin, length: length, max_stack: max_stack)
         )
       end
 
@@ -826,6 +858,54 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def spi_write(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        cs_pin:,
+        bytes:,
+        max_stack: 5
+      )
+        results = upload_spi_write(
+          program_id: program_id,
+          cs_pin: cs_pin,
+          bytes: bytes,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
+      def spi_read(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        cs_pin:,
+        length:,
+        max_stack: 5
+      )
+        results = upload_spi_read(
+          program_id: program_id,
+          cs_pin: cs_pin,
+          length: length,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def i2c_write_u8(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -1151,6 +1231,10 @@ module CodingAdventures
           upload_spi_open(**spi_open_command_options(words, command, options, require_budget: false))
         when "upload-spi-transfer", "upload-spi.transfer"
           upload_spi_transfer(**spi_transfer_command_options(words, command, options, require_budget: false))
+        when "upload-spi-write", "upload-spi.write"
+          upload_spi_write(**spi_write_command_options(words, command, options, require_budget: false))
+        when "upload-spi-read", "upload-spi.read"
+          upload_spi_read(**spi_read_command_options(words, command, options, require_budget: false))
         when "upload-i2c-write-u8", "upload-i2c.write_u8", "upload-i2c-write"
           upload_i2c_write_u8(**i2c_write_u8_command_options(words, command, options, require_budget: false))
         when "upload-i2c-write-bytes", "upload-i2c.write"
@@ -1203,6 +1287,10 @@ module CodingAdventures
           spi_open(**spi_open_command_options(words, command, options))
         when "spi-transfer", "spi.transfer"
           spi_transfer(**spi_transfer_command_options(words, command, options))
+        when "spi-write", "spi.write"
+          spi_write(**spi_write_command_options(words, command, options))
+        when "spi-read", "spi.read"
+          spi_read(**spi_read_command_options(words, command, options))
         when "i2c-write-u8", "i2c.write_u8", "i2c-write"
           i2c_write_u8(**i2c_write_u8_command_options(words, command, options))
         when "i2c-write-bytes", "i2c.write"
@@ -1544,8 +1632,8 @@ module CodingAdventures
       def spi_transfer_command_options(words, command, options, require_budget: true)
         merged = options.dup
         merged[:cs_pin] = integer_argument(words.shift, "#{command} chip select pin") unless words.empty?
-        merged[:write_bytes] = i2c_bytes_argument(words.shift, "#{command} write bytes") unless words.empty?
-        merged[:read_length] = i2c_read_length_value(words.shift) unless words.empty?
+        merged[:write_bytes] = spi_bytes_argument(words.shift, "#{command} write bytes") unless words.empty?
+        merged[:read_length] = spi_read_length_value(words.shift) unless words.empty?
 
         if require_budget && !words.empty?
           merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
@@ -1555,6 +1643,38 @@ module CodingAdventures
         raise ArgumentError, "#{command} requires chip select pin" unless merged.key?(:cs_pin)
         raise ArgumentError, "#{command} requires write bytes" unless merged.key?(:write_bytes)
         raise ArgumentError, "#{command} requires read length" unless merged.key?(:read_length)
+
+        merged
+      end
+
+      def spi_write_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:cs_pin] = integer_argument(words.shift, "#{command} chip select pin") unless words.empty?
+        merged[:bytes] = spi_bytes_argument(words.shift, "#{command} bytes") unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires chip select pin" unless merged.key?(:cs_pin)
+        raise ArgumentError, "#{command} requires bytes" unless merged.key?(:bytes)
+
+        merged
+      end
+
+      def spi_read_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:cs_pin] = integer_argument(words.shift, "#{command} chip select pin") unless words.empty?
+        merged[:length] = spi_read_length_value(words.shift) unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires chip select pin" unless merged.key?(:cs_pin)
+        raise ArgumentError, "#{command} requires length" unless merged.key?(:length)
 
         merged
       end
@@ -1681,9 +1801,20 @@ module CodingAdventures
         i2c_bytes_value(value)
       end
 
+      alias spi_bytes_value i2c_bytes_value
+      alias spi_bytes_argument i2c_bytes_argument
+
       def i2c_read_length_value(value)
+        byte_buffer_read_length_value(value, "I2C")
+      end
+
+      def spi_read_length_value(value)
+        byte_buffer_read_length_value(value, "SPI")
+      end
+
+      def byte_buffer_read_length_value(value, label)
         length = byte_value(value)
-        raise ArgumentError, "I2C read length must be at most 32 bytes" if length > 32
+        raise ArgumentError, "#{label} read length must be at most 32 bytes" if length > 32
 
         length
       end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -1361,6 +1361,46 @@ module CodingAdventures
           transfer_result.results.map(&:command)
       end
 
+      def test_spi_write_and_read_dispatch_native_transfer_wrappers_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        open_result = nil
+        write_result = nil
+        read_result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          open_result = board.spi.open(bus: 0, program_id: 10, budget: 24)
+          write_result = board.spi.write(
+            cs_pin: 10,
+            bytes: [0xde, 0xad, 0xbe],
+            program_id: 11,
+            budget: 24
+          )
+          read_result = board.spi.read(
+            cs_pin: 10,
+            length: 3,
+            program_id: 12,
+            budget: 24
+          )
+        end
+
+        assert_empty runner.calls
+        assert_equal 14, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal open_result.frames + write_result.frames + read_result.frames, transport.frames
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          open_result.results.map(&:command)
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          write_result.results.map(&:command)
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          read_result.results.map(&:command)
+      end
+
       def test_i2c_write_u8_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -1944,6 +1984,36 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_spi_write_and_read
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          open = board.session.run_command("spi-open 0 24", program_id: 8)
+          write = board.session.run_command("spi-write 10 0xdeadbe 24", program_id: 9)
+          read = board.session.run_command("spi-read 10 3 24", program_id: 10)
+          upload_write = board.session.run_command("upload-spi.write 10 0xdeadbe", program_id: 11)
+          upload_read = board.session.run_command("upload-spi.read 10 3", program_id: 12)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            open.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            write.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            read.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload_write.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload_read.results.map(&:command)
+          assert_equal open.frames + write.frames + read.frames + upload_write.frames + upload_read.frames,
+            transport.frames
+        end
+      end
+
       def test_session_run_command_accepts_repl_style_i2c_write_u8
         transport = FakeWriteTransport.new
 
@@ -2204,6 +2274,14 @@ module CodingAdventures
         spi_transfer_module_bytes = session.spi_transfer_module(10, "\x9F".b, 3, 5)
         assert_instance_of String, spi_transfer_module_bytes
         assert_operator spi_transfer_module_bytes.bytesize, :>, 0
+
+        spi_write_module_bytes = session.spi_write_module(10, "\xDE\xAD\xBE".b, 5)
+        assert_instance_of String, spi_write_module_bytes
+        assert_operator spi_write_module_bytes.bytesize, :>, 0
+
+        spi_read_module_bytes = session.spi_read_module(10, 3, 5)
+        assert_instance_of String, spi_read_module_bytes
+        assert_operator spi_read_module_bytes.bytesize, :>, 0
 
         i2c_write_module_bytes = session.i2c_write_u8_module(0x3c, 0xa5, 4)
         assert_instance_of String, i2c_write_module_bytes

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -60,6 +60,8 @@ pub const SPI_OPEN_MODULE_LEN: usize = 16;
 pub const SPI_TRANSFER_CODE_LEN: usize = 13;
 pub const SPI_TRANSFER_MAX_MODULE_LEN: usize =
     8 + 1 + SPI_TRANSFER_CODE_LEN + 1 + MAX_BYTE_BUFFER_LEN;
+pub const SPI_WRITE_MAX_MODULE_LEN: usize = SPI_TRANSFER_MAX_MODULE_LEN;
+pub const SPI_READ_MODULE_LEN: usize = 8 + 1 + SPI_TRANSFER_CODE_LEN + 1;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -251,6 +253,20 @@ pub struct SpiTransferProgram<'a> {
     pub max_stack: u8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpiWriteProgram<'a> {
+    pub cs_pin: u16,
+    pub bytes: &'a [u8],
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpiReadProgram {
+    pub cs_pin: u16,
+    pub len: u8,
+    pub max_stack: u8,
+}
+
 impl I2cOpenProgram {
     pub const fn new(bus: u8) -> Self {
         Self { bus, max_stack: 2 }
@@ -319,6 +335,26 @@ impl<'a> SpiTransferProgram<'a> {
             cs_pin,
             write_bytes,
             read_len,
+            max_stack: 5,
+        }
+    }
+}
+
+impl<'a> SpiWriteProgram<'a> {
+    pub const fn new(cs_pin: u16, bytes: &'a [u8]) -> Self {
+        Self {
+            cs_pin,
+            bytes,
+            max_stack: 5,
+        }
+    }
+}
+
+impl SpiReadProgram {
+    pub const fn new(cs_pin: u16, len: u8) -> Self {
+        Self {
+            cs_pin,
+            len,
             max_stack: 5,
         }
     }
@@ -1411,6 +1447,64 @@ pub fn write_spi_transfer_module(
     Ok(offset)
 }
 
+pub fn spi_write_module_len(byte_len: usize) -> Result<usize, HostError> {
+    spi_transfer_module_len(byte_len)
+}
+
+pub fn write_spi_write_code(
+    program: SpiWriteProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    write_spi_transfer_code(
+        SpiTransferProgram {
+            cs_pin: program.cs_pin,
+            write_bytes: program.bytes,
+            read_len: 0,
+            max_stack: program.max_stack,
+        },
+        out,
+    )
+}
+
+pub fn write_spi_write_module(
+    program: SpiWriteProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    write_spi_transfer_module(
+        SpiTransferProgram {
+            cs_pin: program.cs_pin,
+            write_bytes: program.bytes,
+            read_len: 0,
+            max_stack: program.max_stack,
+        },
+        out,
+    )
+}
+
+pub fn write_spi_read_code(program: SpiReadProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    write_spi_transfer_code(
+        SpiTransferProgram {
+            cs_pin: program.cs_pin,
+            write_bytes: &[],
+            read_len: program.len,
+            max_stack: program.max_stack,
+        },
+        out,
+    )
+}
+
+pub fn write_spi_read_module(program: SpiReadProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    write_spi_transfer_module(
+        SpiTransferProgram {
+            cs_pin: program.cs_pin,
+            write_bytes: &[],
+            read_len: program.len,
+            max_stack: program.max_stack,
+        },
+        out,
+    )
+}
+
 pub fn write_i2c_write_u8_code(
     program: I2cWriteU8Program,
     out: &mut [u8],
@@ -2133,6 +2227,50 @@ mod tests {
         assert_eq!(&module[..len], SPI_TRANSFER_CS10_9F_READ_03_MODULE_HEX);
 
         let parsed = parse_module(&module[..len]).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_spi(), 5).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_SPI_TRANSFER]);
+    }
+
+    #[test]
+    fn builds_spi_write_module_as_transfer_wrapper() {
+        let payload = [0xde, 0xad, 0xbe];
+        let mut write_module = [0u8; SPI_WRITE_MAX_MODULE_LEN];
+        let write_len =
+            write_spi_write_module(SpiWriteProgram::new(10, &payload), &mut write_module).unwrap();
+        assert_eq!(write_len, spi_write_module_len(payload.len()).unwrap());
+
+        let mut transfer_module = [0u8; SPI_TRANSFER_MAX_MODULE_LEN];
+        let transfer_len = write_spi_transfer_module(
+            SpiTransferProgram::new(10, &payload, 0),
+            &mut transfer_module,
+        )
+        .unwrap();
+        assert_eq!(write_len, transfer_len);
+        assert_eq!(&write_module[..write_len], &transfer_module[..transfer_len]);
+
+        let parsed = parse_module(&write_module[..write_len]).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_spi(), 5).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_SPI_TRANSFER]);
+    }
+
+    #[test]
+    fn builds_spi_read_module_as_transfer_wrapper() {
+        let mut read_module = [0u8; SPI_READ_MODULE_LEN];
+        let read_len = write_spi_read_module(SpiReadProgram::new(10, 3), &mut read_module).unwrap();
+        assert_eq!(read_len, SPI_READ_MODULE_LEN);
+
+        let mut transfer_module = [0u8; SPI_TRANSFER_MAX_MODULE_LEN];
+        let transfer_len =
+            write_spi_transfer_module(SpiTransferProgram::new(10, &[], 3), &mut transfer_module)
+                .unwrap();
+        assert_eq!(read_len, transfer_len);
+        assert_eq!(&read_module[..read_len], &transfer_module[..transfer_len]);
+
+        let parsed = parse_module(&read_module[..read_len]).unwrap();
         validate(&parsed, CapabilitySet::blink_mvp().with_spi(), 5).unwrap();
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -35,25 +35,26 @@ use board_vm_esp_rom::{
     DEFAULT_TIMEOUT_MS as ESP_DEFAULT_TIMEOUT_MS,
 };
 use board_vm_host::{
-    i2c_transfer_module_len, i2c_write_module_len, spi_transfer_module_len, write_adc_read_module,
-    write_blink_module, write_dac_write_u12_module, write_gpio_handle_close_module,
-    write_gpio_handle_read_module, write_gpio_handle_write_module, write_gpio_open_module,
-    write_gpio_read_module, write_gpio_write_module, write_i2c_open_module, write_i2c_read_module,
-    write_i2c_read_u8_module, write_i2c_transfer_module, write_i2c_write_module,
-    write_i2c_write_u8_module, write_led_matrix_frame_module, write_module, write_pwm_write_module,
-    write_spi_open_module, write_spi_transfer_module, write_time_now_module,
+    i2c_transfer_module_len, i2c_write_module_len, spi_transfer_module_len, spi_write_module_len,
+    write_adc_read_module, write_blink_module, write_dac_write_u12_module,
+    write_gpio_handle_close_module, write_gpio_handle_read_module, write_gpio_handle_write_module,
+    write_gpio_open_module, write_gpio_read_module, write_gpio_write_module, write_i2c_open_module,
+    write_i2c_read_module, write_i2c_read_u8_module, write_i2c_transfer_module,
+    write_i2c_write_module, write_i2c_write_u8_module, write_led_matrix_frame_module, write_module,
+    write_pwm_write_module, write_spi_open_module, write_spi_read_module,
+    write_spi_transfer_module, write_spi_write_module, write_time_now_module,
     write_time_sleep_ms_module, AdcReadProgram, BlinkProgram, DacWriteU12Program,
     GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram,
     GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram, I2cReadProgram,
     I2cReadU8Program, I2cTransferProgram, I2cWriteProgram, I2cWriteU8Program,
-    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, SpiOpenProgram, SpiTransferProgram,
-    TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
-    DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
-    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
-    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
-    I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN,
-    LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, TIME_NOW_MODULE_LEN,
-    TIME_SLEEP_MS_MODULE_LEN,
+    LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, SpiOpenProgram, SpiReadProgram,
+    SpiTransferProgram, SpiWriteProgram, TimeNowProgram, TimeSleepMsProgram, ADC_READ_MODULE_LEN,
+    BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
+    DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
+    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
+    GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN,
+    I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN,
+    SPI_OPEN_MODULE_LEN, SPI_READ_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -1680,6 +1681,20 @@ pub fn build_spi_transfer_module(
     Ok(write_spi_transfer_module(program, out)?)
 }
 
+pub fn build_spi_write_module(
+    program: SpiWriteProgram<'_>,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_spi_write_module(program, out)?)
+}
+
+pub fn build_spi_read_module(
+    program: SpiReadProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_spi_read_module(program, out)?)
+}
+
 pub fn build_i2c_write_u8_module(
     program: I2cWriteU8Program,
     out: &mut [u8],
@@ -2485,6 +2500,58 @@ pub unsafe extern "C" fn board_vm_language_spi_transfer_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_spi_write_module(
+    cs_pin: u16,
+    bytes: *const u8,
+    bytes_len: u64,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let bytes = unsafe { in_slice(bytes, bytes_len, "bytes") }?;
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_spi_write_module(
+            SpiWriteProgram {
+                cs_pin,
+                bytes,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn board_vm_language_spi_read_module(
+    cs_pin: u16,
+    read_len: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_spi_read_module(
+            SpiReadProgram {
+                cs_pin,
+                len: read_len,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_i2c_write_u8_module(
     address: u16,
     byte: u8,
@@ -2943,6 +3010,19 @@ pub extern "C" fn board_vm_language_spi_transfer_module_len(write_len: u64) -> u
         return 0;
     };
     spi_transfer_module_len(write_len).unwrap_or(0) as u64
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_spi_write_module_len(byte_len: u64) -> u64 {
+    let Ok(byte_len) = usize::try_from(byte_len) else {
+        return 0;
+    };
+    spi_write_module_len(byte_len).unwrap_or(0) as u64
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_spi_read_module_len() -> u64 {
+    SPI_READ_MODULE_LEN as u64
 }
 
 #[no_mangle]
@@ -4077,6 +4157,37 @@ mod tests {
             spi_transfer_status.len,
             board_vm_language_spi_transfer_module_len(spi_transfer_payload.len() as u64)
         );
+
+        let spi_write_payload = [0xde, 0xad, 0xbe];
+        let mut spi_write_module = [0u8; board_vm_host::SPI_WRITE_MAX_MODULE_LEN];
+        let spi_write_status = unsafe {
+            board_vm_language_spi_write_module(
+                10,
+                spi_write_payload.as_ptr(),
+                spi_write_payload.len() as u64,
+                5,
+                spi_write_module.as_mut_ptr(),
+                spi_write_module.len() as u64,
+            )
+        };
+        assert_eq!(spi_write_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(
+            spi_write_status.len,
+            board_vm_language_spi_write_module_len(spi_write_payload.len() as u64)
+        );
+
+        let mut spi_read_module = [0u8; SPI_READ_MODULE_LEN];
+        let spi_read_status = unsafe {
+            board_vm_language_spi_read_module(
+                10,
+                3,
+                5,
+                spi_read_module.as_mut_ptr(),
+                spi_read_module.len() as u64,
+            )
+        };
+        assert_eq!(spi_read_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(spi_read_status.len, board_vm_language_spi_read_module_len());
 
         let mut i2c_write_module = [0u8; I2C_WRITE_U8_MODULE_LEN];
         let i2c_write_status = unsafe {

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -239,7 +239,9 @@ select is asserted, then clocks `read_length` bytes with zero-valued dummy write
 and returns those bounded read bytes. `spi.transfer` therefore covers write-only
 transactions with `read_length = 0`, read-only transactions with an empty write
 buffer, and register-style write-then-read exchanges without repeating SPI bus
-metadata in language frontends.
+metadata in language frontends. Host SDKs may expose `spi.write` and `spi.read`
+as convenience builders, but those must lower to `spi.transfer` rather than
+claiming separate bytecode capability ids.
 
 ### LED Matrix
 

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -30,7 +30,7 @@ Source snapshot:
 | Analog input | A0-A5 | implemented as direct read | `adc.read` |
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
 | I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, byte-buffer write/read, and write-read transfer implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, `i2c.read`, `i2c.transfer` |
-| SPI master | COPI D11, CIPO D12, SCK D13, conventional CS D10 | bus metadata, handle open, and bounded write-then-read transfer implemented | `spi.open`, `spi.transfer`; convenience read/write commands follow |
+| SPI master | COPI D11, CIPO D12, SCK D13, conventional CS D10 | bus metadata, handle open, bounded write-then-read transfer, and transfer-backed read/write SDK commands implemented | `spi.open`, `spi.transfer`; SDK `spi.write`/`spi.read` lower to transfer |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
 | RTC | one RTC instance in the core | pending | `rtc.now`, `rtc.set`, alarms/events later |
@@ -73,7 +73,9 @@ reject conflicting handles.
    `Wire`/`Wire1`. `i2c.write`, `i2c.read`, and `i2c.transfer` cover the
    bounded byte-buffer transfer path. `spi.open` establishes the SPI handle
    tranche over Rust-owned UNO R4 bus metadata; `spi.transfer` layers a bounded
-   chip-select-scoped write-then-read transaction on that handle.
+   chip-select-scoped write-then-read transaction on that handle, with host SDK
+   `spi.write` and `spi.read` wrappers covering write-only and read-only SPI
+   cases without adding duplicate VM opcodes.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests.
 


### PR DESCRIPTION
## Summary
- add Rust-owned `spi.write` and `spi.read` host builders that lower to the existing `spi.transfer` bytecode capability
- expose the wrappers through the language-core C ABI and Ruby native/session/connection/REPL APIs
- update Board VM specs to document read/write as transfer-backed SDK conveniences rather than new opcodes

## Validation
- `cargo fmt -p board-vm-host -p board-vm-language-core`
- `cargo test -p board-vm-host -p board-vm-language-core`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core`
- `bundle exec ruby -c lib/coding_adventures/board_vm/session.rb && bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb`
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`