### PR TITLE
feat(forme-pipeline-config): Forme orchestrator config layer (FM03 §2)

### DIFF
--- a/code/packages/typescript/forme-pipeline-config/BUILD
+++ b/code/packages/typescript/forme-pipeline-config/BUILD
@@ -1,0 +1,6 @@
+cd ../document-ast && npm install --silent
+cd ../forme-types && npm install --silent
+cd ../forme-errors && npm install --silent
+cd ../forme-capability && npm install --silent
+cd ../forme-stage && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-pipeline-config/CHANGELOG.md
+++ b/code/packages/typescript/forme-pipeline-config/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog — @coding-adventures/forme-pipeline-config
+
+## 0.1.0 — 2026-05-15
+
+Initial release. First package of the FM03 orchestrator stack — the
+user-authored description of *what to build* (PipelineConfig types,
+validator, TS-form loader).
+
+### Added
+
+- `PipelineConfig` interface with `name`, `settings`, `stages`,
+  optional `wires`, optional `outputs`.
+- `PipelineSettings` — storageRoot, cacheDir, reproducibleBuild,
+  maxConcurrency, logLevel, bestEffort, deadlineMs.
+- `StageInstanceSpec` with optional `id`, `config`, `capabilities`.
+- `StageRef` (`{ kind: "stage-ref", packageName, export? }`) for
+  the future FM02 plugin-host flow.
+- `isStageRef(value)` predicate.
+- `EdgeSpec` and `OutputSpec` for explicit wiring + named outputs.
+- `validateConfig(config)` — collects every FM03 §2.4 violation in
+  one pass, throws a single `ConfigError` summarising all of them.
+  Returns a `ResolvedPipelineConfig` carrying the original config
+  plus per-spec resolved instance IDs.
+- `ConfigError` with structured `errors[]` array; `name = "ConfigError"`,
+  multi-line summary in `message`. Entries are frozen.
+- `CONFIG_ERROR_CODES` (frozen) and `ConfigErrorCode` type alias —
+  `DUPLICATE_INSTANCE_ID`, `API_VERSION_MISMATCH`,
+  `STAGE_REF_UNRESOLVED`, `CAPABILITY_NOT_DECLARED`, `CONFIG_REQUIRED`,
+  `MULTIPLE_OUTPUTS_UNNAMED`, `UNKNOWN_INSTANCE_ID`,
+  `INVALID_STAGE_VALUE`, `MALFORMED`.
+- `loadTsConfig(path, options?)` — dynamically imports a
+  `forme.config.ts` and returns its default export. Resolves
+  relative paths against the supplied (or current) working
+  directory; converts to a `file://` URL for cross-platform
+  compatibility. Wraps import errors with the file:// URL in the
+  message. Test hook (`importModule` option) for unit tests.
+
+### Spec divergences from FM03 §2
+
+- **JSON-Schema validation** of stage configs is deferred to the
+  orchestrator. The validator only enforces the *presence* rule
+  (`configSchema !== null` ⇒ `config !== undefined`); structural
+  schema validation needs a JSON-Schema validator that doesn't yet
+  live in the monorepo.
+- **TOML form loader** (FM03 §2.3) is not implemented in v0. The
+  TS form is the canonical surface; a TOML loader will compile to
+  the same `PipelineConfig` shape in a sibling package.
+
+### Notes
+
+- Multiple-terminal detection uses a coarse heuristic: any stage
+  whose `produces.name` is in `{DeployArtifact, RequestHandler,
+  Feed, SearchIndex}` counts as terminal. The orchestrator's full
+  DAG construction (FM03 §3.3) does the precise determination later;
+  this catches the common "I forgot to name my outputs" mistake at
+  config time.

--- a/code/packages/typescript/forme-pipeline-config/README.md
+++ b/code/packages/typescript/forme-pipeline-config/README.md
@@ -1,0 +1,62 @@
+# @coding-adventures/forme-pipeline-config
+
+The user-authored description of *what to build* — `PipelineConfig` types, validator, and TS-form config loader. First package of the Forme orchestrator stack (FM03 §2).
+
+## What's exported
+
+| Group       | Exports                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------- |
+| Types       | `PipelineConfig`, `PipelineSettings`, `StageInstanceSpec`, `StageRef`, `EdgeSpec`, `OutputSpec` |
+| Predicates  | `isStageRef(value)`                                                                             |
+| Validation  | `validateConfig(config)` → `ResolvedPipelineConfig` (or throws `ConfigError`)                    |
+| Errors      | `ConfigError`, `ConfigErrorEntry`, `ConfigErrorCode`, `CONFIG_ERROR_CODES`                       |
+| Loading     | `loadTsConfig(path, options?)` → `Promise<PipelineConfig>`                                       |
+
+## Validation rules (FM03 §2.4)
+
+`validateConfig` enforces every spec rule in one pass and collects every violation before throwing:
+
+1. **`STAGE_REF_UNRESOLVED`** — `StageRef` requires the FM02 plugin host. v0 supports direct-import flows only.
+2. **`INVALID_STAGE_VALUE`** — stage missing required identification fields.
+3. **`API_VERSION_MISMATCH`** — stage targets a different `KERNEL_API_VERSION`.
+4. **`DUPLICATE_INSTANCE_ID`** — multiple instances resolve to the same id (auto-derived from `stage.name`, or explicit).
+5. **`CAPABILITY_NOT_DECLARED`** — per-instance grants must be a subset of the stage's declared capabilities (FM01 §5.5).
+6. **`CONFIG_REQUIRED`** — stage with non-null `configSchema` was given no config.
+7. **`UNKNOWN_INSTANCE_ID`** — `EdgeSpec` or `OutputSpec` references a non-existent instance.
+8. **`MULTIPLE_OUTPUTS_UNNAMED`** — pipeline has 2+ terminal stages but doesn't name them in `outputs`.
+9. **`MALFORMED`** — top-level fields or settings have wrong types.
+
+The validator collects ALL violations rather than stopping at the first. `ConfigError.errors` carries the full list; `ConfigError.message` is a multi-line summary.
+
+## Quick reference
+
+```typescript
+import {
+  loadTsConfig,
+  validateConfig,
+  ConfigError,
+} from "@coding-adventures/forme-pipeline-config";
+
+try {
+  const config = await loadTsConfig("./forme.config.ts");
+  const resolved = validateConfig(config);
+  // resolved.config + resolved.resolvedIds — ready for the orchestrator
+} catch (e) {
+  if (e instanceof ConfigError) {
+    for (const { path, code, message } of e.errors) {
+      console.error(`  ${path}: ${message} [${code}]`);
+    }
+  } else {
+    throw e;
+  }
+}
+```
+
+## Coverage
+
+```bash
+npm install
+npx vitest run --coverage
+```
+
+Targets 100% line + branch.

--- a/code/packages/typescript/forme-pipeline-config/package-lock.json
+++ b/code/packages/typescript/forme-pipeline-config/package-lock.json
@@ -1,0 +1,2370 @@
+{
+  "name": "@coding-adventures/forme-pipeline-config",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-pipeline-config",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-capability": "file:../forme-capability",
+        "@coding-adventures/forme-errors": "file:../forme-errors",
+        "@coding-adventures/forme-stage": "file:../forme-stage",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-capability": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-errors": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-stage": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-capability": "file:../forme-capability",
+        "@coding-adventures/forme-errors": "file:../forme-errors",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-types": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-capability": {
+      "resolved": "../forme-capability",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-errors": {
+      "resolved": "../forme-errors",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-stage": {
+      "resolved": "../forme-stage",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-types": {
+      "resolved": "../forme-types",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-pipeline-config/package.json
+++ b/code/packages/typescript/forme-pipeline-config/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@coding-adventures/forme-pipeline-config",
+  "version": "0.1.0",
+  "description": "Forme orchestrator: PipelineConfig types, validator, and TS-form config loader (FM03 §2).",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-types": "file:../forme-types",
+    "@coding-adventures/forme-stage": "file:../forme-stage",
+    "@coding-adventures/forme-capability": "file:../forme-capability",
+    "@coding-adventures/forme-errors": "file:../forme-errors"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-pipeline-config/required_capabilities.json
+++ b/code/packages/typescript/forme-pipeline-config/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-pipeline-config",
+  "capabilities": [],
+  "justification": "Pure types and a pure validator. The TS-config loader uses dynamic import which is a Node/runtime primitive, not a kernel-gated capability — it's how every TypeScript app loads modules and the orchestrator decides whether the surrounding context is trusted enough to invoke it."
+}

--- a/code/packages/typescript/forme-pipeline-config/src/errors.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/errors.ts
@@ -1,0 +1,90 @@
+/**
+ * `ConfigError` — typed validation errors raised by `validateConfig`.
+ *
+ * Per FM03 §2.4, every error carries:
+ *
+ *   - The failing field path (`"stages[2].id"`, `"settings.maxConcurrency"`)
+ *   - The rule that was violated (machine-readable code)
+ *   - A human-readable remediation message
+ *
+ * `ConfigError` is *not* a `StageError` — it surfaces before any stage
+ * runs, during the orchestrator's resolve/typecheck phase, and the
+ * orchestrator's per-stage error boundary doesn't apply here.  The CLI
+ * (and dev-server, and editor preview) format these with their own UI.
+ *
+ * The validator collects ALL violations across the config rather than
+ * stopping at the first.  This is a usability lever — users want to
+ * see every problem in one pass, not chase them one at a time.  The
+ * thrown `ConfigError` carries an `errors[]` array of all violations;
+ * its top-level `code`/`message` summarise the count.
+ */
+
+export interface ConfigErrorEntry {
+  /** JSON-pointer-ish path to the offending field. */
+  readonly path: string;
+  /** Machine-readable rule code (e.g. "DUPLICATE_INSTANCE_ID"). */
+  readonly code: string;
+  /** Human-readable explanation + remediation. */
+  readonly message: string;
+}
+
+/**
+ * Aggregate validation failure.  Subclass `Error` so existing
+ * `instanceof Error` boundaries (Vitest, IDE error reporters) handle
+ * it correctly.
+ */
+export class ConfigError extends Error {
+  readonly errors: readonly ConfigErrorEntry[];
+
+  constructor(errors: readonly ConfigErrorEntry[]) {
+    if (errors.length === 0) {
+      throw new Error("ConfigError must be constructed with at least one entry");
+    }
+    super(buildSummary(errors));
+    this.name = "ConfigError";
+    this.errors = Object.freeze(errors.map(e => Object.freeze({ ...e })));
+  }
+}
+
+function buildSummary(errors: readonly ConfigErrorEntry[]): string {
+  if (errors.length === 1) {
+    const e = errors[0]!;
+    return `Pipeline config invalid: ${e.path}: ${e.message} [${e.code}]`;
+  }
+  const lines = errors.map(e => `  - ${e.path}: ${e.message} [${e.code}]`);
+  return `Pipeline config invalid (${errors.length} errors):\n${lines.join("\n")}`;
+}
+
+/**
+ * Canonical rule codes the validator emits.  Matches the spec rules
+ * in FM03 §2.4.  Stages and the orchestrator MAY introduce additional
+ * codes via the `<package>/<code>` convention; the kernel reserves
+ * the unprefixed names below.
+ */
+export const CONFIG_ERROR_CODES = Object.freeze({
+  /** Two stage instances share the same `id` (or default-derived id). */
+  DUPLICATE_INSTANCE_ID:     "DUPLICATE_INSTANCE_ID",
+  /** A stage value is missing required fields (name, version, …). */
+  INVALID_STAGE_VALUE:       "INVALID_STAGE_VALUE",
+  /** Stage targets an `apiVersion` the kernel doesn't support. */
+  API_VERSION_MISMATCH:      "API_VERSION_MISMATCH",
+  /**
+   * A `StageRef` slipped through without a plugin host loaded.
+   * v0's default-direct-import host refuses these.
+   */
+  STAGE_REF_UNRESOLVED:      "STAGE_REF_UNRESOLVED",
+  /** An instance requests a capability the stage's manifest doesn't declare. */
+  CAPABILITY_NOT_DECLARED:   "CAPABILITY_NOT_DECLARED",
+  /** A stage demands a config but none was provided. */
+  CONFIG_REQUIRED:           "CONFIG_REQUIRED",
+  /**
+   * Multiple terminal stages (no consumer) exist without a matching
+   * `OutputSpec` for each (FM03 §3.3 step 5).
+   */
+  MULTIPLE_OUTPUTS_UNNAMED:  "MULTIPLE_OUTPUTS_UNNAMED",
+  /** An `EdgeSpec` or `OutputSpec` references an instance ID that doesn't exist. */
+  UNKNOWN_INSTANCE_ID:       "UNKNOWN_INSTANCE_ID",
+  /** Top-level field is missing or has the wrong type. */
+  MALFORMED:                 "MALFORMED",
+} as const);
+export type ConfigErrorCode = (typeof CONFIG_ERROR_CODES)[keyof typeof CONFIG_ERROR_CODES];

--- a/code/packages/typescript/forme-pipeline-config/src/index.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/index.ts
@@ -1,0 +1,46 @@
+/**
+ * @coding-adventures/forme-pipeline-config
+ *
+ * The user-authored description of *what to build* — `PipelineConfig`
+ * types, validator, and TS-form loader.
+ *
+ * Three responsibilities:
+ *
+ *   - **Types** — `PipelineConfig`, `PipelineSettings`,
+ *     `StageInstanceSpec`, `StageRef`, `EdgeSpec`, `OutputSpec`.
+ *
+ *   - **Validation** — `validateConfig(config)` checks every FM03 §2.4
+ *     rule (unique IDs, capability subset, apiVersion match, …),
+ *     collects every violation, and throws a single `ConfigError`
+ *     summarising all of them.
+ *
+ *   - **Loading** — `loadTsConfig(path)` dynamically imports a TS-form
+ *     `forme.config.ts` and returns its default export, ready to be
+ *     fed to `validateConfig`.
+ *
+ * See FM03 §2 for the design.  The TOML-form loader (FM03 §2.3) lives
+ * in a sibling package (not yet built); both forms produce the same
+ * `PipelineConfig` shape declared here.
+ */
+
+export type {
+  PipelineConfig,
+  PipelineSettings,
+  StageInstanceSpec,
+  StageRef,
+  EdgeSpec,
+  OutputSpec,
+} from "./types.js";
+export { isStageRef } from "./types.js";
+
+export {
+  CONFIG_ERROR_CODES,
+  ConfigError,
+} from "./errors.js";
+export type { ConfigErrorEntry, ConfigErrorCode } from "./errors.js";
+
+export { validateConfig } from "./validate.js";
+export type { ResolvedPipelineConfig } from "./validate.js";
+
+export { loadTsConfig } from "./load.js";
+export type { LoadTsConfigOptions } from "./load.js";

--- a/code/packages/typescript/forme-pipeline-config/src/load.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/load.ts
@@ -1,0 +1,109 @@
+/**
+ * `loadTsConfig` — load a `forme.config.ts` (or `.js`) module by path
+ * and extract its default-exported `PipelineConfig`.
+ *
+ * The contract is intentionally tiny: hand a path, get back the
+ * config object.  No validation, no DAG construction — those happen
+ * in `validateConfig` and the orchestrator respectively.
+ *
+ * === Why dynamic import? ===
+ *
+ * The TS form lets stages be referenced *by value* (imported and passed
+ * directly), so the config has to be evaluated as JavaScript.  Static
+ * `import` won't do — the path is data, not a literal.  Dynamic
+ * `import()` is the standard Node/browser primitive for this and works
+ * with `tsx`, `ts-node`, ESM Node, and bundlers.
+ *
+ * === Path resolution ===
+ *
+ * We require an absolute path or `file://` URL.  Relative paths get
+ * resolved against the current working directory — but that's a
+ * footgun (CWD varies with how the orchestrator was invoked) so we
+ * normalise to a `file://` URL up front and surface bad paths as
+ * thrown errors with a clear message.
+ *
+ * === Why not parse the source ===
+ *
+ * Parsing TypeScript without executing it would let us inspect the
+ * config without running side effects, but it would also force us to
+ * statically resolve all `import` statements — duplicating what the
+ * Node/TS toolchain already does.  Executing the module via dynamic
+ * import is the conventional approach for tools like Vite, Astro, and
+ * Vitest's own config loading.  The cost is that a config file with
+ * top-level side effects will run them; the spec already constrains
+ * configs to be effect-free.
+ */
+
+import { pathToFileURL } from "node:url";
+import { resolve as resolvePath, isAbsolute } from "node:path";
+import type { PipelineConfig } from "./types.js";
+
+export interface LoadTsConfigOptions {
+  /**
+   * Working directory to resolve relative paths against.  Default:
+   * `process.cwd()`.  Tests pin this so they don't depend on the
+   * caller's CWD.
+   */
+  readonly cwd?: string;
+  /**
+   * Override the dynamic-import implementation.  Test hook — production
+   * uses the platform's `import()`.
+   */
+  readonly importModule?: (specifier: string) => Promise<unknown>;
+}
+
+/**
+ * Load a `forme.config.{ts,js,mjs}` file and return its default-exported
+ * `PipelineConfig` value.  Throws a clear error if the path doesn't
+ * resolve, the module fails to import, or the default export is missing.
+ *
+ * The returned config is *not* validated — callers should pass it to
+ * `validateConfig` next.
+ */
+export async function loadTsConfig(
+  path: string,
+  options: LoadTsConfigOptions = {},
+): Promise<PipelineConfig> {
+  if (typeof path !== "string" || path.length === 0) {
+    throw new Error("loadTsConfig: path must be a non-empty string");
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const absolute = isAbsolute(path) ? path : resolvePath(cwd, path);
+  // Convert to file:// URL so the dynamic import works on Windows where
+  // bare paths can be ambiguous (drive-letter prefix vs. URL scheme).
+  const specifier = pathToFileURL(absolute).href;
+
+  const importer = options.importModule ?? defaultImport;
+  let mod: unknown;
+  try {
+    mod = await importer(specifier);
+  } catch (err) {
+    throw new Error(
+      `loadTsConfig: failed to import ${specifier}: ${stringify(err)}`,
+    );
+  }
+
+  if (typeof mod !== "object" || mod === null) {
+    throw new Error(
+      `loadTsConfig: ${specifier} did not produce an object (got ${typeof mod})`,
+    );
+  }
+  const config = (mod as { default?: unknown }).default;
+  if (typeof config !== "object" || config === null) {
+    throw new Error(
+      `loadTsConfig: ${specifier} has no default export of a PipelineConfig object`,
+    );
+  }
+  return config as PipelineConfig;
+}
+
+function defaultImport(specifier: string): Promise<unknown> {
+  // Wrapped so test hooks can replace just the import call.
+  return import(specifier);
+}
+
+function stringify(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try { return String(err); } catch { return "<unstringifiable>"; }
+}

--- a/code/packages/typescript/forme-pipeline-config/src/types.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/types.ts
@@ -1,0 +1,155 @@
+/**
+ * `PipelineConfig` and friends — the user-authored description of *what
+ * to build* (FM03 §2).
+ *
+ * Two surface forms in the spec — TypeScript and TOML — share this
+ * single underlying type.  v0 implements the TypeScript form only
+ * (`loadTsConfig`); the TOML loader lives in a sibling that compiles
+ * to the same shape and is gated behind FM03's "TOML-only feature is
+ * a feature gap" rule.
+ *
+ * === Stages by value vs. by reference ===
+ *
+ * In the TS form, `stage` is an imported `Stage<In, Out>` value — the
+ * compiler verifies the consumes/produces descriptors at edit time.
+ *
+ * In the TOML form (and in plugin-host flows generally), `stage` is a
+ * `StageRef` naming a package; FM02's plugin host resolves it to a
+ * loaded Stage at typecheck time.  v0 doesn't ship FM02, so the
+ * default-direct-import host (FM03 §12) treats every direct value as
+ * already-loaded and refuses to honour `StageRef`s.
+ *
+ * === Why optional `id`, `wires`, `outputs`, and `capabilities` ===
+ *
+ * The common case is a linear pipeline of unique stages — one
+ * `source-fs`, one `parse-markdown`, one `render-static`, one
+ * `emit-fs`.  Defaults handle that:
+ *
+ *   - `id` defaults to `stage.name` when no other instance shares it.
+ *     The validator rejects collisions and demands explicit IDs only
+ *     when the same stage appears more than once.
+ *
+ *   - `wires` is empty: edges are inferred from kind compatibility,
+ *     declaration order is the tiebreaker (FM03 §3.3).
+ *
+ *   - `outputs` is required only when more than one emitter is
+ *     present (FM03 §3.3 step 5).  A single-emitter pipeline doesn't
+ *     need to name its sole output.
+ *
+ *   - Per-instance `capabilities` defaults to the stage's own
+ *     declarations.  Override only when the host wants to grant a
+ *     subset (e.g. a pipeline run that explicitly denies network
+ *     access for one specific instance).
+ */
+
+import type {
+  KindDescriptor,
+} from "@coding-adventures/forme-types";
+import type { Stage } from "@coding-adventures/forme-stage";
+import type { Capability } from "@coding-adventures/forme-capability";
+
+// ─── Settings ─────────────────────────────────────────────────────────────
+
+/** Pipeline-wide settings — see FM03 §2.1 PipelineSettings. */
+export interface PipelineSettings {
+  /** Storage root for the pipeline's StorageApi. */
+  readonly storageRoot: string;
+  /** Where the orchestrator's persistent cache lives, or null to disable. */
+  readonly cacheDir: string | null;
+  /** Reproducible-build mode (FM03 §8). */
+  readonly reproducibleBuild: boolean;
+  /** Maximum stage-level parallelism.  Null = hardware concurrency. */
+  readonly maxConcurrency: number | null;
+  /** Logging verbosity. */
+  readonly logLevel: "trace" | "debug" | "info" | "warn" | "error";
+  /** Continue past recoverable errors and report at the end. */
+  readonly bestEffort: boolean;
+  /** Maximum wall-clock for the entire run.  Null = unlimited. */
+  readonly deadlineMs: number | null;
+}
+
+// ─── Stage references ─────────────────────────────────────────────────────
+
+/**
+ * Indirect reference to a stage that the plugin host (FM02) resolves
+ * at typecheck time.  v0's default-direct-import host refuses to load
+ * these — see FM03 §12.
+ */
+export interface StageRef {
+  readonly kind: "stage-ref";
+  /** Package name as known to the plugin host. */
+  readonly packageName: string;
+  /** Optional sub-export name; defaults to `default`. */
+  readonly export?: string;
+}
+
+/** Predicate: is this value a `StageRef` rather than a direct `Stage`? */
+export function isStageRef(value: unknown): value is StageRef {
+  return (
+    typeof value === "object"
+    && value !== null
+    && (value as { kind?: unknown }).kind === "stage-ref"
+    && typeof (value as { packageName?: unknown }).packageName === "string"
+  );
+}
+
+// ─── Stage instance spec ──────────────────────────────────────────────────
+
+/** One use of a stage in a pipeline.  Same stage can appear multiple times. */
+export interface StageInstanceSpec {
+  /**
+   * The stage value or a deferred `StageRef` for the plugin host to
+   * resolve.  Direct-import flows pass values; manifest flows pass refs.
+   */
+  readonly stage: Stage<KindDescriptor, KindDescriptor> | StageRef;
+  /**
+   * Stable, user-chosen instance ID.  Defaults to `stage.name` when
+   * no other instance shares it; required when collisions exist.
+   */
+  readonly id?: string;
+  /** Configuration passed to the stage.  Validated against `stage.configSchema`. */
+  readonly config?: unknown;
+  /**
+   * Capability grants for this instance.  Defaults to the stage's own
+   * declared capabilities; explicit grants must be a subset.
+   */
+  readonly capabilities?: readonly Capability[];
+}
+
+// ─── Edges & outputs ──────────────────────────────────────────────────────
+
+/** Explicit edge from one instance's output to another's input. */
+export interface EdgeSpec {
+  readonly from: { readonly id: string; readonly port?: string };
+  readonly to:   { readonly id: string; readonly port?: string };
+}
+
+/** Friendly name for an emitter's output, required when >1 emitter exists. */
+export interface OutputSpec {
+  readonly fromInstance: string;
+  readonly name: string;
+}
+
+// ─── PipelineConfig ───────────────────────────────────────────────────────
+
+/**
+ * The complete user-authored description of a pipeline.  In TypeScript
+ * form, default-exported by a `forme.config.ts` and consumed by the
+ * orchestrator via `loadTsConfig` + `validateConfig`.
+ */
+export interface PipelineConfig {
+  /** Human-friendly identifier used in logs and the dev-server UI. */
+  readonly name: string;
+  /** Pipeline-wide settings. */
+  readonly settings: PipelineSettings;
+  /**
+   * Ordered list of stage instances.  Order is human-readability +
+   * tiebreaking only — the orchestrator infers the actual DAG from
+   * declared kinds (FM03 §3.3).
+   */
+  readonly stages: readonly StageInstanceSpec[];
+  /** Explicit edges, used when type inference is ambiguous.  Empty by default. */
+  readonly wires?: readonly EdgeSpec[];
+  /** Output destinations when more than one emitter is present. */
+  readonly outputs?: readonly OutputSpec[];
+}

--- a/code/packages/typescript/forme-pipeline-config/src/validate.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/validate.ts
@@ -1,0 +1,363 @@
+/**
+ * `validateConfig` — checks a `PipelineConfig` against every FM03 §2.4
+ * rule and returns a `ResolvedPipelineConfig` (the input plus
+ * orchestrator-friendly derived fields like resolved instance IDs).
+ *
+ * Rules enforced (per FM03 §2.4 + the pragmatic v0 cuts):
+ *
+ *   1. Every `StageInstanceSpec.stage` is a loaded `Stage` value
+ *      (StageRef → STAGE_REF_UNRESOLVED in v0; FM02 will resolve).
+ *   2. Every stage value carries the required identification fields.
+ *   3. Every stage's `apiVersion` matches `KERNEL_API_VERSION`.
+ *   4. Every instance has a unique resolved ID.  The validator
+ *      auto-derives `stage.name` when no collision exists; collisions
+ *      require explicit `id` on every colliding spec.
+ *   5. Per-instance capability grants must be a subset of the stage's
+ *      declared capabilities (FM01 §5.5: a stage can't be granted
+ *      what it didn't ask for).
+ *   6. Stages with non-null `configSchema` need a non-undefined config.
+ *      (Full JSON-Schema validation is deferred to the orchestrator;
+ *      we only enforce the presence rule here.)
+ *   7. Wires/outputs reference real instance IDs.
+ *   8. If more than one terminal stage exists (no consumer), each
+ *      must have a corresponding `OutputSpec`.
+ *
+ * The validator collects ALL violations rather than throwing on the
+ * first.  Users want to see every problem in one pass — chasing them
+ * one at a time is the slowest possible feedback loop for config UX.
+ */
+
+import { KERNEL_API_VERSION } from "@coding-adventures/forme-types";
+import { isStageRef } from "./types.js";
+import { CONFIG_ERROR_CODES, ConfigError } from "./errors.js";
+import type { ConfigErrorEntry } from "./errors.js";
+import type {
+  PipelineConfig,
+  PipelineSettings,
+  StageInstanceSpec,
+} from "./types.js";
+
+/** Resolved view of a config — same as input plus derived instance IDs. */
+export interface ResolvedPipelineConfig {
+  readonly config: PipelineConfig;
+  /**
+   * Per-spec resolved instance ID, in the same order as
+   * `config.stages`.  `resolvedIds[i]` is the ID for `config.stages[i]`.
+   */
+  readonly resolvedIds: readonly string[];
+}
+
+/**
+ * Validate a config and return a resolved view.  Throws `ConfigError`
+ * (carrying the full list of violations) on any failure.
+ */
+export function validateConfig(config: PipelineConfig): ResolvedPipelineConfig {
+  const errors: ConfigErrorEntry[] = [];
+
+  // Top-level shape.  We record violations but only bail when the
+  // remaining checks would crash (config null, or `stages` not an
+  // array we can iterate).  Continuing past lesser top-level mistakes
+  // lets us surface every downstream problem in one pass — users want
+  // the full punch list, not just the first symptom.
+  if (typeof config !== "object" || config === null) {
+    errors.push({ path: "$", code: CONFIG_ERROR_CODES.MALFORMED, message: "config is not an object" });
+    throw new ConfigError(errors);
+  }
+  recordTopShapeIssues(config, errors);
+  if (!Array.isArray(config.stages)) {
+    // Already recorded.  Per-instance loop would crash without an array.
+    throw new ConfigError(errors);
+  }
+
+  if (typeof config.settings === "object" && config.settings !== null) {
+    validateSettings(config.settings, errors);
+  }
+
+  const resolvedIds = resolveInstanceIds(config.stages, errors);
+
+  for (let i = 0; i < config.stages.length; i++) {
+    validateStageInstance(config.stages[i]!, i, errors);
+  }
+
+  // ID-dependent rules require the resolution pass to have run first.
+  const idSet = new Set(resolvedIds);
+  validateWires(config, idSet, errors);
+  validateOutputs(config, idSet, errors);
+  validateMultipleTerminals(config, resolvedIds, idSet, errors);
+
+  if (errors.length > 0) throw new ConfigError(errors);
+  return { config, resolvedIds };
+}
+
+// ─── Top-level shape ──────────────────────────────────────────────────────
+
+/**
+ * Record top-level shape problems.  Does not bail — the caller decides
+ * which (if any) failures are fatal enough to skip later passes.
+ */
+function recordTopShapeIssues(c: PipelineConfig, errors: ConfigErrorEntry[]): void {
+  if (typeof c.name !== "string" || c.name.length === 0) {
+    errors.push({ path: "name", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be a non-empty string" });
+  }
+  if (typeof c.settings !== "object" || c.settings === null) {
+    errors.push({ path: "settings", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be an object" });
+  }
+  if (!Array.isArray(c.stages) || c.stages.length === 0) {
+    errors.push({ path: "stages", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be a non-empty array" });
+  }
+}
+
+// ─── Settings ─────────────────────────────────────────────────────────────
+
+const VALID_LOG_LEVELS = new Set(["trace", "debug", "info", "warn", "error"]);
+
+function validateSettings(s: PipelineSettings, errors: ConfigErrorEntry[]): void {
+  if (typeof s.storageRoot !== "string" || s.storageRoot.length === 0) {
+    errors.push({ path: "settings.storageRoot", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be a non-empty string" });
+  }
+  if (s.cacheDir !== null && typeof s.cacheDir !== "string") {
+    errors.push({ path: "settings.cacheDir", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be a string or null" });
+  }
+  if (typeof s.reproducibleBuild !== "boolean") {
+    errors.push({ path: "settings.reproducibleBuild", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be a boolean" });
+  }
+  if (s.maxConcurrency !== null
+      && (typeof s.maxConcurrency !== "number" || !Number.isInteger(s.maxConcurrency) || s.maxConcurrency < 1)) {
+    errors.push({ path: "settings.maxConcurrency", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be a positive integer or null" });
+  }
+  if (typeof s.logLevel !== "string" || !VALID_LOG_LEVELS.has(s.logLevel)) {
+    errors.push({ path: "settings.logLevel", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be one of trace|debug|info|warn|error" });
+  }
+  if (typeof s.bestEffort !== "boolean") {
+    errors.push({ path: "settings.bestEffort", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be a boolean" });
+  }
+  if (s.deadlineMs !== null
+      && (typeof s.deadlineMs !== "number" || !Number.isFinite(s.deadlineMs) || s.deadlineMs <= 0)) {
+    errors.push({ path: "settings.deadlineMs", code: CONFIG_ERROR_CODES.MALFORMED, message: "must be a positive number or null" });
+  }
+}
+
+// ─── Per-stage validation ─────────────────────────────────────────────────
+
+function validateStageInstance(
+  spec: StageInstanceSpec,
+  index: number,
+  errors: ConfigErrorEntry[],
+): void {
+  const path = `stages[${index}]`;
+
+  if (isStageRef(spec.stage)) {
+    errors.push({
+      path: `${path}.stage`,
+      code: CONFIG_ERROR_CODES.STAGE_REF_UNRESOLVED,
+      message:
+        `StageRef ${JSON.stringify(spec.stage.packageName)} requires a plugin host (FM02). ` +
+        `v0 supports direct-import flows only — import the stage value and pass it directly.`,
+    });
+    return; // remaining checks are stage-shape-dependent
+  }
+
+  const stage = spec.stage;
+  if (typeof stage !== "object" || stage === null) {
+    errors.push({ path: `${path}.stage`, code: CONFIG_ERROR_CODES.INVALID_STAGE_VALUE, message: "stage must be an object" });
+    return;
+  }
+  if (typeof stage.name !== "string" || stage.name.length === 0) {
+    errors.push({ path: `${path}.stage.name`, code: CONFIG_ERROR_CODES.INVALID_STAGE_VALUE, message: "stage.name must be a non-empty string" });
+  }
+  if (typeof stage.version !== "string") {
+    errors.push({ path: `${path}.stage.version`, code: CONFIG_ERROR_CODES.INVALID_STAGE_VALUE, message: "stage.version must be a string" });
+  }
+  if (typeof stage.apiVersion !== "number") {
+    errors.push({ path: `${path}.stage.apiVersion`, code: CONFIG_ERROR_CODES.INVALID_STAGE_VALUE, message: "stage.apiVersion must be a number" });
+  } else if (stage.apiVersion !== KERNEL_API_VERSION) {
+    errors.push({
+      path: `${path}.stage.apiVersion`,
+      code: CONFIG_ERROR_CODES.API_VERSION_MISMATCH,
+      message:
+        `stage targets apiVersion ${stage.apiVersion}; kernel is ${KERNEL_API_VERSION}. ` +
+        `Upgrade the stage package or pin a kernel version that matches.`,
+    });
+  }
+  if (!Array.isArray(stage.capabilities)) {
+    errors.push({ path: `${path}.stage.capabilities`, code: CONFIG_ERROR_CODES.INVALID_STAGE_VALUE, message: "stage.capabilities must be an array" });
+  } else if (Array.isArray(spec.capabilities)) {
+    // Per-instance grants must be a subset of the stage's declarations.
+    const declared = new Set(stage.capabilities as readonly string[]);
+    for (const requested of spec.capabilities) {
+      if (!declared.has(requested)) {
+        errors.push({
+          path: `${path}.capabilities`,
+          code: CONFIG_ERROR_CODES.CAPABILITY_NOT_DECLARED,
+          message:
+            `Instance asks for capability ${JSON.stringify(requested)} but the stage's manifest does not declare it. ` +
+            `Add it to the stage's capabilities array, or remove the per-instance grant.`,
+        });
+      }
+    }
+  }
+  // Config presence rule (FM03 §2.4 #3 — full JSON-Schema validation
+  // is the orchestrator's job; we only enforce the presence half here).
+  if (stage.configSchema !== null && spec.config === undefined) {
+    errors.push({
+      path: `${path}.config`,
+      code: CONFIG_ERROR_CODES.CONFIG_REQUIRED,
+      message:
+        `Stage ${JSON.stringify(stage.name)} declares a configSchema but no config was supplied.`,
+    });
+  }
+}
+
+// ─── Instance ID resolution ───────────────────────────────────────────────
+
+/**
+ * Resolve every instance's ID.  `id` field wins; otherwise we use
+ * `stage.name`.  Collisions on the resolved ID are an error — the user
+ * must add an explicit `id` to disambiguate.
+ *
+ * Returns the array of resolved IDs aligned with the input order, with
+ * `""` placeholders for entries that couldn't be resolved (validator
+ * still reports their problems individually).
+ */
+function resolveInstanceIds(
+  specs: readonly StageInstanceSpec[],
+  errors: ConfigErrorEntry[],
+): string[] {
+  const out: string[] = new Array(specs.length).fill("");
+  const seen = new Map<string, number[]>();
+
+  for (let i = 0; i < specs.length; i++) {
+    const spec = specs[i]!;
+    let id: string | null = null;
+    if (typeof spec.id === "string" && spec.id.length > 0) {
+      id = spec.id;
+    } else if (!isStageRef(spec.stage) && typeof spec.stage?.name === "string") {
+      id = spec.stage.name;
+    }
+    if (id === null) {
+      // No explicit id and stage.name unavailable; leave placeholder.
+      // Per-instance validation will surface the underlying problem.
+      continue;
+    }
+    out[i] = id;
+    const list = seen.get(id);
+    if (list) list.push(i);
+    else seen.set(id, [i]);
+  }
+
+  // Report duplicates with paths to *every* colliding occurrence.
+  for (const [id, indices] of seen) {
+    if (indices.length > 1) {
+      const paths = indices.map(i => `stages[${i}]`).join(", ");
+      errors.push({
+        path: paths,
+        code: CONFIG_ERROR_CODES.DUPLICATE_INSTANCE_ID,
+        message:
+          `Multiple stage instances resolve to id ${JSON.stringify(id)}. ` +
+          `Add explicit \`id\` fields to disambiguate.`,
+      });
+    }
+  }
+
+  return out;
+}
+
+// ─── Wires / outputs / terminals ──────────────────────────────────────────
+
+function validateWires(
+  c: PipelineConfig,
+  idSet: ReadonlySet<string>,
+  errors: ConfigErrorEntry[],
+): void {
+  if (!c.wires) return;
+  for (let i = 0; i < c.wires.length; i++) {
+    const w = c.wires[i]!;
+    if (!idSet.has(w.from.id)) {
+      errors.push({
+        path: `wires[${i}].from.id`,
+        code: CONFIG_ERROR_CODES.UNKNOWN_INSTANCE_ID,
+        message: `Edge references unknown instance ${JSON.stringify(w.from.id)}.`,
+      });
+    }
+    if (!idSet.has(w.to.id)) {
+      errors.push({
+        path: `wires[${i}].to.id`,
+        code: CONFIG_ERROR_CODES.UNKNOWN_INSTANCE_ID,
+        message: `Edge references unknown instance ${JSON.stringify(w.to.id)}.`,
+      });
+    }
+  }
+}
+
+function validateOutputs(
+  c: PipelineConfig,
+  idSet: ReadonlySet<string>,
+  errors: ConfigErrorEntry[],
+): void {
+  if (!c.outputs) return;
+  for (let i = 0; i < c.outputs.length; i++) {
+    const o = c.outputs[i]!;
+    if (!idSet.has(o.fromInstance)) {
+      errors.push({
+        path: `outputs[${i}].fromInstance`,
+        code: CONFIG_ERROR_CODES.UNKNOWN_INSTANCE_ID,
+        message: `Output references unknown instance ${JSON.stringify(o.fromInstance)}.`,
+      });
+    }
+  }
+}
+
+/**
+ * If the pipeline has more than one terminal stage (no consumer in the
+ * declaration), each must be named in `outputs`.  We approximate
+ * "terminal" here as "produces something but isn't followed by anything
+ * that consumes it" — for v0 we use a coarse heuristic: every instance
+ * whose produced kind name is in TERMINAL_KIND_NAMES counts as a
+ * potential output sink.  If there are 2+ such instances, each must
+ * appear in `outputs`.
+ *
+ * The orchestrator's full DAG construction (FM03 §3.3) does the
+ * precise determination later; this is a config-time tripwire that
+ * catches the common "I forgot to name my outputs" mistake without
+ * needing the full DAG.
+ */
+const TERMINAL_KIND_NAMES = new Set([
+  "DeployArtifact", "RequestHandler", "Feed", "SearchIndex",
+]);
+
+function validateMultipleTerminals(
+  c: PipelineConfig,
+  resolvedIds: readonly string[],
+  idSet: ReadonlySet<string>,
+  errors: ConfigErrorEntry[],
+): void {
+  void idSet; // (currently unused; kept for symmetry with sibling validators)
+  const terminals: string[] = [];
+  for (let i = 0; i < c.stages.length; i++) {
+    const spec = c.stages[i]!;
+    if (isStageRef(spec.stage)) continue;
+    // Defensive — a malformed entry (`stage: null`, `stage: 42`) was
+    // already flagged by validateStageInstance; we just skip it here so
+    // a property-access TypeError doesn't escape the validator.
+    const stage = spec.stage as { produces?: { name?: unknown } } | null | undefined;
+    if (!stage || typeof stage !== "object") continue;
+    const produced = stage.produces?.name;
+    if (typeof produced === "string" && TERMINAL_KIND_NAMES.has(produced)) {
+      terminals.push(resolvedIds[i] ?? "");
+    }
+  }
+  if (terminals.length < 2) return;
+  const named = new Set((c.outputs ?? []).map(o => o.fromInstance));
+  const missing = terminals.filter(id => id !== "" && !named.has(id));
+  if (missing.length > 0) {
+    errors.push({
+      path: "outputs",
+      code: CONFIG_ERROR_CODES.MULTIPLE_OUTPUTS_UNNAMED,
+      message:
+        `Pipeline has multiple terminal stages (${terminals.map(t => JSON.stringify(t)).join(", ")}) ` +
+        `but ${missing.length === terminals.length ? "no" : "some"} `+
+        `OutputSpec entries name them.  Add OutputSpec entries to ` +
+        `\`outputs\` for: ${missing.map(m => JSON.stringify(m)).join(", ")}.`,
+    });
+  }
+}

--- a/code/packages/typescript/forme-pipeline-config/tests/errors.test.ts
+++ b/code/packages/typescript/forme-pipeline-config/tests/errors.test.ts
@@ -1,0 +1,75 @@
+/**
+ * forme-pipeline-config — ConfigError tests
+ */
+
+import { describe, it, expect } from "vitest";
+import { CONFIG_ERROR_CODES, ConfigError } from "../src/index.js";
+
+describe("ConfigError construction", () => {
+  it("requires at least one entry", () => {
+    expect(() => new ConfigError([])).toThrow(/at least one entry/);
+  });
+
+  it("name is ConfigError", () => {
+    const e = new ConfigError([{ path: "x", code: "X", message: "y" }]);
+    expect(e.name).toBe("ConfigError");
+  });
+
+  it("is an Error subclass", () => {
+    const e = new ConfigError([{ path: "x", code: "X", message: "y" }]);
+    expect(e).toBeInstanceOf(Error);
+  });
+
+  it("freezes individual entries (no mutation)", () => {
+    const e = new ConfigError([{ path: "x", code: "X", message: "y" }]);
+    expect(() => {
+      // @ts-expect-error — readonly
+      e.errors[0]!.message = "hack";
+    }).toThrow(TypeError);
+  });
+
+  it("freezes the entries array (no push)", () => {
+    const e = new ConfigError([{ path: "x", code: "X", message: "y" }]);
+    expect(() => {
+      // @ts-expect-error — readonly
+      e.errors.push({ path: "z", code: "Z", message: "z" });
+    }).toThrow(TypeError);
+  });
+});
+
+describe("ConfigError.message summary", () => {
+  it("single error → one-line summary with path/message/code", () => {
+    const e = new ConfigError([{ path: "stages[0].id", code: "DUPLICATE_INSTANCE_ID", message: "uh oh" }]);
+    expect(e.message).toContain("stages[0].id");
+    expect(e.message).toContain("uh oh");
+    expect(e.message).toContain("DUPLICATE_INSTANCE_ID");
+  });
+
+  it("multiple errors → multi-line summary with count", () => {
+    const e = new ConfigError([
+      { path: "a", code: "X", message: "first" },
+      { path: "b", code: "Y", message: "second" },
+    ]);
+    expect(e.message).toContain("(2 errors)");
+    expect(e.message).toContain("first");
+    expect(e.message).toContain("second");
+  });
+});
+
+describe("CONFIG_ERROR_CODES", () => {
+  it("includes the FM03 §2.4 spec rules", () => {
+    expect(CONFIG_ERROR_CODES.DUPLICATE_INSTANCE_ID).toBe("DUPLICATE_INSTANCE_ID");
+    expect(CONFIG_ERROR_CODES.API_VERSION_MISMATCH).toBe("API_VERSION_MISMATCH");
+    expect(CONFIG_ERROR_CODES.CAPABILITY_NOT_DECLARED).toBe("CAPABILITY_NOT_DECLARED");
+    expect(CONFIG_ERROR_CODES.CONFIG_REQUIRED).toBe("CONFIG_REQUIRED");
+    expect(CONFIG_ERROR_CODES.MULTIPLE_OUTPUTS_UNNAMED).toBe("MULTIPLE_OUTPUTS_UNNAMED");
+    expect(CONFIG_ERROR_CODES.STAGE_REF_UNRESOLVED).toBe("STAGE_REF_UNRESOLVED");
+  });
+
+  it("is frozen", () => {
+    expect(() => {
+      // @ts-expect-error — readonly
+      CONFIG_ERROR_CODES.NEW = "NEW";
+    }).toThrow(TypeError);
+  });
+});

--- a/code/packages/typescript/forme-pipeline-config/tests/load.test.ts
+++ b/code/packages/typescript/forme-pipeline-config/tests/load.test.ts
@@ -1,0 +1,93 @@
+/**
+ * forme-pipeline-config — loadTsConfig tests
+ *
+ * Uses the `importModule` test hook so we don't have to write actual
+ * TS files in a temp dir.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { loadTsConfig } from "../src/index.js";
+
+describe("loadTsConfig — happy path", () => {
+  it("returns the default export of the imported module", async () => {
+    const config = { name: "x", settings: {}, stages: [] };
+    const importModule = vi.fn(async () => ({ default: config }));
+    const result = await loadTsConfig("/abs/forme.config.ts", { importModule });
+    expect(result).toBe(config);
+    expect(importModule).toHaveBeenCalledTimes(1);
+  });
+
+  it("converts the path to a file:// URL", async () => {
+    let received = "";
+    const importModule = vi.fn(async (specifier: string) => {
+      received = specifier;
+      return { default: {} };
+    });
+    await loadTsConfig("/abs/forme.config.ts", { importModule });
+    expect(received.startsWith("file://")).toBe(true);
+    expect(received).toContain("forme.config.ts");
+  });
+
+  it("resolves relative paths against the supplied cwd", async () => {
+    let received = "";
+    const importModule = vi.fn(async (specifier: string) => {
+      received = specifier;
+      return { default: {} };
+    });
+    await loadTsConfig("forme.config.ts", { cwd: "/some/work/dir", importModule });
+    expect(received).toContain("/some/work/dir/forme.config.ts");
+  });
+});
+
+describe("loadTsConfig — rejection paths", () => {
+  it("rejects empty path", async () => {
+    await expect(loadTsConfig("")).rejects.toThrow(/non-empty string/);
+  });
+
+  it("rejects non-string path", async () => {
+    // @ts-expect-error — runtime check
+    await expect(loadTsConfig(null)).rejects.toThrow(/non-empty string/);
+  });
+
+  it("wraps import errors with the file:// URL in the message", async () => {
+    const importModule = async () => { throw new Error("module borked"); };
+    await expect(loadTsConfig("/abs/x.ts", { importModule })).rejects.toThrow(
+      /failed to import.*x\.ts.*module borked/s,
+    );
+  });
+
+  it("handles non-Error throws inside the importer", async () => {
+    const importModule = async () => { throw "string error"; };
+    await expect(loadTsConfig("/abs/x.ts", { importModule })).rejects.toThrow(
+      /failed to import.*string error/s,
+    );
+  });
+
+  it("rejects when the imported module is not an object", async () => {
+    const importModule = async () => 42;
+    await expect(loadTsConfig("/abs/x.ts", { importModule })).rejects.toThrow(
+      /did not produce an object/,
+    );
+  });
+
+  it("rejects when default export is missing", async () => {
+    const importModule = async () => ({ named: { name: "x" } });
+    await expect(loadTsConfig("/abs/x.ts", { importModule })).rejects.toThrow(
+      /no default export/,
+    );
+  });
+
+  it("rejects when default export is not an object", async () => {
+    const importModule = async () => ({ default: "not a config" });
+    await expect(loadTsConfig("/abs/x.ts", { importModule })).rejects.toThrow(
+      /no default export/,
+    );
+  });
+
+  it("rejects when default export is null", async () => {
+    const importModule = async () => ({ default: null });
+    await expect(loadTsConfig("/abs/x.ts", { importModule })).rejects.toThrow(
+      /no default export/,
+    );
+  });
+});

--- a/code/packages/typescript/forme-pipeline-config/tests/types.test.ts
+++ b/code/packages/typescript/forme-pipeline-config/tests/types.test.ts
@@ -1,0 +1,35 @@
+/**
+ * forme-pipeline-config — type/predicate tests
+ */
+
+import { describe, it, expect } from "vitest";
+import { isStageRef } from "../src/index.js";
+
+describe("isStageRef", () => {
+  it("recognises a well-formed StageRef", () => {
+    expect(isStageRef({ kind: "stage-ref", packageName: "@forme/source-fs" })).toBe(true);
+  });
+
+  it("rejects missing kind discriminator", () => {
+    expect(isStageRef({ packageName: "@forme/source-fs" })).toBe(false);
+  });
+
+  it("rejects wrong kind discriminator", () => {
+    expect(isStageRef({ kind: "stage", packageName: "@forme/source-fs" })).toBe(false);
+  });
+
+  it("rejects missing packageName", () => {
+    expect(isStageRef({ kind: "stage-ref" })).toBe(false);
+  });
+
+  it("rejects non-string packageName", () => {
+    expect(isStageRef({ kind: "stage-ref", packageName: 42 })).toBe(false);
+  });
+
+  it("rejects null and primitives", () => {
+    expect(isStageRef(null)).toBe(false);
+    expect(isStageRef(undefined)).toBe(false);
+    expect(isStageRef("string")).toBe(false);
+    expect(isStageRef(42)).toBe(false);
+  });
+});

--- a/code/packages/typescript/forme-pipeline-config/tests/validate.test.ts
+++ b/code/packages/typescript/forme-pipeline-config/tests/validate.test.ts
@@ -1,0 +1,457 @@
+/**
+ * forme-pipeline-config — validateConfig tests
+ *
+ * Builds tiny-but-real Stage objects rather than mocks so we exercise
+ * the actual cross-package contract.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  KERNEL_API_VERSION,
+  Kinds,
+  streamOf,
+} from "@coding-adventures/forme-types";
+import type { KindDescriptor } from "@coding-adventures/forme-types";
+import { defineStage } from "@coding-adventures/forme-stage";
+import type { Stage } from "@coding-adventures/forme-stage";
+import {
+  CONFIG_ERROR_CODES,
+  ConfigError,
+  validateConfig,
+} from "../src/index.js";
+import type {
+  PipelineConfig,
+  PipelineSettings,
+  StageInstanceSpec,
+} from "../src/index.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function settings(overrides: Partial<PipelineSettings> = {}): PipelineSettings {
+  return {
+    storageRoot: "./content",
+    cacheDir: null,
+    reproducibleBuild: false,
+    maxConcurrency: null,
+    logLevel: "info",
+    bestEffort: false,
+    deadlineMs: null,
+    ...overrides,
+  };
+}
+
+function makeStage<In extends KindDescriptor, Out extends KindDescriptor>(
+  name: string,
+  consumes: In,
+  produces: Out,
+  opts: {
+    capabilities?: readonly string[];
+    configSchema?: unknown;
+    apiVersion?: number;
+  } = {},
+): Stage<In, Out> {
+  return defineStage({
+    name,
+    version: "0.1.0",
+    apiVersion: opts.apiVersion ?? KERNEL_API_VERSION,
+    description: `test stage ${name}`,
+    consumes,
+    produces,
+    capabilities: (opts.capabilities ?? []) as never[],
+    configSchema: (opts.configSchema ?? null) as never,
+    async run() { throw new Error("not invoked in validation tests"); },
+  });
+}
+
+function config(stages: readonly StageInstanceSpec[], extra: Partial<PipelineConfig> = {}): PipelineConfig {
+  return {
+    name: "test",
+    settings: settings(),
+    stages,
+    ...extra,
+  };
+}
+
+// ─── Happy path ───────────────────────────────────────────────────────────
+
+describe("validateConfig — happy paths", () => {
+  it("accepts a minimal linear pipeline", () => {
+    const c = config([
+      { stage: makeStage("source", Kinds.Void, streamOf(Kinds.ContentSource)) },
+      { stage: makeStage("parse", Kinds.ContentSource, Kinds.ContentNode) },
+      { stage: makeStage("emit", Kinds.RenderedPage, Kinds.DeployArtifact) },
+    ]);
+    const resolved = validateConfig(c);
+    expect(resolved.resolvedIds).toEqual(["source", "parse", "emit"]);
+  });
+
+  it("auto-derives unique IDs from stage.name", () => {
+    const c = config([
+      { stage: makeStage("@forme/source-fs", Kinds.Void, streamOf(Kinds.ContentSource)) },
+    ]);
+    const resolved = validateConfig(c);
+    expect(resolved.resolvedIds).toEqual(["@forme/source-fs"]);
+  });
+
+  it("uses explicit id when provided", () => {
+    const c = config([
+      { stage: makeStage("source", Kinds.Void, streamOf(Kinds.ContentSource)), id: "src-1" },
+    ]);
+    expect(validateConfig(c).resolvedIds).toEqual(["src-1"]);
+  });
+
+  it("permits a per-instance capability that the stage declares", () => {
+    const stage = makeStage("source", Kinds.Void, streamOf(Kinds.ContentSource), {
+      capabilities: ["storage:read", "storage:write"],
+    });
+    const c = config([{ stage, capabilities: ["storage:read"] }]);
+    expect(() => validateConfig(c)).not.toThrow();
+  });
+
+  it("accepts wires referencing real instance IDs", () => {
+    const c = config([
+      { stage: makeStage("a", Kinds.Void, Kinds.ContentSource), id: "a" },
+      { stage: makeStage("b", Kinds.ContentSource, Kinds.ContentNode), id: "b" },
+    ], { wires: [{ from: { id: "a" }, to: { id: "b" } }] });
+    expect(() => validateConfig(c)).not.toThrow();
+  });
+
+  it("accepts outputs naming real instances", () => {
+    const c = config([
+      { stage: makeStage("a", Kinds.Void, Kinds.DeployArtifact), id: "a" },
+      { stage: makeStage("b", Kinds.Void, Kinds.DeployArtifact), id: "b" },
+    ], { outputs: [
+      { fromInstance: "a", name: "primary" },
+      { fromInstance: "b", name: "secondary" },
+    ]});
+    expect(() => validateConfig(c)).not.toThrow();
+  });
+});
+
+// ─── Top-level shape ──────────────────────────────────────────────────────
+
+describe("validateConfig — top-level shape", () => {
+  it("rejects null", () => {
+    expect(() => validateConfig(null as never)).toThrow(ConfigError);
+  });
+
+  it("rejects missing name", () => {
+    try {
+      validateConfig({ ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]), name: "" });
+    } catch (e) {
+      const ce = e as ConfigError;
+      expect(ce.errors.some(x => x.path === "name" && x.code === CONFIG_ERROR_CODES.MALFORMED)).toBe(true);
+    }
+  });
+
+  it("rejects empty stages array", () => {
+    try {
+      validateConfig({ ...config([]), stages: [] });
+    } catch (e) {
+      expect((e as ConfigError).errors.some(x => x.path === "stages")).toBe(true);
+    }
+  });
+
+  it("bails when stages is not an array (downstream loop would crash)", () => {
+    const c = { name: "t", settings: settings(), stages: "not-an-array" } as unknown as PipelineConfig;
+    try {
+      validateConfig(c);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ConfigError);
+      expect((e as ConfigError).errors.some(x => x.path === "stages" && x.code === CONFIG_ERROR_CODES.MALFORMED)).toBe(true);
+    }
+  });
+
+  it("skips settings validation when settings is not an object", () => {
+    const c = { name: "t", settings: null, stages: [{ stage: makeStage("a", Kinds.Void, Kinds.ContentSource) }] } as unknown as PipelineConfig;
+    try {
+      validateConfig(c);
+    } catch (e) {
+      // We see the top-level MALFORMED for settings, but downstream
+      // checks (stage validation, ID resolution) still ran.
+      const codes = (e as ConfigError).errors.map(x => x.code);
+      expect(codes).toContain(CONFIG_ERROR_CODES.MALFORMED);
+      // No DUPLICATE_INSTANCE_ID because there's only one stage —
+      // but the stage *did* get validated (no API_VERSION_MISMATCH
+      // because the stage is well-formed).
+    }
+  });
+});
+
+// ─── Settings validation ──────────────────────────────────────────────────
+
+describe("validateConfig — settings", () => {
+  it("rejects empty storageRoot", () => {
+    try {
+      validateConfig({
+        ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+        settings: settings({ storageRoot: "" }),
+      });
+    } catch (e) {
+      expect((e as ConfigError).errors.some(x => x.path === "settings.storageRoot")).toBe(true);
+    }
+  });
+
+  it("rejects bogus log level", () => {
+    expect(() => validateConfig({
+      ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+      settings: settings({ logLevel: "shout" as never }),
+    })).toThrow(ConfigError);
+  });
+
+  it("rejects negative maxConcurrency", () => {
+    expect(() => validateConfig({
+      ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+      settings: settings({ maxConcurrency: -1 }),
+    })).toThrow(ConfigError);
+  });
+
+  it("rejects fractional maxConcurrency", () => {
+    expect(() => validateConfig({
+      ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+      settings: settings({ maxConcurrency: 1.5 }),
+    })).toThrow(ConfigError);
+  });
+
+  it("rejects non-positive deadlineMs", () => {
+    expect(() => validateConfig({
+      ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+      settings: settings({ deadlineMs: 0 }),
+    })).toThrow(ConfigError);
+  });
+
+  it("accepts cacheDir = null and cacheDir = string", () => {
+    expect(() => validateConfig({
+      ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+      settings: settings({ cacheDir: ".forme/cache" }),
+    })).not.toThrow();
+  });
+
+  it("rejects non-boolean reproducibleBuild", () => {
+    expect(() => validateConfig({
+      ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+      settings: settings({ reproducibleBuild: "yes" as never }),
+    })).toThrow(ConfigError);
+  });
+
+  it("rejects non-boolean bestEffort", () => {
+    expect(() => validateConfig({
+      ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+      settings: settings({ bestEffort: 1 as never }),
+    })).toThrow(ConfigError);
+  });
+
+  it("rejects non-string cacheDir", () => {
+    expect(() => validateConfig({
+      ...config([{ stage: makeStage("s", Kinds.Void, Kinds.ContentSource) }]),
+      settings: settings({ cacheDir: 42 as never }),
+    })).toThrow(ConfigError);
+  });
+});
+
+// ─── Stage instance validation ────────────────────────────────────────────
+
+describe("validateConfig — stage instances", () => {
+  it("rejects API version mismatch", () => {
+    const stage = makeStage("s", Kinds.Void, Kinds.ContentSource, { apiVersion: 99 });
+    try { validateConfig(config([{ stage }])); }
+    catch (e) {
+      const ce = e as ConfigError;
+      expect(ce.errors.some(x => x.code === CONFIG_ERROR_CODES.API_VERSION_MISMATCH)).toBe(true);
+    }
+  });
+
+  it("rejects unresolved StageRef", () => {
+    try {
+      validateConfig(config([
+        { stage: { kind: "stage-ref", packageName: "@forme/source-fs" } as never },
+      ]));
+    } catch (e) {
+      const ce = e as ConfigError;
+      expect(ce.errors.some(x => x.code === CONFIG_ERROR_CODES.STAGE_REF_UNRESOLVED)).toBe(true);
+    }
+  });
+
+  it("rejects per-instance capability not declared by stage", () => {
+    const stage = makeStage("s", Kinds.Void, Kinds.ContentSource, {
+      capabilities: ["storage:read"],
+    });
+    try {
+      validateConfig(config([{ stage, capabilities: ["network:*"] }]));
+    } catch (e) {
+      expect((e as ConfigError).errors.some(x => x.code === CONFIG_ERROR_CODES.CAPABILITY_NOT_DECLARED)).toBe(true);
+    }
+  });
+
+  it("rejects missing config when configSchema is non-null", () => {
+    const stage = makeStage("s", Kinds.Void, Kinds.ContentSource, {
+      configSchema: { type: "object" },
+    });
+    try {
+      validateConfig(config([{ stage }]));
+    } catch (e) {
+      expect((e as ConfigError).errors.some(x => x.code === CONFIG_ERROR_CODES.CONFIG_REQUIRED)).toBe(true);
+    }
+  });
+
+  it("accepts non-null config when schema is non-null", () => {
+    const stage = makeStage("s", Kinds.Void, Kinds.ContentSource, {
+      configSchema: { type: "object" },
+    });
+    expect(() => validateConfig(config([{ stage, config: { ok: true } }]))).not.toThrow();
+  });
+
+  it("rejects invalid stage value (null)", () => {
+    expect(() => validateConfig(config([{ stage: null as never }]))).toThrow(ConfigError);
+  });
+
+  it("rejects stage missing name", () => {
+    const bogus = { ...makeStage("real", Kinds.Void, Kinds.ContentSource), name: "" };
+    expect(() => validateConfig(config([{ stage: bogus as never }]))).toThrow(ConfigError);
+  });
+
+  it("rejects stage with non-array capabilities", () => {
+    const bogus = { ...makeStage("real", Kinds.Void, Kinds.ContentSource) } as Record<string, unknown>;
+    bogus.capabilities = "all" as never;
+    expect(() => validateConfig(config([{ stage: bogus as never }]))).toThrow(ConfigError);
+  });
+
+  it("rejects stage with non-number apiVersion", () => {
+    const bogus = { ...makeStage("real", Kinds.Void, Kinds.ContentSource) } as Record<string, unknown>;
+    bogus.apiVersion = "1" as never;
+    expect(() => validateConfig(config([{ stage: bogus as never }]))).toThrow(ConfigError);
+  });
+
+  it("rejects stage with non-string version", () => {
+    const bogus = { ...makeStage("real", Kinds.Void, Kinds.ContentSource) } as Record<string, unknown>;
+    bogus.version = 1 as never;
+    expect(() => validateConfig(config([{ stage: bogus as never }]))).toThrow(ConfigError);
+  });
+});
+
+// ─── Instance ID resolution ───────────────────────────────────────────────
+
+describe("validateConfig — instance ID resolution", () => {
+  it("auto-numbers when only one instance per stage name (no collision)", () => {
+    const c = config([
+      { stage: makeStage("a", Kinds.Void, Kinds.ContentSource) },
+      { stage: makeStage("b", Kinds.ContentSource, Kinds.ContentNode) },
+    ]);
+    expect(validateConfig(c).resolvedIds).toEqual(["a", "b"]);
+  });
+
+  it("collisions on auto-derived IDs trigger DUPLICATE_INSTANCE_ID", () => {
+    const stage = makeStage("dup", Kinds.Void, Kinds.ContentSource);
+    try {
+      validateConfig(config([{ stage }, { stage }]));
+    } catch (e) {
+      const ce = e as ConfigError;
+      const dupe = ce.errors.find(x => x.code === CONFIG_ERROR_CODES.DUPLICATE_INSTANCE_ID);
+      expect(dupe).toBeDefined();
+      expect(dupe!.path).toContain("stages[0]");
+      expect(dupe!.path).toContain("stages[1]");
+    }
+  });
+
+  it("explicit ids on collisions disambiguate cleanly", () => {
+    const stage = makeStage("dup", Kinds.Void, Kinds.ContentSource);
+    const c = config([
+      { stage, id: "first" },
+      { stage, id: "second" },
+    ]);
+    expect(validateConfig(c).resolvedIds).toEqual(["first", "second"]);
+  });
+
+  it("explicit id collides with auto-derived id from another instance", () => {
+    expect(() => validateConfig(config([
+      { stage: makeStage("a", Kinds.Void, Kinds.ContentSource) },
+      { stage: makeStage("b", Kinds.Void, Kinds.ContentNode), id: "a" },
+    ]))).toThrow(ConfigError);
+  });
+});
+
+// ─── Wires & outputs ──────────────────────────────────────────────────────
+
+describe("validateConfig — wires", () => {
+  it("rejects edge from unknown instance", () => {
+    expect(() => validateConfig(config([
+      { stage: makeStage("a", Kinds.Void, Kinds.ContentSource), id: "a" },
+    ], { wires: [{ from: { id: "ghost" }, to: { id: "a" } }] }))).toThrow(ConfigError);
+  });
+
+  it("rejects edge to unknown instance", () => {
+    expect(() => validateConfig(config([
+      { stage: makeStage("a", Kinds.Void, Kinds.ContentSource), id: "a" },
+    ], { wires: [{ from: { id: "a" }, to: { id: "ghost" } }] }))).toThrow(ConfigError);
+  });
+});
+
+describe("validateConfig — outputs & multiple terminals", () => {
+  it("rejects output naming unknown instance", () => {
+    expect(() => validateConfig(config([
+      { stage: makeStage("a", Kinds.Void, Kinds.DeployArtifact), id: "a" },
+    ], { outputs: [{ fromInstance: "ghost", name: "x" }] }))).toThrow(ConfigError);
+  });
+
+  it("flags MULTIPLE_OUTPUTS_UNNAMED when 2+ terminals exist with no outputs", () => {
+    try {
+      validateConfig(config([
+        { stage: makeStage("a", Kinds.Void, Kinds.DeployArtifact), id: "a" },
+        { stage: makeStage("b", Kinds.Void, Kinds.DeployArtifact), id: "b" },
+      ]));
+    } catch (e) {
+      expect((e as ConfigError).errors.some(x => x.code === CONFIG_ERROR_CODES.MULTIPLE_OUTPUTS_UNNAMED)).toBe(true);
+    }
+  });
+
+  it("accepts 2+ terminals when outputs name them all", () => {
+    expect(() => validateConfig(config([
+      { stage: makeStage("a", Kinds.Void, Kinds.DeployArtifact), id: "a" },
+      { stage: makeStage("b", Kinds.Void, Kinds.DeployArtifact), id: "b" },
+    ], { outputs: [
+      { fromInstance: "a", name: "primary" },
+      { fromInstance: "b", name: "secondary" },
+    ]}))).not.toThrow();
+  });
+
+  it("flags partial naming (some terminals named, some not)", () => {
+    try {
+      validateConfig(config([
+        { stage: makeStage("a", Kinds.Void, Kinds.DeployArtifact), id: "a" },
+        { stage: makeStage("b", Kinds.Void, Kinds.Feed), id: "b" },
+      ], { outputs: [{ fromInstance: "a", name: "primary" }] }));
+    } catch (e) {
+      expect((e as ConfigError).errors.some(x => x.code === CONFIG_ERROR_CODES.MULTIPLE_OUTPUTS_UNNAMED)).toBe(true);
+    }
+  });
+
+  it("a single-terminal pipeline never needs outputs named", () => {
+    expect(() => validateConfig(config([
+      { stage: makeStage("a", Kinds.Void, Kinds.DeployArtifact), id: "a" },
+    ]))).not.toThrow();
+  });
+});
+
+// ─── Multi-error aggregation ──────────────────────────────────────────────
+
+describe("validateConfig — collects all errors in one pass", () => {
+  it("multiple distinct violations all surface together", () => {
+    try {
+      validateConfig({
+        name: "",
+        settings: settings({ logLevel: "shout" as never, maxConcurrency: -1 }),
+        stages: [
+          { stage: makeStage("dup", Kinds.Void, Kinds.ContentSource, { apiVersion: 99 }) },
+          { stage: makeStage("dup", Kinds.Void, Kinds.ContentNode) },
+        ],
+      });
+    } catch (e) {
+      const codes = (e as ConfigError).errors.map(x => x.code);
+      expect(codes).toContain(CONFIG_ERROR_CODES.MALFORMED);
+      expect(codes).toContain(CONFIG_ERROR_CODES.DUPLICATE_INSTANCE_ID);
+      expect(codes).toContain(CONFIG_ERROR_CODES.API_VERSION_MISMATCH);
+      // We expect at least three distinct codes (not just one error rolled up).
+      expect(new Set(codes).size).toBeGreaterThanOrEqual(3);
+    }
+  });
+});

--- a/code/packages/typescript/forme-pipeline-config/tsconfig.json
+++ b/code/packages/typescript/forme-pipeline-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-pipeline-config/vitest.config.ts
+++ b/code/packages/typescript/forme-pipeline-config/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Sixth Forme package — first of the **FM03 orchestrator stack**. Implements FM03 §2: the user-authored description of *what to build* (PipelineConfig types, validator, TS-form loader).

### Three responsibilities

1. **Types** — `PipelineConfig`, `PipelineSettings`, `StageInstanceSpec`, `StageRef`, `EdgeSpec`, `OutputSpec`, plus the `isStageRef` predicate.

2. **Validation** — `validateConfig(config)` enforces every FM03 §2.4 rule **in one pass** and returns a `ResolvedPipelineConfig` (input + per-spec resolved instance IDs). The validator collects ALL violations rather than stopping at the first — users want the full punch list, not the first symptom. Throws a single `ConfigError` carrying the structured `errors[]` array.

   Rules covered:
   - `STAGE_REF_UNRESOLVED` — v0 supports direct-import flows only
   - `INVALID_STAGE_VALUE` — stage missing required identification
   - `API_VERSION_MISMATCH` — stage targets wrong `KERNEL_API_VERSION`
   - `DUPLICATE_INSTANCE_ID` — collisions on resolved IDs
   - `CAPABILITY_NOT_DECLARED` — per-instance grant must be a subset of stage's declared capabilities
   - `CONFIG_REQUIRED` — `configSchema` set ⇒ `config` can't be undefined
   - `UNKNOWN_INSTANCE_ID` — wires/outputs reference non-existent IDs
   - `MULTIPLE_OUTPUTS_UNNAMED` — 2+ terminals need an `OutputSpec` each
   - `MALFORMED` — top-level fields wrong shape

3. **Loading** — `loadTsConfig(path, options?)` dynamically imports a `forme.config.ts` and returns its default export. Resolves relative paths against the supplied (or current) cwd; converts to `file://` URL for cross-platform compatibility. Wraps import errors with the URL in the message. Test hook (`importModule`) for unit tests.

### Spec divergences (documented in CHANGELOG)

- **JSON-Schema validation of configs** is deferred to the orchestrator. We enforce only the *presence* rule (`configSchema !== null` ⇒ `config !== undefined`); structural schema validation needs a JSON-Schema validator that doesn't yet live in the monorepo.
- **TOML form loader** (FM03 §2.3) not implemented in v0. The TS form is the canonical surface; a TOML loader will compile to the same shape later.

### Roadmap

- ✅ kernel: `forme-types`, `forme-errors`, `forme-identity`, `forme-capability`, `forme-stage`
- ✅ `forme-pipeline-config` (this PR — first FM03 package)
- ⏳ `forme-cache` (persistence layer)
- ⏳ `forme-orchestrator` (runtime, DAG, scheduler)
- ⏳ `forme-cli` + 5 stage packages
- ⏳ `code/sites/blog/` + `.github/workflows/deploy-blog.yml`

## Test plan

- [x] `npx vitest run --coverage` — 68 tests pass
- [x] **99.05% line / 97.61% branch coverage**. Uncovered are production-only paths (real dynamic-import wrapper, defensive catches for unstringifiable throws).
- [x] Validator collects multiple errors in one pass — single test exercises 3+ distinct codes simultaneously
- [x] Hostile inputs handled: null config, non-array stages, null stage values, mixed StageRef + Stage
- [x] Loader hostile inputs: empty path, non-string path, non-Error throws, missing default export, non-object default
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
