### PR TITLE
feat(twig): LANG59 TW05-F self-hosted IIR emitter

### DIFF
--- a/code/packages/rust/twig-module-driver/CHANGELOG.md
+++ b/code/packages/rust/twig-module-driver/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — twig-module-driver
 
+## [0.4.0] — 2026-05-15
+
+### Added (LANG59 — TW05-F self-hosted IIR emitter integration tests)
+
+New `#[cfg(test)] mod tw05f_tests` with 6 tests exercising `compiler/emit.tw`
+(the self-hosted IIR emitter) through the full module driver pipeline.
+`copy_all_tw_modules` updated to include `"emit"`.
+
+| Test | Verifies |
+|------|----------|
+| `emit_intlit_one_instruction` | emit `(IntLit 42 sp)` → 1 instruction |
+| `emit_call_plus_1_2` | emit `(CallExpr (VarRef "+") [IntLit 1, IntLit 2])` → 3 instructions |
+| `emit_if_expr_count` | emit `(IfExpr (BoolLit #t) (IntLit 1) (IntLit 2))` → 9 instructions |
+| `emit_let_binding_count` | emit `(LetExpr [("x", IntLit 1)] (VarRef "x"))` → 1 instruction |
+| `emit_begin_sequence_count` | emit `(BeginExpr [IntLit 1, IntLit 2, IntLit 3])` → 3 instructions |
+| `full_lex_parse_emit_roundtrip` | All 9 modules + main.tw → `(main) = 42` |
+
+`full_lex_parse_roundtrip` (tw05e_tests) updated: comment clarified to reflect
+that main.tw now runs the full lex → parse → emit pipeline (still returns 42).
+
 ## [0.3.0] — 2026-05-15
 
 ### Added (LANG58 — TW05-E self-hosted lexer + parser integration tests)

--- a/code/packages/rust/twig-module-driver/Cargo.toml
+++ b/code/packages/rust/twig-module-driver/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name        = "twig-module-driver"
-version     = "0.3.0"
+version     = "0.4.0"
 edition     = "2021"
-description = "LANG56-LANG58 — multi-file module resolver for Twig.  Resolves (import …) declarations recursively, compiles and links all modules into a single IIRModule ready for twig-vm.  LANG57 adds TW05-D data-model tests; LANG58 adds TW05-E lexer+parser integration tests."
+description = "LANG56-LANG59 — multi-file module resolver for Twig.  Resolves (import …) declarations recursively, compiles and links all modules into a single IIRModule ready for twig-vm.  LANG57 adds TW05-D data-model tests; LANG58 adds TW05-E lexer+parser tests; LANG59 adds TW05-F IIR emitter tests."
 
 [dependencies]
 twig-parser       = { path = "../twig-parser" }

--- a/code/packages/rust/twig-module-driver/src/lib.rs
+++ b/code/packages/rust/twig-module-driver/src/lib.rs
@@ -1335,7 +1335,16 @@ mod tw05f_tests {
     }
 
     fn tempdir(tag: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("twig_tw05f_test_{tag}"));
+        // Use process ID + subsecond nanos to avoid predictable temp paths
+        // that could be pre-created as symlinks on shared CI machines.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+        let d = std::env::temp_dir()
+            .join(format!("twig_tw05f_test_{tag}_{}_{}",
+                          std::process::id(), nonce));
         fs::create_dir_all(&d).unwrap();
         d
     }

--- a/code/packages/rust/twig-module-driver/src/lib.rs
+++ b/code/packages/rust/twig-module-driver/src/lib.rs
@@ -1046,16 +1046,18 @@ mod tw05d_tests {
 
     #[test]
     fn full_module_tree_smoke_test() {
-        // Compile all 9 .tw files (the actual source files from code/twig/compiler/,
-        // including the TW05-E lexer and parser added in LANG58) and run (main).
+        // Compile all 10 .tw files (the actual source files from code/twig/compiler/,
+        // including the TW05-E lexer and parser (LANG58) and TW05-F emitter (LANG59))
+        // and run (main).
         //
-        // main.tw was updated in LANG58 to import compiler/lexer and compiler/parser
-        // and return 42 (the integer value of "42" round-tripped through lex+parse).
+        // main.tw was updated in LANG59 to import compiler/emit and run the full
+        // lex → parse → emit pipeline, returning 42 (the integer constant extracted
+        // from the emitted IirInstr).
         let src = twig_compiler_src();
         let dir = tempdir("full_tree");
 
         for name in &["span", "token", "diagnostic", "ast", "iir-types",
-                      "iir-builder", "lexer", "parser", "main"] {
+                      "iir-builder", "lexer", "parser", "emit", "main"] {
             copy_tw(&src, &dir, name);
         }
 
@@ -1063,7 +1065,7 @@ mod tw05d_tests {
         let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
             .expect("full compiler data-model tree should compile and run");
         assert_eq!(v.as_int(), Some(42),
-            "(main) should return 42 — lex+parse roundtrip of \"42\" (LANG58 TW05-E)");
+            "(main) should return 42 — lex+parse+emit roundtrip of \"42\" (LANG59 TW05-F)");
     }
 }
 
@@ -1125,9 +1127,10 @@ mod tw05e_tests {
         path
     }
 
-    /// Copy all TW05-D + TW05-E modules to dest_dir.
+    /// Copy all TW05-D, TW05-E, and TW05-F modules to dest_dir.
     fn copy_all_tw_modules(twig_src: &Path, dest_dir: &Path) {
-        for name in &["span", "token", "diagnostic", "ast", "iir-types", "iir-builder", "lexer", "parser"] {
+        for name in &["span", "token", "diagnostic", "ast", "iir-types", "iir-builder",
+                      "lexer", "parser", "emit"] {
             copy_tw(twig_src, dest_dir, name);
         }
     }
@@ -1283,9 +1286,10 @@ mod tw05e_tests {
 
     #[test]
     fn full_lex_parse_roundtrip() {
-        // Compile all 8 modules (span, token, diagnostic, ast, iir-types,
-        // iir-builder, lexer, parser) + main.tw, then run (main).
-        // main.tw lexes "42", parses it, and returns (intlit-value first) = 42.
+        // Compile all 9 modules (span, token, diagnostic, ast, iir-types,
+        // iir-builder, lexer, parser, emit) + main.tw, then run (main).
+        // main.tw now goes through the full lex → parse → emit pipeline and
+        // extracts (car (iirinstr-srcs first-instr)) = 42.
         let src = twig_compiler_src();
         let dir = tempdir("full_e2e");
         copy_all_tw_modules(&src, &dir);
@@ -1296,6 +1300,265 @@ mod tw05e_tests {
         let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
             .expect("full_lex_parse_roundtrip: compile+run");
         assert_eq!(v.as_int(), Some(42),
-            "(main) should return 42 — the integer literal value roundtripped through lex+parse");
+            "(main) should return 42 — the integer literal value roundtripped through lex+parse+emit");
+    }
+}
+
+// ── TW05-F integration tests ──────────────────────────────────────────────────
+//
+// Tests for `compiler/emit.tw` — the self-hosted IIR emitter (LANG59).
+// Each test compiles a small subset of the Twig compiler modules, constructs
+// an AST fragment in Twig source, calls `emit-expr`, and verifies the number
+// of IIR instructions produced.
+//
+// Instruction counts:
+//   IntLit(42)                                  → 1  (const)
+//   CallExpr(VarRef "+", [IntLit 1, IntLit 2])  → 3  (const, const, call_builtin)
+//   IfExpr(BoolLit #t, IntLit 1, IntLit 2)      → 9  (see spec for breakdown)
+//   LetExpr([("x", IntLit 1)], VarRef "x")      → 1  (const; VarRef emits nothing)
+//   BeginExpr([IntLit 1, IntLit 2, IntLit 3])   → 3  (const, const, const)
+
+#[cfg(test)]
+mod tw05f_tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    fn twig_compiler_src() -> PathBuf {
+        // CARGO_MANIFEST_DIR is <repo>/code/packages/rust/twig-module-driver
+        // so ../../../twig/compiler reaches code/twig/compiler/
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        PathBuf::from(manifest)
+            .join("../../../twig/compiler")
+            .canonicalize()
+            .expect("code/twig/compiler/ must exist")
+    }
+
+    fn tempdir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("twig_tw05f_test_{tag}"));
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn copy_tw(twig_src: &Path, dest_dir: &Path, name: &str) {
+        let src = twig_src.join(format!("{name}.tw"));
+        let dest = dest_dir.join("compiler").join(format!("{name}.tw"));
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        fs::copy(&src, &dest)
+            .unwrap_or_else(|e| panic!("copy {}: {e}", src.display()));
+    }
+
+    fn write_test_main(dest_dir: &Path, imports: &[&str], body: &str) -> PathBuf {
+        let import_clause: String = imports
+            .iter()
+            .map(|i| format!("          (import {i})"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let src = format!(
+            "(module compiler/main\n  (typed lenient)\n  (export main)\n{import_clause})\n\n(define (main) {body})\n"
+        );
+        let path = dest_dir.join("compiler").join("main.tw");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, &src).unwrap();
+        path
+    }
+
+    /// Copy all modules needed by emit.tw tests (span, ast, iir-types, iir-builder, emit).
+    fn copy_emit_modules(twig_src: &Path, dest_dir: &Path) {
+        for name in &["span", "ast", "iir-types", "iir-builder", "emit"] {
+            copy_tw(twig_src, dest_dir, name);
+        }
+    }
+
+    /// Copy all TW05-D, TW05-E, and TW05-F modules to dest_dir.
+    fn copy_all_tw_modules(twig_src: &Path, dest_dir: &Path) {
+        for name in &["span", "token", "diagnostic", "ast", "iir-types", "iir-builder",
+                      "lexer", "parser", "emit"] {
+            copy_tw(twig_src, dest_dir, name);
+        }
+    }
+
+    // ── Test 1: emitting a single IntLit produces exactly 1 instruction ───────
+
+    #[test]
+    fn emit_intlit_one_instruction() {
+        // Construct (IntLit 42 sp) directly in Twig source and emit it.
+        // The emitter should produce exactly one "const" instruction.
+        let src = twig_compiler_src();
+        let dir = tempdir("emit_intlit");
+        copy_emit_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/ast",
+              "compiler/iir-types", "compiler/iir-builder", "compiler/emit"],
+            r#"(let* ((sp    (make-span 0 0 0))
+                     (expr  (IntLit 42 sp))
+                     (b0    (new-builder "test"))
+                     (env   (env-empty))
+                     (res   (emit-expr expr b0 env))
+                     (b-fin (car res))
+                     (instrs (finalise-builder b-fin)))
+               (length instrs))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("emit_intlit_one_instruction: compile+run");
+        assert_eq!(v.as_int(), Some(1),
+            "emit-expr on IntLit should produce exactly 1 instruction (const)");
+    }
+
+    // ── Test 2: emitting (+ 1 2) produces exactly 3 instructions ─────────────
+
+    #[test]
+    fn emit_call_plus_1_2() {
+        // Construct (CallExpr (VarRef "+") [IntLit 1, IntLit 2]) and emit.
+        // Expected: const r0 1, const r1 2, call_builtin r2 "+" r0 r1 = 3.
+        let src = twig_compiler_src();
+        let dir = tempdir("emit_call");
+        copy_emit_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/ast",
+              "compiler/iir-types", "compiler/iir-builder", "compiler/emit"],
+            r#"(let* ((sp    (make-span 0 0 0))
+                     (arg1  (IntLit 1 sp))
+                     (arg2  (IntLit 2 sp))
+                     (fn-e  (VarRef "+" sp))
+                     (expr  (CallExpr fn-e (list arg1 arg2) sp))
+                     (b0    (new-builder "test"))
+                     (env   (env-empty))
+                     (res   (emit-expr expr b0 env))
+                     (b-fin (car res))
+                     (instrs (finalise-builder b-fin)))
+               (length instrs))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("emit_call_plus_1_2: compile+run");
+        assert_eq!(v.as_int(), Some(3),
+            "(+ 1 2) should emit 3 instructions: const, const, call_builtin");
+    }
+
+    // ── Test 3: emitting (if #t 1 2) produces exactly 9 instructions ─────────
+
+    #[test]
+    fn emit_if_expr_count() {
+        // IfExpr with single-literal arms emits 9 instructions:
+        //   1 (cond: BoolLit) + 1 (jmp_if_false) + 1 (then: IntLit) +
+        //   1 (_move) + 1 (jmp) + 1 (label else) + 1 (else: IntLit) +
+        //   1 (_move) + 1 (label end) = 9
+        let src = twig_compiler_src();
+        let dir = tempdir("emit_if");
+        copy_emit_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/ast",
+              "compiler/iir-types", "compiler/iir-builder", "compiler/emit"],
+            r#"(let* ((sp    (make-span 0 0 0))
+                     (cond  (BoolLit #t sp))
+                     (then  (IntLit 1 sp))
+                     (els   (IntLit 2 sp))
+                     (expr  (IfExpr cond then els sp))
+                     (b0    (new-builder "test"))
+                     (env   (env-empty))
+                     (res   (emit-expr expr b0 env))
+                     (b-fin (car res))
+                     (instrs (finalise-builder b-fin)))
+               (length instrs))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("emit_if_expr_count: compile+run");
+        assert_eq!(v.as_int(), Some(9),
+            "(if #t 1 2) should emit 9 instructions (cond + branch + arms + moves + labels)");
+    }
+
+    // ── Test 4: emitting (let ((x 1)) x) produces exactly 1 instruction ──────
+
+    #[test]
+    fn emit_let_binding_count() {
+        // LetExpr: emit RHS (IntLit 1 → 1 instruction), bind x, then
+        // VarRef x looks up r0 in env without emitting a new instruction.
+        // Total: 1 instruction.
+        let src = twig_compiler_src();
+        let dir = tempdir("emit_let");
+        copy_emit_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/ast",
+              "compiler/iir-types", "compiler/iir-builder", "compiler/emit"],
+            r#"(let* ((sp       (make-span 0 0 0))
+                     (rhs      (IntLit 1 sp))
+                     (body     (VarRef "x" sp))
+                     (bindings (list (cons "x" rhs)))
+                     (expr     (LetExpr bindings body sp))
+                     (b0       (new-builder "test"))
+                     (env      (env-empty))
+                     (res      (emit-expr expr b0 env))
+                     (b-fin    (car res))
+                     (instrs   (finalise-builder b-fin)))
+               (length instrs))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("emit_let_binding_count: compile+run");
+        assert_eq!(v.as_int(), Some(1),
+            "(let ((x 1)) x) should emit 1 instruction (VarRef reuses existing register)");
+    }
+
+    // ── Test 5: emitting (begin 1 2 3) produces exactly 3 instructions ────────
+
+    #[test]
+    fn emit_begin_sequence_count() {
+        // BeginExpr emits each sub-expression in sequence.
+        // Three IntLits → 3 const instructions.
+        let src = twig_compiler_src();
+        let dir = tempdir("emit_begin");
+        copy_emit_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/ast",
+              "compiler/iir-types", "compiler/iir-builder", "compiler/emit"],
+            r#"(let* ((sp    (make-span 0 0 0))
+                     (e1    (IntLit 1 sp))
+                     (e2    (IntLit 2 sp))
+                     (e3    (IntLit 3 sp))
+                     (expr  (BeginExpr (list e1 e2 e3) sp))
+                     (b0    (new-builder "test"))
+                     (env   (env-empty))
+                     (res   (emit-expr expr b0 env))
+                     (b-fin (car res))
+                     (instrs (finalise-builder b-fin)))
+               (length instrs))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("emit_begin_sequence_count: compile+run");
+        assert_eq!(v.as_int(), Some(3),
+            "(begin 1 2 3) should emit 3 instructions (one const per IntLit)");
+    }
+
+    // ── Test 6: full lex+parse+emit roundtrip via main.tw ────────────────────
+
+    #[test]
+    fn full_lex_parse_emit_roundtrip() {
+        // Compile all 9 modules + main.tw.
+        // main.tw runs: lex "42" → parse → emit → extract const value → 42.
+        let src = twig_compiler_src();
+        let dir = tempdir("full_tw05f");
+        copy_all_tw_modules(&src, &dir);
+        // Copy the actual main.tw (TW05-F version with emitter)
+        copy_tw(&src, &dir, "main");
+
+        let root = dir.join("compiler").join("main.tw");
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("full_lex_parse_emit_roundtrip: compile+run");
+        assert_eq!(v.as_int(), Some(42),
+            "(main) should return 42 via lex → parse → emit → extract const value");
     }
 }

--- a/code/specs/LANG59-tw05f-self-hosted-iir-emitter.md
+++ b/code/specs/LANG59-tw05f-self-hosted-iir-emitter.md
@@ -1,0 +1,208 @@
+# LANG59 — TW05-F: Self-Hosted Twig IIR Emitter
+
+**Status:** In Progress
+**Branch:** `feat/lang59-tw05f-self-hosted-iir-emitter`
+**Depends on:** LANG58 (TW05-E: self-hosted lexer + parser)
+
+---
+
+## Overview
+
+TW05-F is the third compilation phase of the self-hosted Twig compiler: turning
+an Abstract Syntax Tree (AST) into Interpreter IR (IIR) instructions.  The
+deliverable is one new Twig module:
+
+- `code/twig/compiler/emit.tw` — `emit-expr : Expr × IirBuilder × Env → (cons IirBuilder reg)`
+
+`emit-expr` walks an `Expr` node (from `compiler/ast`), threads an `IirBuilder`
+(from `compiler/iir-builder`), emits `IirInstr` records for each AST node, and
+returns the pair `(updated-builder . result-register)`.
+
+A smoke-test update to `main.tw` round-trips `"42"` through the full pipeline —
+lex → parse → emit — and extracts the constant value from the emitted instruction
+(returning `42` again).
+
+---
+
+## Why self-host the emitter?
+
+TW05-E produced an in-memory AST.  TW05-F converts that AST to IIR — the flat
+three-address representation the VM executes.  Writing this phase in Twig:
+
+1. Exercises recursive AST traversal and builder-threading idioms in Twig
+2. Validates the `IirBuilder` and `IirInstr` data model from TW05-D
+3. Brings us one phase closer to TW05-G (self-compilation): lex → parse → emit
+   in Twig produces IIR that can in principle compile *more* Twig
+
+---
+
+## Language features used
+
+| Feature | Provided by |
+|---------|-------------|
+| `string-append`, `number->string`, `string=?` | LANG47 / LANG58 |
+| `cons`, `car`, `cdr`, `list`, `reverse`, `null?`, `length` | LANG52 |
+| `let*`, `if`, `and`, `or` | LANG52 |
+| Records, unions, predicate functions | LANG48 / LANG57 |
+| Multi-file modules, `(import ...)` | LANG56 |
+
+---
+
+## Key design constraints
+
+### 1. No `(match ...)` on imported union variants
+
+`Expr` variants are imported from `compiler/ast`; their tags are not propagated
+across module boundaries.  All dispatch uses generated predicates:
+`IntLit?`, `BoolLit?`, `VarRef?`, `CallExpr?`, etc.
+
+### 2. No top-level value constants
+
+Top-level `(define NAME value)` forms (non-lambda) are not exposed across module
+boundaries by the module driver.  All inline constants are literals.
+
+### 3. No mutable state
+
+The `IirBuilder` is threaded functionally through every `emit-*` helper.  Each
+function receives a builder and returns an updated one.
+
+### 4. Gate-chain dispatch
+
+Since we cannot use `(match ...)` on `Expr`, the dispatch uses a chain of small
+functions (`emit-expr`, `emit-expr-2`, …, `emit-expr-9`), each testing one
+predicate and tailing into the next.  This keeps paren-nesting flat.
+
+---
+
+## Module: `compiler/emit`
+
+### Exported API
+
+```scheme
+(define (emit-expr expr b env) ...)
+; expr : Expr (from compiler/ast)
+; b    : IirBuilder
+; env  : association list mapping name-strings to register-symbols
+; Returns: (cons updated-IirBuilder result-register)
+
+(define (env-empty) ...)
+; Returns an empty environment (nil)
+
+(define (env-lookup env name) ...)
+; env  : association list
+; name : string
+; Returns: register symbol, or nil if not found
+
+(define (env-extend env name reg) ...)
+; env  : association list
+; name : string
+; reg  : register symbol
+; Returns: extended environment
+```
+
+### Instruction formats emitted
+
+| AST node | IIR instructions emitted |
+|----------|-------------------------|
+| `IntLit(v)`  | `%rN = const v : TInt` |
+| `BoolLit(v)` | `%rN = const v : TBool` |
+| `StrLit(v)`  | `%rN = const v : TStr` |
+| `NilLit`     | `%rN = call_builtin make_nil : TAny` |
+| `VarRef(x)`  | *(no new instruction; return existing register from env)* |
+| `CallExpr(fn, args)` | emit each arg → `%rN = call_builtin fn arg0 arg1 … : TAny` |
+| `BeginExpr(es)` | emit each ei in sequence; return last register |
+| `LetExpr(bindings, body)` | emit each RHS, extend env, emit body |
+| `IfExpr(cond, then, else)` | cond + `jmp_if_false` + then + `_move` + `jmp` + label + else + `_move` + label |
+| *(other)*   | emit nil fallback |
+
+### IfExpr instruction sequence
+
+For `(if cond then-br else-br)`:
+
+```
+%r_cond   = emit cond
+            jmp_if_false %r_cond L_else
+%r_then   = emit then-br
+%r_result = call_builtin _move %r_then
+            jmp L_end
+            label L_else
+%r_else   = emit else-br
+%r_result = call_builtin _move %r_else
+            label L_end
+```
+
+Total: 9 instructions when cond, then, and else are each single literals.
+
+### Environment
+
+An environment is a simple association list of `(cons name reg)` pairs.
+`env-lookup` performs linear search using `string=?` on the name.
+`env-extend` prepends a new pair (shadowing earlier bindings with the same name).
+
+---
+
+## Updated `main.tw`
+
+```scheme
+(define (main)
+  ; Full pipeline: lex "42" → parse → emit → extract constant value
+  (let* ((tokens  (lex-source "42"))
+         (exprs   (parse-program tokens))
+         (expr    (car exprs))            ; IntLit 42
+         (b0      (new-builder "test"))
+         (env     (env-empty))
+         (result  (emit-expr expr b0 env))
+         (b-final (car result))
+         (instrs  (finalise-builder b-final))
+         ; emitted: (IirInstr "const" r0 (list 42) (TInt) sp)
+         (instr   (car instrs)))
+    (car (iirinstr-srcs instr))))   ; → 42
+```
+
+---
+
+## Integration tests (`twig-module-driver` 0.3.0 → 0.4.0)
+
+New `#[cfg(test)] mod tw05f_tests` block in `twig-module-driver/src/lib.rs`.
+
+| Test | Verifies |
+|------|----------|
+| `emit_intlit_one_instruction` | emit `(IntLit 42 sp)` → 1 instruction |
+| `emit_call_plus_1_2` | emit `(CallExpr (VarRef "+") [IntLit 1, IntLit 2])` → 3 instructions |
+| `emit_if_expr_count` | emit `(IfExpr (BoolLit #t) (IntLit 1) (IntLit 2))` → 9 instructions |
+| `emit_let_binding_count` | emit `(LetExpr [("x", IntLit 1)] (VarRef "x"))` → 1 instruction |
+| `emit_begin_sequence_count` | emit `(BeginExpr [IntLit 1, IntLit 2, IntLit 3])` → 3 instructions |
+| `full_lex_parse_emit_roundtrip` | All 9 modules + main.tw → `(main) = 42` |
+
+---
+
+## Version bumps
+
+| Package | Before | After |
+|---------|--------|-------|
+| `twig-module-driver` | 0.3.0 | 0.4.0 |
+
+No Rust compiler changes needed — all new functionality is pure Twig.
+
+---
+
+## Commit sequence
+
+1. `docs(specs)` — this file
+2. `feat(twig)` — `emit.tw` + updated `main.tw` (new emitter phase)
+3. `test(twig-module-driver)` — 6 tw05f integration tests, bump 0.4.0
+
+---
+
+## Divergence from plan
+
+None — implementation matches the LANG59 plan exactly.
+
+---
+
+## What comes next (TW05-G)
+
+TW05-G will attempt the fixed-point self-compilation: stage0 (existing Rust
+compiler) compiles a Twig source of the compiler → stage1 binary.  Stage1 then
+compiles the same source → stage2 binary.  If stage1 == stage2, bootstrapping
+is complete.

--- a/code/twig/compiler/emit.tw
+++ b/code/twig/compiler/emit.tw
@@ -1,0 +1,383 @@
+; # emit.tw — Self-Hosted Twig IIR Emitter (LANG59 / TW05-F)
+;
+; The emitter walks an `Expr` AST (from `compiler/ast`) and produces a list of
+; `IirInstr` records (from `compiler/iir-types`) via the `IirBuilder` API
+; (from `compiler/iir-builder`).
+;
+; ## Design: functional builder threading
+;
+; Each emit function takes `(expr b env)` and returns `(cons b2 reg)`:
+;   b2  — updated builder with new instructions prepended
+;   reg — register symbol holding the result of this expression
+;
+; The builder accumulates instructions in reverse order (O(1) prepend).
+; Call `(finalise-builder b)` to get the instruction list in source order.
+;
+; ## Environment: association list
+;
+; `env` is a list of `(cons name reg)` pairs, where `name` is a string
+; and `reg` is a register symbol (from `alloc-slot`).  Lookup uses `string=?`.
+;
+; ## Gate-chain dispatch
+;
+; `Expr` variants are imported from `compiler/ast`; their integer tags are NOT
+; propagated across module boundaries.  We cannot use `(match expr ...)`.
+; Instead, each predicate (`IntLit?`, `BoolLit?`, etc.) is tested in a chain
+; of small functions, each handling one case and tailing into the next.
+;
+; ## Label naming
+;
+; `alloc-label` returns an integer ID.  Label names are strings: `"L0"`, `"L1"`.
+; These appear as operands in `jmp_if_false`, `jmp`, and `label` instructions.
+;
+; ## Example: emitting `(+ 1 2)`
+;
+;   (let* ((b0  (new-builder "f"))
+;          (e   (CallExpr (VarRef "+" sp) (list (IntLit 1 sp) (IntLit 2 sp)) sp))
+;          (r   (emit-expr e b0 (env-empty)))
+;          (b1  (car r))
+;          (ins (finalise-builder b1)))
+;     (length ins))   ; → 3
+;
+; The three instructions are:
+;   (IirInstr "const"        r0  (list 1)        (TInt)  sp)
+;   (IirInstr "const"        r1  (list 2)        (TInt)  sp)
+;   (IirInstr "call_builtin" r2  (list "+" r0 r1) (TAny) sp)
+
+(module compiler/emit
+  (typed lenient)
+  (export emit-expr env-empty env-lookup env-extend)
+  (import compiler/span
+          compiler/ast
+          compiler/iir-types
+          compiler/iir-builder))
+
+; ── Environment helpers ───────────────────────────────────────────────────────
+;
+; An environment is a Twig association list: ((name . reg) ...).
+; `name` is a string; `reg` is a register symbol from `alloc-slot`.
+
+; env-empty: start with no bindings.
+(define (env-empty) nil)
+
+; env-lookup: search for `name` by string equality.
+; Returns the register symbol, or nil if not found.
+(define (env-lookup env name)
+  (if (null? env)
+      nil
+      (if (string=? (car (car env)) name)
+          (cdr (car env))
+          (env-lookup (cdr env) name))))
+
+; env-extend: prepend a new (name . reg) binding.
+; Shadowing is intentional — newer bindings hide older ones.
+(define (env-extend env name reg)
+  (cons (cons name reg) env))
+
+; ── Span helper ───────────────────────────────────────────────────────────────
+;
+; All emitted instructions use a dummy span (0 0 0).  Source-accurate spans
+; would require threading the original token spans through the AST, which is
+; deferred to TW05-H.
+
+(define (emit-span)
+  (make-span 0 0 0))
+
+; ── Label name ────────────────────────────────────────────────────────────────
+;
+; Convert an integer label ID (from alloc-label) to the string "LN" used in
+; jmp / jmp_if_false / label instructions.
+
+(define (label-name id)
+  (string-append "L" (number->string id)))
+
+; ── emit-expr: gate-chain dispatch ───────────────────────────────────────────
+;
+; Each gate tests one Expr variant predicate and either handles it or tails
+; into the next gate.  Returns (cons updated-builder result-register).
+
+; Gate 1: IntLit — emit a const int instruction.
+(define (emit-expr expr b env)
+  (if (IntLit? expr)
+      (emit-intlit expr b)
+      (emit-expr-2 expr b env)))
+
+; Gate 2: BoolLit — emit a const bool instruction.
+(define (emit-expr-2 expr b env)
+  (if (BoolLit? expr)
+      (emit-boollit expr b)
+      (emit-expr-3 expr b env)))
+
+; Gate 3: StrLit — emit a const str instruction.
+(define (emit-expr-3 expr b env)
+  (if (StrLit? expr)
+      (emit-strlit expr b)
+      (emit-expr-4 expr b env)))
+
+; Gate 4: NilLit — emit a call_builtin make_nil instruction.
+(define (emit-expr-4 expr b env)
+  (if (NilLit? expr)
+      (emit-nillit b)
+      (emit-expr-5 expr b env)))
+
+; Gate 5: VarRef — look up the register in env (no new instruction).
+(define (emit-expr-5 expr b env)
+  (if (VarRef? expr)
+      (emit-varref expr b env)
+      (emit-expr-6 expr b env)))
+
+; Gate 6: IfExpr — conditional branch with jmp_if_false.
+(define (emit-expr-6 expr b env)
+  (if (IfExpr? expr)
+      (emit-ifexpr expr b env)
+      (emit-expr-7 expr b env)))
+
+; Gate 7: BeginExpr — emit each sub-expression, return the last register.
+(define (emit-expr-7 expr b env)
+  (if (BeginExpr? expr)
+      (emit-beginexpr expr b env)
+      (emit-expr-8 expr b env)))
+
+; Gate 8: LetExpr — emit bindings sequentially, extend env, emit body.
+(define (emit-expr-8 expr b env)
+  (if (LetExpr? expr)
+      (emit-letexpr expr b env)
+      (emit-expr-9 expr b env)))
+
+; Gate 9: CallExpr — emit arguments, emit call_builtin.
+; Fallback for any unrecognised form: emit nil.
+(define (emit-expr-9 expr b env)
+  (if (CallExpr? expr)
+      (emit-callexpr expr b env)
+      (emit-nillit b)))
+
+; ── emit-intlit ───────────────────────────────────────────────────────────────
+;
+; (IntLit value span) → %rN = const value : TInt
+;
+; The `srcs` list contains the integer value directly.  The type-hint is TInt.
+
+(define (emit-intlit expr b)
+  (let* ((p     (alloc-slot b))
+         (b2    (car p))
+         (dest  (car (cdr p)))
+         (val   (intlit-value expr))
+         (sp    (emit-span))
+         (instr (IirInstr "const" dest (list val) (TInt) sp))
+         (b3    (append-instr b2 instr)))
+    (cons b3 dest)))
+
+; ── emit-boollit ──────────────────────────────────────────────────────────────
+;
+; (BoolLit value span) → %rN = const value : TBool
+
+(define (emit-boollit expr b)
+  (let* ((p     (alloc-slot b))
+         (b2    (car p))
+         (dest  (car (cdr p)))
+         (val   (boollit-value expr))
+         (sp    (emit-span))
+         (instr (IirInstr "const" dest (list val) (TBool) sp))
+         (b3    (append-instr b2 instr)))
+    (cons b3 dest)))
+
+; ── emit-strlit ───────────────────────────────────────────────────────────────
+;
+; (StrLit value span) → %rN = const value : TStr
+
+(define (emit-strlit expr b)
+  (let* ((p     (alloc-slot b))
+         (b2    (car p))
+         (dest  (car (cdr p)))
+         (val   (strlit-value expr))
+         (sp    (emit-span))
+         (instr (IirInstr "const" dest (list val) (TStr) sp))
+         (b3    (append-instr b2 instr)))
+    (cons b3 dest)))
+
+; ── emit-nillit ───────────────────────────────────────────────────────────────
+;
+; (NilLit span) → %rN = call_builtin make_nil : TAny
+;
+; Note: `b` is the builder at the call site; `expr` is not needed here since
+; NilLit carries only a span and we use the dummy span.
+
+(define (emit-nillit b)
+  (let* ((p     (alloc-slot b))
+         (b2    (car p))
+         (dest  (car (cdr p)))
+         (sp    (emit-span))
+         (instr (IirInstr "call_builtin" dest (list "make_nil") (TAny) sp))
+         (b3    (append-instr b2 instr)))
+    (cons b3 dest)))
+
+; ── emit-varref ───────────────────────────────────────────────────────────────
+;
+; (VarRef name span) → look up name in env, return existing register.
+;
+; No instruction is emitted.  If the name is not in the environment (undefined
+; variable), fall back to emitting nil (undefined-variable error handling is
+; deferred to TW05-H).
+
+(define (emit-varref expr b env)
+  (let* ((name (varref-name expr))
+         (reg  (env-lookup env name)))
+    (if (null? reg)
+        (emit-nillit b)
+        (cons b reg))))
+
+; ── emit-ifexpr ───────────────────────────────────────────────────────────────
+;
+; (IfExpr cond then-br else-br span) → conditional branch sequence:
+;
+;   emit cond         → %r_cond
+;   jmp_if_false %r_cond L_else
+;   emit then-br      → %r_then
+;   call_builtin _move %r_then → %r_result
+;   jmp L_end
+;   label L_else
+;   emit else-br      → %r_else
+;   call_builtin _move %r_else → %r_result
+;   label L_end
+;
+; Returns (cons b_final r_result).
+;
+; Instruction count for single-literal arms: 9
+;   1 (cond) + 1 (jmp_if_false) + 1 (then) + 1 (_move) + 1 (jmp) +
+;   1 (label else) + 1 (else) + 1 (_move) + 1 (label end)
+
+(define (emit-ifexpr expr b env)
+  (let* ((cond-r   (emit-expr (ifexpr-cond expr) b env))
+         (b1       (car cond-r))
+         (r-cond   (cdr cond-r))
+         (res-p    (alloc-slot b1))
+         (b2       (car res-p))
+         (r-result (car (cdr res-p)))
+         (else-p   (alloc-label b2))
+         (b3       (car else-p))
+         (else-id  (car (cdr else-p)))
+         (end-p    (alloc-label b3))
+         (b4       (car end-p))
+         (end-id   (car (cdr end-p)))
+         (l-else   (label-name else-id))
+         (l-end    (label-name end-id))
+         (sp       (emit-span))
+         (b5       (append-instr b4
+                     (IirInstr "jmp_if_false" nil
+                               (list r-cond l-else) (TVoid) sp)))
+         (then-r   (emit-expr (ifexpr-then-br expr) b5 env))
+         (b6       (car then-r))
+         (r-then   (cdr then-r))
+         (b7       (append-instr b6
+                     (IirInstr "call_builtin" r-result
+                               (list "_move" r-then) (TAny) sp)))
+         (b8       (append-instr b7
+                     (IirInstr "jmp" nil (list l-end) (TVoid) sp)))
+         (b9       (append-instr b8
+                     (IirInstr "label" nil (list l-else) (TVoid) sp)))
+         (else-r   (emit-expr (ifexpr-else-br expr) b9 env))
+         (b10      (car else-r))
+         (r-else   (cdr else-r))
+         (b11      (append-instr b10
+                     (IirInstr "call_builtin" r-result
+                               (list "_move" r-else) (TAny) sp)))
+         (b12      (append-instr b11
+                     (IirInstr "label" nil (list l-end) (TVoid) sp))))
+    (cons b12 r-result)))
+
+; ── emit-beginexpr ────────────────────────────────────────────────────────────
+;
+; (BeginExpr exprs span) → emit each sub-expression in order.
+; Returns the register of the last sub-expression.
+; If exprs is empty, emits nil.
+
+(define (emit-beginexpr expr b env)
+  (let* ((exprs (beginexpr-exprs expr)))
+    (if (null? exprs)
+        (emit-nillit b)
+        (emit-begin-list exprs b env nil))))
+
+; emit-begin-list: tail-recursive loop that threads the builder through
+; each sub-expression, keeping track of the last register seen.
+; Returns (cons b2 last-reg).
+
+(define (emit-begin-list exprs b env last-reg)
+  (if (null? exprs)
+      (cons b last-reg)
+      (let* ((result (emit-expr (car exprs) b env))
+             (b2     (car result))
+             (reg    (cdr result)))
+        (emit-begin-list (cdr exprs) b2 env reg))))
+
+; ── emit-letexpr ──────────────────────────────────────────────────────────────
+;
+; (LetExpr bindings body span) → emit bindings sequentially (let* semantics),
+; each binding's register enters env before the next binding's RHS is emitted.
+; Then emit body with the fully extended environment.
+;
+; `bindings` is a list of (cons name rhs-expr) pairs, as produced by the parser.
+
+(define (emit-letexpr expr b env)
+  (let* ((bindings (letexpr-bindings expr))
+         (body     (letexpr-body expr))
+         (env-b    (emit-let-bindings bindings b env))
+         (b-out    (car env-b))
+         (env2     (cdr env-b)))
+    (emit-expr body b-out env2)))
+
+; emit-let-bindings: process each (name . rhs) pair in order.
+; Returns (cons updated-builder extended-env).
+
+(define (emit-let-bindings bindings b env)
+  (if (null? bindings)
+      (cons b env)
+      (let* ((binding (car bindings))
+             (name    (car binding))
+             (rhs     (cdr binding))
+             (rhs-r   (emit-expr rhs b env))
+             (b2      (car rhs-r))
+             (reg     (cdr rhs-r))
+             (env2    (env-extend env name reg)))
+        (emit-let-bindings (cdr bindings) b2 env2))))
+
+; ── emit-callexpr ─────────────────────────────────────────────────────────────
+;
+; (CallExpr fn-expr args span) → emit each argument, then emit call_builtin.
+;
+; For TW05-F scope, `fn-expr` must be a VarRef; the name becomes the first
+; operand to `call_builtin`.  Non-VarRef callees (closures, higher-order calls)
+; fall back to emitting nil and are addressed in TW05-G.
+;
+; Example: (+ r0 r1) →
+;   (IirInstr "call_builtin" r2 (list "+" r0 r1) (TAny) sp)
+
+(define (emit-callexpr expr b env)
+  (let* ((fn-expr (callexpr-fn-expr expr))
+         (args    (callexpr-args expr))
+         (sp      (emit-span)))
+    (if (VarRef? fn-expr)
+        (let* ((fn-name (varref-name fn-expr))
+               (args-r  (emit-args args b env nil))
+               (b2      (car args-r))
+               (regs    (cdr args-r))
+               (res-p   (alloc-slot b2))
+               (b3      (car res-p))
+               (dest    (car (cdr res-p)))
+               (srcs    (cons fn-name regs))
+               (instr   (IirInstr "call_builtin" dest srcs (TAny) sp))
+               (b4      (append-instr b3 instr)))
+          (cons b4 dest))
+        (emit-nillit b))))
+
+; emit-args: emit each argument expression and collect result registers.
+; Arguments are accumulated in reverse order and then reversed before returning,
+; so the register list matches the source order.
+; Returns (cons updated-builder list-of-registers).
+
+(define (emit-args args b env acc)
+  (if (null? args)
+      (cons b (reverse acc))
+      (let* ((result (emit-expr (car args) b env))
+             (b2     (car result))
+             (reg    (cdr result)))
+        (emit-args (cdr args) b2 env (cons reg acc)))))

--- a/code/twig/compiler/main.tw
+++ b/code/twig/compiler/main.tw
@@ -1,17 +1,27 @@
-; # main.tw — Root Module + Smoke-Test Entry Point (LANG58 / TW05-E)
+; # main.tw — Root Module + Smoke-Test Entry Point (LANG59 / TW05-F)
 ;
-; This is the root module of the self-hosted compiler.  It imports all eight
-; sub-modules (six data-model modules from TW05-D plus lexer and parser from
-; TW05-E) and exposes a `(main)` function that exercises the full pipeline:
+; This is the root module of the self-hosted compiler.  It imports all nine
+; sub-modules (six data-model modules from TW05-D, lexer and parser from
+; TW05-E, and the IIR emitter from TW05-F) and exposes a `(main)` function
+; that exercises the full pipeline:
 ;
 ;   1. Lex the string `"42"` → list of tokens
 ;   2. Parse the token list → list of AST nodes
-;   3. Extract the integer value from the first node (an IntLit)
-;   4. Return 42
+;   3. Emit the first AST node (an IntLit) through the IIR emitter
+;   4. Extract the constant value from the emitted instruction
+;   5. Return 42
 ;
 ; The `(main)` return value of `42` is the integration test assertion:
-; if the entire module graph compiles and links correctly, and the lexer +
-; parser correctly round-trip a single integer literal, the result is 42.
+; if the entire module graph compiles and links correctly, and the full
+; lex → parse → emit pipeline correctly round-trips a single integer literal,
+; the result is 42.
+;
+; ## How the round-trip works
+;
+;   lex "42"                    → [TkInteger "42", TkEOF]
+;   parse                       → [IntLit 42 sp]
+;   emit IntLit 42              → [IirInstr "const" r0 (list 42) (TInt) sp]
+;   (car (iirinstr-srcs instr)) → 42
 ;
 ; ## Naming conventions for generated accessors
 ;
@@ -27,9 +37,6 @@
 ; Union variant tags are NOT propagated by the module driver.  Never use
 ; `(match ...)` on a union value that was constructed in an imported module.
 ; Use the predicate functions instead: `(IntLit? node)`, `(TkInteger? kind)`.
-;
-; Downstream passes will expand main.tw to include the IIR emitter, resolver,
-; and self-compilation driver once each phase is ported (TW05-F through TW05-G).
 
 (module compiler/main
   (typed lenient)
@@ -41,28 +48,42 @@
           compiler/iir-types
           compiler/iir-builder
           compiler/lexer
-          compiler/parser))
+          compiler/parser
+          compiler/emit))
 
 ; ── Entry point ──────────────────────────────────────────────────────────────
 ;
-; `(main)` is the end-to-end smoke test: lex "42", parse it, extract 42.
+; `(main)` is the end-to-end smoke test: lex "42", parse it, emit it,
+; extract the constant value from the emitted instruction.
 ;
-; Returns: 42  (the integer literal value round-tripped through lex + parse)
+; Returns: 42  (the integer literal value round-tripped through lex + parse + emit)
 
 (define (main)
   ; Step 1: lex the string "42"
   ; lex-source returns a list: (Token TkInteger "42" sp) (Token TkEOF "" sp)
-  (let* ((tokens (lex-source "42"))
+  (let* ((tokens  (lex-source "42"))
 
          ; Step 2: parse the token list
          ; parse-program returns a list of top-level Expr nodes.
          ; For "42", the list has one element: (IntLit 42 sp).
-         (exprs  (parse-program tokens))
+         (exprs   (parse-program tokens))
 
-         ; Step 3: extract the first (and only) expression
-         (first  (car exprs)))
+         ; Step 3: emit the first (and only) expression
+         ; emit-expr returns (cons updated-builder result-register).
+         (expr    (car exprs))
+         (b0      (new-builder "main-test"))
+         (env     (env-empty))
+         (result  (emit-expr expr b0 env))
+         (b-final (car result))
 
-    ; Step 4: read its integer value via the generated accessor.
-    ; `intlit-value` is the accessor for the `value` field of IntLit.
-    ; The field was declared `(value : int)` so this returns an integer.
-    (intlit-value first)))   ; → 42
+         ; Step 4: finalise the builder to get the instruction list.
+         ; For IntLit 42, this is [(IirInstr "const" r0 (list 42) (TInt) sp)].
+         (instrs  (finalise-builder b-final))
+
+         ; Step 5: extract the first instruction and read its srcs list.
+         ; srcs = (list 42), so (car srcs) = 42.
+         (instr   (car instrs)))
+
+    ; The `srcs` field of a const instruction holds the operand value.
+    ; `(car (iirinstr-srcs instr))` retrieves the integer 42.
+    (car (iirinstr-srcs instr))))   ; → 42


### PR DESCRIPTION
## Summary

- Adds `code/twig/compiler/emit.tw` — the self-hosted IIR emitter (TW05-F), completing the lex → parse → emit pipeline in Twig
- Updates `code/twig/compiler/main.tw` to run the full pipeline on `"42"`, extracting the constant from the emitted instruction (still returns `42`)
- Adds `code/specs/LANG59-tw05f-self-hosted-iir-emitter.md` spec
- Adds 6 `tw05f_tests` integration tests to `twig-module-driver`, bumps to 0.4.0

### `emit.tw` design

- **Gate-chain dispatch**: `emit-expr` → `emit-expr-2` → … → `emit-expr-9`, one predicate check per gate (required because cross-module `match` on `Expr` tags doesn't work)
- **Functional builder threading**: every function receives `(expr b env)` and returns `(cons updated-builder result-register)`
- **Environment**: association list of `(name . reg)` pairs with `string=?` lookup
- **Handled variants**: `IntLit`, `BoolLit`, `StrLit`, `NilLit`, `VarRef`, `IfExpr` (9-instruction sequence), `BeginExpr`, `LetExpr`, `CallExpr`

### Test results

```
test tw05f_tests::emit_intlit_one_instruction     ... ok
test tw05f_tests::emit_call_plus_1_2              ... ok
test tw05f_tests::emit_if_expr_count              ... ok
test tw05f_tests::emit_let_binding_count          ... ok
test tw05f_tests::emit_begin_sequence_count       ... ok
test tw05f_tests::full_lex_parse_emit_roundtrip   ... ok

test result: ok. 32 passed; 0 failed   (full suite)
```

## Test plan

- [x] `cargo test -p twig-module-driver --lib` — all 32 tests pass
- [x] `cargo build -p twig-module-driver -p twig-ir-compiler -p twig-vm` — clean build
- [x] Security review completed (1 MEDIUM fixed: unpredictable temp paths in tw05f_tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)