### PR TITLE
python(spice): add AC source bias parsing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Explicit AC source phasors** — `VoltageSource` and `CurrentSource` now
+  accept an optional `AcSource(magnitude, phase_degrees=0.0)` value.  AC
+  analysis uses those phasors independently from the DC bias value, and zeros
+  unspecified independent sources once any explicit AC source is present.
+
 ## [0.12.0] — 2026-05-13
 
 ### Added

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -1,6 +1,7 @@
 """spice-engine: SPICE-compatible analog simulator (MNA + DC + transient + AC + DC sweep + .SENS + .MC + .NOISE + controlled sources + time-varying sources)."""
 
 from spice_engine.elements import (
+    AcSource,
     BJT,
     CCCS,
     CCVS,
@@ -52,6 +53,7 @@ __version__ = "0.12.0"
 __all__ = [
     "AcPoint",
     "AcResult",
+    "AcSource",
     "BJT",
     "CCCS",
     "CCVS",

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -235,6 +235,18 @@ Waveform = PwlWaveform | SinWaveform | PulseWaveform | ExpWaveform
 
 
 @dataclass(frozen=True, slots=True)
+class AcSource:
+    """Small-signal AC source specification.
+
+    ``magnitude`` is the source phasor magnitude in volts or amperes.
+    ``phase_degrees`` is the optional phase angle in degrees.
+    """
+
+    magnitude: float
+    phase_degrees: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
 class Resistor:
     """R<name> n+ n- value"""
 
@@ -267,11 +279,12 @@ class Inductor:
 
 @dataclass(frozen=True, slots=True)
 class VoltageSource:
-    """V<name> n+ n- value [waveform]
+    """V<name> n+ n- value [waveform] [ac]
 
-    An independent voltage source.  In DC and AC analysis the ``voltage``
-    field is used directly.  In *transient* analysis, if ``waveform`` is not
-    ``None`` the engine calls ``waveform(t)`` at each timestep and
+    An independent voltage source.  In DC analysis the ``voltage`` field is
+    used directly.  In AC analysis, ``ac`` supplies the small-signal phasor
+    when present.  In *transient* analysis, if ``waveform`` is not ``None``
+    the engine calls ``waveform(t)`` at each timestep and
     temporarily substitutes the returned value for ``voltage``; the stored
     ``voltage`` field then serves only as the t = 0 bias.
 
@@ -286,15 +299,17 @@ class VoltageSource:
     n_minus: str
     voltage: float  # volts (DC value / t=0 bias)
     waveform: Waveform | None = None  # time-varying override
+    ac: AcSource | None = None  # small-signal AC phasor
 
 
 @dataclass(frozen=True, slots=True)
 class CurrentSource:
-    """I<name> n+ n- value [waveform] (current flows from n+ to n-)
+    """I<name> n+ n- value [waveform] [ac] (current flows from n+ to n-)
 
-    An independent current source.  In DC and AC analysis the ``current``
-    field is used directly.  In *transient* analysis, if ``waveform`` is not
-    ``None`` the engine calls ``waveform(t)`` at each timestep and
+    An independent current source.  In DC analysis the ``current`` field is
+    used directly.  In AC analysis, ``ac`` supplies the small-signal phasor
+    when present.  In *transient* analysis, if ``waveform`` is not ``None``
+    the engine calls ``waveform(t)`` at each timestep and
     temporarily substitutes the returned value for ``current``; the stored
     ``current`` field then serves only as the t = 0 bias.
 
@@ -310,6 +325,7 @@ class CurrentSource:
     n_minus: str
     current: float  # amperes (DC value / t=0 bias)
     waveform: Waveform | None = None  # time-varying override
+    ac: AcSource | None = None  # small-signal AC phasor
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -54,6 +54,7 @@ import statistics
 from dataclasses import dataclass, field
 
 from spice_engine.elements import (
+    AcSource,
     BJT,
     CCCS,
     CCVS,
@@ -603,6 +604,8 @@ def _dc_source_step(
                     n_plus=e.n_plus,
                     n_minus=e.n_minus,
                     voltage=e.voltage * scale,
+                    waveform=e.waveform,
+                    ac=e.ac,
                 ))
             elif isinstance(e, CurrentSource):
                 scaled_elements.append(CurrentSource(
@@ -610,6 +613,8 @@ def _dc_source_step(
                     n_plus=e.n_plus,
                     n_minus=e.n_minus,
                     current=e.current * scale,
+                    waveform=e.waveform,
+                    ac=e.ac,
                 ))
             else:
                 scaled_elements.append(e)
@@ -1278,6 +1283,7 @@ def _build_transient_companions(
                 n_plus=e.n_plus,
                 n_minus=e.n_minus,
                 voltage=e.waveform(t),
+                ac=e.ac,
             ))
         elif isinstance(e, CurrentSource) and e.waveform is not None:
             base_elements.append(CurrentSource(
@@ -1285,6 +1291,7 @@ def _build_transient_companions(
                 n_plus=e.n_plus,
                 n_minus=e.n_minus,
                 current=e.waveform(t),
+                ac=e.ac,
             ))
         else:
             base_elements.append(e)
@@ -1530,6 +1537,7 @@ def transient(
                 n_plus=e.n_plus,
                 n_minus=e.n_minus,
                 voltage=e.waveform(0.0),
+                ac=e.ac,
             ))
         elif isinstance(e, CurrentSource) and e.waveform is not None:
             init_elements.append(CurrentSource(
@@ -1537,6 +1545,7 @@ def transient(
                 n_plus=e.n_plus,
                 n_minus=e.n_minus,
                 current=e.waveform(0.0),
+                ac=e.ac,
             ))
         else:
             init_elements.append(e)
@@ -1796,6 +1805,36 @@ def _stamp_g_c(
         G[node_to_idx[n_minus]][node_to_idx[n_plus]] -= g
 
 
+def _has_explicit_ac_sources(circuit: Circuit) -> bool:
+    """Return True when at least one independent source has an AC spec."""
+
+    return any(
+        isinstance(el, (VoltageSource, CurrentSource)) and el.ac is not None
+        for el in circuit.elements
+    )
+
+
+def _ac_phasor(
+    name: str,
+    ac: AcSource | None,
+    fallback: float,
+    explicit_ac: bool,
+) -> complex:
+    """Return the source phasor for AC analysis.
+
+    Legacy circuits without explicit ``AC`` source specs keep using the DC
+    value as the AC phasor.  Once any independent source declares an explicit
+    AC spec, unspecified independent sources become zero small-signal sources.
+    """
+
+    if ac is None:
+        return 0j if explicit_ac else fallback + 0j
+    if not math.isfinite(ac.magnitude) or not math.isfinite(ac.phase_degrees):
+        raise ValueError(f"{name}: AC magnitude and phase must be finite")
+    phase = math.radians(ac.phase_degrees)
+    return ac.magnitude * complex(math.cos(phase), math.sin(phase))
+
+
 def _stamp_ac(
     el: Element,
     G: list[list[complex]],
@@ -1804,6 +1843,8 @@ def _stamp_ac(
     node_to_idx: dict[str, int],
     branch_srcs: list[VoltageSource | VCVS | CCVS],
     dc_x: list[float],
+    *,
+    explicit_ac_sources: bool = False,
 ) -> None:
     """Stamp one element's AC small-signal contribution at angular frequency ω.
 
@@ -1815,10 +1856,11 @@ def _stamp_ac(
 
     VoltageSource AC handling
     -------------------------
-    Each VoltageSource is treated as an ideal AC source with amplitude
-    ``el.voltage`` volts (AC amplitude, typically 1 V for the input and 0 V
-    for bias sources).  A 0 V AC source acts as a short circuit, which is
-    correct for DC-bias voltage sources in an AC analysis.
+    Each VoltageSource is treated as an ideal AC source.  If any independent
+    source has an explicit ``ac`` spec, only explicit AC specs contribute
+    phasors and unspecified sources are zeroed.  For backwards compatibility,
+    circuits with no explicit AC specs still use the DC source value as the
+    AC phasor.
 
     Parameters
     ----------
@@ -1870,14 +1912,15 @@ def _stamp_ac(
             q = node_to_idx[el.n_minus]
             G[q][branch] -= 1.0 + 0j
             G[branch][q] -= 1.0 + 0j
-        b[branch] += el.voltage + 0j
+        b[branch] += _ac_phasor(el.name, el.ac, el.voltage, explicit_ac_sources)
 
     elif isinstance(el, CurrentSource):
         # AC current source: inject phasor current.
+        current = _ac_phasor(el.name, el.ac, el.current, explicit_ac_sources)
         if not _is_ground(el.n_plus):
-            b[node_to_idx[el.n_plus]] -= el.current + 0j
+            b[node_to_idx[el.n_plus]] -= current
         if not _is_ground(el.n_minus):
-            b[node_to_idx[el.n_minus]] += el.current + 0j
+            b[node_to_idx[el.n_minus]] += current
 
     elif isinstance(el, VCCS):
         # Frequency-independent transconductance: same stamp as DC.
@@ -2101,6 +2144,7 @@ def ac_sweep(
     n_nodes = len(node_to_idx)
     n_branch = len(branch_srcs)
     size = n_nodes + n_branch
+    explicit_ac_sources = _has_explicit_ac_sources(circuit)
 
     # Reconstruct the indexed dc_x vector from the DcResult dict.
     dc_x: list[float] = [0.0] * size
@@ -2135,7 +2179,16 @@ def ac_sweep(
         b_c: list[complex] = [0j] * size
 
         for el in circuit.elements:
-            _stamp_ac(el, G_c, b_c, omega, node_to_idx, branch_srcs, dc_x)
+            _stamp_ac(
+                el,
+                G_c,
+                b_c,
+                omega,
+                node_to_idx,
+                branch_srcs,
+                dc_x,
+                explicit_ac_sources=explicit_ac_sources,
+            )
 
         try:
             x_c = _solve_complex(G_c, b_c)
@@ -2738,11 +2791,21 @@ def dc_sweep(
         # Create a new source element with the swept value.
         if isinstance(source_el, VoltageSource):
             new_el: VoltageSource | CurrentSource = VoltageSource(
-                source_el.name, source_el.n_plus, source_el.n_minus, val
+                source_el.name,
+                source_el.n_plus,
+                source_el.n_minus,
+                val,
+                source_el.waveform,
+                source_el.ac,
             )
         else:
             new_el = CurrentSource(
-                source_el.name, source_el.n_plus, source_el.n_minus, val
+                source_el.name,
+                source_el.n_plus,
+                source_el.n_minus,
+                val,
+                source_el.waveform,
+                source_el.ac,
             )
 
         # Rebuild circuit with the new element in place of the original.
@@ -3049,7 +3112,14 @@ def sens_dc(
             _make_entry(
                 "voltage",
                 el.voltage,
-                VoltageSource(el.name, el.n_plus, el.n_minus, el.voltage + delta_v),
+                VoltageSource(
+                    el.name,
+                    el.n_plus,
+                    el.n_minus,
+                    el.voltage + delta_v,
+                    el.waveform,
+                    el.ac,
+                ),
             )
 
         elif isinstance(el, CurrentSource):
@@ -3058,7 +3128,14 @@ def sens_dc(
             _make_entry(
                 "current",
                 el.current,
-                CurrentSource(el.name, el.n_plus, el.n_minus, el.current + delta_i),
+                CurrentSource(
+                    el.name,
+                    el.n_plus,
+                    el.n_minus,
+                    el.current + delta_i,
+                    el.waveform,
+                    el.ac,
+                ),
             )
 
         elif isinstance(el, Diode):
@@ -3274,10 +3351,24 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
         return Resistor(el.name, el.n_plus, el.n_minus, _draw(el.resistance))
 
     if isinstance(el, VoltageSource):
-        return VoltageSource(el.name, el.n_plus, el.n_minus, _draw(el.voltage))
+        return VoltageSource(
+            el.name,
+            el.n_plus,
+            el.n_minus,
+            _draw(el.voltage),
+            el.waveform,
+            el.ac,
+        )
 
     if isinstance(el, CurrentSource):
-        return CurrentSource(el.name, el.n_plus, el.n_minus, _draw(el.current))
+        return CurrentSource(
+            el.name,
+            el.n_plus,
+            el.n_minus,
+            _draw(el.current),
+            el.waveform,
+            el.ac,
+        )
 
     if isinstance(el, Diode):
         return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt)
@@ -3864,7 +3955,16 @@ def noise_ac(
         G_c: list[list[complex]] = [[0j] * size for _ in range(size)]
         b_c: list[complex] = [0j] * size  # dummy RHS for stamping (unused)
         for el in circuit.elements:
-            _stamp_ac(el, G_c, b_c, omega, node_to_idx, branch_srcs_noise, dc_x)
+            _stamp_ac(
+                el,
+                G_c,
+                b_c,
+                omega,
+                node_to_idx,
+                branch_srcs_noise,
+                dc_x,
+                explicit_ac_sources=_has_explicit_ac_sources(circuit),
+            )
 
         # Transpose G_c → G_T for the adjoint solve.
         # G_T[i][j] = G_c[j][i]

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -85,6 +85,7 @@ from spice_engine import (
     VCVS,
     AcPoint,
     AcResult,
+    AcSource,
     Capacitor,
     Circuit,
     CurrentSource,
@@ -1048,6 +1049,39 @@ def test_ac_source_node_equals_source_voltage():
         assert isclose(abs(pt.node_voltages["vin"]), 2.5, abs_tol=1e-6), (
             f"f={pt.freq:.1f} Hz: V_in={pt.node_voltages['vin']}"
         )
+
+
+def test_ac_explicit_voltage_source_phasor_separate_from_dc_bias():
+    """An explicit AC source phasor is independent from the DC bias value."""
+    c = Circuit()
+    c.add(VoltageSource("Vin", "in", "0", 10.0, ac=AcSource(2.0, 90.0)))
+    c.add(Resistor("R1", "in", "out", 1000.0))
+    c.add(Resistor("R2", "out", "0", 1000.0))
+
+    result = ac_sweep(c, f_start=1000.0, f_stop=1000.0, n_points=1)
+    pt = result.points[0]
+
+    assert isclose(pt.node_voltages["in"].real, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["in"].imag, 2.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["out"].real, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["out"].imag, 1.0, abs_tol=1e-12)
+
+
+def test_ac_unspecified_sources_zero_when_any_explicit_ac_source_exists():
+    """DC bias sources become zero small-signal sources with explicit AC input."""
+    c = Circuit()
+    c.add(VoltageSource("Vbias", "bias", "0", 5.0))
+    c.add(CurrentSource("Iac", "0", "out", 0.0, ac=AcSource(1.0e-3, 90.0)))
+    c.add(Resistor("Rbias", "bias", "out", 1000.0))
+    c.add(Resistor("Rload", "out", "0", 1000.0))
+
+    result = ac_sweep(c, f_start=1000.0, f_stop=1000.0, n_points=1)
+    pt = result.points[0]
+
+    assert isclose(pt.node_voltages["bias"].real, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["bias"].imag, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["out"].real, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["out"].imag, 0.5, abs_tol=1e-12)
 
 
 def test_ac_unequal_resistive_divider():

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Parse SPICE independent source `AC <magnitude> [phase]` specifications for
+  voltage and current sources, including `DC <value> AC ...` mixed bias/input
+  forms.
+
 ## 0.1.6
 
 - Parse `.model <name> NMOS(...)` and `.model <name> PMOS(...)` cards into

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -8,6 +8,7 @@ from dataclasses import fields as dataclass_fields
 
 from mosfet_models import MOSFET, Level1Model, Level1Params, MosfetType
 from spice_engine import (
+    AcSource,
     BJT,
     CCCS,
     CCVS,
@@ -76,6 +77,13 @@ class ModelCard:
     name: str
     kind: str
     params: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceSpec:
+    dc_value: float
+    waveform: Waveform | None = None
+    ac: AcSource | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -240,12 +248,16 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
         return Inductor(name, fields[1], fields[2], parse_value(fields[3]))
     if prefix == "V":
         _require_min_fields(fields, 4, "voltage source")
-        voltage, waveform = _parse_source_value(fields[3:])
-        return VoltageSource(name, fields[1], fields[2], voltage, waveform)
+        source = _parse_source_value(fields[3:])
+        return VoltageSource(
+            name, fields[1], fields[2], source.dc_value, source.waveform, source.ac
+        )
     if prefix == "I":
         _require_min_fields(fields, 4, "current source")
-        current, waveform = _parse_source_value(fields[3:])
-        return CurrentSource(name, fields[1], fields[2], current, waveform)
+        source = _parse_source_value(fields[3:])
+        return CurrentSource(
+            name, fields[1], fields[2], source.dc_value, source.waveform, source.ac
+        )
     if prefix == "D":
         _require_fields(fields, 4, "diode")
         model = models.get(fields[3].lower())
@@ -432,21 +444,35 @@ def _element_prefix(name: str) -> str:
     return local_name[0].upper()
 
 
-def _parse_source_value(fields: list[str]) -> tuple[float, Waveform | None]:
+def _parse_source_value(fields: list[str]) -> _SourceSpec:
     if not fields:
         raise NetlistParseError("source is missing a value")
     if fields[0].upper() == "DC":
         if len(fields) < 2:
             raise NetlistParseError("DC source form requires a value")
-        return parse_value(fields[1]), None
+        return _SourceSpec(parse_value(fields[1]), ac=_parse_ac_suffix(fields[2:]))
+    if fields[0].upper() == "AC":
+        return _SourceSpec(0.0, ac=_parse_ac_suffix(fields))
     if len(fields) == 1 and "(" in fields[0]:
         waveform = _parse_waveform(fields[0])
-        return waveform(0.0), waveform
+        return _SourceSpec(waveform(0.0), waveform)
     if fields[0].upper().startswith(("PWL(", "SIN(", "PULSE(", "EXP(")):
         joined = " ".join(fields)
         waveform = _parse_waveform(joined)
-        return waveform(0.0), waveform
-    return parse_value(fields[0]), None
+        return _SourceSpec(waveform(0.0), waveform)
+    return _SourceSpec(parse_value(fields[0]), ac=_parse_ac_suffix(fields[1:]))
+
+
+def _parse_ac_suffix(fields: list[str]) -> AcSource | None:
+    if not fields:
+        return None
+    if fields[0].upper() != "AC":
+        raise NetlistParseError(f"unsupported source suffix {fields[0]!r}")
+    if len(fields) not in {2, 3}:
+        raise NetlistParseError("AC source form requires magnitude and optional phase")
+    magnitude = parse_value(fields[1])
+    phase = parse_value(fields[2]) if len(fields) == 3 else 0.0
+    return AcSource(magnitude=magnitude, phase_degrees=phase)
 
 
 def _parse_waveform(token: str) -> Waveform:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3,6 +3,7 @@ from math import isclose
 import pytest
 from mosfet_models import Level1Model, MosfetType
 from spice_engine import (
+    AcSource,
     BJT,
     CCCS,
     CCVS,
@@ -15,6 +16,7 @@ from spice_engine import (
     Mosfet,
     Resistor,
     VoltageSource,
+    ac_sweep,
     dc_op,
 )
 
@@ -286,6 +288,40 @@ I1 in 0 SIN(0 2m 1k 10u 5)
     assert current.waveform is not None
     assert isclose(voltage.waveform(0.5e-9), 0.9, abs_tol=1e-12)
     assert isclose(current.waveform(1.0e-6), 0.0, abs_tol=1e-12)
+
+
+def test_parse_ac_source_specs_separate_from_dc_bias() -> None:
+    parsed = parse_netlist(
+        """
+Vin in 0 DC 10 AC 2 90
+Vbias bias 0 5
+Iprobe 0 out AC 1m 90
+R1 in out 1k
+R2 out 0 1k
+.ac dec 1 1k 1k
+"""
+    )
+
+    vin = parsed.circuit.elements[0]
+    vbias = parsed.circuit.elements[1]
+    iprobe = parsed.circuit.elements[2]
+    assert isinstance(vin, VoltageSource)
+    assert isinstance(vbias, VoltageSource)
+    assert isinstance(iprobe, CurrentSource)
+    assert vin.voltage == 10.0
+    assert vin.ac == AcSource(2.0, 90.0)
+    assert vbias.ac is None
+    assert iprobe.current == 0.0
+    assert iprobe.ac == AcSource(1.0e-3, 90.0)
+
+    result = ac_sweep(parsed.circuit, f_start=1.0e3, f_stop=1.0e3, n_points=1)
+    pt = result.points[0]
+    assert isclose(pt.node_voltages["bias"].real, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["bias"].imag, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["in"].real, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["in"].imag, 2.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["out"].real, 0.0, abs_tol=1e-12)
+    assert isclose(pt.node_voltages["out"].imag, 1.5, abs_tol=1e-12)
 
 
 def test_expands_subcircuit_instances_into_engine_elements() -> None:


### PR DESCRIPTION
## Summary

- add Python SPICE `AcSource` metadata for independent voltage/current sources
- make Python AC analysis use explicit source magnitude/phase while zeroing other bias sources when any AC spec is present
- parse SPICE `AC <magnitude> [phase]` and `DC <bias> AC <magnitude> [phase]` source forms in the Python netlist parser

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-spice-ac-source-bias PYTHONPATH=src python -m pytest tests/test_engine.py -q` (`code/packages/python/spice-engine`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-spice-ac-source-bias PYTHONPATH=src:../spice-engine/src:../mosfet-models/src:../device-physics/src python -m pytest tests/test_spice_netlist_parser.py -q` (`code/packages/python/spice-netlist-parser`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-spice-ac-source-bias sh BUILD` (`code/packages/python/spice-engine`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-python-spice-ac-source-bias sh BUILD` (`code/packages/python/spice-netlist-parser`)
- `git diff --check`
