### PR TITLE
ts(spice): add AC source bias parsing

### DIFF
--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add independent-source AC phasors with separate DC bias for AC analysis.
+  Voltage and current sources can now carry an explicit AC magnitude and
+  phase; once any explicit AC source is present, other independent sources are
+  treated as AC-zero bias sources.
 - Add DC operating-point convergence metadata and opt-in controls, with
   nonlinear Gmin/source stepping fallback aids for difficult bias points.
 - Add Level-1 NMOS/PMOS MOSFET elements with Newton-linearized DC operating

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -48,6 +48,11 @@ export type Waveform =
   | PulseWaveform
   | ExpWaveform;
 
+export interface AcSource {
+  readonly magnitude: number;
+  readonly phaseDegrees: number;
+}
+
 export class PwlWaveform {
   constructor(readonly points: readonly (readonly [number, number])[]) {}
 
@@ -262,6 +267,7 @@ export interface VoltageSource {
   readonly positive: string;
   readonly negative: string;
   readonly voltage: number;
+  readonly ac?: AcSource;
   readonly waveform?: Waveform;
 }
 
@@ -271,6 +277,7 @@ export interface CurrentSource {
   readonly positive: string;
   readonly negative: string;
   readonly current: number;
+  readonly ac?: AcSource;
   readonly waveform?: Waveform;
 }
 
@@ -566,6 +573,28 @@ export function voltageSource(
   return { kind: "voltage-source", name, positive, negative, voltage };
 }
 
+export function acSource(magnitude: number, phaseDegrees = 0.0): AcSource {
+  return { magnitude, phaseDegrees };
+}
+
+export function voltageSourceWithAc(
+  name: string,
+  positive: string,
+  negative: string,
+  voltage: number,
+  magnitude: number,
+  phaseDegrees = 0.0,
+): VoltageSource {
+  return {
+    kind: "voltage-source",
+    name,
+    positive,
+    negative,
+    voltage,
+    ac: acSource(magnitude, phaseDegrees),
+  };
+}
+
 export function voltageSourceWithWaveform(
   name: string,
   positive: string,
@@ -590,6 +619,24 @@ export function currentSource(
   current: number,
 ): CurrentSource {
   return { kind: "current-source", name, positive, negative, current };
+}
+
+export function currentSourceWithAc(
+  name: string,
+  positive: string,
+  negative: string,
+  current: number,
+  magnitude: number,
+  phaseDegrees = 0.0,
+): CurrentSource {
+  return {
+    kind: "current-source",
+    name,
+    positive,
+    negative,
+    current,
+    ac: acSource(magnitude, phaseDegrees),
+  };
 }
 
 export function currentSourceWithWaveform(
@@ -2077,6 +2124,7 @@ function buildSmallSignalMatrix(
 function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
   const nodeIndices = collectNodeIndices(circuit);
   const voltageSources = collectAcVoltageSources(circuit);
+  const explicitAcSources = usesExplicitAcSources(circuit);
   const nodeCount = nodeIndices.size;
   const branchCount = voltageSources.size;
   const matrixSize = nodeCount + branchCount;
@@ -2095,11 +2143,12 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
           element,
           voltageSources,
           nodeCount,
+          explicitAcSources,
           rhs,
         );
         break;
       case "current-source":
-        stampAcCurrentSource(element, nodeIndices, rhs);
+        stampAcCurrentSource(element, nodeIndices, explicitAcSources, rhs);
         break;
       case "resistor":
       case "capacitor":
@@ -2461,6 +2510,14 @@ function collectAcVoltageSources(circuit: Circuit): Map<string, number> {
     }
   }
   return sources;
+}
+
+function usesExplicitAcSources(circuit: Circuit): boolean {
+  return circuit.elements().some(
+    (element) =>
+      (element.kind === "voltage-source" || element.kind === "current-source") &&
+      element.ac !== undefined,
+  );
 }
 
 function findInputSource(circuit: Circuit, inputSource: string): InputSource {
@@ -3438,6 +3495,7 @@ function stampAcVoltageSourceRhs(
   element: VoltageSource,
   voltageSources: ReadonlyMap<string, number>,
   nodeCount: number,
+  explicitAcSources: boolean,
   rhs: Complex[],
 ): void {
   if (!Number.isFinite(element.voltage)) {
@@ -3449,9 +3507,10 @@ function stampAcVoltageSourceRhs(
     throw invalidElement(element.name, "voltage source was not indexed");
   }
 
+  const phasor = voltageSourceAcPhasor(element, explicitAcSources);
   rhs[nodeCount + sourceIndex] = complexAdd(
     rhs[nodeCount + sourceIndex],
-    complex(element.voltage, 0.0),
+    phasor,
   );
 }
 
@@ -3497,13 +3556,14 @@ function stampComplexBranchMatrix(
 function stampAcCurrentSource(
   element: CurrentSource,
   nodeIndices: ReadonlyMap<string, number>,
+  explicitAcSources: boolean,
   rhs: Complex[],
 ): void {
   if (!Number.isFinite(element.current)) {
     throw invalidElement(element.name, "current must be finite");
   }
 
-  const current = complex(element.current, 0.0);
+  const current = currentSourceAcPhasor(element, explicitAcSources);
   const positive = nodeIndex(nodeIndices, element.positive);
   const negative = nodeIndex(nodeIndices, element.negative);
   if (positive !== undefined) {
@@ -3511,6 +3571,43 @@ function stampAcCurrentSource(
   }
   if (negative !== undefined) {
     rhs[negative] = complexAdd(rhs[negative], current);
+  }
+}
+
+function voltageSourceAcPhasor(
+  element: VoltageSource,
+  explicitAcSources: boolean,
+): Complex {
+  return sourceAcPhasor(element.name, element.ac, element.voltage, explicitAcSources);
+}
+
+function currentSourceAcPhasor(
+  element: CurrentSource,
+  explicitAcSources: boolean,
+): Complex {
+  return sourceAcPhasor(element.name, element.ac, element.current, explicitAcSources);
+}
+
+function sourceAcPhasor(
+  elementName: string,
+  ac: AcSource | undefined,
+  legacyValue: number,
+  explicitAcSources: boolean,
+): Complex {
+  if (ac === undefined) {
+    return explicitAcSources ? complex(0.0, 0.0) : complex(legacyValue, 0.0);
+  }
+  validateAcSource(elementName, ac);
+  const phaseRadians = (ac.phaseDegrees * Math.PI) / 180.0;
+  return complex(
+    ac.magnitude * Math.cos(phaseRadians),
+    ac.magnitude * Math.sin(phaseRadians),
+  );
+}
+
+function validateAcSource(elementName: string, ac: AcSource): void {
+  if (!Number.isFinite(ac.magnitude) || !Number.isFinite(ac.phaseDegrees)) {
+    throw invalidElement(elementName, "AC magnitude and phase must be finite");
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -9,10 +9,12 @@ import {
   complexAbs,
   complexPhase,
   currentSource,
+  currentSourceWithAc,
   inductor,
   resistor,
   vcvs,
   voltageSource,
+  voltageSourceWithAc,
 } from "../src/index.js";
 
 function expectClose(actual: number | undefined, expected: number): void {
@@ -89,6 +91,45 @@ describe("acSweep", () => {
     expect(n1).not.toBeUndefined();
     expectClose(n1!.real, 1.0);
     expectClose(n1!.imag, 0.0);
+  });
+
+  it("uses explicit voltage-source AC magnitude and phase separately from DC bias", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSourceWithAc("Vin", "vin", "0", 10.0, 2.0, 90.0));
+    circuit.add(resistor("R1", "vin", "out", 1_000.0));
+    circuit.add(resistor("R2", "out", "0", 1_000.0));
+
+    const points = acSweep(circuit, 1_000.0, 1_000.0, 10);
+
+    expect(points).toHaveLength(1);
+    const vin = points[0].voltage("vin");
+    const out = points[0].voltage("out");
+    expect(vin).not.toBeUndefined();
+    expect(out).not.toBeUndefined();
+    expectClose(vin!.real, 0.0);
+    expectClose(vin!.imag, 2.0);
+    expectClose(out!.real, 0.0);
+    expectClose(out!.imag, 1.0);
+  });
+
+  it("zeros sources without AC specs when any explicit AC source is present", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vbias", "bias", "0", 5.0));
+    circuit.add(currentSourceWithAc("Iac", "0", "out", 0.0, 1.0e-3, 90.0));
+    circuit.add(resistor("R1", "bias", "out", 1_000.0));
+    circuit.add(resistor("R2", "out", "0", 1_000.0));
+
+    const points = acSweep(circuit, 1_000.0, 1_000.0, 10);
+
+    expect(points).toHaveLength(1);
+    const bias = points[0].voltage("bias");
+    const out = points[0].voltage("out");
+    expect(bias).not.toBeUndefined();
+    expect(out).not.toBeUndefined();
+    expectClose(bias!.real, 0.0);
+    expectClose(bias!.imag, 0.0);
+    expectClose(out!.real, 0.0);
+    expectClose(out!.imag, 0.5);
   });
 
   it("applies VCVS gain in AC analysis", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Parse independent-source `AC <magnitude> [phase]` specs, including combined
+  `DC <bias> AC <magnitude> [phase]` forms, and pass the AC phasor through to
+  TypeScript SPICE engine AC analysis while preserving DC bias.
+
 ## 0.1.6
 
 - Add SPICE `M` MOSFET element parsing via `.model <name> NMOS(...)` and

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -9,6 +9,7 @@ import {
   cccs,
   ccvs,
   currentSource,
+  currentSourceWithAc,
   currentSourceWithWaveform,
   diode,
   dcOp,
@@ -18,6 +19,7 @@ import {
   vccs,
   vcvs,
   voltageSource,
+  voltageSourceWithAc,
   voltageSourceWithWaveform,
   type Element,
   type MosfetLevel1Params,
@@ -100,6 +102,15 @@ interface SubcktDefinition {
   readonly pins: string[];
   readonly body: Statement[];
   readonly lineNumber: number;
+}
+
+interface SourceSpec {
+  readonly dcValue: number;
+  readonly waveform?: Waveform;
+  readonly ac?: {
+    readonly magnitude: number;
+    readonly phaseDegrees: number;
+  };
 }
 
 const VALUE_RE = /^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)([a-zA-Z]*)\s*$/;
@@ -346,17 +357,49 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
   }
   if (prefix === "V") {
     requireMinFields(fields, 4, "voltage source");
-    const [voltage, waveform] = parseSourceValue(fields.slice(3));
-    return waveform === undefined
-      ? voltageSource(name, fields[1], fields[2], voltage)
-      : voltageSourceWithWaveform(name, fields[1], fields[2], voltage, waveform);
+    const source = parseSourceValue(fields.slice(3));
+    if (source.waveform !== undefined) {
+      return voltageSourceWithWaveform(
+        name,
+        fields[1],
+        fields[2],
+        source.dcValue,
+        source.waveform,
+      );
+    }
+    return source.ac === undefined
+      ? voltageSource(name, fields[1], fields[2], source.dcValue)
+      : voltageSourceWithAc(
+          name,
+          fields[1],
+          fields[2],
+          source.dcValue,
+          source.ac.magnitude,
+          source.ac.phaseDegrees,
+        );
   }
   if (prefix === "I") {
     requireMinFields(fields, 4, "current source");
-    const [current, waveform] = parseSourceValue(fields.slice(3));
-    return waveform === undefined
-      ? currentSource(name, fields[1], fields[2], current)
-      : currentSourceWithWaveform(name, fields[1], fields[2], current, waveform);
+    const source = parseSourceValue(fields.slice(3));
+    if (source.waveform !== undefined) {
+      return currentSourceWithWaveform(
+        name,
+        fields[1],
+        fields[2],
+        source.dcValue,
+        source.waveform,
+      );
+    }
+    return source.ac === undefined
+      ? currentSource(name, fields[1], fields[2], source.dcValue)
+      : currentSourceWithAc(
+          name,
+          fields[1],
+          fields[2],
+          source.dcValue,
+          source.ac.magnitude,
+          source.ac.phaseDegrees,
+        );
   }
   if (prefix === "D") {
     requireFields(fields, 4, "diode");
@@ -577,7 +620,7 @@ function elementPrefix(name: string): string {
   return localName[0].toUpperCase();
 }
 
-function parseSourceValue(fields: readonly string[]): readonly [number, Waveform | undefined] {
+function parseSourceValue(fields: readonly string[]): SourceSpec {
   if (fields.length === 0) {
     throw new NetlistParseError("source is missing a value");
   }
@@ -585,17 +628,52 @@ function parseSourceValue(fields: readonly string[]): readonly [number, Waveform
     if (fields.length < 2) {
       throw new NetlistParseError("DC source form requires a value");
     }
-    return [parseValue(fields[1]), undefined];
+    return {
+      dcValue: parseValue(fields[1]),
+      ac: parseSourceAc(fields.slice(2)),
+    };
+  }
+  if (fields[0].toUpperCase() === "AC") {
+    return {
+      dcValue: 0.0,
+      ac: parseSourceAc(fields),
+    };
   }
   if (fields.length === 1 && fields[0].includes("(")) {
     const waveform = parseWaveform(fields[0]);
-    return [waveform.valueAt(0.0), waveform];
+    return { dcValue: waveform.valueAt(0.0), waveform };
   }
   if (/^(PWL|SIN|PULSE|EXP)\(/i.test(fields[0])) {
     const waveform = parseWaveform(fields.join(" "));
-    return [waveform.valueAt(0.0), waveform];
+    return { dcValue: waveform.valueAt(0.0), waveform };
   }
-  return [parseValue(fields[0]), undefined];
+  return {
+    dcValue: parseValue(fields[0]),
+    ac: parseSourceAc(fields.slice(1)),
+  };
+}
+
+function parseSourceAc(
+  fields: readonly string[],
+): { readonly magnitude: number; readonly phaseDegrees: number } | undefined {
+  if (fields.length === 0) {
+    return undefined;
+  }
+  if (fields[0].toUpperCase() !== "AC") {
+    throw new NetlistParseError(
+      `unsupported source suffix ${JSON.stringify(fields.join(" "))}`,
+    );
+  }
+  if (fields.length < 2) {
+    throw new NetlistParseError("AC source form requires a magnitude");
+  }
+  if (fields.length > 3) {
+    throw new NetlistParseError("AC source form accepts magnitude and optional phase");
+  }
+  return {
+    magnitude: parseValue(fields[1]),
+    phaseDegrees: fields.length >= 3 ? parseValue(fields[2]) : 0.0,
+  };
 }
 
 function parseWaveform(token: string): Waveform {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1,4 +1,4 @@
-import { dcOp } from "@coding-adventures/spice-engine";
+import { acSweep, dcOp } from "@coding-adventures/spice-engine";
 import { describe, expect, it } from "vitest";
 import {
   NetlistParseError,
@@ -57,6 +57,35 @@ G1 out 0 in 0 2m
       { kind: "dc", sourceName: "Vstep", start: 0.0, stop: 1.0, step: 0.5 },
       { kind: "ac", mode: "dec", points: 10, startHz: 1.0e3, stopHz: 1.0e6 },
     ]);
+  });
+
+  it("parses independent-source AC specs separately from DC bias", () => {
+    const parsed = parseNetlist(`
+Vin in 0 DC 10 AC 2 90
+Vbias bias 0 5
+R1 in out 1k
+R2 out 0 1k
+.ac dec 10 1k 1k
+`);
+
+    const vin = parsed.circuit.elements()[0];
+    expect(vin).toMatchObject({
+      kind: "voltage-source",
+      voltage: 10.0,
+      ac: { magnitude: 2.0, phaseDegrees: 90.0 },
+    });
+    const bias = parsed.circuit.elements()[1];
+    expect(bias).toMatchObject({ kind: "voltage-source", voltage: 5.0 });
+
+    const points = acSweep(parsed.circuit, 1_000.0, 1_000.0, 10);
+    const out = points[0].voltage("out");
+    const biasVoltage = points[0].voltage("bias");
+    expect(out).not.toBeUndefined();
+    expect(biasVoltage).not.toBeUndefined();
+    expect(out!.real).toBeCloseTo(0.0, 9);
+    expect(out!.imag).toBeCloseTo(1.0, 9);
+    expect(biasVoltage!.real).toBeCloseTo(0.0, 9);
+    expect(biasVoltage!.imag).toBeCloseTo(0.0, 9);
   });
 
   it("parses VCVS elements into operating-point circuits", () => {


### PR DESCRIPTION
## Summary

- add TypeScript SPICE engine AC phasor metadata for independent voltage/current sources
- make AC analysis use explicit source magnitude/phase while zeroing other bias sources when any AC spec is present
- parse SPICE `AC <magnitude> [phase]` and `DC <bias> AC <magnitude> [phase]` source forms in the TypeScript netlist parser

## Validation

- npm test -- --run tests/ac.test.ts (`code/packages/typescript/spice-engine`)
- npm test -- --run tests/spice-netlist-parser.test.ts (`code/packages/typescript/spice-netlist-parser`)
- npm run build (`code/packages/typescript/spice-engine`)
- npm run build (`code/packages/typescript/spice-netlist-parser`)
- npm test (`code/packages/typescript/spice-engine`)
- npm test (`code/packages/typescript/spice-netlist-parser`)
- git diff --check