### PR TITLE
feat(forme-orchestrator): Forme pipeline runtime (FM03 §3-4, §9-10)

### DIFF
--- a/code/packages/typescript/forme-orchestrator/BUILD
+++ b/code/packages/typescript/forme-orchestrator/BUILD
@@ -1,0 +1,10 @@
+cd ../document-ast && npm install --silent
+cd ../forme-types && npm install --silent
+cd ../forme-errors && npm install --silent
+cd ../forme-capability && npm install --silent
+cd ../forme-stage && npm install --silent
+cd ../forme-pipeline-config && npm install --silent
+cd ../blake2b && npm install --silent
+cd ../forme-identity && npm install --silent
+cd ../forme-cache && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-orchestrator/CHANGELOG.md
+++ b/code/packages/typescript/forme-orchestrator/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog — @coding-adventures/forme-orchestrator
+
+## 0.1.0 — 2026-05-15
+
+Initial release.  FM03 §3-4, §9-10 — the runtime that takes a
+`PipelineConfig`, builds a typed DAG, and executes it.  Last big
+package of the FM03 orchestrator stack.
+
+### Added
+
+- `createOrchestrator(options?)` → `Orchestrator` factory.
+- `Orchestrator.buildPipeline(config)` → `Pipeline` (validate + DAG).
+- `Orchestrator.runOnce(pipeline, options?)` → `RunResult`.
+- `Orchestrator.dispose()` lifecycle.
+- `buildPipeline(config)` standalone (`createOrchestrator` is a thin
+  factory wrapper around it).
+- `runOnce(pipeline, options?, ctx?)` standalone.
+- `buildDag(resolved)` — direct DAG construction.
+- `areKindsCompatible(produces, consumes)` — FM01 §2.6 typecheck
+  predicate covering name match, version compatibility (major must
+  match, producer minor ≥ consumer minor), discriminant equality,
+  and Stream wrapping (Stream<X> can feed single-X via iteration;
+  single-X cannot feed Stream<X>).
+- `RunResult` with `outcome`, `stages`, `outputs`, `errors`,
+  `elapsedMs`, `buildId`.
+- `RunError` and `StageRunSummary` for per-stage reporting.
+
+### v0 simplifications (deferred)
+
+- **No parallelism.** Sequential topological execution.
+  `settings.maxConcurrency` is honoured at 1.
+- **No streaming pipelining.** Stream producers are fully drained
+  before downstream consumers see values.
+- **No incremental rebuild.** Cache backend exists but isn't hit yet.
+- **No reproducible-build mode.**
+- **No watch mode.**
+- **No OpenTelemetry traces.**
+
+### What works
+
+- Linear and fan-out-1 pipelines (source → transform... → sink)
+- Stream producers feeding single-input consumers (executor iterates)
+- init / dispose lifecycle (init failure → abort + dispose initialized)
+- Fail-fast (default) and best-effort error handling
+- Cancellation: composing tokens, throwIfCancelled inside loops
+- Named outputs via `OutputSpec` mapping
+- buildId via `computeRevisionId` over source/sink ids
+
+### Dependencies
+
+- `@coding-adventures/forme-types` — Kinds, KindDescriptor
+- `@coding-adventures/forme-stage` — Stage, StageContext, defaults
+- `@coding-adventures/forme-errors` — StageError, CancellationError
+- `@coding-adventures/forme-pipeline-config` — validateConfig
+- `@coding-adventures/forme-cache` — CacheBackend (held but not
+  invoked in v0)
+- `@coding-adventures/forme-identity` — computeRevisionId for buildId
+- `@coding-adventures/forme-capability` — Capability (type only)

--- a/code/packages/typescript/forme-orchestrator/README.md
+++ b/code/packages/typescript/forme-orchestrator/README.md
@@ -1,0 +1,61 @@
+# @coding-adventures/forme-orchestrator
+
+The runtime that takes a `PipelineConfig`, builds a typed DAG, and executes it (FM03 §3-4, §9-10).
+
+Last big package of the FM03 orchestrator stack.
+
+## v0 surface
+
+```typescript
+import { createOrchestrator } from "@coding-adventures/forme-orchestrator";
+
+const o = createOrchestrator();
+const pipeline = await o.buildPipeline(config);
+const result = await o.runOnce(pipeline);
+console.log(result.outcome, result.outputs);
+await o.dispose();
+```
+
+| Function/Type             | Purpose                                                                |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `createOrchestrator()`    | Build a runtime handle (cache + logger + pipeline lifecycle).          |
+| `buildPipeline(config)`   | Validate config + construct typed DAG.                                 |
+| `runOnce(pipeline, opts?)`| Execute the DAG; return a structured `RunResult`.                       |
+| `Orchestrator`            | The runtime handle interface.                                          |
+| `Pipeline`                | The built pipeline (config + DAG).                                     |
+| `RunResult`               | Outcome, per-stage summaries, outputs, errors, timing, buildId.         |
+| `RunError`                | Per-stage error surface.                                               |
+| `StageRunSummary`         | Per-stage execution summary.                                            |
+| `buildDag`                | Direct DAG construction (used by `buildPipeline`; exported for tests).  |
+| `areKindsCompatible`      | Type-compatibility predicate (FM01 §2.6).                               |
+
+## v0 simplifications
+
+These are deferred to follow-up packages:
+
+- **No parallelism.** Stages execute sequentially in topological order. `settings.maxConcurrency` is honoured at `1`.
+- **No streaming pipelining.** A `Stream<X>` producer is fully drained into memory before downstream consumers see values. Lazy streaming lands in v1 alongside parallelism.
+- **No incremental rebuild.** Every run executes every stage; the cache backend exists but isn't hit yet (FM03 §6).
+- **No reproducible-build mode.** Stages get `systemClock`, not `frozenClock` (FM03 §8).
+- **No watch mode.** `forme watch` lives in a future companion package (FM03 §7).
+- **No OpenTelemetry traces.** Telemetry surface is no-op by default.
+
+## What v0 *does* implement
+
+- Topological execution honouring kind-compatibility wiring
+- Per-stage `StageContext` construction with denied-by-default capability APIs
+- `init` / `dispose` lifecycle hooks (init failure aborts before any `run`; dispose always runs)
+- Fail-fast and best-effort error handling
+- Cancellation propagation (composes a fresh token if caller doesn't supply one)
+- Per-stage timing + error counts + outcome in `StageRunSummary`
+- Named outputs from `OutputSpec` overriding sink instance ids
+- `buildId` derived from `computeRevisionId` over pipeline source/sink ids
+
+## Coverage
+
+```bash
+npm install
+npx vitest run --coverage
+```
+
+Targets ≥85% line coverage. The scheduler has many branches (init failure, fail-fast, best-effort, cancellation, dispose-on-failure) — integration tests cover the canonical paths.

--- a/code/packages/typescript/forme-orchestrator/package-lock.json
+++ b/code/packages/typescript/forme-orchestrator/package-lock.json
@@ -1,0 +1,2427 @@
+{
+  "name": "@coding-adventures/forme-orchestrator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-orchestrator",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-cache": "file:../forme-cache",
+        "@coding-adventures/forme-capability": "file:../forme-capability",
+        "@coding-adventures/forme-errors": "file:../forme-errors",
+        "@coding-adventures/forme-identity": "file:../forme-identity",
+        "@coding-adventures/forme-pipeline-config": "file:../forme-pipeline-config",
+        "@coding-adventures/forme-stage": "file:../forme-stage",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-cache": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/blake2b": "file:../blake2b",
+        "@coding-adventures/forme-identity": "file:../forme-identity",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-capability": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-errors": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-identity": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/blake2b": "file:../blake2b",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-pipeline-config": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-capability": "file:../forme-capability",
+        "@coding-adventures/forme-errors": "file:../forme-errors",
+        "@coding-adventures/forme-stage": "file:../forme-stage",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-stage": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-capability": "file:../forme-capability",
+        "@coding-adventures/forme-errors": "file:../forme-errors",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-types": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-cache": {
+      "resolved": "../forme-cache",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-capability": {
+      "resolved": "../forme-capability",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-errors": {
+      "resolved": "../forme-errors",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-identity": {
+      "resolved": "../forme-identity",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-pipeline-config": {
+      "resolved": "../forme-pipeline-config",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-stage": {
+      "resolved": "../forme-stage",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-types": {
+      "resolved": "../forme-types",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-orchestrator/package.json
+++ b/code/packages/typescript/forme-orchestrator/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@coding-adventures/forme-orchestrator",
+  "version": "0.1.0",
+  "description": "Forme orchestrator runtime: DAG construction, sequential topological execution, error handling, cancellation, dispose lifecycle (FM03 §3-4, §9-10).",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-types": "file:../forme-types",
+    "@coding-adventures/forme-errors": "file:../forme-errors",
+    "@coding-adventures/forme-stage": "file:../forme-stage",
+    "@coding-adventures/forme-pipeline-config": "file:../forme-pipeline-config",
+    "@coding-adventures/forme-cache": "file:../forme-cache",
+    "@coding-adventures/forme-identity": "file:../forme-identity",
+    "@coding-adventures/forme-capability": "file:../forme-capability"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-orchestrator/required_capabilities.json
+++ b/code/packages/typescript/forme-orchestrator/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-orchestrator",
+  "capabilities": [],
+  "justification": "Pure runtime: DAG construction, sequential execution, error/cancellation handling.  No I/O, no network — concrete StorageApi/NetworkApi implementations are plugged in by the caller (CLI, dev-server) and stages, both of which carry their own capability declarations."
+}

--- a/code/packages/typescript/forme-orchestrator/src/build-pipeline.ts
+++ b/code/packages/typescript/forme-orchestrator/src/build-pipeline.ts
@@ -1,0 +1,28 @@
+/**
+ * `buildPipeline` — turn a `PipelineConfig` into an executable
+ * `Pipeline` (FM03 §3.2 "Resolve" + "Typecheck").
+ *
+ * Two phases:
+ *
+ *   1. **Validate** — delegated to `forme-pipeline-config`'s
+ *      `validateConfig`.  Throws `ConfigError` with a structured
+ *      list of every violation.
+ *
+ *   2. **Build DAG** — kind-match consumes against produces from the
+ *      most-recent compatible producer.  Throws an error if any
+ *      consumer can't be wired.
+ *
+ * The result is a `Pipeline` carrying the original config and the
+ * fully-built DAG, ready for `runOnce`.
+ */
+
+import { validateConfig } from "@coding-adventures/forme-pipeline-config";
+import type { PipelineConfig } from "@coding-adventures/forme-pipeline-config";
+import { buildDag } from "./dag.js";
+import type { Pipeline } from "./types.js";
+
+export async function buildPipeline(config: PipelineConfig): Promise<Pipeline> {
+  const resolved = validateConfig(config);
+  const dag = buildDag(resolved);
+  return { config: resolved.config, dag };
+}

--- a/code/packages/typescript/forme-orchestrator/src/dag.ts
+++ b/code/packages/typescript/forme-orchestrator/src/dag.ts
@@ -1,0 +1,139 @@
+/**
+ * Pipeline DAG construction (FM03 §3.3).
+ *
+ * Given a validated config (`ResolvedPipelineConfig`), build a typed
+ * directed acyclic graph the executor can walk.
+ *
+ * === Algorithm ===
+ *
+ * For each consumer instance, find the most recently declared
+ * producer of a compatible kind.  "Most recent" means the latest
+ * instance in the `stages` array before the consumer.  Falls back to
+ * any prior instance (without that "before" constraint) if no later
+ * one exists.
+ *
+ * Sources (`consumes: Void`) have no incoming edge.  Sinks (no
+ * downstream consumer) are marked as terminal.
+ *
+ * v0 simplification: explicit `wires` overrides are not yet
+ * implemented; pipelines must be inferable from kind compatibility.
+ * The validator already accepts only inferable shapes for v0.
+ */
+
+import { isStageRef } from "@coding-adventures/forme-pipeline-config";
+import type { ResolvedPipelineConfig } from "@coding-adventures/forme-pipeline-config";
+import type { Capability } from "@coding-adventures/forme-capability";
+import type { KindDescriptor } from "@coding-adventures/forme-types";
+import type { Stage } from "@coding-adventures/forme-stage";
+import { areKindsCompatible } from "./typecheck.js";
+
+/** A resolved stage instance ready to run. */
+export interface ResolvedInstance {
+  readonly id: string;
+  readonly stage: Stage<KindDescriptor, KindDescriptor>;
+  readonly config: unknown;
+  readonly capabilities: readonly Capability[];
+  /** Producer instance id whose output feeds this instance, or null for sources. */
+  readonly producer: string | null;
+}
+
+export interface PipelineDag {
+  /** All instances, keyed by id. */
+  readonly instances: ReadonlyMap<string, ResolvedInstance>;
+  /** Topological order (one valid linearisation). */
+  readonly topoOrder: readonly string[];
+  /** Stages with no consumer — produce final outputs. */
+  readonly sinks: readonly string[];
+  /** Stages with no producer (consumes: Void). */
+  readonly sources: readonly string[];
+}
+
+/**
+ * Build a `PipelineDag` from a validated config.  Throws `Error` on
+ * type-incompatibility or unresolvable producer.
+ */
+export function buildDag(resolved: ResolvedPipelineConfig): PipelineDag {
+  const instances = new Map<string, ResolvedInstance>();
+  const sources: string[] = [];
+  const sinks: string[] = [];
+
+  // First pass: collect ResolvedInstance with producer = null.
+  for (let i = 0; i < resolved.config.stages.length; i++) {
+    const spec = resolved.config.stages[i]!;
+    const id = resolved.resolvedIds[i]!;
+    if (isStageRef(spec.stage)) {
+      // Validator rejects this; defensive guard.
+      throw new Error(`buildDag: instance ${id} is an unresolved StageRef`);
+    }
+    instances.set(id, {
+      id,
+      stage: spec.stage,
+      config: spec.config,
+      capabilities: spec.capabilities ?? spec.stage.capabilities,
+      producer: null,
+    });
+  }
+
+  // Second pass: resolve producers by walking earlier instances and
+  // finding the most-recent compatible kind.  Track which producers
+  // are consumed so we can identify sinks.
+  const consumedAsProducer = new Set<string>();
+  const ids = resolved.resolvedIds;
+  const updated: ResolvedInstance[] = [];
+  for (let i = 0; i < ids.length; i++) {
+    const id = ids[i]!;
+    const inst = instances.get(id)!;
+    const consumes = inst.stage.consumes;
+
+    // Sources: consumes: Void (or void).
+    if (consumes.name === "Void") {
+      sources.push(id);
+      updated.push(inst);
+      continue;
+    }
+
+    // Walk earlier instances in declaration order from most-recent backwards.
+    let producerId: string | null = null;
+    for (let j = i - 1; j >= 0; j--) {
+      const prior = instances.get(ids[j]!)!;
+      if (areKindsCompatible(prior.stage.produces, consumes)) {
+        producerId = prior.id;
+        break;
+      }
+    }
+    // FM03 §3.3 step 2: fallback to any prior instance if none follows
+    // — for v0 we only walk earlier instances anyway, so the same loop
+    // covers it.
+
+    if (producerId === null) {
+      throw new Error(
+        `buildDag: instance ${JSON.stringify(id)} consumes ` +
+        `${describeKind(consumes)} but no earlier instance produces a compatible kind`,
+      );
+    }
+    consumedAsProducer.add(producerId);
+    updated.push({ ...inst, producer: producerId });
+  }
+
+  // Replace map with updated instances (now carrying producer info).
+  for (const inst of updated) instances.set(inst.id, inst);
+
+  // Sinks: instances NOT in consumedAsProducer.
+  for (const id of ids) {
+    if (!consumedAsProducer.has(id)) sinks.push(id);
+  }
+
+  return {
+    instances,
+    topoOrder: ids,
+    sinks,
+    sources,
+  };
+}
+
+function describeKind(k: KindDescriptor): string {
+  if (k.name === "Stream" && k.inner) {
+    return `Stream<${k.inner.name}>`;
+  }
+  return k.name;
+}

--- a/code/packages/typescript/forme-orchestrator/src/index.ts
+++ b/code/packages/typescript/forme-orchestrator/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @coding-adventures/forme-orchestrator
+ *
+ * The runtime that takes a `PipelineConfig`, builds a typed DAG, and
+ * executes it (FM03 §3-4, §9-10).
+ *
+ * v0 surface: `createOrchestrator()` → `buildPipeline(config)` →
+ * `runOnce(pipeline, options?)` → `RunResult`.  Linear and
+ * fan-out-1 pipelines work; full parallelism, watch mode, incremental
+ * rebuild, reproducible-build mode, and OpenTelemetry traces are
+ * deferred to follow-ups.
+ *
+ * See FM03 §3 for the lifecycle, §9 for error handling, §10 for
+ * cancellation.  See `scheduler.ts` for the v0 simplifications listed
+ * verbatim.
+ */
+
+export { createOrchestrator } from "./orchestrator.js";
+export { buildPipeline } from "./build-pipeline.js";
+export { runOnce } from "./run.js";
+export { buildDag } from "./dag.js";
+export { areKindsCompatible } from "./typecheck.js";
+
+export type {
+  Orchestrator,
+  OrchestratorOptions,
+  Pipeline,
+  RunOptions,
+  RunOutcome,
+  RunResult,
+  RunError,
+  StageRunSummary,
+} from "./types.js";
+
+export type { PipelineDag, ResolvedInstance } from "./dag.js";

--- a/code/packages/typescript/forme-orchestrator/src/orchestrator.ts
+++ b/code/packages/typescript/forme-orchestrator/src/orchestrator.ts
@@ -1,0 +1,63 @@
+/**
+ * `createOrchestrator` — factory for the runtime handle.
+ *
+ * Holds the persistent cache backend, default logger, and any other
+ * cross-call state the orchestrator needs.  The returned `Orchestrator`
+ * exposes the three FM03 §3.1 lifecycle methods: `buildPipeline`,
+ * `runOnce`, `dispose`.
+ *
+ * v0 omits `watch` (FM03 §7) — that lands in a follow-up package.
+ */
+
+import { memoryCache } from "@coding-adventures/forme-cache";
+import { silentLogger } from "@coding-adventures/forme-stage";
+import { buildPipeline } from "./build-pipeline.js";
+import { runOnce } from "./run.js";
+import type {
+  Orchestrator,
+  OrchestratorOptions,
+  Pipeline,
+  RunOptions,
+  RunResult,
+} from "./types.js";
+
+class OrchestratorImpl implements Orchestrator {
+  private disposed = false;
+  constructor(private readonly options: Required<OrchestratorOptions>) {}
+
+  async buildPipeline(config: Parameters<Orchestrator["buildPipeline"]>[0]): Promise<Pipeline> {
+    this.assertNotDisposed();
+    return buildPipeline(config);
+  }
+
+  async runOnce(pipeline: Pipeline, options?: RunOptions): Promise<RunResult> {
+    this.assertNotDisposed();
+    return runOnce(pipeline, options, { logger: this.options.logger });
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    await this.options.cache.dispose();
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) {
+      throw new Error("Orchestrator: instance has been disposed");
+    }
+  }
+}
+
+/**
+ * Build a new orchestrator instance.  Defaults to an in-memory cache
+ * and a silent logger — callers (CLI, dev-server) plug in
+ * `consoleLogger()` and `filesystemCache(dir)` as needed.
+ */
+export function createOrchestrator(
+  options: OrchestratorOptions = {},
+): Orchestrator {
+  return new OrchestratorImpl({
+    cache: options.cache ?? memoryCache(),
+    logger: options.logger ?? silentLogger(),
+  });
+}

--- a/code/packages/typescript/forme-orchestrator/src/run.ts
+++ b/code/packages/typescript/forme-orchestrator/src/run.ts
@@ -1,0 +1,85 @@
+/**
+ * `runOnce` — execute a built `Pipeline` and return a structured `RunResult`.
+ *
+ * Wraps the scheduler with the public-API niceties:
+ *
+ *   - Composes a cancellation token (caller's override or fresh).
+ *   - Resolves `bestEffort` from RunOptions / config.
+ *   - Maps scheduler outputs (keyed by sink instance id) to the public
+ *     `outputs` map (keyed by `OutputSpec.name` when one exists, else
+ *     by instance id).
+ *   - Computes a `buildId` from the input revisions of every source
+ *     stage.  For v0 we hash the joined source instance ids — the
+ *     full revision-tracking story lands when sources start emitting
+ *     real revisions.
+ *   - Times the wall-clock end-to-end.
+ */
+
+import { computeRevisionId } from "@coding-adventures/forme-identity";
+import {
+  consoleLogger,
+  createCancellationTokenSource,
+  silentLogger,
+} from "@coding-adventures/forme-stage";
+import type { Logger } from "@coding-adventures/forme-stage";
+import { executeDag } from "./scheduler.js";
+import type { Pipeline, RunOptions, RunResult } from "./types.js";
+
+export interface RunOnceContext {
+  readonly logger?: Logger;
+}
+
+export async function runOnce(
+  pipeline: Pipeline,
+  options: RunOptions = {},
+  ctx: RunOnceContext = {},
+): Promise<RunResult> {
+  const start = Date.now();
+
+  const cancellation = options.cancellation
+    ?? createCancellationTokenSource().token;
+  const bestEffort = options.bestEffort
+    ?? pipeline.config.settings.bestEffort;
+
+  // Default logger respects the pipeline's logLevel; tests/CLI can
+  // override via `ctx.logger`.
+  const logger: Logger = ctx.logger
+    ?? consoleLogger({ level: pipeline.config.settings.logLevel })
+      .child({ pipeline: pipeline.config.name });
+
+  const result = await executeDag(pipeline.dag, {
+    cancellation,
+    bestEffort,
+    logger,
+  });
+
+  // Map sink-keyed outputs to OutputSpec names when present.
+  const outputs: Record<string, unknown> = {};
+  const namedOutputs = new Map<string, string>();
+  for (const o of pipeline.config.outputs ?? []) {
+    namedOutputs.set(o.fromInstance, o.name);
+  }
+  for (const [instanceId, value] of result.outputs) {
+    const key = namedOutputs.get(instanceId) ?? instanceId;
+    outputs[key] = value;
+  }
+
+  const buildId = computeRevisionId({
+    pipeline: pipeline.config.name,
+    sources: pipeline.dag.sources,
+    sinks: pipeline.dag.sinks,
+  });
+
+  return {
+    outcome: result.outcome,
+    stages: result.summaries,
+    outputs,
+    errors: result.errors,
+    elapsedMs: Date.now() - start,
+    buildId,
+  };
+}
+
+// Internal — silentLogger is exported so the dispose() flow can
+// silence late warnings without re-importing forme-stage.
+export { silentLogger };

--- a/code/packages/typescript/forme-orchestrator/src/scheduler.ts
+++ b/code/packages/typescript/forme-orchestrator/src/scheduler.ts
@@ -1,0 +1,422 @@
+/**
+ * Pipeline scheduler — executes a DAG sequentially in topological order.
+ *
+ * v0 simplifications (deferred to follow-up):
+ *
+ *   - **Sequential execution.**  Each stage runs to completion before
+ *     the next starts.  `settings.maxConcurrency` is honoured at "1".
+ *     Real parallelism for fan-out / fan-in lands in v1.
+ *
+ *   - **No streaming pipelining.**  When a stage produces a Stream<X>,
+ *     we drain it fully into memory before passing per-value to the
+ *     downstream consumer.  This is correct (the consumer is invoked
+ *     once per value) but not lazy — large streams allocate fully.
+ *     Lazy streaming lands in v1 alongside parallelism.
+ *
+ *   - **No incremental rebuild.**  Every run executes every stage;
+ *     the cache backend exists but isn't hit yet.  Incremental
+ *     rebuild (FM03 §6) lands when the orchestrator gains revision
+ *     tracking per instance.
+ *
+ *   - **No reproducible-build mode.**  Stages get systemClock, not
+ *     frozenClock.  Reproducible-build mode (FM03 §8) lands as a
+ *     `RunOptions` flag.
+ *
+ * What v0 *does* implement:
+ *
+ *   - Topological execution
+ *   - Per-stage StageContext construction with denied-by-default
+ *     capability APIs
+ *   - init/dispose lifecycle hooks
+ *   - Fail-fast and best-effort error handling
+ *   - Cancellation propagation
+ *   - Per-stage timing + error counts in StageRunSummary
+ */
+
+import {
+  CancellationError,
+  StageError,
+} from "@coding-adventures/forme-errors";
+import {
+  consoleLogger,
+  createCancellationTokenSource,
+  deniedEnvApi,
+  deniedFilesystemApi,
+  deniedNetworkApi,
+  deniedShellApi,
+  deniedStorageApi,
+  inMemoryCache,
+  inMemoryEventBus,
+  noOpTelemetryEmitter,
+  systemClock,
+} from "@coding-adventures/forme-stage";
+import type {
+  CancellationToken,
+  Logger,
+  StageContext,
+  StageInitContext,
+} from "@coding-adventures/forme-stage";
+import type { JsonValue } from "@coding-adventures/forme-types";
+import type { ResolvedInstance, PipelineDag } from "./dag.js";
+import type { RunError, RunOutcome, StageRunSummary } from "./types.js";
+
+/** Per-instance run state held during execution. */
+interface RunState {
+  /** Output value from the stage's run().  For streams, the fully-drained array. */
+  output: unknown;
+  /** Whether output is from a Stream<X> producer (consumers iterate). */
+  isStreamOutput: boolean;
+  /** init() was called — must dispose. */
+  initialized: boolean;
+  /** Per-stage summary accumulator. */
+  summary: {
+    instanceId: string;
+    stageName: string;
+    itemsConsumed: number;
+    itemsProduced: number;
+    elapsedMs: number;
+    cacheHits: number;
+    cacheMisses: number;
+    outcome: "success" | "skipped" | "failed";
+    errorCount: number;
+  };
+}
+
+export interface SchedulerOptions {
+  readonly logger: Logger;
+  readonly cancellation: CancellationToken;
+  readonly bestEffort: boolean;
+}
+
+export interface SchedulerResult {
+  readonly outcome: RunOutcome;
+  readonly outputs: Map<string, unknown>;
+  readonly summaries: readonly StageRunSummary[];
+  readonly errors: readonly RunError[];
+}
+
+/**
+ * Execute the DAG.  Returns the per-instance outputs (keyed by
+ * instance id), per-stage summaries, and any collected errors.
+ *
+ * On fail-fast error: cancels remaining work, runs `dispose` on
+ * everything that was initialised, returns outcome = "failed".
+ *
+ * On cancellation: returns outcome = "cancelled".
+ *
+ * On best-effort with errors: returns outcome = "partial" and
+ * continues past recoverable failures.
+ */
+export async function executeDag(
+  dag: PipelineDag,
+  options: SchedulerOptions,
+): Promise<SchedulerResult> {
+  const states = new Map<string, RunState>();
+  const errors: RunError[] = [];
+  const outputs = new Map<string, unknown>();
+
+  // Init pass: call init() on every stage that has one.  If any init
+  // throws, we abort before any run() is called and surface the failure.
+  for (const id of dag.topoOrder) {
+    const inst = dag.instances.get(id)!;
+    states.set(id, makeState(inst));
+    if (typeof inst.stage.init !== "function") continue;
+    const initCtx: StageInitContext = makeInitContext(inst, options);
+    try {
+      await inst.stage.init(inst.config, initCtx);
+      states.get(id)!.initialized = true;
+    } catch (err) {
+      // Init failure → fail the whole run (no per-input concept yet).
+      const re = toRunError(err, inst);
+      errors.push(re);
+      await disposeAll(dag, states, options);
+      const summaries = Array.from(states.values()).map(s => ({
+        ...s.summary,
+        outcome: "failed" as const,
+      }));
+      return { outcome: "failed", outputs, summaries, errors };
+    }
+  }
+
+  // Execute pass.
+  let cancelled = false;
+  let anyRecoverableErrors = false;
+  let anyFatal = false;
+
+  for (const id of dag.topoOrder) {
+    if (options.cancellation.cancelled) {
+      cancelled = true;
+      states.get(id)!.summary.outcome = "skipped";
+      continue;
+    }
+    if (anyFatal) {
+      // Skip downstream stages after a fatal error.
+      states.get(id)!.summary.outcome = "skipped";
+      continue;
+    }
+    const state = states.get(id)!;
+    const inst = dag.instances.get(id)!;
+    const startMonotonic = options.cancellation.cancelled ? 0 : Date.now();
+
+    try {
+      // Sources have no input; non-sources read from their producer's
+      // output (which we previously stored in `outputs`).
+      const inputs = collectInputs(inst, states);
+      const ctx: StageContext = makeRunContext(inst, options);
+
+      if (inst.stage.consumes.name === "Stream" || inst.stage.consumes.name === "Void"
+          || isSingleProducer(inst, dag, states)) {
+        // One invocation: source / collector-style / single-input.
+        const result = await inst.stage.run(inputs.value as never, inst.config, ctx);
+        const stored = await materialize(result, inst.stage.produces.name === "Stream");
+        state.output = stored.value;
+        state.isStreamOutput = stored.isStream;
+        state.summary.itemsConsumed = inputs.itemCount;
+        state.summary.itemsProduced = stored.isStream
+          ? (stored.value as unknown[]).length
+          : 1;
+      } else {
+        // Multi-invocation: producer was a stream, consumer takes one
+        // value at a time.  Iterate over the producer's drained array.
+        // Mark the result stream-shaped so downstream consumers
+        // iterate again — semantically this stage produced N values.
+        const list = inputs.value as unknown[];
+        const collected: unknown[] = [];
+        for (const item of list) {
+          options.cancellation.throwIfCancelled();
+          const r = await inst.stage.run(item as never, inst.config, ctx);
+          const sub = await materialize(r, false);
+          collected.push(sub.value);
+        }
+        state.output = collected;
+        state.isStreamOutput = true;
+        state.summary.itemsConsumed = list.length;
+        state.summary.itemsProduced = collected.length;
+      }
+      state.summary.outcome = "success";
+    } catch (err) {
+      if (err instanceof CancellationError) {
+        cancelled = true;
+        state.summary.outcome = "skipped";
+        continue;
+      }
+      const runError = toRunError(err, inst);
+      errors.push(runError);
+      state.summary.outcome = "failed";
+      state.summary.errorCount = 1;
+      if (runError.recoverable && options.bestEffort) {
+        anyRecoverableErrors = true;
+        // Continue to next stage; downstream stages that need this
+        // output will see undefined and will likely fail too — but
+        // best-effort is best-effort.
+      } else {
+        // Fail-fast OR non-recoverable best-effort: stop scheduling more.
+        anyFatal = true;
+      }
+    } finally {
+      state.summary.elapsedMs = Date.now() - startMonotonic;
+    }
+  }
+
+  // Sinks → outputs map (keyed by instance id; OutputSpec naming
+  // happens in the run.ts wrapper that knows about the config).
+  for (const sinkId of dag.sinks) {
+    const state = states.get(sinkId)!;
+    if (state.summary.outcome === "success") {
+      outputs.set(sinkId, state.output);
+    }
+  }
+
+  // Always dispose, regardless of outcome.
+  await disposeAll(dag, states, options);
+
+  const outcome: RunOutcome = cancelled
+    ? "cancelled"
+    : anyFatal
+      ? "failed"
+      : anyRecoverableErrors
+        ? "partial"
+        : "success";
+
+  return {
+    outcome,
+    outputs,
+    summaries: dag.topoOrder.map(id => ({ ...states.get(id)!.summary })),
+    errors,
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeState(inst: ResolvedInstance): RunState {
+  return {
+    output: undefined,
+    isStreamOutput: false,
+    initialized: false,
+    summary: {
+      instanceId: inst.id,
+      stageName: inst.stage.name,
+      itemsConsumed: 0,
+      itemsProduced: 0,
+      elapsedMs: 0,
+      cacheHits: 0,
+      cacheMisses: 0,
+      outcome: "success", // mutated below
+      errorCount: 0,
+    },
+  };
+}
+
+function isSingleProducer(
+  inst: ResolvedInstance,
+  dag: PipelineDag,
+  states: Map<string, RunState>,
+): boolean {
+  if (inst.producer === null) return true;
+  const prod = states.get(inst.producer);
+  if (!prod) return true;
+  // If producer's output isn't a stream, this consumer takes one value.
+  return !prod.isStreamOutput;
+}
+
+interface CollectedInput {
+  value: unknown;
+  itemCount: number;
+}
+
+function collectInputs(
+  inst: ResolvedInstance,
+  states: Map<string, RunState>,
+): CollectedInput {
+  if (inst.producer === null) {
+    return { value: undefined, itemCount: 0 };
+  }
+  const prod = states.get(inst.producer);
+  if (!prod) return { value: undefined, itemCount: 0 };
+  if (prod.isStreamOutput) {
+    // Stream-typed input: pass the array.  Consumer is a collector.
+    if (inst.stage.consumes.name === "Stream") {
+      const list = prod.output as unknown[];
+      return { value: makeAsyncIterableFromArray(list), itemCount: list.length };
+    }
+    // Stream-producer feeding single-input consumer: caller iterates.
+    const list = prod.output as unknown[];
+    return { value: list, itemCount: list.length };
+  }
+  return { value: prod.output, itemCount: 1 };
+}
+
+async function materialize(
+  result: unknown,
+  expectStream: boolean,
+): Promise<{ value: unknown; isStream: boolean }> {
+  if (isAsyncIterable(result)) {
+    const collected: unknown[] = [];
+    for await (const item of result as AsyncIterable<unknown>) {
+      collected.push(item);
+    }
+    return { value: collected, isStream: true };
+  }
+  if (result instanceof Promise) {
+    const v = await result;
+    return materialize(v, expectStream);
+  }
+  return { value: result, isStream: false };
+}
+
+function isAsyncIterable(v: unknown): boolean {
+  return typeof v === "object" && v !== null
+    && typeof (v as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === "function";
+}
+
+function makeAsyncIterableFromArray<T>(arr: readonly T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of arr) yield item;
+    },
+  };
+}
+
+function makeRunContext(
+  inst: ResolvedInstance,
+  options: SchedulerOptions,
+): StageContext {
+  return {
+    logger: options.logger.child({ stage: inst.stage.name, instance: inst.id }),
+    cancellation: options.cancellation,
+    time: systemClock(),
+    cache: inMemoryCache(),
+    telemetry: noOpTelemetryEmitter(),
+    storage: deniedStorageApi(),
+    network: deniedNetworkApi(),
+    env: deniedEnvApi(),
+    filesystem: deniedFilesystemApi(),
+    shell: deniedShellApi(),
+    events: inMemoryEventBus(),
+  };
+}
+
+function makeInitContext(
+  inst: ResolvedInstance,
+  options: SchedulerOptions,
+): StageInitContext {
+  // StageInitContext omits `cancellation` and `cache`, adds `config`.
+  return {
+    config: inst.config as JsonValue,
+    logger: options.logger.child({ stage: inst.stage.name, instance: inst.id, phase: "init" }),
+    time: systemClock(),
+    telemetry: noOpTelemetryEmitter(),
+    storage: deniedStorageApi(),
+    network: deniedNetworkApi(),
+    env: deniedEnvApi(),
+    filesystem: deniedFilesystemApi(),
+    shell: deniedShellApi(),
+    events: inMemoryEventBus(),
+  };
+}
+
+async function disposeAll(
+  dag: PipelineDag,
+  states: Map<string, RunState>,
+  options: SchedulerOptions,
+): Promise<void> {
+  for (const id of dag.topoOrder) {
+    const state = states.get(id)!;
+    if (!state.initialized) continue;
+    const inst = dag.instances.get(id)!;
+    if (typeof inst.stage.dispose !== "function") continue;
+    try {
+      const disposeCtx = makeInitContext(inst, options);
+      await inst.stage.dispose(disposeCtx);
+    } catch (err) {
+      // Per FM03 §3.2 Dispose: failures are logged warnings, never escalated.
+      options.logger.warn(
+        `dispose failed for ${inst.stage.name} (${inst.id})`,
+        { error: String(err) },
+      );
+    }
+  }
+}
+
+function toRunError(err: unknown, inst: ResolvedInstance): RunError {
+  if (err instanceof StageError) {
+    return {
+      stageName: err.stageName ?? inst.stage.name,
+      instanceId: inst.id,
+      code: err.code,
+      message: err.message,
+      recoverable: err.recoverable,
+      fields: err.fields,
+    };
+  }
+  return {
+    stageName: inst.stage.name,
+    instanceId: inst.id,
+    code: "UNCAUGHT",
+    message: err instanceof Error ? err.message : String(err),
+    recoverable: false,
+    fields: {},
+  };
+}
+
+// (Iterator helper polyfill removed — Array.from used directly above.)

--- a/code/packages/typescript/forme-orchestrator/src/typecheck.ts
+++ b/code/packages/typescript/forme-orchestrator/src/typecheck.ts
@@ -1,0 +1,87 @@
+/**
+ * Kind compatibility check for typed DAG construction (FM01 §2.6).
+ *
+ * Implements the four rules from the spec:
+ *
+ *   1. Name match (or extension subtype — TODO when ext: kinds land).
+ *   2. Major-version match; minor-version compatibility (newer-minor
+ *      producer can feed older-minor consumer).
+ *   3. Discriminant equality if both declare one.
+ *   4. Constraint satisfaction — best-effort structural match;
+ *      unknown keys are warnings (logged by the caller), not errors.
+ *
+ * For Stream<K>, the wrapped kind's compatibility is checked
+ * recursively.  A `Stream<X>` produced by one stage matches a
+ * `Stream<X>` consumed by another, and a `Stream<X>` produced by a
+ * source can also feed a single-`X` consumer (the orchestrator
+ * iterates and invokes the consumer once per yielded value).
+ */
+
+import type { KindDescriptor } from "@coding-adventures/forme-types";
+
+/**
+ * Test whether a producer's `produces` descriptor is compatible with
+ * a consumer's `consumes` descriptor.  Returns `true` if the
+ * orchestrator can wire them; `false` if not.
+ */
+export function areKindsCompatible(
+  produces: KindDescriptor,
+  consumes: KindDescriptor,
+): boolean {
+  // Stream-of-X can feed a single-X consumer (the executor iterates).
+  if (produces.name === "Stream" && consumes.name !== "Stream") {
+    if (!produces.inner) return false;
+    return areKindsCompatible(produces.inner, consumes);
+  }
+  // A single-X producer cannot feed a Stream-of-X consumer (the
+  // consumer expects multiple values; producer yields exactly one).
+  if (produces.name !== "Stream" && consumes.name === "Stream") {
+    return false;
+  }
+  // Stream<X> → Stream<Y> requires inner compatibility.
+  if (produces.name === "Stream" && consumes.name === "Stream") {
+    if (!produces.inner || !consumes.inner) return false;
+    return areKindsCompatible(produces.inner, consumes.inner);
+  }
+  // Both are non-stream descriptors.
+  if (produces.name !== consumes.name) return false;
+  if (!areVersionsCompatible(produces.version, consumes.version)) return false;
+  if (!areDiscriminantsCompatible(produces.discriminant, consumes.discriminant)) return false;
+  // Constraints are advisory at this layer.
+  return true;
+}
+
+/**
+ * Major versions must match; producer minor must be ≥ consumer minor.
+ * Patch is ignored.  Pre-release tags (e.g. "1.0.0-alpha") are
+ * treated as ordinary string suffixes — the kernel doesn't ship
+ * pre-release stages so this isn't a meaningful gap for v0.
+ */
+function areVersionsCompatible(produces: string, consumes: string): boolean {
+  const p = parseSemver(produces);
+  const c = parseSemver(consumes);
+  if (p === null || c === null) {
+    // If either fails to parse, fall back to string equality —
+    // exotic version strings just need to match exactly.
+    return produces === consumes;
+  }
+  if (p.major !== c.major) return false;
+  return p.minor >= c.minor;
+}
+
+function parseSemver(v: string): { major: number; minor: number } | null {
+  const m = /^(\d+)\.(\d+)/.exec(v);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]) };
+}
+
+function areDiscriminantsCompatible(
+  produces: string | undefined,
+  consumes: string | undefined,
+): boolean {
+  // If consumer doesn't care, anything matches.
+  if (consumes === undefined) return true;
+  // If producer doesn't declare but consumer does, mismatch.
+  if (produces === undefined) return false;
+  return produces === consumes;
+}

--- a/code/packages/typescript/forme-orchestrator/src/types.ts
+++ b/code/packages/typescript/forme-orchestrator/src/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Public API types for the orchestrator (FM03 §3.1).
+ *
+ * Five surfaces:
+ *
+ *   - `Orchestrator` — the runtime handle returned by
+ *     `createOrchestrator`.  Three methods: buildPipeline, runOnce,
+ *     dispose.  v0 omits `watch` (FM03 §7) — that's deferred to a
+ *     follow-up.
+ *
+ *   - `Pipeline` — the resolved + typechecked + DAG-constructed value
+ *     handed to runOnce.  Carries the original config so the caller
+ *     can introspect, plus the constructed DAG.
+ *
+ *   - `RunOptions` — per-call knobs (cancellation, best-effort
+ *     override, useCache toggle).
+ *
+ *   - `RunResult` — the structured return.  Outcome + per-stage
+ *     summaries + collected outputs + errors + timing + buildId.
+ *
+ *   - `StageRunSummary` — one entry per stage instance describing
+ *     what happened during this run.
+ */
+
+import type { JsonValue, RevisionId } from "@coding-adventures/forme-types";
+import type { CancellationToken, Logger } from "@coding-adventures/forme-stage";
+import type { CacheBackend } from "@coding-adventures/forme-cache";
+import type { PipelineConfig } from "@coding-adventures/forme-pipeline-config";
+import type { PipelineDag } from "./dag.js";
+
+/** Outcome of a single end-to-end run. */
+export type RunOutcome = "success" | "partial" | "failed" | "cancelled";
+
+/** Per-stage execution summary returned in `RunResult.stages`. */
+export interface StageRunSummary {
+  readonly instanceId: string;
+  readonly stageName: string;
+  readonly itemsConsumed: number;
+  readonly itemsProduced: number;
+  readonly elapsedMs: number;
+  readonly cacheHits: number;
+  readonly cacheMisses: number;
+  readonly outcome: "success" | "skipped" | "failed";
+  readonly errorCount: number;
+}
+
+/** Error surface in `RunResult.errors`. */
+export interface RunError {
+  readonly stageName: string;
+  readonly instanceId: string;
+  readonly code: string;
+  readonly message: string;
+  readonly recoverable: boolean;
+  readonly fields: Readonly<Record<string, JsonValue>>;
+}
+
+/** Aggregated result of a single end-to-end run. */
+export interface RunResult {
+  readonly outcome: RunOutcome;
+  readonly stages: readonly StageRunSummary[];
+  /** Final outputs keyed by `OutputSpec.name` (or stage instance id when no OutputSpec). */
+  readonly outputs: Readonly<Record<string, unknown>>;
+  readonly errors: readonly RunError[];
+  readonly elapsedMs: number;
+  /** Hash identifying this build's inputs.  Stable across re-runs of identical content. */
+  readonly buildId: RevisionId;
+}
+
+/** Per-call options for `runOnce`. */
+export interface RunOptions {
+  /** Override the pipeline-wide cancellation token. */
+  readonly cancellation?: CancellationToken;
+  /** Override `bestEffort` from the config. */
+  readonly bestEffort?: boolean;
+  /** Reuse cached results when available.  Default: true. */
+  readonly useCache?: boolean;
+}
+
+/** Pipeline value — the resolved+validated config plus its constructed DAG. */
+export interface Pipeline {
+  readonly config: PipelineConfig;
+  readonly dag: PipelineDag;
+}
+
+/** Construction-time options for the orchestrator. */
+export interface OrchestratorOptions {
+  /** Cache backend to use; default: a fresh in-memory cache. */
+  readonly cache?: CacheBackend;
+  /** Logger to use; default: silent (caller wires console logging through the CLI). */
+  readonly logger?: Logger;
+}
+
+/** The orchestrator runtime handle. */
+export interface Orchestrator {
+  /** Validate a config and build its typed DAG.  Throws on invalid configs. */
+  buildPipeline(config: PipelineConfig): Promise<Pipeline>;
+  /** Run a pipeline once. */
+  runOnce(pipeline: Pipeline, options?: RunOptions): Promise<RunResult>;
+  /** Tear down resources held by the orchestrator. */
+  dispose(): Promise<void>;
+}

--- a/code/packages/typescript/forme-orchestrator/tests/integration.test.ts
+++ b/code/packages/typescript/forme-orchestrator/tests/integration.test.ts
@@ -1,0 +1,368 @@
+/**
+ * forme-orchestrator — end-to-end integration tests
+ *
+ * The single test that matters: build a real linear pipeline of three
+ * stages (source → transform → sink), run it, verify the output.
+ * Plus error/cancellation/dispose paths around it.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  KERNEL_API_VERSION,
+  Kinds,
+  streamOf,
+} from "@coding-adventures/forme-types";
+import { defineStage } from "@coding-adventures/forme-stage";
+import { StageError } from "@coding-adventures/forme-errors";
+import {
+  createCancellationTokenSource,
+  silentLogger,
+} from "@coding-adventures/forme-stage";
+import {
+  buildDag,
+  buildPipeline,
+  createOrchestrator,
+  runOnce,
+} from "../src/index.js";
+import type { PipelineConfig } from "@coding-adventures/forme-pipeline-config";
+import { validateConfig } from "@coding-adventures/forme-pipeline-config";
+
+// ─── Stage builders ──────────────────────────────────────────────────────
+
+function tinySource(items: readonly string[]) {
+  return defineStage({
+    name: "@test/source",
+    version: "0.1.0",
+    apiVersion: KERNEL_API_VERSION,
+    description: "yields fixed strings",
+    consumes: Kinds.Void,
+    produces: streamOf(Kinds.ContentSource),
+    capabilities: [],
+    configSchema: null,
+    async *run() {
+      for (const item of items) {
+        yield {
+          path: item,
+          bytes: new TextEncoder().encode(item),
+          mimeType: "text/plain",
+          identity: "01952c0d-7e63-7000-8000-000000000000" as never,
+          revision: "blake2b:00" as never,
+          providerMeta: {},
+        } as never;
+      }
+    },
+  });
+}
+
+const upper = defineStage({
+  name: "@test/upper",
+  version: "0.1.0",
+  apiVersion: KERNEL_API_VERSION,
+  description: "uppercases path of a content source",
+  consumes: Kinds.ContentSource,
+  produces: Kinds.ContentSource,
+  capabilities: [],
+  configSchema: null,
+  async run(source) {
+    return {
+      ...(source as Record<string, unknown>),
+      path: (source as { path: string }).path.toUpperCase(),
+    } as never;
+  },
+});
+
+const sink = defineStage({
+  name: "@test/sink",
+  version: "0.1.0",
+  apiVersion: KERNEL_API_VERSION,
+  description: "wraps a content source as a deploy artifact",
+  consumes: Kinds.ContentSource,
+  produces: Kinds.DeployArtifact,
+  capabilities: [],
+  configSchema: null,
+  async run(source) {
+    const s = source as { path: string };
+    return {
+      variant: { kind: "dist-tree" },
+      files: { [s.path]: new TextEncoder().encode("hi") },
+      manifest: {
+        routes: [], assets: [], buildTime: "2026-05-15T00:00:00Z",
+        buildId: "blake2b:00" as never,
+      },
+    } as never;
+  },
+});
+
+function makeConfig(stages: readonly { stage: ReturnType<typeof defineStage>; id?: string }[]): PipelineConfig {
+  return {
+    name: "test",
+    settings: {
+      storageRoot: "./",
+      cacheDir: null,
+      reproducibleBuild: false,
+      maxConcurrency: null,
+      logLevel: "error",
+      bestEffort: false,
+      deadlineMs: null,
+    },
+    stages: stages as never,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe("buildPipeline + runOnce — happy path", () => {
+  it("source(stream) → transform(per-item) → sink(per-item)", async () => {
+    const source = tinySource(["a.md", "b.md"]);
+    const config = makeConfig([{ stage: source }, { stage: upper }, { stage: sink }]);
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(config);
+    const result = await o.runOnce(pipeline);
+
+    expect(result.outcome).toBe("success");
+    expect(result.errors).toEqual([]);
+    expect(result.stages.length).toBe(3);
+    // Sink received 2 invocations (one per source item).
+    const sinkSummary = result.stages.find(s => s.stageName === "@test/sink")!;
+    expect(sinkSummary.itemsConsumed).toBe(2);
+    expect(sinkSummary.itemsProduced).toBe(2);
+    // Output is the array of per-item DeployArtifact values.
+    const out = result.outputs["@test/sink"];
+    expect(Array.isArray(out)).toBe(true);
+    expect((out as unknown[]).length).toBe(2);
+    await o.dispose();
+  });
+
+  it("named outputs override sink instance ids", async () => {
+    const source = tinySource(["x.md"]);
+    const config: PipelineConfig = {
+      ...makeConfig([{ stage: source }, { stage: upper }, { stage: sink, id: "the-sink" }]),
+      outputs: [{ fromInstance: "the-sink", name: "primary" }],
+    };
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(config);
+    const result = await o.runOnce(pipeline);
+    expect(result.outputs.primary).toBeDefined();
+    expect(result.outputs["the-sink"]).toBeUndefined();
+    await o.dispose();
+  });
+});
+
+describe("Error handling", () => {
+  it("fail-fast: one stage throws → outcome 'failed', dispose still runs", async () => {
+    const disposeSpy = vi.fn();
+    const failing = defineStage({
+      name: "@test/failing",
+      version: "0.1.0",
+      apiVersion: KERNEL_API_VERSION,
+      description: "throws",
+      consumes: Kinds.ContentSource,
+      produces: Kinds.DeployArtifact,
+      capabilities: [],
+      configSchema: null,
+      async run() {
+        throw new StageError({ code: "PARSE_ERROR", message: "boom", recoverable: false });
+      },
+      async dispose() { disposeSpy(); },
+    });
+    const config = makeConfig([{ stage: tinySource(["a.md"]) }, { stage: failing }]);
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(config);
+    const result = await o.runOnce(pipeline);
+    expect(result.outcome).toBe("failed");
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]!.code).toBe("PARSE_ERROR");
+    // dispose hook ran even though there was no init() — no, init is required for dispose.
+    // Actually: per scheduler, dispose only runs when initialized=true.
+    // This stage has no init, so disposeSpy stays at 0.
+    expect(disposeSpy).not.toHaveBeenCalled();
+    await o.dispose();
+  });
+
+  it("best-effort: recoverable error continues, outcome 'partial'", async () => {
+    const failing = defineStage({
+      name: "@test/recoverable-fail",
+      version: "0.1.0",
+      apiVersion: KERNEL_API_VERSION,
+      description: "recoverable failure",
+      consumes: Kinds.ContentSource,
+      produces: Kinds.DeployArtifact,
+      capabilities: [],
+      configSchema: null,
+      async run() {
+        throw new StageError({ code: "PARSE_ERROR", message: "soft", recoverable: true });
+      },
+    });
+    const config = { ...makeConfig([{ stage: tinySource(["a.md"]) }, { stage: failing }]),
+                     settings: { ...makeConfig([]).settings, bestEffort: true } };
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(config);
+    const result = await o.runOnce(pipeline);
+    expect(result.outcome).toBe("partial");
+    expect(result.errors.length).toBe(1);
+    await o.dispose();
+  });
+
+  it("non-StageError throw is wrapped as UNCAUGHT", async () => {
+    const failing = defineStage({
+      name: "@test/uncaught",
+      version: "0.1.0",
+      apiVersion: KERNEL_API_VERSION,
+      description: "throws plain",
+      consumes: Kinds.ContentSource,
+      produces: Kinds.DeployArtifact,
+      capabilities: [],
+      configSchema: null,
+      async run() { throw new Error("plain"); },
+    });
+    const config = makeConfig([{ stage: tinySource(["a.md"]) }, { stage: failing }]);
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(config);
+    const result = await o.runOnce(pipeline);
+    expect(result.outcome).toBe("failed");
+    expect(result.errors[0]!.code).toBe("UNCAUGHT");
+    await o.dispose();
+  });
+});
+
+describe("init/dispose lifecycle", () => {
+  it("init runs before run; dispose runs after", async () => {
+    const order: string[] = [];
+    const stage = defineStage({
+      name: "@test/lifecycle",
+      version: "0.1.0",
+      apiVersion: KERNEL_API_VERSION,
+      description: "tracks lifecycle order",
+      consumes: Kinds.ContentSource,
+      produces: Kinds.DeployArtifact,
+      capabilities: [],
+      configSchema: null,
+      async init() { order.push("init"); },
+      async run() {
+        order.push("run");
+        return {
+          variant: { kind: "dist-tree" }, files: {}, manifest: {
+            routes: [], assets: [], buildTime: "2026-05-15T00:00:00Z",
+            buildId: "blake2b:00" as never,
+          },
+        } as never;
+      },
+      async dispose() { order.push("dispose"); },
+    });
+    const config = makeConfig([{ stage: tinySource(["x.md"]) }, { stage }]);
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(config);
+    await o.runOnce(pipeline);
+    expect(order).toEqual(["init", "run", "dispose"]);
+    await o.dispose();
+  });
+
+  it("init failure aborts before any run() and disposes initialised stages", async () => {
+    const initOk = vi.fn(); const disposeOk = vi.fn();
+    const stage = defineStage({
+      name: "@test/init-fail",
+      version: "0.1.0",
+      apiVersion: KERNEL_API_VERSION,
+      description: "fails init",
+      consumes: Kinds.ContentSource,
+      produces: Kinds.DeployArtifact,
+      capabilities: [],
+      configSchema: null,
+      async init() { throw new Error("init blew up"); },
+      async run() { throw new Error("never called"); },
+      async dispose() { /* never called for this stage */ },
+    });
+    const goodSource = defineStage({
+      name: "@test/good-source",
+      version: "0.1.0",
+      apiVersion: KERNEL_API_VERSION,
+      description: "ok",
+      consumes: Kinds.Void,
+      produces: streamOf(Kinds.ContentSource),
+      capabilities: [],
+      configSchema: null,
+      async init() { initOk(); },
+      async dispose() { disposeOk(); },
+      async *run() { yield { path: "x", bytes: new Uint8Array(), mimeType: null,
+        identity: "01952c0d-7e63-7000-8000-000000000000" as never,
+        revision: "blake2b:00" as never, providerMeta: {} } as never; },
+    });
+    const config = makeConfig([{ stage: goodSource }, { stage }]);
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(config);
+    const result = await o.runOnce(pipeline);
+    expect(result.outcome).toBe("failed");
+    expect(initOk).toHaveBeenCalledTimes(1);
+    expect(disposeOk).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Cancellation", () => {
+  it("cancel before run yields outcome 'cancelled'", async () => {
+    const source = tinySource(["a.md"]);
+    const config = makeConfig([{ stage: source }, { stage: upper }, { stage: sink }]);
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(config);
+    const cs = createCancellationTokenSource();
+    cs.cancel("test");
+    const result = await o.runOnce(pipeline, { cancellation: cs.token });
+    expect(result.outcome).toBe("cancelled");
+  });
+});
+
+describe("Orchestrator lifecycle", () => {
+  it("dispose makes subsequent calls throw", async () => {
+    const o = createOrchestrator({ logger: silentLogger() });
+    await o.dispose();
+    await expect(o.buildPipeline(makeConfig([{ stage: tinySource(["a"]) }])))
+      .rejects.toThrow(/disposed/);
+  });
+
+  it("dispose is idempotent", async () => {
+    const o = createOrchestrator({ logger: silentLogger() });
+    await o.dispose();
+    await expect(o.dispose()).resolves.toBeUndefined();
+  });
+});
+
+describe("buildDag — direct API", () => {
+  it("builds expected source/sink arrays for a linear pipeline", () => {
+    const source = tinySource(["a"]);
+    const config = makeConfig([{ stage: source }, { stage: upper }, { stage: sink }]);
+    const resolved = validateConfig(config);
+    const dag = buildDag(resolved);
+    expect(dag.sources).toEqual(["@test/source"]);
+    expect(dag.sinks).toEqual(["@test/sink"]);
+    expect(dag.topoOrder).toEqual(["@test/source", "@test/upper", "@test/sink"]);
+  });
+
+  it("throws when no compatible producer exists", () => {
+    // Two stages where the second can't be wired to the first.
+    const a = defineStage({
+      name: "a", version: "0.1.0", apiVersion: KERNEL_API_VERSION,
+      description: "x", consumes: Kinds.Void, produces: Kinds.ContentSource,
+      capabilities: [], configSchema: null,
+      async run() { return null as never; },
+    });
+    const b = defineStage({
+      name: "b", version: "0.1.0", apiVersion: KERNEL_API_VERSION,
+      description: "x", consumes: Kinds.Asset, produces: Kinds.DeployArtifact,
+      capabilities: [], configSchema: null,
+      async run() { return null as never; },
+    });
+    const config = makeConfig([{ stage: a }, { stage: b }]);
+    const resolved = validateConfig(config);
+    expect(() => buildDag(resolved)).toThrow(/no earlier instance produces/);
+  });
+});
+
+describe("runOnce direct (without the orchestrator wrapper)", () => {
+  it("returns a result with elapsedMs and buildId", async () => {
+    const source = tinySource(["a"]);
+    const config = makeConfig([{ stage: source }, { stage: upper }, { stage: sink }]);
+    const pipeline = await buildPipeline(config);
+    const result = await runOnce(pipeline, {}, { logger: silentLogger() });
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(result.buildId).toMatch(/^blake2b:[0-9a-f]+$/);
+  });
+});

--- a/code/packages/typescript/forme-orchestrator/tests/typecheck.test.ts
+++ b/code/packages/typescript/forme-orchestrator/tests/typecheck.test.ts
@@ -1,0 +1,105 @@
+/**
+ * forme-orchestrator — typecheck tests
+ */
+
+import { describe, it, expect } from "vitest";
+import { Kinds, streamOf } from "@coding-adventures/forme-types";
+import { areKindsCompatible } from "../src/index.js";
+
+describe("areKindsCompatible — basic", () => {
+  it("identical descriptors match", () => {
+    expect(areKindsCompatible(Kinds.ContentSource, Kinds.ContentSource)).toBe(true);
+  });
+
+  it("name mismatch fails", () => {
+    expect(areKindsCompatible(Kinds.ContentSource, Kinds.ContentNode)).toBe(false);
+  });
+});
+
+describe("areKindsCompatible — stream wrapping", () => {
+  it("Stream<X> can feed single-X consumer (executor iterates)", () => {
+    expect(areKindsCompatible(streamOf(Kinds.ContentSource), Kinds.ContentSource)).toBe(true);
+  });
+
+  it("single-X cannot feed Stream<X> consumer", () => {
+    expect(areKindsCompatible(Kinds.ContentSource, streamOf(Kinds.ContentSource))).toBe(false);
+  });
+
+  it("Stream<X> → Stream<X> matches", () => {
+    expect(areKindsCompatible(streamOf(Kinds.ContentNode), streamOf(Kinds.ContentNode))).toBe(true);
+  });
+
+  it("Stream<X> → Stream<Y> mismatches when inner kinds differ", () => {
+    expect(areKindsCompatible(streamOf(Kinds.ContentSource), streamOf(Kinds.ContentNode))).toBe(false);
+  });
+
+  it("Stream without inner is treated as incompatible", () => {
+    const bogus = { name: "Stream" as const, version: "1.0" };
+    expect(areKindsCompatible(bogus, Kinds.ContentSource)).toBe(false);
+    expect(areKindsCompatible(streamOf(Kinds.ContentSource), bogus)).toBe(false);
+  });
+});
+
+describe("areKindsCompatible — version compatibility", () => {
+  it("major mismatch fails", () => {
+    expect(areKindsCompatible(
+      { name: "ContentSource", version: "2.0" },
+      { name: "ContentSource", version: "1.0" },
+    )).toBe(false);
+  });
+
+  it("producer minor ≥ consumer minor passes", () => {
+    expect(areKindsCompatible(
+      { name: "ContentSource", version: "1.2" },
+      { name: "ContentSource", version: "1.1" },
+    )).toBe(true);
+  });
+
+  it("producer minor < consumer minor fails", () => {
+    expect(areKindsCompatible(
+      { name: "ContentSource", version: "1.1" },
+      { name: "ContentSource", version: "1.2" },
+    )).toBe(false);
+  });
+
+  it("non-semver strings require exact match", () => {
+    expect(areKindsCompatible(
+      { name: "ContentSource", version: "v1" },
+      { name: "ContentSource", version: "v1" },
+    )).toBe(true);
+    expect(areKindsCompatible(
+      { name: "ContentSource", version: "v1" },
+      { name: "ContentSource", version: "v2" },
+    )).toBe(false);
+  });
+});
+
+describe("areKindsCompatible — discriminants", () => {
+  it("consumer with no discriminant accepts anything", () => {
+    expect(areKindsCompatible(
+      { name: "Feed", version: "1.0", discriminant: "rss" },
+      { name: "Feed", version: "1.0" },
+    )).toBe(true);
+  });
+
+  it("matching discriminants pass", () => {
+    expect(areKindsCompatible(
+      { name: "Feed", version: "1.0", discriminant: "rss" },
+      { name: "Feed", version: "1.0", discriminant: "rss" },
+    )).toBe(true);
+  });
+
+  it("differing discriminants fail", () => {
+    expect(areKindsCompatible(
+      { name: "Feed", version: "1.0", discriminant: "rss" },
+      { name: "Feed", version: "1.0", discriminant: "atom" },
+    )).toBe(false);
+  });
+
+  it("producer missing discriminant fails when consumer demands one", () => {
+    expect(areKindsCompatible(
+      { name: "Feed", version: "1.0" },
+      { name: "Feed", version: "1.0", discriminant: "atom" },
+    )).toBe(false);
+  });
+});

--- a/code/packages/typescript/forme-orchestrator/tsconfig.json
+++ b/code/packages/typescript/forme-orchestrator/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-orchestrator/vitest.config.ts
+++ b/code/packages/typescript/forme-orchestrator/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Eighth Forme package — **last big kernel/FM03 piece before the actual pipeline stages start landing.** Implements FM03 §3-4 + §9-10: the runtime that takes a `PipelineConfig`, builds a typed DAG, and executes it.

### Public API

```typescript
import { createOrchestrator } from "@coding-adventures/forme-orchestrator";

const o = createOrchestrator();
const pipeline = await o.buildPipeline(config);
const result = await o.runOnce(pipeline);
console.log(result.outcome, result.outputs);
await o.dispose();
```

### What v0 implements

- **Topological execution** honouring kind-compatibility wiring
- **Stream<X> → single-X consumer iteration** — executor invokes the consumer once per yielded value
- **Stream-shaped output propagation** — a stage iterated N times produces a logical stream of N values; downstream consumers iterate again
- **Per-stage StageContext** with denied-by-default capability APIs
- **`init` / `dispose` lifecycle hooks** — init failure aborts before any `run()`; dispose runs for every initialised stage regardless of outcome
- **Fail-fast (default) and best-effort** error handling
- **Cancellation propagation** with composed token
- **`StageError` wrapping** of non-StageError throws as `code: "UNCAUGHT"`
- Per-stage timing, error counts, outcome in `StageRunSummary`
- **Named outputs via `OutputSpec`** mapping (else keyed by sink instance id)
- **`buildId`** via `computeRevisionId` over pipeline source/sink ids

### v0 simplifications (deferred, all documented)

- No parallelism — sequential execution (`maxConcurrency` honoured at 1)
- No streaming pipelining — streams fully drained before downstream consumers
- No incremental rebuild — cache backend exists but isn't hit yet
- No reproducible-build mode (frozenClock exists in `forme-stage` but isn't wired through here)
- No watch mode (FM03 §7 lives in a future companion package)
- No OpenTelemetry traces

### Roadmap

- ✅ kernel: `forme-types`, `forme-errors`, `forme-identity`, `forme-capability`, `forme-stage`
- ✅ FM03: `forme-pipeline-config`, `forme-cache`, `forme-orchestrator` (this PR — **kernel + FM03 stack complete**)
- ⏳ `forme-cli` — `forme run` command
- ⏳ `forme-source-fs`, `forme-parse-markdown`, `forme-collect-chronological`, `forme-render-static`, `forme-emit-fs` (5 stages)
- ⏳ `code/sites/blog/` + `.github/workflows/deploy-blog.yml`

## Test plan

- [x] `npx vitest run --coverage` — 28 tests pass
- [x] **92.62% line / 87.41% branch coverage** (above the 85% target)
- [x] Integration tests cover the canonical flows: linear stream pipeline, named outputs, fail-fast, best-effort, init-failure-with-dispose-cleanup, lifecycle ordering, cancellation, dispose idempotency, DAG kind-incompatibility errors
- [x] Typecheck unit tests cover: name/version/discriminant/Stream wrapping rules
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
