### PR TITLE
spice: parse transfer-function netlist cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Parse SPICE independent source `AC <magnitude> [phase]` specifications for
   voltage and current sources, including `DC <value> AC ...` mixed bias/input
   forms.
+- Parse SPICE `.tf V(output_node) input_source` transfer-function analysis
+  cards.
 
 ## 0.1.6
 

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -24,4 +24,4 @@ This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`,
 MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`), SPICE engineering suffixes,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
-expansion, and `.op`, `.tran`, `.dc`, and `.ac` analysis cards.
+expansion, and `.op`, `.tran`, `.dc`, `.ac`, and `.tf` analysis cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -7,6 +7,7 @@ from spice_netlist_parser.parser import (
     NetlistParseError,
     OpAnalysis,
     ParsedNetlist,
+    TfAnalysis,
     TranAnalysis,
     parse_netlist,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "NetlistParseError",
     "OpAnalysis",
     "ParsedNetlist",
+    "TfAnalysis",
     "TranAnalysis",
     "__version__",
     "parse",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -67,7 +67,15 @@ class AcAnalysis:
     stop_hz: float
 
 
-type Analysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis
+@dataclass(frozen=True, slots=True)
+class TfAnalysis:
+    """A `.tf V(output_node) input_source` transfer-function analysis card."""
+
+    output_node: str
+    input_source: str
+
+
+type Analysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis | TfAnalysis
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +128,9 @@ class ParsedNetlist:
 
     def ac_cards(self) -> list[AcAnalysis]:
         return [analysis for analysis in self.analyses if isinstance(analysis, AcAnalysis)]
+
+    def tf_cards(self) -> list[TfAnalysis]:
+        return [analysis for analysis in self.analyses if isinstance(analysis, TfAnalysis)]
 
 
 _VALUE_RE = re.compile(
@@ -542,7 +553,17 @@ def _parse_directive(fields: list[str]) -> Analysis:
             start_hz=parse_value(fields[3]),
             stop_hz=parse_value(fields[4]),
         )
+    if directive == ".tf":
+        _require_fields(fields, 3, ".tf")
+        return TfAnalysis(output_node=_parse_voltage_probe(fields[1]), input_source=fields[2])
     raise NetlistParseError(f"unsupported directive {fields[0]!r}")
+
+
+def _parse_voltage_probe(token: str) -> str:
+    match = re.fullmatch(r"(?i)v\(([^()\s]+)\)", token)
+    if match is None:
+        raise NetlistParseError(f".tf output must be a voltage probe V(node), got {token!r}")
+    return match.group(1)
 
 
 def _parse_model_card(fields: list[str]) -> ModelCard:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -18,6 +18,7 @@ from spice_engine import (
     VoltageSource,
     ac_sweep,
     dc_op,
+    tf,
 )
 
 from spice_netlist_parser import (
@@ -26,6 +27,7 @@ from spice_netlist_parser import (
     ModelCard,
     NetlistParseError,
     OpAnalysis,
+    TfAnalysis,
     TranAnalysis,
     parse_netlist,
 )
@@ -83,6 +85,34 @@ G1 out 0 in 0 2m
         DcAnalysis(source_name="Vstep", start=0.0, stop=1.0, step=0.5),
         AcAnalysis(mode="dec", points=10, start_hz=1.0e3, stop_hz=1.0e6),
     ]
+
+
+def test_parse_tf_analysis_card_and_run_transfer_function() -> None:
+    parsed = parse_netlist(
+        """
+Vin in 0 DC 1
+R1 in out 1k
+R2 out 0 1k
+.tf V(out) Vin
+"""
+    )
+
+    assert parsed.analyses == [TfAnalysis(output_node="out", input_source="Vin")]
+    assert parsed.tf_cards() == [TfAnalysis(output_node="out", input_source="Vin")]
+    card = parsed.tf_cards()[0]
+    result = tf(parsed.circuit, output_node=card.output_node, input_source=card.input_source)
+    assert isclose(result.transfer_ratio, 0.5, abs_tol=1e-9)
+
+
+def test_tf_analysis_card_rejects_non_voltage_output_probe() -> None:
+    with pytest.raises(NetlistParseError, match=r"\.tf output must be a voltage probe"):
+        parse_netlist(
+            """
+Vin in 0 DC 1
+R1 in out 1k
+.tf out Vin
+"""
+        )
 
 
 def test_parse_vcvs_into_operating_point_circuit() -> None:

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Parse SPICE `.tf V(output_node) input_source` transfer-function analysis
+  cards.
+
 ## 0.1.7
 
 - Add independent-source `AC <magnitude> [phase]` parsing, including combined

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -25,4 +25,4 @@ cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering
 suffixes, independent-source `AC <magnitude> [phase]` forms, PWL/PULSE/SIN/EXP
 source forms, comments, `.end`, `.subckt` / `X` instance expansion, and
-`.op`, `.tran`, `.dc`, and `.ac` analysis cards.
+`.op`, `.tran`, `.dc`, `.ac`, and `.tf` analysis cards.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -52,12 +52,19 @@ pub struct AcAnalysis {
     pub stop_hz: f64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TfAnalysis {
+    pub output_node: String,
+    pub input_source: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Analysis {
     Op(OpAnalysis),
     Tran(TranAnalysis),
     Dc(DcAnalysis),
     Ac(AcAnalysis),
+    Tf(TfAnalysis),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -111,6 +118,16 @@ impl ParsedNetlist {
             .iter()
             .filter_map(|analysis| match analysis {
                 Analysis::Ac(card) => Some(card),
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn tf_cards(&self) -> Vec<&TfAnalysis> {
+        self.analyses
+            .iter()
+            .filter_map(|analysis| match analysis {
+                Analysis::Tf(card) => Some(card),
                 _ => None,
             })
             .collect()
@@ -937,11 +954,38 @@ fn parse_directive(fields: &[String]) -> Result<Analysis, NetlistParseError> {
                 stop_hz: parse_value(&fields[4])?,
             }))
         }
+        ".tf" => {
+            require_fields(fields, 3, ".tf")?;
+            Ok(Analysis::Tf(TfAnalysis {
+                output_node: parse_voltage_probe(&fields[1])?,
+                input_source: fields[2].clone(),
+            }))
+        }
         _ => Err(NetlistParseError::new(format!(
             "unsupported directive {:?}",
             fields[0]
         ))),
     }
+}
+
+fn parse_voltage_probe(token: &str) -> Result<String, NetlistParseError> {
+    let lower = token.to_ascii_lowercase();
+    if !lower.starts_with("v(") || !token.ends_with(')') {
+        return Err(NetlistParseError::new(format!(
+            ".tf output must be a voltage probe V(node), got {token:?}"
+        )));
+    }
+    let node = &token[2..token.len() - 1];
+    if node.is_empty()
+        || node.contains('(')
+        || node.contains(')')
+        || node.chars().any(char::is_whitespace)
+    {
+        return Err(NetlistParseError::new(format!(
+            ".tf output must be a voltage probe V(node), got {token:?}"
+        )));
+    }
+    Ok(node.to_string())
 }
 
 fn split_fields(line: &str) -> Result<Vec<String>, NetlistParseError> {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1,7 +1,7 @@
-use spice_engine::{ac_sweep, dc_op, BjtPolarity, Element, MosfetType};
+use spice_engine::{ac_sweep, dc_op, tf, BjtPolarity, Element, MosfetType};
 use spice_netlist_parser::{
     parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, NetlistParseError, OpAnalysis,
-    TranAnalysis,
+    TfAnalysis, TranAnalysis,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -94,6 +94,53 @@ G1 out 0 in 0 2m
             }),
         ]
     );
+}
+
+#[test]
+fn parses_tf_transfer_function_analysis_cards() {
+    let parsed = parse_netlist(
+        r#"
+Vin in 0 DC 1
+R1 in out 1k
+R2 out 0 1k
+.tf V(out) Vin
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        parsed.analyses,
+        vec![Analysis::Tf(TfAnalysis {
+            output_node: "out".to_string(),
+            input_source: "Vin".to_string(),
+        })]
+    );
+    assert_eq!(
+        parsed.tf_cards(),
+        vec![&TfAnalysis {
+            output_node: "out".to_string(),
+            input_source: "Vin".to_string(),
+        }]
+    );
+    let card = parsed.tf_cards()[0];
+    let result = tf(&parsed.circuit, &card.output_node, &card.input_source).unwrap();
+    assert_close(result.transfer_ratio, 0.5);
+}
+
+#[test]
+fn rejects_tf_cards_without_voltage_output_probe() {
+    let error = parse_netlist(
+        r#"
+Vin in 0 DC 1
+R1 in out 1k
+.tf out Vin
+"#,
+    )
+    .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains(".tf output must be a voltage probe"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Parse independent-source `AC <magnitude> [phase]` specs, including combined
   `DC <bias> AC <magnitude> [phase]` forms, and pass the AC phasor through to
   TypeScript SPICE engine AC analysis while preserving DC bias.
+- Parse SPICE `.tf V(output_node) input_source` transfer-function analysis
+  cards.
 
 ## 0.1.6
 

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -27,5 +27,5 @@ elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` /
 `TNOM` parameters,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
-`.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, and `.ac`
-analysis cards.
+`.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, `.ac`, and
+`.tf` analysis cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -59,7 +59,13 @@ export interface AcAnalysis {
   readonly stopHz: number;
 }
 
-export type Analysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis;
+export interface TfAnalysis {
+  readonly kind: "tf";
+  readonly outputNode: string;
+  readonly inputSource: string;
+}
+
+export type Analysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis | TfAnalysis;
 
 export interface ModelCard {
   readonly name: string;
@@ -89,6 +95,10 @@ export class ParsedNetlist {
 
   acCards(): AcAnalysis[] {
     return this.analyses.filter((analysis): analysis is AcAnalysis => analysis.kind === "ac");
+  }
+
+  tfCards(): TfAnalysis[] {
+    return this.analyses.filter((analysis): analysis is TfAnalysis => analysis.kind === "tf");
   }
 }
 
@@ -763,7 +773,25 @@ function parseDirective(fields: readonly string[]): Analysis {
       stopHz: parseValue(fields[4]),
     };
   }
+  if (directive === ".tf") {
+    requireFields(fields, 3, ".tf");
+    return {
+      kind: "tf",
+      outputNode: parseVoltageProbe(fields[1]),
+      inputSource: fields[2],
+    };
+  }
   throw new NetlistParseError(`unsupported directive ${JSON.stringify(fields[0])}`);
+}
+
+function parseVoltageProbe(token: string): string {
+  const match = /^v\(([^()\s]+)\)$/i.exec(token);
+  if (match === null) {
+    throw new NetlistParseError(
+      `.tf output must be a voltage probe V(node), got ${JSON.stringify(token)}`,
+    );
+  }
+  return match[1];
 }
 
 function splitFields(line: string): string[] {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1,4 +1,4 @@
-import { acSweep, dcOp } from "@coding-adventures/spice-engine";
+import { acSweep, dcOp, tf } from "@coding-adventures/spice-engine";
 import { describe, expect, it } from "vitest";
 import {
   NetlistParseError,
@@ -86,6 +86,35 @@ R2 out 0 1k
     expect(out!.imag).toBeCloseTo(1.0, 9);
     expect(biasVoltage!.real).toBeCloseTo(0.0, 9);
     expect(biasVoltage!.imag).toBeCloseTo(0.0, 9);
+  });
+
+  it("parses .tf transfer-function analysis cards", () => {
+    const parsed = parseNetlist(`
+Vin in 0 DC 1
+R1 in out 1k
+R2 out 0 1k
+.tf V(out) Vin
+`);
+
+    expect(parsed.analyses).toEqual([
+      { kind: "tf", outputNode: "out", inputSource: "Vin" },
+    ]);
+    expect(parsed.tfCards()).toEqual([
+      { kind: "tf", outputNode: "out", inputSource: "Vin" },
+    ]);
+    const [card] = parsed.tfCards();
+    const result = tf(parsed.circuit, card.outputNode, card.inputSource);
+    expect(result.transferRatio).toBeCloseTo(0.5, 9);
+  });
+
+  it("rejects .tf cards without a voltage output probe", () => {
+    expect(() =>
+      parseNetlist(`
+Vin in 0 DC 1
+R1 in out 1k
+.tf out Vin
+`),
+    ).toThrow(/\.tf output must be a voltage probe/);
   });
 
   it("parses VCVS elements into operating-point circuits", () => {


### PR DESCRIPTION
## Summary

- add `.tf V(output_node) input_source` analysis-card parsing to the Python, TypeScript, and Rust SPICE netlist parsers
- expose typed TF-card accessors on parsed netlists in all three implementations
- add parser tests that feed the parsed card into the existing engine transfer-function API

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-tf-cards sh BUILD` (`code/packages/python/spice-netlist-parser`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-tf-cards sh BUILD` (`code/packages/typescript/spice-netlist-parser`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-tf-cards cargo test -p spice-netlist-parser -- --nocapture` (`code/packages/rust`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-tf-cards .venv/bin/python -m pytest tests/test_spice_netlist_parser.py -q` (`code/packages/python/spice-netlist-parser`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-tf-cards npm test -- --run` (`code/packages/typescript/spice-netlist-parser`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-tf-cards npm run build` (`code/packages/typescript/spice-netlist-parser`)
- `git diff --check`
