### PR TITLE
rust(spice): add BJT model netlists

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -6,6 +6,9 @@
   sources, and independent current sources.
 - Add Shockley diode elements with Newton-linearized DC operating-point support
   and zero-bias small-signal conductance for AC/transfer analysis.
+- Add BJT elements with NPN/PNP polarity, Newton-linearized DC operating-point
+  support, and zero-bias small-signal transconductance for AC/transfer
+  analysis.
 - Add voltage-controlled current sources (VCCS) for linear transconductance
   stages.
 - Add voltage-controlled voltage sources (VCVS) across DC, AC, transfer

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -19,10 +19,10 @@ The initial slices implement:
 - Backward-Euler transient analysis for linear RC/RL circuits.
 - Time-varying transient source waveforms: PWL, SIN, PULSE, and EXP.
 
-The package supports resistors, capacitors, inductors, diodes, independent
-current sources, independent voltage sources, voltage-controlled current
-sources, optional source waveforms, ground aliases, node voltages, and voltage
-source branch currents.
+The package supports resistors, capacitors, inductors, diodes, BJTs,
+independent current sources, independent voltage sources, voltage-controlled
+current sources, optional source waveforms, ground aliases, node voltages, and
+voltage source branch currents.
 
 ```rust
 use spice_engine::{Circuit, Element, PwlWaveform, Resistor, VoltageSource, Waveform};

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -341,6 +341,7 @@ pub enum Element {
     VoltageSource(VoltageSource),
     CurrentSource(CurrentSource),
     Diode(Diode),
+    Bjt(Bjt),
     Vccs(Vccs),
     Vcvs(Vcvs),
     Cccs(Cccs),
@@ -557,6 +558,66 @@ impl Diode {
             anode: anode.into(),
             cathode: cathode.into(),
             saturation_current,
+            thermal_voltage,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BjtPolarity {
+    Npn,
+    Pnp,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Bjt {
+    pub name: String,
+    pub collector: String,
+    pub base: String,
+    pub emitter: String,
+    pub polarity: BjtPolarity,
+    pub saturation_current: f64,
+    pub forward_beta: f64,
+    pub thermal_voltage: f64,
+}
+
+impl Bjt {
+    pub fn new(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+    ) -> Self {
+        Self::with_model(
+            name,
+            collector,
+            base,
+            emitter,
+            BjtPolarity::Npn,
+            1.0e-14,
+            100.0,
+            0.02585,
+        )
+    }
+
+    pub fn with_model(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+        polarity: BjtPolarity,
+        saturation_current: f64,
+        forward_beta: f64,
+        thermal_voltage: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            collector: collector.into(),
+            base: base.into(),
+            emitter: emitter.into(),
+            polarity,
+            saturation_current,
+            forward_beta,
             thermal_voltage,
         }
     }
@@ -1510,6 +1571,11 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
             "saturation_current".to_string(),
             diode.saturation_current,
         )),
+        Element::Bjt(bjt) => Some((
+            bjt.name.clone(),
+            "saturation_current".to_string(),
+            bjt.saturation_current,
+        )),
         Element::Vccs(source) => Some((
             source.name.clone(),
             "transconductance_siemens".to_string(),
@@ -1536,6 +1602,7 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::VoltageSource(source) => source.voltage += delta,
         Element::CurrentSource(source) => source.current += delta,
         Element::Diode(diode) => diode.saturation_current += delta,
+        Element::Bjt(bjt) => bjt.saturation_current += delta,
         Element::Vccs(source) => source.transconductance_siemens += delta,
         Element::Vcvs(source) => source.gain += delta,
         Element::Cccs(source) => source.gain += delta,
@@ -1625,6 +1692,12 @@ fn randomized_element(
             varied.saturation_current =
                 randomized_value(varied.saturation_current, tolerance, distribution, rng);
             Element::Diode(varied)
+        }
+        Element::Bjt(bjt) => {
+            let mut varied = bjt.clone();
+            varied.saturation_current =
+                randomized_value(varied.saturation_current, tolerance, distribution, rng);
+            Element::Bjt(varied)
         }
         Element::Vccs(source) => {
             let mut varied = source.clone();
@@ -1738,10 +1811,10 @@ fn solve_linear_circuit(
         });
     }
 
-    let has_diode = circuit
+    let has_nonlinear = circuit
         .elements()
         .iter()
-        .any(|element| matches!(element, Element::Diode(_)));
+        .any(|element| matches!(element, Element::Diode(_) | Element::Bjt(_)));
     let mut operating_point = vec![0.0; matrix_size];
     let mut solution = solve_linear_circuit_at_operating_point(
         circuit,
@@ -1754,7 +1827,7 @@ fn solve_linear_circuit(
         matrix_size,
         &operating_point,
     )?;
-    if !has_diode {
+    if !has_nonlinear {
         return Ok(solution);
     }
 
@@ -1827,6 +1900,9 @@ fn solve_linear_circuit_at_operating_point(
             }
             Element::Diode(diode) => {
                 stamp_diode(diode, node_indices, &mut matrix, &mut rhs, operating_point)?
+            }
+            Element::Bjt(bjt) => {
+                stamp_bjt(bjt, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
             Element::Vccs(source) => stamp_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_vcvs(
@@ -1908,6 +1984,7 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             | Element::Capacitor(_)
             | Element::Inductor(_)
             | Element::Diode(_)
+            | Element::Bjt(_)
             | Element::Vccs(_)
             | Element::Vcvs(_)
             | Element::Cccs(_)
@@ -1974,6 +2051,7 @@ fn build_ac_matrix(
                     Complex::new(diode.saturation_current / diode.thermal_voltage, 0.0),
                 );
             }
+            Element::Bjt(bjt) => stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix)?,
             Element::Vccs(source) => stamp_ac_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_ac_vcvs(
                 source,
@@ -2050,6 +2128,7 @@ fn build_small_signal_matrix(
                     diode.saturation_current / diode.thermal_voltage,
                 );
             }
+            Element::Bjt(bjt) => stamp_bjt_small_signal(bjt, node_indices, &mut matrix)?,
             Element::Vccs(source) => {
                 stamp_vccs(source, node_indices, &mut matrix)?;
             }
@@ -2133,6 +2212,11 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
             Element::Diode(diode) => {
                 insert_node(&mut names, &diode.anode);
                 insert_node(&mut names, &diode.cathode);
+            }
+            Element::Bjt(bjt) => {
+                insert_node(&mut names, &bjt.collector);
+                insert_node(&mut names, &bjt.base);
+                insert_node(&mut names, &bjt.emitter);
             }
             Element::Vccs(source) => {
                 insert_node(&mut names, &source.positive);
@@ -2241,6 +2325,9 @@ fn find_input_source<'a>(
             }
             Element::Diode(diode) if diode.name == input_source => {
                 return Err(input_source_type_error(input_source, "diode"));
+            }
+            Element::Bjt(bjt) if bjt.name == input_source => {
+                return Err(input_source_type_error(input_source, "BJT"));
             }
             Element::Vccs(source) if source.name == input_source => {
                 return Err(input_source_type_error(input_source, "VCCS"));
@@ -2521,6 +2608,114 @@ fn stamp_diode(
     Ok(())
 }
 
+fn stamp_bjt(
+    bjt: &Bjt,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_bjt(bjt)?;
+    let collector = node_index(node_indices, &bjt.collector);
+    let base = node_index(node_indices, &bjt.base);
+    let emitter = node_index(node_indices, &bjt.emitter);
+    let base_voltage = base.map_or(0.0, |index| operating_point[index]);
+    let emitter_voltage = emitter.map_or(0.0, |index| operating_point[index]);
+    let junction_voltage = match bjt.polarity {
+        BjtPolarity::Npn => base_voltage - emitter_voltage,
+        BjtPolarity::Pnp => emitter_voltage - base_voltage,
+    };
+    let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
+    let exp_value = exponent.exp();
+    let collector_current = bjt.saturation_current * (exp_value - 1.0);
+    let gm = bjt.saturation_current / bjt.thermal_voltage * exp_value;
+    let gpi = gm / bjt.forward_beta;
+    let base_current = collector_current / bjt.forward_beta;
+    let equivalent_collector_current = collector_current - gm * junction_voltage;
+    let equivalent_base_current = base_current - gpi * junction_voltage;
+
+    match bjt.polarity {
+        BjtPolarity::Npn => {
+            stamp_conductance(matrix, base, emitter, gpi);
+            stamp_transconductance(matrix, collector, emitter, base, emitter, gm);
+            stamp_equivalent_current_source(rhs, base, emitter, equivalent_base_current);
+            stamp_equivalent_current_source(rhs, collector, emitter, equivalent_collector_current);
+        }
+        BjtPolarity::Pnp => {
+            stamp_conductance(matrix, emitter, base, gpi);
+            stamp_transconductance(matrix, emitter, collector, emitter, base, gm);
+            stamp_equivalent_current_source(rhs, emitter, base, equivalent_base_current);
+            stamp_equivalent_current_source(rhs, emitter, collector, equivalent_collector_current);
+        }
+    }
+    Ok(())
+}
+
+fn stamp_equivalent_current_source(
+    rhs: &mut [f64],
+    positive: Option<usize>,
+    negative: Option<usize>,
+    current: f64,
+) {
+    if let Some(index) = positive {
+        rhs[index] -= current;
+    }
+    if let Some(index) = negative {
+        rhs[index] += current;
+    }
+}
+
+fn stamp_bjt_small_signal(
+    bjt: &Bjt,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+) -> Result<(), SpiceError> {
+    validate_bjt(bjt)?;
+    let collector = node_index(node_indices, &bjt.collector);
+    let base = node_index(node_indices, &bjt.base);
+    let emitter = node_index(node_indices, &bjt.emitter);
+    let gm = bjt.saturation_current / bjt.thermal_voltage;
+    let gpi = gm / bjt.forward_beta;
+    match bjt.polarity {
+        BjtPolarity::Npn => {
+            stamp_conductance(matrix, base, emitter, gpi);
+            stamp_transconductance(matrix, collector, emitter, base, emitter, gm);
+        }
+        BjtPolarity::Pnp => {
+            stamp_conductance(matrix, emitter, base, gpi);
+            stamp_transconductance(matrix, emitter, collector, emitter, base, gm);
+        }
+    }
+    Ok(())
+}
+
+fn stamp_ac_bjt_small_signal(
+    bjt: &Bjt,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<Complex>],
+) -> Result<(), SpiceError> {
+    validate_bjt(bjt)?;
+    let collector = node_index(node_indices, &bjt.collector);
+    let base = node_index(node_indices, &bjt.base);
+    let emitter = node_index(node_indices, &bjt.emitter);
+    let gm = Complex::new(bjt.saturation_current / bjt.thermal_voltage, 0.0);
+    let gpi = Complex::new(
+        bjt.saturation_current / bjt.thermal_voltage / bjt.forward_beta,
+        0.0,
+    );
+    match bjt.polarity {
+        BjtPolarity::Npn => {
+            stamp_complex_conductance(matrix, base, emitter, gpi);
+            stamp_complex_transconductance(matrix, collector, emitter, base, emitter, gm);
+        }
+        BjtPolarity::Pnp => {
+            stamp_complex_conductance(matrix, emitter, base, gpi);
+            stamp_complex_transconductance(matrix, emitter, collector, emitter, base, gm);
+        }
+    }
+    Ok(())
+}
+
 fn validate_reactive_elements(circuit: &Circuit) -> Result<(), SpiceError> {
     for element in circuit.elements() {
         match element {
@@ -2542,6 +2737,28 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
     if !diode.thermal_voltage.is_finite() || diode.thermal_voltage <= 0.0 {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
+            reason: "thermal voltage must be finite and positive".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
+    if !bjt.saturation_current.is_finite() || bjt.saturation_current <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "saturation current must be finite and positive".to_string(),
+        });
+    }
+    if !bjt.forward_beta.is_finite() || bjt.forward_beta <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward beta must be finite and positive".to_string(),
+        });
+    }
+    if !bjt.thermal_voltage.is_finite() || bjt.thermal_voltage <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
             reason: "thermal voltage must be finite and positive".to_string(),
         });
     }

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    ac_sweep, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor, Resistor,
-    SpiceError, Vcvs, VoltageSource,
+    ac_sweep, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor,
+    Resistor, SpiceError, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -119,6 +119,34 @@ fn ac_vcvs_applies_controlled_voltage_gain() {
     assert_close(out.real, 4.0);
     assert_close(out.imag, 0.0);
     assert_close(points[0].branch_current("E1").unwrap().real, -4.0e-3);
+}
+
+#[test]
+fn ac_bjt_applies_zero_bias_common_emitter_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "base", "0", 1.0,
+    )));
+    circuit.add(Element::Bjt(Bjt::with_model(
+        "Q1",
+        "out",
+        "base",
+        "0",
+        BjtPolarity::Npn,
+        25.85e-6,
+        100.0,
+        0.02585,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let points = ac_sweep(&circuit, 1_000.0, 1_000.0, 10).unwrap();
+
+    assert_eq!(points.len(), 1);
+    let out = points[0].voltage("out").unwrap();
+    assert_close(out.real, -1.0);
+    assert_close(out.imag, 0.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    dc_op, dc_sweep, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, Inductor, Resistor,
-    SinWaveform, SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
+    dc_op, dc_sweep, Bjt, BjtPolarity, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element,
+    Inductor, Resistor, SinWaveform, SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -161,6 +161,66 @@ fn dc_diode_solves_forward_biased_operating_point() {
     let out = result.voltage("out").unwrap();
     assert!(out > 0.1, "expected forward-biased output, got {out}");
     assert!(out < 0.7, "expected diode drop below source, got {out}");
+}
+
+#[test]
+fn dc_bjt_solves_npn_emitter_follower_operating_point() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vcc", "vcc", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbase", "base", "0", 0.7,
+    )));
+    circuit.add(Element::Bjt(Bjt::with_model(
+        "Q1",
+        "vcc",
+        "base",
+        "out",
+        BjtPolarity::Npn,
+        1.0e-13,
+        120.0,
+        0.026,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+    let out = result.voltage("out").unwrap();
+    assert!(
+        out > 0.0,
+        "expected emitter current through load, got {out}"
+    );
+    assert!(out < 0.7, "expected emitter below base bias, got {out}");
+}
+
+#[test]
+fn dc_bjt_solves_pnp_pullup_operating_point() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vcc", "vcc", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbase", "base", "0", 4.3,
+    )));
+    circuit.add(Element::Bjt(Bjt::with_model(
+        "Q1",
+        "out",
+        "base",
+        "vcc",
+        BjtPolarity::Pnp,
+        1.0e-13,
+        100.0,
+        0.026,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+    let out = result.voltage("out").unwrap();
+    assert!(out > 0.0, "expected pullup current through load, got {out}");
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    tf, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor, Resistor, SpiceError,
-    TfResult, Vccs, Vcvs, VoltageSource,
+    tf, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor,
+    Resistor, SpiceError, TfResult, Vccs, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -112,6 +112,33 @@ fn tf_vcvs_stage_reports_voltage_gain() {
     assert_close(result.gain(), 4.0);
     assert_close(result.output_impedance_ohms, 0.0);
     assert!(result.input_impedance_ohms.is_infinite());
+}
+
+#[test]
+fn tf_bjt_common_emitter_reports_small_signal_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "base", "0", 1.0,
+    )));
+    circuit.add(Element::Bjt(Bjt::with_model(
+        "Q1",
+        "out",
+        "base",
+        "0",
+        BjtPolarity::Npn,
+        25.85e-6,
+        100.0,
+        0.02585,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = tf(&circuit, "out", "Vin").unwrap();
+
+    assert_close(result.gain(), -1.0);
+    assert_close(result.input_impedance_ohms, 100_000.0);
+    assert_close(result.output_impedance_ohms, 1_000.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.5
+
+- Add SPICE `Q` BJT element parsing via `.model <name> NPN|PNP(...)` cards
+  with `IS`, `BF` / `BETA_F`, and `VT` parameters, including subcircuit
+  terminal remapping.
+
 ## 0.1.4
 
 - Add SPICE `D` diode element parsing via `.model <name> D(...)` cards with

--- a/code/packages/rust/spice-netlist-parser/Cargo.toml
+++ b/code/packages/rust/spice-netlist-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spice-netlist-parser"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -17,8 +17,9 @@ C1 out 0 1u
 assert_eq!(parsed.tran_cards().len(), 1);
 ```
 
-This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `G`, `E`, `F`, and `H`
-elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
-SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
-`.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
-analysis cards.
+This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `G`, `E`, `F`, and
+`H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`
+parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
+`BETA_F`, and `VT` parameters, SPICE engineering suffixes, PWL/PULSE/SIN/EXP
+source forms, comments, `.end`, `.subckt` / `X` instance expansion, and `.op`,
+`.tran`, `.dc`, and `.ac` analysis cards.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1,8 +1,9 @@
 use std::{collections::HashMap, fmt};
 
 use spice_engine::{
-    Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, ExpWaveform, Inductor,
-    PulseWaveform, PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
+    Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, ExpWaveform,
+    Inductor, PulseWaveform, PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource,
+    Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -437,6 +438,38 @@ fn parse_element(
                 *model.params.get("VT").unwrap_or(&0.02585),
             )))
         }
+        'Q' => {
+            require_fields(fields, 5, "BJT")?;
+            let model = models.get(&fields[4].to_ascii_lowercase()).ok_or_else(|| {
+                NetlistParseError::new(format!("unknown model {:?} for BJT {:?}", fields[4], name))
+            })?;
+            let polarity = match model.kind.as_str() {
+                "NPN" => BjtPolarity::Npn,
+                "PNP" => BjtPolarity::Pnp,
+                _ => {
+                    return Err(NetlistParseError::new(format!(
+                        "model {:?} has kind {:?}, expected \"NPN\" or \"PNP\"",
+                        model.name, model.kind
+                    )));
+                }
+            };
+            let forward_beta = model
+                .params
+                .get("BF")
+                .or_else(|| model.params.get("BETA_F"))
+                .copied()
+                .unwrap_or(100.0);
+            Ok(Element::Bjt(Bjt::with_model(
+                name,
+                &fields[1],
+                &fields[2],
+                &fields[3],
+                polarity,
+                *model.params.get("IS").unwrap_or(&1.0e-14),
+                forward_beta,
+                *model.params.get("VT").unwrap_or(&0.02585),
+            )))
+        }
         'G' => {
             require_fields(fields, 6, "VCCS")?;
             Ok(Element::Vccs(Vccs::new(
@@ -604,6 +637,12 @@ fn map_subckt_fields(
             require_min_fields(fields, 3, "subcircuit element")?;
             mapped[1] = map_subckt_node(&fields[1], instance_name, node_map);
             mapped[2] = map_subckt_node(&fields[2], instance_name, node_map);
+        }
+        'Q' => {
+            require_min_fields(fields, 4, "subcircuit BJT")?;
+            for index in 1..4 {
+                mapped[index] = map_subckt_node(&fields[index], instance_name, node_map);
+            }
         }
         'E' | 'G' => {
             require_min_fields(fields, 5, "subcircuit controlled source")?;

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1,4 +1,4 @@
-use spice_engine::{dc_op, Element};
+use spice_engine::{dc_op, BjtPolarity, Element};
 use spice_netlist_parser::{
     parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, NetlistParseError, OpAnalysis,
     TranAnalysis,
@@ -198,6 +198,64 @@ Rload out 0 1k
     let out = result.voltage("out").unwrap();
     assert!(out > 0.1, "expected forward-biased output, got {out}");
     assert!(out < 0.7, "expected diode drop below source, got {out}");
+}
+
+#[test]
+fn parses_bjt_models_into_operating_point_circuits() {
+    let parsed = parse_netlist(
+        r#"
+.model fast NPN(IS=1e-13 BF=120 VT=26m)
+Vcc vcc 0 DC 5
+Vbase base 0 DC 0.7
+Q1 vcc base out fast
+Rload out 0 1k
+.op
+"#,
+    )
+    .unwrap();
+
+    let model = parsed.models.get("fast").unwrap();
+    assert_eq!(model.name, "fast");
+    assert_eq!(model.kind, "NPN");
+    assert_close(*model.params.get("IS").unwrap(), 1.0e-13);
+    assert_close(*model.params.get("BF").unwrap(), 120.0);
+    assert_close(*model.params.get("VT").unwrap(), 26.0e-3);
+
+    let Element::Bjt(bjt) = &parsed.circuit.elements()[2] else {
+        panic!("expected BJT");
+    };
+    assert_eq!(bjt.name, "Q1");
+    assert_eq!(bjt.collector, "vcc");
+    assert_eq!(bjt.base, "base");
+    assert_eq!(bjt.emitter, "out");
+    assert_eq!(bjt.polarity, BjtPolarity::Npn);
+    assert_close(bjt.saturation_current, 1.0e-13);
+    assert_close(bjt.forward_beta, 120.0);
+    assert_close(bjt.thermal_voltage, 26.0e-3);
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    let out = result.voltage("out").unwrap();
+    assert!(out > 0.0, "expected emitter follower output, got {out}");
+    assert!(out < 0.7, "expected output below base bias, got {out}");
+}
+
+#[test]
+fn parses_pnp_bjt_model_aliases() {
+    let parsed = parse_netlist(
+        r#"
+.model pullup PNP(IS=2e-14 BETA_F=80 VT=27m)
+Q1 vcc base out pullup
+"#,
+    )
+    .unwrap();
+
+    let Element::Bjt(bjt) = &parsed.circuit.elements()[0] else {
+        panic!("expected BJT");
+    };
+    assert_eq!(bjt.polarity, BjtPolarity::Pnp);
+    assert_close(bjt.saturation_current, 2.0e-14);
+    assert_close(bjt.forward_beta, 80.0);
+    assert_close(bjt.thermal_voltage, 27.0e-3);
 }
 
 #[test]
@@ -406,6 +464,28 @@ Xlim in out limiter
 }
 
 #[test]
+fn expands_subcircuit_bjt_nodes_into_engine_elements() {
+    let parsed = parse_netlist(
+        r#"
+.model fast NPN(IS=1e-13 BF=120)
+.subckt follower c b e
+Qdrive c b e fast
+.ends follower
+Xbuf vcc in out follower
+"#,
+    )
+    .unwrap();
+
+    let Element::Bjt(bjt) = &parsed.circuit.elements()[0] else {
+        panic!("expected BJT");
+    };
+    assert_eq!(bjt.name, "Xbuf.Qdrive");
+    assert_eq!(bjt.collector, "vcc");
+    assert_eq!(bjt.base, "in");
+    assert_eq!(bjt.emitter, "out");
+}
+
+#[test]
 fn scopes_subcircuit_internal_nodes_by_instance() {
     let parsed = parse_netlist(
         r#"
@@ -439,7 +519,7 @@ fn parses_engineering_suffixes() {
 
 #[test]
 fn rejects_unsupported_elements_with_line_numbers() {
-    let err = parse_netlist("\nQ1 c b e model\n").unwrap_err();
+    let err = parse_netlist("\nZ1 c b e model\n").unwrap_err();
 
     assert!(err.to_string().contains("line 2: unsupported element"));
     assert_error_type(err);
@@ -461,6 +541,24 @@ fn rejects_non_diode_models_for_diode_elements() {
     assert!(err
         .to_string()
         .contains("line 2: model \"amp\" has kind \"NPN\", expected \"D\""));
+}
+
+#[test]
+fn rejects_unknown_bjt_models() {
+    let err = parse_netlist("Q1 c b e missing\n").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("line 1: unknown model \"missing\" for BJT \"Q1\""));
+}
+
+#[test]
+fn rejects_non_bjt_models_for_bjt_elements() {
+    let err = parse_netlist(".model clamp D(IS=1e-12)\nQ1 c b e clamp\n").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("line 2: model \"clamp\" has kind \"D\", expected \"NPN\" or \"PNP\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Rust SPICE engine BJT elements with NPN/PNP polarity, nonlinear DC stamping, and small-signal AC/TF support
- parse SPICE Q devices from NPN/PNP .model cards with IS, BF/BETA_F, and VT parameters
- remap BJT collector/base/emitter terminals during .subckt expansion

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-rust-spice-bjt-model cargo test -p spice-engine -p spice-netlist-parser
- git diff --check