### PR TITLE
rust(spice): parse MOSFET model netlists

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Add BJT elements with NPN/PNP polarity, Newton-linearized DC operating-point
   support, and zero-bias small-signal transconductance for AC/transfer
   analysis.
+- Add Level-1 NMOS/PMOS MOSFET elements with body-effect parameters,
+  Newton-linearized DC operating-point support, and zero-bias small-signal
+  conductance/transconductance for AC/transfer analysis.
 - Add voltage-controlled current sources (VCCS) for linear transconductance
   stages.
 - Add voltage-controlled voltage sources (VCVS) across DC, AC, transfer

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -342,6 +342,7 @@ pub enum Element {
     CurrentSource(CurrentSource),
     Diode(Diode),
     Bjt(Bjt),
+    Mosfet(Mosfet),
     Vccs(Vccs),
     Vcvs(Vcvs),
     Cccs(Cccs),
@@ -619,6 +620,94 @@ impl Bjt {
             saturation_current,
             forward_beta,
             thermal_voltage,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MosfetType {
+    Nmos,
+    Pmos,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct MosfetLevel1Params {
+    pub vt0: f64,
+    pub kp: f64,
+    pub lambda: f64,
+    pub gamma: f64,
+    pub phi: f64,
+    pub w: f64,
+    pub l: f64,
+    pub saturation_current: f64,
+    pub n_sub: f64,
+    pub t_nom: f64,
+}
+
+impl Default for MosfetLevel1Params {
+    fn default() -> Self {
+        Self {
+            vt0: 0.42,
+            kp: 220.0e-6,
+            lambda: 0.05,
+            gamma: 0.27,
+            phi: 0.84,
+            w: 1.0e-6,
+            l: 130.0e-9,
+            saturation_current: 1.0e-15,
+            n_sub: 1.4,
+            t_nom: 300.15,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Mosfet {
+    pub name: String,
+    pub drain: String,
+    pub gate: String,
+    pub source: String,
+    pub body: String,
+    pub mosfet_type: MosfetType,
+    pub params: MosfetLevel1Params,
+}
+
+impl Mosfet {
+    pub fn new(
+        name: impl Into<String>,
+        drain: impl Into<String>,
+        gate: impl Into<String>,
+        source: impl Into<String>,
+        body: impl Into<String>,
+    ) -> Self {
+        Self::with_model(
+            name,
+            drain,
+            gate,
+            source,
+            body,
+            MosfetType::Nmos,
+            MosfetLevel1Params::default(),
+        )
+    }
+
+    pub fn with_model(
+        name: impl Into<String>,
+        drain: impl Into<String>,
+        gate: impl Into<String>,
+        source: impl Into<String>,
+        body: impl Into<String>,
+        mosfet_type: MosfetType,
+        params: MosfetLevel1Params,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            drain: drain.into(),
+            gate: gate.into(),
+            source: source.into(),
+            body: body.into(),
+            mosfet_type,
+            params,
         }
     }
 }
@@ -1576,6 +1665,7 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
             "saturation_current".to_string(),
             bjt.saturation_current,
         )),
+        Element::Mosfet(mosfet) => Some((mosfet.name.clone(), "kp".to_string(), mosfet.params.kp)),
         Element::Vccs(source) => Some((
             source.name.clone(),
             "transconductance_siemens".to_string(),
@@ -1603,6 +1693,7 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::CurrentSource(source) => source.current += delta,
         Element::Diode(diode) => diode.saturation_current += delta,
         Element::Bjt(bjt) => bjt.saturation_current += delta,
+        Element::Mosfet(mosfet) => mosfet.params.kp += delta,
         Element::Vccs(source) => source.transconductance_siemens += delta,
         Element::Vcvs(source) => source.gain += delta,
         Element::Cccs(source) => source.gain += delta,
@@ -1698,6 +1789,11 @@ fn randomized_element(
             varied.saturation_current =
                 randomized_value(varied.saturation_current, tolerance, distribution, rng);
             Element::Bjt(varied)
+        }
+        Element::Mosfet(mosfet) => {
+            let mut varied = mosfet.clone();
+            varied.params.kp = randomized_value(varied.params.kp, tolerance, distribution, rng);
+            Element::Mosfet(varied)
         }
         Element::Vccs(source) => {
             let mut varied = source.clone();
@@ -1811,10 +1907,12 @@ fn solve_linear_circuit(
         });
     }
 
-    let has_nonlinear = circuit
-        .elements()
-        .iter()
-        .any(|element| matches!(element, Element::Diode(_) | Element::Bjt(_)));
+    let has_nonlinear = circuit.elements().iter().any(|element| {
+        matches!(
+            element,
+            Element::Diode(_) | Element::Bjt(_) | Element::Mosfet(_)
+        )
+    });
     let mut operating_point = vec![0.0; matrix_size];
     let mut solution = solve_linear_circuit_at_operating_point(
         circuit,
@@ -1904,6 +2002,9 @@ fn solve_linear_circuit_at_operating_point(
             Element::Bjt(bjt) => {
                 stamp_bjt(bjt, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
+            Element::Mosfet(mosfet) => {
+                stamp_mosfet(mosfet, node_indices, &mut matrix, &mut rhs, operating_point)?
+            }
             Element::Vccs(source) => stamp_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_vcvs(
                 source,
@@ -1985,6 +2086,7 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             | Element::Inductor(_)
             | Element::Diode(_)
             | Element::Bjt(_)
+            | Element::Mosfet(_)
             | Element::Vccs(_)
             | Element::Vcvs(_)
             | Element::Cccs(_)
@@ -2052,6 +2154,9 @@ fn build_ac_matrix(
                 );
             }
             Element::Bjt(bjt) => stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix)?,
+            Element::Mosfet(mosfet) => {
+                stamp_ac_mosfet_small_signal(mosfet, node_indices, &mut matrix)?
+            }
             Element::Vccs(source) => stamp_ac_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_ac_vcvs(
                 source,
@@ -2129,6 +2234,9 @@ fn build_small_signal_matrix(
                 );
             }
             Element::Bjt(bjt) => stamp_bjt_small_signal(bjt, node_indices, &mut matrix)?,
+            Element::Mosfet(mosfet) => {
+                stamp_mosfet_small_signal(mosfet, node_indices, &mut matrix)?
+            }
             Element::Vccs(source) => {
                 stamp_vccs(source, node_indices, &mut matrix)?;
             }
@@ -2217,6 +2325,12 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &bjt.collector);
                 insert_node(&mut names, &bjt.base);
                 insert_node(&mut names, &bjt.emitter);
+            }
+            Element::Mosfet(mosfet) => {
+                insert_node(&mut names, &mosfet.drain);
+                insert_node(&mut names, &mosfet.gate);
+                insert_node(&mut names, &mosfet.source);
+                insert_node(&mut names, &mosfet.body);
             }
             Element::Vccs(source) => {
                 insert_node(&mut names, &source.positive);
@@ -2328,6 +2442,9 @@ fn find_input_source<'a>(
             }
             Element::Bjt(bjt) if bjt.name == input_source => {
                 return Err(input_source_type_error(input_source, "BJT"));
+            }
+            Element::Mosfet(mosfet) if mosfet.name == input_source => {
+                return Err(input_source_type_error(input_source, "MOSFET"));
             }
             Element::Vccs(source) if source.name == input_source => {
                 return Err(input_source_type_error(input_source, "VCCS"));
@@ -2716,6 +2833,160 @@ fn stamp_ac_bjt_small_signal(
     Ok(())
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+struct MosfetDcResult {
+    drain_current: f64,
+    gm: f64,
+    gds: f64,
+    gmb: f64,
+}
+
+fn stamp_mosfet(
+    mosfet: &Mosfet,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_mosfet(mosfet)?;
+    let drain = node_index(node_indices, &mosfet.drain);
+    let gate = node_index(node_indices, &mosfet.gate);
+    let source = node_index(node_indices, &mosfet.source);
+    let body = node_index(node_indices, &mosfet.body);
+    let drain_voltage = vector_voltage(operating_point, drain);
+    let gate_voltage = vector_voltage(operating_point, gate);
+    let source_voltage = vector_voltage(operating_point, source);
+    let body_voltage = vector_voltage(operating_point, body);
+    let vgs = gate_voltage - source_voltage;
+    let vds = drain_voltage - source_voltage;
+    let vbs = body_voltage - source_voltage;
+    let result = evaluate_mosfet_level1(mosfet, vgs, vds, vbs);
+    let equivalent_current =
+        result.drain_current - result.gm * vgs - result.gds * vds - result.gmb * vbs;
+
+    stamp_conductance(matrix, drain, source, result.gds);
+    stamp_transconductance(matrix, drain, source, gate, source, result.gm);
+    stamp_transconductance(matrix, drain, source, body, source, result.gmb);
+    stamp_equivalent_current_source(rhs, drain, source, equivalent_current);
+    Ok(())
+}
+
+fn evaluate_mosfet_level1(mosfet: &Mosfet, vgs: f64, vds: f64, vbs: f64) -> MosfetDcResult {
+    match mosfet.mosfet_type {
+        MosfetType::Pmos => {
+            let result = evaluate_nmos_level1(&mosfet.params, -vgs, -vds, -vbs);
+            MosfetDcResult {
+                drain_current: -result.drain_current,
+                gm: result.gm,
+                gds: result.gds,
+                gmb: result.gmb,
+            }
+        }
+        MosfetType::Nmos => evaluate_nmos_level1(&mosfet.params, vgs, vds, vbs),
+    }
+}
+
+fn evaluate_nmos_level1(
+    params: &MosfetLevel1Params,
+    vgs: f64,
+    vds: f64,
+    vbs: f64,
+) -> MosfetDcResult {
+    let beta = params.kp * (params.w / params.l);
+    let threshold = if params.phi - vbs >= 0.0 {
+        params.vt0 + params.gamma * ((params.phi - vbs).sqrt() - params.phi.sqrt())
+    } else {
+        params.vt0
+    };
+    let overdrive = vgs - threshold;
+    if overdrive <= 0.0 {
+        return MosfetDcResult {
+            drain_current: 0.0,
+            gm: 0.0,
+            gds: 0.0,
+            gmb: 0.0,
+        };
+    }
+
+    let body_factor = if params.phi - vbs > 0.0 {
+        params.gamma / (2.0 * (params.phi - vbs).sqrt())
+    } else {
+        0.0
+    };
+    if vds < overdrive {
+        let channel = overdrive * vds - 0.5 * vds * vds;
+        let modulation = 1.0 + params.lambda * vds;
+        let gm = beta * vds * modulation;
+        return MosfetDcResult {
+            drain_current: beta * channel * modulation,
+            gm,
+            gds: beta * (overdrive - vds) * modulation + beta * channel * params.lambda,
+            gmb: gm * body_factor,
+        };
+    }
+
+    let drain_current = 0.5 * beta * overdrive * overdrive * (1.0 + params.lambda * vds);
+    let gm = beta * overdrive * (1.0 + params.lambda * vds);
+    MosfetDcResult {
+        drain_current,
+        gm,
+        gds: 0.5 * beta * overdrive * overdrive * params.lambda,
+        gmb: gm * body_factor,
+    }
+}
+
+fn vector_voltage(vector: &[f64], index: Option<usize>) -> f64 {
+    index.map_or(0.0, |index| vector[index])
+}
+
+fn stamp_mosfet_small_signal(
+    mosfet: &Mosfet,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+) -> Result<(), SpiceError> {
+    validate_mosfet(mosfet)?;
+    let drain = node_index(node_indices, &mosfet.drain);
+    let gate = node_index(node_indices, &mosfet.gate);
+    let source = node_index(node_indices, &mosfet.source);
+    let body = node_index(node_indices, &mosfet.body);
+    let result = evaluate_mosfet_level1(mosfet, 0.0, 0.0, 0.0);
+    stamp_conductance(matrix, drain, source, result.gds);
+    stamp_transconductance(matrix, drain, source, gate, source, result.gm);
+    stamp_transconductance(matrix, drain, source, body, source, result.gmb);
+    Ok(())
+}
+
+fn stamp_ac_mosfet_small_signal(
+    mosfet: &Mosfet,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<Complex>],
+) -> Result<(), SpiceError> {
+    validate_mosfet(mosfet)?;
+    let drain = node_index(node_indices, &mosfet.drain);
+    let gate = node_index(node_indices, &mosfet.gate);
+    let source = node_index(node_indices, &mosfet.source);
+    let body = node_index(node_indices, &mosfet.body);
+    let result = evaluate_mosfet_level1(mosfet, 0.0, 0.0, 0.0);
+    stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
+    stamp_complex_transconductance(
+        matrix,
+        drain,
+        source,
+        gate,
+        source,
+        Complex::new(result.gm, 0.0),
+    );
+    stamp_complex_transconductance(
+        matrix,
+        drain,
+        source,
+        body,
+        source,
+        Complex::new(result.gmb, 0.0),
+    );
+    Ok(())
+}
+
 fn validate_reactive_elements(circuit: &Circuit) -> Result<(), SpiceError> {
     for element in circuit.elements() {
         match element {
@@ -2760,6 +3031,54 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "thermal voltage must be finite and positive".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
+    let params = mosfet.params;
+    for (name, value) in [
+        ("VT0", params.vt0),
+        ("KP", params.kp),
+        ("LAMBDA", params.lambda),
+        ("GAMMA", params.gamma),
+        ("PHI", params.phi),
+        ("W", params.w),
+        ("L", params.l),
+        ("IS", params.saturation_current),
+        ("N_SUB", params.n_sub),
+        ("T_NOM", params.t_nom),
+    ] {
+        if !value.is_finite() {
+            return Err(SpiceError::InvalidElement {
+                name: mosfet.name.clone(),
+                reason: format!("MOSFET {name} must be finite"),
+            });
+        }
+    }
+    if params.kp <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET KP must be positive".to_string(),
+        });
+    }
+    if params.w <= 0.0 || params.l <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET W and L must be positive".to_string(),
+        });
+    }
+    if params.phi <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET PHI must be positive".to_string(),
+        });
+    }
+    if params.saturation_current <= 0.0 || params.n_sub <= 0.0 || params.t_nom <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET IS, N_SUB, and T_NOM must be positive".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,6 +1,7 @@
 use spice_engine::{
     dc_op, dc_sweep, Bjt, BjtPolarity, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element,
-    Inductor, Resistor, SinWaveform, SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
+    Inductor, Mosfet, MosfetLevel1Params, MosfetType, Resistor, SinWaveform, SpiceError, Vccs,
+    Vcvs, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -221,6 +222,68 @@ fn dc_bjt_solves_pnp_pullup_operating_point() {
     let result = dc_op(&circuit).unwrap();
     let out = result.voltage("out").unwrap();
     assert!(out > 0.0, "expected pullup current through load, got {out}");
+}
+
+#[test]
+fn dc_mosfet_solves_nmos_source_follower_operating_point() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 2.5,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "vdd",
+        "gate",
+        "out",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            kp: 250.0e-6,
+            w: 4.0e-6,
+            l: 200.0e-9,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+    let out = result.voltage("out").unwrap();
+    assert!(out > 0.0, "expected source follower output, got {out}");
+    assert!(out < 2.5, "expected source below gate bias, got {out}");
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_level1_params() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "Mbad",
+        "vdd",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            kp: 0.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let err = dc_op(&circuit).unwrap_err();
+    assert_eq!(
+        err,
+        SpiceError::InvalidElement {
+            name: "Mbad".to_string(),
+            reason: "MOSFET KP must be positive".to_string(),
+        }
+    );
 }
 
 #[test]

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.6
+
+- Add SPICE `M` MOSFET element parsing via `.model <name> NMOS|PMOS(...)`
+  Level-1 cards, per-instance parameter overrides such as `W=...` and `L=...`,
+  and subcircuit drain/gate/source/body terminal remapping.
+
 ## 0.1.5
 
 - Add SPICE `Q` BJT element parsing via `.model <name> NPN|PNP(...)` cards

--- a/code/packages/rust/spice-netlist-parser/Cargo.toml
+++ b/code/packages/rust/spice-netlist-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spice-netlist-parser"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -17,9 +17,11 @@ C1 out 0 1u
 assert_eq!(parsed.tran_cards().len(), 1);
 ```
 
-This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `G`, `E`, `F`, and
+This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`
 parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
-`BETA_F`, and `VT` parameters, SPICE engineering suffixes, PWL/PULSE/SIN/EXP
+`BETA_F`, and `VT` parameters, `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
+cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
+`W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering suffixes, PWL/PULSE/SIN/EXP
 source forms, comments, `.end`, `.subckt` / `X` instance expansion, and `.op`,
 `.tran`, `.dc`, and `.ac` analysis cards.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, fmt};
 
 use spice_engine::{
     Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, ExpWaveform,
-    Inductor, PulseWaveform, PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource,
-    Waveform,
+    Inductor, Mosfet, MosfetLevel1Params, MosfetType, PulseWaveform, PwlWaveform, Resistor,
+    SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -359,6 +359,54 @@ fn parse_model_params(params_text: &str) -> Result<HashMap<String, f64>, Netlist
     Ok(params)
 }
 
+fn parse_element_params(
+    fields: &[String],
+    label: &str,
+) -> Result<HashMap<String, f64>, NetlistParseError> {
+    let mut params = HashMap::new();
+    for token in fields {
+        let Some((name, value)) = token.split_once('=') else {
+            return Err(NetlistParseError::new(format!(
+                "invalid {label} parameter syntax {token:?}"
+            )));
+        };
+        if name.is_empty() || value.is_empty() {
+            return Err(NetlistParseError::new(format!(
+                "invalid {label} parameter syntax {token:?}"
+            )));
+        }
+        params.insert(name.to_ascii_uppercase(), parse_value(value)?);
+    }
+    Ok(params)
+}
+
+fn build_mosfet_params(
+    model: &ModelCard,
+    instance_params: &HashMap<String, f64>,
+) -> MosfetLevel1Params {
+    let mut params = MosfetLevel1Params::default();
+    for (name, value) in model.params.iter().chain(instance_params.iter()) {
+        apply_mosfet_param(&mut params, name, *value);
+    }
+    params
+}
+
+fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
+    match name {
+        "VT0" | "VTO" => params.vt0 = value,
+        "KP" => params.kp = value,
+        "LAMBDA" => params.lambda = value,
+        "GAMMA" => params.gamma = value,
+        "PHI" => params.phi = value,
+        "W" => params.w = value,
+        "L" => params.l = value,
+        "IS" => params.saturation_current = value,
+        "N_SUB" | "NSUB" | "N" => params.n_sub = value,
+        "T_NOM" | "TNOM" => params.t_nom = value,
+        _ => {}
+    }
+}
+
 fn parse_element(
     fields: &[String],
     models: &HashMap<String, ModelCard>,
@@ -468,6 +516,35 @@ fn parse_element(
                 *model.params.get("IS").unwrap_or(&1.0e-14),
                 forward_beta,
                 *model.params.get("VT").unwrap_or(&0.02585),
+            )))
+        }
+        'M' => {
+            require_min_fields(fields, 6, "MOSFET")?;
+            let model = models.get(&fields[5].to_ascii_lowercase()).ok_or_else(|| {
+                NetlistParseError::new(format!(
+                    "unknown model {:?} for MOSFET {:?}",
+                    fields[5], name
+                ))
+            })?;
+            let mosfet_type = match model.kind.as_str() {
+                "NMOS" => MosfetType::Nmos,
+                "PMOS" => MosfetType::Pmos,
+                _ => {
+                    return Err(NetlistParseError::new(format!(
+                        "model {:?} has kind {:?}, expected \"NMOS\" or \"PMOS\"",
+                        model.name, model.kind
+                    )));
+                }
+            };
+            let instance_params = parse_element_params(&fields[6..], "MOSFET")?;
+            Ok(Element::Mosfet(Mosfet::with_model(
+                name,
+                &fields[1],
+                &fields[2],
+                &fields[3],
+                &fields[4],
+                mosfet_type,
+                build_mosfet_params(model, &instance_params),
             )))
         }
         'G' => {
@@ -641,6 +718,12 @@ fn map_subckt_fields(
         'Q' => {
             require_min_fields(fields, 4, "subcircuit BJT")?;
             for index in 1..4 {
+                mapped[index] = map_subckt_node(&fields[index], instance_name, node_map);
+            }
+        }
+        'M' => {
+            require_min_fields(fields, 5, "subcircuit MOSFET")?;
+            for index in 1..5 {
                 mapped[index] = map_subckt_node(&fields[index], instance_name, node_map);
             }
         }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1,4 +1,4 @@
-use spice_engine::{dc_op, BjtPolarity, Element};
+use spice_engine::{dc_op, BjtPolarity, Element, MosfetType};
 use spice_netlist_parser::{
     parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, NetlistParseError, OpAnalysis,
     TranAnalysis,
@@ -259,6 +259,70 @@ Q1 vcc base out pullup
 }
 
 #[test]
+fn parses_mosfet_models_into_operating_point_circuits() {
+    let parsed = parse_netlist(
+        r#"
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n NSUB=1.5 TNOM=300)
+Vdd vdd 0 DC 5
+Vgate gate 0 DC 2.5
+M1 vdd gate out 0 nch W=4u L=200n
+Rload out 0 1k
+.op
+"#,
+    )
+    .unwrap();
+
+    let model = parsed.models.get("nch").unwrap();
+    assert_eq!(model.name, "nch");
+    assert_eq!(model.kind, "NMOS");
+    assert_close(*model.params.get("VTO").unwrap(), 0.45);
+    assert_close(*model.params.get("KP").unwrap(), 250.0e-6);
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[2] else {
+        panic!("expected MOSFET");
+    };
+    assert_eq!(mosfet.name, "M1");
+    assert_eq!(mosfet.drain, "vdd");
+    assert_eq!(mosfet.gate, "gate");
+    assert_eq!(mosfet.source, "out");
+    assert_eq!(mosfet.body, "0");
+    assert_eq!(mosfet.mosfet_type, MosfetType::Nmos);
+    assert_close(mosfet.params.vt0, 0.45);
+    assert_close(mosfet.params.kp, 250.0e-6);
+    assert_close(mosfet.params.lambda, 0.02);
+    assert_close(mosfet.params.gamma, 0.3);
+    assert_close(mosfet.params.phi, 0.8);
+    assert_close(mosfet.params.w, 4.0e-6);
+    assert_close(mosfet.params.l, 200.0e-9);
+    assert_close(mosfet.params.n_sub, 1.5);
+    assert_close(mosfet.params.t_nom, 300.0);
+
+    let result = dc_op(&parsed.circuit).unwrap();
+    let out = result.voltage("out").unwrap();
+    assert!(out > 0.0, "expected source follower output, got {out}");
+    assert!(out < 2.5, "expected source below gate bias, got {out}");
+}
+
+#[test]
+fn parses_pmos_mosfet_model_cards() {
+    let parsed = parse_netlist(
+        r#"
+.model pch PMOS(VT0=-0.5 KP=90u W=3u L=180n)
+Mpull out gate vdd vdd pch
+"#,
+    )
+    .unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_eq!(mosfet.mosfet_type, MosfetType::Pmos);
+    assert_close(mosfet.params.vt0, -0.5);
+    assert_close(mosfet.params.kp, 90.0e-6);
+    assert_close(mosfet.params.w, 3.0e-6);
+}
+
+#[test]
 fn parses_pwl_and_sin_source_waveforms() {
     let parsed = parse_netlist(
         r#"
@@ -486,6 +550,30 @@ Xbuf vcc in out follower
 }
 
 #[test]
+fn expands_subcircuit_mosfet_nodes_into_engine_elements() {
+    let parsed = parse_netlist(
+        r#"
+.model nch NMOS(KP=220u)
+.subckt source_follower d g s b
+Mdrive d g s b nch W=2u
+.ends source_follower
+Xbuf vdd in out 0 source_follower
+"#,
+    )
+    .unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_eq!(mosfet.name, "Xbuf.Mdrive");
+    assert_eq!(mosfet.drain, "vdd");
+    assert_eq!(mosfet.gate, "in");
+    assert_eq!(mosfet.source, "out");
+    assert_eq!(mosfet.body, "0");
+    assert_close(mosfet.params.w, 2.0e-6);
+}
+
+#[test]
 fn scopes_subcircuit_internal_nodes_by_instance() {
     let parsed = parse_netlist(
         r#"
@@ -559,6 +647,33 @@ fn rejects_non_bjt_models_for_bjt_elements() {
     assert!(err
         .to_string()
         .contains("line 2: model \"clamp\" has kind \"D\", expected \"NPN\" or \"PNP\""));
+}
+
+#[test]
+fn rejects_unknown_mosfet_models() {
+    let err = parse_netlist("M1 d g s b missing\n").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("line 1: unknown model \"missing\" for MOSFET \"M1\""));
+}
+
+#[test]
+fn rejects_non_mosfet_models_for_mosfet_elements() {
+    let err = parse_netlist(".model clamp D(IS=1e-12)\nM1 d g s b clamp\n").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("line 2: model \"clamp\" has kind \"D\", expected \"NMOS\" or \"PMOS\""));
+}
+
+#[test]
+fn rejects_invalid_mosfet_instance_parameters() {
+    let err = parse_netlist(".model nch NMOS(KP=220u)\nM1 d g s b nch W\n").unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("line 2: invalid MOSFET parameter syntax \"W\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Rust spice-engine Level-1 NMOS/PMOS MOSFET elements with DC Newton linearization and small-signal AC/TF participation
- parse SPICE M elements and NMOS/PMOS .model cards, including common Level-1 aliases and per-instance W/L overrides
- cover MOSFET parser errors, subcircuit drain/gate/source/body remapping, and engine DC validation

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-rust-spice-netlist-mosfet-model cargo test -p spice-engine -p spice-netlist-parser
- git diff --check