### PR TITLE
feat(forme-types): Forme kernel type vocabulary (FM01 §2)

### DIFF
--- a/code/packages/typescript/forme-types/BUILD
+++ b/code/packages/typescript/forme-types/BUILD
@@ -1,0 +1,2 @@
+cd ../document-ast && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-types/CHANGELOG.md
+++ b/code/packages/typescript/forme-types/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog — @coding-adventures/forme-types
+
+## 0.1.0 — 2026-05-14
+
+Initial release. Implements the FM01 §2 kernel types.
+
+### Added
+
+- `KERNEL_API_VERSION = 1` — the kernel-API stability marker.
+- `KINDS` tuple and `KindName` union covering all 13 built-in kind names.
+- `KindDescriptor` interface — the runtime type tag for a kind.
+- `Kinds` canonical descriptor object (one per built-in non-Stream kind).
+- `streamOf(inner)` and `isStreamDescriptor(d)` — Stream meta-kind helpers.
+- `JsonValue`, `ReadonlyRecord` utility type aliases.
+- `LogicalId`, `RevisionId` branded type aliases.
+- TypeScript interfaces for all 12 built-in kind shapes:
+  `ContentSource`, `ContentNode`, `Collection`, `Asset`, `Document`,
+  `RenderedPage`, `PrintForme`, `RequestHandler`, `SearchIndex`,
+  `Feed`, `DeployArtifact`, `Stream<T>`.
+- Stub `StyleDocument` and `Interactivity` interfaces (FM04 / FM05 will
+  replace these without breaking field names).
+- `EMPTY_STYLE` and `EMPTY_INTERACTIVITY` sentinel constants.
+- `KindPayload<K>` mapped type and augmentable `KindPayloadMap` interface.
+
+### Spec divergences from FM01
+
+- **Stream descriptors** use a closed-shape `{ name: "Stream", inner: K, version: "1.0" }`
+  via the `streamOf()` helper instead of FM01's sketched
+  `{ ...Kinds.X, kind: "Stream" }` (which adds a `kind` field outside
+  the `KindDescriptor` interface). Cleaner, equivalent expressively.
+- **`RevisionId`** uses `blake2b:<hex>` (the monorepo's existing
+  from-scratch hash) instead of FM01's `blake3:<hex>`. The `<algo>:`
+  prefix keeps the format forward-compatible.

--- a/code/packages/typescript/forme-types/README.md
+++ b/code/packages/typescript/forme-types/README.md
@@ -1,0 +1,84 @@
+# @coding-adventures/forme-types
+
+The Forme kernel's shared TypeScript type vocabulary — Kinds, KindDescriptors, branded identity types, and JSON utilities.
+
+This is the leaf of the Forme dependency graph: every other Forme package imports from here. It contains **types and constants only**. There is no I/O, no runtime side-effects, no implementation logic. The matching implementations (identity hashing, capability parsing, the Stage interface) live in sibling packages.
+
+See [code/specs/FM01-forme-kernel.md](../../../specs/FM01-forme-kernel.md) §2 for the full design.
+
+## What's in here
+
+| Module        | Purpose                                                                  |
+| ------------- | ------------------------------------------------------------------------ |
+| `utility.ts`  | `JsonValue`, `ReadonlyRecord`                                            |
+| `identity.ts` | `LogicalId`, `RevisionId` branded type aliases                           |
+| `kinds.ts`    | `KIND` constants, `KindDescriptor`, canonical `Kinds` object, `streamOf` |
+| `shapes.ts`   | TypeScript interfaces for all 12 built-in kinds + stub style/interactivity |
+| `payload.ts`  | `KindPayload<K>` mapped type — descriptor → value type                    |
+
+## Quick reference
+
+### The 12 built-in Kinds
+
+```
+Void                  → no payload (source-stage input, sink-stage output)
+ContentSource         → raw bytes + metadata from a storage adapter
+ContentNode           → parsed document (DocumentNode + frontmatter + identity)
+Collection            → ordered set of content references with grouping discriminant
+Asset                 → image / video / font / binary with metadata
+Document              → (content, style, interactivity) triple ready to render
+RenderedPage          → HTML + metadata for a web page
+PrintForme            → backend-neutral page for LaTeX / PDF / EPUB
+RequestHandler        → per-request handler (Workers, Node, Deno, Bun)
+SearchIndex           → serialised search index
+Feed                  → RSS / Atom / JSON Feed / sitemap
+DeployArtifact        → final shippable bundle
+Stream<K>             → meta-kind wrapping a kind for streaming
+```
+
+### Defining a stage's I/O
+
+```typescript
+import { Kinds, streamOf } from "@coding-adventures/forme-types";
+
+// A source: takes nothing, produces a stream of ContentSources.
+const source = {
+  consumes: Kinds.Void,
+  produces: streamOf(Kinds.ContentSource),
+  // ...
+};
+
+// A parser: takes one ContentSource, produces one ContentNode.
+const parser = {
+  consumes: Kinds.ContentSource,
+  produces: Kinds.ContentNode,
+  // ...
+};
+```
+
+### Branded ID types
+
+```typescript
+import type { LogicalId, RevisionId } from "@coding-adventures/forme-types";
+
+const id  = "01952c0d-7e63-7000-8000-000000000000" as LogicalId;
+const rev = "blake2b:abc123..." as RevisionId;
+```
+
+The implementations of `computeRevisionId`, `canonicalJson`, etc. live in `@coding-adventures/forme-identity`. This package only declares the types so any package that *carries* an ID can use it without depending on the hashing code.
+
+## Spec divergences (v0)
+
+These deliberate differences from FM01 are documented here so future readers can find them:
+
+1. **`Stream` descriptors.** FM01 §3.6 sketches `{ ...Kinds.X, kind: "Stream" }` which adds an unrelated `kind` field to a `KindDescriptor`. We use `streamOf(K)` producing `{ name: "Stream", version: "1.0", inner: K }` — a closed-shape descriptor with a dedicated `inner` field. See [src/kinds.ts](src/kinds.ts) header.
+2. **`RevisionId` algorithm.** FM01 §7 specifies `blake3:<hex>`. The monorepo currently has a from-scratch BLAKE2b but no BLAKE3. v0 uses `blake2b:<hex>`; the format is forward-compatible (the `<algo>:` prefix tells consumers what was used).
+
+## Coverage
+
+```bash
+npm install
+npx vitest run --coverage
+```
+
+Lines and branches >95% (most of the package is types — non-executable — but the const values, helpers, and public exports are exercised).

--- a/code/packages/typescript/forme-types/package-lock.json
+++ b/code/packages/typescript/forme-types/package-lock.json
@@ -1,0 +1,2317 @@
+{
+  "name": "@coding-adventures/forme-types",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-types",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../document-ast": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/document-ast": {
+      "resolved": "../document-ast",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-types/package.json
+++ b/code/packages/typescript/forme-types/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@coding-adventures/forme-types",
+  "version": "0.1.0",
+  "description": "Forme kernel: shared TypeScript types — Kinds, KindDescriptors, branded identity types, JSON utilities. The type system every Forme stage speaks (FM01 §2).",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/document-ast": "file:../document-ast"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-types/required_capabilities.json
+++ b/code/packages/typescript/forme-types/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-types",
+  "capabilities": [],
+  "justification": "Pure types and constant declarations. No runtime side effects, no I/O, no environment access."
+}

--- a/code/packages/typescript/forme-types/src/identity.ts
+++ b/code/packages/typescript/forme-types/src/identity.ts
@@ -1,0 +1,51 @@
+/**
+ * Identity types — the two stable identifiers every piece of Forme content
+ * carries.  See FM01 §7 for the full theory; the short version is below.
+ *
+ * === Two distinct IDs ===
+ *
+ * - LogicalId  — identifies a *thing over time*.  "This particular post,"
+ *                "this author."  Stable across content edits and file
+ *                renames.  Encoded as a UUIDv7 string.
+ *
+ * - RevisionId — identifies *a specific version of a thing*.  Changes
+ *                whenever the canonical serialisation changes.  Two
+ *                entities with the same RevisionId are byte-identical.
+ *                Encoded as `<algo>:<hex>` (algo is `blake2b` in the v0
+ *                implementation; FM01 originally specified `blake3` and
+ *                we will migrate when a from-scratch BLAKE3 lands in the
+ *                monorepo — the format is forward-compatible).
+ *
+ * === Why brand the strings? ===
+ *
+ * Both IDs are strings at runtime.  Without TypeScript brands, a function
+ * expecting `LogicalId` would silently accept any string — including a
+ * RevisionId, a file path, or `""`.  Branding turns these mistakes into
+ * compile errors at the API boundary while costing nothing at runtime.
+ *
+ * The actual *value-producing* functions — `computeRevisionId`,
+ * `canonicalJson`, UUIDv7 generation — live in `@coding-adventures/forme-identity`.
+ * `forme-types` only declares the type aliases so every package that
+ * carries an ID can import them without depending on the hashing code.
+ *
+ * === Cross-package usage ===
+ *
+ *   import type { LogicalId, RevisionId } from "@coding-adventures/forme-types";
+ *   import { computeRevisionId } from "@coding-adventures/forme-identity";
+ *
+ *   const rev: RevisionId = computeRevisionId(payload);
+ */
+
+/**
+ * Stable logical identity.  A UUIDv7 string, branded.  Assigned to an
+ * entity the first time a source observes it; preserved across renames
+ * and content edits.
+ */
+export type LogicalId = string & { readonly __brand: "LogicalId" };
+
+/**
+ * Content-addressed revision identity.  A `<algo>:<hex>` string, branded.
+ * Two entities with the same RevisionId are byte-identical under the
+ * canonical-JSON encoding (FM01 §7.3).
+ */
+export type RevisionId = string & { readonly __brand: "RevisionId" };

--- a/code/packages/typescript/forme-types/src/index.ts
+++ b/code/packages/typescript/forme-types/src/index.ts
@@ -1,0 +1,86 @@
+/**
+ * @coding-adventures/forme-types
+ *
+ * The Forme kernel's shared type vocabulary — Kinds, KindDescriptors,
+ * branded identity types, and JSON utilities.  Every other Forme
+ * package imports from here.
+ *
+ * This package is types and constants only.  No I/O, no runtime side
+ * effects, no dependencies beyond `@coding-adventures/document-ast`
+ * (which supplies `DocumentNode`, the Content IR root).  The
+ * implementations of identity hashing live in `forme-identity`; the
+ * stage interface lives in `forme-stage`; etc.
+ *
+ * See FM01 §2 for the full design.  See the per-module headers for
+ * the rationale behind each type group:
+ *
+ *   utility.ts  — JsonValue, ReadonlyRecord
+ *   identity.ts — LogicalId, RevisionId branded aliases
+ *   kinds.ts    — KIND name set, KindDescriptor, canonical Kinds object,
+ *                 Stream helpers, KERNEL_API_VERSION
+ *   shapes.ts   — Each kind's TypeScript interface (12 kernel kinds)
+ *                 plus stub StyleDocument / Interactivity that FM04 / FM05
+ *                 will replace.
+ *   payload.ts  — KindPayload mapped type that infers the value type
+ *                 for a stage's `In` and `Out` from its descriptors.
+ */
+
+export type { JsonValue, ReadonlyRecord } from "./utility.js";
+
+export type { LogicalId, RevisionId } from "./identity.js";
+
+export {
+  KERNEL_API_VERSION,
+  KINDS,
+  Kinds,
+  streamOf,
+  isStreamDescriptor,
+} from "./kinds.js";
+export type {
+  KernelApiVersion,
+  BuiltinKindName,
+  KindName,
+  KindDescriptor,
+} from "./kinds.js";
+
+export {
+  EMPTY_STYLE,
+  EMPTY_INTERACTIVITY,
+} from "./shapes.js";
+export type {
+  AssetRole,
+  AssetRef,
+  ContentSource,
+  ContentNode,
+  OrderKey,
+  CollectionEntry,
+  Collection,
+  Asset,
+  StyleDocument,
+  Interactivity,
+  Document,
+  StyleRuleId,
+  IslandId,
+  PageMeta,
+  RenderedPage,
+  Length,
+  Margins,
+  PageSizeName,
+  PageSize,
+  PageSettings,
+  RunningElement,
+  PrintForme,
+  RuntimeRequirement,
+  RequestHandler,
+  SearchIndex,
+  FeedFormat,
+  Feed,
+  DeployVariant,
+  DeployRoute,
+  DeployAssetEntry,
+  DeployManifest,
+  DeployArtifact,
+  Stream,
+} from "./shapes.js";
+
+export type { KindPayloadMap, KindPayload } from "./payload.js";

--- a/code/packages/typescript/forme-types/src/kinds.ts
+++ b/code/packages/typescript/forme-types/src/kinds.ts
@@ -1,0 +1,196 @@
+/**
+ * Kinds — the runtime-visible type system of the Forme pipeline.
+ *
+ * A "Kind" is the discriminator for a unit of data flowing through a
+ * pipeline.  Every edge between two stages is typed by a Kind, and every
+ * stage declares the Kinds it consumes and produces.  See FM01 §2 for
+ * the full design.
+ *
+ * Kinds exist in two parallel layers:
+ *
+ *   1. At compile time — as the TypeScript interfaces declared in
+ *      `shapes.ts`.  The compiler enforces that wired stages have
+ *      compatible I/O when stages are composed in pure TypeScript.
+ *
+ *   2. At runtime — as the `KindDescriptor` value declared in this file.
+ *      The orchestrator reads descriptors when building a DAG from
+ *      configuration the compiler never sees (TOML, plugin manifests).
+ *
+ * Two layers exist because TypeScript types are erased at runtime.
+ *
+ * === Stream descriptors — note on spec divergence ===
+ *
+ * FM01 §3.6 sketches stream descriptors with the syntax
+ * `{ ...Kinds.X, kind: "Stream" }`, which adds an unrelated `kind`
+ * field to a `KindDescriptor`.  We instead use the `Stream` KindName
+ * with an `inner` field on the descriptor itself, produced by the
+ * `streamOf()` helper:
+ *
+ *   streamOf(Kinds.ContentSource)
+ *     === { name: "Stream", version: "1.0", inner: Kinds.ContentSource }
+ *
+ * This keeps `KindDescriptor` a single closed shape and makes "is this a
+ * stream?" a clean `descriptor.name === "Stream"` check.  The Stream
+ * *value* type (the AsyncIterable wrapper passed at runtime) is unchanged.
+ */
+
+import type { JsonValue, ReadonlyRecord } from "./utility.js";
+
+// ─── API version ──────────────────────────────────────────────────────────
+
+/**
+ * The version of the kernel API surface.  Stages declare the version they
+ * target; the host refuses to load stages targeting a different version.
+ *
+ * Bump this only on source-breaking changes to the kernel contracts.
+ * Adding optional fields, growing a union in a backward-compatible way,
+ * adding a new Kind that defaults gracefully — none of these bump the
+ * API version.
+ *
+ * Initial value: 1.
+ */
+export const KERNEL_API_VERSION = 1 as const;
+
+export type KernelApiVersion = typeof KERNEL_API_VERSION;
+
+// ─── Kind names ───────────────────────────────────────────────────────────
+
+/**
+ * The closed set of built-in Kind names.  Plugins extend this through
+ * `ext:<name>` strings (FM01 §2.5); kernel-level kinds cannot be
+ * overridden.
+ *
+ * `Void` is the special name for "no payload" — used as the input of
+ * source stages and the output of sink stages.
+ *
+ * `Stream` is the meta-kind that wraps another kind to represent a lazy
+ * stream of values; see `streamOf`.
+ */
+export const KINDS = Object.freeze([
+  "Void",
+  "ContentSource",
+  "ContentNode",
+  "Collection",
+  "Asset",
+  "Document",
+  "RenderedPage",
+  "PrintForme",
+  "RequestHandler",
+  "SearchIndex",
+  "Feed",
+  "DeployArtifact",
+  "Stream",
+] as const);
+
+/** A built-in Kind name. */
+export type BuiltinKindName = (typeof KINDS)[number];
+
+/**
+ * A Kind name — either built-in or a plugin-contributed `ext:` name.
+ * Plugin-contributed names live in their own namespace and are
+ * registered with the host at manifest-load time.
+ */
+export type KindName = BuiltinKindName | `ext:${string}`;
+
+// ─── Kind descriptors ─────────────────────────────────────────────────────
+
+/**
+ * The runtime type tag for a kind.  Carried by every stage's `consumes`
+ * and `produces` declaration; the orchestrator reads these to verify
+ * compatibility before the pipeline starts.
+ *
+ * Compatibility rules — see FM01 §2.6 and the `forme-orchestrator`
+ * implementation:
+ *
+ *   1. Name match or registered subtype.
+ *   2. Major-version match; minor versions are forward-compatible.
+ *   3. Discriminant equality if both sides declare one.
+ *   4. Constraint satisfaction (best-effort; unknown keys warn).
+ */
+export interface KindDescriptor {
+  /** The Kind name.  Built-in or `ext:`-prefixed. */
+  readonly name: KindName;
+
+  /** Semver-compatible version of the kind's shape. */
+  readonly version: string;
+
+  /**
+   * Optional polymorphism discriminant.  When two stages both declare a
+   * discriminant, they must be equal for the edge to type-check.  Used
+   * by polymorphic kinds like `Feed` (rss vs atom vs sitemap) when a
+   * downstream stage cares about the variant.
+   */
+  readonly discriminant?: string;
+
+  /**
+   * Open-ended constraint vocabulary.  A producer documents what it
+   * guarantees ("mimeType starts with text/markdown"); a consumer
+   * documents what it requires.  The orchestrator does best-effort
+   * structural matching and warns rather than errors on unknown keys —
+   * stages can declare custom constraints without teaching the
+   * orchestrator about them.
+   */
+  readonly constraints?: ReadonlyRecord<string, JsonValue>;
+
+  /**
+   * For descriptors with `name === "Stream"`, the inner kind being
+   * streamed.  Absent for non-stream descriptors.
+   */
+  readonly inner?: KindDescriptor;
+}
+
+// ─── Canonical descriptors ────────────────────────────────────────────────
+
+/**
+ * The canonical descriptor for each built-in kind.  Stages reference
+ * these directly:
+ *
+ *   defineStage({
+ *     consumes: Kinds.ContentSource,
+ *     produces: Kinds.ContentNode,
+ *     ...
+ *   });
+ *
+ * Initial version is "1.0" for every kernel kind.  When a kind's shape
+ * grows, bump the minor; when it breaks compatibility, bump the major
+ * AND the kernel API version.
+ */
+export const Kinds = Object.freeze({
+  Void:           Object.freeze({ name: "Void",           version: "1.0" }),
+  ContentSource:  Object.freeze({ name: "ContentSource",  version: "1.0" }),
+  ContentNode:    Object.freeze({ name: "ContentNode",    version: "1.0" }),
+  Collection:     Object.freeze({ name: "Collection",     version: "1.0" }),
+  Asset:          Object.freeze({ name: "Asset",          version: "1.0" }),
+  Document:       Object.freeze({ name: "Document",       version: "1.0" }),
+  RenderedPage:   Object.freeze({ name: "RenderedPage",   version: "1.0" }),
+  PrintForme:     Object.freeze({ name: "PrintForme",     version: "1.0" }),
+  RequestHandler: Object.freeze({ name: "RequestHandler", version: "1.0" }),
+  SearchIndex:    Object.freeze({ name: "SearchIndex",    version: "1.0" }),
+  Feed:           Object.freeze({ name: "Feed",           version: "1.0" }),
+  DeployArtifact: Object.freeze({ name: "DeployArtifact", version: "1.0" }),
+} as const) satisfies Record<Exclude<BuiltinKindName, "Stream">, KindDescriptor>;
+
+// ─── Stream helpers ───────────────────────────────────────────────────────
+
+/**
+ * Produce a `Stream<K>` descriptor wrapping the given inner descriptor.
+ *
+ * Example:
+ *
+ *   const sourceProduces = streamOf(Kinds.ContentSource);
+ *   //  → { name: "Stream", version: "1.0", inner: Kinds.ContentSource }
+ *
+ * Equivalent to writing the descriptor by hand; the helper exists so
+ * stage definitions stay short and readable.
+ */
+export function streamOf(inner: KindDescriptor): KindDescriptor {
+  return { name: "Stream", version: "1.0", inner };
+}
+
+/**
+ * Predicate: is this descriptor a stream wrapper?  When true,
+ * `descriptor.inner` is set to the wrapped descriptor.
+ */
+export function isStreamDescriptor(d: KindDescriptor): boolean {
+  return d.name === "Stream";
+}

--- a/code/packages/typescript/forme-types/src/payload.ts
+++ b/code/packages/typescript/forme-types/src/payload.ts
@@ -1,0 +1,78 @@
+/**
+ * KindPayload — map a runtime KindDescriptor to its compile-time
+ * TypeScript value type.
+ *
+ * Stages are parameterised by `Stage<In, Out>` where `In` and `Out`
+ * are KindDescriptor values (runtime objects).  TypeScript infers the
+ * concrete value type the stage's `run` method should accept and return
+ * by looking up the descriptor's `name` in `KindPayloadMap`.
+ *
+ * Example:
+ *
+ *   type T1 = KindPayload<typeof Kinds.ContentSource>; // → ContentSource
+ *   type T2 = KindPayload<typeof Kinds.Void>;          // → void
+ *
+ * For Stream descriptors built with `streamOf(inner)`, the payload is
+ * `AsyncIterable<KindPayload<inner>>` — the consumer iterates lazily.
+ *
+ * Plugin-contributed `ext:*` kinds resolve to `unknown` — they need
+ * their own type augmentation to be statically typed.  Augmentation
+ * pattern:
+ *
+ *   declare module "@coding-adventures/forme-types" {
+ *     interface KindPayloadMap {
+ *       "ext:my-kind": MyKindShape;
+ *     }
+ *   }
+ *
+ * Augmentation is *additive* — declaring `KindPayloadMap` in a plugin
+ * only adds new keys; existing keys keep their kernel-defined types.
+ */
+
+import type {
+  Asset, Collection, ContentNode, ContentSource,
+  DeployArtifact, Document, Feed,
+  PrintForme, RenderedPage, RequestHandler, SearchIndex,
+} from "./shapes.js";
+import type { KindDescriptor } from "./kinds.js";
+
+/**
+ * The mapping from kind name (string) to its TypeScript payload type.
+ * Declared as an `interface` (not `type`) so plugins can augment it.
+ */
+export interface KindPayloadMap {
+  Void:           void;
+  ContentSource:  ContentSource;
+  ContentNode:    ContentNode;
+  Collection:     Collection;
+  Asset:          Asset;
+  Document:       Document;
+  RenderedPage:   RenderedPage;
+  PrintForme:     PrintForme;
+  RequestHandler: RequestHandler;
+  SearchIndex:    SearchIndex;
+  Feed:           Feed;
+  DeployArtifact: DeployArtifact;
+}
+
+/**
+ * Compile-time mapping from a `KindDescriptor` to its TypeScript
+ * payload type.  Stream descriptors resolve to AsyncIterable wrappers;
+ * unknown / `ext:*` names resolve to `unknown` (must be narrowed by
+ * the consumer or made known via module augmentation).
+ *
+ * Implementation note: TypeScript can't peek inside `descriptor.inner`
+ * at the type level for a runtime value, so the AsyncIterable case
+ * resolves to `AsyncIterable<unknown>` here.  Stages that produce or
+ * consume streams typically annotate explicitly via `Stage<typeof
+ * streamOf(Kinds.X), ...>` and rely on `unknown` being narrowed at the
+ * call boundary.  A stricter mapping is possible with conditional types
+ * over `K["inner"]` but adds noise without much win — the orchestrator
+ * checks descriptor compatibility at runtime regardless.
+ */
+export type KindPayload<K extends KindDescriptor> =
+  K["name"] extends "Stream"
+    ? AsyncIterable<unknown>
+    : K["name"] extends keyof KindPayloadMap
+      ? KindPayloadMap[K["name"]]
+      : unknown;

--- a/code/packages/typescript/forme-types/src/shapes.ts
+++ b/code/packages/typescript/forme-types/src/shapes.ts
@@ -1,0 +1,434 @@
+/**
+ * Kind shapes — the TypeScript interfaces for each built-in kind.
+ *
+ * One interface per kind, each `readonly` end-to-end.  Stages should
+ * never mutate kind values; the orchestrator caches and shares them
+ * across consumers, so a sneaky in-place edit would corrupt the
+ * downstream pipeline in a hard-to-reproduce way.
+ *
+ * See FM01 §2.3 for the design rationale of each kind.
+ *
+ * The shape types here intentionally omit a runtime discriminator (no
+ * `kind: "ContentSource" as const` field on every type).  TypeScript's
+ * structural typing handles "is this a ContentNode?" by checking the
+ * shape; the runtime `KindDescriptor` from `kinds.ts` provides the
+ * separate string discriminator the orchestrator uses for typing edges
+ * in pipeline configs.  Mixing the two — putting `kind` on the value
+ * AND on the descriptor — invited the "{ ...Kinds.X, kind: 'Stream' }"
+ * confusion documented in `kinds.ts`.
+ *
+ * Kind shapes that reference unspecified kernel concepts (StyleDocument,
+ * Interactivity) carry intentionally minimal stub types so the kernel
+ * is buildable today.  FM04 (Style IR) and FM05 (Interactivity IR) will
+ * tighten these without changing field names.
+ */
+
+import type { DocumentNode } from "@coding-adventures/document-ast";
+import type { JsonValue, ReadonlyRecord } from "./utility.js";
+import type { LogicalId, RevisionId } from "./identity.js";
+
+// ─── Asset roles & references ─────────────────────────────────────────────
+
+/**
+ * The role an asset plays inside a content document.  Used by AssetRef
+ * (which lives inside ContentNode) to tell renderers what kind of
+ * placeholder to leave when the asset isn't ready yet, and used by Asset
+ * itself to choose a default mime category.
+ */
+export type AssetRole =
+  | "image"
+  | "video"
+  | "audio"
+  | "font"
+  | "embed"
+  | "binary";
+
+/**
+ * A pointer from a ContentNode to an Asset it depends on.  The
+ * `nodePath` is a list of child indices walking from the document root
+ * to the referencing node, used by the orchestrator's incremental
+ * rebuild to know which downstream stages need to re-run when an asset
+ * changes.
+ */
+export interface AssetRef {
+  readonly id: LogicalId;
+  readonly nodePath: readonly number[];
+  readonly role: AssetRole;
+}
+
+// ─── ContentSource ────────────────────────────────────────────────────────
+
+/**
+ * Raw bytes plus enough metadata for downstream parsers to know what
+ * they're looking at.  Produced by sources, consumed by parsers.
+ *
+ * `bytes` is a `Uint8Array`, not a string, because not every source is
+ * UTF-8 — a parser might need to detect or honour an explicit encoding
+ * before decoding.  The `mimeType` field is advisory; parsers that care
+ * about mime sniff again to be sure.
+ */
+export interface ContentSource {
+  readonly path: string;
+  readonly bytes: Uint8Array;
+  readonly mimeType: string | null;
+  readonly identity: LogicalId;
+  readonly revision: RevisionId;
+  readonly providerMeta: ReadonlyRecord<string, JsonValue>;
+}
+
+// ─── ContentNode ──────────────────────────────────────────────────────────
+
+/**
+ * A parsed content document.  Wraps `document-ast`'s `DocumentNode`
+ * with the surrounding metadata the rest of the pipeline cares about:
+ * frontmatter, assigned route, asset references, source provenance.
+ *
+ * `route` is null until a collector assigns one.  Stages between the
+ * parser and the collector should not depend on it.
+ */
+export interface ContentNode {
+  readonly identity: LogicalId;
+  readonly revision: RevisionId;
+  readonly document: DocumentNode;
+  readonly frontmatter: ReadonlyRecord<string, JsonValue>;
+  readonly route: string | null;
+  readonly assetRefs: readonly AssetRef[];
+  readonly sourcePath: string;
+}
+
+// ─── Collection ───────────────────────────────────────────────────────────
+
+/**
+ * An ordering key for `CollectionEntry`.  Three forms cover the common
+ * cases (lexicographic name, numeric position, RFC-3339 date) plus a
+ * composite for tie-breaking.  Keeping the union closed lets sorting
+ * logic be exhaustive and total.
+ */
+export type OrderKey =
+  | { readonly kind: "lexicographic"; readonly value: string }
+  | { readonly kind: "numeric"; readonly value: number }
+  | { readonly kind: "date"; readonly value: string }
+  | { readonly kind: "composite"; readonly value: readonly OrderKey[] };
+
+/**
+ * One entry in a Collection.  Stores a *reference* (LogicalId + revision)
+ * rather than embedding the full ContentNode — collections of millions
+ * of items must remain cheap to construct, hash, and diff.
+ */
+export interface CollectionEntry {
+  readonly identity: LogicalId;
+  readonly revision: RevisionId;
+  readonly route: string | null;
+  readonly orderKey: OrderKey;
+  readonly overlay: ReadonlyRecord<string, JsonValue>;
+}
+
+/**
+ * An ordered set of CollectionEntry references plus a grouping
+ * discriminant.  Two collections with the same discriminant are
+ * "the same kind of collection" and stages may operate across them
+ * (e.g. a single pagination stage handling all `tag:*` collections).
+ */
+export interface Collection {
+  readonly name: string;
+  readonly entries: readonly CollectionEntry[];
+  readonly discriminant: string;
+  readonly meta: ReadonlyRecord<string, JsonValue>;
+}
+
+// ─── Asset ────────────────────────────────────────────────────────────────
+
+/**
+ * An image, video, font, or binary file plus the metadata derived
+ * stages need.  `byteLength` duplicates `bytes.byteLength` so cheap
+ * size checks don't have to touch the buffer.
+ */
+export interface Asset {
+  readonly identity: LogicalId;
+  readonly revision: RevisionId;
+  readonly role: AssetRole;
+  readonly mimeType: string;
+  readonly bytes: Uint8Array;
+  readonly byteLength: number;
+  readonly dimensions: { readonly w: number; readonly h: number } | null;
+  readonly durationMs: number | null;
+  /** For derived assets (e.g. resized image), the original's id.  Null for originals. */
+  readonly derivedFrom: LogicalId | null;
+  readonly meta: ReadonlyRecord<string, JsonValue>;
+}
+
+// ─── Style & Interactivity stubs ──────────────────────────────────────────
+
+/**
+ * Minimal placeholder for the Style IR.  FM04 will replace this with
+ * the full token / selector / rule model.  Until then, stages that
+ * don't actually use style information can carry an empty StyleDocument
+ * and downstream renderers will fall back to their built-in defaults.
+ */
+export interface StyleDocument {
+  readonly tokens: ReadonlyRecord<string, JsonValue>;
+  readonly rules: readonly JsonValue[];
+  readonly theme: string | null;
+}
+
+/**
+ * Empty StyleDocument constant — convenient for tests and default
+ * pipelines that don't carry style information yet.
+ */
+export const EMPTY_STYLE: StyleDocument = {
+  tokens: {},
+  rules: [],
+  theme: null,
+};
+
+/**
+ * Minimal placeholder for the Interactivity IR.  FM05 will replace
+ * with the full state / bindings / handlers model.  An empty
+ * Interactivity is the default for static pages — those ship zero JS.
+ */
+export interface Interactivity {
+  readonly state: readonly JsonValue[];
+  readonly bindings: readonly JsonValue[];
+  readonly handlers: readonly JsonValue[];
+  readonly islands: readonly string[];
+}
+
+/**
+ * Empty Interactivity constant — convenient for tests and the default
+ * static-rendering path that has no client-side behaviour.
+ */
+export const EMPTY_INTERACTIVITY: Interactivity = {
+  state: [],
+  bindings: [],
+  handlers: [],
+  islands: [],
+};
+
+// ─── Document ─────────────────────────────────────────────────────────────
+
+/**
+ * The (content, style, interactivity) triple for one renderable unit.
+ * The unit a renderer turns into a RenderedPage / PrintForme / etc.
+ *
+ * `route` is non-null here: by the time a Document exists the route
+ * has been assigned (or the renderer wouldn't know where to put the
+ * output).  This is the difference between a `ContentNode` (route may
+ * be null) and a `Document` (route is set).
+ */
+export interface Document {
+  readonly identity: LogicalId;
+  readonly revision: RevisionId;
+  readonly content: ContentNode;
+  readonly style: StyleDocument;
+  readonly interactivity: Interactivity;
+  readonly route: string;
+}
+
+// ─── RenderedPage ─────────────────────────────────────────────────────────
+
+/** Branded ID for a single style rule, before bundling. */
+export type StyleRuleId = string & { readonly __brand: "StyleRuleId" };
+
+/** Branded ID for an interactivity island, before bundling. */
+export type IslandId = string & { readonly __brand: "IslandId" };
+
+/**
+ * Per-page metadata used by the renderer to populate <head> tags and
+ * by feed/sitemap stages to know what to syndicate.
+ */
+export interface PageMeta {
+  readonly title: string;
+  readonly description: string | null;
+  readonly canonicalUrl: string | null;
+  readonly openGraph: ReadonlyRecord<string, string>;
+  readonly structured: readonly JsonValue[];
+  readonly extra: ReadonlyRecord<string, string>;
+}
+
+/**
+ * The output of a web-backend renderer, before bundling and per-page
+ * code-splitting.  The `usedStyle` and `usedIslands` arrays drive the
+ * AOT compiler's "smallest artifact" decision (FM06).
+ */
+export interface RenderedPage {
+  readonly route: string;
+  readonly html: string;
+  readonly usedStyle: readonly StyleRuleId[];
+  readonly usedIslands: readonly IslandId[];
+  readonly usedAssets: readonly LogicalId[];
+  readonly meta: PageMeta;
+  readonly source: LogicalId;
+}
+
+// ─── PrintForme ───────────────────────────────────────────────────────────
+
+/**
+ * A typed length with explicit unit.  Print backends translate to their
+ * native unit (PDF uses points; LaTeX uses TeX `pt` which is *not* the
+ * same as PostScript pt) so we never lose information by collapsing to
+ * pixels.
+ */
+export type Length =
+  | { readonly unit: "pt"; readonly value: number }
+  | { readonly unit: "mm"; readonly value: number }
+  | { readonly unit: "in"; readonly value: number };
+
+export interface Margins {
+  readonly top: Length;
+  readonly right: Length;
+  readonly bottom: Length;
+  readonly left: Length;
+}
+
+/** Standardised page-size names that print backends agree on. */
+export type PageSizeName =
+  | "A4" | "A5" | "Letter" | "Legal" | "Tabloid" | "B5" | "B6";
+
+export type PageSize =
+  | { readonly kind: "named"; readonly name: PageSizeName }
+  | { readonly kind: "custom"; readonly w: Length; readonly h: Length };
+
+export interface PageSettings {
+  readonly size: PageSize;
+  readonly margins: Margins;
+  readonly orientation: "portrait" | "landscape";
+}
+
+/**
+ * One running header or footer on a print page.  The `content` is a
+ * DocumentNode so it can carry rich content (page numbers via inline
+ * raw nodes, an image of a logo, etc.).
+ */
+export interface RunningElement {
+  readonly position:
+    | "header-left" | "header-center" | "header-right"
+    | "footer-left" | "footer-center" | "footer-right";
+  readonly content: DocumentNode;
+}
+
+/**
+ * Backend-neutral composed page destined for a print backend (LaTeX,
+ * direct PDF, EPUB).  Layout decisions are deferred to the backend —
+ * a PrintForme says "this content, this style, this page geometry"
+ * and lets the backend handle line breaking, page breaking, kerning.
+ */
+export interface PrintForme {
+  readonly source: LogicalId;
+  readonly page: PageSettings;
+  readonly runningElements: readonly RunningElement[];
+  readonly content: ContentNode;
+  readonly style: StyleDocument;
+  readonly usedAssets: readonly LogicalId[];
+}
+
+// ─── RequestHandler ───────────────────────────────────────────────────────
+
+/**
+ * Runtime requirements for a per-request handler.  Emitters use this
+ * to decide whether to bundle for Cloudflare Workers, Node, Deno, etc.
+ */
+export type RuntimeRequirement =
+  | { readonly kind: "cloudflare-worker" }
+  | { readonly kind: "node"; readonly minVersion: string }
+  | { readonly kind: "deno"; readonly minVersion: string }
+  | { readonly kind: "bun"; readonly minVersion: string };
+
+/**
+ * A dynamic, per-request handler emitted by `render-dynamic` backends.
+ * The `code` is a serialised JS string that the emitter packages for
+ * its target runtime; the orchestrator does not execute it.
+ */
+export interface RequestHandler {
+  readonly routePattern: string;
+  readonly code: string;
+  readonly runtime: RuntimeRequirement;
+  readonly staticAssets: readonly LogicalId[];
+}
+
+// ─── SearchIndex ──────────────────────────────────────────────────────────
+
+/**
+ * The output of a search indexer.  Indexers vary widely (Pagefind,
+ * MiniSearch, SQLite FTS, semantic embeddings) so the payload is a
+ * file-tree blob plus an indexer name; downstream stages discriminate
+ * on `indexer` if they care.
+ */
+export interface SearchIndex {
+  readonly indexer: string;
+  readonly indexer_version: string;
+  readonly files: ReadonlyRecord<string, Uint8Array>;
+  readonly manifest: JsonValue;
+}
+
+// ─── Feed ─────────────────────────────────────────────────────────────────
+
+export type FeedFormat = "rss" | "atom" | "jsonfeed" | "sitemap";
+
+/**
+ * A syndication feed (RSS, Atom, JSON Feed, or sitemap).  Carries the
+ * already-serialised file bytes; consumers either upload them to a
+ * destination or include them in a deploy artifact.
+ */
+export interface Feed {
+  readonly format: FeedFormat;
+  readonly files: ReadonlyRecord<string, Uint8Array>;
+}
+
+// ─── DeployArtifact ───────────────────────────────────────────────────────
+
+export type DeployVariant =
+  | { readonly kind: "dist-tree" }
+  | { readonly kind: "worker-bundle"; readonly runtime: RuntimeRequirement }
+  | { readonly kind: "email-bundle" }
+  | { readonly kind: "epub-bundle" }
+  | { readonly kind: "pdf"; readonly pageCount: number };
+
+export interface DeployRoute {
+  readonly pattern: string;
+  readonly target:
+    | { readonly kind: "file"; readonly path: string }
+    | { readonly kind: "handler" };
+  readonly islands: readonly IslandId[];
+  readonly css: readonly string[];
+}
+
+export interface DeployAssetEntry {
+  readonly id: LogicalId;
+  readonly path: string;
+  readonly mime: string;
+  readonly sha256: string;
+}
+
+export interface DeployManifest {
+  readonly routes: readonly DeployRoute[];
+  readonly assets: readonly DeployAssetEntry[];
+  readonly buildTime: string;
+  readonly buildId: RevisionId;
+}
+
+/**
+ * The final shippable thing.  Variant tags discriminate "this is a
+ * static-files tree" from "this is a Worker bundle" from "this is an
+ * email package" — emitters select on it to decide how to deliver.
+ */
+export interface DeployArtifact {
+  readonly variant: DeployVariant;
+  readonly files: ReadonlyRecord<string, Uint8Array>;
+  readonly manifest: DeployManifest;
+}
+
+// ─── Stream value type ───────────────────────────────────────────────────
+
+/**
+ * The runtime value type for streams.  When a stage's `produces`
+ * descriptor is a stream wrapper (built via `streamOf`), it returns
+ * an AsyncIterable directly — the orchestrator does the bookkeeping.
+ *
+ * This `Stream` type exists for the rare case where a value-shaped
+ * stream needs to be passed around as a discrete value (e.g. cached,
+ * fanned out manually).  The common case is for stages to just return
+ * `AsyncIterable<T>` from their `run` method.
+ */
+export interface Stream<T> {
+  readonly iterator: () => AsyncIterable<T>;
+}

--- a/code/packages/typescript/forme-types/src/utility.ts
+++ b/code/packages/typescript/forme-types/src/utility.ts
@@ -1,0 +1,58 @@
+/**
+ * Utility types — the universal JSON value type and read-only record helper
+ * that the rest of the kernel builds on.
+ *
+ * These are type aliases only.  Nothing here has runtime presence — the
+ * compiler erases them.  We export them from a dedicated module so every
+ * package in the Forme kernel can import them without dragging in the
+ * entire kind taxonomy.
+ *
+ * === JsonValue ===
+ *
+ * JsonValue is the canonical "any value safe to serialise as JSON" type.
+ * It is intentionally `readonly` end-to-end: once a JsonValue is produced
+ * it is treated as immutable.  Stages that need mutable scratch data work
+ * with their own local types and only convert to JsonValue at the boundary.
+ *
+ * Shape:
+ *
+ *   JsonValue = null
+ *             | boolean
+ *             | number
+ *             | string
+ *             | readonly JsonValue[]
+ *             | { readonly [key: string]: JsonValue }
+ *
+ * Note that `undefined` is *not* a valid JsonValue — JSON has no
+ * representation for it, and treating it as null surprises callers.
+ * If a field is optional, the schema says so and the field is absent
+ * from the object rather than present-but-undefined.
+ *
+ * === ReadonlyRecord ===
+ *
+ * `ReadonlyRecord<K, V>` is a thin alias for `{ readonly [k in K]: V }`.
+ * The standard library's `Record<K, V>` produces a *mutable* mapped type;
+ * Forme's contracts are immutable, so we use this alias everywhere.
+ */
+
+/**
+ * A value that can be losslessly serialised to JSON and round-tripped
+ * back.  Used for stage configuration, frontmatter, telemetry payloads,
+ * and the canonical-JSON revision-hashing input.
+ */
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+/**
+ * Read-only key-value mapping.  Equivalent to `Readonly<Record<K, V>>`
+ * but spelled out so consumers can see the intent without reading the
+ * standard library's mapped-type definition.
+ */
+export type ReadonlyRecord<K extends string, V> = {
+  readonly [key in K]: V;
+};

--- a/code/packages/typescript/forme-types/tests/identity.test.ts
+++ b/code/packages/typescript/forme-types/tests/identity.test.ts
@@ -1,0 +1,32 @@
+/**
+ * forme-types — identity branded-type tests
+ *
+ * The branded LogicalId / RevisionId types exist only at compile time
+ * (they're plain strings at runtime).  These tests verify the brand
+ * actually keeps the two types apart.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { LogicalId, RevisionId } from "../src/index.js";
+
+describe("LogicalId / RevisionId branding", () => {
+  it("forbids assigning a plain string to a LogicalId", () => {
+    // @ts-expect-error — branded types reject raw strings.
+    const id: LogicalId = "01952c0d-7e63-7000-8000-000000000000";
+    expect(typeof id).toBe("string");
+  });
+
+  it("forbids cross-assignment between the two ID types", () => {
+    const logical = "01952c0d-7e63-7000-8000-000000000000" as LogicalId;
+    // @ts-expect-error — RevisionId and LogicalId are different brands.
+    const rev: RevisionId = logical;
+    expect(typeof rev).toBe("string");
+  });
+
+  it("permits explicit branding via type assertion", () => {
+    const logical = "01952c0d-7e63-7000-8000-000000000000" as LogicalId;
+    const rev = "blake2b:cafebabe" as RevisionId;
+    expect(logical).toContain("01952c0d");
+    expect(rev).toContain("blake2b:");
+  });
+});

--- a/code/packages/typescript/forme-types/tests/kinds.test.ts
+++ b/code/packages/typescript/forme-types/tests/kinds.test.ts
@@ -1,0 +1,125 @@
+/**
+ * forme-types — Kind constants and descriptor tests
+ *
+ * Verifies the Kinds object exposes a descriptor for every built-in
+ * kind (modulo Stream, which is built dynamically), tests the streamOf
+ * helper round-trips, and pins the API version to its initial value
+ * so any unintended bump is caught in code review.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  KERNEL_API_VERSION,
+  KINDS,
+  Kinds,
+  streamOf,
+  isStreamDescriptor,
+} from "../src/index.js";
+import type { KindDescriptor, KindName } from "../src/index.js";
+
+describe("KERNEL_API_VERSION", () => {
+  it("starts at 1 — bumping requires explicit migration plan", () => {
+    expect(KERNEL_API_VERSION).toBe(1);
+  });
+
+  it("is a numeric literal type, not a widening number", () => {
+    // Type-level: this assignment is OK only if the version is `1`.
+    const v: 1 = KERNEL_API_VERSION;
+    expect(v).toBe(1);
+  });
+});
+
+describe("KINDS", () => {
+  it("includes all 13 built-in kind names (12 data kinds + Void)", () => {
+    expect(KINDS.length).toBe(13);
+  });
+
+  it("includes Void, Stream, and the canonical 11 data kinds", () => {
+    const expected = new Set([
+      "Void",
+      "ContentSource", "ContentNode", "Collection", "Asset",
+      "Document", "RenderedPage", "PrintForme",
+      "RequestHandler", "SearchIndex", "Feed", "DeployArtifact",
+      "Stream",
+    ]);
+    expect(new Set(KINDS)).toEqual(expected);
+  });
+
+  it("is frozen at runtime — push/splice throw rather than corrupt", () => {
+    expect(() => {
+      // @ts-expect-error — KINDS is readonly at the type level.
+      KINDS.push("Bogus");
+    }).toThrow(TypeError);
+    expect(KINDS.length).toBe(13);
+  });
+});
+
+describe("Kinds canonical descriptors", () => {
+  it("provides a v1.0 descriptor for every built-in non-Stream kind", () => {
+    // Stream is built via streamOf(); every other kind has an entry.
+    const expectedKeys = KINDS.filter(k => k !== "Stream");
+    const actualKeys = Object.keys(Kinds);
+    expect(new Set(actualKeys)).toEqual(new Set(expectedKeys));
+  });
+
+  it("uses semver-compatible version strings", () => {
+    for (const key of Object.keys(Kinds) as Array<keyof typeof Kinds>) {
+      expect(Kinds[key].version).toMatch(/^\d+\.\d+(\.\d+)?$/);
+    }
+  });
+
+  it("has matching .name fields", () => {
+    for (const key of Object.keys(Kinds) as Array<keyof typeof Kinds>) {
+      expect(Kinds[key].name).toBe(key);
+    }
+  });
+});
+
+describe("streamOf / isStreamDescriptor", () => {
+  it("wraps a descriptor with name=Stream and inner=...", () => {
+    const wrapped = streamOf(Kinds.ContentSource);
+    expect(wrapped).toEqual({
+      name: "Stream",
+      version: "1.0",
+      inner: Kinds.ContentSource,
+    });
+  });
+
+  it("recognises stream descriptors", () => {
+    expect(isStreamDescriptor(streamOf(Kinds.ContentNode))).toBe(true);
+    expect(isStreamDescriptor(Kinds.ContentNode)).toBe(false);
+    expect(isStreamDescriptor(Kinds.Void)).toBe(false);
+  });
+
+  it("can wrap an extension kind name", () => {
+    const ext: KindDescriptor = { name: "ext:youtube-embed", version: "1.0" };
+    const wrapped = streamOf(ext);
+    expect(wrapped.inner).toBe(ext);
+    expect(isStreamDescriptor(wrapped)).toBe(true);
+  });
+
+  it("nests — streamOf(streamOf(X)) yields a stream of streams", () => {
+    const inner = streamOf(Kinds.ContentSource);
+    const outer = streamOf(inner);
+    expect(outer.inner).toBe(inner);
+    expect(outer.inner?.inner).toBe(Kinds.ContentSource);
+  });
+});
+
+describe("KindName", () => {
+  it("accepts built-in names", () => {
+    const a: KindName = "ContentSource";
+    expect(a).toBe("ContentSource");
+  });
+
+  it("accepts ext:-prefixed extension names", () => {
+    const a: KindName = "ext:youtube-embed";
+    expect(a).toMatch(/^ext:/);
+  });
+
+  it("rejects arbitrary strings without ext: prefix at compile time", () => {
+    // @ts-expect-error — "MyKind" is neither built-in nor ext:-prefixed.
+    const a: KindName = "MyKind";
+    expect(a).toBe("MyKind");
+  });
+});

--- a/code/packages/typescript/forme-types/tests/payload.test.ts
+++ b/code/packages/typescript/forme-types/tests/payload.test.ts
@@ -1,0 +1,107 @@
+/**
+ * forme-types — KindPayload mapped-type tests
+ *
+ * These tests are entirely compile-time: they verify the `KindPayload`
+ * type infers the correct value type from a runtime descriptor.  Each
+ * `assertType<E, A>()` call is a no-op at runtime; failures appear as
+ * TypeScript errors when running `tsc` (vitest invokes this).
+ */
+
+import { describe, it, expect } from "vitest";
+import { Kinds, streamOf } from "../src/index.js";
+import type {
+  Asset, Collection, ContentNode, ContentSource,
+  DeployArtifact, Document, Feed,
+  KindPayload, PrintForme, RenderedPage, RequestHandler, SearchIndex,
+} from "../src/index.js";
+
+// Compile-time equality assertion using a conditional-type trick.
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+function assertType<_T extends true>(): void {
+  /* compile-time only */
+}
+
+describe("KindPayload<typeof Kinds.X>", () => {
+  it("Void → void", () => {
+    assertType<Equal<KindPayload<typeof Kinds.Void>, void>>();
+    expect(true).toBe(true);
+  });
+
+  it("ContentSource → ContentSource", () => {
+    assertType<Equal<KindPayload<typeof Kinds.ContentSource>, ContentSource>>();
+    expect(true).toBe(true);
+  });
+
+  it("ContentNode → ContentNode", () => {
+    assertType<Equal<KindPayload<typeof Kinds.ContentNode>, ContentNode>>();
+    expect(true).toBe(true);
+  });
+
+  it("Collection → Collection", () => {
+    assertType<Equal<KindPayload<typeof Kinds.Collection>, Collection>>();
+    expect(true).toBe(true);
+  });
+
+  it("Asset → Asset", () => {
+    assertType<Equal<KindPayload<typeof Kinds.Asset>, Asset>>();
+    expect(true).toBe(true);
+  });
+
+  it("Document → Document", () => {
+    assertType<Equal<KindPayload<typeof Kinds.Document>, Document>>();
+    expect(true).toBe(true);
+  });
+
+  it("RenderedPage → RenderedPage", () => {
+    assertType<Equal<KindPayload<typeof Kinds.RenderedPage>, RenderedPage>>();
+    expect(true).toBe(true);
+  });
+
+  it("PrintForme → PrintForme", () => {
+    assertType<Equal<KindPayload<typeof Kinds.PrintForme>, PrintForme>>();
+    expect(true).toBe(true);
+  });
+
+  it("RequestHandler → RequestHandler", () => {
+    assertType<Equal<KindPayload<typeof Kinds.RequestHandler>, RequestHandler>>();
+    expect(true).toBe(true);
+  });
+
+  it("SearchIndex → SearchIndex", () => {
+    assertType<Equal<KindPayload<typeof Kinds.SearchIndex>, SearchIndex>>();
+    expect(true).toBe(true);
+  });
+
+  it("Feed → Feed", () => {
+    assertType<Equal<KindPayload<typeof Kinds.Feed>, Feed>>();
+    expect(true).toBe(true);
+  });
+
+  it("DeployArtifact → DeployArtifact", () => {
+    assertType<Equal<KindPayload<typeof Kinds.DeployArtifact>, DeployArtifact>>();
+    expect(true).toBe(true);
+  });
+});
+
+describe("KindPayload<streamOf(...)>", () => {
+  it("a stream descriptor maps to AsyncIterable<unknown>", () => {
+    // streamOf returns KindDescriptor (its return type); the inner is
+    // not preserved at the type level, so payload widens to AsyncIterable<unknown>.
+    // This is a deliberate trade-off — see payload.ts header.
+    const sd = streamOf(Kinds.ContentSource);
+    assertType<Equal<KindPayload<typeof sd>, AsyncIterable<unknown>>>();
+    expect(sd.name).toBe("Stream");
+  });
+});
+
+describe("KindPayload<{ name: ext:..., ... }>", () => {
+  it("an unaugmented ext: name maps to unknown", () => {
+    const ext = { name: "ext:my-thing" as const, version: "1.0" };
+    assertType<Equal<KindPayload<typeof ext>, unknown>>();
+    expect(ext.name).toBe("ext:my-thing");
+  });
+});

--- a/code/packages/typescript/forme-types/tests/shapes.test.ts
+++ b/code/packages/typescript/forme-types/tests/shapes.test.ts
@@ -1,0 +1,422 @@
+/**
+ * forme-types — Kind shape construction tests
+ *
+ * Builds a representative value of every kernel kind and verifies
+ * basic invariants (e.g. byteLength matches bytes.length).  The bulk
+ * of the work is at compile time: the type system rejects any value
+ * that doesn't match the spec.
+ *
+ * These tests serve as living documentation — copy from here when
+ * authoring a stage that needs to construct a value of a given kind.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_INTERACTIVITY,
+  EMPTY_STYLE,
+} from "../src/index.js";
+import type {
+  Asset, AssetRef,
+  Collection, CollectionEntry,
+  ContentNode, ContentSource,
+  DeployArtifact, DeployManifest,
+  Document, Feed,
+  IslandId, LogicalId,
+  PrintForme, RenderedPage, RequestHandler, RevisionId,
+  SearchIndex, Stream,
+  StyleRuleId,
+} from "../src/index.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+const SAMPLE_ID    = "01952c0d-7e63-7000-8000-000000000000" as LogicalId;
+const SAMPLE_REV   = "blake2b:cafebabe" as RevisionId;
+const SAMPLE_BYTES = new TextEncoder().encode("hello world");
+
+// ─── ContentSource ────────────────────────────────────────────────────────
+
+describe("ContentSource", () => {
+  it("constructs a minimal source", () => {
+    const src: ContentSource = {
+      path: "posts/hello.md",
+      bytes: SAMPLE_BYTES,
+      mimeType: "text/markdown",
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      providerMeta: {},
+    };
+    expect(src.bytes.byteLength).toBe(11);
+    expect(src.mimeType).toBe("text/markdown");
+  });
+
+  it("permits a null mimeType when the source can't sniff one", () => {
+    const src: ContentSource = {
+      path: "blob.bin",
+      bytes: new Uint8Array([0, 1, 2]),
+      mimeType: null,
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      providerMeta: { from: "manual" },
+    };
+    expect(src.mimeType).toBeNull();
+  });
+});
+
+// ─── ContentNode ──────────────────────────────────────────────────────────
+
+describe("ContentNode", () => {
+  it("wraps a DocumentNode with frontmatter and route", () => {
+    const node: ContentNode = {
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      document: { type: "document", children: [] },
+      frontmatter: { title: "Hello", date: "2026-05-14" },
+      route: "/posts/hello",
+      assetRefs: [],
+      sourcePath: "posts/hello.md",
+    };
+    expect(node.document.type).toBe("document");
+    expect(node.frontmatter.title).toBe("Hello");
+  });
+
+  it("permits a null route before a collector assigns one", () => {
+    const node: ContentNode = {
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      document: { type: "document", children: [] },
+      frontmatter: {},
+      route: null,
+      assetRefs: [],
+      sourcePath: "posts/draft.md",
+    };
+    expect(node.route).toBeNull();
+  });
+
+  it("supports asset references with a node-path locator", () => {
+    const ref: AssetRef = {
+      id: "01952c0d-7e63-7000-8000-000000000111" as LogicalId,
+      nodePath: [0, 2, 1],
+      role: "image",
+    };
+    const node: ContentNode = {
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      document: { type: "document", children: [] },
+      frontmatter: {},
+      route: null,
+      assetRefs: [ref],
+      sourcePath: "posts/with-image.md",
+    };
+    expect(node.assetRefs[0]?.role).toBe("image");
+    expect(node.assetRefs[0]?.nodePath).toEqual([0, 2, 1]);
+  });
+});
+
+// ─── Collection ───────────────────────────────────────────────────────────
+
+describe("Collection", () => {
+  it("orders entries by an OrderKey", () => {
+    const entry: CollectionEntry = {
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      route: "/posts/hello",
+      orderKey: { kind: "date", value: "2026-05-14T00:00:00Z" },
+      overlay: { excerpt: "Hi" },
+    };
+    const c: Collection = {
+      name: "posts",
+      entries: [entry],
+      discriminant: "chronological",
+      meta: { count: 1 },
+    };
+    expect(c.entries.length).toBe(1);
+    expect(c.discriminant).toBe("chronological");
+  });
+
+  it("supports composite ordering for tie-breaking", () => {
+    const entry: CollectionEntry = {
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      route: null,
+      orderKey: {
+        kind: "composite",
+        value: [
+          { kind: "date", value: "2026-05-14" },
+          { kind: "lexicographic", value: "alpha" },
+        ],
+      },
+      overlay: {},
+    };
+    expect(entry.orderKey.kind).toBe("composite");
+  });
+});
+
+// ─── Asset ────────────────────────────────────────────────────────────────
+
+describe("Asset", () => {
+  it("constructs a raster image asset with dimensions", () => {
+    const asset: Asset = {
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      role: "image",
+      mimeType: "image/png",
+      bytes: SAMPLE_BYTES,
+      byteLength: SAMPLE_BYTES.byteLength,
+      dimensions: { w: 800, h: 600 },
+      durationMs: null,
+      derivedFrom: null,
+      meta: {},
+    };
+    expect(asset.dimensions?.w).toBe(800);
+    expect(asset.derivedFrom).toBeNull();
+  });
+
+  it("links derived assets to their original", () => {
+    const original = SAMPLE_ID;
+    const resized: Asset = {
+      identity: "01952c0d-7e63-7000-8000-000000000222" as LogicalId,
+      revision: SAMPLE_REV,
+      role: "image",
+      mimeType: "image/avif",
+      bytes: new Uint8Array(),
+      byteLength: 0,
+      dimensions: { w: 400, h: 300 },
+      durationMs: null,
+      derivedFrom: original,
+      meta: { variant: "thumb" },
+    };
+    expect(resized.derivedFrom).toBe(original);
+  });
+});
+
+// ─── Document / RenderedPage / PrintForme ─────────────────────────────────
+
+describe("Document", () => {
+  it("composes content + style + interactivity with an assigned route", () => {
+    const content: ContentNode = {
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      document: { type: "document", children: [] },
+      frontmatter: {},
+      route: "/posts/hello",
+      assetRefs: [],
+      sourcePath: "posts/hello.md",
+    };
+    const doc: Document = {
+      identity: SAMPLE_ID,
+      revision: SAMPLE_REV,
+      content,
+      style: EMPTY_STYLE,
+      interactivity: EMPTY_INTERACTIVITY,
+      route: "/posts/hello",
+    };
+    expect(doc.style.theme).toBeNull();
+    expect(doc.interactivity.islands.length).toBe(0);
+  });
+});
+
+describe("RenderedPage", () => {
+  it("carries html, used-style/island/asset arrays, and source provenance", () => {
+    const page: RenderedPage = {
+      route: "/posts/hello",
+      html: "<!doctype html><html><body>hi</body></html>",
+      usedStyle: ["body" as StyleRuleId],
+      usedIslands: ["search" as IslandId],
+      usedAssets: [],
+      meta: {
+        title: "Hello",
+        description: null,
+        canonicalUrl: null,
+        openGraph: {},
+        structured: [],
+        extra: {},
+      },
+      source: SAMPLE_ID,
+    };
+    expect(page.usedStyle.length).toBe(1);
+    expect(page.usedIslands.length).toBe(1);
+  });
+});
+
+describe("PrintForme", () => {
+  it("describes a print-ready page with explicit geometry", () => {
+    const print: PrintForme = {
+      source: SAMPLE_ID,
+      page: {
+        size: { kind: "named", name: "A4" },
+        margins: {
+          top:    { unit: "mm", value: 25 },
+          right:  { unit: "mm", value: 20 },
+          bottom: { unit: "mm", value: 25 },
+          left:   { unit: "mm", value: 20 },
+        },
+        orientation: "portrait",
+      },
+      runningElements: [],
+      content: {
+        identity: SAMPLE_ID,
+        revision: SAMPLE_REV,
+        document: { type: "document", children: [] },
+        frontmatter: {},
+        route: "/print",
+        assetRefs: [],
+        sourcePath: "src.md",
+      },
+      style: EMPTY_STYLE,
+      usedAssets: [],
+    };
+    expect(print.page.orientation).toBe("portrait");
+    if (print.page.size.kind === "named") {
+      expect(print.page.size.name).toBe("A4");
+    }
+  });
+
+  it("supports custom page sizes via Length", () => {
+    const print: PrintForme = {
+      source: SAMPLE_ID,
+      page: {
+        size: {
+          kind: "custom",
+          w: { unit: "in", value: 8.5 },
+          h: { unit: "in", value: 11 },
+        },
+        margins: {
+          top: { unit: "in", value: 1 }, right:  { unit: "in", value: 1 },
+          bottom: { unit: "in", value: 1 }, left: { unit: "in", value: 1 },
+        },
+        orientation: "landscape",
+      },
+      runningElements: [],
+      content: {
+        identity: SAMPLE_ID,
+        revision: SAMPLE_REV,
+        document: { type: "document", children: [] },
+        frontmatter: {},
+        route: "/print",
+        assetRefs: [],
+        sourcePath: "src.md",
+      },
+      style: EMPTY_STYLE,
+      usedAssets: [],
+    };
+    if (print.page.size.kind === "custom") {
+      expect(print.page.size.w.value).toBe(8.5);
+    }
+  });
+});
+
+// ─── RequestHandler / SearchIndex / Feed / DeployArtifact ─────────────────
+
+describe("RequestHandler", () => {
+  it("describes a Cloudflare Worker handler", () => {
+    const h: RequestHandler = {
+      routePattern: "/api/echo",
+      code: "export default { fetch(req) { return new Response('hi'); } }",
+      runtime: { kind: "cloudflare-worker" },
+      staticAssets: [],
+    };
+    expect(h.runtime.kind).toBe("cloudflare-worker");
+  });
+
+  it("describes a Node 22+ handler with min version", () => {
+    const h: RequestHandler = {
+      routePattern: "/api/v2/*",
+      code: "module.exports = (req, res) => res.end('hi');",
+      runtime: { kind: "node", minVersion: "22.0.0" },
+      staticAssets: [SAMPLE_ID],
+    };
+    if (h.runtime.kind === "node") {
+      expect(h.runtime.minVersion).toBe("22.0.0");
+    }
+  });
+});
+
+describe("SearchIndex", () => {
+  it("packages indexer name and serialised files", () => {
+    const idx: SearchIndex = {
+      indexer: "pagefind",
+      indexer_version: "1.0.0",
+      files: { "pagefind.js": new Uint8Array([0x2f, 0x2f]) },
+      manifest: { lang: "en" },
+    };
+    expect(idx.files["pagefind.js"]?.byteLength).toBe(2);
+  });
+});
+
+describe("Feed", () => {
+  it("packages a feed format and bytes", () => {
+    const feed: Feed = {
+      format: "rss",
+      files: { "/feed.xml": new TextEncoder().encode("<rss></rss>") },
+    };
+    expect(feed.format).toBe("rss");
+  });
+});
+
+describe("DeployArtifact", () => {
+  it("describes a static-tree deploy with manifest", () => {
+    const manifest: DeployManifest = {
+      routes: [{
+        pattern: "/posts/hello",
+        target:  { kind: "file", path: "posts/hello.html" },
+        islands: [],
+        css:     [],
+      }],
+      assets: [],
+      buildTime: "2026-05-14T12:00:00Z",
+      buildId:   SAMPLE_REV,
+    };
+    const artifact: DeployArtifact = {
+      variant: { kind: "dist-tree" },
+      files: { "posts/hello.html": new TextEncoder().encode("<!doctype html>") },
+      manifest,
+    };
+    expect(artifact.variant.kind).toBe("dist-tree");
+    expect(artifact.manifest.routes.length).toBe(1);
+  });
+
+  it("describes a worker-bundle deploy with runtime", () => {
+    const artifact: DeployArtifact = {
+      variant: { kind: "worker-bundle", runtime: { kind: "cloudflare-worker" } },
+      files: {},
+      manifest: {
+        routes: [],
+        assets: [],
+        buildTime: "2026-05-14T12:00:00Z",
+        buildId:   SAMPLE_REV,
+      },
+    };
+    if (artifact.variant.kind === "worker-bundle") {
+      expect(artifact.variant.runtime.kind).toBe("cloudflare-worker");
+    }
+  });
+});
+
+// ─── Stream value type ────────────────────────────────────────────────────
+
+describe("Stream value type", () => {
+  it("wraps an iterator factory", async () => {
+    async function* gen() { yield 1; yield 2; yield 3; }
+    const s: Stream<number> = { iterator: () => gen() };
+    const out: number[] = [];
+    for await (const v of s.iterator()) out.push(v);
+    expect(out).toEqual([1, 2, 3]);
+  });
+});
+
+// ─── Empty constants ──────────────────────────────────────────────────────
+
+describe("EMPTY_STYLE / EMPTY_INTERACTIVITY", () => {
+  it("EMPTY_STYLE has no tokens, no rules, no theme", () => {
+    expect(Object.keys(EMPTY_STYLE.tokens).length).toBe(0);
+    expect(EMPTY_STYLE.rules.length).toBe(0);
+    expect(EMPTY_STYLE.theme).toBeNull();
+  });
+
+  it("EMPTY_INTERACTIVITY has no state, bindings, handlers, or islands", () => {
+    expect(EMPTY_INTERACTIVITY.state.length).toBe(0);
+    expect(EMPTY_INTERACTIVITY.bindings.length).toBe(0);
+    expect(EMPTY_INTERACTIVITY.handlers.length).toBe(0);
+    expect(EMPTY_INTERACTIVITY.islands.length).toBe(0);
+  });
+});

--- a/code/packages/typescript/forme-types/tests/utility.test.ts
+++ b/code/packages/typescript/forme-types/tests/utility.test.ts
@@ -1,0 +1,74 @@
+/**
+ * forme-types — utility type tests
+ *
+ * The utility types are erased at runtime, so the tests here are
+ * compile-time shape checks: build values that must satisfy the type,
+ * and a tiny runtime sanity check that the test file actually executed.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { JsonValue, ReadonlyRecord } from "../src/index.js";
+
+describe("JsonValue", () => {
+  it("accepts every JSON-serialisable form", () => {
+    const samples: JsonValue[] = [
+      null,
+      true,
+      false,
+      0,
+      -1.5,
+      "hello",
+      "",
+      [],
+      [1, "two", null, [3, 4], { a: 1 }],
+      {},
+      { name: "Adhithya", age: 1, tags: ["dev"], nested: { ok: true } },
+    ];
+    expect(samples.length).toBe(11);
+  });
+
+  it("rejects undefined at compile time", () => {
+    // @ts-expect-error — undefined is not a valid JsonValue.
+    const bad: JsonValue = undefined;
+    expect(bad).toBeUndefined();
+  });
+
+  it("rejects functions at compile time", () => {
+    // @ts-expect-error — functions are not JSON-serialisable.
+    const bad: JsonValue = () => 1;
+    expect(typeof bad).toBe("function");
+  });
+});
+
+describe("ReadonlyRecord", () => {
+  it("forbids assignment at the type level", () => {
+    const r: ReadonlyRecord<string, number> = { a: 1, b: 2 };
+    // @ts-expect-error — properties are readonly at the TypeScript level.
+    // (Without Object.freeze the assignment still mutates at runtime — this
+    // is a compile-time guarantee only.  The @ts-expect-error directive
+    // above IS the real assertion; if the type ever became mutable, the
+    // expect-error itself would error out.)
+    r.a = 99;
+    expect(r.a).toBe(99);
+  });
+
+  it("becomes runtime-immutable when explicitly frozen", () => {
+    const r = Object.freeze({ a: 1, b: 2 } as ReadonlyRecord<string, number>);
+    expect(() => {
+      // Cast through `unknown` so the compile-time check doesn't shadow
+      // the runtime test we're trying to make.
+      (r as unknown as { a: number }).a = 99;
+    }).toThrow(TypeError);
+    expect(r.a).toBe(1);
+  });
+
+  it("preserves narrow key unions", () => {
+    type ColourKey = "red" | "green" | "blue";
+    const palette: ReadonlyRecord<ColourKey, string> = {
+      red:   "#ff0000",
+      green: "#00ff00",
+      blue:  "#0000ff",
+    };
+    expect(palette.red).toBe("#ff0000");
+  });
+});

--- a/code/packages/typescript/forme-types/tsconfig.json
+++ b/code/packages/typescript/forme-types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-types/vitest.config.ts
+++ b/code/packages/typescript/forme-types/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

First package of the **Forme blog v0** effort: a Jekyll-shaped Markdown→HTML+CSS pipeline that builds the entire FM01/FM03 architecture properly (not a one-off script). End target: a static blog at `https://adhithyan15.github.io/coding-adventures/blog/`.

`@coding-adventures/forme-types` is the leaf of the dependency graph — types and constants only, no runtime logic. Every other Forme package will import from here.

### Implements

FM01 §2 (Kernel — Kinds and the Kind type system):

- `KERNEL_API_VERSION = 1` — kernel-stability marker
- `KINDS` / `KindName` — the 13 built-in kind names (Void, ContentSource, ContentNode, Collection, Asset, Document, RenderedPage, PrintForme, RequestHandler, SearchIndex, Feed, DeployArtifact, Stream)
- `KindDescriptor` + canonical `Kinds` object with one frozen descriptor per built-in non-Stream kind
- TypeScript interfaces for all 12 built-in kind shapes (plus stub `StyleDocument` / `Interactivity` that FM04 / FM05 will replace)
- `LogicalId` / `RevisionId` branded type aliases (impls live in the upcoming `forme-identity`)
- `JsonValue` / `ReadonlyRecord` utility aliases
- `streamOf()` / `isStreamDescriptor()` Stream meta-kind helpers
- `KindPayload<K>` mapped type for compile-time descriptor → value-type lookup

### Spec divergences from FM01 (documented in CHANGELOG and module headers)

1. **Stream descriptors** use a closed-shape `{ name: "Stream", inner: K, version: "1.0" }` produced by `streamOf()`, instead of FM01 §3.6's sketched `{ ...Kinds.X, kind: "Stream" }` (which would add a `kind` field outside `KindDescriptor`). Cleaner, equivalent expressively.
2. **`RevisionId`** uses `blake2b:<hex>` instead of FM01's `blake3:<hex>` — the monorepo has a from-scratch BLAKE2b but no BLAKE3. Format is forward-compatible thanks to the `<algo>:` prefix.

### Roadmap (this PR is 1 of ~10)

- ✅ `forme-types` — this PR
- ⏳ `forme-errors` — StageError, CapabilityError, CancellationError
- ⏳ `forme-identity` — LogicalId / RevisionId values, canonical JSON, blake2b hashing
- ⏳ `forme-capability` — capability parser/matcher
- ⏳ `forme-stage` — `Stage<In, Out>`, `defineStage`, `StageContext`
- ⏳ `forme-pipeline-config` — `PipelineConfig` types + TS loader + validator
- ⏳ `forme-cache` — `CacheBackend`, `MemoryCache`, key derivation
- ⏳ `forme-orchestrator` — DAG, scheduler, error/cancellation handling
- ⏳ `forme-cli` + 5 stage packages (source-fs, parse-markdown, collect-chronological, render-static, emit-fs)
- ⏳ `code/sites/blog/` + `.github/workflows/deploy-blog.yml`

## Test plan

- [x] `npx vitest run --coverage` — 60 tests pass, 100% line/branch coverage on every executable file
- [x] Type-only files (`utility.ts`, `identity.ts`, `payload.ts`) report 0% — that's the v8 quirk where "no executable code" reads as "no coverage"
- [ ] CI green
- [ ] Diff-based change detection picks up the new package on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
