### PR TITLE
[codex] Add Board VM UNO R4 UART metadata

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -223,6 +223,10 @@ class BoardTarget:
     def spi_buses(self) -> list[dict[str, Any]]:
         return [dict(item) for item in self.raw.get("spi_buses", [])]
 
+    @property
+    def uart_buses(self) -> list[dict[str, Any]]:
+        return [dict(item) for item in self.raw.get("uart_buses", [])]
+
     def digital_pin(self, pin: int) -> dict[str, Any] | None:
         for item in self.digital_pins:
             if int(item["pin"]) == int(pin):

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -32,7 +32,7 @@ use board_vm_language_core::{
     LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
     LanguageDigitalPin, LanguageEspUploadOptions, LanguageHostDevice, LanguageI2cBus,
     LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageSpiBus, LanguageTargetInfo,
-    LanguageValue, LanguageWirelessInterface,
+    LanguageUartBus, LanguageValue, LanguageWirelessInterface,
 };
 use python_bridge::*;
 
@@ -894,6 +894,11 @@ unsafe fn language_target_to_py(target: &LanguageTargetInfo) -> PyObjectPtr {
     );
     dict_set(dict, "i2c_buses", language_i2c_buses_to_py(&target.i2c_buses));
     dict_set(dict, "spi_buses", language_spi_buses_to_py(&target.spi_buses));
+    dict_set(
+        dict,
+        "uart_buses",
+        language_uart_buses_to_py(&target.uart_buses),
+    );
     dict_set(dict, "wireless", language_wireless_to_py(&target.wireless));
     dict_set(
         dict,
@@ -975,6 +980,26 @@ unsafe fn language_spi_buses_to_py(buses: &[LanguageSpiBus]) -> PyObjectPtr {
             "default_cs_pin",
             usize_to_py(bus.default_cs_pin as usize),
         );
+        dict_set(dict, "notes", str_to_py(&bus.notes));
+        PyList_SetItem(list, index as isize, dict);
+    }
+    list
+}
+
+unsafe fn language_uart_buses_to_py(buses: &[LanguageUartBus]) -> PyObjectPtr {
+    let list = PyList_New(buses.len() as isize);
+    for (index, bus) in buses.iter().enumerate() {
+        let dict = PyDict_New();
+        dict_set(dict, "bus", usize_to_py(bus.bus as usize));
+        dict_set(dict, "name", str_to_py(&bus.name));
+        dict_set(dict, "tx_pin", usize_to_py(bus.tx_pin as usize));
+        dict_set(dict, "rx_pin", usize_to_py(bus.rx_pin as usize));
+        dict_set(
+            dict,
+            "arduino_uart",
+            usize_to_py(bus.arduino_uart as usize),
+        );
+        dict_set(dict, "internal", bool_to_py(bus.internal));
         dict_set(dict, "notes", str_to_py(&bus.notes));
         PyList_SetItem(list, index as isize, dict);
     }

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -156,6 +156,35 @@ def test_known_targets_are_exposed_from_rust_registry():
             "notes": "Header SPI bus on D11/COPI, D12/CIPO, and D13/SCK with D10 as the conventional chip select",
         }
     ]
+    assert uno_r4_wifi.uart_buses == [
+        {
+            "bus": 0,
+            "name": "Serial1",
+            "tx_pin": 22,
+            "rx_pin": 23,
+            "arduino_uart": 1,
+            "internal": False,
+            "notes": "UNO R4 WiFi UART on D22/TX and D23/RX",
+        },
+        {
+            "bus": 1,
+            "name": "Serial2",
+            "tx_pin": 1,
+            "rx_pin": 0,
+            "arduino_uart": 2,
+            "internal": False,
+            "notes": "Header UART on D1/TX0 and D0/RX0",
+        },
+        {
+            "bus": 2,
+            "name": "Serial3",
+            "tx_pin": 24,
+            "rx_pin": 25,
+            "arduino_uart": 3,
+            "internal": True,
+            "notes": "UNO R4 WiFi module UART on D24/TX WIFI and D25/RX WIFI",
+        },
+    ]
     assert uno_r4_wifi.digital_pin_count == len(uno_r4_wifi.digital_pins)
     d3 = uno_r4_wifi.digital_pin(3)
     assert d3 is not None

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -44,7 +44,7 @@ use board_vm_language_core::{
     LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
     LanguageDigitalPin, LanguageEspUploadOptions, LanguageHostDevice, LanguageI2cBus,
     LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageSpiBus, LanguageTargetInfo,
-    LanguageValue, LanguageWirelessInterface,
+    LanguageUartBus, LanguageValue, LanguageWirelessInterface,
 };
 use ruby_bridge::VALUE;
 
@@ -958,6 +958,11 @@ fn language_target_to_rb(target: &LanguageTargetInfo) -> VALUE {
     );
     hash_set(hash, "i2c_buses", language_i2c_buses_to_rb(&target.i2c_buses));
     hash_set(hash, "spi_buses", language_spi_buses_to_rb(&target.spi_buses));
+    hash_set(
+        hash,
+        "uart_buses",
+        language_uart_buses_to_rb(&target.uart_buses),
+    );
     hash_set(hash, "wireless", language_wireless_to_rb(&target.wireless));
     hash_set(
         hash,
@@ -1066,6 +1071,22 @@ fn language_spi_buses_to_rb(buses: &[LanguageSpiBus]) -> VALUE {
         hash_set(hash, "cipo_pin", rb_usize(bus.cipo_pin));
         hash_set(hash, "sck_pin", rb_usize(bus.sck_pin));
         hash_set(hash, "default_cs_pin", rb_usize(bus.default_cs_pin));
+        hash_set(hash, "notes", ruby_bridge::str_to_rb(&bus.notes));
+        ruby_bridge::array_push(array, hash);
+    }
+    array
+}
+
+fn language_uart_buses_to_rb(buses: &[LanguageUartBus]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for bus in buses {
+        let hash = ruby_bridge::hash_new();
+        hash_set(hash, "bus", rb_usize(bus.bus));
+        hash_set(hash, "name", ruby_bridge::str_to_rb(&bus.name));
+        hash_set(hash, "tx_pin", rb_usize(bus.tx_pin));
+        hash_set(hash, "rx_pin", rb_usize(bus.rx_pin));
+        hash_set(hash, "arduino_uart", rb_usize(bus.arduino_uart));
+        hash_set(hash, "internal", ruby_bridge::bool_to_rb(bus.internal));
         hash_set(hash, "notes", ruby_bridge::str_to_rb(&bus.notes));
         ruby_bridge::array_push(array, hash);
     }

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -58,6 +58,11 @@ module CodingAdventures
         assert_equal [
           {"bus" => 0, "name" => "SPI", "copi_pin" => 11, "cipo_pin" => 12, "sck_pin" => 13, "default_cs_pin" => 10, "notes" => "Header SPI bus on D11/COPI, D12/CIPO, and D13/SCK with D10 as the conventional chip select"}
         ], uno_r4_wifi["spi_buses"]
+        assert_equal [
+          {"bus" => 0, "name" => "Serial1", "tx_pin" => 22, "rx_pin" => 23, "arduino_uart" => 1, "internal" => false, "notes" => "UNO R4 WiFi UART on D22/TX and D23/RX"},
+          {"bus" => 1, "name" => "Serial2", "tx_pin" => 1, "rx_pin" => 0, "arduino_uart" => 2, "internal" => false, "notes" => "Header UART on D1/TX0 and D0/RX0"},
+          {"bus" => 2, "name" => "Serial3", "tx_pin" => 24, "rx_pin" => 25, "arduino_uart" => 3, "internal" => true, "notes" => "UNO R4 WiFi module UART on D24/TX WIFI and D25/RX WIFI"}
+        ], uno_r4_wifi["uart_buses"]
         assert_equal uno_r4_wifi["digital_pin_count"], uno_r4_wifi["digital_pins"].length
         d3 = uno_r4_wifi["digital_pins"].find { |pin| pin["pin"] == 3 }
         assert_equal "D3", d3["label"]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -66,7 +66,8 @@ use board_vm_protocol::{
 use board_vm_targets::{
     all_targets, BoardFamily, BoardTargetInfo, DigitalPinInfo as TargetDigitalPin,
     I2cBusInfo as TargetI2cBus, OnboardLed as TargetOnboardLed, SpiBusInfo as TargetSpiBus,
-    WirelessInterfaceInfo as TargetWirelessInterface, WirelessTransport as TargetWirelessTransport,
+    UartBusInfo as TargetUartBus, WirelessInterfaceInfo as TargetWirelessInterface,
+    WirelessTransport as TargetWirelessTransport,
 };
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
@@ -394,6 +395,7 @@ pub struct LanguageTargetInfo {
     pub digital_pins: Vec<LanguageDigitalPin>,
     pub i2c_buses: Vec<LanguageI2cBus>,
     pub spi_buses: Vec<LanguageSpiBus>,
+    pub uart_buses: Vec<LanguageUartBus>,
     pub wireless: Vec<LanguageWirelessInterface>,
     pub connection_options: Vec<LanguageConnectionOption>,
     pub capabilities: Vec<String>,
@@ -417,6 +419,17 @@ pub struct LanguageSpiBus {
     pub cipo_pin: u8,
     pub sck_pin: u8,
     pub default_cs_pin: u8,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageUartBus {
+    pub bus: u8,
+    pub name: String,
+    pub tx_pin: u8,
+    pub rx_pin: u8,
+    pub arduino_uart: u8,
+    pub internal: bool,
     pub notes: String,
 }
 
@@ -1095,6 +1108,7 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
             .collect(),
         i2c_buses: target.i2c_buses.iter().map(language_i2c_bus).collect(),
         spi_buses: target.spi_buses.iter().map(language_spi_bus).collect(),
+        uart_buses: target.uart_buses.iter().map(language_uart_bus).collect(),
         wireless: target
             .wireless
             .iter()
@@ -1146,6 +1160,18 @@ fn language_spi_bus(bus: &TargetSpiBus) -> LanguageSpiBus {
         cipo_pin: bus.cipo_pin,
         sck_pin: bus.sck_pin,
         default_cs_pin: bus.default_cs_pin,
+        notes: bus.notes.to_owned(),
+    }
+}
+
+fn language_uart_bus(bus: &TargetUartBus) -> LanguageUartBus {
+    LanguageUartBus {
+        bus: bus.bus,
+        name: bus.name.to_owned(),
+        tx_pin: bus.tx_pin,
+        rx_pin: bus.rx_pin,
+        arduino_uart: bus.arduino_uart,
+        internal: bus.internal,
         notes: bus.notes.to_owned(),
     }
 }
@@ -3296,6 +3322,19 @@ mod tests {
         assert_eq!(uno.spi_buses[0].cipo_pin, 12);
         assert_eq!(uno.spi_buses[0].sck_pin, 13);
         assert_eq!(uno.spi_buses[0].default_cs_pin, 10);
+        assert_eq!(uno.uart_buses.len(), 3);
+        assert_eq!(uno.uart_buses[0].name, "Serial1");
+        assert_eq!(uno.uart_buses[0].tx_pin, 22);
+        assert_eq!(uno.uart_buses[0].rx_pin, 23);
+        assert_eq!(uno.uart_buses[0].arduino_uart, 1);
+        assert!(!uno.uart_buses[0].internal);
+        assert_eq!(uno.uart_buses[1].name, "Serial2");
+        assert_eq!(uno.uart_buses[1].tx_pin, 1);
+        assert_eq!(uno.uart_buses[1].rx_pin, 0);
+        assert_eq!(uno.uart_buses[2].name, "Serial3");
+        assert_eq!(uno.uart_buses[2].tx_pin, 24);
+        assert_eq!(uno.uart_buses[2].rx_pin, 25);
+        assert!(uno.uart_buses[2].internal);
         assert!(uno.capabilities.contains(&"pwm.write".to_owned()));
         assert!(uno.capabilities.contains(&"adc.read".to_owned()));
         assert!(uno.capabilities.contains(&"dac.write_u12".to_owned()));

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -56,6 +56,17 @@ pub struct SpiBusInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UartBusInfo {
+    pub bus: u8,
+    pub name: &'static str,
+    pub tx_pin: u8,
+    pub rx_pin: u8,
+    pub arduino_uart: u8,
+    pub internal: bool,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DigitalPinInfo {
     pub pin: u8,
     pub label: &'static str,
@@ -109,6 +120,7 @@ pub struct BoardTargetInfo {
     pub digital_pins: &'static [DigitalPinInfo],
     pub i2c_buses: &'static [I2cBusInfo],
     pub spi_buses: &'static [SpiBusInfo],
+    pub uart_buses: &'static [UartBusInfo],
     pub wireless: &'static [WirelessInterfaceInfo],
     pub capabilities: &'static [&'static str],
 }
@@ -272,6 +284,10 @@ pub const UNO_R4_WIFI_I2C_BUSES: [I2cBusInfo; 2] =
     map_uno_r4_i2c_buses(board_vm_uno_r4::UNO_R4_WIFI_I2C_BUSES);
 pub const UNO_R4_SPI_BUSES: [SpiBusInfo; 1] =
     map_uno_r4_spi_buses(board_vm_uno_r4::UNO_R4_SPI_BUSES);
+pub const UNO_R4_MINIMA_UART_BUSES: [UartBusInfo; 1] =
+    map_uno_r4_uart_buses(board_vm_uno_r4::UNO_R4_MINIMA_UART_BUSES);
+pub const UNO_R4_WIFI_UART_BUSES: [UartBusInfo; 3] =
+    map_uno_r4_uart_buses(board_vm_uno_r4::UNO_R4_WIFI_UART_BUSES);
 
 pub const ESP32_DIGITAL_PINS: [DigitalPinInfo; 30] =
     map_esp32_digital_pins(board_vm_esp32::ESP32_DEVKIT_V1_DIGITAL_PINS);
@@ -365,6 +381,35 @@ const fn map_uno_r4_spi_buses<const N: usize>(
     buses
 }
 
+const fn map_uno_r4_uart_buses<const N: usize>(
+    source: [board_vm_uno_r4::UartBusDescriptor; N],
+) -> [UartBusInfo; N] {
+    let mut buses = [UartBusInfo {
+        bus: 0,
+        name: "",
+        tx_pin: 0,
+        rx_pin: 0,
+        arduino_uart: 0,
+        internal: false,
+        notes: "",
+    }; N];
+    let mut index = 0;
+    while index < N {
+        let bus = source[index];
+        buses[index] = UartBusInfo {
+            bus: bus.bus,
+            name: bus.name,
+            tx_pin: bus.tx_pin,
+            rx_pin: bus.rx_pin,
+            arduino_uart: bus.arduino_uart,
+            internal: bus.internal,
+            notes: bus.notes,
+        };
+        index += 1;
+    }
+    buses
+}
+
 const fn map_esp32_digital_pins<const N: usize>(
     source: [board_vm_esp32::DigitalPinDescriptor; N],
 ) -> [DigitalPinInfo; N] {
@@ -444,6 +489,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         digital_pins: &UNO_R4_DIGITAL_PINS,
         i2c_buses: &UNO_R4_MINIMA_I2C_BUSES,
         spi_buses: &UNO_R4_SPI_BUSES,
+        uart_buses: &UNO_R4_MINIMA_UART_BUSES,
         wireless: &[],
         capabilities: &UNO_R4_MINIMA_CAPABILITIES,
     },
@@ -469,6 +515,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         digital_pins: &UNO_R4_DIGITAL_PINS,
         i2c_buses: &UNO_R4_WIFI_I2C_BUSES,
         spi_buses: &UNO_R4_SPI_BUSES,
+        uart_buses: &UNO_R4_WIFI_UART_BUSES,
         wireless: &UNO_R4_WIFI_WIRELESS,
         capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
@@ -491,6 +538,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         digital_pins: &ESP32_DIGITAL_PINS,
         i2c_buses: &[],
         spi_buses: &[],
+        uart_buses: &[],
         wireless: &ESP32_WIRELESS,
         capabilities: &ESP32_CAPABILITIES,
     },
@@ -516,6 +564,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         digital_pins: &PICO_DIGITAL_PINS,
         i2c_buses: &[],
         spi_buses: &[],
+        uart_buses: &[],
         wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
@@ -541,6 +590,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         digital_pins: &PICO_DIGITAL_PINS,
         i2c_buses: &[],
         spi_buses: &[],
+        uart_buses: &[],
         wireless: &PICO_W_WIRELESS,
         capabilities: &PICO_W_CAPABILITIES,
     },
@@ -630,6 +680,35 @@ mod tests {
         assert_eq!(uno.spi_buses[0].default_cs_pin, 10);
 
         assert!(find_target("esp32-devkit-v1").unwrap().spi_buses.is_empty());
+    }
+
+    #[test]
+    fn registry_exposes_uart_bus_metadata() {
+        let minima = find_target("arduino-uno-r4-minima").unwrap();
+        assert_eq!(minima.uart_buses.len(), 1);
+        assert_eq!(minima.uart_buses[0].name, "Serial1");
+        assert_eq!(minima.uart_buses[0].tx_pin, 1);
+        assert_eq!(minima.uart_buses[0].rx_pin, 0);
+        assert_eq!(minima.uart_buses[0].arduino_uart, 1);
+        assert!(!minima.uart_buses[0].internal);
+
+        let wifi = find_target("arduino-uno-r4-wifi").unwrap();
+        assert_eq!(wifi.uart_buses.len(), 3);
+        assert_eq!(wifi.uart_buses[0].name, "Serial1");
+        assert_eq!(wifi.uart_buses[0].tx_pin, 22);
+        assert_eq!(wifi.uart_buses[0].rx_pin, 23);
+        assert_eq!(wifi.uart_buses[1].name, "Serial2");
+        assert_eq!(wifi.uart_buses[1].tx_pin, 1);
+        assert_eq!(wifi.uart_buses[1].rx_pin, 0);
+        assert_eq!(wifi.uart_buses[2].name, "Serial3");
+        assert_eq!(wifi.uart_buses[2].tx_pin, 24);
+        assert_eq!(wifi.uart_buses[2].rx_pin, 25);
+        assert!(wifi.uart_buses[2].internal);
+
+        assert!(find_target("esp32-devkit-v1")
+            .unwrap()
+            .uart_buses
+            .is_empty());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -64,6 +64,7 @@ pub struct TargetDescriptor {
     pub digital_pins: &'static [DigitalPinDescriptor],
     pub i2c_buses: &'static [I2cBusDescriptor],
     pub spi_buses: &'static [SpiBusDescriptor],
+    pub uart_buses: &'static [UartBusDescriptor],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,6 +96,17 @@ pub struct SpiBusDescriptor {
     pub cipo_pin: u8,
     pub sck_pin: u8,
     pub default_cs_pin: u8,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UartBusDescriptor {
+    pub bus: u8,
+    pub name: &'static str,
+    pub tx_pin: u8,
+    pub rx_pin: u8,
+    pub arduino_uart: u8,
+    pub internal: bool,
     pub notes: &'static str,
 }
 
@@ -316,6 +328,53 @@ pub const UNO_R4_HEADER_SPI_BUS: SpiBusDescriptor = SpiBusDescriptor {
 
 pub const UNO_R4_SPI_BUSES: [SpiBusDescriptor; 1] = [UNO_R4_HEADER_SPI_BUS];
 
+pub const UNO_R4_MINIMA_HEADER_UART_BUS: UartBusDescriptor = UartBusDescriptor {
+    bus: 0,
+    name: "Serial1",
+    tx_pin: 1,
+    rx_pin: 0,
+    arduino_uart: 1,
+    internal: false,
+    notes: "Header UART on D1/TX0 and D0/RX0",
+};
+
+pub const UNO_R4_WIFI_D22_D23_UART_BUS: UartBusDescriptor = UartBusDescriptor {
+    bus: 0,
+    name: "Serial1",
+    tx_pin: 22,
+    rx_pin: 23,
+    arduino_uart: 1,
+    internal: false,
+    notes: "UNO R4 WiFi UART on D22/TX and D23/RX",
+};
+
+pub const UNO_R4_WIFI_HEADER_UART_BUS: UartBusDescriptor = UartBusDescriptor {
+    bus: 1,
+    name: "Serial2",
+    tx_pin: 1,
+    rx_pin: 0,
+    arduino_uart: 2,
+    internal: false,
+    notes: "Header UART on D1/TX0 and D0/RX0",
+};
+
+pub const UNO_R4_WIFI_MODULE_UART_BUS: UartBusDescriptor = UartBusDescriptor {
+    bus: 2,
+    name: "Serial3",
+    tx_pin: 24,
+    rx_pin: 25,
+    arduino_uart: 3,
+    internal: true,
+    notes: "UNO R4 WiFi module UART on D24/TX WIFI and D25/RX WIFI",
+};
+
+pub const UNO_R4_MINIMA_UART_BUSES: [UartBusDescriptor; 1] = [UNO_R4_MINIMA_HEADER_UART_BUS];
+pub const UNO_R4_WIFI_UART_BUSES: [UartBusDescriptor; 3] = [
+    UNO_R4_WIFI_D22_D23_UART_BUS,
+    UNO_R4_WIFI_HEADER_UART_BUS,
+    UNO_R4_WIFI_MODULE_UART_BUS,
+];
+
 pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     board_id: "arduino-uno-r4-minima",
     display_name: "Arduino Uno R4 Minima",
@@ -341,6 +400,7 @@ pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     digital_pins: &UNO_R4_DIGITAL_PINS,
     i2c_buses: &UNO_R4_MINIMA_I2C_BUSES,
     spi_buses: &UNO_R4_SPI_BUSES,
+    uart_buses: &UNO_R4_MINIMA_UART_BUSES,
 };
 
 pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
@@ -369,6 +429,7 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
     digital_pins: &UNO_R4_DIGITAL_PINS,
     i2c_buses: &UNO_R4_WIFI_I2C_BUSES,
     spi_buses: &UNO_R4_SPI_BUSES,
+    uart_buses: &UNO_R4_WIFI_UART_BUSES,
 };
 
 pub trait UnoR4Backend {
@@ -1083,6 +1144,24 @@ mod tests {
         assert_eq!(UNO_R4_WIFI.spi_buses[0].cipo_pin, 12);
         assert_eq!(UNO_R4_WIFI.spi_buses[0].sck_pin, 13);
         assert_eq!(UNO_R4_WIFI.spi_buses[0].default_cs_pin, 10);
+    }
+
+    #[test]
+    fn knows_uno_r4_uart_buses() {
+        assert_eq!(UNO_R4_MINIMA.uart_buses, &[UNO_R4_MINIMA_HEADER_UART_BUS]);
+        assert_eq!(UNO_R4_WIFI.uart_buses.len(), 3);
+        assert_eq!(UNO_R4_WIFI.uart_buses[0].name, "Serial1");
+        assert_eq!(UNO_R4_WIFI.uart_buses[0].tx_pin, 22);
+        assert_eq!(UNO_R4_WIFI.uart_buses[0].rx_pin, 23);
+        assert_eq!(UNO_R4_WIFI.uart_buses[0].arduino_uart, 1);
+        assert!(!UNO_R4_WIFI.uart_buses[0].internal);
+        assert_eq!(UNO_R4_WIFI.uart_buses[1].name, "Serial2");
+        assert_eq!(UNO_R4_WIFI.uart_buses[1].tx_pin, 1);
+        assert_eq!(UNO_R4_WIFI.uart_buses[1].rx_pin, 0);
+        assert_eq!(UNO_R4_WIFI.uart_buses[2].name, "Serial3");
+        assert_eq!(UNO_R4_WIFI.uart_buses[2].tx_pin, 24);
+        assert_eq!(UNO_R4_WIFI.uart_buses[2].rx_pin, 25);
+        assert!(UNO_R4_WIFI.uart_buses[2].internal);
     }
 
     #[test]

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -31,7 +31,7 @@ Source snapshot:
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
 | I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, byte-buffer write/read, and write-read transfer implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, `i2c.read`, `i2c.transfer` |
 | SPI master | COPI D11, CIPO D12, SCK D13, conventional CS D10 | bus metadata, handle open, bounded write-then-read transfer, and transfer-backed read/write SDK commands implemented | `spi.open`, `spi.transfer`; SDK `spi.write`/`spi.read` lower to transfer |
-| Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | partially transport-only | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
+| Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | descriptor metadata implemented; VM open/read/write pending | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
 | RTC | one RTC instance in the core | pending | `rtc.now`, `rtc.set`, alarms/events later |
 | EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | pending | `program.store` and possibly `kv.store` |
@@ -77,7 +77,9 @@ reject conflicting handles.
    `spi.write` and `spi.read` wrappers covering write-only and read-only SPI
    cases without adding duplicate VM opcodes.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
-   capabilities in separate tranches with conformance tests.
+   capabilities in separate tranches with conformance tests. UART now has
+   descriptor metadata for Minima `Serial1` and WiFi `Serial1`/`Serial2`/
+   `Serial3`, so the next UART tranche can focus on handles and byte I/O.
 
 Every tranche should include the same layers: spec entry, IR capability id,
 runtime HAL method, UNO R4 target descriptor, firmware backend, host builder,


### PR DESCRIPTION
Summary
- Add Rust-owned UART bus descriptors for UNO R4 Minima and WiFi targets.
- Surface UART metadata through board-vm-targets, language-core, Ruby native, and Python native wrappers.
- Update BVM07 to mark UART descriptor metadata implemented while VM UART operations remain pending.

Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-uno-r4-uart-metadata cargo fmt -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-uno-r4-uart-metadata cargo test -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core
- bundle exec ruby -c lib/coding_adventures/board_vm/session.rb
- bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb
- bundle exec rake test
- bash BUILD in code/packages/python/board-vm-native
- bash BUILD in code/packages/lua/board_vm_native
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check