### PR TITLE
feat(board-vm): add UART byte I/O capability

### DIFF
--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -22,6 +22,13 @@ describe("coding_adventures.board_vm_native", function()
         assert.is_true(uno.connection_options[2].ota_update)
         assert.are.equal(8, uno.led_matrix.rows)
         assert.are.equal(12, uno.led_matrix.columns)
+        local capabilities = {}
+        for _, capability in ipairs(uno.capabilities) do
+            capabilities[capability] = true
+        end
+        assert.is_true(capabilities["uart.open"])
+        assert.is_true(capabilities["uart.write"])
+        assert.is_true(capabilities["uart.read"])
         assert.are.equal(uno.digital_pin_count, #uno.digital_pins)
         local d3 = nil
         for _, pin in ipairs(uno.digital_pins) do

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -136,6 +136,8 @@ def test_known_targets_are_exposed_from_rust_registry():
     assert "spi.open" in uno_r4_wifi.capabilities
     assert "spi.transfer" in uno_r4_wifi.capabilities
     assert "uart.open" in uno_r4_wifi.capabilities
+    assert "uart.write" in uno_r4_wifi.capabilities
+    assert "uart.read" in uno_r4_wifi.capabilities
     assert uno_r4_wifi.wireless_transports == ["wifi", "bluetooth_le"]
     assert uno_r4_wifi.supports_wifi is True
     assert uno_r4_wifi.supports_bluetooth is True

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -8,14 +8,14 @@ use board_vm_host::{
     GpioWriteProgram, I2cOpenProgram, I2cReadProgram, I2cReadU8Program, I2cTransferProgram,
     I2cWriteProgram, I2cWriteU8Program, LedMatrixFrameProgram, PwmWriteProgram, SpiOpenProgram,
     SpiReadProgram, SpiTransferProgram, SpiWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    UartOpenProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN,
-    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
-    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
-    I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_TRANSFER_MAX_MODULE_LEN,
-    I2C_WRITE_MAX_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
-    PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, SPI_READ_MODULE_LEN, SPI_TRANSFER_MAX_MODULE_LEN,
-    SPI_WRITE_MAX_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
-    UART_OPEN_MODULE_LEN,
+    UartOpenProgram, UartReadProgram, UartWriteProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
+    DAC_WRITE_U12_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
+    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
+    GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN,
+    I2C_TRANSFER_MAX_MODULE_LEN, I2C_WRITE_MAX_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN,
+    LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, SPI_READ_MODULE_LEN,
+    SPI_TRANSFER_MAX_MODULE_LEN, SPI_WRITE_MAX_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    TIME_SLEEP_MS_MODULE_LEN, UART_OPEN_MODULE_LEN, UART_READ_MODULE_LEN, UART_WRITE_MODULE_LEN,
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
@@ -30,7 +30,7 @@ use board_vm_language_core::{
     build_run_background_wire_frame, build_run_wire_frame, build_spi_open_module,
     build_spi_read_module, build_spi_transfer_module, build_spi_write_module, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
-    build_uart_open_module,
+    build_uart_open_module, build_uart_read_module, build_uart_write_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, connection_transport_name, decode_wire_response,
     detect_target as core_detect_target,
@@ -305,6 +305,27 @@ extern "C" fn session_uart_open_module(
 
     let module = build_uart_open_module_value(bus, max_stack)
         .unwrap_or_else(|error| raise_core_error("uart_open_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_uart_write_module(
+    _self_val: VALUE,
+    byte_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let byte = rb_u8(byte_val, "byte");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_uart_write_module_value(byte, max_stack)
+        .unwrap_or_else(|error| raise_core_error("uart_write_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_uart_read_module(_self_val: VALUE, max_stack_val: VALUE) -> VALUE {
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_uart_read_module_value(max_stack)
+        .unwrap_or_else(|error| raise_core_error("uart_read_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -1699,6 +1720,20 @@ fn build_uart_open_module_value(bus: u8, max_stack: u8) -> Result<Vec<u8>, Langu
     Ok(module)
 }
 
+fn build_uart_write_module_value(byte: u8, max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; UART_WRITE_MODULE_LEN];
+    let len = build_uart_write_module(UartWriteProgram { byte, max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_uart_read_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; UART_READ_MODULE_LEN];
+    let len = build_uart_read_module(UartReadProgram { max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_spi_transfer_module_value(
     cs_pin: u16,
     write_bytes: &[u8],
@@ -2164,6 +2199,18 @@ pub extern "C" fn Init_board_vm_native() {
         "uart_open_module",
         session_uart_open_module as *const c_void,
         2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "uart_write_module",
+        session_uart_write_module as *const c_void,
+        2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "uart_read_module",
+        session_uart_read_module as *const c_void,
+        1,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -496,6 +496,36 @@ module CodingAdventures
         )
       end
 
+      def uart_write!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        byte:,
+        max_stack: 3
+      )
+        ensure_uno_r4_wifi!
+
+        session.uart_write(
+          program_id: program_id,
+          budget: budget,
+          byte: byte,
+          max_stack: max_stack
+        )
+      end
+
+      def uart_read!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 2
+      )
+        ensure_uno_r4_wifi!
+
+        session.uart_read(
+          program_id: program_id,
+          budget: budget,
+          max_stack: max_stack
+        )
+      end
+
       def spi_transfer!(
         program_id: DEFAULT_PROGRAM_ID,
         budget: DEFAULT_INSTRUCTION_BUDGET,
@@ -1360,6 +1390,7 @@ module CodingAdventures
           max_stack: max_stack
         )
       end
+
     end
 
     class Spi
@@ -1432,6 +1463,7 @@ module CodingAdventures
           max_stack: max_stack
         )
       end
+
     end
 
     class Uart
@@ -1451,6 +1483,32 @@ module CodingAdventures
           budget: budget,
           host_nonce: host_nonce,
           bus: bus,
+          max_stack: max_stack
+        )
+      end
+
+      def write(
+        byte:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 3
+      )
+        @connection.uart_write!(
+          program_id: program_id,
+          budget: budget,
+          byte: byte,
+          max_stack: max_stack
+        )
+      end
+
+      def read(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 2
+      )
+        @connection.uart_read!(
+          program_id: program_id,
+          budget: budget,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -221,6 +221,14 @@ module CodingAdventures
         native_session.uart_open_module(bus, max_stack)
       end
 
+      def uart_write_module(byte:, max_stack: 3)
+        native_session.uart_write_module(byte_value(byte), max_stack)
+      end
+
+      def uart_read_module(max_stack: 2)
+        native_session.uart_read_module(max_stack)
+      end
+
       def spi_transfer_module(cs_pin:, write_bytes:, read_length:, max_stack: 5)
         native_session.spi_transfer_module(
           cs_pin,
@@ -368,6 +376,24 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: uart_open_module(bus: bus, max_stack: max_stack)
+        )
+      end
+
+      def upload_uart_write(
+        program_id: @program_id,
+        byte:,
+        max_stack: 3
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: uart_write_module(byte: byte, max_stack: max_stack)
+        )
+      end
+
+      def upload_uart_read(program_id: @program_id, max_stack: 2)
+        upload(
+          program_id: program_id,
+          module_bytes: uart_read_module(max_stack: max_stack)
         )
       end
 
@@ -871,6 +897,48 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def uart_write(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        byte:,
+        max_stack: 3
+      )
+        results = upload_uart_write(
+          program_id: program_id,
+          byte: byte,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
+      def uart_read(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        max_stack: 2
+      )
+        results = upload_uart_read(
+          program_id: program_id,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def spi_transfer(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -1270,6 +1338,10 @@ module CodingAdventures
           upload_spi_open(**spi_open_command_options(words, command, options, require_budget: false))
         when "upload-uart-open", "upload-uart.open"
           upload_uart_open(**uart_open_command_options(words, command, options, require_budget: false))
+        when "upload-uart-write", "upload-uart.write"
+          upload_uart_write(**uart_write_command_options(words, command, options, require_budget: false))
+        when "upload-uart-read", "upload-uart.read"
+          upload_uart_read(**uart_read_command_options(words, command, options, require_budget: false))
         when "upload-spi-transfer", "upload-spi.transfer"
           upload_spi_transfer(**spi_transfer_command_options(words, command, options, require_budget: false))
         when "upload-spi-write", "upload-spi.write"
@@ -1328,6 +1400,10 @@ module CodingAdventures
           spi_open(**spi_open_command_options(words, command, options))
         when "uart-open", "uart.open"
           uart_open(**uart_open_command_options(words, command, options))
+        when "uart-write", "uart.write"
+          uart_write(**uart_write_command_options(words, command, options))
+        when "uart-read", "uart.read"
+          uart_read(**uart_read_command_options(words, command, options))
         when "spi-transfer", "spi.transfer"
           spi_transfer(**spi_transfer_command_options(words, command, options))
         when "spi-write", "spi.write"
@@ -1592,6 +1668,31 @@ module CodingAdventures
 
       alias spi_open_command_options i2c_open_command_options
       alias uart_open_command_options i2c_open_command_options
+
+      def uart_write_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:byte] = byte_value(words.shift) unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires byte" unless merged.key?(:byte)
+
+        merged
+      end
+
+      def uart_read_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        merged
+      end
 
       def i2c_write_u8_command_options(words, command, options, require_budget: true)
         merged = options.dup

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -47,6 +47,8 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "spi.open"
         assert_includes uno_r4_wifi["capabilities"], "spi.transfer"
         assert_includes uno_r4_wifi["capabilities"], "uart.open"
+        assert_includes uno_r4_wifi["capabilities"], "uart.write"
+        assert_includes uno_r4_wifi["capabilities"], "uart.read"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
@@ -1357,6 +1359,36 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_uart_write_and_read_dispatch_native_byte_io_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        open_result = nil
+        write_result = nil
+        read_result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          open_result = board.uart.open(bus: 0, program_id: 10, budget: 24)
+          write_result = board.uart.write(byte: 0xa5, program_id: 11, budget: 24)
+          read_result = board.uart.read(program_id: 12, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 14, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal open_result.frames + write_result.frames + read_result.frames, transport.frames
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          open_result.results.map(&:command)
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          write_result.results.map(&:command)
+        assert_equal [:program_begin, :program_chunk, :program_end, :run],
+          read_result.results.map(&:command)
+      end
+
       def test_spi_transfer_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -2009,6 +2041,36 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_uart_write_and_read
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          open = board.session.run_command("uart-open 0 24", program_id: 8)
+          write = board.session.run_command("uart-write 0xa5 24", program_id: 9)
+          read = board.session.run_command("uart-read 24", program_id: 10)
+          upload_write = board.session.run_command("upload-uart.write 0xa5", program_id: 11)
+          upload_read = board.session.run_command("upload-uart.read", program_id: 12)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            open.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            write.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            read.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload_write.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload_read.results.map(&:command)
+          assert_equal open.frames + write.frames + read.frames + upload_write.frames + upload_read.frames,
+            transport.frames
+        end
+      end
+
       def test_session_run_command_accepts_repl_style_spi_transfer
         transport = FakeWriteTransport.new
 
@@ -2322,6 +2384,14 @@ module CodingAdventures
         uart_module_bytes = session.uart_open_module(0, 2)
         assert_instance_of String, uart_module_bytes
         assert_operator uart_module_bytes.bytesize, :>, 0
+
+        uart_write_module_bytes = session.uart_write_module(0xa5, 3)
+        assert_instance_of String, uart_write_module_bytes
+        assert_operator uart_write_module_bytes.bytesize, :>, 0
+
+        uart_read_module_bytes = session.uart_read_module(2)
+        assert_instance_of String, uart_read_module_bytes
+        assert_operator uart_read_module_bytes.bytesize, :>, 0
 
         spi_transfer_module_bytes = session.spi_transfer_module(10, "\x9F".b, 3, 5)
         assert_instance_of String, spi_transfer_module_bytes

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -4,7 +4,8 @@ use board_vm_ir::{
     parse_module, validate, CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN,
     CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER,
     CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_SPI_OPEN,
-    CAP_SPI_TRANSFER, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, CAP_UART_OPEN,
+    CAP_SPI_TRANSFER, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, CAP_UART_OPEN, CAP_UART_READ,
+    CAP_UART_WRITE,
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -141,6 +142,18 @@ const UART_OPEN_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "uart.open",
+};
+const UART_WRITE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_UART_WRITE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "uart.write",
+};
+const UART_READ_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_UART_READ,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "uart.read",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -677,7 +690,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_AND_SPI_CAPABILITIES: [CapabilityDescri
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_AND_UART_CAPABILITIES: [CapabilityDescriptor<
     'static,
->; 19] = [
+>; 21] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -696,6 +709,8 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_AND_UART_CAPABILITIES: [CapabilityD
     SPI_OPEN_DESCRIPTOR,
     SPI_TRANSFER_DESCRIPTOR,
     UART_OPEN_DESCRIPTOR,
+    UART_WRITE_DESCRIPTOR,
+    UART_READ_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];
 
@@ -799,7 +814,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_AND_LED_MATRIX_CAPABILITIES: [Capab
 ];
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_AND_LED_MATRIX_CAPABILITIES:
-    [CapabilityDescriptor<'static>; 20] = [
+    [CapabilityDescriptor<'static>; 22] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -818,6 +833,8 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_AND_LED_MATRIX_CAPABILITIES:
     SPI_OPEN_DESCRIPTOR,
     SPI_TRANSFER_DESCRIPTOR,
     UART_OPEN_DESCRIPTOR,
+    UART_WRITE_DESCRIPTOR,
+    UART_READ_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
 ];

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -3,7 +3,7 @@ use board_vm_ir::{
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
     CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
     CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_SPI_OPEN, CAP_SPI_TRANSFER, CAP_TIME_NOW_MS,
-    CAP_TIME_SLEEP_MS, CAP_UART_OPEN, FLAG_PROGRAM_MAY_RUN_FOREVER,
+    CAP_TIME_SLEEP_MS, CAP_UART_OPEN, CAP_UART_READ, CAP_UART_WRITE, FLAG_PROGRAM_MAY_RUN_FOREVER,
     FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MAX_BYTE_BUFFER_LEN, MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
@@ -64,6 +64,10 @@ pub const SPI_WRITE_MAX_MODULE_LEN: usize = SPI_TRANSFER_MAX_MODULE_LEN;
 pub const SPI_READ_MODULE_LEN: usize = 8 + 1 + SPI_TRANSFER_CODE_LEN + 1;
 pub const UART_OPEN_CODE_LEN: usize = 6;
 pub const UART_OPEN_MODULE_LEN: usize = 16;
+pub const UART_WRITE_CODE_LEN: usize = 5;
+pub const UART_WRITE_MODULE_LEN: usize = 15;
+pub const UART_READ_CODE_LEN: usize = 4;
+pub const UART_READ_MODULE_LEN: usize = 14;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -219,6 +223,17 @@ pub struct UartOpenProgram {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UartWriteProgram {
+    pub byte: u8,
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UartReadProgram {
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct I2cWriteU8Program {
     pub address: u16,
     pub byte: u8,
@@ -290,6 +305,24 @@ impl SpiOpenProgram {
 impl UartOpenProgram {
     pub const fn new(bus: u8) -> Self {
         Self { bus, max_stack: 2 }
+    }
+}
+
+impl UartWriteProgram {
+    pub const fn new(byte: u8) -> Self {
+        Self { byte, max_stack: 3 }
+    }
+}
+
+impl UartReadProgram {
+    pub const fn new() -> Self {
+        Self { max_stack: 2 }
+    }
+}
+
+impl Default for UartReadProgram {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1435,6 +1468,88 @@ pub fn write_uart_open_module(
     Ok(offset)
 }
 
+pub fn write_uart_write_code(
+    program: UartWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < UART_WRITE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.byte)?;
+    write_call_u8(out, &mut offset, CAP_UART_WRITE)?;
+    Ok(offset)
+}
+
+pub fn write_uart_write_module(
+    program: UartWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < UART_WRITE_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; UART_WRITE_CODE_LEN];
+    let code_len = write_uart_write_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_uart(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
+pub fn write_uart_read_code(_program: UartReadProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if out.len() < UART_READ_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_call_u8(out, &mut offset, CAP_UART_READ)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_uart_read_module(
+    program: UartReadProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < UART_READ_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; UART_READ_CODE_LEN];
+    let code_len = write_uart_read_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_uart(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn spi_transfer_module_len(write_len: usize) -> Result<usize, HostError> {
     if write_len > MAX_BYTE_BUFFER_LEN {
         return Err(HostError::ProgramTooLarge);
@@ -1968,7 +2083,7 @@ mod tests {
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
         CAP_ADC_READ, CAP_DAC_WRITE_U12, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8,
         CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE,
-        CAP_SPI_OPEN,
+        CAP_SPI_OPEN, CAP_UART_READ, CAP_UART_WRITE,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -2030,6 +2145,12 @@ mod tests {
     const UART_OPEN_BUS0_MODULE_HEX: [u8; UART_OPEN_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x02, 0x00, 0x06, 0x12, 0x00, 0x40, 0x2B, 0x20, 0x50,
         0x00,
+    ];
+    const UART_WRITE_A5_MODULE_HEX: [u8; UART_WRITE_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x03, 0x00, 0x05, 0x20, 0x12, 0xA5, 0x40, 0x2C, 0x00,
+    ];
+    const UART_READ_MODULE_HEX: [u8; UART_READ_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x02, 0x00, 0x04, 0x20, 0x40, 0x2D, 0x50, 0x00,
     ];
     const SPI_TRANSFER_CS10_9F_READ_03_MODULE_HEX: [u8; 24] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x05, 0x00, 0x0D, 0x20, 0x13, 0x0A, 0x00, 0x16, 0x00,
@@ -2284,6 +2405,29 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_UART_OPEN]);
+    }
+
+    #[test]
+    fn builds_uart_byte_io_modules() {
+        let mut write = [0u8; UART_WRITE_MODULE_LEN];
+        let write_len = write_uart_write_module(UartWriteProgram::new(0xa5), &mut write).unwrap();
+        assert_eq!(write_len, UART_WRITE_MODULE_LEN);
+        assert_eq!(write, UART_WRITE_A5_MODULE_HEX);
+        let parsed = parse_module(&write).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_uart(), 3).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_UART_WRITE]);
+
+        let mut read = [0u8; UART_READ_MODULE_LEN];
+        let read_len = write_uart_read_module(UartReadProgram::new(), &mut read).unwrap();
+        assert_eq!(read_len, UART_READ_MODULE_LEN);
+        assert_eq!(read, UART_READ_MODULE_HEX);
+        let parsed = parse_module(&read).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_uart(), 2).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_UART_READ]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -29,6 +29,8 @@ pub const CAP_I2C_TRANSFER: u16 = 0x28;
 pub const CAP_SPI_OPEN: u16 = 0x29;
 pub const CAP_SPI_TRANSFER: u16 = 0x2A;
 pub const CAP_UART_OPEN: u16 = 0x2B;
+pub const CAP_UART_WRITE: u16 = 0x2C;
+pub const CAP_UART_READ: u16 = 0x2D;
 pub const CAP_LED_MATRIX_FRAME: u16 = 0x30;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
@@ -49,6 +51,8 @@ const CAP_I2C_TRANSFER_U8: u8 = CAP_I2C_TRANSFER as u8;
 const CAP_SPI_OPEN_U8: u8 = CAP_SPI_OPEN as u8;
 const CAP_SPI_TRANSFER_U8: u8 = CAP_SPI_TRANSFER as u8;
 const CAP_UART_OPEN_U8: u8 = CAP_UART_OPEN as u8;
+const CAP_UART_WRITE_U8: u8 = CAP_UART_WRITE as u8;
+const CAP_UART_READ_U8: u8 = CAP_UART_READ as u8;
 const CAP_LED_MATRIX_FRAME_U8: u8 = CAP_LED_MATRIX_FRAME as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -203,7 +207,7 @@ impl CapabilitySet {
             CAP_I2C_OPEN | CAP_I2C_WRITE_U8 | CAP_I2C_READ_U8 | CAP_I2C_WRITE | CAP_I2C_READ
             | CAP_I2C_TRANSFER => self.i2c,
             CAP_SPI_OPEN | CAP_SPI_TRANSFER => self.spi,
-            CAP_UART_OPEN => self.uart,
+            CAP_UART_OPEN | CAP_UART_WRITE | CAP_UART_READ => self.uart,
             CAP_LED_MATRIX_FRAME => self.led_matrix,
             _ => false,
         }
@@ -478,6 +482,8 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_SPI_OPEN_U8) | Op::CallU16(CAP_SPI_OPEN) => (1, 1),
         Op::CallU8(CAP_SPI_TRANSFER_U8) | Op::CallU16(CAP_SPI_TRANSFER) => (4, 1),
         Op::CallU8(CAP_UART_OPEN_U8) | Op::CallU16(CAP_UART_OPEN) => (1, 1),
+        Op::CallU8(CAP_UART_WRITE_U8) | Op::CallU16(CAP_UART_WRITE) => (2, 0),
+        Op::CallU8(CAP_UART_READ_U8) | Op::CallU16(CAP_UART_READ) => (1, 1),
         Op::CallU8(CAP_LED_MATRIX_FRAME_U8) | Op::CallU16(CAP_LED_MATRIX_FRAME) => (3, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
@@ -849,6 +855,36 @@ mod tests {
     }
 
     #[test]
+    fn validates_uart_write_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 3,
+            code: &[0x20, 0x12, 0xa5, 0x40, CAP_UART_WRITE as u8],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_uart(), 3).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_UART_WRITE]);
+    }
+
+    #[test]
+    fn validates_uart_read_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 2,
+            code: &[0x20, 0x40, CAP_UART_READ as u8, 0x50],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp().with_uart(), 2).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&module, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_UART_READ]);
+    }
+
+    #[test]
     fn validates_spi_transfer_capability() {
         let module = Module {
             flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
@@ -964,6 +1000,36 @@ mod tests {
         assert_eq!(
             validate(&module, CapabilitySet::blink_mvp(), 2),
             Err(ValidateError::UnsupportedCapability(CAP_UART_OPEN))
+        );
+    }
+
+    #[test]
+    fn rejects_uart_write_without_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 3,
+            code: &[0x20, 0x12, 0xa5, 0x40, CAP_UART_WRITE as u8],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 3),
+            Err(ValidateError::UnsupportedCapability(CAP_UART_WRITE))
+        );
+    }
+
+    #[test]
+    fn rejects_uart_read_without_capability() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 2,
+            code: &[0x20, 0x40, CAP_UART_READ as u8, 0x50],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 2),
+            Err(ValidateError::UnsupportedCapability(CAP_UART_READ))
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -43,19 +43,21 @@ use board_vm_host::{
     write_i2c_write_module, write_i2c_write_u8_module, write_led_matrix_frame_module, write_module,
     write_pwm_write_module, write_spi_open_module, write_spi_read_module,
     write_spi_transfer_module, write_spi_write_module, write_time_now_module,
-    write_time_sleep_ms_module, write_uart_open_module, AdcReadProgram, BlinkProgram,
-    DacWriteU12Program, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
-    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram,
-    I2cReadProgram, I2cReadU8Program, I2cTransferProgram, I2cWriteProgram, I2cWriteU8Program,
+    write_time_sleep_ms_module, write_uart_open_module, write_uart_read_module,
+    write_uart_write_module, AdcReadProgram, BlinkProgram, DacWriteU12Program,
+    GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram, GpioOpenProgram,
+    GpioReadProgram, GpioWriteProgram, HostError, HostSession, I2cOpenProgram, I2cReadProgram,
+    I2cReadU8Program, I2cTransferProgram, I2cWriteProgram, I2cWriteU8Program,
     LedMatrixFrameProgram, ModuleSpec, PwmWriteProgram, SpiOpenProgram, SpiReadProgram,
     SpiTransferProgram, SpiWriteProgram, TimeNowProgram, TimeSleepMsProgram, UartOpenProgram,
-    ADC_READ_MODULE_LEN, BLINK_MODULE_LEN, DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
-    DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN,
-    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
-    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN, I2C_READ_MODULE_LEN,
-    I2C_READ_U8_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN, LED_MATRIX_FRAME_MODULE_LEN,
-    PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, SPI_READ_MODULE_LEN, TIME_NOW_MODULE_LEN,
-    TIME_SLEEP_MS_MODULE_LEN, UART_OPEN_MODULE_LEN,
+    UartReadProgram, UartWriteProgram, ADC_READ_MODULE_LEN, BLINK_MODULE_LEN,
+    DAC_WRITE_U12_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
+    GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN,
+    GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, I2C_OPEN_MODULE_LEN,
+    I2C_READ_MODULE_LEN, I2C_READ_U8_MODULE_LEN, I2C_WRITE_U8_MODULE_LEN,
+    LED_MATRIX_FRAME_MODULE_LEN, PWM_WRITE_MODULE_LEN, SPI_OPEN_MODULE_LEN, SPI_READ_MODULE_LEN,
+    TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN, UART_OPEN_MODULE_LEN, UART_READ_MODULE_LEN,
+    UART_WRITE_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -1708,6 +1710,20 @@ pub fn build_uart_open_module(
     Ok(write_uart_open_module(program, out)?)
 }
 
+pub fn build_uart_write_module(
+    program: UartWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_uart_write_module(program, out)?)
+}
+
+pub fn build_uart_read_module(
+    program: UartReadProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_uart_read_module(program, out)?)
+}
+
 pub fn build_spi_transfer_module(
     program: SpiTransferProgram<'_>,
     out: &mut [u8],
@@ -2522,6 +2538,39 @@ pub unsafe extern "C" fn board_vm_language_uart_open_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_uart_write_module(
+    byte: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_uart_write_module(UartWriteProgram { byte, max_stack }, module_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn board_vm_language_uart_read_module(
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_uart_read_module(UartReadProgram { max_stack }, module_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_spi_transfer_module(
     cs_pin: u16,
     write_bytes: *const u8,
@@ -3061,6 +3110,16 @@ pub extern "C" fn board_vm_language_uart_open_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_uart_write_module_len() -> u64 {
+    UART_WRITE_MODULE_LEN as u64
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_uart_read_module_len() -> u64 {
+    UART_READ_MODULE_LEN as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_spi_transfer_module_len(write_len: u64) -> u64 {
     let Ok(write_len) = usize::try_from(write_len) else {
         return 0;
@@ -3377,6 +3436,8 @@ mod tests {
         assert!(uno.capabilities.contains(&"spi.open".to_owned()));
         assert!(uno.capabilities.contains(&"spi.transfer".to_owned()));
         assert!(uno.capabilities.contains(&"uart.open".to_owned()));
+        assert!(uno.capabilities.contains(&"uart.write".to_owned()));
+        assert!(uno.capabilities.contains(&"uart.read".to_owned()));
         assert_eq!(
             known_target("arduino-uno-r4-minima").unwrap().led_matrix,
             None
@@ -4217,6 +4278,35 @@ mod tests {
         };
         assert_eq!(uart_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(uart_status.len, UART_OPEN_MODULE_LEN as u64);
+
+        let mut uart_write_module = [0u8; UART_WRITE_MODULE_LEN];
+        let uart_write_status = unsafe {
+            board_vm_language_uart_write_module(
+                0xa5,
+                3,
+                uart_write_module.as_mut_ptr(),
+                uart_write_module.len() as u64,
+            )
+        };
+        assert_eq!(uart_write_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(
+            uart_write_status.len,
+            board_vm_language_uart_write_module_len()
+        );
+
+        let mut uart_read_module = [0u8; UART_READ_MODULE_LEN];
+        let uart_read_status = unsafe {
+            board_vm_language_uart_read_module(
+                2,
+                uart_read_module.as_mut_ptr(),
+                uart_read_module.len() as u64,
+            )
+        };
+        assert_eq!(uart_read_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(
+            uart_read_status.len,
+            board_vm_language_uart_read_module_len()
+        );
 
         let spi_transfer_payload = [0x9f];
         let mut spi_transfer_module = [0u8; board_vm_host::SPI_TRANSFER_MAX_MODULE_LEN];

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -5,7 +5,7 @@ use board_vm_ir::{
     CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ,
     CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME,
     CAP_PWM_WRITE, CAP_SPI_OPEN, CAP_SPI_TRANSFER, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
-    CAP_UART_OPEN, MAX_BYTE_BUFFER_LEN,
+    CAP_UART_OPEN, CAP_UART_READ, CAP_UART_WRITE, MAX_BYTE_BUFFER_LEN,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -170,6 +170,14 @@ pub trait BoardHal {
     }
 
     fn uart_open(&mut self, _bus: u16) -> Result<u32, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn uart_write(&mut self, _token: u32, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn uart_read(&mut self, _token: u32) -> Result<u8, HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -706,6 +714,26 @@ where
                 let handle = self.alloc_handle(HandleKind::Uart, token, ip)?;
                 self.push(Value::Handle(handle), ip)
             }
+            CAP_UART_WRITE => {
+                let byte = self.pop_u8(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::Uart, ip)?;
+                self.hal
+                    .uart_write(token, byte)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })
+            }
+            CAP_UART_READ => {
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::Uart, ip)?;
+                let byte = self.hal.uart_read(token).map_err(|err| RuntimeError {
+                    ip,
+                    kind: hal_error_kind(err),
+                })?;
+                self.push(Value::U8(byte), ip)
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -968,6 +996,8 @@ mod tests {
         SpiOpen(u16),
         SpiTransfer(u32, u16, ByteBuffer, u8),
         UartOpen(u16),
+        UartWrite(u32, u8),
+        UartRead(u32),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -1116,6 +1146,16 @@ mod tests {
         fn uart_open(&mut self, bus: u16) -> Result<u32, HalError> {
             self.events.push(Event::UartOpen(bus));
             Ok(0x3_2000 | bus as u32)
+        }
+
+        fn uart_write(&mut self, token: u32, byte: u8) -> Result<(), HalError> {
+            self.events.push(Event::UartWrite(token, byte));
+            Ok(())
+        }
+
+        fn uart_read(&mut self, token: u32) -> Result<u8, HalError> {
+            self.events.push(Event::UartRead(token));
+            Ok(0x5a)
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -1339,6 +1379,41 @@ mod tests {
         );
         assert_eq!(report.open_handles, 1);
         assert_eq!(runtime.hal().events, vec![Event::UartOpen(0)]);
+    }
+
+    #[test]
+    fn uart_write_dispatches_handle_and_byte() {
+        let mut runtime: Runtime<FakeHal, 4, 2> = Runtime::new(FakeHal::new());
+        let open = [0x12, 2, 0x40, CAP_UART_OPEN as u8, 0x20, 0x50];
+        let write = [0x20, 0x12, 0xa5, 0x40, CAP_UART_WRITE as u8];
+
+        runtime.run_code(&open, 10).unwrap();
+        let report = runtime.run_code(&write, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            runtime.hal().events,
+            vec![Event::UartOpen(2), Event::UartWrite(0x3_2002, 0xa5)]
+        );
+    }
+
+    #[test]
+    fn uart_read_dispatches_handle_and_returns_byte() {
+        let mut runtime: Runtime<FakeHal, 4, 2> = Runtime::new(FakeHal::new());
+        let open = [0x12, 2, 0x40, CAP_UART_OPEN as u8, 0x20, 0x50];
+        let read = [0x20, 0x40, CAP_UART_READ as u8, 0x50];
+
+        runtime.run_code(&open, 10).unwrap();
+        let report = runtime.run_code(&read, 10).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.return_value, Value::U8(0x5a));
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            runtime.hal().events,
+            vec![Event::UartOpen(2), Event::UartRead(0x3_2002)]
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -136,7 +136,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 20] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 22] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -156,10 +156,12 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 20] = [
     "spi.open",
     "spi.transfer",
     "uart.open",
+    "uart.write",
+    "uart.read",
     "program.ram_exec",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 24] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 26] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -182,6 +184,8 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 24] = [
     "spi.open",
     "spi.transfer",
     "uart.open",
+    "uart.write",
+    "uart.read",
     "led_matrix.frame",
     "program.ram_exec",
 ];
@@ -771,6 +775,8 @@ mod tests {
         assert!(uno.capabilities.contains(&"spi.open"));
         assert!(uno.capabilities.contains(&"spi.transfer"));
         assert!(uno.capabilities.contains(&"uart.open"));
+        assert!(uno.capabilities.contains(&"uart.write"));
+        assert!(uno.capabilities.contains(&"uart.read"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -1,5 +1,7 @@
 use arduino_uno_r4_hal::Delay;
 use board_vm_runtime::{ByteBuffer, GpioMode, HalError, Level};
+#[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
+use board_vm_uart::BlockingUart;
 use board_vm_uno_r4::UnoR4Backend;
 use embedded_hal::delay::DelayNs;
 
@@ -99,6 +101,7 @@ impl UnoR4Backend for UnoR4WifiLedBackend {
 #[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
 pub struct UnoR4WifiPwmBackend {
     inner: UnoR4WifiLedBackend,
+    uart: Option<board_vm_uno_r4_uart::UnoR4WifiSerialUart>,
 }
 
 #[cfg(all(target_arch = "arm", board_vm_uno_r4_arduino_usb_link))]
@@ -106,6 +109,7 @@ impl UnoR4WifiPwmBackend {
     pub fn new() -> Self {
         Self {
             inner: UnoR4WifiLedBackend::new(),
+            uart: None,
         }
     }
 
@@ -123,6 +127,22 @@ impl UnoR4WifiPwmBackend {
 
     pub fn refresh_led_matrix_once(&mut self) {
         self.inner.refresh_led_matrix_once();
+    }
+
+    fn uart(
+        &mut self,
+        bus: u8,
+    ) -> Result<&mut board_vm_uno_r4_uart::UnoR4WifiSerialUart, HalError> {
+        if bus != 0 {
+            return Err(HalError::UnsupportedMode);
+        }
+        if self.uart.is_none() {
+            self.uart = Some(
+                board_vm_uno_r4_uart::UnoR4WifiSerialUart::new()
+                    .map_err(|_| HalError::UnsupportedMode)?,
+            );
+        }
+        self.uart.as_mut().ok_or(HalError::BoardFault)
     }
 }
 
@@ -221,7 +241,20 @@ impl UnoR4Backend for UnoR4WifiPwmBackend {
     }
 
     fn open_uart(&mut self, bus: u8) -> Result<u32, HalError> {
+        self.uart(bus)?;
         Ok(0x14_0000 | bus as u32)
+    }
+
+    fn write_uart(&mut self, bus: u8, byte: u8) -> Result<(), HalError> {
+        let uart = self.uart(bus)?;
+        uart.write_byte(byte).map_err(|_| HalError::BoardFault)?;
+        uart.flush().map_err(|_| HalError::BoardFault)
+    }
+
+    fn read_uart(&mut self, bus: u8) -> Result<u8, HalError> {
+        self.uart(bus)?
+            .read_byte()
+            .map_err(|_| HalError::BoardFault)
     }
 
     fn transfer_spi(

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -495,6 +495,14 @@ pub trait UnoR4Backend {
         Err(HalError::UnsupportedMode)
     }
 
+    fn write_uart(&mut self, _bus: u8, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn read_uart(&mut self, _bus: u8) -> Result<u8, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn transfer_spi(
         &mut self,
         _bus: u8,
@@ -664,6 +672,16 @@ where
         self.backend.open_uart(bus)
     }
 
+    fn uart_write(&mut self, token: u32, byte: u8) -> Result<(), HalError> {
+        let bus = normalize_uart_token(self.target, token)?;
+        self.backend.write_uart(bus, byte)
+    }
+
+    fn uart_read(&mut self, token: u32) -> Result<u8, HalError> {
+        let bus = normalize_uart_token(self.target, token)?;
+        self.backend.read_uart(bus)
+    }
+
     fn spi_transfer(
         &mut self,
         token: u32,
@@ -814,6 +832,11 @@ fn normalize_uart_bus(target: &TargetDescriptor, bus: u16) -> Result<u8, HalErro
     } else {
         Err(HalError::InvalidPin)
     }
+}
+
+fn normalize_uart_token(target: &TargetDescriptor, token: u32) -> Result<u8, HalError> {
+    let bus = u16::try_from(token & 0xff).map_err(|_| HalError::InvalidPin)?;
+    normalize_uart_bus(target, bus)
 }
 
 fn normalize_i2c_address(address: u16) -> Result<(), HalError> {
@@ -983,6 +1006,8 @@ mod tests {
         SpiOpen(u8),
         SpiTransfer(u8, u8, Vec<u8>, u8),
         UartOpen(u8),
+        UartWrite(u8, u8),
+        UartRead(u8),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -1082,6 +1107,16 @@ mod tests {
         fn open_uart(&mut self, bus: u8) -> Result<u32, HalError> {
             self.events.push(Event::UartOpen(bus));
             Ok(0x3_2000 | bus as u32)
+        }
+
+        fn write_uart(&mut self, bus: u8, byte: u8) -> Result<(), HalError> {
+            self.events.push(Event::UartWrite(bus, byte));
+            Ok(())
+        }
+
+        fn read_uart(&mut self, bus: u8) -> Result<u8, HalError> {
+            self.events.push(Event::UartRead(bus));
+            Ok(0x5a)
         }
 
         fn transfer_spi(
@@ -1290,6 +1325,12 @@ mod tests {
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_UART_OPEN));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_UART_WRITE));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_UART_READ));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -1326,6 +1367,12 @@ mod tests {
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_UART_OPEN));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_UART_WRITE));
+        assert!(UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_UART_READ));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_LED_MATRIX_FRAME));
@@ -1452,6 +1499,39 @@ mod tests {
 
         assert_eq!(board.uart_open(1), Err(HalError::InvalidPin));
         assert_eq!(board.uart_open(99), Err(HalError::InvalidPin));
+    }
+
+    #[test]
+    fn uart_write_runs_through_bus_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        board.uart_write(0x3_2002, 0xa5).unwrap();
+
+        assert_eq!(board.backend().events, vec![Event::UartWrite(2, 0xa5)]);
+    }
+
+    #[test]
+    fn uart_write_rejects_unknown_bus() {
+        let mut board = UnoR4Board::minima(FakeBackend::new());
+
+        assert_eq!(board.uart_write(0x3_2001, 0xa5), Err(HalError::InvalidPin));
+        assert_eq!(board.uart_write(0x3_2099, 0xa5), Err(HalError::InvalidPin));
+    }
+
+    #[test]
+    fn uart_read_runs_through_bus_metadata() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(board.uart_read(0x3_2002).unwrap(), 0x5a);
+        assert_eq!(board.backend().events, vec![Event::UartRead(2)]);
+    }
+
+    #[test]
+    fn uart_read_rejects_unknown_bus() {
+        let mut board = UnoR4Board::minima(FakeBackend::new());
+
+        assert_eq!(board.uart_read(0x3_2001), Err(HalError::InvalidPin));
+        assert_eq!(board.uart_read(0x3_2099), Err(HalError::InvalidPin));
     }
 
     #[test]

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -215,6 +215,8 @@ metadata. The operation is intentionally direct and stateless, mirroring
 | `0x29` | `spi.open` | `bus: u16/u8` | `handle` |
 | `0x2A` | `spi.transfer` | `handle`, `cs_pin: u16/u8`, `write_bytes: bytes`, `read_length: u8` | `bytes` |
 | `0x2B` | `uart.open` | `bus: u16/u8` | `handle` |
+| `0x2C` | `uart.write` | `handle`, `byte: u8` | `unit` |
+| `0x2D` | `uart.read` | `handle` | `u8` |
 
 `i2c.open` opens a board-advertised I2C controller and returns a persistent bus
 handle. The handle is the lifetime anchor for transfer operations, keeping bus
@@ -249,7 +251,11 @@ claiming separate bytecode capability ids.
 `uart.open` opens a board-advertised hardware UART and returns a persistent bus
 handle. The bus id is resolved from Rust-owned board descriptors, keeping UNO R4
 `Serial1`/`Serial2`/`Serial3` pin layout knowledge out of language frontends.
-Byte write/read operations are separate follow-on VM calls.
+`uart.write` writes a single byte through that handle and preserves the handle
+for subsequent calls. `uart.read` blocks for one byte on the same handle,
+returns it as `u8`, and also preserves the handle. Host SDKs may layer stream or
+buffer conveniences over these byte operations, but board discovery, descriptor
+metadata, and handle-token validation remain Rust-owned.
 
 ### LED Matrix
 

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -31,7 +31,7 @@ Source snapshot:
 | DAC output | A0, one 12-bit DAC channel | implemented as direct write | `dac.write_u12` |
 | I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, byte-buffer write/read, and write-read transfer implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, `i2c.read`, `i2c.transfer` |
 | SPI master | COPI D11, CIPO D12, SCK D13, conventional CS D10 | bus metadata, handle open, bounded write-then-read transfer, and transfer-backed read/write SDK commands implemented | `spi.open`, `spi.transfer`; SDK `spi.write`/`spi.read` lower to transfer |
-| Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | descriptor metadata and handle open implemented; VM byte write/read pending | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
+| Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | descriptor metadata, handle open, and single-byte write/read implemented | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
 | RTC | one RTC instance in the core | pending | `rtc.now`, `rtc.set`, alarms/events later |
 | EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | pending | `program.store` and possibly `kv.store` |
@@ -79,8 +79,10 @@ reject conflicting handles.
 5. Add UART, CAN, RTC, watchdog, EEPROM/store, and WiFi/network
    capabilities in separate tranches with conformance tests. UART now has
    descriptor metadata for Minima `Serial1` and WiFi `Serial1`/`Serial2`/
-   `Serial3`, and `uart.open` now establishes the first UART handle tranche, so
-   the next UART tranche can focus on byte write/read.
+   `Serial3`, while `uart.open`, `uart.write`, and `uart.read` establish the
+   first UART handle and byte I/O tranche. The next independent tranche can move
+   on to CAN, RTC, watchdog, EEPROM/store, or WiFi/network metadata and
+   capability slices.
 
 Every tranche should include the same layers: spec entry, IR capability id,
 runtime HAL method, UNO R4 target descriptor, firmware backend, host builder,


### PR DESCRIPTION
## Summary

Adds the UART byte write/read capability slice on top of the Rust-owned UART handle path introduced by PR #3266. The slice adds `uart.write` and `uart.read` capability IDs, host bytecode builders, runtime HAL dispatch, UNO R4 target/device metadata, UNO R4 backend validation, firmware SerialUSB byte I/O wiring, Rust language-core ABI builders, and thin Ruby/Python/Lua frontend coverage.

The firmware-linked UNO R4 WiFi path currently backs bus 0 through the existing SCI9 D22/D23 direct UART backend while board descriptors still advertise the Rust-owned UNO R4 UART metadata.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-uart-byte-io-capability cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-uart-byte-io-capability cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-uart-byte-io-capability cargo test -p board-vm-uno-r4-firmware`
- `bundle exec ruby -c lib/coding_adventures/board_vm/session.rb`
- `bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb`
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-uart-byte-io-capability RUSTC="$(rustup which --toolchain stable rustc)" cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" --arm-toolchain-bin /opt/homebrew/bin --bossac-path /tmp/arduino-bossa/bin`