### PR TITLE
feat(twig): LANG60 TW05-G lambda expressions and function definitions

### DIFF
--- a/code/packages/rust/twig-module-driver/CHANGELOG.md
+++ b/code/packages/rust/twig-module-driver/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog — twig-module-driver
 
+## [0.5.0] — 2026-05-15
+
+### Added (LANG60 — TW05-G lambda expressions + function definitions)
+
+New `#[cfg(test)] mod tw05g_tests` with 6 tests exercising the updated
+`compiler/ast.tw`, `compiler/parser.tw`, `compiler/emit.tw`, and `main.tw`
+that together implement lambda expressions and the `(define (name args) body)`
+function-definition shorthand.
+
+#### AST changes (`ast.tw`)
+`LambdaExpr (params : any) (body : any) (span : any)` added as tag 11.
+Exports `LambdaExpr`, `LambdaExpr?`, `lambdaexpr-params`, `lambdaexpr-body`,
+`lambdaexpr-span`.
+
+#### Parser changes (`parser.tw`)
+- New gate `parse-list-6` dispatches on `"lambda"` keyword.
+- `parse-define` now dispatches: `TkLParen` first token → `parse-define-fn`
+  (function shorthand); otherwise → `parse-define-simple` (original path).
+- New helpers: `parse-define-fn`, `parse-define-simple`, `parse-lambda`,
+  `parse-param-list`.
+- `(define (name params) body)` parses to
+  `DefExpr name (LambdaExpr params body sp)`.
+
+#### Emitter changes (`emit.tw`)
+- Gate 9 (new): `DefExpr?` → `emit-defexpr`.
+- Gate 10 (new): `LambdaExpr?` → `emit-lambdaexpr`.
+- Gate 11 (was 9): `CallExpr?` / fallback.
+- New functions: `emit-defexpr`, `emit-lambdaexpr`, `emit-lambda-params`.
+
+#### `main.tw` updated to TW05-G smoke test
+Lexes and emits `"(define (answer) 42)"` through the full pipeline; still
+returns 42.
+
+| Test | Verifies |
+|------|----------|
+| `parser_lambda_expr` | `(parse-program "(lambda (x) x)")` → `LambdaExpr?` = 1 |
+| `parser_define_fn_form` | `(define (f x) x)` → `defexpr-expr` is a `LambdaExpr` |
+| `emit_lambda_no_params` | emit `(LambdaExpr [] (IntLit 99))` → 1 instruction |
+| `emit_lambda_with_param` | emit `(LambdaExpr ["x"] (+ x 1))` → 2 instructions |
+| `emit_defexpr_answer_42` | emit `(DefExpr "answer" (LambdaExpr [] (IntLit 42)))` → 1 instruction |
+| `full_lex_parse_emit_defexpr` | All 9 modules + main.tw → `(main) = 42` |
+
 ## [0.4.0] — 2026-05-15
 
 ### Added (LANG59 — TW05-F self-hosted IIR emitter integration tests)

--- a/code/packages/rust/twig-module-driver/Cargo.toml
+++ b/code/packages/rust/twig-module-driver/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name        = "twig-module-driver"
-version     = "0.4.0"
+version     = "0.5.0"
 edition     = "2021"
-description = "LANG56-LANG59 — multi-file module resolver for Twig.  Resolves (import …) declarations recursively, compiles and links all modules into a single IIRModule ready for twig-vm.  LANG57 adds TW05-D data-model tests; LANG58 adds TW05-E lexer+parser tests; LANG59 adds TW05-F IIR emitter tests."
+description = "LANG56-LANG60 — multi-file module resolver for Twig.  Resolves (import …) declarations recursively, compiles and links all modules into a single IIRModule ready for twig-vm.  LANG57 adds TW05-D data-model tests; LANG58 adds TW05-E lexer+parser tests; LANG59 adds TW05-F IIR emitter tests; LANG60 adds TW05-G lambda+DefExpr tests."
 
 [dependencies]
 twig-parser       = { path = "../twig-parser" }

--- a/code/packages/rust/twig-module-driver/src/lib.rs
+++ b/code/packages/rust/twig-module-driver/src/lib.rs
@@ -1320,7 +1320,6 @@ mod tw05e_tests {
 
 #[cfg(test)]
 mod tw05f_tests {
-    use super::*;
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -1557,11 +1556,12 @@ mod tw05f_tests {
     #[test]
     fn full_lex_parse_emit_roundtrip() {
         // Compile all 9 modules + main.tw.
-        // main.tw runs: lex "42" → parse → emit → extract const value → 42.
+        // main.tw (TW05-G) runs: lex "(define (answer) 42)" → parse → emit
+        // → extract const value → 42.
         let src = twig_compiler_src();
         let dir = tempdir("full_tw05f");
         copy_all_tw_modules(&src, &dir);
-        // Copy the actual main.tw (TW05-F version with emitter)
+        // Copy the actual main.tw (updated to TW05-G)
         copy_tw(&src, &dir, "main");
 
         let root = dir.join("compiler").join("main.tw");
@@ -1569,5 +1569,265 @@ mod tw05f_tests {
             .expect("full_lex_parse_emit_roundtrip: compile+run");
         assert_eq!(v.as_int(), Some(42),
             "(main) should return 42 via lex → parse → emit → extract const value");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TW05-G integration tests — LANG60: lambda expressions + function definitions
+// ---------------------------------------------------------------------------
+//
+// These tests verify that the parser and emitter correctly handle:
+//   • `(lambda (params) body)` — LambdaExpr variant (tag 11 in ast.tw)
+//   • `(define (name params) body)` — function-definition shorthand
+//     (parses to DefExpr wrapping a LambdaExpr)
+//
+// Instruction counts for lambda emission:
+//   (lambda () 99)         → 1  (const; no param-slot instructions)
+//   (lambda (x) (+ x 1))  → 2  (const 1 + call_builtin; VarRef x is free)
+//   (define (answer) 42)  → 1  (const; single body literal)
+
+#[cfg(test)]
+mod tw05g_tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn twig_compiler_src() -> PathBuf {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        PathBuf::from(manifest)
+            .join("../../../twig/compiler")
+            .canonicalize()
+            .expect("code/twig/compiler/ must exist")
+    }
+
+    fn tempdir(tag: &str) -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+        let d = std::env::temp_dir()
+            .join(format!("twig_tw05g_test_{tag}_{}_{}",
+                          std::process::id(), nonce));
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn copy_tw(twig_src: &Path, dest_dir: &Path, name: &str) {
+        let src = twig_src.join(format!("{name}.tw"));
+        let dest = dest_dir.join("compiler").join(format!("{name}.tw"));
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        fs::copy(&src, &dest)
+            .unwrap_or_else(|e| panic!("copy {}: {e}", src.display()));
+    }
+
+    fn write_test_main(dest_dir: &Path, imports: &[&str], body: &str) -> PathBuf {
+        let import_clause: String = imports
+            .iter()
+            .map(|i| format!("          (import {i})"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let src = format!(
+            "(module compiler/main\n  (typed lenient)\n  (export main)\n{import_clause})\n\n(define (main) {body})\n"
+        );
+        let path = dest_dir.join("compiler").join("main.tw");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, &src).unwrap();
+        path
+    }
+
+    /// Copy all modules needed by the full pipeline.
+    fn copy_all_tw_modules(twig_src: &Path, dest_dir: &Path) {
+        for name in &["span", "token", "diagnostic", "ast", "iir-types", "iir-builder",
+                      "lexer", "parser", "emit"] {
+            copy_tw(twig_src, dest_dir, name);
+        }
+    }
+
+    /// Copy modules needed for parser tests (no emitter).
+    fn copy_parser_modules(twig_src: &Path, dest_dir: &Path) {
+        for name in &["span", "token", "ast", "lexer", "parser"] {
+            copy_tw(twig_src, dest_dir, name);
+        }
+    }
+
+    /// Copy modules needed for emit tests (no lexer/parser).
+    fn copy_emit_modules(twig_src: &Path, dest_dir: &Path) {
+        for name in &["span", "ast", "iir-types", "iir-builder", "emit"] {
+            copy_tw(twig_src, dest_dir, name);
+        }
+    }
+
+    // ── Test 1: parser produces LambdaExpr for "(lambda (x) x)" ─────────────
+
+    #[test]
+    fn parser_lambda_expr() {
+        // lex + parse "(lambda (x) x)" → the result should be a LambdaExpr.
+        // We verify with (LambdaExpr? ...) predicate → 1.
+        let src = twig_compiler_src();
+        let dir = tempdir("parse_lambda");
+        copy_parser_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/token", "compiler/ast",
+              "compiler/lexer", "compiler/parser"],
+            r#"(if (LambdaExpr? (car (parse-program (lex-source "(lambda (x) x)")))) 1 0)"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("parser_lambda_expr: compile+run");
+        assert_eq!(v.as_int(), Some(1),
+            "(parse-program \"(lambda (x) x)\") should produce a LambdaExpr");
+    }
+
+    // ── Test 2: parser produces DefExpr(LambdaExpr) for "(define (f x) x)" ──
+
+    #[test]
+    fn parser_define_fn_form() {
+        // lex + parse "(define (f x) x)":
+        //   → DefExpr "f" (LambdaExpr ["x"] (VarRef "x") sp) sp
+        // We verify that defexpr-expr is a LambdaExpr → 1.
+        let src = twig_compiler_src();
+        let dir = tempdir("parse_define_fn");
+        copy_parser_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/token", "compiler/ast",
+              "compiler/lexer", "compiler/parser"],
+            r#"(let* ((def (car (parse-program (lex-source "(define (f x) x)")))))
+                 (if (LambdaExpr? (defexpr-expr def)) 1 0))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("parser_define_fn_form: compile+run");
+        assert_eq!(v.as_int(), Some(1),
+            "(define (f x) x) body should be a LambdaExpr");
+    }
+
+    // ── Test 3: emitting (lambda () 99) produces exactly 1 instruction ───────
+
+    #[test]
+    fn emit_lambda_no_params() {
+        // LambdaExpr with no params emits exactly as many instructions as its body.
+        // (lambda () 99) body = IntLit 99 → 1 "const" instruction.
+        let src = twig_compiler_src();
+        let dir = tempdir("emit_lambda_no_params");
+        copy_emit_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/ast",
+              "compiler/iir-types", "compiler/iir-builder", "compiler/emit"],
+            r#"(let* ((sp     (make-span 0 0 0))
+                     (body   (IntLit 99 sp))
+                     (expr   (LambdaExpr (list) body sp))
+                     (b0     (new-builder "test"))
+                     (env    (env-empty))
+                     (res    (emit-expr expr b0 env))
+                     (b-fin  (car res))
+                     (instrs (finalise-builder b-fin)))
+               (length instrs))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("emit_lambda_no_params: compile+run");
+        assert_eq!(v.as_int(), Some(1),
+            "(lambda () 99) should emit 1 instruction (const; no param slots)");
+    }
+
+    // ── Test 4: emitting (lambda (x) (+ x 1)) produces exactly 2 instructions ─
+
+    #[test]
+    fn emit_lambda_with_param() {
+        // (lambda (x) (+ x 1)):
+        //   param: alloc slot for x — no instruction emitted
+        //   body: (+ x 1)
+        //     VarRef "x" → existing slot, no instruction
+        //     IntLit 1   → 1 const instruction
+        //     CallExpr   → 1 call_builtin instruction
+        //   Total: 2 instructions.
+        let src = twig_compiler_src();
+        let dir = tempdir("emit_lambda_param");
+        copy_emit_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/ast",
+              "compiler/iir-types", "compiler/iir-builder", "compiler/emit"],
+            r#"(let* ((sp      (make-span 0 0 0))
+                     (x-ref   (VarRef "x" sp))
+                     (one     (IntLit 1 sp))
+                     (plus    (VarRef "+" sp))
+                     (body    (CallExpr plus (list x-ref one) sp))
+                     (params  (list "x"))
+                     (expr    (LambdaExpr params body sp))
+                     (b0      (new-builder "test"))
+                     (env     (env-empty))
+                     (res     (emit-expr expr b0 env))
+                     (b-fin   (car res))
+                     (instrs  (finalise-builder b-fin)))
+               (length instrs))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("emit_lambda_with_param: compile+run");
+        assert_eq!(v.as_int(), Some(2),
+            "(lambda (x) (+ x 1)) should emit 2 instructions (const 1 + call_builtin)");
+    }
+
+    // ── Test 5: emitting (define (answer) 42) produces exactly 1 instruction ──
+
+    #[test]
+    fn emit_defexpr_answer_42() {
+        // DefExpr "answer" (LambdaExpr [] (IntLit 42) sp):
+        //   emit-defexpr detects LambdaExpr body, delegates to emit-lambdaexpr
+        //   emit-lambdaexpr: no params, emit body IntLit 42 → 1 const instruction.
+        let src = twig_compiler_src();
+        let dir = tempdir("emit_defexpr_42");
+        copy_emit_modules(&src, &dir);
+
+        let root = write_test_main(
+            &dir,
+            &["compiler/span", "compiler/ast",
+              "compiler/iir-types", "compiler/iir-builder", "compiler/emit"],
+            r#"(let* ((sp     (make-span 0 0 0))
+                     (body   (IntLit 42 sp))
+                     (lam    (LambdaExpr (list) body sp))
+                     (expr   (DefExpr "answer" lam sp))
+                     (b0     (new-builder "answer"))
+                     (env    (env-empty))
+                     (res    (emit-expr expr b0 env))
+                     (b-fin  (car res))
+                     (instrs (finalise-builder b-fin)))
+               (length instrs))"#,
+        );
+
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("emit_defexpr_answer_42: compile+run");
+        assert_eq!(v.as_int(), Some(1),
+            "(define (answer) 42) should emit 1 instruction (const 42)");
+    }
+
+    // ── Test 6: full lex+parse+emit pipeline for (define (answer) 42) ─────────
+
+    #[test]
+    fn full_lex_parse_emit_defexpr() {
+        // Compile all 9 modules + main.tw.
+        // main.tw (TW05-G) runs:
+        //   lex "(define (answer) 42)" → parse → emit DefExpr
+        //   → LambdaExpr body → const 42 → extract srcs[0] = 42.
+        let src = twig_compiler_src();
+        let dir = tempdir("full_tw05g");
+        copy_all_tw_modules(&src, &dir);
+        copy_tw(&src, &dir, "main");
+
+        let root = dir.join("compiler").join("main.tw");
+        let v = twig_vm::run_module_tree(&root, &[dir.as_path()])
+            .expect("full_lex_parse_emit_defexpr: compile+run");
+        assert_eq!(v.as_int(), Some(42),
+            "(main) should return 42 — lex+parse+emit of (define (answer) 42)");
     }
 }

--- a/code/specs/LANG60-tw05g-lambda-and-defexpr.md
+++ b/code/specs/LANG60-tw05g-lambda-and-defexpr.md
@@ -1,0 +1,183 @@
+# LANG60 — TW05-G: Lambda Expressions and Function Definitions
+
+**Status:** In Progress
+**Branch:** `feat/lang60-tw05g-lambda-and-defexpr`
+**Depends on:** LANG59 (TW05-F: self-hosted IIR emitter)
+
+---
+
+## Overview
+
+TW05-G extends the self-hosted Twig compiler with support for **lambda
+expressions** and the **function-definition shorthand**, completing the ability
+to parse and emit complete Twig programs.
+
+The deliverable is updates to three existing modules:
+
+- `compiler/ast.tw` — new `LambdaExpr` variant (tag 11)
+- `compiler/parser.tw` — parse `(lambda (args) body)` and `(define (name args) body)`
+- `compiler/emit.tw` — emit `LambdaExpr` and `DefExpr` with lambda bodies
+
+A smoke-test update to `main.tw` compiles `"(define (answer) 42)"` through the
+full lex → parse → emit pipeline and extracts `42` from the emitted constant
+instruction.
+
+---
+
+## Motivation
+
+Every Twig source file uses `(define (fn args) body)` — the function-definition
+shorthand.  Without it, the self-hosted compiler cannot parse any real Twig
+module, including itself.  TW05-G adds this capability, enabling future
+milestones (TW05-H: self-compilation) to process actual `.tw` source files.
+
+---
+
+## AST change: `LambdaExpr`
+
+A new variant is added to the `Expr` union in `compiler/ast.tw`:
+
+```scheme
+(LambdaExpr (params : any) (body : any) (span : any))
+```
+
+- **Tag**: 11 (auto-assigned after `BeginExpr` at tag 10)
+- **`params`**: a list of parameter-name strings (e.g., `(list "x" "y")`)
+- **`body`**: a single `Expr` representing the function body
+- **Generated exports**: `LambdaExpr`, `LambdaExpr?`,
+  `lambdaexpr-params`, `lambdaexpr-body`, `lambdaexpr-span`
+
+---
+
+## Parser changes
+
+### `(lambda (params) body)` → `LambdaExpr`
+
+New helper chain in `parse-list`:
+
+```scheme
+; Gate 6: `lambda`
+(define (parse-list-6 tokens head-tok head-kind head-lex open-sp)
+  (if (and (TkIdentifier? head-kind) (string=? head-lex "lambda"))
+      (parse-lambda (cdr tokens) open-sp)
+      (parse-call tokens open-sp)))
+```
+
+`parse-lambda`:
+1. Expect `(` — consume it to get the parameter list
+2. `parse-param-list` — read identifier tokens until `)`, collect as list of strings
+3. `parse-expr` — parse the body
+4. Consume the closing `)` of the lambda form
+5. Return `(cons rest (LambdaExpr params body sp))`
+
+### `(define (name args) body)` shorthand
+
+`parse-define` now dispatches on the first token:
+
+- If `TkLParen`: call `parse-define-fn` (function shorthand)
+- Otherwise: call `parse-define-simple` (original `(define name expr)` behaviour)
+
+`parse-define-fn`:
+1. Read the function name token (first after `(`)
+2. `parse-param-list` — read params until `)`
+3. `parse-expr` — parse the body
+4. Consume closing `)`
+5. Return `(cons rest (DefExpr name (LambdaExpr params body sp) sp))`
+
+`parse-define-simple` is the original `parse-define` body (unchanged logic).
+
+---
+
+## Emitter changes
+
+### New dispatch gates
+
+Two new gates are inserted before `CallExpr` in the chain:
+
+| Gate | Predicate | Action |
+|------|-----------|--------|
+| `emit-expr-9` | `DefExpr?` | → `emit-defexpr` |
+| `emit-expr-10` | `LambdaExpr?` | → `emit-lambdaexpr` |
+| `emit-expr-11` | `CallExpr?` / fallback | (was gate 9) |
+
+### `emit-lambdaexpr`
+
+1. Allocate one register per parameter (via `alloc-slot`), bind each to its name in `env`
+2. Emit the body expression with the extended environment
+3. Return `(cons updated-builder body-result-register)`
+
+No "load param" instructions are emitted — the VM's calling convention
+pre-populates parameter registers when calling a function.
+
+### `emit-defexpr`
+
+- If `(defexpr-expr def)` is a `LambdaExpr`: delegate to `emit-lambdaexpr`
+- Otherwise: delegate to `emit-expr` on the body (simple value binding)
+
+---
+
+## Updated `main.tw`
+
+```scheme
+(define (main)
+  ; TW05-G pipeline: lex → parse → emit function definition → 42
+  ;
+  ; (define (answer) 42) parses to:
+  ;   DefExpr "answer" (LambdaExpr [] (IntLit 42 sp) sp)
+  ;
+  ; emit-expr on this DefExpr → emit-lambdaexpr → emit IntLit 42:
+  ;   (IirInstr "const" r0 (list 42) (TInt) sp)
+  ;
+  ; Extracting (car (iirinstr-srcs (car instrs))) = 42.
+  (let* ((tokens  (lex-source "(define (answer) 42)"))
+         (exprs   (parse-program tokens))
+         (expr    (car exprs))
+         (b0      (new-builder "answer"))
+         (env     (env-empty))
+         (result  (emit-expr expr b0 env))
+         (b-final (car result))
+         (instrs  (finalise-builder b-final))
+         (instr   (car instrs)))
+    (car (iirinstr-srcs instr))))   ; → 42
+```
+
+---
+
+## Integration tests (`twig-module-driver` 0.4.0 → 0.5.0)
+
+New `#[cfg(test)] mod tw05g_tests`:
+
+| Test | Verifies |
+|------|----------|
+| `parser_lambda_expr` | `(parse-program "(lambda (x) x)")` → `(LambdaExpr? result) = 1` |
+| `parser_define_fn_form` | `(parse-program "(define (f x) x)")` → `(LambdaExpr? (defexpr-expr def)) = 1` |
+| `emit_lambda_no_params` | emit `(lambda () 99)` → 1 instruction |
+| `emit_lambda_with_param` | emit `(lambda (x) (+ x 1))` → 2 instructions |
+| `emit_defexpr_answer_42` | emit `(define (answer) 42)` → 1 instruction |
+| `full_lex_parse_emit_defexpr` | all 9 modules + main.tw → `(main) = 42` |
+
+---
+
+## Version bumps
+
+| Package | Before | After |
+|---------|--------|-------|
+| `twig-module-driver` | 0.4.0 | 0.5.0 |
+
+---
+
+## Commit sequence
+
+1. `docs(specs)` — this file
+2. `feat(twig)` — `ast.tw` + `parser.tw` + `emit.tw` + updated `main.tw`
+3. `test(twig-module-driver)` — 6 tw05g integration tests, bump 0.5.0
+
+---
+
+## What comes next (TW05-H)
+
+TW05-H will attempt the self-compilation fixed-point: compiling the Twig
+compiler source files through the self-hosted pipeline (lex → parse → emit)
+and verifying that the emitted IIR structure is consistent across runs.  This
+requires the emitter to handle all remaining `Expr` variants and produce
+executable IIR.

--- a/code/twig/compiler/ast.tw
+++ b/code/twig/compiler/ast.tw
@@ -1,4 +1,4 @@
-; # ast.tw — Abstract Syntax Tree Nodes (LANG57 / TW05-D)
+; # ast.tw — Abstract Syntax Tree Nodes (LANG57 / TW05-D, updated LANG60 / TW05-G)
 ;
 ; The `Expr` union covers every expression form that the Twig parser can
 ; produce.  It mirrors the Rust `twig-parser` `Expr` enum, translated into
@@ -9,34 +9,35 @@
 ;
 ; ## Variant overview
 ;
-;   IntLit   (value : int)  (span : any)         integer literal, e.g. `42`
-;   BoolLit  (value : any)  (span : any)         #t or #f
-;   StrLit   (value : any)  (span : any)         "hello"
-;   SymLit   (value : any)  (span : any)         'foo
-;   NilLit   (span : any)                        nil
-;   VarRef   (name  : any)  (span : any)         bare identifier reference
-;   IfExpr   (cond : any) (then-br : any)
-;            (else-br : any) (span : any)        (if c t e)
-;   LetExpr  (bindings : any) (body : any)
-;            (span : any)                        (let ((x e) ...) body)
-;   DefExpr  (name : any) (expr : any)
-;            (span : any)                        (define name expr)
-;   CallExpr (fn-expr : any) (args : any)
-;            (span : any)                        (fn arg ...)
-;   BeginExpr (exprs : any) (span : any)         (begin e1 e2 ...)
+;   IntLit    (value : int)  (span : any)         integer literal, e.g. `42`
+;   BoolLit   (value : any)  (span : any)         #t or #f
+;   StrLit    (value : any)  (span : any)         "hello"
+;   SymLit    (value : any)  (span : any)         'foo
+;   NilLit    (span : any)                        nil
+;   VarRef    (name  : any)  (span : any)         bare identifier reference
+;   IfExpr    (cond : any) (then-br : any)
+;             (else-br : any) (span : any)        (if c t e)
+;   LetExpr   (bindings : any) (body : any)
+;             (span : any)                        (let ((x e) ...) body)
+;   DefExpr   (name : any) (expr : any)
+;             (span : any)                        (define name expr)
+;   CallExpr  (fn-expr : any) (args : any)
+;             (span : any)                        (fn arg ...)
+;   BeginExpr (exprs : any) (span : any)          (begin e1 e2 ...)
+;   LambdaExpr (params : any) (body : any)
+;              (span : any)                       (lambda (p ...) body)
+;                                                 added in TW05-G (LANG60)
 ;
-; Note: `value`, `name`, `span`, `cond`, `then-br`, `else-br`, `bindings`,
-; `body`, `fn-expr`, `args`, and `exprs` are all typed `any` because the
-; Twig type checker does not yet resolve nested record/union types.  The
-; runtime heap enforces the correct structure.
+; Note: all field types are `any` because the Twig type checker does not yet
+; resolve nested record/union types.  The runtime heap enforces structure.
 
 (module compiler/ast
   (typed lenient)
   (export Expr
           IntLit BoolLit StrLit SymLit NilLit VarRef
-          IfExpr LetExpr DefExpr CallExpr BeginExpr
+          IfExpr LetExpr DefExpr CallExpr BeginExpr LambdaExpr
           IntLit? BoolLit? StrLit? SymLit? NilLit? VarRef?
-          IfExpr? LetExpr? DefExpr? CallExpr? BeginExpr?
+          IfExpr? LetExpr? DefExpr? CallExpr? BeginExpr? LambdaExpr?
           intlit-value intlit-span
           boollit-value boollit-span
           strlit-value strlit-span
@@ -47,7 +48,8 @@
           letexpr-bindings letexpr-body letexpr-span
           defexpr-name defexpr-expr defexpr-span
           callexpr-fn-expr callexpr-args callexpr-span
-          beginexpr-exprs beginexpr-span)
+          beginexpr-exprs beginexpr-span
+          lambdaexpr-params lambdaexpr-body lambdaexpr-span)
   (import compiler/span))
 
 ; ── AST node union ───────────────────────────────────────────────────────────
@@ -68,16 +70,18 @@
 ;   8 = DefExpr
 ;   9 = CallExpr
 ;  10 = BeginExpr
+;  11 = LambdaExpr  ← added in TW05-G (LANG60)
 
 (union Expr
-  (IntLit    (value   : int) (span : any))
-  (BoolLit   (value   : any) (span : any))
-  (StrLit    (value   : any) (span : any))
-  (SymLit    (value   : any) (span : any))
-  (NilLit    (span    : any))
-  (VarRef    (name    : any) (span : any))
-  (IfExpr    (cond    : any) (then-br : any) (else-br : any) (span : any))
-  (LetExpr   (bindings : any) (body : any) (span : any))
-  (DefExpr   (name    : any) (expr : any) (span : any))
-  (CallExpr  (fn-expr : any) (args : any) (span : any))
-  (BeginExpr (exprs   : any) (span : any)))
+  (IntLit     (value   : int) (span : any))
+  (BoolLit    (value   : any) (span : any))
+  (StrLit     (value   : any) (span : any))
+  (SymLit     (value   : any) (span : any))
+  (NilLit     (span    : any))
+  (VarRef     (name    : any) (span : any))
+  (IfExpr     (cond    : any) (then-br : any) (else-br : any) (span : any))
+  (LetExpr    (bindings : any) (body : any) (span : any))
+  (DefExpr    (name    : any) (expr : any) (span : any))
+  (CallExpr   (fn-expr : any) (args : any) (span : any))
+  (BeginExpr  (exprs   : any) (span : any))
+  (LambdaExpr (params  : any) (body : any) (span : any)))

--- a/code/twig/compiler/emit.tw
+++ b/code/twig/compiler/emit.tw
@@ -144,9 +144,25 @@
       (emit-letexpr expr b env)
       (emit-expr-9 expr b env)))
 
-; Gate 9: CallExpr — emit arguments, emit call_builtin.
-; Fallback for any unrecognised form: emit nil.
+; Gate 9: DefExpr — delegate to emit-defexpr (added in TW05-G / LANG60).
+; For a simple `(define name expr)` the body is emitted directly.
+; For `(define (fn params) body)` the body is a LambdaExpr, handled by gate 10.
 (define (emit-expr-9 expr b env)
+  (if (DefExpr? expr)
+      (emit-defexpr expr b env)
+      (emit-expr-10 expr b env)))
+
+; Gate 10: LambdaExpr — allocate param slots, extend env, emit body.
+; Added in TW05-G (LANG60).
+(define (emit-expr-10 expr b env)
+  (if (LambdaExpr? expr)
+      (emit-lambdaexpr expr b env)
+      (emit-expr-11 expr b env)))
+
+; Gate 11: CallExpr — emit arguments, emit call_builtin.
+; Fallback for any unrecognised form: emit nil.
+; (Was gate 9 in TW05-F; renumbered in TW05-G to make room for gates 9 and 10.)
+(define (emit-expr-11 expr b env)
   (if (CallExpr? expr)
       (emit-callexpr expr b env)
       (emit-nillit b)))
@@ -381,3 +397,67 @@
              (b2     (car result))
              (reg    (cdr result)))
         (emit-args (cdr args) b2 env (cons reg acc)))))
+
+; ── emit-defexpr ─────────────────────────────────────────────────────────────
+;
+; (DefExpr name expr span)
+;
+; Two sub-cases:
+;   • `expr` is a LambdaExpr   → delegate to emit-lambdaexpr
+;     (handles `(define (fn params) body)` shorthand from the parser)
+;   • `expr` is anything else  → emit the body directly
+;     (handles `(define name value)` simple binding)
+;
+; Returns (cons updated-builder result-register) from whichever delegate is
+; called.  The result register holds the value of the body expression.
+
+(define (emit-defexpr expr b env)
+  (let* ((body (defexpr-expr expr)))
+    (if (LambdaExpr? body)
+        (emit-lambdaexpr body b env)
+        (emit-expr body b env))))
+
+; ── emit-lambdaexpr ───────────────────────────────────────────────────────────
+;
+; (LambdaExpr params body span)
+;
+; params  — a list of parameter-name strings, e.g. `(list "x" "y")`
+; body    — a single Expr representing the function body
+;
+; Behaviour:
+;   1. Allocate one register per parameter via `alloc-slot`.
+;   2. Bind each parameter name to its register in the environment.
+;   3. Emit the body expression with the extended environment.
+;   4. Return (cons updated-builder body-result-register).
+;
+; Why no "load param" instructions?
+;   The VM's calling convention pre-populates the parameter registers before
+;   control reaches the function body.  The emitter only needs to assign
+;   names to the right slots so that VarRef lookups resolve correctly.
+;
+; Instruction count:
+;   Same as emitting the body alone — no extra instructions for params.
+;   Example: `(lambda () 42)` → 1 instruction (const 42).
+;   Example: `(lambda (x) (+ x 1))` → 2 instructions (const 1, call_builtin +).
+
+(define (emit-lambdaexpr expr b env)
+  (let* ((params (lambdaexpr-params expr))
+         (body   (lambdaexpr-body expr))
+         (env-b  (emit-lambda-params params b env))
+         (b2     (car env-b))
+         (env2   (cdr env-b)))
+    (emit-expr body b2 env2)))
+
+; emit-lambda-params: allocate a register for each parameter name and
+; build an extended environment.  Tail-recursive over the params list.
+; Returns (cons updated-builder extended-env).
+
+(define (emit-lambda-params params b env)
+  (if (null? params)
+      (cons b env)
+      (let* ((name  (car params))
+             (p     (alloc-slot b))
+             (b2    (car p))
+             (reg   (car (cdr p)))
+             (env2  (env-extend env name reg)))
+        (emit-lambda-params (cdr params) b2 env2))))

--- a/code/twig/compiler/main.tw
+++ b/code/twig/compiler/main.tw
@@ -1,27 +1,28 @@
-; # main.tw — Root Module + Smoke-Test Entry Point (LANG59 / TW05-F)
+; # main.tw — Root Module + Smoke-Test Entry Point (LANG60 / TW05-G)
 ;
 ; This is the root module of the self-hosted compiler.  It imports all nine
 ; sub-modules (six data-model modules from TW05-D, lexer and parser from
-; TW05-E, and the IIR emitter from TW05-F) and exposes a `(main)` function
-; that exercises the full pipeline:
+; TW05-E, and the IIR emitter from TW05-F/G) and exposes a `(main)` function
+; that exercises the full pipeline including lambda + function-definition
+; support added in TW05-G.
 ;
-;   1. Lex the string `"42"` → list of tokens
-;   2. Parse the token list → list of AST nodes
-;   3. Emit the first AST node (an IntLit) through the IIR emitter
-;   4. Extract the constant value from the emitted instruction
-;   5. Return 42
+; ## TW05-G pipeline (updated from TW05-F)
 ;
-; The `(main)` return value of `42` is the integration test assertion:
-; if the entire module graph compiles and links correctly, and the full
-; lex → parse → emit pipeline correctly round-trips a single integer literal,
-; the result is 42.
+;   lex "(define (answer) 42)"
+;     → [TkLParen, TkIdentifier "define", TkLParen,
+;        TkIdentifier "answer", TkRParen, TkInteger "42", TkRParen, TkEOF]
 ;
-; ## How the round-trip works
+;   parse
+;     → [DefExpr "answer" (LambdaExpr [] (IntLit 42 sp) sp) sp]
 ;
-;   lex "42"                    → [TkInteger "42", TkEOF]
-;   parse                       → [IntLit 42 sp]
-;   emit IntLit 42              → [IirInstr "const" r0 (list 42) (TInt) sp]
-;   (car (iirinstr-srcs instr)) → 42
+;   emit DefExpr
+;     → LambdaExpr? (defexpr-expr def) = #t
+;     → emit-lambdaexpr: no params to allocate, emit body IntLit 42
+;     → [IirInstr "const" r0 (list 42) (TInt) sp]
+;
+;   (car (iirinstr-srcs (car instrs))) = 42
+;
+; The `(main)` return value of `42` is the integration test assertion.
 ;
 ; ## Naming conventions for generated accessors
 ;
@@ -53,35 +54,43 @@
 
 ; ── Entry point ──────────────────────────────────────────────────────────────
 ;
-; `(main)` is the end-to-end smoke test: lex "42", parse it, emit it,
-; extract the constant value from the emitted instruction.
+; `(main)` is the TW05-G end-to-end smoke test:
+;   lex "(define (answer) 42)" → parse → emit function definition → 42
 ;
-; Returns: 42  (the integer literal value round-tripped through lex + parse + emit)
+; The source "(define (answer) 42)" parses to:
+;   DefExpr "answer" (LambdaExpr [] (IntLit 42 sp) sp) sp
+;
+; emit-expr on this DefExpr calls emit-defexpr, which detects a LambdaExpr
+; body and delegates to emit-lambdaexpr.  emit-lambdaexpr allocates no
+; parameter slots (answer takes no args) and emits the body: IntLit 42.
+; Result: one IirInstr "const" r0 (list 42) (TInt) sp.
+;
+; Extracting (car (iirinstr-srcs (car instrs))) gives back 42.
+;
+; Returns: 42
 
 (define (main)
-  ; Step 1: lex the string "42"
-  ; lex-source returns a list: (Token TkInteger "42" sp) (Token TkEOF "" sp)
-  (let* ((tokens  (lex-source "42"))
+  ; TW05-G pipeline: lex → parse → emit function definition → 42
+  (let* ((tokens  (lex-source "(define (answer) 42)"))
 
-         ; Step 2: parse the token list
          ; parse-program returns a list of top-level Expr nodes.
-         ; For "42", the list has one element: (IntLit 42 sp).
+         ; For "(define (answer) 42)", the list has one element:
+         ;   DefExpr "answer" (LambdaExpr [] (IntLit 42 sp) sp) sp
          (exprs   (parse-program tokens))
 
-         ; Step 3: emit the first (and only) expression
          ; emit-expr returns (cons updated-builder result-register).
+         ; For a DefExpr with LambdaExpr body, it calls emit-lambdaexpr
+         ; which emits the body (IntLit 42 → const instruction).
          (expr    (car exprs))
-         (b0      (new-builder "main-test"))
+         (b0      (new-builder "answer"))
          (env     (env-empty))
          (result  (emit-expr expr b0 env))
          (b-final (car result))
 
-         ; Step 4: finalise the builder to get the instruction list.
-         ; For IntLit 42, this is [(IirInstr "const" r0 (list 42) (TInt) sp)].
+         ; finalise-builder reverses the accumulated instruction list.
+         ; For (define (answer) 42) this is:
+         ;   [(IirInstr "const" r0 (list 42) (TInt) sp)]
          (instrs  (finalise-builder b-final))
-
-         ; Step 5: extract the first instruction and read its srcs list.
-         ; srcs = (list 42), so (car srcs) = 42.
          (instr   (car instrs)))
 
     ; The `srcs` field of a const instruction holds the operand value.

--- a/code/twig/compiler/parser.tw
+++ b/code/twig/compiler/parser.tw
@@ -134,13 +134,63 @@
   (if (and (TkIdentifier? head-kind)
            (or (string=? head-lex "let") (string=? head-lex "let*")))
       (parse-let (cdr tokens) open-sp)
+      (parse-list-6 tokens head-tok head-kind head-lex open-sp)))
+
+; Gate 6: `lambda`
+(define (parse-list-6 tokens head-tok head-kind head-lex open-sp)
+  (if (and (TkIdentifier? head-kind) (string=? head-lex "lambda"))
+      ; tokens starts AT `lambda`; cdr skips past it to the `(` of params
+      (parse-lambda (cdr tokens) open-sp)
       ; Fallback: general call (fn arg …)
       (parse-call tokens open-sp)))
 
 ; ── Special form parsers ──────────────────────────────────────────────────────
 
-; Parse `(define name expr)` — tokens start AFTER `define`.
+; Parse `(define …)` — tokens start AFTER `define`.
+;
+; Two forms are supported:
+;   (define name expr)           → DefExpr name expr
+;   (define (name params) body)  → DefExpr name (LambdaExpr params body)
+;
+; The first token tells us which branch to take:
+;   TkLParen → function-definition shorthand
+;   otherwise → simple value binding
 (define (parse-define tokens open-sp)
+  (let* ((first-tok  (car tokens))
+         (first-kind (token-kind first-tok)))
+    (if (TkLParen? first-kind)
+        ; Function shorthand: consume `(` and parse (name params) + body
+        (parse-define-fn (cdr tokens) open-sp)
+        ; Simple binding: parse as before
+        (parse-define-simple tokens open-sp))))
+
+; Parse the function-definition shorthand `(define (name params) body)`.
+; tokens start AFTER the `(` of `(name params)`.
+;
+; Steps:
+;   1. Read function name (first identifier)
+;   2. Collect parameters until `)`
+;   3. Parse body expression
+;   4. Consume closing `)` of the define form
+;   5. Return DefExpr name (LambdaExpr params body sp)
+(define (parse-define-fn tokens open-sp)
+  (let* ((name-tok     (car tokens))
+         (name-lex     (token-lexeme name-tok))
+         (after-name   (cdr tokens))
+         (params-r     (parse-param-list after-name (list)))
+         (after-params (car params-r))
+         (params       (cdr params-r))
+         (body-r       (parse-expr after-params))
+         (after-body   (car body-r))
+         (body-expr    (cdr body-r))
+         (lambda-expr  (LambdaExpr params body-expr open-sp)))
+    ; consume the closing `)` of the define form
+    (cons (cdr after-body)
+          (DefExpr name-lex lambda-expr open-sp))))
+
+; Parse `(define name expr)` — original simple form.
+; tokens start AT the name token (AFTER `define`).
+(define (parse-define-simple tokens open-sp)
   (let* ((name-tok    (car tokens))
          (name-lex    (token-lexeme name-tok))
          (after-name  (cdr tokens))
@@ -150,6 +200,40 @@
     ; consume closing `)`
     (cons (cdr after-body)
           (DefExpr name-lex body-expr open-sp))))
+
+; Parse `(lambda (params) body)` — tokens start AFTER `lambda`, at `(`.
+;
+; Steps:
+;   1. Consume `(` — tokens starts at it
+;   2. Collect parameter names until `)`
+;   3. Parse body expression
+;   4. Consume closing `)` of the lambda form
+;   5. Return LambdaExpr params body sp
+(define (parse-lambda tokens open-sp)
+  ; tokens is AT the `(` opening the param list — consume it
+  (let* ((after-lp     (cdr tokens))
+         (params-r     (parse-param-list after-lp (list)))
+         (after-params (car params-r))
+         (params       (cdr params-r))
+         (body-r       (parse-expr after-params))
+         (after-body   (car body-r))
+         (body-expr    (cdr body-r)))
+    ; consume the closing `)` of the lambda form
+    (cons (cdr after-body)
+          (LambdaExpr params body-expr open-sp))))
+
+; Collect parameter name strings until `)`.
+; tokens starts at the first param identifier (or `)` for no-param lambdas).
+; Returns (cons rest-after-rparen list-of-name-strings).
+(define (parse-param-list tokens acc)
+  (let* ((tok  (car tokens))
+         (kind (token-kind tok))
+         (lex  (token-lexeme tok)))
+    (if (TkRParen? kind)
+        ; `)` ends the param list — consume it and return accumulated names
+        (cons (cdr tokens) (reverse acc))
+        ; identifier — add its lexeme to the accumulator
+        (parse-param-list (cdr tokens) (cons lex acc)))))
 
 ; Parse `(if cond then else)` — tokens start AFTER `if`.
 (define (parse-if tokens open-sp)


### PR DESCRIPTION
## Summary

- **`compiler/ast.tw`**: New `LambdaExpr` variant (tag 11) with `params`, `body`, `span` fields; adds `LambdaExpr?` predicate and `lambdaexpr-*` accessors to exports
- **`compiler/parser.tw`**: Adds `(lambda (params) body)` parsing (gate 6 + `parse-lambda` + `parse-param-list`); updates `parse-define` to dispatch function shorthand `(define (name args) body)` → `DefExpr name (LambdaExpr params body sp)`
- **`compiler/emit.tw`**: Inserts gates 9 (DefExpr → `emit-defexpr`) and 10 (LambdaExpr → `emit-lambdaexpr`) before the CallExpr gate (renumbered to 11); param slots allocated without load instructions (VM calling convention pre-populates registers)
- **`compiler/main.tw`**: Updated TW05-G smoke test: lexes `"(define (answer) 42)"` through the full pipeline, still returns 42
- **`twig-module-driver`**: 6 new `tw05g_tests` integration tests; version bump 0.4.0 → 0.5.0

## Test plan

- [x] `cargo test -p twig-module-driver --lib -- tw05g` — all 6 new tests pass
- [x] `cargo test -p twig-module-driver --lib` — all 38 tests pass (32 existing + 6 new)
- [x] `cargo build -p twig-module-driver -p twig-vm -p twig-ir-compiler -p twig-parser` — clean build
- [x] Security review passed (no vulnerabilities found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)