### PR TITLE
ts(spice): parse MOSFET model netlists

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add Level-1 NMOS/PMOS MOSFET elements with Newton-linearized DC operating
+  point support and zero-bias small-signal AC/transfer participation.
 - Add Ebers-Moll-style BJT elements with Newton-linearized DC operating-point
   support and zero-bias small-signal conductance/transconductance for AC and
   transfer analysis.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -8,7 +8,7 @@ sensitivity analysis, seeded DC Monte Carlo analysis, DC small-signal
 transfer-function analysis, AC small-signal frequency sweeps, and fixed-step
 AC noise analysis, and RC/RL transient analysis for linear circuits using
 modified nodal analysis (MNA). The package supports
-resistors, capacitors, inductors, diodes, BJTs, independent current sources,
+resistors, capacitors, inductors, diodes, BJTs, Level-1 MOSFETs, independent current sources,
 independent voltage sources, voltage-controlled current sources (VCCS),
 PWL/SIN/PULSE/EXP
 source waveforms for transient analysis, ground aliases, node voltages,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -10,6 +10,7 @@ export type Element =
   | CurrentSource
   | Diode
   | Bjt
+  | Mosfet
   | Vccs
   | Vcvs
   | Cccs
@@ -294,6 +295,33 @@ export interface Bjt {
   readonly saturationCurrent: number;
   readonly forwardBeta: number;
   readonly thermalVoltage: number;
+}
+
+export type MosfetType = "NMOS" | "PMOS";
+
+export interface MosfetLevel1Params {
+  readonly VT0: number;
+  readonly KP: number;
+  readonly LAMBDA: number;
+  readonly GAMMA: number;
+  readonly PHI: number;
+  readonly W: number;
+  readonly L: number;
+  readonly IS: number;
+  readonly N_SUB: number;
+  readonly T_NOM: number;
+}
+
+export interface Mosfet {
+  readonly kind: "mosfet";
+  readonly name: string;
+  readonly drain: string;
+  readonly gate: string;
+  readonly source: string;
+  readonly body: string;
+  readonly type: MosfetType;
+  readonly model: "level1";
+  readonly params: MosfetLevel1Params;
 }
 
 export interface Vccs {
@@ -610,6 +638,43 @@ export function bjt(
     saturationCurrent,
     forwardBeta,
     thermalVoltage,
+  };
+}
+
+export function defaultMosfetLevel1Params(): MosfetLevel1Params {
+  return {
+    VT0: 0.42,
+    KP: 220.0e-6,
+    LAMBDA: 0.05,
+    GAMMA: 0.27,
+    PHI: 0.84,
+    W: 1.0e-6,
+    L: 130.0e-9,
+    IS: 1.0e-15,
+    N_SUB: 1.4,
+    T_NOM: 300.15,
+  };
+}
+
+export function mosfet(
+  name: string,
+  drain: string,
+  gate: string,
+  source: string,
+  body: string,
+  type: MosfetType = "NMOS",
+  params: Partial<MosfetLevel1Params> = {},
+): Mosfet {
+  return {
+    kind: "mosfet",
+    name,
+    drain,
+    gate,
+    source,
+    body,
+    type,
+    model: "level1",
+    params: { ...defaultMosfetLevel1Params(), ...params },
   };
 }
 
@@ -1168,6 +1233,12 @@ function elementParameter(element: Element): ElementParameter | undefined {
         parameter: "saturationCurrent",
         nominalValue: element.saturationCurrent,
       };
+    case "mosfet":
+      return {
+        elementName: element.name,
+        parameter: "KP",
+        nominalValue: element.params.KP,
+      };
     case "vccs":
       return {
         elementName: element.name,
@@ -1237,6 +1308,12 @@ function circuitWithPerturbedElement(
         perturbed.add({
           ...element,
           saturationCurrent: element.saturationCurrent + delta,
+        });
+        break;
+      case "mosfet":
+        perturbed.add({
+          ...element,
+          params: { ...element.params, KP: element.params.KP + delta },
         });
         break;
       case "vccs":
@@ -1363,6 +1440,14 @@ function randomizedElement(
           rng,
         ),
       };
+    case "mosfet":
+      return {
+        ...element,
+        params: {
+          ...element.params,
+          KP: randomizedValue(element.params.KP, tolerance, distribution, rng),
+        },
+      };
     case "vccs":
       return {
         ...element,
@@ -1468,7 +1553,7 @@ function solveLinearCircuit(
 
   const hasNonlinearElement = circuit
     .elements()
-    .some((element) => element.kind === "diode" || element.kind === "bjt");
+    .some((element) => element.kind === "diode" || element.kind === "bjt" || element.kind === "mosfet");
   let operatingPoint = Array.from({ length: matrixSize }, () => 0.0);
   let solution = solveLinearCircuitAtOperatingPoint(
     circuit,
@@ -1562,6 +1647,9 @@ function solveLinearCircuitAtOperatingPoint(
         break;
       case "bjt":
         stampBjt(element, nodeIndices, matrix, rhs, operatingPoint);
+        break;
+      case "mosfet":
+        stampMosfet(element, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
@@ -1678,6 +1766,9 @@ function buildSmallSignalMatrix(
       case "bjt":
         stampBjtSmallSignal(element, nodeIndices, matrix);
         break;
+      case "mosfet":
+        stampMosfetSmallSignal(element, nodeIndices, matrix);
+        break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
         break;
@@ -1740,6 +1831,7 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
       case "inductor":
       case "diode":
       case "bjt":
+      case "mosfet":
       case "vccs":
       case "vcvs":
       case "cccs":
@@ -1812,6 +1904,9 @@ function buildAcMatrix(
         break;
       case "bjt":
         stampAcBjtSmallSignal(element, nodeIndices, matrix);
+        break;
+      case "mosfet":
+        stampAcMosfetSmallSignal(element, nodeIndices, matrix);
         break;
       case "vccs":
         stampAcVccs(element, nodeIndices, matrix);
@@ -2015,6 +2110,12 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.base);
         insertNode(names, element.emitter);
         break;
+      case "mosfet":
+        insertNode(names, element.drain);
+        insertNode(names, element.gate);
+        insertNode(names, element.source);
+        insertNode(names, element.body);
+        break;
       case "vccs":
         insertNode(names, element.positive);
         insertNode(names, element.negative);
@@ -2097,6 +2198,7 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
         element.kind === "inductor" ||
         element.kind === "diode" ||
         element.kind === "bjt" ||
+        element.kind === "mosfet" ||
         element.kind === "vccs" ||
         element.kind === "vcvs" ||
         element.kind === "cccs" ||
@@ -2405,6 +2507,104 @@ function stampBjt(
   }
 }
 
+interface MosfetDcResult {
+  readonly drainCurrent: number;
+  readonly gm: number;
+  readonly gds: number;
+  readonly gmb: number;
+}
+
+function stampMosfet(
+  element: Mosfet,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+  operatingPoint: readonly number[],
+): void {
+  validateMosfet(element);
+  const drain = nodeIndex(nodeIndices, element.drain);
+  const gate = nodeIndex(nodeIndices, element.gate);
+  const source = nodeIndex(nodeIndices, element.source);
+  const body = nodeIndex(nodeIndices, element.body);
+  const drainVoltage = vectorVoltage(operatingPoint, drain);
+  const gateVoltage = vectorVoltage(operatingPoint, gate);
+  const sourceVoltage = vectorVoltage(operatingPoint, source);
+  const bodyVoltage = vectorVoltage(operatingPoint, body);
+  const vgs = gateVoltage - sourceVoltage;
+  const vds = drainVoltage - sourceVoltage;
+  const vbs = bodyVoltage - sourceVoltage;
+  const result = evaluateMosfetLevel1(element, vgs, vds, vbs);
+  const equivalentCurrent =
+    result.drainCurrent - result.gm * vgs - result.gds * vds - result.gmb * vbs;
+
+  stampConductance(matrix, drain, source, result.gds);
+  stampTransconductance(matrix, drain, source, gate, source, result.gm);
+  stampTransconductance(matrix, drain, source, body, source, result.gmb);
+  stampCurrentSourceEquivalent(rhs, drain, source, equivalentCurrent);
+}
+
+function evaluateMosfetLevel1(
+  element: Mosfet,
+  vgs: number,
+  vds: number,
+  vbs: number,
+): MosfetDcResult {
+  if (element.type === "PMOS") {
+    const result = evaluateNmosLevel1(element.params, -vgs, -vds, -vbs);
+    return {
+      drainCurrent: -result.drainCurrent,
+      gm: result.gm,
+      gds: result.gds,
+      gmb: result.gmb,
+    };
+  }
+  return evaluateNmosLevel1(element.params, vgs, vds, vbs);
+}
+
+function evaluateNmosLevel1(
+  params: MosfetLevel1Params,
+  vgs: number,
+  vds: number,
+  vbs: number,
+): MosfetDcResult {
+  const beta = params.KP * (params.W / params.L);
+  const threshold =
+    params.PHI - vbs >= 0.0
+      ? params.VT0 + params.GAMMA * (Math.sqrt(params.PHI - vbs) - Math.sqrt(params.PHI))
+      : params.VT0;
+  const overdrive = vgs - threshold;
+  if (overdrive <= 0.0) {
+    return { drainCurrent: 0.0, gm: 0.0, gds: 0.0, gmb: 0.0 };
+  }
+  const bodyFactor =
+    params.PHI - vbs > 0.0
+      ? params.GAMMA / (2.0 * Math.sqrt(params.PHI - vbs))
+      : 0.0;
+  if (vds < overdrive) {
+    const channel = overdrive * vds - 0.5 * vds * vds;
+    const modulation = 1.0 + params.LAMBDA * vds;
+    const gm = beta * vds * modulation;
+    return {
+      drainCurrent: beta * channel * modulation,
+      gm,
+      gds: beta * (overdrive - vds) * modulation + beta * channel * params.LAMBDA,
+      gmb: gm * bodyFactor,
+    };
+  }
+  const current = 0.5 * beta * overdrive * overdrive * (1.0 + params.LAMBDA * vds);
+  const gm = beta * overdrive * (1.0 + params.LAMBDA * vds);
+  return {
+    drainCurrent: current,
+    gm,
+    gds: 0.5 * beta * overdrive * overdrive * params.LAMBDA,
+    gmb: gm * bodyFactor,
+  };
+}
+
+function vectorVoltage(vector: readonly number[], index: number | undefined): number {
+  return index === undefined ? 0.0 : vector[index];
+}
+
 function stampCurrentSourceEquivalent(
   rhs: number[],
   positive: number | undefined,
@@ -2450,6 +2650,30 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.thermalVoltage) || element.thermalVoltage <= 0.0) {
     throw invalidElement(element.name, "thermal voltage must be finite and positive");
+  }
+}
+
+function validateMosfet(element: Mosfet): void {
+  if (element.type !== "NMOS" && element.type !== "PMOS") {
+    throw invalidElement(element.name, "MOSFET type must be NMOS or PMOS");
+  }
+  const params = element.params;
+  for (const [name, value] of Object.entries(params)) {
+    if (!Number.isFinite(value)) {
+      throw invalidElement(element.name, `MOSFET ${name} must be finite`);
+    }
+  }
+  if (params.KP <= 0.0) {
+    throw invalidElement(element.name, "MOSFET KP must be positive");
+  }
+  if (params.W <= 0.0 || params.L <= 0.0) {
+    throw invalidElement(element.name, "MOSFET W and L must be positive");
+  }
+  if (params.PHI <= 0.0) {
+    throw invalidElement(element.name, "MOSFET PHI must be positive");
+  }
+  if (params.IS <= 0.0 || params.N_SUB <= 0.0 || params.T_NOM <= 0.0) {
+    throw invalidElement(element.name, "MOSFET IS, N_SUB, and T_NOM must be positive");
   }
 }
 
@@ -2856,6 +3080,22 @@ function stampBjtSmallSignal(
   }
 }
 
+function stampMosfetSmallSignal(
+  element: Mosfet,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+): void {
+  validateMosfet(element);
+  const drain = nodeIndex(nodeIndices, element.drain);
+  const gate = nodeIndex(nodeIndices, element.gate);
+  const source = nodeIndex(nodeIndices, element.source);
+  const body = nodeIndex(nodeIndices, element.body);
+  const result = evaluateMosfetLevel1(element, 0.0, 0.0, 0.0);
+  stampConductance(matrix, drain, source, result.gds);
+  stampTransconductance(matrix, drain, source, gate, source, result.gm);
+  stampTransconductance(matrix, drain, source, body, source, result.gmb);
+}
+
 function stampAcResistor(
   element: Resistor,
   nodeIndices: ReadonlyMap<string, number>,
@@ -3224,6 +3464,36 @@ function stampAcBjtSmallSignal(
       complex(transconductance, 0.0),
     );
   }
+}
+
+function stampAcMosfetSmallSignal(
+  element: Mosfet,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: Complex[][],
+): void {
+  validateMosfet(element);
+  const drain = nodeIndex(nodeIndices, element.drain);
+  const gate = nodeIndex(nodeIndices, element.gate);
+  const source = nodeIndex(nodeIndices, element.source);
+  const body = nodeIndex(nodeIndices, element.body);
+  const result = evaluateMosfetLevel1(element, 0.0, 0.0, 0.0);
+  stampComplexConductance(matrix, drain, source, complex(result.gds, 0.0));
+  stampComplexTransconductance(
+    matrix,
+    drain,
+    source,
+    gate,
+    source,
+    complex(result.gm, 0.0),
+  );
+  stampComplexTransconductance(
+    matrix,
+    drain,
+    source,
+    body,
+    source,
+    complex(result.gmb, 0.0),
+  );
 }
 
 function solveLinearSystem(matrix: number[][], rhs: number[]): number[] {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -11,6 +11,7 @@ import {
   dcSweep,
   diode,
   inductor,
+  mosfet,
   resistor,
   vccs,
   vcvs,
@@ -169,6 +170,35 @@ describe("dcOp", () => {
 
     expect(result.voltage("collector")).toBeGreaterThan(0.0);
     expect(result.voltage("collector")).toBeLessThan(5.0);
+  });
+
+  it("solves an NMOS operating point", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 1.8));
+    circuit.add(voltageSource("Vgate", "gate", "0", 1.8));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", {
+      VT0: 0.45,
+      KP: 200.0e-6,
+      W: 2.0e-6,
+      L: 180.0e-9,
+      LAMBDA: 0.02,
+    }));
+
+    const result = dcOp(circuit);
+
+    expect(result.voltage("out")).toBeGreaterThanOrEqual(0.0);
+    expect(result.voltage("out")).toBeLessThan(1.8);
+  });
+
+  it("rejects invalid MOSFET model parameters", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 1.8));
+    circuit.add(voltageSource("Vgate", "gate", "0", 1.8));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add(mosfet("Mbad", "out", "gate", "0", "0", "NMOS", { KP: 0.0 }));
+
+    expect(() => dcOp(circuit)).toThrowError("MOSFET KP must be positive");
   });
 
   it("rejects invalid BJT model parameters", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.6
+
+- Add SPICE `M` MOSFET element parsing via `.model <name> NMOS(...)` and
+  `.model <name> PMOS(...)` cards with Level-1 parameter aliases and
+  per-instance overrides such as `W=...` and `L=...`.
+- Remap MOSFET drain/gate/source/body terminals during subcircuit expansion.
+
 ## 0.1.5
 
 - Add SPICE `Q` BJT element parsing via `.model <name> NPN(...)` and

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -19,10 +19,13 @@ netlist.circuit.elements();
 netlist.analyses;
 ```
 
-This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `G`, `E`, `F`, and `H`
+This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and `H`
 elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 `.model <name> NPN(...)` / `.model <name> PNP(...)` BJT cards with `IS`,
-`BF` / `BETA_F`, and `VT` parameters,
+`BF` / `BETA_F`, and `VT` parameters, `.model <name> NMOS(...)` /
+`.model <name> PMOS(...)` MOSFET cards with Level-1 `VT0` / `VTO`, `KP`,
+`LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` /
+`TNOM` parameters,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
 analysis cards.

--- a/code/packages/typescript/spice-netlist-parser/package-lock.json
+++ b/code/packages/typescript/spice-netlist-parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/spice-netlist-parser",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/spice-netlist-parser",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/spice-engine": "file:../spice-engine"

--- a/code/packages/typescript/spice-netlist-parser/package.json
+++ b/code/packages/typescript/spice-netlist-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/spice-netlist-parser",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -13,12 +13,14 @@ import {
   diode,
   dcOp,
   inductor,
+  mosfet,
   resistor,
   vccs,
   vcvs,
   voltageSource,
   voltageSourceWithWaveform,
   type Element,
+  type MosfetLevel1Params,
   type Waveform,
 } from "@coding-adventures/spice-engine";
 
@@ -279,6 +281,54 @@ function parseModelParams(paramsText: string): ReadonlyMap<string, number> {
   return params;
 }
 
+function parseElementParams(tokens: readonly string[], label: string): ReadonlyMap<string, number> {
+  const params = new Map<string, number>();
+  for (const token of tokens) {
+    const equals = token.indexOf("=");
+    if (equals <= 0 || equals === token.length - 1) {
+      throw new NetlistParseError(`invalid ${label} parameter syntax ${JSON.stringify(token)}`);
+    }
+    params.set(token.slice(0, equals).toUpperCase(), parseValue(token.slice(equals + 1)));
+  }
+  return params;
+}
+
+const MOSFET_PARAM_ALIASES = new Map<string, keyof MosfetLevel1Params>([
+  ["VTO", "VT0"],
+  ["NSUB", "N_SUB"],
+  ["N", "N_SUB"],
+  ["TNOM", "T_NOM"],
+]);
+
+function mosfetParams(
+  modelParams: ReadonlyMap<string, number>,
+  instanceParams: ReadonlyMap<string, number>,
+): Partial<MosfetLevel1Params> {
+  const params: Record<string, number> = {};
+  for (const [name, value] of [...modelParams, ...instanceParams]) {
+    const key = MOSFET_PARAM_ALIASES.get(name) ?? (name as keyof MosfetLevel1Params);
+    if (isMosfetParam(key)) {
+      params[key] = value;
+    }
+  }
+  return params;
+}
+
+function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
+  return [
+    "VT0",
+    "KP",
+    "LAMBDA",
+    "GAMMA",
+    "PHI",
+    "W",
+    "L",
+    "IS",
+    "N_SUB",
+    "T_NOM",
+  ].includes(name);
+}
+
 function parseElement(fields: readonly string[], models: ReadonlyMap<string, ModelCard>): Element {
   const name = fields[0];
   const prefix = elementPrefix(name);
@@ -351,6 +401,29 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("IS") ?? 1.0e-14,
       model.params.get("BF") ?? model.params.get("BETA_F") ?? 100.0,
       model.params.get("VT") ?? 0.02585,
+    );
+  }
+  if (prefix === "M") {
+    requireMinFields(fields, 6, "MOSFET");
+    const model = models.get(fields[5].toLowerCase());
+    if (model === undefined) {
+      throw new NetlistParseError(
+        `unknown model ${JSON.stringify(fields[5])} for MOSFET ${JSON.stringify(name)}`,
+      );
+    }
+    if (model.kind !== "NMOS" && model.kind !== "PMOS") {
+      throw new NetlistParseError(
+        `model ${JSON.stringify(model.name)} has kind ${JSON.stringify(model.kind)}, expected "NMOS" or "PMOS"`,
+      );
+    }
+    return mosfet(
+      name,
+      fields[1],
+      fields[2],
+      fields[3],
+      fields[4],
+      model.kind,
+      mosfetParams(model.params, parseElementParams(fields.slice(6), "MOSFET")),
     );
   }
   if (prefix === "G") {
@@ -461,6 +534,11 @@ function mapSubcktFields(
     mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
     mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);
     mapped[3] = mapSubcktNode(fields[3], instanceName, nodeMap);
+  } else if (prefix === "M") {
+    requireMinFields(fields, 5, "subcircuit MOSFET");
+    for (let index = 1; index < 5; index++) {
+      mapped[index] = mapSubcktNode(fields[index], instanceName, nodeMap);
+    }
   } else if (prefix === "E" || prefix === "G") {
     requireMinFields(fields, 5, "subcircuit controlled source");
     for (let index = 1; index < 5; index++) {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -208,6 +208,67 @@ Q2 out base emit slow
     expect(element.thermalVoltage).toBeCloseTo(26.0e-3, 12);
   });
 
+  it("parses MOSFET models into operating-point circuits", () => {
+    const parsed = parseNetlist(`
+.model nfast NMOS(VT0=0.45 KP=200u LAMBDA=0.02)
+Vdd vdd 0 DC 1.8
+Vgate gate 0 DC 1.8
+Rload vdd out 1k
+M1 out gate 0 0 nfast W=2u L=180n
+.op
+`);
+
+    const model = parsed.models.get("nfast");
+    expect(model?.name).toBe("nfast");
+    expect(model?.kind).toBe("NMOS");
+    expect(model?.params.get("VT0")).toBe(0.45);
+    expect(model?.params.get("KP")).toBeCloseTo(200.0e-6, 12);
+    expect(parsed.circuit.elements()[3]).toMatchObject({
+      kind: "mosfet",
+      name: "M1",
+      drain: "out",
+      gate: "gate",
+      source: "0",
+      body: "0",
+      type: "NMOS",
+      params: {
+        VT0: 0.45,
+        LAMBDA: 0.02,
+      },
+    });
+    const element = parsed.circuit.elements()[3];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.KP).toBeCloseTo(200.0e-6, 12);
+    expect(element.params.W).toBeCloseTo(2.0e-6, 12);
+    expect(element.params.L).toBeCloseTo(180.0e-9, 12);
+
+    const result = dcOp(parsed.circuit);
+    expect(result.voltage("out")).toBeGreaterThanOrEqual(0.0);
+    expect(result.voltage("out")).toBeLessThan(1.8);
+  });
+
+  it("parses PMOS MOSFET aliases", () => {
+    const parsed = parseNetlist(`
+.model pfast PMOS(VTO=0.4 KP=120u NSUB=1.2)
+Mp out gate vdd vdd pfast W=3u L=250n
+`);
+
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.type).toBe("PMOS");
+    expect(element.params.VT0).toBe(0.4);
+    expect(element.params.N_SUB).toBe(1.2);
+    expect(element.params.KP).toBeCloseTo(120.0e-6, 12);
+    expect(element.params.W).toBeCloseTo(3.0e-6, 12);
+    expect(element.params.L).toBeCloseTo(250.0e-9, 12);
+  });
+
   it("parses PWL and SIN source waveforms", () => {
     const parsed = parseNetlist(`
 V1 in 0 PWL(0 0, 1n 1.8, 2n 0)
@@ -377,6 +438,31 @@ Xstage out in 0 stage
     });
   });
 
+  it("expands subcircuit MOSFET nodes into engine elements", () => {
+    const parsed = parseNetlist(`
+.model nfast NMOS(W=1u L=130n)
+.subckt pulldown in out vss
+Mpull out in inner vss nfast
+Rtail inner vss 10
+.ends pulldown
+Xpd gate drain 0 pulldown
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "mosfet",
+      name: "Xpd.Mpull",
+      drain: "drain",
+      gate: "gate",
+      source: "Xpd.inner",
+      body: "0",
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "resistor",
+      n1: "Xpd.inner",
+      n2: "0",
+    });
+  });
+
   it("scopes subcircuit internal nodes by instance", () => {
     const parsed = parseNetlist(`
 .subckt load in out
@@ -431,6 +517,24 @@ Xright c d load
   it("rejects non-BJT models for BJT elements", () => {
     expect(() => parseNetlist(".model clamp D(IS=1e-12)\nQ1 c b e clamp\n")).toThrow(
       'line 2: model "clamp" has kind "D", expected "NPN" or "PNP"',
+    );
+  });
+
+  it("rejects unknown MOSFET models", () => {
+    expect(() => parseNetlist("M1 d g s b missing\n")).toThrow(
+      'line 1: unknown model "missing" for MOSFET "M1"',
+    );
+  });
+
+  it("rejects non-MOSFET models for MOSFET elements", () => {
+    expect(() => parseNetlist(".model clamp D(IS=1e-12)\nM1 d g s b clamp\n")).toThrow(
+      'line 2: model "clamp" has kind "D", expected "NMOS" or "PMOS"',
+    );
+  });
+
+  it("rejects MOSFET parameters without assignments", () => {
+    expect(() => parseNetlist(".model nfast NMOS\nM1 d g s b nfast W\n")).toThrow(
+      'line 2: invalid MOSFET parameter syntax "W"',
     );
   });
 


### PR DESCRIPTION
## Summary

- add TypeScript SPICE engine Level-1 NMOS/PMOS MOSFET elements with Newton-linearized DC stamping
- parse `M` MOSFET netlist elements from `NMOS`/`PMOS` model cards with Level-1 parameter aliases and instance overrides
- remap MOSFET drain/gate/source/body terminals during `.subckt` expansion

## Validation

- `npm run build` in `code/packages/typescript/spice-engine`
- `npm test` in `code/packages/typescript/spice-engine`
- `npm run build` in `code/packages/typescript/spice-netlist-parser`
- `npm test` in `code/packages/typescript/spice-netlist-parser`
- `git diff --check`