### PR TITLE
feat(matrix-ir): add Op::Concat — second V2 op (wire tag 0x1D)

### DIFF
--- a/code/packages/rust/compute-ir/CHANGELOG.md
+++ b/code/packages/rust/compute-ir/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to `compute-ir` are documented here.  The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] — 2026-05-13
+
+### Added — wire-format support for `Op::Concat`
+
+`matrix-ir` 0.3.0 added `Op::Concat` (wire tag 0x1D).  compute-ir's
+encoder / decoder + `dump::op_name` helper now know about it.
+
+Wire layout:
+
+```
+tag (0x1D) | n_inputs: uv64 | input_id: u32 × n_inputs |
+axis: u32  | output: u32
+```
+
+Decoder uses `bounded_capacity` to cap the input-id Vec
+preallocation against the remaining buffer, same defense-in-depth
+as the reduction-axes decoders.
+
 ## [0.2.0] — 2026-05-13
 
 ### Added — wire-format support for `Op::Slice`

--- a/code/packages/rust/compute-ir/Cargo.toml
+++ b/code/packages/rust/compute-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compute-ir"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "MX02 — placed compute graph. The lower IR of the matrix execution layer: same dataflow as matrix-ir, plus explicit device placement, residency, and Transfer ops. Pure data, no execution."
 license = "MIT"

--- a/code/packages/rust/compute-ir/src/dump.rs
+++ b/code/packages/rust/compute-ir/src/dump.rs
@@ -207,6 +207,7 @@ fn op_name(op: &matrix_ir::Op) -> &'static str {
         Op::Cast { .. } => "cast",
         Op::Const { .. } => "const",
         Op::Slice { .. } => "slice",
+        Op::Concat { .. } => "concat",
     }
 }
 

--- a/code/packages/rust/compute-ir/src/wire.rs
+++ b/code/packages/rust/compute-ir/src/wire.rs
@@ -224,6 +224,18 @@ fn encode_op(op: &Op, w: &mut Writer<'_>) {
             w.u32(*step);
             w.u32(output.0);
         }
+        Op::Concat {
+            inputs,
+            axis,
+            output,
+        } => {
+            w.uv64(inputs.len() as u64);
+            for inp in inputs {
+                w.u32(inp.0);
+            }
+            w.u32(*axis);
+            w.u32(output.0);
+        }
     }
 }
 
@@ -593,6 +605,21 @@ fn decode_op(r: &mut Reader<'_>) -> Result<Op, ComputeIrError> {
             step: r.u32()?,
             output: TensorId(r.u32()?),
         },
+        0x1D => {
+            let n = r.uv64()?;
+            let cap = bounded_capacity(n, 4, r.remaining());
+            let mut inputs = Vec::with_capacity(cap);
+            for _ in 0..n {
+                inputs.push(TensorId(r.u32()?));
+            }
+            let axis = r.u32()?;
+            let output = TensorId(r.u32()?);
+            Op::Concat {
+                inputs,
+                axis,
+                output,
+            }
+        }
         unknown => {
             return Err(ComputeIrError::WireUnknownTag {
                 what: "matrix_ir::Op",

--- a/code/packages/rust/matrix-cpu/CHANGELOG.md
+++ b/code/packages/rust/matrix-cpu/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to `matrix-cpu` are documented here.
 
+## [0.9.0] — 2026-05-13
+
+### Added — `Op::Concat` execution
+
+Implements the new MX01 V2 `Op::Concat` op (wire tag 0x1D) added in
+`matrix-ir` 0.3.0.
+
+- `eval::concat_bytes(inputs, axis, elem_bytes) -> (Vec<u8>,
+  Vec<u32>)` — pure scalar reference.  Walks the output index
+  space, picks the right input per output element by checking
+  the axis-coordinate against running input offsets.
+- `dispatch::exec_compute` gains an arm for `Op::Concat` that
+  gathers each input's bytes + dims then calls `concat_bytes`.
+- `profile().supported_ops` widened from `0x1FFF_FFFF` (Slice
+  added) to `0x3FFF_FFFF` (Concat adds bit 29).
+
+### Tests
+
+5 new unit tests in `eval::tests`:
+- `concat_two_1d_tensors_axis0`
+- `concat_three_1d_tensors_axis0` (variadic)
+- `concat_2d_axis0_stacks_rows`
+- `concat_2d_axis1_interleaves_columns`
+- `concat_then_slice_round_trips_pairs` — the FFT even/odd
+  reassembly pattern (concat halves → slice them back), end-to-end
+
 ## [0.8.0] — 2026-05-13
 
 ### Added — `Op::Slice` execution

--- a/code/packages/rust/matrix-cpu/Cargo.toml
+++ b/code/packages/rust/matrix-cpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-cpu"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "CPU reference executor for the matrix execution layer. Implements every matrix-ir op on every dtype using straight-line Rust. The always-available safety net that supports operations no GPU backend can take. v0.4 (MX05 Phase 4.1) adds the per-handle specialised kernel table and live DispatchSpecialised handler: install a closure under a u64 handle via install_specialised, then DispatchSpecialised invokes it and returns DispatchDone instead of NOT_IMPLEMENTED. Zero external dependencies."
 license = "MIT"

--- a/code/packages/rust/matrix-cpu/src/dispatch.rs
+++ b/code/packages/rust/matrix-cpu/src/dispatch.rs
@@ -329,6 +329,35 @@ fn exec_compute(buffers: &mut BufferStore, graph: &ComputeGraph, op: &Op) -> Res
             buffers.write(out_residency.buffer, 0, &out_bytes)?;
             Ok(())
         }
+        Op::Concat {
+            inputs,
+            axis,
+            output,
+        } => {
+            let out_t = lookup_meta(graph, *output)?;
+            let elem = out_t.dtype.size_bytes();
+            // Gather each input's bytes + dims.  Materialise the Vec<u8>
+            // and Vec<u32> dim copies up front so the borrow chain in
+            // `concat_bytes` stays simple.
+            let metas: Vec<Meta> = inputs
+                .iter()
+                .map(|id| lookup_meta(graph, *id))
+                .collect::<Result<_, _>>()?;
+            let buf_vecs: Vec<Vec<u8>> = metas
+                .iter()
+                .map(|m| lookup_buffer(buffers, graph, m.id).map(|s| s.to_vec()))
+                .collect::<Result<_, _>>()?;
+            let dim_vecs: Vec<Vec<u32>> = metas.iter().map(|m| m.shape.dims.clone()).collect();
+            let inputs_view: Vec<(&[u8], &[u32])> = buf_vecs
+                .iter()
+                .zip(dim_vecs.iter())
+                .map(|(b, d)| (b.as_slice(), d.as_slice()))
+                .collect();
+            let (out_bytes, _out_dims) = eval::concat_bytes(&inputs_view, *axis, elem);
+            let out_residency = lookup_residency(graph, out_t.id)?;
+            buffers.write(out_residency.buffer, 0, &out_bytes)?;
+            Ok(())
+        }
 
         // ──── MatMul ────
         Op::MatMul { a, b, output } => {

--- a/code/packages/rust/matrix-cpu/src/eval.rs
+++ b/code/packages/rust/matrix-cpu/src/eval.rs
@@ -497,6 +497,72 @@ pub fn slice_bytes(
     (out, out_dims)
 }
 
+// ──────────────────────────── Concat ────────────────────────────
+//
+// MX01 V2 op: concatenate two or more inputs along one axis.  All
+// inputs share dtype and shape on every axis except the concat axis;
+// the output's dim on that axis is the sum of input dims.
+//
+// We walk the output index space.  For each output element, decide
+// which input it belongs to (by checking the axis offset against
+// running input sizes) and read the corresponding input byte.
+
+/// Concatenate `inputs` (each with its dims) along `axis`.  All
+/// inputs must agree on dtype and on every non-axis dim — the
+/// validator has already enforced that.
+pub fn concat_bytes(
+    inputs: &[(&[u8], &[u32])],
+    axis: u32,
+    elem_bytes: usize,
+) -> (Vec<u8>, Vec<u32>) {
+    assert!(!inputs.is_empty(), "concat_bytes called with no inputs");
+    let first_dims = inputs[0].1;
+    let rank = first_dims.len();
+    let mut out_dims: Vec<u32> = first_dims.to_vec();
+    let mut axis_total: u32 = 0;
+    for (_, dims) in inputs.iter() {
+        axis_total += dims[axis as usize];
+    }
+    out_dims[axis as usize] = axis_total;
+
+    let n_out = numel(&out_dims);
+    let mut out = vec![0u8; n_out * elem_bytes];
+    let out_strides = row_major_strides(&out_dims);
+
+    // Per-input strides + cumulative axis offset.
+    let mut input_offsets: Vec<u32> = Vec::with_capacity(inputs.len());
+    let mut cum: u32 = 0;
+    for (_, dims) in inputs.iter() {
+        input_offsets.push(cum);
+        cum += dims[axis as usize];
+    }
+    let input_strides: Vec<Vec<usize>> =
+        inputs.iter().map(|(_, d)| row_major_strides(d)).collect();
+
+    for flat_out in 0..n_out {
+        let out_coords = unravel_with_strides(flat_out, &out_strides, rank);
+        let axis_coord = out_coords[axis as usize] as u32;
+        // Find which input this output element comes from.
+        let mut chosen = 0usize;
+        for (i, &off) in input_offsets.iter().enumerate() {
+            let end = off + inputs[i].1[axis as usize];
+            if axis_coord < end {
+                chosen = i;
+                break;
+            }
+            chosen = i; // keep advancing — last hit wins for axis_coord == axis_total
+        }
+        let local_axis = axis_coord - input_offsets[chosen];
+        let mut in_coords = out_coords.clone();
+        in_coords[axis as usize] = local_axis as usize;
+        let flat_in = ravel(&in_coords, &input_strides[chosen]);
+        let src = inputs[chosen].0;
+        out[flat_out * elem_bytes..(flat_out + 1) * elem_bytes]
+            .copy_from_slice(&src[flat_in * elem_bytes..(flat_in + 1) * elem_bytes]);
+    }
+    (out, out_dims)
+}
+
 // ──────────────────────────── Cast ────────────────────────────
 
 pub fn cast(input: &[u8], src: DType, dst: DType, n: usize) -> Vec<u8> {
@@ -687,5 +753,89 @@ mod tests {
         let (out, dims) = slice_bytes(&input, &[4], 0, 2, 2, 1, 4);
         assert_eq!(dims, vec![0]);
         assert!(out.is_empty());
+    }
+
+    // ── Concat tests (MX01 Phase 3b.i / DSP01 FFT prerequisite) ──
+
+    #[test]
+    fn concat_two_1d_tensors_axis0() {
+        let xs1 = [1.0f32, 2.0, 3.0];
+        let xs2 = [10.0f32, 20.0];
+        let mut a = vec![0u8; 12];
+        let mut b = vec![0u8; 8];
+        write_f32_vec(&mut a, &xs1);
+        write_f32_vec(&mut b, &xs2);
+        let (out, dims) = concat_bytes(&[(&a, &[3]), (&b, &[2])], 0, 4);
+        assert_eq!(dims, vec![5]);
+        assert_eq!(read_f32_vec(&out, 5), vec![1.0, 2.0, 3.0, 10.0, 20.0]);
+    }
+
+    #[test]
+    fn concat_three_1d_tensors_axis0() {
+        let xs1 = [1.0f32];
+        let xs2 = [2.0f32, 3.0];
+        let xs3 = [4.0f32, 5.0, 6.0];
+        let mut a = vec![0u8; 4];
+        let mut b = vec![0u8; 8];
+        let mut c = vec![0u8; 12];
+        write_f32_vec(&mut a, &xs1);
+        write_f32_vec(&mut b, &xs2);
+        write_f32_vec(&mut c, &xs3);
+        let (out, dims) = concat_bytes(&[(&a, &[1]), (&b, &[2]), (&c, &[3])], 0, 4);
+        assert_eq!(dims, vec![6]);
+        assert_eq!(read_f32_vec(&out, 6), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn concat_2d_axis0_stacks_rows() {
+        // [[1,2,3]] ++ [[4,5,6], [7,8,9]] along axis 0 → 3x3.
+        let a_data = [1.0f32, 2.0, 3.0];
+        let b_data = [4.0f32, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let mut a = vec![0u8; 12];
+        let mut b = vec![0u8; 24];
+        write_f32_vec(&mut a, &a_data);
+        write_f32_vec(&mut b, &b_data);
+        let (out, dims) = concat_bytes(&[(&a, &[1, 3]), (&b, &[2, 3])], 0, 4);
+        assert_eq!(dims, vec![3, 3]);
+        assert_eq!(
+            read_f32_vec(&out, 9),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+        );
+    }
+
+    #[test]
+    fn concat_2d_axis1_interleaves_columns() {
+        // [[1,2], [3,4]] ++ [[5,6,7], [8,9,10]] along axis 1 → 2x5.
+        let a_data = [1.0f32, 2.0, 3.0, 4.0];
+        let b_data = [5.0f32, 6.0, 7.0, 8.0, 9.0, 10.0];
+        let mut a = vec![0u8; 16];
+        let mut b = vec![0u8; 24];
+        write_f32_vec(&mut a, &a_data);
+        write_f32_vec(&mut b, &b_data);
+        let (out, dims) = concat_bytes(&[(&a, &[2, 2]), (&b, &[2, 3])], 1, 4);
+        assert_eq!(dims, vec![2, 5]);
+        assert_eq!(
+            read_f32_vec(&out, 10),
+            vec![1.0, 2.0, 5.0, 6.0, 7.0, 3.0, 4.0, 8.0, 9.0, 10.0]
+        );
+    }
+
+    #[test]
+    fn concat_then_slice_round_trips_pairs() {
+        // The FFT pattern: produce a tensor by concat'ing two halves,
+        // then slice it back into halves and verify each matches.
+        let even = [0.0f32, 2.0, 4.0, 6.0];
+        let odd = [1.0f32, 3.0, 5.0, 7.0];
+        let mut e = vec![0u8; 16];
+        let mut o = vec![0u8; 16];
+        write_f32_vec(&mut e, &even);
+        write_f32_vec(&mut o, &odd);
+        let (concat, dims) = concat_bytes(&[(&e, &[4]), (&o, &[4])], 0, 4);
+        assert_eq!(dims, vec![8]);
+        // Slice the first half back.
+        let (re_even, _) = slice_bytes(&concat, &dims, 0, 0, 4, 1, 4);
+        assert_eq!(read_f32_vec(&re_even, 4), vec![0.0, 2.0, 4.0, 6.0]);
+        let (re_odd, _) = slice_bytes(&concat, &dims, 0, 4, 8, 1, 4);
+        assert_eq!(read_f32_vec(&re_odd, 4), vec![1.0, 3.0, 5.0, 7.0]);
     }
 }

--- a/code/packages/rust/matrix-cpu/src/lib.rs
+++ b/code/packages/rust/matrix-cpu/src/lib.rs
@@ -55,16 +55,16 @@ pub use buffers::BufferStore;
 pub fn profile() -> BackendProfile {
     BackendProfile {
         kind: "cpu".to_string(),
-        // Supports every V1 op + the V2 Slice op (tag 0x1C, added with
-        // DSP01 Phase 3a).  V1 was 28 bits (0x00..=0x1B); after Slice
-        // it's 29 (0x00..=0x1C).  `0x1FFF_FFFF` sets bits 0..=28.
+        // Supports V1 (28 ops, tags 0x00..=0x1B) + V2 Slice (0x1C,
+        // DSP01 Phase 3a) + V2 Concat (0x1D, DSP01 Phase 3b.i).
+        // `0x3FFF_FFFF` sets bits 0..=29 — every op CPU knows about.
         //
         // Historical context: the original bitset `0x07FF_FFFF` set
         // only bits 0..=26 and accidentally dropped `Op::Const`
         // (tag 0x1B = bit 27).  The fix expanded to `0x0FFF_FFFF`
-        // (bits 0..=27).  Slice adds bit 28 — matrix-cpu's dispatch
-        // already handles the new op.
-        supported_ops: 0x1FFF_FFFF,
+        // (bits 0..=27).  Slice added bit 28 → `0x1FFF_FFFF`.
+        // Concat adds bit 29 → `0x3FFF_FFFF`.
+        supported_ops: 0x3FFF_FFFF,
         // Supports F32 (bit 0), U8 (bit 1), I32 (bit 2).
         supported_dtypes: 0b0000_0111,
         gflops_f32: 40,

--- a/code/packages/rust/matrix-ir/CHANGELOG.md
+++ b/code/packages/rust/matrix-ir/CHANGELOG.md
@@ -3,6 +3,65 @@
 All notable changes to `matrix-ir` are documented here.  The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] — 2026-05-13
+
+### Added — `Op::Concat` (V2 op, wire tag 0x1D)
+
+Second post-V1 op.  Concatenates two or more inputs along one axis:
+
+```rust
+Op::Concat {
+    inputs: Vec<TensorId>,
+    axis: u32,
+    output: TensorId,
+}
+```
+
+All inputs must share dtype and shape on every axis except `axis`;
+the output's dim on `axis` is the sum of input dims on `axis`.
+Equivalent to numpy `np.concatenate([a, b, …], axis=axis)`.
+
+### Why
+
+DSP01 Phase 3b needs to reassemble even/odd halves of an
+interleaved complex tensor after each FFT butterfly stage.
+`Slice` (0.2.0) reads them; `Concat` reassembles them.  The
+slice-then-concat pattern is also the right primitive for
+many CV transforms (image stacking, channel concat).
+
+### Builder
+
+- `GraphBuilder::concat(inputs: &[&Tensor], axis: u32) -> Tensor` —
+  asserts on empty inputs, axis bounds, dtype mismatch, rank
+  mismatch, non-axis dim mismatch, and u32 overflow on the
+  summed axis.
+
+### Wire format
+
+Tag `0x1D` followed by:
+
+```
+uv64 n_inputs
+u32 input_id × n_inputs
+u32 axis
+u32 output_id
+```
+
+Decoder uses `bounded_capacity` to cap the Vec preallocation
+against the remaining input buffer (same defense-in-depth
+pattern as the existing reduction-axes decoding).
+
+### New error variant
+
+- `IrError::InvalidConcat { op_index, reason: &'static str }` for
+  empty inputs / dtype mismatch / rank mismatch / non-axis dim
+  mismatch / u32 overflow.
+
+### Tests
+
+`wire_tags_are_unique` updated from 28 → 29 variants.
+`sample_one_per_variant` gained a Concat sample.
+
 ## [0.2.0] — 2026-05-13
 
 ### Added — `Op::Slice` (V2 op, wire tag 0x1C)

--- a/code/packages/rust/matrix-ir/Cargo.toml
+++ b/code/packages/rust/matrix-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-ir"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "MX01 — pure tensor algebra IR. The upper IR that domain libraries (image processing, neural networks, signal processing) emit when they want computation done. Static-shape, SSA over tensors, zero external dependencies."
 license = "MIT"

--- a/code/packages/rust/matrix-ir/src/builder.rs
+++ b/code/packages/rust/matrix-ir/src/builder.rs
@@ -422,6 +422,66 @@ impl GraphBuilder {
         out
     }
 
+    /// **V2 op.**  Concatenate two or more tensors along `axis`.
+    ///
+    /// All inputs must share dtype and shape on every axis except
+    /// `axis`.  Output dim on `axis` is the sum of input dims on
+    /// `axis`.
+    ///
+    /// Panics if:
+    /// - `inputs` is empty.
+    /// - `axis >= input.shape.rank()` for any input.
+    /// - inputs disagree on dtype, rank, or any non-axis dim.
+    pub fn concat(&mut self, inputs: &[&Tensor], axis: u32) -> Tensor {
+        assert!(!inputs.is_empty(), "concat: at least one input required");
+        let first = inputs[0];
+        let rank = first.shape.rank();
+        assert!(
+            (axis as usize) < rank,
+            "concat: axis {} out of bounds for rank {}",
+            axis,
+            rank
+        );
+        let mut axis_total: u32 = first.shape.dims[axis as usize];
+        for (i, t) in inputs.iter().enumerate().skip(1) {
+            assert_eq!(
+                t.dtype, first.dtype,
+                "concat: input {} dtype {:?} differs from input 0 dtype {:?}",
+                i, t.dtype, first.dtype
+            );
+            assert_eq!(
+                t.shape.rank(),
+                rank,
+                "concat: input {} rank {} differs from input 0 rank {}",
+                i,
+                t.shape.rank(),
+                rank
+            );
+            for (ai, (a, b)) in t.shape.dims.iter().zip(first.shape.dims.iter()).enumerate() {
+                if ai as u32 == axis {
+                    continue;
+                }
+                assert_eq!(
+                    a, b,
+                    "concat: input {} dim {} = {} != input 0 dim {} = {}",
+                    i, ai, a, ai, b
+                );
+            }
+            axis_total = axis_total
+                .checked_add(t.shape.dims[axis as usize])
+                .expect("concat: axis dim overflows u32");
+        }
+        let mut new_dims = first.shape.dims.clone();
+        new_dims[axis as usize] = axis_total;
+        let out = self.alloc(first.dtype, Shape::from(&new_dims[..]));
+        self.ops.push(Op::Concat {
+            inputs: inputs.iter().map(|t| t.id).collect(),
+            axis,
+            output: out.id,
+        });
+        out
+    }
+
     // ──────────── linear algebra ────────────
 
     /// 2D matrix multiply.  `a: [m,k]` × `b: [k,n]` → `[m,n]`.

--- a/code/packages/rust/matrix-ir/src/op.rs
+++ b/code/packages/rust/matrix-ir/src/op.rs
@@ -20,14 +20,14 @@ use crate::tensor::{DType, Shape, TensorId};
 /// - **Elementwise unary** (7): Neg, Abs, Sqrt, Exp, Log, Tanh, Recip
 /// - **Elementwise binary** (7): Add, Sub, Mul, Div, Max, Min, Pow
 /// - **Reductions** (3): ReduceSum, ReduceMax, ReduceMean
-/// - **Shape** (4): Reshape, Transpose, Broadcast, **Slice** (V2)
+/// - **Shape** (5): Reshape, Transpose, Broadcast, **Slice** (V2), **Concat** (V2)
 /// - **Linear algebra** (1): MatMul
 /// - **Comparison** (3): Equal, Less, Greater
 /// - **Selection** (1): Where
 /// - **Conversion** (1): Cast
 /// - **Constants** (1): Const
 ///
-/// Total: 28 ops.  See spec MX01 §"V1 op set" for the contract on each.
+/// Total: 29 ops.  See spec MX01 §"V1 op set" for the contract on each.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Op {
     // ──────────── elementwise unary ────────────
@@ -134,6 +134,23 @@ pub enum Op {
         step: u32,
         output: TensorId,
     },
+    /// **V2 op (MX01 extension).**  Concatenate two or more input
+    /// tensors along the given `axis`.  All inputs must share dtype
+    /// and shape on every axis **except** `axis`; the output's dim
+    /// on `axis` is the sum of input dims on `axis`.
+    ///
+    /// At least one input is required.  V1 of this op accepts an
+    /// arbitrary number of inputs; specific executors may cap that
+    /// number for kernel-launch reasons.
+    ///
+    /// Equivalent to numpy `np.concatenate([a, b, …], axis=axis)`.
+    /// Exists to round-trip the slice / concat dance that FFT
+    /// butterflies and many other DSP / CV transforms perform.
+    Concat {
+        inputs: Vec<TensorId>,
+        axis: u32,
+        output: TensorId,
+    },
 
     // ──────────── linear algebra ────────────
     /// 2D matrix multiplication.  `a` is `[m, k]`, `b` is `[k, n]`,
@@ -211,6 +228,7 @@ impl Op {
             Op::Cast { .. } => 0x1A,
             Op::Const { .. } => 0x1B,
             Op::Slice { .. } => 0x1C,
+            Op::Concat { .. } => 0x1D,
         }
     }
 
@@ -245,6 +263,7 @@ impl Op {
             Op::Cast { output, .. } => output,
             Op::Const { output, .. } => output,
             Op::Slice { output, .. } => output,
+            Op::Concat { output, .. } => output,
         }
     }
 
@@ -291,6 +310,8 @@ impl Op {
                 false_value,
                 ..
             } => vec![*predicate, *true_value, *false_value],
+
+            Op::Concat { inputs, .. } => inputs.clone(),
 
             Op::Const { .. } => Vec::new(),
         }
@@ -345,8 +366,8 @@ mod tests {
             "duplicate wire tag in Op enum: {:?}",
             tags
         );
-        // 28 variants in V1 + Slice (V2 extension).
-        assert_eq!(len_before, 28);
+        // 29 variants: V1 (27) + Slice (0x1C) + Concat (0x1D).
+        assert_eq!(len_before, 29);
     }
 
     #[test]
@@ -487,6 +508,11 @@ mod tests {
                 end: 4,
                 step: 1,
                 output: t(1),
+            },
+            Op::Concat {
+                inputs: vec![t(0), t(1)],
+                axis: 0,
+                output: t(2),
             },
         ]
     }

--- a/code/packages/rust/matrix-ir/src/validate.rs
+++ b/code/packages/rust/matrix-ir/src/validate.rs
@@ -83,6 +83,13 @@ pub enum IrError {
         op_index: u32,
         reason: &'static str,
     },
+    /// A concat is malformed: empty inputs, dtype mismatch across
+    /// inputs, rank mismatch, or non-axis dim mismatch.  `reason`
+    /// is a short human-readable tag.
+    InvalidConcat {
+        op_index: u32,
+        reason: &'static str,
+    },
     /// A matmul received an input with the wrong rank.
     BadMatMulRank {
         op_index: u32,
@@ -513,6 +520,70 @@ impl Graph {
                 Ok(())
             }
 
+            // ──── concat (V2 shape op) ────
+            Op::Concat {
+                inputs,
+                axis,
+                output,
+            } => {
+                if inputs.is_empty() {
+                    return Err(IrError::InvalidConcat {
+                        op_index: i,
+                        reason: "at least one input required",
+                    });
+                }
+                let first = self.must_tensor(i, inputs[0])?;
+                let rank = first.shape.rank();
+                if (*axis as usize) >= rank {
+                    return Err(IrError::InvalidAxis {
+                        op_index: i,
+                        axis: *axis,
+                        rank: rank as u32,
+                    });
+                }
+                let mut axis_total: u32 = first.shape.dims[*axis as usize];
+                for inp_id in inputs.iter().skip(1) {
+                    let t = self.must_tensor(i, *inp_id)?;
+                    if t.dtype != first.dtype {
+                        return Err(IrError::DTypeMismatch {
+                            op_index: i,
+                            expected: first.dtype,
+                            actual: t.dtype,
+                        });
+                    }
+                    if t.shape.rank() != rank {
+                        return Err(IrError::InvalidConcat {
+                            op_index: i,
+                            reason: "input rank mismatch",
+                        });
+                    }
+                    for (ai, (a, b)) in t.shape.dims.iter().zip(first.shape.dims.iter()).enumerate()
+                    {
+                        if ai as u32 == *axis {
+                            continue;
+                        }
+                        if a != b {
+                            return Err(IrError::InvalidConcat {
+                                op_index: i,
+                                reason: "non-axis dim mismatch",
+                            });
+                        }
+                    }
+                    axis_total =
+                        axis_total
+                            .checked_add(t.shape.dims[*axis as usize])
+                            .ok_or(IrError::InvalidConcat {
+                                op_index: i,
+                                reason: "axis dim overflows u32",
+                            })?;
+                }
+                let mut new_dims = first.shape.dims.clone();
+                new_dims[*axis as usize] = axis_total;
+                let expected_shape = Shape::from(&new_dims[..]);
+                self.expect_output(i, *output, &first.dtype, &expected_shape)?;
+                Ok(())
+            }
+
             // ──── slice (V2 shape op) ────
             Op::Slice {
                 input,
@@ -654,5 +725,6 @@ fn op_name(op: &Op) -> &'static str {
         Op::Cast { .. } => "cast",
         Op::Const { .. } => "const",
         Op::Slice { .. } => "slice",
+        Op::Concat { .. } => "concat",
     }
 }

--- a/code/packages/rust/matrix-ir/src/wire.rs
+++ b/code/packages/rust/matrix-ir/src/wire.rs
@@ -257,6 +257,18 @@ fn encode_op(op: &Op, w: &mut Writer<'_>) {
             w.u32(*step);
             w.u32(output.0);
         }
+        Op::Concat {
+            inputs,
+            axis,
+            output,
+        } => {
+            w.uv64(inputs.len() as u64);
+            for inp in inputs {
+                w.u32(inp.0);
+            }
+            w.u32(*axis);
+            w.u32(output.0);
+        }
     }
 }
 
@@ -634,6 +646,24 @@ fn decode_op(r: &mut Reader<'_>) -> Result<Op, IrError> {
             step: r.u32()?,
             output: TensorId(r.u32()?),
         }),
+        0x1D => {
+            let n_inputs = r.uv64()?;
+            // Each input id is 4 bytes; cap allocation against the
+            // remaining buffer size so a malicious header can't
+            // amplify a small input into a giant Vec.
+            let cap = bounded_capacity(n_inputs, 4, r.remaining());
+            let mut inputs = Vec::with_capacity(cap);
+            for _ in 0..n_inputs {
+                inputs.push(TensorId(r.u32()?));
+            }
+            let axis = r.u32()?;
+            let output = TensorId(r.u32()?);
+            Ok(Op::Concat {
+                inputs,
+                axis,
+                output,
+            })
+        }
         unknown => Err(IrError::WireUnknownTag {
             what: "op",
             tag: unknown as u64,

--- a/code/packages/rust/matrix-metal/CHANGELOG.md
+++ b/code/packages/rust/matrix-metal/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — matrix-metal
 
+## 0.11.2 — 2026-05-13
+
+### Compatibility update — `Op::Concat` keep-up
+
+`matrix-ir` 0.3.0 added `Op::Concat` (wire tag 0x1D).  matrix-metal
+does **not** claim Concat in its `supported_ops` bitset, so the
+planner routes Concat ops to CPU — but the local `op_kind_name`
+helper gained an arm so the exhaustive match still compiles.
+
+Same pattern as the 0.11.1 keep-up for Op::Slice.
+
 ## 0.11.1 — 2026-05-13
 
 ### Compatibility update — `Op::Slice` keep-up

--- a/code/packages/rust/matrix-metal/Cargo.toml
+++ b/code/packages/rust/matrix-metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-metal"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "First real GPU executor for the matrix execution layer. Lowers a subset of MatrixIR ops to MSL kernels and dispatches via the metal-compute crate. Falls back to CPU automatically (via the planner's capability filter) for ops it doesn't yet support. v0.6 (MX05 Phase 4.2) ships the MSL emitter — given a SpecKey it generates an MSL kernel string with observed constants folded in as literal values — plus the per-handle specialised pipeline table and live DispatchSpecialised handler that runs on Apple targets."
 license = "MIT"

--- a/code/packages/rust/matrix-metal/src/dispatch.rs
+++ b/code/packages/rust/matrix-metal/src/dispatch.rs
@@ -861,5 +861,6 @@ fn op_kind_name(op: &Op) -> &'static str {
         Op::Cast { .. } => "Cast",
         Op::Const { .. } => "Const",
         Op::Slice { .. } => "Slice",
+        Op::Concat { .. } => "Concat",
     }
 }

--- a/code/packages/rust/matrix-runtime/CHANGELOG.md
+++ b/code/packages/rust/matrix-runtime/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to `matrix-runtime` are documented here.  The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.10.0] — 2026-05-13
+
+### Changed — cost model knows `Op::Concat`
+
+`cost::estimate_flops` now handles `Op::Concat` (matrix-ir 0.3.0).
+Same shape-op weighting as Reshape / Transpose / Broadcast / Slice
+— one op per output element.
+
 ## [0.9.0] — 2026-05-13
 
 ### Changed — cost model knows `Op::Slice`

--- a/code/packages/rust/matrix-runtime/Cargo.toml
+++ b/code/packages/rust/matrix-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-runtime"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "MX04 — the brain of the matrix execution layer. Planner, executor registry, and cost-model-driven placement. Lowers matrix-ir Graphs to compute-ir ComputeGraphs by routing each op to the cheapest available executor. v0.2 adds pass 2b (single-executor preference); v0.3–v0.7 added the MX05 specialisation pipeline (sampler, SpecKey, policy, cache, router) as inline modules. v0.8 promotes those modules into the standalone matrix-profile crate; they remain re-exported from matrix-runtime for back-compat."
 license = "MIT"

--- a/code/packages/rust/matrix-runtime/src/cost.rs
+++ b/code/packages/rust/matrix-runtime/src/cost.rs
@@ -53,9 +53,11 @@ pub fn estimate_flops(op: &Op, output_shape: Option<&Shape>, input_shape: Option
         Op::ReduceSum { .. } | Op::ReduceMax { .. } | Op::ReduceMean { .. } => in_numel,
         // Shape ops: memory traffic, not flops, but we count one op
         // per output element so the planner sees a non-zero cost.
-        Op::Reshape { .. } | Op::Transpose { .. } | Op::Broadcast { .. } | Op::Slice { .. } => {
-            out_numel
-        }
+        Op::Reshape { .. }
+        | Op::Transpose { .. }
+        | Op::Broadcast { .. }
+        | Op::Slice { .. }
+        | Op::Concat { .. } => out_numel,
         // MatMul: caller must supply both input shapes via `input_shape`.
         Op::MatMul { .. } => {
             // Without per-input shape access at this level, fall back


### PR DESCRIPTION
## Summary

Adds tensor concatenation along an axis to `matrix-ir`. All inputs must share dtype and shape on every axis except the concat axis; the output's dim on that axis is the sum of input dims. Equivalent to `numpy.np.concatenate([a, b, …], axis=axis)`.

**Second V2 op** after Slice (wire tag 0x1C). Wire tag `0x1D`.

## Why

DSP01 Phase 3b (matrix-ir-lowered FFT) needs to reassemble even / odd halves of an interleaved complex tensor after each butterfly stage. `Slice` (matrix-ir 0.2.0) reads them; `Concat` reassembles. The slice-then-concat pattern is also the canonical primitive for many CV transforms (image stacking, channel concat).

This is **Phase 3b.i of DSP01** — Phase 3b.ii will build the actual FFT graph on top of Slice + Concat.

## Cross-cutting changes

| Crate | Version | Change |
| --- | --- | --- |
| matrix-ir | **0.3.0** | new Op::Concat; builder; wire encode/decode (bounded_capacity for n_inputs Vec); validator (+ `IrError::InvalidConcat`); checked_add on axis dim sum |
| compute-ir | **0.3.0** | wire support + `dump::op_name` arm |
| matrix-runtime | **0.10.0** | cost-model arm |
| matrix-cpu | **0.9.0** | `eval::concat_bytes` + dispatch arm + `supported_ops` widened to `0x3FFF_FFFF` |
| matrix-metal | **0.11.2** | `op_kind_name` arm; doesn't claim Concat → planner routes to CPU |

## Validator constraints

- At least one input.
- `axis < input.shape.rank()`.
- All inputs share dtype.
- All inputs share rank.
- All inputs agree on every non-axis dim.
- Summed axis dim does not overflow u32 (`checked_add`).

## Test plan

- [x] `cargo test -p matrix-ir -p matrix-cpu -p matrix-runtime -p compute-ir -p matrix-metal` — all pass.
- [x] 5 new `concat_bytes` unit tests: 1-D two-tensor, 1-D variadic three-tensor, 2-D axis-0 row stack, 2-D axis-1 column interleave, and the FFT round-trip pattern (`concat_then_slice_round_trips_pairs`).
- [x] `wire_tags_are_unique` updated 28 → 29 variants.
- [x] `/security-review` — passed. Wire decoder uses `bounded_capacity` against remaining buffer; validator catches all malformed-input cases; index math in `concat_bytes` is bounded by validated dimensions; no `unsafe`; Metal kept routing Concat to CPU (no new GPU attack surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)