### PR TITLE
python(spice): parse MOSFET model netlists

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.6
+
+- Parse `.model <name> NMOS(...)` and `.model <name> PMOS(...)` cards into
+  `mosfet_models.MOSFET` Level-1 wrappers.
+- Parse `M` MOSFET elements into `spice_engine.Mosfet` instances, including
+  per-instance Level-1 parameter overrides such as `W=...` and `L=...`.
+- Remap MOSFET drain/gate/source/body terminals during `.subckt` expansion.
+
 ## 0.1.5
 
 - Parse `.model <name> NPN(...)` and `.model <name> PNP(...)` cards into

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -18,8 +18,10 @@ netlist.circuit.elements
 netlist.analyses
 ```
 
-This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `G`, `E`, `F`,
-and `H` elements, `.model` cards for Shockley diode parameters (`IS`, `VT`) and
-BJT parameters (`NPN`/`PNP`, `IS`, `BF`/`BETA_F`, `VT`), SPICE engineering
-suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X`
-instance expansion, and `.op`, `.tran`, `.dc`, and `.ac` analysis cards.
+This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`,
+`F`, and `H` elements, `.model` cards for Shockley diode parameters (`IS`,
+`VT`), BJT parameters (`NPN`/`PNP`, `IS`, `BF`/`BETA_F`, `VT`), and Level-1
+MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
+`W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`), SPICE engineering suffixes,
+PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
+expansion, and `.op`, `.tran`, `.dc`, and `.ac` analysis cards.

--- a/code/packages/python/spice-netlist-parser/pyproject.toml
+++ b/code/packages/python/spice-netlist-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-netlist-parser"
-version = "0.1.5"
+version = "0.1.6"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 requires-python = ">=3.12"
 license = "MIT"
@@ -12,6 +12,7 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["spice", "netlist", "parser", "circuits", "education"]
 dependencies = [
+    "coding-adventures-mosfet-models",
     "coding-adventures-spice-engine",
 ]
 classifiers = [

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -12,7 +12,7 @@ from spice_netlist_parser.parser import (
 )
 
 parse = parse_netlist
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 __all__ = [
     "AcAnalysis",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from dataclasses import fields as dataclass_fields
 
+from mosfet_models import MOSFET, Level1Model, Level1Params, MosfetType
 from spice_engine import (
     BJT,
     CCCS,
@@ -17,6 +19,7 @@ from spice_engine import (
     Diode,
     ExpWaveform,
     Inductor,
+    Mosfet,
     PulseWaveform,
     PwlWaveform,
     Resistor,
@@ -278,6 +281,24 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             beta_f=model.params.get("BETA_F", model.params.get("BF", 100.0)),
             Vt=model.params.get("VT", 0.02585),
         )
+    if prefix == "M":
+        _require_min_fields(fields, 6, "MOSFET")
+        model = models.get(fields[5].lower())
+        if model is None:
+            raise NetlistParseError(f"unknown model {fields[5]!r} for MOSFET {name!r}")
+        if model.kind not in {"NMOS", "PMOS"}:
+            raise NetlistParseError(
+                f"model {model.name!r} has kind {model.kind!r}, expected 'NMOS' or 'PMOS'"
+            )
+        instance_params = _parse_element_params(fields[6:], "MOSFET")
+        return Mosfet(
+            name,
+            fields[1],
+            fields[2],
+            fields[3],
+            fields[4],
+            _build_mosfet_model(model, instance_params),
+        )
     if prefix == "G":
         _require_fields(fields, 6, "VCCS")
         return VCCS(name, fields[1], fields[2], fields[3], fields[4], parse_value(fields[5]))
@@ -370,6 +391,10 @@ def _map_subckt_fields(
         mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
         mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)
         mapped[3] = _map_subckt_node(fields[3], instance_name, node_map)
+    elif prefix == "M":
+        _require_min_fields(fields, 5, "subcircuit MOSFET")
+        for index in range(1, 5):
+            mapped[index] = _map_subckt_node(fields[index], instance_name, node_map)
     elif prefix in {"E", "G"}:
         _require_min_fields(fields, 5, "subcircuit controlled source")
         for index in range(1, 5):
@@ -528,6 +553,45 @@ def _parse_model_params(params_text: str) -> dict[str, float]:
     if params_text[cursor:].strip(" \t,"):
         raise NetlistParseError(f"invalid .model parameter syntax {params_text!r}")
     return params
+
+
+def _parse_element_params(tokens: list[str], label: str) -> dict[str, float]:
+    params: dict[str, float] = {}
+    for token in tokens:
+        if "=" not in token:
+            raise NetlistParseError(f"invalid {label} parameter syntax {token!r}")
+        name, value = token.split("=", 1)
+        if not name or not value:
+            raise NetlistParseError(f"invalid {label} parameter syntax {token!r}")
+        params[name.upper()] = parse_value(value)
+    return params
+
+
+_LEVEL1_PARAM_ALIASES = {
+    "NSUB": "N_SUB",
+    "N": "N_SUB",
+    "TNOM": "T_NOM",
+    "TOX": "T_OX",
+    "VTO": "VT0",
+}
+
+
+def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> MOSFET:
+    params = {**model.params, **instance_params}
+    defaults = Level1Params()
+    values = {
+        field.name: getattr(defaults, field.name)
+        for field in dataclass_fields(Level1Params)
+        if field.init
+    }
+    for name, value in params.items():
+        param_name = _LEVEL1_PARAM_ALIASES.get(name, name)
+        if param_name in values and not isinstance(values[param_name], bool):
+            values[param_name] = value
+    return MOSFET(
+        type=MosfetType[model.kind],
+        model=Level1Model(Level1Params(**values)),
+    )
 
 
 def _split_fields(line: str) -> list[str]:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1,6 +1,7 @@
 from math import isclose
 
 import pytest
+from mosfet_models import Level1Model, MosfetType
 from spice_engine import (
     BJT,
     CCCS,
@@ -11,6 +12,7 @@ from spice_engine import (
     CurrentSource,
     Diode,
     Inductor,
+    Mosfet,
     Resistor,
     VoltageSource,
     dc_op,
@@ -214,6 +216,60 @@ Qp col base emit slow
     assert isclose(bjt.Vt, 26.0e-3)
 
 
+def test_parse_mosfet_model_into_operating_point_circuit() -> None:
+    parsed = parse_netlist(
+        """
+.model nfast NMOS(VT0=0.45 KP=200u LAMBDA=0.02)
+Vdd vdd 0 DC 1.8
+Vgate gate 0 DC 1.8
+Rload vdd out 1k
+M1 out gate 0 0 nfast W=2u L=180n
+.op
+"""
+    )
+
+    assert parsed.models["nfast"].name == "nfast"
+    assert parsed.models["nfast"].kind == "NMOS"
+    assert parsed.models["nfast"].params["VT0"] == 0.45
+    assert isclose(parsed.models["nfast"].params["KP"], 200.0e-6)
+    assert parsed.models["nfast"].params["LAMBDA"] == 0.02
+    mosfet = parsed.circuit.elements[3]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.drain == "out"
+    assert mosfet.gate == "gate"
+    assert mosfet.source == "0"
+    assert mosfet.body == "0"
+    assert mosfet.model.type == MosfetType.NMOS
+    assert isinstance(mosfet.model.model, Level1Model)
+    assert mosfet.model.model.params.VT0 == 0.45
+    assert isclose(mosfet.model.model.params.KP, 200.0e-6)
+    assert isclose(mosfet.model.model.params.W, 2.0e-6)
+    assert isclose(mosfet.model.model.params.L, 180.0e-9)
+
+    result = dc_op(parsed.circuit)
+    assert result.converged
+    assert 0.0 <= result.node_voltages["out"] < 1.8
+
+
+def test_parse_pmos_mosfet_model() -> None:
+    parsed = parse_netlist(
+        """
+.model pfast PMOS(VTO=0.4 KP=120u NSUB=1.2)
+Mp out gate vdd vdd pfast W=3u L=250n
+"""
+    )
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.type == MosfetType.PMOS
+    assert isinstance(mosfet.model.model, Level1Model)
+    assert mosfet.model.model.params.VT0 == 0.4
+    assert isclose(mosfet.model.model.params.KP, 120.0e-6)
+    assert mosfet.model.model.params.N_SUB == 1.2
+    assert isclose(mosfet.model.model.params.W, 3.0e-6)
+    assert isclose(mosfet.model.model.params.L, 250.0e-9)
+
+
 def test_parse_pwl_and_sin_source_waveforms() -> None:
     parsed = parse_netlist(
         """
@@ -395,6 +451,31 @@ Xbuf out in 0 follower
     assert resistor.n_minus == "0"
 
 
+def test_expands_subcircuit_mosfet_nodes_into_engine_elements() -> None:
+    parsed = parse_netlist(
+        """
+.model nfast NMOS(W=1u L=130n)
+.subckt pulldown in out vss
+Mpull out in inner vss nfast
+Rtail inner vss 10
+.ends pulldown
+Xpd gate drain 0 pulldown
+"""
+    )
+
+    mosfet = parsed.circuit.elements[0]
+    resistor = parsed.circuit.elements[1]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.name == "Xpd.Mpull"
+    assert mosfet.drain == "drain"
+    assert mosfet.gate == "gate"
+    assert mosfet.source == "Xpd.inner"
+    assert mosfet.body == "0"
+    assert isinstance(resistor, Resistor)
+    assert resistor.n_plus == "Xpd.inner"
+    assert resistor.n_minus == "0"
+
+
 def test_subcircuit_internal_nodes_are_instance_scoped() -> None:
     parsed = parse_netlist(
         """
@@ -465,6 +546,38 @@ def test_rejects_bjt_bound_to_non_bjt_model() -> None:
             """
 .model clamp D(IS=1e-15)
 Q1 c b e clamp
+"""
+        )
+
+
+def test_rejects_mosfet_with_unknown_model() -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="line 2: unknown model 'missing' for MOSFET 'M1'",
+    ):
+        parse_netlist(
+            """
+M1 d g s b missing
+"""
+        )
+
+
+def test_rejects_mosfet_bound_to_non_mosfet_model() -> None:
+    with pytest.raises(NetlistParseError, match="line 3: model 'clamp' has kind 'D'"):
+        parse_netlist(
+            """
+.model clamp D(IS=1e-15)
+M1 d g s b clamp
+"""
+        )
+
+
+def test_rejects_mosfet_parameter_without_assignment() -> None:
+    with pytest.raises(NetlistParseError, match="line 3: invalid MOSFET parameter syntax 'W'"):
+        parse_netlist(
+            """
+.model nfast NMOS
+M1 d g s b nfast W
 """
         )
 


### PR DESCRIPTION
## Summary

- add Python SPICE netlist parsing for `M` MOSFET elements backed by `mosfet_models` Level-1 NMOS/PMOS wrappers
- support model-card and per-instance Level-1 parameters such as `VT0`/`VTO`, `KP`, `W`, and `L`
- remap MOSFET drain/gate/source/body terminals during `.subckt` expansion

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-spice-netlist-mosfet-model PYTHONPATH=code/packages/python/spice-netlist-parser/src:code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src python -m pytest code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-spice-netlist-mosfet-model PYTHONPATH=code/packages/python/spice-netlist-parser/src:code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src python -m ruff check code/packages/python/spice-netlist-parser`
- `git diff --check`