### PR TITLE
feat(riscv-rv64i-simulator): RISC-V RV64I + M extension behavioral simulator — Layer 07y

### DIFF
--- a/code/packages/python/riscv-rv64i-simulator/BUILD
+++ b/code/packages/python/riscv-rv64i-simulator/BUILD
@@ -1,0 +1,4 @@
+uv venv --quiet --clear
+uv pip install -e ../simulator-protocol -e ".[dev]" --quiet
+.venv/bin/ruff check src/ tests/
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/riscv-rv64i-simulator/CHANGELOG.md
+++ b/code/packages/python/riscv-rv64i-simulator/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## 0.1.0 (2026-05-15)
+
+Initial release — Layer 07y in the coding-adventures simulator series.
+
+### Added
+
+- `RV64ISimulator` implementing the SIM00 protocol:
+  - `reset()`, `load()`, `step()`, `execute()`, `get_state()`
+  - I/O stubs: `set_input_port()`, `get_output_port()`, `interrupt()`, `nmi()`
+- `RV64IState` frozen dataclass with ABI register properties (ra, sp, gp, tp,
+  t0–t6, s0–s11, a0–a7, zero) and full memory tuple
+- `StepTrace` local dataclass with `pc_before`, `pc_after`, `halted`
+- Full **RV64I** base integer instruction set:
+  - LUI, AUIPC
+  - JAL, JALR
+  - BEQ, BNE, BLT, BGE, BLTU, BGEU
+  - LB, LH, LW, LD, LBU, LHU, LWU
+  - SB, SH, SW, SD
+  - ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI
+  - ADDIW, SLLIW, SRLIW, SRAIW
+  - ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND
+  - ADDW, SUBW, SLLW, SRLW, SRAW
+  - FENCE (NOP)
+  - ECALL/EBREAK (halt)
+- **M extension** multiply/divide:
+  - MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU (64-bit)
+  - MULW, DIVW, DIVUW, REMW, REMUW (32-bit word, result sign-extended)
+- Halt sentinel: 32-bit word `0x00000000`
+- Reset initializes SP=0xFFF8, all other registers and memory = 0
+- Full test suite: 15 protocol tests + instruction/program tests (>80% coverage)
+- `py.typed` marker for PEP 561 compliance
+- Literate code comments throughout

--- a/code/packages/python/riscv-rv64i-simulator/README.md
+++ b/code/packages/python/riscv-rv64i-simulator/README.md
@@ -1,0 +1,41 @@
+# riscv-rv64i-simulator
+
+RISC-V RV64I + M extension behavioral simulator — Layer 07y in the
+coding-adventures simulator series.
+
+## What it implements
+
+- Full **RV64I** base integer instruction set (64-bit)
+- **M extension**: integer multiply and divide (64-bit and 32-bit word forms)
+- SIM00 simulator protocol: `reset`, `load`, `step`, `execute`, `get_state`
+
+## Usage
+
+```python
+from riscv_rv64i_simulator import RV64ISimulator
+
+sim = RV64ISimulator()
+# ADDI x10, x0, 42 (0x02A00513) + halt (0x00000000)
+state = sim.execute(bytes.fromhex("1305A002" + "00000000"))
+print(state.a0)  # 42
+```
+
+## Architecture
+
+- 32 × 64-bit integer registers (x0–x31); x0 hardwired to zero
+- Fixed 32-bit instruction width; little-endian
+- 64 KiB flat memory (addresses masked to 16 bits)
+- Halt sentinel: 32-bit zero word `0x00000000`
+
+## Layer position
+
+```
+07a riscv (RV32I minimal) → ... → 07x ARMv7-A → [07y YOU ARE HERE] → 07z Apple M1
+```
+
+## Running tests
+
+```bash
+uv venv && uv pip install -e ../simulator-protocol -e ".[dev]"
+python -m pytest tests/ -v
+```

--- a/code/packages/python/riscv-rv64i-simulator/pyproject.toml
+++ b/code/packages/python/riscv-rv64i-simulator/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-riscv-rv64i-simulator"
+version = "0.1.0"
+description = "RISC-V RV64I + M extension behavioral simulator — Layer 07y"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = ["coding-adventures-simulator-protocol"]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/riscv_rv64i_simulator"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=riscv_rv64i_simulator --cov-report=term-missing --cov-fail-under=80"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]

--- a/code/packages/python/riscv-rv64i-simulator/src/riscv_rv64i_simulator/__init__.py
+++ b/code/packages/python/riscv-rv64i-simulator/src/riscv_rv64i_simulator/__init__.py
@@ -1,0 +1,22 @@
+"""RISC-V RV64I + M extension behavioral simulator — Layer 07y."""
+
+from .simulator import RV64ISimulator, StepTrace
+from .state import (
+    MASK32,
+    MASK64,
+    MEM_SIZE,
+    RA,
+    SP,
+    RV64IState,
+)
+
+__all__ = [
+    "RV64ISimulator",
+    "RV64IState",
+    "StepTrace",
+    "MEM_SIZE",
+    "MASK32",
+    "MASK64",
+    "SP",
+    "RA",
+]

--- a/code/packages/python/riscv-rv64i-simulator/src/riscv_rv64i_simulator/simulator.py
+++ b/code/packages/python/riscv-rv64i-simulator/src/riscv_rv64i_simulator/simulator.py
@@ -1,0 +1,850 @@
+"""
+RISC-V RV64I + M Extension Behavioral Simulator
+================================================
+
+RISC-V is a clean, load-store RISC ISA with:
+  - 32 general-purpose 64-bit integer registers (x0–x31)
+  - x0 hardwired to zero; writes are silently ignored
+  - Fixed 32-bit instruction width, always 4-byte aligned
+  - Little-endian memory
+  - No condition codes; comparisons produce 0/1 in a destination register
+
+Instruction encoding uses six formats (R/I/S/B/U/J).  The opcode in bits[6:0]
+uniquely identifies the format.  Because the two LSBs are always 0b11 for
+32-bit instructions, fetching a word of 0x00000000 (which has LSBs=00) is used
+as the halt sentinel.
+
+This module implements:
+  - Full RV64I base integer instruction set
+  - M extension: integer multiply and divide (both 64-bit and 32-bit word forms)
+  - ECALL/EBREAK treated as halt
+
+Not implemented (out of scope for behavioral compiler testing):
+  - F/D floating-point extensions
+  - A atomic extension
+  - C compressed (16-bit) extension
+  - Privilege modes, CSRs, MMU, interrupts
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .state import (
+    MASK8,
+    MASK16,
+    MASK32,
+    MASK64,
+    MEM_SIZE,
+    NUM_REGS,
+    SP,
+    RV64IState,
+    sext,
+    sext12,
+    sext32_to_64,
+    to_signed32,
+    to_signed64,
+)
+
+# ── Step trace ─────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StepTrace:
+    """
+    Record of a single instruction execution, returned by RV64ISimulator.step().
+
+    Attributes
+    ----------
+    pc_before   Address from which the instruction was fetched.
+    pc_after    PC value after the instruction executed (next fetch address).
+    halted      True if the simulator halted (fetched the zero sentinel).
+    """
+
+    pc_before: int
+    pc_after:  int
+    halted:    bool
+
+
+# ── Opcode constants ───────────────────────────────────────────────────────────
+# All opcodes have the two LSBs == 0b11 for standard 32-bit instructions.
+
+OP_LUI:    int = 0x37   # 0110111 — Load Upper Immediate
+OP_AUIPC:  int = 0x17   # 0010111 — Add Upper Immediate to PC
+OP_JAL:    int = 0x6F   # 1101111 — Jump And Link
+OP_JALR:   int = 0x67   # 1100111 — Jump And Link Register
+OP_BRANCH: int = 0x63   # 1100011 — Conditional branches
+OP_LOAD:   int = 0x03   # 0000011 — Load (LB/LH/LW/LD/LBU/LHU/LWU)
+OP_STORE:  int = 0x23   # 0100011 — Store (SB/SH/SW/SD)
+OP_ALUI:   int = 0x13   # 0010011 — ALU immediate (ADDI/SLTI/…)
+OP_ALUR:   int = 0x33   # 0110011 — ALU register (ADD/SUB/…) + M-ext (mul/div)
+OP_ALUIW:  int = 0x1B   # 0011011 — RV64I word ALU immediate (ADDIW/SLLIW/…)
+OP_ALURW:  int = 0x3B   # 0111011 — RV64I word ALU register (ADDW/SUBW/…)
+OP_FENCE:  int = 0x0F   # 0001111 — Memory fence (NOP in this simulator)
+OP_SYSTEM: int = 0x73   # 1110011 — ECALL / EBREAK / CSR (halt here)
+
+# funct3 for branch instructions
+FUNCT3_BEQ:  int = 0b000
+FUNCT3_BNE:  int = 0b001
+FUNCT3_BLT:  int = 0b100
+FUNCT3_BGE:  int = 0b101
+FUNCT3_BLTU: int = 0b110
+FUNCT3_BGEU: int = 0b111
+
+# funct3 for load instructions
+FUNCT3_LB:  int = 0b000
+FUNCT3_LH:  int = 0b001
+FUNCT3_LW:  int = 0b010
+FUNCT3_LD:  int = 0b011
+FUNCT3_LBU: int = 0b100
+FUNCT3_LHU: int = 0b101
+FUNCT3_LWU: int = 0b110
+
+# funct3 for store instructions
+FUNCT3_SB: int = 0b000
+FUNCT3_SH: int = 0b001
+FUNCT3_SW: int = 0b010
+FUNCT3_SD: int = 0b011
+
+# funct3 for ALU immediate
+FUNCT3_ADDI:      int = 0b000
+FUNCT3_SLTI:      int = 0b010
+FUNCT3_SLTIU:     int = 0b011
+FUNCT3_XORI:      int = 0b100
+FUNCT3_ORI:       int = 0b110
+FUNCT3_ANDI:      int = 0b111
+FUNCT3_SLLI:      int = 0b001
+FUNCT3_SRLI_SRAI: int = 0b101
+
+# funct3 for ALU register (also used for M-extension)
+FUNCT3_ADD_SUB:   int = 0b000   # funct7 distinguishes ADD(0) vs SUB(0x20)
+FUNCT3_SLL:       int = 0b001
+FUNCT3_SLT:       int = 0b010
+FUNCT3_SLTU:      int = 0b011
+FUNCT3_XOR:       int = 0b100
+FUNCT3_SRL_SRA:   int = 0b101   # funct7 distinguishes SRL(0) vs SRA(0x20)
+FUNCT3_OR:        int = 0b110
+FUNCT3_AND:       int = 0b111
+FUNCT3_MUL:       int = 0b000   # M-ext (funct7=0b0000001)
+FUNCT3_MULH:      int = 0b001
+FUNCT3_MULHSU:    int = 0b010
+FUNCT3_MULHU:     int = 0b011
+FUNCT3_DIV:       int = 0b100
+FUNCT3_DIVU:      int = 0b101
+FUNCT3_REM:       int = 0b110
+FUNCT3_REMU:      int = 0b111
+
+FUNCT7_NORMAL: int = 0x00   # standard R-type
+FUNCT7_ALT:    int = 0x20   # SUB / SRA
+FUNCT7_MEXT:   int = 0x01   # M extension
+
+
+# ── CPU mutable state ──────────────────────────────────────────────────────────
+
+
+class _CPU:
+    """
+    Mutable simulator state owned by RV64ISimulator.
+
+    Kept mutable for efficiency during execution; external callers only see the
+    frozen RV64IState snapshots returned by get_state().
+    """
+
+    __slots__ = ("gpr", "memory", "pc", "halted")
+
+    def __init__(self) -> None:
+        self.gpr: list[int] = [0] * NUM_REGS    # x0–x31, all 64-bit
+        self.memory: bytearray = bytearray(MEM_SIZE)
+        self.pc: int = 0
+        self.halted: bool = False
+
+    # ── Register access ───────────────────────────────────────────────────────
+
+    def read_reg(self, r: int) -> int:
+        """Read register r.  x0 always returns 0."""
+        return 0 if r == 0 else self.gpr[r] & MASK64
+
+    def write_reg(self, r: int, val: int) -> None:
+        """Write register r.  Writes to x0 are silently discarded."""
+        if r != 0:
+            self.gpr[r] = val & MASK64
+
+    # ── Memory helpers ────────────────────────────────────────────────────────
+
+    def read8(self, addr: int) -> int:
+        return self.memory[addr & 0xFFFF]
+
+    def write8(self, addr: int, val: int) -> None:
+        self.memory[addr & 0xFFFF] = val & 0xFF
+
+    def read16(self, addr: int) -> int:
+        a = addr & 0xFFFF
+        return self.memory[a] | (self.memory[(a + 1) & 0xFFFF] << 8)
+
+    def write16(self, addr: int, val: int) -> None:
+        a = addr & 0xFFFF
+        self.memory[a] = val & 0xFF
+        self.memory[(a + 1) & 0xFFFF] = (val >> 8) & 0xFF
+
+    def read32(self, addr: int) -> int:
+        a = addr & 0xFFFF
+        return (self.memory[a]
+                | (self.memory[(a + 1) & 0xFFFF] << 8)
+                | (self.memory[(a + 2) & 0xFFFF] << 16)
+                | (self.memory[(a + 3) & 0xFFFF] << 24))
+
+    def write32(self, addr: int, val: int) -> None:
+        a = addr & 0xFFFF
+        self.memory[a]                    = val & 0xFF
+        self.memory[(a + 1) & 0xFFFF]    = (val >> 8)  & 0xFF
+        self.memory[(a + 2) & 0xFFFF]    = (val >> 16) & 0xFF
+        self.memory[(a + 3) & 0xFFFF]    = (val >> 24) & 0xFF
+
+    def read64(self, addr: int) -> int:
+        a = addr & 0xFFFF
+        lo = self.read32(a)
+        hi = self.read32((a + 4) & 0xFFFF)
+        return (hi << 32) | lo
+
+    def write64(self, addr: int, val: int) -> None:
+        a = addr & 0xFFFF
+        self.write32(a, val & MASK32)
+        self.write32((a + 4) & 0xFFFF, (val >> 32) & MASK32)
+
+    def fetch32(self) -> int:
+        """Fetch a 32-bit instruction at PC and advance PC by 4."""
+        instr = self.read32(self.pc)
+        self.pc = (self.pc + 4) & MASK64
+        return instr
+
+
+# ── Immediate decoding ─────────────────────────────────────────────────────────
+
+
+def _decode_i_imm(instr: int) -> int:
+    """Decode and sign-extend a 12-bit I-type immediate."""
+    return sext12(instr >> 20)
+
+
+def _decode_s_imm(instr: int) -> int:
+    """Decode and sign-extend a 12-bit S-type immediate."""
+    hi = (instr >> 25) & 0x7F   # bits [11:5]
+    lo = (instr >> 7)  & 0x1F   # bits [4:0]
+    return sext12((hi << 5) | lo)
+
+
+def _decode_b_imm(instr: int) -> int:
+    """
+    Decode and sign-extend a 13-bit B-type immediate.
+
+    The B-type scatters the immediate across the word to keep register fields
+    in the same position as the S-type:
+      bit[12] = instr[31]
+      bit[11] = instr[7]
+      bits[10:5] = instr[30:25]
+      bits[4:1] = instr[11:8]
+      bit[0] = 0 (always, since branches target aligned addresses)
+    """
+    b12  = (instr >> 31) & 1
+    b11  = (instr >> 7)  & 1
+    b105 = (instr >> 25) & 0x3F
+    b41  = (instr >> 8)  & 0xF
+    raw  = (b12 << 12) | (b11 << 11) | (b105 << 5) | (b41 << 1)
+    return sext(raw, 13)
+
+
+def _decode_u_imm(instr: int) -> int:
+    """
+    Decode a U-type immediate (upper 20 bits, sign-extended to 64 bits).
+
+    LUI / AUIPC use this form.  The result is already shifted left 12 bits.
+    """
+    raw = instr & 0xFFFFF000   # bits[31:12] << 12, bits[11:0] = 0
+    return sext(raw, 32)
+
+
+def _decode_j_imm(instr: int) -> int:
+    """
+    Decode and sign-extend a 21-bit J-type immediate (JAL).
+
+    Bit layout:
+      bit[20]    = instr[31]
+      bits[10:1] = instr[30:21]
+      bit[11]    = instr[20]
+      bits[19:12]= instr[19:12]
+      bit[0]     = 0
+    """
+    b20   = (instr >> 31) & 1
+    b1910 = (instr >> 21) & 0x3FF
+    b11   = (instr >> 20) & 1
+    b1912 = (instr >> 12) & 0xFF
+    raw   = (b20 << 20) | (b1912 << 12) | (b11 << 11) | (b1910 << 1)
+    return sext(raw, 21)
+
+
+# ── Instruction execution ──────────────────────────────────────────────────────
+
+
+def _exec_lui(cpu: _CPU, instr: int) -> None:
+    """LUI rd, imm20 — load upper 20 bits into rd; lower 12 bits = 0."""
+    rd  = (instr >> 7) & 0x1F
+    imm = _decode_u_imm(instr)
+    cpu.write_reg(rd, imm & MASK64)
+
+
+def _exec_auipc(cpu: _CPU, instr: int, pc_at_fetch: int) -> None:
+    """AUIPC rd, imm20 — rd = PC + (imm20 << 12)."""
+    rd  = (instr >> 7) & 0x1F
+    imm = _decode_u_imm(instr)
+    cpu.write_reg(rd, (pc_at_fetch + imm) & MASK64)
+
+
+def _exec_jal(cpu: _CPU, instr: int, pc_at_fetch: int) -> None:
+    """
+    JAL rd, offset — unconditional jump with link.
+
+    rd = PC + 4  (return address, one instruction past JAL)
+    PC = PC + sign_extend(offset, 21)
+    """
+    rd     = (instr >> 7) & 0x1F
+    offset = _decode_j_imm(instr)
+    ret    = (pc_at_fetch + 4) & MASK64
+    cpu.write_reg(rd, ret)
+    cpu.pc = (pc_at_fetch + offset) & MASK64
+
+
+def _exec_jalr(cpu: _CPU, instr: int, pc_at_fetch: int) -> None:
+    """
+    JALR rd, rs1, imm — indirect jump with link.
+
+    rd = PC + 4
+    PC = (rs1 + sign_extend(imm,12)) & ~1  (clear LSB)
+    """
+    rd  = (instr >> 7)  & 0x1F
+    rs1 = (instr >> 15) & 0x1F
+    imm = _decode_i_imm(instr)
+    ret    = (pc_at_fetch + 4) & MASK64
+    target = (cpu.read_reg(rs1) + imm) & MASK64 & ~1
+    cpu.write_reg(rd, ret)
+    cpu.pc = target
+
+
+def _exec_branch(cpu: _CPU, instr: int, pc_at_fetch: int) -> None:
+    """
+    Conditional branches (BEQ/BNE/BLT/BGE/BLTU/BGEU).
+
+    Branch target = PC + sign_extend(imm, 13).
+    No branch-delay slot (unlike MIPS).
+    """
+    funct3 = (instr >> 12) & 0x7
+    rs1    = (instr >> 15) & 0x1F
+    rs2    = (instr >> 20) & 0x1F
+    offset = _decode_b_imm(instr)
+
+    a = cpu.read_reg(rs1)
+    b = cpu.read_reg(rs2)
+
+    # Unsigned comparisons use the 64-bit unsigned values directly.
+    # Signed comparisons need to interpret the values as signed.
+    taken = False
+    if funct3 == FUNCT3_BEQ:
+        taken = a == b
+    elif funct3 == FUNCT3_BNE:
+        taken = a != b
+    elif funct3 == FUNCT3_BLT:
+        taken = to_signed64(a) < to_signed64(b)
+    elif funct3 == FUNCT3_BGE:
+        taken = to_signed64(a) >= to_signed64(b)
+    elif funct3 == FUNCT3_BLTU:
+        taken = a < b
+    elif funct3 == FUNCT3_BGEU:
+        taken = a >= b
+
+    if taken:
+        cpu.pc = (pc_at_fetch + offset) & MASK64
+
+
+def _exec_load(cpu: _CPU, instr: int) -> None:
+    """
+    Load instructions (LB/LH/LW/LD/LBU/LHU/LWU).
+
+    Address = rs1 + sign_extend(imm, 12).
+    """
+    funct3 = (instr >> 12) & 0x7
+    rd     = (instr >> 7)  & 0x1F
+    rs1    = (instr >> 15) & 0x1F
+    imm    = _decode_i_imm(instr)
+    addr   = (cpu.read_reg(rs1) + imm) & MASK64
+
+    if funct3 == FUNCT3_LB:
+        val = sext(cpu.read8(addr), 8) & MASK64
+    elif funct3 == FUNCT3_LH:
+        val = sext(cpu.read16(addr), 16) & MASK64
+    elif funct3 == FUNCT3_LW:
+        val = sext(cpu.read32(addr), 32) & MASK64
+    elif funct3 == FUNCT3_LD:
+        val = cpu.read64(addr) & MASK64
+    elif funct3 == FUNCT3_LBU:
+        val = cpu.read8(addr)
+    elif funct3 == FUNCT3_LHU:
+        val = cpu.read16(addr)
+    elif funct3 == FUNCT3_LWU:
+        val = cpu.read32(addr) & MASK32
+    else:
+        return   # undefined funct3 — treat as NOP
+
+    cpu.write_reg(rd, val)
+
+
+def _exec_store(cpu: _CPU, instr: int) -> None:
+    """
+    Store instructions (SB/SH/SW/SD).
+
+    Address = rs1 + sign_extend(imm, 12).
+    """
+    funct3 = (instr >> 12) & 0x7
+    rs1    = (instr >> 15) & 0x1F
+    rs2    = (instr >> 20) & 0x1F
+    imm    = _decode_s_imm(instr)
+    addr   = (cpu.read_reg(rs1) + imm) & MASK64
+    val    = cpu.read_reg(rs2)
+
+    if funct3 == FUNCT3_SB:
+        cpu.write8(addr, val & MASK8)
+    elif funct3 == FUNCT3_SH:
+        cpu.write16(addr, val & MASK16)
+    elif funct3 == FUNCT3_SW:
+        cpu.write32(addr, val & MASK32)
+    elif funct3 == FUNCT3_SD:
+        cpu.write64(addr, val)
+
+
+def _exec_alui(cpu: _CPU, instr: int) -> None:
+    """
+    ALU immediate instructions (ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI,
+    SRLI, SRAI).
+
+    Encoding: I-type; imm is sign-extended 12-bit.
+    For shifts, the shift amount (shamt) is in bits[25:20] (6 bits for RV64I).
+    """
+    funct3 = (instr >> 12) & 0x7
+    rd     = (instr >> 7)  & 0x1F
+    rs1    = (instr >> 15) & 0x1F
+    a      = cpu.read_reg(rs1)
+
+    if funct3 == FUNCT3_ADDI:
+        imm = _decode_i_imm(instr)
+        cpu.write_reg(rd, (a + imm) & MASK64)
+
+    elif funct3 == FUNCT3_SLTI:
+        imm = _decode_i_imm(instr)
+        cpu.write_reg(rd, 1 if to_signed64(a) < imm else 0)
+
+    elif funct3 == FUNCT3_SLTIU:
+        # Compare unsigned; imm is still sign-extended then treated as unsigned
+        imm = _decode_i_imm(instr) & MASK64
+        cpu.write_reg(rd, 1 if a < imm else 0)
+
+    elif funct3 == FUNCT3_XORI:
+        imm = _decode_i_imm(instr) & MASK64
+        cpu.write_reg(rd, (a ^ imm) & MASK64)
+
+    elif funct3 == FUNCT3_ORI:
+        imm = _decode_i_imm(instr) & MASK64
+        cpu.write_reg(rd, (a | imm) & MASK64)
+
+    elif funct3 == FUNCT3_ANDI:
+        imm = _decode_i_imm(instr) & MASK64
+        cpu.write_reg(rd, (a & imm) & MASK64)
+
+    elif funct3 == FUNCT3_SLLI:
+        # For RV64I, shamt is bits[25:20] (6 bits)
+        shamt = (instr >> 20) & 0x3F
+        cpu.write_reg(rd, (a << shamt) & MASK64)
+
+    elif funct3 == FUNCT3_SRLI_SRAI:
+        shamt  = (instr >> 20) & 0x3F
+        funct7 = (instr >> 25) & 0x7F
+        if funct7 & 0x20:   # SRAI: arithmetic (sign-preserving)
+            signed_a = to_signed64(a)
+            cpu.write_reg(rd, (signed_a >> shamt) & MASK64)
+        else:               # SRLI: logical (zero-fill)
+            cpu.write_reg(rd, (a >> shamt) & MASK64)
+
+
+def _exec_alur(cpu: _CPU, instr: int) -> None:
+    """
+    ALU register instructions (ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR,
+    AND) plus M-extension (MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU).
+
+    funct7 = 0x00: standard ops
+    funct7 = 0x20: ALT ops (SUB, SRA)
+    funct7 = 0x01: M extension
+    """
+    funct3 = (instr >> 12) & 0x7
+    funct7 = (instr >> 25) & 0x7F
+    rd     = (instr >> 7)  & 0x1F
+    rs1    = (instr >> 15) & 0x1F
+    rs2    = (instr >> 20) & 0x1F
+    a      = cpu.read_reg(rs1)
+    b      = cpu.read_reg(rs2)
+
+    if funct7 == FUNCT7_MEXT:
+        _exec_mext_64(cpu, rd, funct3, a, b)
+        return
+
+    # Standard ALU register
+    if funct3 == FUNCT3_ADD_SUB:
+        if funct7 & 0x20:
+            cpu.write_reg(rd, (a - b) & MASK64)   # SUB
+        else:
+            cpu.write_reg(rd, (a + b) & MASK64)   # ADD
+
+    elif funct3 == FUNCT3_SLL:
+        cpu.write_reg(rd, (a << (b & 63)) & MASK64)
+
+    elif funct3 == FUNCT3_SLT:
+        cpu.write_reg(rd, 1 if to_signed64(a) < to_signed64(b) else 0)
+
+    elif funct3 == FUNCT3_SLTU:
+        cpu.write_reg(rd, 1 if a < b else 0)
+
+    elif funct3 == FUNCT3_XOR:
+        cpu.write_reg(rd, (a ^ b) & MASK64)
+
+    elif funct3 == FUNCT3_SRL_SRA:
+        shamt = b & 63
+        if funct7 & 0x20:
+            cpu.write_reg(rd, (to_signed64(a) >> shamt) & MASK64)   # SRA
+        else:
+            cpu.write_reg(rd, (a >> shamt) & MASK64)                 # SRL
+
+    elif funct3 == FUNCT3_OR:
+        cpu.write_reg(rd, (a | b) & MASK64)
+
+    elif funct3 == FUNCT3_AND:
+        cpu.write_reg(rd, (a & b) & MASK64)
+
+
+def _exec_mext_64(cpu: _CPU, rd: int, funct3: int, a: int, b: int) -> None:
+    """
+    M-extension 64-bit multiply and divide.
+
+    Multiply produces a 128-bit product; MUL takes the lower 64 bits,
+    MULH/MULHSU/MULHU take the upper 64 bits.
+
+    Division-by-zero returns -1 (signed) / MAXUINT (unsigned) for the quotient
+    and the dividend for the remainder, per the RISC-V specification.
+    """
+    if funct3 == FUNCT3_MUL:
+        # Lower 64 bits of 64-bit × 64-bit product
+        cpu.write_reg(rd, (a * b) & MASK64)
+
+    elif funct3 == FUNCT3_MULH:
+        # Upper 64 bits of signed × signed 128-bit product
+        result = (to_signed64(a) * to_signed64(b)) >> 64
+        cpu.write_reg(rd, result & MASK64)
+
+    elif funct3 == FUNCT3_MULHSU:
+        # Upper 64 bits of signed × unsigned 128-bit product
+        result = (to_signed64(a) * b) >> 64
+        cpu.write_reg(rd, result & MASK64)
+
+    elif funct3 == FUNCT3_MULHU:
+        # Upper 64 bits of unsigned × unsigned 128-bit product
+        result = (a * b) >> 64
+        cpu.write_reg(rd, result & MASK64)
+
+    elif funct3 == FUNCT3_DIV:
+        # Signed division, truncated toward zero
+        sa, sb = to_signed64(a), to_signed64(b)
+        if sb == 0:
+            cpu.write_reg(rd, MASK64)   # -1 as unsigned 64-bit
+        elif sa == -(1 << 63) and sb == -1:
+            cpu.write_reg(rd, a)        # overflow: quotient = dividend
+        else:
+            # Python truncates toward negative infinity; we need toward zero
+            result = int(sa / sb)
+            cpu.write_reg(rd, result & MASK64)
+
+    elif funct3 == FUNCT3_DIVU:
+        if b == 0:
+            cpu.write_reg(rd, MASK64)
+        else:
+            cpu.write_reg(rd, (a // b) & MASK64)
+
+    elif funct3 == FUNCT3_REM:
+        sa, sb = to_signed64(a), to_signed64(b)
+        if sb == 0:
+            cpu.write_reg(rd, a)        # remainder = dividend
+        elif sa == -(1 << 63) and sb == -1:
+            cpu.write_reg(rd, 0)        # overflow: remainder = 0
+        else:
+            # RISC-V: sign of remainder matches dividend
+            result = int(sa / sb)
+            cpu.write_reg(rd, (sa - result * sb) & MASK64)
+
+    elif funct3 == FUNCT3_REMU:
+        if b == 0:
+            cpu.write_reg(rd, a)
+        else:
+            cpu.write_reg(rd, (a % b) & MASK64)
+
+
+def _exec_aluiw(cpu: _CPU, instr: int) -> None:
+    """
+    RV64I word ALU immediate (opcode 0x1B).
+
+    Operate on lower 32 bits of rs1 with a sign-extended 12-bit immediate,
+    then sign-extend the 32-bit result to 64 bits.
+
+    Instructions: ADDIW, SLLIW, SRLIW, SRAIW.
+    """
+    funct3 = (instr >> 12) & 0x7
+    rd     = (instr >> 7)  & 0x1F
+    rs1    = (instr >> 15) & 0x1F
+    a32    = cpu.read_reg(rs1) & MASK32
+
+    if funct3 == FUNCT3_ADDI:   # ADDIW
+        imm = _decode_i_imm(instr)
+        cpu.write_reg(rd, sext32_to_64((a32 + imm) & MASK32) & MASK64)
+
+    elif funct3 == FUNCT3_SLLI:   # SLLIW — shamt is bits[24:20] (5-bit)
+        shamt = (instr >> 20) & 0x1F
+        cpu.write_reg(rd, sext32_to_64((a32 << shamt) & MASK32) & MASK64)
+
+    elif funct3 == FUNCT3_SRLI_SRAI:   # SRLIW / SRAIW
+        shamt  = (instr >> 20) & 0x1F
+        funct7 = (instr >> 25) & 0x7F
+        if funct7 & 0x20:   # SRAIW: arithmetic
+            signed_a32 = to_signed32(a32)
+            cpu.write_reg(rd, sext32_to_64((signed_a32 >> shamt) & MASK32) & MASK64)
+        else:               # SRLIW: logical
+            cpu.write_reg(rd, sext32_to_64((a32 >> shamt) & MASK32) & MASK64)
+
+
+def _exec_alurw(cpu: _CPU, instr: int) -> None:
+    """
+    RV64I word ALU register (opcode 0x3B).
+
+    Operate on lower 32 bits of rs1 and rs2, then sign-extend result to 64
+    bits.  Includes M-extension word multiply/divide.
+
+    Instructions: ADDW, SUBW, SLLW, SRLW, SRAW, MULW, DIVW, DIVUW, REMW,
+    REMUW.
+    """
+    funct3 = (instr >> 12) & 0x7
+    funct7 = (instr >> 25) & 0x7F
+    rd     = (instr >> 7)  & 0x1F
+    rs1    = (instr >> 15) & 0x1F
+    rs2    = (instr >> 20) & 0x1F
+    a32    = cpu.read_reg(rs1) & MASK32
+    b32    = cpu.read_reg(rs2) & MASK32
+
+    if funct7 == FUNCT7_MEXT:
+        _exec_mext_word(cpu, rd, funct3, a32, b32)
+        return
+
+    if funct3 == FUNCT3_ADD_SUB:
+        if funct7 & 0x20:   # SUBW
+            cpu.write_reg(rd, sext32_to_64((a32 - b32) & MASK32) & MASK64)
+        else:                # ADDW
+            cpu.write_reg(rd, sext32_to_64((a32 + b32) & MASK32) & MASK64)
+
+    elif funct3 == FUNCT3_SLL:   # SLLW — shift by rs2[4:0]
+        shamt = b32 & 31
+        cpu.write_reg(rd, sext32_to_64((a32 << shamt) & MASK32) & MASK64)
+
+    elif funct3 == FUNCT3_SRL_SRA:
+        shamt = b32 & 31
+        if funct7 & 0x20:   # SRAW
+            cpu.write_reg(rd, sext32_to_64((to_signed32(a32) >> shamt) & MASK32) & MASK64)
+        else:                # SRLW
+            cpu.write_reg(rd, sext32_to_64((a32 >> shamt) & MASK32) & MASK64)
+
+
+def _exec_mext_word(cpu: _CPU, rd: int, funct3: int, a32: int, b32: int) -> None:
+    """M-extension 32-bit word multiply and divide, results sign-extended to 64."""
+    if funct3 == FUNCT3_MUL:   # MULW
+        cpu.write_reg(rd, sext32_to_64((a32 * b32) & MASK32) & MASK64)
+
+    elif funct3 == FUNCT3_DIV:   # DIVW
+        sa, sb = to_signed32(a32), to_signed32(b32)
+        if sb == 0:
+            cpu.write_reg(rd, MASK64)
+        elif sa == -(1 << 31) and sb == -1:
+            cpu.write_reg(rd, sext32_to_64(a32) & MASK64)
+        else:
+            cpu.write_reg(rd, sext32_to_64(int(sa / sb) & MASK32) & MASK64)
+
+    elif funct3 == FUNCT3_DIVU:   # DIVUW
+        if b32 == 0:
+            cpu.write_reg(rd, MASK64)
+        else:
+            cpu.write_reg(rd, sext32_to_64((a32 // b32) & MASK32) & MASK64)
+
+    elif funct3 == FUNCT3_REM:   # REMW
+        sa, sb = to_signed32(a32), to_signed32(b32)
+        if sb == 0:
+            cpu.write_reg(rd, sext32_to_64(a32) & MASK64)
+        elif sa == -(1 << 31) and sb == -1:
+            cpu.write_reg(rd, 0)
+        else:
+            result = int(sa / sb)
+            cpu.write_reg(rd, sext32_to_64((sa - result * sb) & MASK32) & MASK64)
+
+    elif funct3 == FUNCT3_REMU:   # REMUW
+        if b32 == 0:
+            cpu.write_reg(rd, sext32_to_64(a32) & MASK64)
+        else:
+            cpu.write_reg(rd, sext32_to_64((a32 % b32) & MASK32) & MASK64)
+
+
+# ── Main step logic ────────────────────────────────────────────────────────────
+
+
+def _step(cpu: _CPU) -> None:
+    """
+    Fetch and execute one instruction.
+
+    RISC-V has a fixed 32-bit instruction width.  The all-zero word 0x00000000
+    is the halt sentinel (it decodes to ADDI x0, x0, 0 which would be a NOP,
+    but we treat it as halt to simplify the protocol).
+    """
+    pc_before = cpu.pc
+    instr = cpu.fetch32()   # fetches 4 bytes; advances PC by 4
+
+    # Halt sentinel: any all-zero word
+    if instr == 0x0000_0000:
+        cpu.halted = True
+        return
+
+    opcode = instr & 0x7F
+
+    if opcode == OP_LUI:
+        _exec_lui(cpu, instr)
+
+    elif opcode == OP_AUIPC:
+        _exec_auipc(cpu, instr, pc_before)
+
+    elif opcode == OP_JAL:
+        _exec_jal(cpu, instr, pc_before)
+
+    elif opcode == OP_JALR:
+        _exec_jalr(cpu, instr, pc_before)
+
+    elif opcode == OP_BRANCH:
+        _exec_branch(cpu, instr, pc_before)
+
+    elif opcode == OP_LOAD:
+        _exec_load(cpu, instr)
+
+    elif opcode == OP_STORE:
+        _exec_store(cpu, instr)
+
+    elif opcode == OP_ALUI:
+        _exec_alui(cpu, instr)
+
+    elif opcode == OP_ALUR:
+        _exec_alur(cpu, instr)
+
+    elif opcode == OP_ALUIW:
+        _exec_aluiw(cpu, instr)
+
+    elif opcode == OP_ALURW:
+        _exec_alurw(cpu, instr)
+
+    elif opcode == OP_FENCE:
+        pass   # NOP — no memory ordering model in behavioral simulator
+
+    elif opcode == OP_SYSTEM:
+        # ECALL (imm=0) and EBREAK (imm=1) both halt
+        cpu.halted = True
+
+
+# ── Public Simulator class ─────────────────────────────────────────────────────
+
+
+class RV64ISimulator:
+    """
+    RISC-V RV64I + M extension behavioral simulator implementing SIM00 protocol.
+
+    Usage
+    -----
+        sim = RV64ISimulator()
+        state = sim.execute(program_bytes)
+        print(state.a0)  # return value in a0 (x10)
+
+    The simulator starts with SP=0xFFF8 and all other registers and memory
+    zeroed.  PC starts at 0.
+    """
+
+    def __init__(self) -> None:
+        self._cpu = _CPU()
+        self.reset()
+
+    # ── SIM00 protocol ────────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Zero all registers and memory; set SP=0xFFF8, PC=0."""
+        cpu = self._cpu
+        for i in range(NUM_REGS):
+            cpu.gpr[i] = 0
+        cpu.pc = 0
+        cpu.halted = False
+        cpu.gpr[SP] = 0xFFF8
+        for i in range(MEM_SIZE):
+            cpu.memory[i] = 0
+
+    def load(self, program: bytes) -> None:
+        """Reset and copy program bytes into memory starting at address 0."""
+        self.reset()
+        cpu = self._cpu
+        for i, b in enumerate(program):
+            if i >= MEM_SIZE:
+                break
+            cpu.memory[i] = b
+
+    def get_state(self) -> RV64IState:
+        """Return a frozen snapshot of the current simulator state."""
+        cpu = self._cpu
+        return RV64IState(
+            pc=cpu.pc,
+            gpr=tuple(cpu.gpr),
+            memory=tuple(cpu.memory),
+            halted=cpu.halted,
+        )
+
+    def step(self) -> StepTrace:
+        """Execute one instruction and return a StepTrace."""
+        cpu = self._cpu
+        if cpu.halted:
+            return StepTrace(pc_before=cpu.pc, pc_after=cpu.pc, halted=True)
+        pc_before = cpu.pc
+        _step(cpu)
+        return StepTrace(pc_before=pc_before, pc_after=cpu.pc, halted=cpu.halted)
+
+    def execute(self, program: bytes, max_steps: int = 100_000) -> RV64IState:
+        """Load program and run until halted or max_steps reached."""
+        self.load(program)
+        cpu = self._cpu
+        for _ in range(max_steps):
+            if cpu.halted:
+                break
+            _step(cpu)
+        return self.get_state()
+
+    # ── I/O stubs (SIM00 completeness) ────────────────────────────────────────
+
+    def set_input_port(self, port: int, value: int) -> None:
+        """Stub — RISC-V has no I/O in this simulation."""
+
+    def get_output_port(self, port: int) -> int:
+        """Stub — returns 0."""
+        return 0
+
+    def interrupt(self, vector: int) -> None:
+        """Stub — interrupts not modeled."""
+
+    def nmi(self) -> None:
+        """Stub — NMI not modeled."""

--- a/code/packages/python/riscv-rv64i-simulator/src/riscv_rv64i_simulator/state.py
+++ b/code/packages/python/riscv-rv64i-simulator/src/riscv_rv64i_simulator/state.py
@@ -1,0 +1,230 @@
+"""
+RV64I architectural constants and immutable state snapshot.
+
+RISC-V has 32 general-purpose 64-bit integer registers (x0–x31) plus a
+program counter.  Register x0 is hardwired to zero — reads always return 0
+and writes are silently discarded.
+
+ABI register aliases (used in assembly; the simulator only tracks numbers):
+
+  zero = x0   ra = x1   sp = x2   gp = x3   tp = x4
+  t0–t2 = x5–x7          s0/fp = x8     s1 = x9
+  a0–a1 = x10–x11        a2–a7 = x12–x17
+  s2–s11 = x18–x27       t3–t6 = x28–x31
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+NUM_REGS: int = 32       # x0–x31
+MEM_SIZE: int = 65_536   # 64 KiB flat address space
+
+MASK64: int = 0xFFFF_FFFF_FFFF_FFFF   # 64-bit mask
+MASK32: int = 0xFFFF_FFFF              # 32-bit mask
+MASK16: int = 0xFFFF                   # 16-bit mask
+MASK8:  int = 0xFF                     # 8-bit mask
+
+# ABI register numbers
+ZERO: int = 0    # hardwired zero
+RA:   int = 1    # return address
+SP:   int = 2    # stack pointer
+
+# Sign bit positions
+SIGN64: int = 1 << 63
+SIGN32: int = 1 << 31
+
+# ── Sign-extension helpers ─────────────────────────────────────────────────────
+
+
+def sext(value: int, bits: int) -> int:
+    """
+    Sign-extend a `bits`-wide value to Python's arbitrary-precision integer.
+
+    If the MSB (bit `bits-1`) is set, the value is negative; we extend it by
+    flipping all higher bits.
+
+    Example:
+      sext(0xFF, 8)  →  -1   (8-bit 0xFF = -1 in two's complement)
+      sext(0x7F, 8)  → 127   (positive, no extension)
+    """
+    if value & (1 << (bits - 1)):
+        value -= (1 << bits)
+    return value
+
+
+def sext12(v: int) -> int:
+    """Sign-extend a 12-bit immediate to Python int."""
+    return sext(v & 0xFFF, 12)
+
+
+def sext13(v: int) -> int:
+    """Sign-extend a 13-bit B-type immediate."""
+    return sext(v & 0x1FFF, 13)
+
+
+def sext21(v: int) -> int:
+    """Sign-extend a 21-bit J-type immediate."""
+    return sext(v & 0x1FFFFF, 21)
+
+
+def sext32_to_64(v: int) -> int:
+    """
+    Sign-extend a 32-bit value to a Python 64-bit two's-complement integer.
+
+    Used for RV64I "word" instructions (ADDW, SLLW, etc.) where the 32-bit
+    result must be sign-extended into the full 64-bit register.
+
+    Example:
+      sext32_to_64(0xFFFF_FFFE)  →  -2   (0xFFFF_FFFF_FFFF_FFFE)
+      sext32_to_64(0x0000_0001)  →   1
+    """
+    return sext(v & MASK32, 32)
+
+
+def to_signed64(v: int) -> int:
+    """Interpret a 64-bit unsigned value as a signed Python integer."""
+    v &= MASK64
+    if v & SIGN64:
+        v -= (1 << 64)
+    return v
+
+
+def to_signed32(v: int) -> int:
+    """Interpret the lower 32 bits of v as a signed Python integer."""
+    v &= MASK32
+    if v & SIGN32:
+        v -= (1 << 32)
+    return v
+
+
+# ── Immutable state snapshot ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RV64IState:
+    """
+    Frozen snapshot of the RV64I simulator state, returned by get_state()
+    and execute().
+
+    Attributes
+    ----------
+    pc       : Program counter (byte address).
+    gpr      : Tuple of 32 × 64-bit general-purpose register values.
+               Index 0 is always 0 (the zero register).
+    memory   : Tuple of MEM_SIZE bytes (the full address space).
+    halted   : True after the halt sentinel (0x00000000) has been fetched.
+    """
+
+    pc:     int
+    gpr:    tuple[int, ...]    # length 32
+    memory: tuple[int, ...]    # length MEM_SIZE
+    halted: bool
+
+    # ── Convenience register properties ──────────────────────────────────────
+
+    @property
+    def zero(self) -> int: return 0          # always 0
+
+    @property
+    def ra(self) -> int: return self.gpr[1]  # return address
+
+    @property
+    def sp(self) -> int: return self.gpr[2]  # stack pointer
+
+    @property
+    def gp(self) -> int: return self.gpr[3]  # global pointer
+
+    @property
+    def tp(self) -> int: return self.gpr[4]  # thread pointer
+
+    # Temporaries t0–t2
+    @property
+    def t0(self) -> int: return self.gpr[5]
+
+    @property
+    def t1(self) -> int: return self.gpr[6]
+
+    @property
+    def t2(self) -> int: return self.gpr[7]
+
+    # Saved s0/fp, s1
+    @property
+    def s0(self) -> int: return self.gpr[8]
+
+    @property
+    def fp(self) -> int: return self.gpr[8]   # alias for s0
+
+    @property
+    def s1(self) -> int: return self.gpr[9]
+
+    # Arguments / return values a0–a7
+    @property
+    def a0(self) -> int: return self.gpr[10]
+
+    @property
+    def a1(self) -> int: return self.gpr[11]
+
+    @property
+    def a2(self) -> int: return self.gpr[12]
+
+    @property
+    def a3(self) -> int: return self.gpr[13]
+
+    @property
+    def a4(self) -> int: return self.gpr[14]
+
+    @property
+    def a5(self) -> int: return self.gpr[15]
+
+    @property
+    def a6(self) -> int: return self.gpr[16]
+
+    @property
+    def a7(self) -> int: return self.gpr[17]
+
+    # Saved s2–s11
+    @property
+    def s2(self) -> int: return self.gpr[18]
+
+    @property
+    def s3(self) -> int: return self.gpr[19]
+
+    @property
+    def s4(self) -> int: return self.gpr[20]
+
+    @property
+    def s5(self) -> int: return self.gpr[21]
+
+    @property
+    def s6(self) -> int: return self.gpr[22]
+
+    @property
+    def s7(self) -> int: return self.gpr[23]
+
+    @property
+    def s8(self) -> int: return self.gpr[24]
+
+    @property
+    def s9(self) -> int: return self.gpr[25]
+
+    @property
+    def s10(self) -> int: return self.gpr[26]
+
+    @property
+    def s11(self) -> int: return self.gpr[27]
+
+    # Temporaries t3–t6
+    @property
+    def t3(self) -> int: return self.gpr[28]
+
+    @property
+    def t4(self) -> int: return self.gpr[29]
+
+    @property
+    def t5(self) -> int: return self.gpr[30]
+
+    @property
+    def t6(self) -> int: return self.gpr[31]

--- a/code/packages/python/riscv-rv64i-simulator/tests/conftest.py
+++ b/code/packages/python/riscv-rv64i-simulator/tests/conftest.py
@@ -1,0 +1,420 @@
+"""
+Shared test helpers for the RISC-V RV64I simulator test suite.
+
+Instruction encoding follows the RISC-V Unprivileged ISA specification.
+All helpers return 4-byte lists (one 32-bit instruction, little-endian).
+"""
+
+from __future__ import annotations
+
+import struct
+
+from riscv_rv64i_simulator import RV64ISimulator, RV64IState
+
+# ── Test runner ────────────────────────────────────────────────────────────────
+
+
+def run(instructions: list[list[int] | bytes]) -> RV64IState:
+    """
+    Assemble a list of encoded instructions into a program, append the halt
+    sentinel (0x00000000), execute, and return the final state.
+    """
+    prog = b"".join(bytes(i) for i in instructions) + b"\x00\x00\x00\x00"
+    sim = RV64ISimulator()
+    return sim.execute(prog)
+
+
+# ── Low-level packing ──────────────────────────────────────────────────────────
+
+
+def w32(word: int) -> list[int]:
+    """Pack a 32-bit instruction word to a little-endian byte list."""
+    return list(struct.pack("<I", word & 0xFFFF_FFFF))
+
+
+# ── R-type encoding ────────────────────────────────────────────────────────────
+
+
+def r_type(opcode: int, funct3: int, funct7: int, rd: int, rs1: int, rs2: int) -> list[int]:
+    """Encode an R-type instruction."""
+    instr = (
+        (funct7 & 0x7F) << 25
+        | (rs2   & 0x1F) << 20
+        | (rs1   & 0x1F) << 15
+        | (funct3 & 0x7) << 12
+        | (rd    & 0x1F) << 7
+        | (opcode & 0x7F)
+    )
+    return w32(instr)
+
+
+# ── I-type encoding ────────────────────────────────────────────────────────────
+
+
+def i_type(opcode: int, funct3: int, rd: int, rs1: int, imm: int) -> list[int]:
+    """Encode an I-type instruction (imm is a signed 12-bit value)."""
+    imm12 = imm & 0xFFF
+    instr = (
+        (imm12  & 0xFFF) << 20
+        | (rs1  & 0x1F) << 15
+        | (funct3 & 0x7) << 12
+        | (rd   & 0x1F) << 7
+        | (opcode & 0x7F)
+    )
+    return w32(instr)
+
+
+# ── S-type encoding ────────────────────────────────────────────────────────────
+
+
+def s_type(opcode: int, funct3: int, rs1: int, rs2: int, imm: int) -> list[int]:
+    """Encode an S-type instruction."""
+    imm12 = imm & 0xFFF
+    hi5 = (imm12 >> 5) & 0x7F
+    lo5 = imm12 & 0x1F
+    instr = (
+        (hi5   & 0x7F) << 25
+        | (rs2  & 0x1F) << 20
+        | (rs1  & 0x1F) << 15
+        | (funct3 & 0x7) << 12
+        | (lo5  & 0x1F) << 7
+        | (opcode & 0x7F)
+    )
+    return w32(instr)
+
+
+# ── B-type encoding ────────────────────────────────────────────────────────────
+
+
+def b_type(opcode: int, funct3: int, rs1: int, rs2: int, offset: int) -> list[int]:
+    """
+    Encode a B-type branch instruction.
+
+    `offset` is the signed byte offset from the instruction's PC.
+    It must be even (4-byte aligned in practice).
+    """
+    imm = offset & 0x1FFF
+    b12  = (imm >> 12) & 1
+    b11  = (imm >> 11) & 1
+    b105 = (imm >> 5) & 0x3F
+    b41  = (imm >> 1) & 0xF
+    instr = (
+        (b12  & 1)    << 31
+        | (b105 & 0x3F) << 25
+        | (rs2  & 0x1F) << 20
+        | (rs1  & 0x1F) << 15
+        | (funct3 & 0x7) << 12
+        | (b41  & 0xF)  << 8
+        | (b11  & 1)    << 7
+        | (opcode & 0x7F)
+    )
+    return w32(instr)
+
+
+# ── U-type encoding ────────────────────────────────────────────────────────────
+
+
+def u_type(opcode: int, rd: int, imm20: int) -> list[int]:
+    """Encode a U-type instruction (imm20 is the upper 20-bit value)."""
+    instr = (
+        (imm20 & 0xFFFFF) << 12
+        | (rd  & 0x1F) << 7
+        | (opcode & 0x7F)
+    )
+    return w32(instr)
+
+
+# ── J-type encoding ────────────────────────────────────────────────────────────
+
+
+def j_type(opcode: int, rd: int, offset: int) -> list[int]:
+    """
+    Encode a J-type instruction (JAL).
+
+    `offset` is the signed byte offset from the instruction's PC.
+    """
+    imm = offset & 0x1FFFFF
+    b20   = (imm >> 20) & 1
+    b1910 = (imm >> 1)  & 0x3FF
+    b11   = (imm >> 11) & 1
+    b1912 = (imm >> 12) & 0xFF
+    instr = (
+        (b20   & 1)    << 31
+        | (b1912 & 0xFF) << 12
+        | (b11   & 1)   << 20
+        | (b1910 & 0x3FF) << 21
+        | (rd    & 0x1F) << 7
+        | (opcode & 0x7F)
+    )
+    return w32(instr)
+
+
+# ── Convenient named encoders ──────────────────────────────────────────────────
+
+OP_LUI    = 0x37
+OP_AUIPC  = 0x17
+OP_JAL    = 0x6F
+OP_JALR   = 0x67
+OP_BRANCH = 0x63
+OP_LOAD   = 0x03
+OP_STORE  = 0x23
+OP_ALUI   = 0x13
+OP_ALUR   = 0x33
+OP_ALUIW  = 0x1B
+OP_ALURW  = 0x3B
+
+
+def addi(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_ALUI, 0b000, rd, rs1, imm)
+
+
+def addiw(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_ALUIW, 0b000, rd, rs1, imm)
+
+
+def add(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b000, 0x00, rd, rs1, rs2)
+
+
+def addw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b000, 0x00, rd, rs1, rs2)
+
+
+def sub(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b000, 0x20, rd, rs1, rs2)
+
+
+def subw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b000, 0x20, rd, rs1, rs2)
+
+
+def sll(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b001, 0x00, rd, rs1, rs2)
+
+
+def srl(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b101, 0x00, rd, rs1, rs2)
+
+
+def sra(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b101, 0x20, rd, rs1, rs2)
+
+
+def slli(rd: int, rs1: int, shamt: int) -> list[int]:
+    return i_type(OP_ALUI, 0b001, rd, rs1, shamt & 0x3F)
+
+
+def srli(rd: int, rs1: int, shamt: int) -> list[int]:
+    return i_type(OP_ALUI, 0b101, rd, rs1, shamt & 0x3F)
+
+
+def srai(rd: int, rs1: int, shamt: int) -> list[int]:
+    # RV64I SRAI: funct6 = 0b010000 = 0x10 in bits[31:26]; shamt is 6-bit.
+    # imm12 = (funct6 << 6) | shamt = (0x10 << 6) | shamt = 0x400 | shamt.
+    # This makes instr[31:25] (funct7) = 0x20, which the simulator checks.
+    return i_type(OP_ALUI, 0b101, rd, rs1, (0x10 << 6) | (shamt & 0x3F))
+
+
+def slliw(rd: int, rs1: int, shamt: int) -> list[int]:
+    return i_type(OP_ALUIW, 0b001, rd, rs1, shamt & 0x1F)
+
+
+def srliw(rd: int, rs1: int, shamt: int) -> list[int]:
+    return i_type(OP_ALUIW, 0b101, rd, rs1, shamt & 0x1F)
+
+
+def sraiw(rd: int, rs1: int, shamt: int) -> list[int]:
+    return i_type(OP_ALUIW, 0b101, rd, rs1, (0x20 << 5) | (shamt & 0x1F))
+
+
+def sllw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b001, 0x00, rd, rs1, rs2)
+
+
+def srlw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b101, 0x00, rd, rs1, rs2)
+
+
+def sraw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b101, 0x20, rd, rs1, rs2)
+
+
+def and_(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b111, 0x00, rd, rs1, rs2)
+
+
+def or_(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b110, 0x00, rd, rs1, rs2)
+
+
+def xor(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b100, 0x00, rd, rs1, rs2)
+
+
+def andi(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_ALUI, 0b111, rd, rs1, imm)
+
+
+def ori(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_ALUI, 0b110, rd, rs1, imm)
+
+
+def xori(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_ALUI, 0b100, rd, rs1, imm)
+
+
+def slt(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b010, 0x00, rd, rs1, rs2)
+
+
+def sltu(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b011, 0x00, rd, rs1, rs2)
+
+
+def slti(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_ALUI, 0b010, rd, rs1, imm)
+
+
+def sltiu(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_ALUI, 0b011, rd, rs1, imm)
+
+
+def lui(rd: int, imm20: int) -> list[int]:
+    return u_type(OP_LUI, rd, imm20)
+
+
+def auipc(rd: int, imm20: int) -> list[int]:
+    return u_type(OP_AUIPC, rd, imm20)
+
+
+def jal(rd: int, offset: int) -> list[int]:
+    return j_type(OP_JAL, rd, offset)
+
+
+def jalr(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_JALR, 0b000, rd, rs1, imm)
+
+
+def beq(rs1: int, rs2: int, offset: int) -> list[int]:
+    return b_type(OP_BRANCH, 0b000, rs1, rs2, offset)
+
+
+def bne(rs1: int, rs2: int, offset: int) -> list[int]:
+    return b_type(OP_BRANCH, 0b001, rs1, rs2, offset)
+
+
+def blt(rs1: int, rs2: int, offset: int) -> list[int]:
+    return b_type(OP_BRANCH, 0b100, rs1, rs2, offset)
+
+
+def bge(rs1: int, rs2: int, offset: int) -> list[int]:
+    return b_type(OP_BRANCH, 0b101, rs1, rs2, offset)
+
+
+def bltu(rs1: int, rs2: int, offset: int) -> list[int]:
+    return b_type(OP_BRANCH, 0b110, rs1, rs2, offset)
+
+
+def bgeu(rs1: int, rs2: int, offset: int) -> list[int]:
+    return b_type(OP_BRANCH, 0b111, rs1, rs2, offset)
+
+
+def lw(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_LOAD, 0b010, rd, rs1, imm)
+
+
+def lh(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_LOAD, 0b001, rd, rs1, imm)
+
+
+def lb(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_LOAD, 0b000, rd, rs1, imm)
+
+
+def ld(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_LOAD, 0b011, rd, rs1, imm)
+
+
+def lbu(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_LOAD, 0b100, rd, rs1, imm)
+
+
+def lhu(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_LOAD, 0b101, rd, rs1, imm)
+
+
+def lwu(rd: int, rs1: int, imm: int) -> list[int]:
+    return i_type(OP_LOAD, 0b110, rd, rs1, imm)
+
+
+def sw(rs1: int, rs2: int, imm: int) -> list[int]:
+    return s_type(OP_STORE, 0b010, rs1, rs2, imm)
+
+
+def sh(rs1: int, rs2: int, imm: int) -> list[int]:
+    return s_type(OP_STORE, 0b001, rs1, rs2, imm)
+
+
+def sb(rs1: int, rs2: int, imm: int) -> list[int]:
+    return s_type(OP_STORE, 0b000, rs1, rs2, imm)
+
+
+def sd(rs1: int, rs2: int, imm: int) -> list[int]:
+    return s_type(OP_STORE, 0b011, rs1, rs2, imm)
+
+
+def mul(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b000, 0x01, rd, rs1, rs2)
+
+
+def mulh(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b001, 0x01, rd, rs1, rs2)
+
+
+def mulhu(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b011, 0x01, rd, rs1, rs2)
+
+
+def mulhsu(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b010, 0x01, rd, rs1, rs2)
+
+
+def div_(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b100, 0x01, rd, rs1, rs2)
+
+
+def divu(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b101, 0x01, rd, rs1, rs2)
+
+
+def rem(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b110, 0x01, rd, rs1, rs2)
+
+
+def remu(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALUR, 0b111, 0x01, rd, rs1, rs2)
+
+
+def mulw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b000, 0x01, rd, rs1, rs2)
+
+
+def divw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b100, 0x01, rd, rs1, rs2)
+
+
+def divuw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b101, 0x01, rd, rs1, rs2)
+
+
+def remw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b110, 0x01, rd, rs1, rs2)
+
+
+def remuw(rd: int, rs1: int, rs2: int) -> list[int]:
+    return r_type(OP_ALURW, 0b111, 0x01, rd, rs1, rs2)
+
+
+def nop() -> list[int]:
+    """ADDI x0, x0, 0 — the canonical RISC-V NOP."""
+    return addi(0, 0, 0)

--- a/code/packages/python/riscv-rv64i-simulator/tests/test_instructions.py
+++ b/code/packages/python/riscv-rv64i-simulator/tests/test_instructions.py
@@ -1,0 +1,752 @@
+"""
+Instruction-level tests for the RV64I + M extension simulator.
+
+Each test encodes a short program, runs it to halt, and asserts register/memory
+state.  All instruction encoders live in conftest.py.
+"""
+
+from __future__ import annotations
+
+from conftest import (
+    add,
+    addi,
+    addiw,
+    addw,
+    and_,
+    andi,
+    auipc,
+    beq,
+    bge,
+    bgeu,
+    blt,
+    bltu,
+    bne,
+    div_,
+    divu,
+    divuw,
+    divw,
+    jal,
+    jalr,
+    lb,
+    lbu,
+    ld,
+    lh,
+    lhu,
+    lui,
+    lw,
+    lwu,
+    mul,
+    mulh,
+    mulhsu,
+    mulhu,
+    mulw,
+    or_,
+    ori,
+    rem,
+    remu,
+    remuw,
+    remw,
+    run,
+    sb,
+    sd,
+    sh,
+    sll,
+    slli,
+    slliw,
+    sllw,
+    slt,
+    slti,
+    sltiu,
+    sltu,
+    sra,
+    srai,
+    sraiw,
+    sraw,
+    srl,
+    srli,
+    srliw,
+    srlw,
+    sub,
+    subw,
+    sw,
+    xor,
+    xori,
+)
+
+from riscv_rv64i_simulator import RV64ISimulator
+
+# ── ALU Immediate ──────────────────────────────────────────────────────────────
+
+
+class TestALUImmediate:
+    def test_addi_positive(self):
+        """ADDI x10, x0, 42 → x10 = 42."""
+        state = run([addi(10, 0, 42)])
+        assert state.a0 == 42
+
+    def test_addi_negative(self):
+        """ADDI x10, x0, -1 → x10 = 0xFFFF_FFFF_FFFF_FFFF (−1 sign-extended)."""
+        state = run([addi(10, 0, -1)])
+        assert state.a0 == 0xFFFF_FFFF_FFFF_FFFF
+
+    def test_addi_accumulate(self):
+        """Two ADDIs: x10 = 0 + 10 + 5 = 15."""
+        state = run([addi(10, 0, 10), addi(10, 10, 5)])
+        assert state.a0 == 15
+
+    def test_xori_flip_bits(self):
+        """XORI x10, x0, 0xFF → x10 = 0xFF."""
+        state = run([xori(10, 0, 0xFF)])
+        assert state.a0 == 0xFF
+
+    def test_ori_set_bits(self):
+        """Set bits via ORI."""
+        state = run([addi(10, 0, 0xF0), ori(10, 10, 0x0F)])
+        assert state.a0 == 0xFF
+
+    def test_andi_clear_bits(self):
+        """ANDI x10, x10, 0x0F clears high nibble."""
+        state = run([addi(10, 0, 0xFF), andi(10, 10, 0x0F)])
+        assert state.a0 == 0x0F
+
+    def test_slti_true(self):
+        """SLTI: -1 < 1 → 1."""
+        state = run([addi(10, 0, -1), slti(11, 10, 1)])
+        assert state.a1 == 1
+
+    def test_slti_false(self):
+        """SLTI: 5 < 3 → 0."""
+        state = run([addi(10, 0, 5), slti(11, 10, 3)])
+        assert state.a1 == 0
+
+    def test_sltiu_unsigned(self):
+        """SLTIU: 1 < 0xFFF (unsigned) → 1."""
+        state = run([addi(10, 0, 1), sltiu(11, 10, 0xFFF)])
+        assert state.a1 == 1
+
+    def test_slli(self):
+        """SLLI x10, x10, 3 → 1 << 3 = 8."""
+        state = run([addi(10, 0, 1), slli(10, 10, 3)])
+        assert state.a0 == 8
+
+    def test_srli(self):
+        """SRLI x10, x10, 2 → 16 >> 2 = 4 (logical, no sign extension)."""
+        state = run([addi(10, 0, 16), srli(10, 10, 2)])
+        assert state.a0 == 4
+
+    def test_srai_positive(self):
+        """SRAI on positive value: 16 >> 2 = 4."""
+        state = run([addi(10, 0, 16), srai(10, 10, 2)])
+        assert state.a0 == 4
+
+    def test_srai_negative(self):
+        """SRAI on negative value propagates sign bit."""
+        # x10 = -8 (0xFFFF_FFFF_FFFF_FFF8)
+        state = run([addi(10, 0, -8), srai(10, 10, 1)])
+        # -8 >> 1 = -4 (0xFFFF_FFFF_FFFF_FFFC)
+        assert state.a0 == 0xFFFF_FFFF_FFFF_FFFC
+
+
+# ── ALU Register ──────────────────────────────────────────────────────────────
+
+
+class TestALURegister:
+    def test_add(self):
+        state = run([addi(10, 0, 20), addi(11, 0, 22), add(12, 10, 11)])
+        assert state.a2 == 42
+
+    def test_sub(self):
+        state = run([addi(10, 0, 10), addi(11, 0, 7), sub(12, 10, 11)])
+        assert state.a2 == 3
+
+    def test_sub_to_negative(self):
+        """5 - 10 = -5 (wraps to 0xFFFF...FFFB)."""
+        state = run([addi(10, 0, 5), addi(11, 0, 10), sub(12, 10, 11)])
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFB
+
+    def test_and(self):
+        state = run([addi(10, 0, 0xFF), addi(11, 0, 0x0F), and_(12, 10, 11)])
+        assert state.a2 == 0x0F
+
+    def test_or(self):
+        state = run([addi(10, 0, 0xF0), addi(11, 0, 0x0F), or_(12, 10, 11)])
+        assert state.a2 == 0xFF
+
+    def test_xor(self):
+        state = run([addi(10, 0, 0xFF), addi(11, 0, 0xF0), xor(12, 10, 11)])
+        assert state.a2 == 0x0F
+
+    def test_sll(self):
+        state = run([addi(10, 0, 1), addi(11, 0, 4), sll(12, 10, 11)])
+        assert state.a2 == 16
+
+    def test_srl(self):
+        state = run([addi(10, 0, 16), addi(11, 0, 2), srl(12, 10, 11)])
+        assert state.a2 == 4
+
+    def test_sra(self):
+        """SRA: -8 >> 2 = -2."""
+        state = run([addi(10, 0, -8), addi(11, 0, 2), sra(12, 10, 11)])
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFE
+
+    def test_slt_signed(self):
+        """-1 < 0 → 1."""
+        state = run([addi(10, 0, -1), addi(11, 0, 0), slt(12, 10, 11)])
+        assert state.a2 == 1
+
+    def test_sltu_unsigned(self):
+        """1 <u 0xFFFF...FFFF → 1."""
+        state = run([addi(10, 0, 1), addi(11, 0, -1), sltu(12, 10, 11)])
+        assert state.a2 == 1
+
+    def test_x0_write_ignored(self):
+        """Writing to x0 must be silently discarded."""
+        state = run([addi(0, 0, 99)])
+        assert state.zero == 0
+        assert state.gpr[0] == 0
+
+
+# ── RV64I Word Ops ─────────────────────────────────────────────────────────────
+
+
+class TestWordOps:
+    def test_addiw_truncates_to_32_and_sext(self):
+        """
+        ADDIW operates on the lower 32 bits and sign-extends to 64.
+
+        x10 = -1 (0xFFFF_FFFF_FFFF_FFFF); ADDIW x10, x10, -1:
+          - takes lower 32 bits: 0xFFFF_FFFF (= -1 in 32-bit)
+          - adds -1: -1 + (-1) = -2 in 32-bit = 0xFFFF_FFFE
+          - sign-extends to 64: 0xFFFF_FFFF_FFFF_FFFE
+        """
+        state = run([addi(10, 0, -1), addiw(10, 10, -1)])
+        assert state.a0 == 0xFFFF_FFFF_FFFF_FFFE
+
+    def test_addw_result_sext(self):
+        """ADDW: 32-bit add with sign extension."""
+        state = run([addi(10, 0, -1), addi(11, 0, 1), addw(12, 10, 11)])
+        assert state.a2 == 0   # -1 + 1 = 0
+
+    def test_subw_result_sext(self):
+        """SUBW: 32-bit sub with sign-extension of result.
+
+        x10 = 0, x11 = 1; SUBW x12, x10, x11:
+          - 0 - 1 = -1 in 32-bit (0xFFFF_FFFF)
+          - sign-extended to 64 → 0xFFFF_FFFF_FFFF_FFFF
+        """
+        state = run([addi(10, 0, 0), addi(11, 0, 1), subw(12, 10, 11)])
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFF
+
+    def test_slliw(self):
+        """SLLIW: shift 1 left by 4 within 32 bits, sign-extend."""
+        state = run([addi(10, 0, 1), slliw(10, 10, 4)])
+        assert state.a0 == 16
+
+    def test_srliw_no_sign_extension(self):
+        """SRLIW: logical shift fills with 0, result sign-extended to 64."""
+        state = run([addi(10, 0, -1), srliw(10, 10, 1)])
+        # 0xFFFF_FFFF >> 1 = 0x7FFF_FFFF; positive → sext is same
+        assert state.a0 == 0x7FFF_FFFF
+
+    def test_sraiw_propagates_sign(self):
+        """SRAIW: arithmetic right shift preserves sign in 32-bit, then sext to 64."""
+        state = run([addi(10, 0, -4), sraiw(10, 10, 1)])
+        # -4 in 32-bit is 0xFFFF_FFFC; >>1 = 0xFFFF_FFFE = -2; sext → 0xFFFF_FFFF_FFFF_FFFE
+        assert state.a0 == 0xFFFF_FFFF_FFFF_FFFE
+
+    def test_sllw(self):
+        state = run([addi(10, 0, 1), addi(11, 0, 3), sllw(12, 10, 11)])
+        assert state.a2 == 8
+
+    def test_srlw(self):
+        state = run([addi(10, 0, 16), addi(11, 0, 2), srlw(12, 10, 11)])
+        assert state.a2 == 4
+
+    def test_sraw_negative(self):
+        """SRAW on negative 32-bit value sign-extends the shift result."""
+        state = run([addi(10, 0, -8), addi(11, 0, 2), sraw(12, 10, 11)])
+        # -8 >> 2 = -2 in 32-bit; sext to 64 → 0xFFFF_FFFF_FFFF_FFFE
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFE
+
+
+# ── LUI / AUIPC ───────────────────────────────────────────────────────────────
+
+
+class TestUpperImmediate:
+    def test_lui_loads_upper(self):
+        """LUI x10, 1 → x10 = 0x1000."""
+        state = run([lui(10, 1)])
+        assert state.a0 == 0x1000
+
+    def test_lui_large(self):
+        """LUI x10, 0xDEADB → x10 = 0xDEADB000."""
+        state = run([lui(10, 0xDEADB)])
+        assert state.a0 == 0xFFFF_FFFF_DEAD_B000
+
+    def test_auipc_adds_pc(self):
+        """
+        AUIPC x10, 1 at PC=0 → x10 = 0 + (1 << 12) = 0x1000.
+        """
+        state = run([auipc(10, 1)])
+        assert state.a0 == 0x1000
+
+    def test_lui_then_addi(self):
+        """
+        Standard two-instruction load of a 32-bit constant:
+          LUI x10, 0xABCDE  →  x10 = 0xABCDE000
+          ADDI x10, x10, 0x123  →  x10 = 0xABCDE123
+        """
+        state = run([lui(10, 0xABCDE), addi(10, 10, 0x123)])
+        assert state.a0 == 0xFFFF_FFFF_ABCDE123
+
+
+# ── Load / Store ──────────────────────────────────────────────────────────────
+
+
+class TestLoadStore:
+    def test_sw_lw_roundtrip(self):
+        """Store a word to memory and load it back."""
+        sim = RV64ISimulator()
+        prog = (
+            bytes(addi(5, 0, 0x100))   # x5 = 0x100 (base address)
+            + bytes(addi(10, 0, 0x5A)) # x10 = 0x5A (value)
+            + bytes(sw(5, 10, 0))      # mem[0x100] = 0x5A
+            + bytes(lw(11, 5, 0))      # x11 = mem[0x100]
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a1 == 0x5A
+
+    def test_sb_lb_sign_extends(self):
+        """LB sign-extends the loaded byte."""
+        sim = RV64ISimulator()
+        prog = (
+            bytes(addi(5, 0, 0x200))
+            + bytes(addi(10, 0, -1))   # x10 = 0xFF (truncated to byte)
+            + bytes(sb(5, 10, 0))
+            + bytes(lb(11, 5, 0))      # x11 = sign_extend(0xFF, 8) = -1
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a1 == 0xFFFF_FFFF_FFFF_FFFF
+
+    def test_lbu_zero_extends(self):
+        """LBU zero-extends the loaded byte."""
+        sim = RV64ISimulator()
+        prog = (
+            bytes(addi(5, 0, 0x200))
+            + bytes(addi(10, 0, -1))
+            + bytes(sb(5, 10, 0))
+            + bytes(lbu(11, 5, 0))   # x11 = 0xFF (zero-extended)
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a1 == 0xFF
+
+    def test_sh_lh_lhu(self):
+        """Store halfword; LH sign-extends; LHU zero-extends."""
+        sim = RV64ISimulator()
+        prog = (
+            bytes(addi(5, 0, 0x300))
+            + bytes(addi(10, 0, -1))
+            + bytes(sh(5, 10, 0))
+            + bytes(lh(11, 5, 0))    # sign-extended: -1
+            + bytes(lhu(12, 5, 0))   # zero-extended: 0xFFFF
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a1 == 0xFFFF_FFFF_FFFF_FFFF
+        assert state.a2 == 0xFFFF
+
+    def test_sd_ld_64bit(self):
+        """Store and load a 64-bit double word."""
+        sim = RV64ISimulator()
+        # Build a 64-bit value: 0x0000_0001_0000_0002
+        prog = (
+            bytes(addi(5, 0, 0x400))          # base address
+            + bytes(addi(10, 0, 1))            # x10 = 1
+            + bytes(slli(10, 10, 32))          # x10 = 1 << 32
+            + bytes(addi(11, 0, 2))            # x11 = 2
+            + bytes(or_(10, 10, 11))           # x10 = 0x1_0000_0002
+            + bytes(sd(5, 10, 0))              # mem[0x400] = x10
+            + bytes(ld(12, 5, 0))              # x12 = mem[0x400]
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a2 == 0x0000_0001_0000_0002
+
+    def test_lw_sign_extends_to_64(self):
+        """LW sign-extends a 32-bit value to 64 bits."""
+        sim = RV64ISimulator()
+        prog = (
+            bytes(addi(5, 0, 0x500))
+            + bytes(addi(10, 0, -1))    # x10 = 0xFFFF_FFFF_FFFF_FFFF
+            + bytes(sw(5, 10, 0))       # stores lower 32 bits: 0xFFFF_FFFF
+            + bytes(lw(11, 5, 0))       # sign-extended → 0xFFFF_FFFF_FFFF_FFFF
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a1 == 0xFFFF_FFFF_FFFF_FFFF
+
+    def test_lwu_zero_extends(self):
+        """LWU zero-extends a 32-bit value to 64 bits."""
+        sim = RV64ISimulator()
+        prog = (
+            bytes(addi(5, 0, 0x500))
+            + bytes(addi(10, 0, -1))
+            + bytes(sw(5, 10, 0))
+            + bytes(lwu(11, 5, 0))   # zero-extended → 0x0000_0000_FFFF_FFFF
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a1 == 0x0000_0000_FFFF_FFFF
+
+    def test_store_load_with_offset(self):
+        """Load/store with positive immediate offset."""
+        sim = RV64ISimulator()
+        prog = (
+            bytes(addi(5, 0, 0x100))
+            + bytes(addi(10, 0, 0x99))
+            + bytes(sw(5, 10, 8))       # mem[0x108] = 0x99
+            + bytes(lw(11, 5, 8))       # x11 = mem[0x108]
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a1 == 0x99
+
+
+# ── Branches ──────────────────────────────────────────────────────────────────
+
+
+class TestBranches:
+    def test_beq_taken(self):
+        """BEQ: equal values → branch taken."""
+        # x10 = x11 = 5; BEQ → skip MOV x12, 1; x12 stays 0
+        state = run([
+            addi(10, 0, 5),
+            addi(11, 0, 5),
+            beq(10, 11, 8),      # skip next 2 instructions (8 bytes)
+            addi(12, 0, 1),      # skipped
+            addi(12, 12, 0),     # skipped
+        ])
+        assert state.a2 == 0
+
+    def test_beq_not_taken(self):
+        """BEQ: unequal values → fall through."""
+        state = run([
+            addi(10, 0, 5),
+            addi(11, 0, 6),
+            beq(10, 11, 8),
+            addi(12, 0, 1),
+        ])
+        assert state.a2 == 1
+
+    def test_bne_taken(self):
+        state = run([
+            addi(10, 0, 1),
+            addi(11, 0, 2),
+            bne(10, 11, 8),
+            addi(12, 0, 99),   # skipped
+            addi(12, 12, 0),   # skipped
+        ])
+        assert state.a2 == 0
+
+    def test_blt_signed(self):
+        """-1 < 1 → BLT taken."""
+        state = run([
+            addi(10, 0, -1),
+            addi(11, 0, 1),
+            blt(10, 11, 8),
+            addi(12, 0, 99),   # skipped
+            addi(12, 12, 0),   # skipped
+        ])
+        assert state.a2 == 0
+
+    def test_blt_not_taken_for_larger(self):
+        """5 < 3 → BLT not taken."""
+        state = run([
+            addi(10, 0, 5),
+            addi(11, 0, 3),
+            blt(10, 11, 8),
+            addi(12, 0, 1),
+        ])
+        assert state.a2 == 1
+
+    def test_bge_taken(self):
+        """3 >= 3 → BGE taken."""
+        state = run([
+            addi(10, 0, 3),
+            addi(11, 0, 3),
+            bge(10, 11, 8),
+            addi(12, 0, 99),   # skipped
+            addi(12, 12, 0),   # skipped
+        ])
+        assert state.a2 == 0
+
+    def test_bltu_treats_as_unsigned(self):
+        """BLTU: 1 <u 0xFFFF...FFFF (= -1 signed) → taken."""
+        state = run([
+            addi(10, 0, 1),
+            addi(11, 0, -1),   # x11 = 0xFFFF...FFFF (large unsigned)
+            bltu(10, 11, 8),
+            addi(12, 0, 99),   # skipped
+            addi(12, 12, 0),   # skipped
+        ])
+        assert state.a2 == 0
+
+    def test_bgeu_taken(self):
+        """-1 >=u 1 → BGEU taken (−1 is max unsigned)."""
+        state = run([
+            addi(10, 0, -1),
+            addi(11, 0, 1),
+            bgeu(10, 11, 8),
+            addi(12, 0, 99),   # skipped
+            addi(12, 12, 0),   # skipped
+        ])
+        assert state.a2 == 0
+
+    def test_backward_branch_loop(self):
+        """Simple countdown loop: x10 = 3, count down to 0."""
+        sim = RV64ISimulator()
+        # Addr 0: addi x10, x0, 3       (x10 = 3)
+        # Addr 4: addi x10, x10, -1     (x10--)
+        # Addr 8: bne  x10, x0, -4     (jump back to addr 4 while x10 != 0)
+        # Addr 12: halt
+        prog = (
+            bytes(addi(10, 0, 3))
+            + bytes(addi(10, 10, -1))
+            + bytes(bne(10, 0, -4))   # back 4 bytes → addr 4
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a0 == 0
+
+
+# ── JAL / JALR ────────────────────────────────────────────────────────────────
+
+
+class TestJumpAndLink:
+    def test_jal_forward(self):
+        """JAL x1, +8: saves return address and jumps forward."""
+        sim = RV64ISimulator()
+        # Addr 0: JAL x1, +8  → jumps to addr 8, x1 = 4
+        # Addr 4: addi x10, x0, 99  (skipped)
+        # Addr 8: addi x10, x0, 42
+        # Addr 12: halt
+        prog = (
+            bytes(jal(1, 8))
+            + bytes(addi(10, 0, 99))   # skipped
+            + bytes(addi(10, 0, 42))
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a0 == 42
+        assert state.ra == 4   # return address
+
+    def test_jalr_returns(self):
+        """JALR returns to the saved RA."""
+        sim = RV64ISimulator()
+        # Addr 0: JAL x1, +8  → jumps to addr 8, x1 = 4
+        # Addr 4: halt (return target)
+        # Addr 8: addi x10, x0, 42
+        # Addr 12: JALR x0, x1, 0  → return to addr 4 (halt)
+        prog = (
+            bytes(jal(1, 8))
+            + b"\x00\x00\x00\x00"   # halt at addr 4
+            + bytes(addi(10, 0, 42))
+            + bytes(jalr(0, 1, 0))   # return via x1
+        )
+        state = sim.execute(prog)
+        assert state.a0 == 42
+        assert state.halted
+
+    def test_jal_x0_plain_jump(self):
+        """JAL x0, offset is a plain jump (return address discarded)."""
+        state = run([
+            jal(0, 8),          # jump over next instruction
+            addi(10, 0, 99),    # skipped
+            addi(10, 0, 42),    # executed
+        ])
+        assert state.a0 == 42
+        assert state.gpr[0] == 0   # x0 always 0
+
+
+# ── M Extension — Multiply ────────────────────────────────────────────────────
+
+
+class TestMultiply:
+    def test_mul_basic(self):
+        """MUL: 6 × 7 = 42."""
+        state = run([addi(10, 0, 6), addi(11, 0, 7), mul(12, 10, 11)])
+        assert state.a2 == 42
+
+    def test_mul_overflow_wraps(self):
+        """MUL takes lower 64 bits of the 128-bit product."""
+        # 2^62 * 4 = 2^64 → lower 64 bits = 0
+        state = run([addi(10, 0, 4), slli(10, 10, 60), addi(11, 0, 4), mul(12, 10, 11)])
+        assert state.a2 == 0
+
+    def test_mulh_signed(self):
+        """MULH: upper 64 bits of signed × signed."""
+        # -1 × -1 = +1 (128-bit); upper 64 bits = 0
+        state = run([addi(10, 0, -1), addi(11, 0, -1), mulh(12, 10, 11)])
+        assert state.a2 == 0
+
+    def test_mulhu_unsigned(self):
+        """MULHU: upper 64 bits of unsigned × unsigned."""
+        # 0xFFFF...FFFF × 0xFFFF...FFFF = large; upper 64 = 0xFFFF...FFFE
+        state = run([addi(10, 0, -1), addi(11, 0, -1), mulhu(12, 10, 11)])
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFE
+
+    def test_mulhsu(self):
+        """MULHSU: upper 64 of signed × unsigned."""
+        # 1 × (2^64-1) = 2^64-1; upper 64 = 0
+        state = run([addi(10, 0, 1), addi(11, 0, -1), mulhsu(12, 10, 11)])
+        assert state.a2 == 0
+
+    def test_mulw(self):
+        """MULW: 32-bit multiply, result sign-extended to 64."""
+        state = run([addi(10, 0, 3), addi(11, 0, 4), mulw(12, 10, 11)])
+        assert state.a2 == 12
+
+
+# ── M Extension — Divide ──────────────────────────────────────────────────────
+
+
+class TestDivide:
+    def test_div_basic(self):
+        """DIV: 42 / 7 = 6."""
+        state = run([addi(10, 0, 42), addi(11, 0, 7), div_(12, 10, 11)])
+        assert state.a2 == 6
+
+    def test_div_truncates_toward_zero(self):
+        """-7 / 2 = -3 (truncated toward zero, not -4)."""
+        state = run([addi(10, 0, -7), addi(11, 0, 2), div_(12, 10, 11)])
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFD   # -3
+
+    def test_div_by_zero_returns_neg_one(self):
+        """DIV by zero → -1 (= 0xFFFF...FFFF)."""
+        state = run([addi(10, 0, 5), addi(11, 0, 0), div_(12, 10, 11)])
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFF
+
+    def test_divu_basic(self):
+        """DIVU: 10 / 3 = 3 (unsigned)."""
+        state = run([addi(10, 0, 10), addi(11, 0, 3), divu(12, 10, 11)])
+        assert state.a2 == 3
+
+    def test_divu_by_zero(self):
+        """DIVU by zero → MAXUINT."""
+        state = run([addi(10, 0, 1), addi(11, 0, 0), divu(12, 10, 11)])
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFF
+
+    def test_rem_basic(self):
+        """REM: 10 % 3 = 1."""
+        state = run([addi(10, 0, 10), addi(11, 0, 3), rem(12, 10, 11)])
+        assert state.a2 == 1
+
+    def test_rem_negative_dividend(self):
+        """-7 % 2 = -1 (sign matches dividend)."""
+        state = run([addi(10, 0, -7), addi(11, 0, 2), rem(12, 10, 11)])
+        assert state.a2 == 0xFFFF_FFFF_FFFF_FFFF   # -1
+
+    def test_rem_by_zero_returns_dividend(self):
+        """REM by zero → dividend."""
+        state = run([addi(10, 0, 5), addi(11, 0, 0), rem(12, 10, 11)])
+        assert state.a2 == 5
+
+    def test_remu_basic(self):
+        """REMU: 10 % 3 = 1."""
+        state = run([addi(10, 0, 10), addi(11, 0, 3), remu(12, 10, 11)])
+        assert state.a2 == 1
+
+    def test_divw_truncates_to_32(self):
+        """DIVW: operates on lower 32 bits."""
+        state = run([addi(10, 0, 12), addi(11, 0, 4), divw(12, 10, 11)])
+        assert state.a2 == 3
+
+    def test_divuw(self):
+        state = run([addi(10, 0, 12), addi(11, 0, 4), divuw(12, 10, 11)])
+        assert state.a2 == 3
+
+    def test_remw(self):
+        state = run([addi(10, 0, 10), addi(11, 0, 3), remw(12, 10, 11)])
+        assert state.a2 == 1
+
+    def test_remuw(self):
+        state = run([addi(10, 0, 10), addi(11, 0, 3), remuw(12, 10, 11)])
+        assert state.a2 == 1
+
+
+# ── ECALL / EBREAK halt ───────────────────────────────────────────────────────
+
+
+class TestSystem:
+    def test_ecall_halts(self):
+        """ECALL (opcode 0x73, imm=0) causes halt."""
+        ecall = [0x73, 0x00, 0x00, 0x00]
+        sim = RV64ISimulator()
+        sim.load(bytes(ecall))
+        state = sim.execute(bytes(ecall))
+        assert state.halted
+
+    def test_ebreak_halts(self):
+        """EBREAK (opcode 0x73, imm=1) causes halt."""
+        ebreak = [0x73, 0x00, 0x10, 0x00]
+        sim = RV64ISimulator()
+        state = sim.execute(bytes(ebreak))
+        assert state.halted
+
+
+# ── Programs ──────────────────────────────────────────────────────────────────
+
+
+class TestPrograms:
+    def test_fibonacci_6(self):
+        """
+        Compute fib(6) = 8 using a simple iterative loop.
+
+        Register usage:
+          x10 = n (countdown)
+          x11 = a (fib(n-2))
+          x12 = b (fib(n-1))
+          x13 = temp
+        """
+        sim = RV64ISimulator()
+        # x10 = 6 (number of iterations)
+        # x11 = 0 (a = fib(0))
+        # x12 = 1 (b = fib(1))
+        # loop: temp = a + b; a = b; b = temp; n--; bne n, 0, loop
+        prog = (
+            bytes(addi(10, 0, 6))    # n = 6
+            + bytes(addi(11, 0, 0))  # a = 0
+            + bytes(addi(12, 0, 1))  # b = 1
+            # loop (addr 12):
+            + bytes(add(13, 11, 12)) # temp = a + b
+            + bytes(addi(11, 12, 0)) # a = b  (ADDI x11, x12, 0)
+            + bytes(addi(12, 13, 0)) # b = temp
+            + bytes(addi(10, 10, -1))# n--
+            + bytes(bne(10, 0, -16)) # if n != 0: back to addr 12
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        # After 6 iterations: a (x11) = fib(6) = 8, b (x12) = fib(7) = 13.
+        # The loop body assigns b←(a+b) and a←(old b), so after n steps:
+        # x11 = fib(n), x12 = fib(n+1).
+        assert state.a1 == 8   # a = fib(6) = 8
+
+    def test_sum_1_to_10(self):
+        """Sum integers 1..10 = 55."""
+        sim = RV64ISimulator()
+        # x10 = 10 (counter), x11 = 0 (sum)
+        # loop: sum += counter; counter--; bne counter, 0, loop
+        prog = (
+            bytes(addi(10, 0, 10))   # counter = 10
+            + bytes(addi(11, 0, 0))  # sum = 0
+            # loop (addr 8):
+            + bytes(add(11, 11, 10)) # sum += counter
+            + bytes(addi(10, 10, -1))# counter--
+            + bytes(bne(10, 0, -8))  # back to addr 8
+            + b"\x00\x00\x00\x00"
+        )
+        state = sim.execute(prog)
+        assert state.a1 == 55

--- a/code/packages/python/riscv-rv64i-simulator/tests/test_protocol.py
+++ b/code/packages/python/riscv-rv64i-simulator/tests/test_protocol.py
@@ -1,0 +1,135 @@
+"""Tests for SIM00 protocol compliance — RV64I simulator."""
+
+from riscv_rv64i_simulator import MEM_SIZE, SP, RV64ISimulator, RV64IState
+
+
+def test_reset_zeroes_registers():
+    sim = RV64ISimulator()
+    sim._cpu.gpr[1] = 0xDEADBEEF
+    sim._cpu.gpr[10] = 0x12345678
+    sim.reset()
+    for i in range(32):
+        if i != SP:
+            assert sim._cpu.gpr[i] == 0, f"x{i} not zeroed after reset"
+
+
+def test_reset_sets_sp():
+    sim = RV64ISimulator()
+    sim.reset()
+    assert sim._cpu.gpr[SP] == 0xFFF8
+
+
+def test_reset_zeroes_memory():
+    sim = RV64ISimulator()
+    sim._cpu.memory[100] = 0xFF
+    sim.reset()
+    assert sim._cpu.memory[100] == 0
+
+
+def test_reset_sets_pc_zero():
+    sim = RV64ISimulator()
+    sim._cpu.pc = 0x1234
+    sim.reset()
+    assert sim._cpu.pc == 0
+
+
+def test_reset_clears_halted():
+    sim = RV64ISimulator()
+    sim._cpu.halted = True
+    sim.reset()
+    assert not sim._cpu.halted
+
+
+def test_load_copies_program():
+    sim = RV64ISimulator()
+    prog = bytes([0x13, 0x05, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00])
+    sim.load(prog)
+    assert sim._cpu.memory[0] == 0x13
+    assert sim._cpu.memory[1] == 0x05
+    assert sim._cpu.pc == 0
+    assert not sim._cpu.halted
+
+
+def test_get_state_returns_frozen_snapshot():
+    sim = RV64ISimulator()
+    state = sim.get_state()
+    assert isinstance(state, RV64IState)
+    assert state.pc == 0
+    assert len(state.gpr) == 32
+    assert len(state.memory) == MEM_SIZE
+    assert not state.halted
+
+
+def test_x0_always_zero_in_state():
+    sim = RV64ISimulator()
+    sim._cpu.gpr[0] = 0xDEAD   # bypass write_reg directly
+    state = sim.get_state()
+    # x0 in gpr might be dirty but read_reg enforces 0; the state
+    # snapshot captures raw gpr, but RV64IState.zero is always 0
+    assert state.zero == 0
+
+
+def test_execute_returns_state():
+    sim = RV64ISimulator()
+    state = sim.execute(b"\x00\x00\x00\x00")  # halt immediately
+    assert isinstance(state, RV64IState)
+    assert state.halted
+
+
+def test_step_returns_step_trace():
+    from riscv_rv64i_simulator import RV64ISimulator, StepTrace
+    sim = RV64ISimulator()
+    # ADDI x10, x0, 42 then halt
+    prog = bytes([0x13, 0x05, 0xA0, 0x02,   # addi x10, x0, 42
+                  0x00, 0x00, 0x00, 0x00])   # halt
+    sim.load(prog)
+    trace = sim.step()
+    assert isinstance(trace, StepTrace)
+    assert trace.pc_before == 0
+    assert trace.pc_after == 4
+    assert not trace.halted
+
+
+def test_step_on_halt_sets_halted():
+    sim = RV64ISimulator()
+    sim.load(b"\x00\x00\x00\x00")
+    trace = sim.step()
+    assert trace.halted
+    assert sim._cpu.halted
+
+
+def test_step_after_halt_does_not_advance_pc():
+    sim = RV64ISimulator()
+    sim.load(b"\x00\x00\x00\x00")
+    sim.step()
+    pc_after = sim._cpu.pc
+    sim.step()
+    assert sim._cpu.pc == pc_after
+
+
+def test_execute_stops_at_max_steps():
+    sim = RV64ISimulator()
+    # 500 NOPs then halt — should stop before reaching halt with max_steps=5
+    nop = bytes([0x13, 0x00, 0x00, 0x00])   # addi x0, x0, 0 (NOP)
+    prog = nop * 500 + b"\x00\x00\x00\x00"
+    state = sim.execute(prog, max_steps=5)
+    assert not state.halted
+
+
+def test_iop_stubs_do_not_crash():
+    sim = RV64ISimulator()
+    sim.set_input_port(0, 0)
+    assert sim.get_output_port(0) == 0
+    sim.interrupt(0)
+    sim.nmi()
+
+
+def test_state_register_properties():
+    sim = RV64ISimulator()
+    sim._cpu.gpr[1]  = 0x100   # ra
+    sim._cpu.gpr[2]  = 0x200   # sp
+    sim._cpu.gpr[10] = 0x42    # a0
+    state = sim.get_state()
+    assert state.ra == 0x100
+    assert state.sp == 0x200
+    assert state.a0 == 0x42

--- a/code/specs/07y-riscv-rv64i-simulator.md
+++ b/code/specs/07y-riscv-rv64i-simulator.md
@@ -1,0 +1,331 @@
+# 07y — RISC-V RV64I Behavioral Simulator
+
+## Overview
+
+Layer 07y implements a behavioral simulator for the **RISC-V RV64I** base
+integer instruction set, plus the standard **M extension** (multiply/divide).
+RISC-V is an open, royalty-free ISA designed at UC Berkeley for simplicity and
+regularity.  RV64I is the 64-bit base that underpins all modern RISC-V
+deployments.
+
+This is Layer 07y in the coding-adventures simulator series.  The earlier
+`riscv-simulator` (Layer 07a) covered a minimal RV32I subset; this package
+covers the full 64-bit ISA with clean SIM00 protocol integration.
+
+---
+
+## Architecture Summary
+
+| Property | Value |
+|----------|-------|
+| Word width | 64-bit |
+| Registers | 32 × 64-bit integer (x0–x31); x0 hardwired to 0 |
+| PC | 64-bit, always 4-byte aligned |
+| Instruction width | Fixed 32 bits |
+| Byte order | Little-endian |
+| Extensions covered | RV64I + M (multiply/divide) |
+
+---
+
+## Register File
+
+| Reg | ABI name | Role |
+|-----|----------|------|
+| x0  | zero     | Hardwired 0 — reads always return 0; writes ignored |
+| x1  | ra       | Return address |
+| x2  | sp       | Stack pointer |
+| x3  | gp       | Global pointer |
+| x4  | tp       | Thread pointer |
+| x5–x7  | t0–t2 | Temporaries |
+| x8  | s0/fp    | Saved / frame pointer |
+| x9  | s1       | Saved |
+| x10–x11 | a0–a1 | Function args / return values |
+| x12–x17 | a2–a7 | Function args |
+| x18–x27 | s2–s11 | Saved |
+| x28–x31 | t3–t6 | Temporaries |
+
+---
+
+## Instruction Encoding Formats
+
+RISC-V uses six instruction formats.  The opcode always sits in bits [6:0]
+(with the two LSBs always `11` for 32-bit instructions).
+
+```
+R-type  [31:25 funct7][24:20 rs2][19:15 rs1][14:12 funct3][11:7 rd][6:0 opcode]
+I-type  [31:20 imm[11:0]][19:15 rs1][14:12 funct3][11:7 rd][6:0 opcode]
+S-type  [31:25 imm[11:5]][24:20 rs2][19:15 rs1][14:12 funct3][11:7 imm[4:0]][6:0 opcode]
+B-type  [31 imm[12]][30:25 imm[10:5]][24:20 rs2][19:15 rs1][14:12 funct3][11:8 imm[4:1]][7 imm[11]][6:0 opcode]
+U-type  [31:12 imm[31:12]][11:7 rd][6:0 opcode]
+J-type  [31 imm[20]][30:21 imm[10:1]][20 imm[11]][19:12 imm[19:12]][11:7 rd][6:0 opcode]
+```
+
+Immediate reconstruction:
+- **I-type**: `imm = sign_extend(bits[31:20], 12)`
+- **S-type**: `imm = sign_extend(bits[31:25]:bits[11:7], 12)`
+- **B-type**: `imm = sign_extend(bits[31]:bits[7]:bits[30:25]:bits[11:8]:0, 13)`
+- **U-type**: `imm = sign_extend(bits[31:12] << 12, 32)`
+- **J-type**: `imm = sign_extend(bits[31]:bits[19:12]:bits[20]:bits[30:21]:0, 21)`
+
+---
+
+## Base Integer ISA (RV64I)
+
+### Opcode table
+
+| Opcode (bits[6:0]) | Mnemonic group   | Format |
+|--------------------|-----------------|--------|
+| 0110111 (0x37)     | LUI             | U      |
+| 0010111 (0x17)     | AUIPC           | U      |
+| 1101111 (0x6F)     | JAL             | J      |
+| 1100111 (0x67)     | JALR            | I      |
+| 1100011 (0x63)     | Branches        | B      |
+| 0000011 (0x03)     | Loads           | I      |
+| 0100011 (0x23)     | Stores          | S      |
+| 0010011 (0x13)     | ALU immediate   | I      |
+| 0110011 (0x33)     | ALU register    | R      |
+| 0011011 (0x1B)     | ALU imm word    | I (RV64) |
+| 0111011 (0x3B)     | ALU reg word    | R (RV64) |
+| 0001111 (0x0F)     | FENCE           | I      |
+| 1110011 (0x73)     | SYSTEM          | I      |
+
+### LUI / AUIPC
+
+```
+LUI   rd, imm20    rd = sign_extend(imm20 << 12, 64)
+AUIPC rd, imm20    rd = PC + sign_extend(imm20 << 12, 64)
+```
+
+### JAL / JALR
+
+```
+JAL   rd, offset   rd = PC+4;  PC = PC + sign_extend(offset, 21)
+JALR  rd, rs1, imm rd = PC+4;  PC = (rs1 + sign_extend(imm,12)) & ~1
+```
+
+### Branches (B-type, funct3)
+
+| funct3 | Mnemonic | Condition |
+|--------|----------|-----------|
+| 000    | BEQ      | rs1 == rs2 |
+| 001    | BNE      | rs1 != rs2 |
+| 100    | BLT      | rs1 < rs2  (signed) |
+| 101    | BGE      | rs1 >= rs2 (signed) |
+| 110    | BLTU     | rs1 < rs2  (unsigned) |
+| 111    | BGEU     | rs1 >= rs2 (unsigned) |
+
+Branch target = PC + sign_extend(imm, 13).
+
+### Loads (I-type, funct3)
+
+| funct3 | Mnemonic | Width    | Sign |
+|--------|----------|----------|------|
+| 000    | LB       | 8-bit    | signed  |
+| 001    | LH       | 16-bit   | signed  |
+| 010    | LW       | 32-bit   | signed  |
+| 011    | LD       | 64-bit   | unsigned|
+| 100    | LBU      | 8-bit    | unsigned|
+| 101    | LHU      | 16-bit   | unsigned|
+| 110    | LWU      | 32-bit   | unsigned|
+
+Address = rs1 + sign_extend(imm, 12).
+
+### Stores (S-type, funct3)
+
+| funct3 | Mnemonic | Width  |
+|--------|----------|--------|
+| 000    | SB       | 8-bit  |
+| 001    | SH       | 16-bit |
+| 010    | SW       | 32-bit |
+| 011    | SD       | 64-bit |
+
+Address = rs1 + sign_extend(imm, 12).
+
+### ALU Immediate (I-type, opcode 0x13)
+
+| funct3 | Mnemonic | Operation |
+|--------|----------|-----------|
+| 000    | ADDI     | rd = rs1 + sext(imm,12) |
+| 010    | SLTI     | rd = (rs1 < sext(imm,12)) ? 1 : 0  (signed) |
+| 011    | SLTIU    | rd = ((u64)rs1 < (u64)sext(imm,12)) ? 1 : 0 |
+| 100    | XORI     | rd = rs1 ^ sext(imm,12) |
+| 110    | ORI      | rd = rs1 | sext(imm,12) |
+| 111    | ANDI     | rd = rs1 & sext(imm,12) |
+| 001    | SLLI     | rd = rs1 << shamt6 |
+| 101    | SRLI/SRAI| funct7[5]=0: SRLI logical; =1: SRAI arithmetic |
+
+For 64-bit shifts, `shamt` is bits [25:20] (6-bit shift amount).
+
+### ALU Register (R-type, opcode 0x33)
+
+| funct7  | funct3 | Mnemonic | Operation |
+|---------|--------|----------|-----------|
+| 0000000 | 000    | ADD      | rd = rs1 + rs2 |
+| 0100000 | 000    | SUB      | rd = rs1 - rs2 |
+| 0000000 | 001    | SLL      | rd = rs1 << (rs2 & 63) |
+| 0000000 | 010    | SLT      | rd = (rs1 < rs2) signed |
+| 0000000 | 011    | SLTU     | rd = (rs1 < rs2) unsigned |
+| 0000000 | 100    | XOR      | rd = rs1 ^ rs2 |
+| 0000000 | 101    | SRL      | rd = rs1 >> (rs2 & 63) logical |
+| 0100000 | 101    | SRA      | rd = rs1 >> (rs2 & 63) arithmetic |
+| 0000000 | 110    | OR       | rd = rs1 \| rs2 |
+| 0000000 | 111    | AND      | rd = rs1 & rs2 |
+
+### RV64I word ops — ALU Immediate Word (opcode 0x1B)
+
+Operate on the lower 32 bits of rs1; result sign-extended to 64 bits.
+
+| funct3 | Mnemonic | Operation |
+|--------|----------|-----------|
+| 000    | ADDIW    | rd = sext32(rs1[31:0] + sext(imm,12)) |
+| 001    | SLLIW    | rd = sext32(rs1[31:0] << shamt5) |
+| 101    | SRLIW/SRAIW | logical or arithmetic 32-bit shift, sext to 64 |
+
+### RV64I word ops — ALU Register Word (opcode 0x3B)
+
+| funct7  | funct3 | Mnemonic | Operation |
+|---------|--------|----------|-----------|
+| 0000000 | 000    | ADDW     | rd = sext32(rs1[31:0] + rs2[31:0]) |
+| 0100000 | 000    | SUBW     | rd = sext32(rs1[31:0] - rs2[31:0]) |
+| 0000000 | 001    | SLLW     | rd = sext32(rs1[31:0] << (rs2 & 31)) |
+| 0000000 | 101    | SRLW     | rd = sext32(rs1[31:0] >> (rs2 & 31)) logical |
+| 0100000 | 101    | SRAW     | rd = sext32(rs1[31:0] >> (rs2 & 31)) arithmetic |
+
+---
+
+## M Extension (Multiply/Divide)
+
+### 64-bit multiply/divide (opcode 0x33, funct7=0000001)
+
+| funct3 | Mnemonic | Operation |
+|--------|----------|-----------|
+| 000    | MUL      | rd = (rs1 * rs2)[63:0] (lower 64 bits) |
+| 001    | MULH     | rd = (signed(rs1) * signed(rs2))[127:64] |
+| 010    | MULHSU   | rd = (signed(rs1) * unsigned(rs2))[127:64] |
+| 011    | MULHU    | rd = (unsigned(rs1) * unsigned(rs2))[127:64] |
+| 100    | DIV      | rd = signed(rs1) / signed(rs2); truncated toward zero |
+| 101    | DIVU     | rd = unsigned(rs1) / unsigned(rs2) |
+| 110    | REM      | rd = signed(rs1) % signed(rs2); sign matches dividend |
+| 111    | REMU     | rd = unsigned(rs1) % unsigned(rs2) |
+
+Division by zero: DIV→-1, DIVU→MAXUINT, REM/REMU→dividend.
+Overflow (INT64_MIN / -1): DIV→INT64_MIN, REM→0.
+
+### 32-bit multiply/divide word (opcode 0x3B, funct7=0000001)
+
+| funct3 | Mnemonic | Operation |
+|--------|----------|-----------|
+| 000    | MULW     | rd = sext32(rs1[31:0] * rs2[31:0]) |
+| 100    | DIVW     | rd = sext32(signed32(rs1) / signed32(rs2)) |
+| 101    | DIVUW    | rd = sext32(unsigned32(rs1) / unsigned32(rs2)) |
+| 110    | REMW     | rd = sext32(signed32(rs1) % signed32(rs2)) |
+| 111    | REMUW    | rd = sext32(unsigned32(rs1) % unsigned32(rs2)) |
+
+---
+
+## SYSTEM Instructions (opcode 0x73)
+
+| imm[11:0] | Mnemonic | Effect |
+|-----------|----------|--------|
+| 000000000000 | ECALL  | Halt (treated as halt sentinel) |
+| 000000000001 | EBREAK | Halt |
+
+All other CSR instructions are NOP in this simulator.
+
+---
+
+## Halt Sentinel
+
+A 32-bit zero word (`0x00000000`) fetched at PC causes an immediate halt.
+This is the `ECALL` encoding with all fields zeroed, which is architecturally
+invalid and unambiguously identifies the halt condition.
+
+---
+
+## Memory Model
+
+| Property | Value |
+|----------|-------|
+| Size | 65 536 bytes (64 KiB) |
+| Layout | Little-endian |
+| Wrapping | All addresses masked with `0xFFFF` |
+
+---
+
+## Reset State
+
+| Resource | Reset value |
+|----------|-------------|
+| x0 | 0 (always) |
+| x2 (sp) | 0xFFF8 |
+| x1, x3–x31 | 0 |
+| PC | 0 |
+| Memory | All 0 |
+| Halted | False |
+
+---
+
+## SIM00 Protocol
+
+The simulator implements the standard SIM00 `Simulator[State]` protocol:
+
+| Method | Behaviour |
+|--------|-----------|
+| `reset()` | Zero all registers and memory; set SP=0xFFF8; PC=0 |
+| `load(program: bytes)` | Reset then copy program bytes to memory[0..] |
+| `step()` | Execute one instruction; return `StepTrace` |
+| `execute(program, max_steps=100_000)` | Load and run until halt or limit |
+| `get_state()` | Return frozen `RV64IState` snapshot |
+| `set_input_port(port, value)` | Stub (no I/O model) |
+| `get_output_port(port)` | Stub → returns 0 |
+| `interrupt(vector)` | Stub |
+| `nmi()` | Stub |
+
+---
+
+## StepTrace
+
+`StepTrace` is a locally defined frozen dataclass (not from `simulator_protocol`):
+
+```python
+@dataclass(frozen=True)
+class StepTrace:
+    pc_before: int
+    pc_after:  int
+    halted:    bool
+```
+
+---
+
+## Implementation Scope
+
+This simulator targets **behavioral correctness** for compiler testing:
+
+- Full RV64I base integer instruction set
+- M extension (integer multiply/divide, 64-bit and word variants)
+- No floating-point (F/D), no atomics (A), no compressed (C)
+- No privilege modes, CSRs, or MMU
+- FENCE is a NOP
+- ECALL/EBREAK halt the simulator
+
+---
+
+## Package Layout
+
+```
+code/packages/python/riscv-rv64i-simulator/
+├── BUILD
+├── CHANGELOG.md
+├── README.md
+├── pyproject.toml
+└── src/
+    └── riscv_rv64i_simulator/
+        ├── __init__.py
+        ├── py.typed
+        ├── state.py       ← constants, sext helpers, RV64IState dataclass
+        └── simulator.py   ← _CPU, instruction decode/execute, RV64ISimulator
+tests/
+    ├── conftest.py
+    ├── test_protocol.py
+    └── test_instructions.py
+```


### PR DESCRIPTION
## Summary

- Adds a full **RISC-V RV64I + M extension** behavioral Python simulator (Layer 07y in the coding-adventures simulator series)
- Implements the complete RV64I base integer ISA (64-bit) and M extension integer multiply/divide
- Follows the SIM00 simulator protocol: `reset`, `load`, `step`, `execute`, `get_state`

## Architecture

- 32 × 64-bit integer registers (x0–x31); x0 hardwired to zero
- Fixed 32-bit instruction width, little-endian byte order
- 64 KiB flat address space (addresses masked to 16 bits)
- Halt sentinel: 32-bit zero word `0x00000000`; ECALL/EBREAK also halt

## Instructions

- **Upper immediate**: LUI, AUIPC
- **Jumps**: JAL, JALR
- **Branches**: BEQ, BNE, BLT, BGE, BLTU, BGEU
- **Loads/stores**: LB, LH, LW, LD, LBU, LHU, LWU / SB, SH, SW, SD
- **ALU immediate**: ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI
- **RV64I word immediate**: ADDIW, SLLIW, SRLIW, SRAIW
- **ALU register**: ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND
- **RV64I word register**: ADDW, SUBW, SLLW, SRLW, SRAW
- **System**: FENCE (NOP), ECALL/EBREAK (halt)
- **M extension 64-bit**: MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU
- **M extension word**: MULW, DIVW, DIVUW, REMW, REMUW

Division-by-zero and signed overflow (INT64_MIN ÷ −1) handled per RISC-V spec without raising exceptions.

## Test plan

- [x] 96 tests passing (15 protocol + 81 instruction/program tests)
- [x] 97.54% test coverage (target ≥80%)
- [x] `ruff check` passes with no findings
- [x] Security review passed — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)