### PR TITLE
rust(spice): separate AC source bias

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -27,7 +27,9 @@
 - Add AC noise analysis with resistor Johnson-Nyquist source PSDs, adjoint
   output contributions, input-referred PSD, and default log sweeps.
 - Add DC small-signal transfer-function analysis with input/output impedance.
-- Add AC small-signal frequency sweeps for linear RC/RL circuits.
+- Add AC small-signal frequency sweeps for linear RC/RL circuits, explicit AC
+  source phasors, and DC-bias operating-point linearization for nonlinear
+  devices when AC source specs are present.
 - Add backward-Euler transient analysis for linear RC circuits.
 - Add ideal-short DC and backward-Euler transient support for inductors.
 - Add transient source waveforms for independent voltage and current sources:

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -15,14 +15,16 @@ The initial slices implement:
   input-referred PSD.
 - DC small-signal transfer-function (`.tf`) analysis with input and output
   impedance estimates.
-- AC small-signal frequency sweeps for linear RC/RL circuits.
+- AC small-signal frequency sweeps for linear RC/RL circuits and explicit AC
+  source phasors with DC-bias operating-point linearization for nonlinear
+  devices.
 - Backward-Euler transient analysis for linear RC/RL circuits.
 - Time-varying transient source waveforms: PWL, SIN, PULSE, and EXP.
 
 The package supports resistors, capacitors, inductors, diodes, BJTs,
 independent current sources, independent voltage sources, voltage-controlled
-current sources, optional source waveforms, ground aliases, node voltages, and
-voltage source branch currents.
+current sources, optional AC source phasors, optional source waveforms, ground
+aliases, node voltages, and voltage source branch currents.
 
 ```rust
 use spice_engine::{Circuit, Element, PwlWaveform, Resistor, VoltageSource, Waveform};

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -451,6 +451,7 @@ pub struct VoltageSource {
     pub positive: String,
     pub negative: String,
     pub voltage: f64,
+    pub ac: Option<AcSource>,
     pub waveform: Option<Waveform>,
 }
 
@@ -466,6 +467,25 @@ impl VoltageSource {
             positive: positive.into(),
             negative: negative.into(),
             voltage,
+            ac: None,
+            waveform: None,
+        }
+    }
+
+    pub fn with_ac(
+        name: impl Into<String>,
+        positive: impl Into<String>,
+        negative: impl Into<String>,
+        voltage: f64,
+        magnitude: f64,
+        phase_degrees: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            positive: positive.into(),
+            negative: negative.into(),
+            voltage,
+            ac: Some(AcSource::new(magnitude, phase_degrees)),
             waveform: None,
         }
     }
@@ -482,6 +502,7 @@ impl VoltageSource {
             positive: positive.into(),
             negative: negative.into(),
             voltage,
+            ac: None,
             waveform: Some(waveform),
         }
     }
@@ -493,6 +514,7 @@ pub struct CurrentSource {
     pub positive: String,
     pub negative: String,
     pub current: f64,
+    pub ac: Option<AcSource>,
     pub waveform: Option<Waveform>,
 }
 
@@ -508,6 +530,25 @@ impl CurrentSource {
             positive: positive.into(),
             negative: negative.into(),
             current,
+            ac: None,
+            waveform: None,
+        }
+    }
+
+    pub fn with_ac(
+        name: impl Into<String>,
+        positive: impl Into<String>,
+        negative: impl Into<String>,
+        current: f64,
+        magnitude: f64,
+        phase_degrees: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            positive: positive.into(),
+            negative: negative.into(),
+            current,
+            ac: Some(AcSource::new(magnitude, phase_degrees)),
             waveform: None,
         }
     }
@@ -524,7 +565,23 @@ impl CurrentSource {
             positive: positive.into(),
             negative: negative.into(),
             current,
+            ac: None,
             waveform: Some(waveform),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct AcSource {
+    pub magnitude: f64,
+    pub phase_degrees: f64,
+}
+
+impl AcSource {
+    pub fn new(magnitude: f64, phase_degrees: f64) -> Self {
+        Self {
+            magnitude,
+            phase_degrees,
         }
     }
 }
@@ -1445,6 +1502,12 @@ pub fn noise_ac(
     let voltage_sources = collect_ac_voltage_sources(circuit)?;
     let node_count = node_indices.len();
     let matrix_size = node_count + voltage_sources.len();
+    let uses_explicit_ac_sources = circuit_has_explicit_ac_sources(circuit);
+    let operating_point = if uses_explicit_ac_sources && matrix_size > 0 {
+        solve_linear_circuit(circuit, &[], &[], None)?.vector
+    } else {
+        vec![0.0; matrix_size]
+    };
     let output_index = node_index(&node_indices, output_node);
     let noise_sources = collect_noise_sources(circuit, &node_indices, temperature_kelvin)?;
     let frequencies = if frequencies_hz.is_empty() {
@@ -1470,6 +1533,7 @@ pub fn noise_ac(
             TWO_PI * frequency_hz,
             &node_indices,
             &voltage_sources,
+            &operating_point,
         )?;
         let mut rhs = vec![Complex::zero(); matrix_size];
         rhs[output_index.unwrap()] = Complex::new(1.0, 0.0);
@@ -2068,6 +2132,7 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
     let node_count = node_indices.len();
     let branch_count = voltage_sources.len();
     let matrix_size = node_count + branch_count;
+    let uses_explicit_ac_sources = circuit_has_explicit_ac_sources(circuit);
 
     if matrix_size == 0 {
         return Ok(AcSolution {
@@ -2076,16 +2141,31 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
         });
     }
 
-    let matrix = build_ac_matrix(circuit, omega, &node_indices, &voltage_sources)?;
+    let operating_point = if uses_explicit_ac_sources {
+        solve_linear_circuit(circuit, &[], &[], None)?.vector
+    } else {
+        vec![0.0; matrix_size]
+    };
+    let matrix = build_ac_matrix(
+        circuit,
+        omega,
+        &node_indices,
+        &voltage_sources,
+        &operating_point,
+    )?;
     let mut rhs = vec![Complex::zero(); matrix_size];
 
     for element in circuit.elements() {
         match element {
-            Element::VoltageSource(source) => {
-                stamp_ac_voltage_source(source, &voltage_sources, node_count, &mut rhs)?
-            }
+            Element::VoltageSource(source) => stamp_ac_voltage_source(
+                source,
+                &voltage_sources,
+                node_count,
+                uses_explicit_ac_sources,
+                &mut rhs,
+            )?,
             Element::CurrentSource(source) => {
-                stamp_ac_current_source(source, &node_indices, &mut rhs)?
+                stamp_ac_current_source(source, &node_indices, uses_explicit_ac_sources, &mut rhs)?
             }
             Element::Resistor(_)
             | Element::Capacitor(_)
@@ -2121,6 +2201,7 @@ fn build_ac_matrix(
     omega: f64,
     node_indices: &HashMap<String, usize>,
     voltage_sources: &BTreeMap<String, usize>,
+    operating_point: &[f64],
 ) -> Result<Vec<Vec<Complex>>, SpiceError> {
     let node_count = node_indices.len();
     let matrix_size = node_count + voltage_sources.len();
@@ -2143,25 +2224,30 @@ fn build_ac_matrix(
                 &mut matrix,
             )?,
             Element::CurrentSource(source) => {
-                if !source.current.is_finite() {
-                    return Err(SpiceError::InvalidElement {
-                        name: source.name.clone(),
-                        reason: "current must be finite".to_string(),
-                    });
-                }
+                validate_ac_current_source(source)?;
             }
             Element::Diode(diode) => {
                 validate_diode(diode)?;
+                let anode = node_index(node_indices, &diode.anode);
+                let cathode = node_index(node_indices, &diode.cathode);
+                let voltage = vector_voltage(operating_point, anode)
+                    - vector_voltage(operating_point, cathode);
+                let exponent = (voltage / diode.thermal_voltage).clamp(-40.0, 40.0);
                 stamp_complex_conductance(
                     &mut matrix,
-                    node_index(node_indices, &diode.anode),
-                    node_index(node_indices, &diode.cathode),
-                    Complex::new(diode.saturation_current / diode.thermal_voltage, 0.0),
+                    anode,
+                    cathode,
+                    Complex::new(
+                        diode.saturation_current / diode.thermal_voltage * exponent.exp(),
+                        0.0,
+                    ),
                 );
             }
-            Element::Bjt(bjt) => stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix)?,
+            Element::Bjt(bjt) => {
+                stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix, operating_point)?
+            }
             Element::Mosfet(mosfet) => {
-                stamp_ac_mosfet_small_signal(mosfet, node_indices, &mut matrix)?
+                stamp_ac_mosfet_small_signal(mosfet, node_indices, &mut matrix, operating_point)?
             }
             Element::Vccs(source) => stamp_ac_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_ac_vcvs(
@@ -2832,16 +2918,24 @@ fn stamp_ac_bjt_small_signal(
     bjt: &Bjt,
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<Complex>],
+    operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
     let collector = node_index(node_indices, &bjt.collector);
     let base = node_index(node_indices, &bjt.base);
     let emitter = node_index(node_indices, &bjt.emitter);
-    let gm = Complex::new(bjt.saturation_current / bjt.thermal_voltage, 0.0);
-    let gpi = Complex::new(
-        bjt.saturation_current / bjt.thermal_voltage / bjt.forward_beta,
+    let base_voltage = vector_voltage(operating_point, base);
+    let emitter_voltage = vector_voltage(operating_point, emitter);
+    let junction_voltage = match bjt.polarity {
+        BjtPolarity::Npn => base_voltage - emitter_voltage,
+        BjtPolarity::Pnp => emitter_voltage - base_voltage,
+    };
+    let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
+    let gm = Complex::new(
+        bjt.saturation_current / bjt.thermal_voltage * exponent.exp(),
         0.0,
     );
+    let gpi = Complex::new(gm.real / bjt.forward_beta, 0.0);
     match bjt.polarity {
         BjtPolarity::Npn => {
             stamp_complex_conductance(matrix, base, emitter, gpi);
@@ -2990,13 +3084,21 @@ fn stamp_ac_mosfet_small_signal(
     mosfet: &Mosfet,
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<Complex>],
+    operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_mosfet(mosfet)?;
     let drain = node_index(node_indices, &mosfet.drain);
     let gate = node_index(node_indices, &mosfet.gate);
     let source = node_index(node_indices, &mosfet.source);
     let body = node_index(node_indices, &mosfet.body);
-    let result = evaluate_mosfet_level1(mosfet, 0.0, 0.0, 0.0);
+    let drain_voltage = vector_voltage(operating_point, drain);
+    let gate_voltage = vector_voltage(operating_point, gate);
+    let source_voltage = vector_voltage(operating_point, source);
+    let body_voltage = vector_voltage(operating_point, body);
+    let vgs = gate_voltage - source_voltage;
+    let vds = drain_voltage - source_voltage;
+    let vbs = body_voltage - source_voltage;
+    let result = evaluate_mosfet_level1(mosfet, vgs, vds, vbs);
     stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
     stamp_complex_transconductance(
         matrix,
@@ -3611,17 +3713,26 @@ fn stamp_ac_voltage_source(
     source: &VoltageSource,
     voltage_sources: &BTreeMap<String, usize>,
     node_count: usize,
+    uses_explicit_ac_sources: bool,
     rhs: &mut [Complex],
 ) -> Result<(), SpiceError> {
+    validate_ac_voltage_source(source)?;
+
+    let branch = node_count + voltage_sources[&source.name];
+    rhs[branch] += voltage_source_ac_phasor(source, uses_explicit_ac_sources);
+    Ok(())
+}
+
+fn validate_ac_voltage_source(source: &VoltageSource) -> Result<(), SpiceError> {
     if !source.voltage.is_finite() {
         return Err(SpiceError::InvalidElement {
             name: source.name.clone(),
             reason: "voltage must be finite".to_string(),
         });
     }
-
-    let branch = node_count + voltage_sources[&source.name];
-    rhs[branch] += Complex::new(source.voltage, 0.0);
+    if let Some(ac) = source.ac {
+        validate_ac_source(&source.name, ac)?;
+    }
     Ok(())
 }
 
@@ -3632,12 +3743,7 @@ fn stamp_ac_voltage_source_matrix(
     node_count: usize,
     matrix: &mut [Vec<Complex>],
 ) -> Result<(), SpiceError> {
-    if !source.voltage.is_finite() {
-        return Err(SpiceError::InvalidElement {
-            name: source.name.clone(),
-            reason: "voltage must be finite".to_string(),
-        });
-    }
+    validate_ac_voltage_source(source)?;
 
     let branch = node_count + voltage_sources[&source.name];
     let positive = node_index(node_indices, &source.positive);
@@ -3665,16 +3771,12 @@ fn stamp_complex_branch_matrix(
 fn stamp_ac_current_source(
     source: &CurrentSource,
     node_indices: &HashMap<String, usize>,
+    uses_explicit_ac_sources: bool,
     rhs: &mut [Complex],
 ) -> Result<(), SpiceError> {
-    if !source.current.is_finite() {
-        return Err(SpiceError::InvalidElement {
-            name: source.name.clone(),
-            reason: "current must be finite".to_string(),
-        });
-    }
+    validate_ac_current_source(source)?;
 
-    let current = Complex::new(source.current, 0.0);
+    let current = current_source_ac_phasor(source, uses_explicit_ac_sources);
     if let Some(i) = node_index(node_indices, &source.positive) {
         rhs[i] -= current;
     }
@@ -3682,6 +3784,67 @@ fn stamp_ac_current_source(
         rhs[j] += current;
     }
     Ok(())
+}
+
+fn validate_ac_current_source(source: &CurrentSource) -> Result<(), SpiceError> {
+    if !source.current.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "current must be finite".to_string(),
+        });
+    }
+    if let Some(ac) = source.ac {
+        validate_ac_source(&source.name, ac)?;
+    }
+    Ok(())
+}
+
+fn validate_ac_source(name: &str, source: AcSource) -> Result<(), SpiceError> {
+    if !source.magnitude.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: name.to_string(),
+            reason: "AC magnitude must be finite".to_string(),
+        });
+    }
+    if !source.phase_degrees.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: name.to_string(),
+            reason: "AC phase must be finite".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn voltage_source_ac_phasor(source: &VoltageSource, uses_explicit_ac_sources: bool) -> Complex {
+    match source.ac {
+        Some(ac) => ac_source_phasor(ac),
+        None if uses_explicit_ac_sources => Complex::zero(),
+        None => Complex::new(source.voltage, 0.0),
+    }
+}
+
+fn current_source_ac_phasor(source: &CurrentSource, uses_explicit_ac_sources: bool) -> Complex {
+    match source.ac {
+        Some(ac) => ac_source_phasor(ac),
+        None if uses_explicit_ac_sources => Complex::zero(),
+        None => Complex::new(source.current, 0.0),
+    }
+}
+
+fn ac_source_phasor(source: AcSource) -> Complex {
+    let phase = source.phase_degrees.to_radians();
+    Complex::new(
+        source.magnitude * phase.cos(),
+        source.magnitude * phase.sin(),
+    )
+}
+
+fn circuit_has_explicit_ac_sources(circuit: &Circuit) -> bool {
+    circuit.elements().iter().any(|element| match element {
+        Element::VoltageSource(source) => source.ac.is_some(),
+        Element::CurrentSource(source) => source.ac.is_some(),
+        _ => false,
+    })
 }
 
 fn stamp_ac_vccs(

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
     ac_sweep, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor,
-    Resistor, SpiceError, Vcvs, VoltageSource,
+    Mosfet, MosfetLevel1Params, MosfetType, Resistor, SpiceError, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -147,6 +147,101 @@ fn ac_bjt_applies_zero_bias_common_emitter_gain() {
     let out = points[0].voltage("out").unwrap();
     assert_close(out.real, -1.0);
     assert_close(out.imag, 0.0);
+}
+
+#[test]
+fn ac_bjt_uses_explicit_ac_source_and_dc_bias_operating_point() {
+    let mut circuit = Circuit::new();
+    let thermal_voltage = 0.02585;
+    circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+        "Vin",
+        "base",
+        "0",
+        thermal_voltage * 2.0_f64.ln(),
+        1.0,
+        0.0,
+    )));
+    circuit.add(Element::Bjt(Bjt::with_model(
+        "Q1",
+        "out",
+        "base",
+        "0",
+        BjtPolarity::Npn,
+        25.85e-6,
+        100.0,
+        thermal_voltage,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let points = ac_sweep(&circuit, 1_000.0, 1_000.0, 10).unwrap();
+
+    assert_eq!(points.len(), 1);
+    let out = points[0].voltage("out").unwrap();
+    assert_close(out.real, -2.0);
+    assert_close(out.imag, 0.0);
+}
+
+#[test]
+fn ac_mosfet_common_source_suppresses_dc_supplies_without_ac_spec() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+        "Vin", "gate", "0", 1.5, 1.0, 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            vt0: 0.5,
+            kp: 1.0e-3,
+            lambda: 0.0,
+            gamma: 0.0,
+            phi: 0.7,
+            w: 1.0,
+            l: 1.0,
+            saturation_current: 1.0e-15,
+            n_sub: 1.0,
+            t_nom: 300.15,
+        },
+    )));
+
+    let points = ac_sweep(&circuit, 1_000.0, 1_000.0, 10).unwrap();
+
+    assert_eq!(points.len(), 1);
+    let out = points[0].voltage("out").unwrap();
+    assert_close(out.real, -1.0);
+    assert_close(out.imag, 0.0);
+    assert_close(points[0].voltage("vdd").unwrap().abs(), 0.0);
+}
+
+#[test]
+fn ac_current_source_supports_explicit_magnitude_and_phase() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::CurrentSource(CurrentSource::with_ac(
+        "I1", "0", "n1", 0.0, 1.0e-3, 90.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("R1", "n1", "0", 1_000.0)));
+
+    let points = ac_sweep(&circuit, 1_000.0, 1_000.0, 10).unwrap();
+
+    assert_eq!(points.len(), 1);
+    let n1 = points[0].voltage("n1").unwrap();
+    assert!(
+        n1.real.abs() < 1.0e-9,
+        "expected real near zero, got {n1:?}"
+    );
+    assert_close(n1.imag, 1.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.7
+
+- Add independent-source `AC <magnitude> [phase]` parsing, including combined
+  `DC <bias> AC <magnitude> [phase]` forms for AC analysis with separate DC
+  bias and small-signal excitation.
+
 ## 0.1.6
 
 - Add SPICE `M` MOSFET element parsing via `.model <name> NMOS|PMOS(...)`

--- a/code/packages/rust/spice-netlist-parser/Cargo.toml
+++ b/code/packages/rust/spice-netlist-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spice-netlist-parser"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -22,6 +22,7 @@ This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `BETA_F`, and `VT` parameters, `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
-`W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering suffixes, PWL/PULSE/SIN/EXP
-source forms, comments, `.end`, `.subckt` / `X` instance expansion, and `.op`,
-`.tran`, `.dc`, and `.ac` analysis cards.
+`W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering
+suffixes, independent-source `AC <magnitude> [phase]` forms, PWL/PULSE/SIN/EXP
+source forms, comments, `.end`, `.subckt` / `X` instance expansion, and
+`.op`, `.tran`, `.dc`, and `.ac` analysis cards.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -444,24 +444,26 @@ fn parse_element(
         }
         'V' => {
             require_min_fields(fields, 4, "voltage source")?;
-            let (voltage, waveform) = parse_source_value(&fields[3..])?;
-            let source = match waveform {
+            let (voltage, waveform, ac) = parse_source_value(&fields[3..])?;
+            let mut source = match waveform {
                 Some(waveform) => {
                     VoltageSource::with_waveform(name, &fields[1], &fields[2], voltage, waveform)
                 }
                 None => VoltageSource::new(name, &fields[1], &fields[2], voltage),
             };
+            source.ac = ac;
             Ok(Element::VoltageSource(source))
         }
         'I' => {
             require_min_fields(fields, 4, "current source")?;
-            let (current, waveform) = parse_source_value(&fields[3..])?;
-            let source = match waveform {
+            let (current, waveform, ac) = parse_source_value(&fields[3..])?;
+            let mut source = match waveform {
                 Some(waveform) => {
                     CurrentSource::with_waveform(name, &fields[1], &fields[2], current, waveform)
                 }
                 None => CurrentSource::new(name, &fields[1], &fields[2], current),
             };
+            source.ac = ac;
             Ok(Element::CurrentSource(source))
         }
         'D' => {
@@ -776,13 +778,56 @@ fn element_prefix(name: &str) -> Result<char, NetlistParseError> {
         .ok_or_else(|| NetlistParseError::new("element name is empty"))
 }
 
-fn parse_source_value(fields: &[String]) -> Result<(f64, Option<Waveform>), NetlistParseError> {
+fn parse_source_value(
+    fields: &[String],
+) -> Result<(f64, Option<Waveform>, Option<spice_engine::AcSource>), NetlistParseError> {
     if fields.is_empty() {
         return Err(NetlistParseError::new("source is missing a value"));
     }
+    let ac_index = fields
+        .iter()
+        .position(|field| field.eq_ignore_ascii_case("AC"));
+    if let Some(ac_index) = ac_index {
+        let (value_fields, ac_fields_with_marker) = fields.split_at(ac_index);
+        let ac_fields = &ac_fields_with_marker[1..];
+        if ac_fields.is_empty() {
+            return Err(NetlistParseError::new(
+                "AC source form requires a magnitude",
+            ));
+        }
+        if ac_fields.len() > 2 {
+            return Err(NetlistParseError::new(
+                "AC source form accepts magnitude and optional phase",
+            ));
+        }
+        let (value, waveform) = if value_fields.is_empty() {
+            (0.0, None)
+        } else {
+            parse_source_dc_value(value_fields)?
+        };
+        let magnitude = parse_value(&ac_fields[0])?;
+        let phase_degrees = if ac_fields.len() == 2 {
+            parse_value(&ac_fields[1])?
+        } else {
+            0.0
+        };
+        return Ok((
+            value,
+            waveform,
+            Some(spice_engine::AcSource::new(magnitude, phase_degrees)),
+        ));
+    }
+    let (value, waveform) = parse_source_dc_value(fields)?;
+    Ok((value, waveform, None))
+}
+
+fn parse_source_dc_value(fields: &[String]) -> Result<(f64, Option<Waveform>), NetlistParseError> {
     if fields[0].eq_ignore_ascii_case("DC") {
         if fields.len() < 2 {
             return Err(NetlistParseError::new("DC source form requires a value"));
+        }
+        if fields.len() > 2 {
+            return Err(NetlistParseError::new("DC source form accepts one value"));
         }
         return Ok((parse_value(&fields[1])?, None));
     }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1,4 +1,4 @@
-use spice_engine::{dc_op, BjtPolarity, Element, MosfetType};
+use spice_engine::{ac_sweep, dc_op, BjtPolarity, Element, MosfetType};
 use spice_netlist_parser::{
     parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, NetlistParseError, OpAnalysis,
     TranAnalysis,
@@ -94,6 +94,40 @@ G1 out 0 in 0 2m
             }),
         ]
     );
+}
+
+#[test]
+fn parses_source_ac_magnitude_phase_separate_from_dc_bias() {
+    let parsed = parse_netlist(
+        r#"
+Vbias in 0 DC 2.5 AC 1 90
+Iprobe out 0 AC 2m
+R1 in out 1k
+R2 out 0 1k
+.ac lin 1 1k 1k
+"#,
+    )
+    .unwrap();
+
+    let Element::VoltageSource(voltage) = &parsed.circuit.elements()[0] else {
+        panic!("expected voltage source");
+    };
+    assert_close(voltage.voltage, 2.5);
+    let voltage_ac = voltage.ac.unwrap();
+    assert_close(voltage_ac.magnitude, 1.0);
+    assert_close(voltage_ac.phase_degrees, 90.0);
+
+    let Element::CurrentSource(current) = &parsed.circuit.elements()[1] else {
+        panic!("expected current source");
+    };
+    assert_close(current.current, 0.0);
+    let current_ac = current.ac.unwrap();
+    assert_close(current_ac.magnitude, 2.0e-3);
+    assert_close(current_ac.phase_degrees, 0.0);
+
+    let points = ac_sweep(&parsed.circuit, 1_000.0, 1_000.0, 1).unwrap();
+    assert_eq!(points.len(), 1);
+    assert!(points[0].voltage("out").unwrap().imag > 0.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add explicit AC magnitude/phase phasors to Rust independent voltage/current sources
- use DC operating-point linearization for AC analysis when explicit AC source specs are present
- parse SPICE `AC <magnitude> [phase]` and `DC <bias> AC <magnitude> [phase]` source forms

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-rust-spice-ac-source-bias cargo test -p spice-engine -p spice-netlist-parser
- git diff --check