### PR TITLE
feat(dsp-fft): DSP01 Phase 3b.iv — public fft() real-input path routes through matrix-runtime

### DIFF
--- a/code/packages/rust/dsp-fft/CHANGELOG.md
+++ b/code/packages/rust/dsp-fft/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Changelog — dsp-fft
 
+## 0.4.0 — 2026-05-15
+
+### Changed — DSP01 Phase 3b.iv (public `fft()` real-input path runs on the matrix execution layer)
+
+The public `fft(signal, complex = false)` entry point now routes
+real-valued, power-of-two inputs through `fft_via_runtime` —
+i.e. the FFT actually runs end-to-end through `matrix-runtime` +
+`matrix-cpu`.  When `matrix-metal` / `matrix-cuda` claim Slice +
+Concat in their `supported_ops` bitsets, the same call lifts to
+GPU automatically with no `dsp-fft` change required.  That's the
+whole point of building on top of MX.
+
+What stays scalar for now:
+
+- `fft(signal, complex = true)` — the matrix-ir graph builder
+  always Concats a zero imaginary lane (i.e. it's real-input
+  only), so complex inputs continue to call `fft_scalar`.  A
+  follow-up phase will add a complex-input graph variant.
+- `ifft(spectrum: &ComplexTensor)` — the matrix-ir FFT graph's
+  input is `[N]` real and its output is `[N, 2]` complex; an
+  inverse from `[N, 2]` complex doesn't fit the same graph and
+  is deferred.
+
+`fft_scalar` and `ifft_scalar` remain available as the canonical
+oracle.
+
+#### Behavior
+
+- `fft(&real, false)` for power-of-two `N ≥ 2` is byte-for-byte
+  equivalent to the Phase 2 scalar path within `1e-4` relative
+  tolerance (matches the Phase 3b.iii contract).
+- `N = 1` still works — the public API falls back to the scalar
+  path for the degenerate single-element case so the API surface
+  is unchanged from Phase 2.
+- `fft(&[], false)` and `fft(&[1.0, 2.0, 3.0], false)` still
+  return errors; the exact `FftError` variant is preserved
+  (`InvalidInput` for empty, `NotPowerOfTwo(3)` for non-pow2).
+
+#### New public re-exports
+
+- `pub use radix2::build_fft_graph_with_input;`
+- `pub use radix2::fft_via_runtime;`
+
+Previously these were only reachable via `dsp_fft::radix2::*`.
+They're now first-class items at the crate root so callers
+don't have to dip into the submodule.
+
+#### New unit tests
+
+6 new tests in `tests`:
+
+- `public_fft_real_matches_scalar_via_runtime_n8` — real ramp,
+  routed through the matrix-runtime path, matches `fft_scalar`
+  to 1e-4.
+- `public_fft_real_matches_scalar_via_runtime_n16_sinusoid` —
+  pure cosine, every butterfly stage exercised.
+- `public_fft_real_impulse_via_runtime` — closed-form impulse
+  check, all bins = 1.0 within 1e-5.
+- `public_round_trip_real_through_runtime_and_scalar_ifft` —
+  `ifft(fft(x)) ≈ x` for an 8-point real signal, where the
+  forward goes through the matrix-ir graph and the inverse
+  through the scalar reference.  Verifies the forward path's
+  correctness end-to-end against the public API.
+- `public_fft_complex_input_still_goes_through_scalar` —
+  contract test: `fft(&interleaved, true)` returns *exactly*
+  what `fft_scalar(&interleaved)` returns (bit-identical, not
+  approximate), pinning the Phase 2 behavior for complex
+  inputs.
+- `public_fft_real_rejects_non_power_of_two` — error path:
+  length validation still returns `FftError::NotPowerOfTwo`.
+
+All 28 unit tests pass (17 from earlier phases + 6 new + 5
+Phase 3b.iii e2e + … net 6 added at the public-API layer).
+
+### What this phase does NOT include
+
+- Complex-input `fft(&interleaved, true)` on the matrix-runtime
+  path.  Needs a new graph builder that takes `[N, 2]` complex
+  input instead of building one out of `[N]` real + Concat.
+- `ifft` on the matrix-runtime path.  Same reason — the
+  current `build_fft_graph(_, Direction::Inverse)` only works
+  when the input is `[N]` real.
+- Performance benchmarking.  Functional parity is the bar
+  for Phase 3b.iv; perf is Phase 5.
+
 ## 0.3.0 — 2026-05-13
 
 ### Added — DSP01 Phase 3b.iii (end-to-end FFT execution via the matrix execution layer)

--- a/code/packages/rust/dsp-fft/Cargo.toml
+++ b/code/packages/rust/dsp-fft/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dsp-fft"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "DSP01 Phases 2-3b.ii: pure-Rust scalar reference + matrix-ir-lowered radix-2 Cooley-Tukey FFT for the DSP layer. Operates on interleaved [re, im] f32 buffers. The scalar reference is the oracle the matrix-ir graph build is tested against. Power-of-2 N only in V1; Bluestein for arbitrary N is DSP01 Phase 4."
+description = "DSP01 Phases 2-3b.iv: pure-Rust scalar reference + matrix-ir-lowered radix-2 Cooley-Tukey FFT for the DSP layer. The public fft() for real inputs runs end-to-end through matrix-runtime + matrix-cpu; complex inputs and ifft still go through the scalar oracle. Operates on interleaved [re, im] f32 buffers. Power-of-2 N only in V1; Bluestein for arbitrary N is DSP01 Phase 4."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/dsp-fft/README.md
+++ b/code/packages/rust/dsp-fft/README.md
@@ -1,12 +1,17 @@
 # dsp-fft
 
-**DSP01 Phase 2** — scalar reference FFT / IFFT for the DSP layer.
+Pure-Rust radix-2 Cooley-Tukey FFT / IFFT for the DSP layer on
+interleaved `[re, im]` f32 buffers — same layout as
+[`dsp-complex::ComplexTensor`](../dsp-complex/README.md).
 
-Pure-Rust radix-2 Cooley-Tukey on interleaved `[re, im]` f32 buffers
-— same layout as
-[`dsp-complex::ComplexTensor`](../dsp-complex/README.md).  This crate
-is the **oracle** the later phases test against; correctness here is
-non-negotiable.
+As of **0.4.0 (DSP01 Phase 3b.iv)** the public `fft()` for
+real-valued, power-of-two inputs runs end-to-end through
+`matrix-runtime` + `matrix-cpu` — i.e. the FFT actually executes
+on the matrix execution layer.  Complex inputs and `ifft` still
+call the scalar reference (the matrix-ir graph builder is
+real-input only for now).  The scalar reference stays available
+as `fft_scalar` / `ifft_scalar`; it's also the oracle every other
+path is tested against.
 
 ```rust
 use dsp_fft::{fft, ifft};
@@ -52,7 +57,8 @@ pseudorandom round-trip up to `N = 1024`.
 | 3a     | `Op::Slice` in matrix-ir                              | landed |
 | 3b.i   | `Op::Concat` in matrix-ir                             | landed |
 | 3b.ii  | matrix-ir-lowered FFT graph builder                   | landed (0.2.0) |
-| **3b.iii** | **End-to-end execution via `matrix-runtime` + `matrix-cpu`** | **this PR (0.3.0)** |
+| 3b.iii | End-to-end execution via `matrix-runtime` + `matrix-cpu` | landed (0.3.0) |
+| **3b.iv** | **Public `fft()` real-input path routes through `fft_via_runtime`** | **this PR (0.4.0)** |
 | 4      | Bluestein for arbitrary lengths; rfft / irfft        | pending |
 | 5      | MX05 specialised emitters (folded twiddles)          | pending |
 
@@ -97,17 +103,29 @@ The Phase 3b.iii test suite verifies the matrix-ir-lowered FFT
 matches the scalar oracle within 1e-4 relative tolerance for
 N ∈ {2, 4, 8, 16} — including a `ifft(fft(x)) ≈ x` round-trip.
 
-The public `fft` / `ifft` functions still call the scalar
-reference; a later phase will swap them once we have a story for
-batched / `complex: true` inputs.
+## Public-API routing (Phase 3b.iv)
 
-Phase 2 is intentionally small and CPU-only.  The public `fft` /
-`ifft` entry points are thin wrappers — Phase 3 will replace their
-bodies with matrix-ir graph builders without changing the API.
+| Call                                  | Path                        |
+| ------------------------------------- | --------------------------- |
+| `fft(&real, false)`, `N ≥ 2` pow2     | matrix-ir → `fft_via_runtime` |
+| `fft(&real, false)`, `N = 1`          | scalar (degenerate)          |
+| `fft(&interleaved, true)`             | scalar                       |
+| `ifft(&spectrum)`                     | scalar                       |
+
+The complex-input and `ifft` paths stay scalar because the
+matrix-ir graph builder's input shape is `[N]` real (it Concats
+a zero imaginary lane internally).  A future phase will add a
+complex-input graph variant; until then `fft_scalar` /
+`ifft_scalar` remain the canonical entry points for those cases
+and the test oracle for everything.
 
 ## Tests
 
-`cargo test -p dsp-fft` — 12 unit tests covering error paths
-(odd length, non-power-of-two, empty signal), known vectors (impulse,
-DC, pure cosine), and round-trip identities (small / medium / large
-N, real / complex / pseudorandom).
+`cargo test -p dsp-fft` — 28 unit tests:
+
+- 12 from Phase 2 — error paths, closed-form known vectors, scalar round-trips.
+- 5 from Phase 3b.ii — graph build / validation.
+- 5 from Phase 3b.iii — `fft_via_runtime` matches scalar for N ∈ {2, 4, 8, 16}.
+- 6 from Phase 3b.iv (this release) — public API routes through
+  the runtime, complex-input contract preserved bit-for-bit
+  against scalar.

--- a/code/packages/rust/dsp-fft/src/lib.rs
+++ b/code/packages/rust/dsp-fft/src/lib.rs
@@ -1,18 +1,28 @@
 //! # `dsp-fft` — FFT / IFFT for the DSP layer
 //!
-//! **DSP01 Phase 2.**  Pure-Rust radix-2 Cooley-Tukey scalar
-//! reference implementations of the FFT and inverse FFT.  Operates
-//! on interleaved `[re, im, re, im, …]` `f32` buffers — same layout
+//! Pure-Rust radix-2 Cooley-Tukey FFT / inverse FFT.  Operates on
+//! interleaved `[re, im, re, im, …]` `f32` buffers — same layout
 //! as `dsp-complex::ComplexTensor`.
 //!
 //! ## Phase scope
 //!
-//! - **Phase 2 (this release)** — scalar reference only.  The
-//!   public [`fft`] / [`ifft`] entry points are thin wrappers that
-//!   forward to the scalar code.  No matrix-ir lowering yet.
-//! - **Phase 3** — replaces the bodies with `matrix-ir::Graph`
-//!   builders that emit Const (twiddle) + Mul + Sub + Add stages.
-//!   The scalar reference stays as the test oracle.
+//! - **Phase 2** — scalar reference (`fft_scalar` / `ifft_scalar`).
+//!   Stays as the test oracle for every later phase.
+//! - **Phase 3a / 3b.i** — Slice + Concat ops landed in
+//!   `matrix-ir`.
+//! - **Phase 3b.ii** — `build_fft_graph` emits a `matrix_ir::Graph`
+//!   that computes the radix-2 FFT entirely in generic tensor ops.
+//! - **Phase 3b.iii** — `fft_via_runtime` plans + dispatches that
+//!   graph through `matrix-runtime` + `matrix-cpu`, downloading the
+//!   spectrum.
+//! - **Phase 3b.iv (this release)** — the public [`fft`] entry
+//!   point routes real-valued power-of-two inputs through
+//!   `fft_via_runtime` instead of the scalar reference.  Complex
+//!   inputs (`complex = true`) and the public [`ifft`] still go
+//!   through the scalar code — the matrix-ir graph builder is
+//!   real-only for now.  The scalar reference stays available as
+//!   [`fft_scalar`] / [`ifft_scalar`] for callers that want it
+//!   directly (it's also the test oracle).
 //! - **Phase 4** — Bluestein for arbitrary lengths, plus
 //!   `rfft` / `irfft`.
 //! - **Phase 5** — MX05 specialised emitters (folded twiddles for
@@ -44,7 +54,7 @@
 #![warn(rust_2018_idioms)]
 
 pub mod radix2;
-pub use radix2::build_fft_graph;
+pub use radix2::{build_fft_graph, build_fft_graph_with_input, fft_via_runtime};
 
 use dsp_complex::ComplexTensor;
 use std::fmt;
@@ -97,28 +107,55 @@ pub fn ifft_scalar(spectrum: &[f32]) -> Result<Vec<f32>, FftError> {
 /// Compute the forward 1-D FFT of a real-valued or already-complex
 /// `signal`.
 ///
-/// - If `signal` has length `N` (real input), it's wrapped as
-///   complex with `im = 0` before transform.
-/// - If `signal` has length `2N` (interleaved complex), it's used
-///   directly.  Pass `complex: true` to disambiguate.
+/// - If `signal` has length `N` (real input), it's routed through
+///   the matrix-ir-lowered FFT graph via
+///   [`fft_via_runtime`](crate::radix2::fft_via_runtime) — i.e.
+///   the FFT actually runs on the matrix execution layer.  When
+///   `matrix-metal` / `matrix-cuda` claim `Slice` + `Concat` in
+///   their `supported_ops` bitsets, the call lifts to GPU
+///   automatically with no `dsp-fft` change required.
+/// - If `signal` has length `2N` (interleaved complex), pass
+///   `complex: true`.  Complex-input transforms still go through
+///   the scalar reference ([`fft_scalar`]) because the matrix-ir
+///   graph builder is real-only in Phase 3b.iv; a future phase
+///   will add a complex-input graph variant.
 ///
 /// Returns a `ComplexTensor` of `N` complex elements.
 ///
-/// **Phase 2**: forwards to [`fft_scalar`].  Phase 3 will replace
-/// the body with a matrix-ir graph build.
+/// **Phase 3b.iv**: real-input path uses the matrix-ir-lowered
+/// graph end-to-end; complex-input path still calls the scalar
+/// oracle.
 pub fn fft(signal: &[f32], complex: bool) -> Result<ComplexTensor, FftError> {
     let interleaved = if complex {
-        signal.to_vec()
-    } else {
-        let mut buf = Vec::with_capacity(signal.len() * 2);
+        // Complex input: matrix-ir graph builder doesn't support
+        // complex inputs yet (the `build_fft_graph` real→complex
+        // step always Concats a zero imaginary lane), so fall back
+        // to the scalar oracle.  Length validation flows through
+        // `fft_scalar`.
+        fft_scalar(signal)?
+    } else if signal.len() < 2 {
+        // The matrix-ir graph builder requires N ≥ 2 (a single
+        // element has no butterfly stages and the Reshape +
+        // Concat plumbing assumes at least one stage).  Fall back
+        // to the scalar oracle so the public API still accepts
+        // the degenerate N = 1 case the way Phase 2 did, and
+        // preserves the exact `FftError` shape Phase 2 produced
+        // for empty input.
+        let mut interleaved_real = Vec::with_capacity(signal.len() * 2);
         for &x in signal {
-            buf.push(x);
-            buf.push(0.0);
+            interleaved_real.push(x);
+            interleaved_real.push(0.0);
         }
-        buf
+        fft_scalar(&interleaved_real)?
+    } else {
+        // Real input, N ≥ 2: run the matrix-ir-lowered FFT graph
+        // end-to-end through `matrix-runtime` + `matrix-cpu`.
+        // Length validation flows through `fft_via_runtime`
+        // (`build_fft_graph_with_input` rejects non-power-of-two
+        // inputs the same way the scalar path does).
+        fft_via_runtime(signal, Direction::Forward)?
     };
-    let result = fft_scalar(&interleaved)?;
-    Ok(ComplexTensor::from_interleaved(result).expect("fft output has even length"))
+    Ok(ComplexTensor::from_interleaved(interleaved).expect("fft output has even length"))
 }
 
 /// Compute the inverse 1-D FFT.  Input is the interleaved spectrum
@@ -126,8 +163,11 @@ pub fn fft(signal: &[f32], complex: bool) -> Result<ComplexTensor, FftError> {
 /// output is a complex `ComplexTensor` whose `real()` part is the
 /// recovered signal when the input was real-valued.
 ///
-/// **Phase 2**: forwards to [`ifft_scalar`].  Phase 3 will replace
-/// the body with a matrix-ir graph build.
+/// **Phase 3b.iv**: still forwards to [`ifft_scalar`].  The
+/// matrix-ir graph builder's input is `[N]` real and its output
+/// is `[N, 2]` complex; an inverse from `[N, 2]` complex doesn't
+/// fit the same graph and is deferred to a follow-up.  Output
+/// matches the scalar oracle exactly.
 pub fn ifft(spectrum: &ComplexTensor) -> Result<ComplexTensor, FftError> {
     let result = ifft_scalar(spectrum.as_interleaved())?;
     Ok(ComplexTensor::from_interleaved(result).expect("ifft output has even length"))
@@ -455,5 +495,94 @@ mod tests {
         // DC bin should be (1+3, 2+4) = (4, 6).
         assert!(approx_eq(spectrum.as_interleaved()[0], 4.0, 1e-5));
         assert!(approx_eq(spectrum.as_interleaved()[1], 6.0, 1e-5));
+    }
+
+    // ── Phase 3b.iv: public real-input fft goes through the
+    //    matrix-ir graph end-to-end via `fft_via_runtime`.  These
+    //    tests verify the routing produces the same answers as the
+    //    scalar oracle (which is what the previous Phase 2 wrapper
+    //    was forwarding to).  Tolerance is 1e-4 to match the
+    //    Phase 3b.iii contract for the matrix-runtime path.
+
+    #[test]
+    fn public_fft_real_matches_scalar_via_runtime_n8() {
+        let real: Vec<f32> = (0..8).map(|i| (i as f32) * 0.5 - 1.5).collect();
+        // New routing.
+        let via_runtime = fft(&real, false).unwrap();
+        // Scalar oracle: wrap as interleaved and call fft_scalar.
+        let mut interleaved = Vec::with_capacity(real.len() * 2);
+        for &x in &real {
+            interleaved.push(x);
+            interleaved.push(0.0);
+        }
+        let scalar = fft_scalar(&interleaved).unwrap();
+        assert_close(via_runtime.as_interleaved(), &scalar, 1e-4);
+    }
+
+    #[test]
+    fn public_fft_real_matches_scalar_via_runtime_n16_sinusoid() {
+        // Pure sinusoid — exercises every butterfly stage's twiddle
+        // arithmetic, not just the trivial diagonal of the impulse.
+        let n: usize = 16;
+        let real: Vec<f32> = (0..n)
+            .map(|i| (2.0 * PI * 3.0 * (i as f32) / (n as f32)).cos())
+            .collect();
+        let via_runtime = fft(&real, false).unwrap();
+        let mut interleaved = Vec::with_capacity(real.len() * 2);
+        for &x in &real {
+            interleaved.push(x);
+            interleaved.push(0.0);
+        }
+        let scalar = fft_scalar(&interleaved).unwrap();
+        assert_close(via_runtime.as_interleaved(), &scalar, 1e-4);
+    }
+
+    #[test]
+    fn public_fft_real_impulse_via_runtime() {
+        // Closed-form: fft(impulse) = all ones.  This is the
+        // canonical "the runtime path actually computes the right
+        // thing" smoke test.
+        let real = vec![1.0f32, 0.0, 0.0, 0.0];
+        let spectrum = fft(&real, false).unwrap();
+        assert_eq!(spectrum.len(), 4);
+        for k in 0..4 {
+            let re = spectrum.as_interleaved()[2 * k];
+            let im = spectrum.as_interleaved()[2 * k + 1];
+            assert!(approx_eq(re, 1.0, 1e-5), "bin {} real = {}", k, re);
+            assert!(approx_eq(im, 0.0, 1e-5), "bin {} imag = {}", k, im);
+        }
+    }
+
+    #[test]
+    fn public_round_trip_real_through_runtime_and_scalar_ifft() {
+        // Forward FFT through the matrix-ir runtime path, inverse
+        // through the scalar reference.  This is the only round
+        // trip we can express today since `ifft` is still scalar
+        // (the matrix-ir graph is real-input only).
+        let real = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let spectrum = fft(&real, false).unwrap();
+        let recovered = ifft(&spectrum).unwrap();
+        let rec_real = recovered.real();
+        assert_close(&real, &rec_real, 1e-4);
+    }
+
+    #[test]
+    fn public_fft_complex_input_still_goes_through_scalar() {
+        // The complex-input path is not yet supported by the
+        // matrix-ir graph builder, so it must continue to match
+        // the Phase 2 scalar oracle exactly (not 1e-4, exactly).
+        let interleaved = vec![1.0f32, 2.0, 3.0, 4.0];
+        let via_public = fft(&interleaved, true).unwrap();
+        let via_scalar = fft_scalar(&interleaved).unwrap();
+        assert_eq!(via_public.as_interleaved(), via_scalar.as_slice());
+    }
+
+    #[test]
+    fn public_fft_real_rejects_non_power_of_two() {
+        // Length validation flows through the matrix-ir graph's
+        // `NotPowerOfTwo` check (in `build_fft_graph_with_input`).
+        let real = vec![1.0f32, 2.0, 3.0];
+        let err = fft(&real, false).unwrap_err();
+        assert_eq!(err, FftError::NotPowerOfTwo(3));
     }
 }


### PR DESCRIPTION
## Summary

- Swaps `fft(signal, complex = false)` to route real-valued, power-of-two inputs through `fft_via_runtime` (matrix-ir → matrix-runtime → matrix-cpu) instead of the scalar reference. The FFT now actually runs on the matrix execution layer, and lifts to GPU automatically when Metal / CUDA claim Slice + Concat.
- Keeps `fft(signal, complex = true)`, `ifft(&spectrum)`, and the degenerate `N = 1` case on the scalar path — the matrix-ir graph builder is real-input only for now. Public API surface and `FftError` shapes are unchanged from Phase 2.
- Bumps `dsp-fft` 0.3.0 → 0.4.0. Re-exports `build_fft_graph_with_input` and `fft_via_runtime` at the crate root so callers don't have to dip into `dsp_fft::radix2::*`.

## Test plan

- [x] `cargo test -p dsp-fft` — 28 tests pass (12 Phase 2 + 5 Phase 3b.ii + 5 Phase 3b.iii + 6 new Phase 3b.iv)
- [x] New tests verify: public real-input fft via runtime matches scalar for N=8 ramp + N=16 sinusoid; closed-form impulse FFT; `ifft(fft(x)) ≈ x` for an 8-point real round-trip; complex-input bit-for-bit preserved; non-pow2 real input still returns `NotPowerOfTwo`.
- [x] Security review passed
- [ ] CI green on origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)