### PR TITLE
spice: parse Monte Carlo netlist cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Parse SPICE `.tf V(output_node) input_source` transfer-function analysis
   cards.
 - Parse SPICE `.sens V(output_node)` DC sensitivity analysis cards.
+- Parse SPICE `.mc V(output_node) n_trials [tolerance] [distribution] [seed]`
+  Monte Carlo DC analysis cards.
 
 ## 0.1.6
 

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -24,5 +24,5 @@ This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`,
 MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`), SPICE engineering suffixes,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
-expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, and `.sens` analysis
-cards.
+expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, and `.mc`
+analysis cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -3,6 +3,7 @@
 from spice_netlist_parser.parser import (
     AcAnalysis,
     DcAnalysis,
+    McAnalysis,
     ModelCard,
     NetlistParseError,
     OpAnalysis,
@@ -19,6 +20,7 @@ __version__ = "0.1.6"
 __all__ = [
     "AcAnalysis",
     "DcAnalysis",
+    "McAnalysis",
     "ModelCard",
     "NetlistParseError",
     "OpAnalysis",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -82,7 +82,26 @@ class SensAnalysis:
     output_node: str
 
 
-type Analysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis | TfAnalysis | SensAnalysis
+@dataclass(frozen=True, slots=True)
+class McAnalysis:
+    """A `.mc V(output_node) n_trials [tolerance] [distribution] [seed]` card."""
+
+    output_node: str
+    n_trials: int
+    tolerance: float = 0.05
+    distribution: str = "gaussian"
+    seed: int | None = None
+
+
+type Analysis = (
+    OpAnalysis
+    | TranAnalysis
+    | DcAnalysis
+    | AcAnalysis
+    | TfAnalysis
+    | SensAnalysis
+    | McAnalysis
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,6 +160,9 @@ class ParsedNetlist:
 
     def sens_cards(self) -> list[SensAnalysis]:
         return [analysis for analysis in self.analyses if isinstance(analysis, SensAnalysis)]
+
+    def mc_cards(self) -> list[McAnalysis]:
+        return [analysis for analysis in self.analyses if isinstance(analysis, McAnalysis)]
 
 
 _VALUE_RE = re.compile(
@@ -572,6 +594,21 @@ def _parse_directive(fields: list[str]) -> Analysis:
     if directive == ".sens":
         _require_fields(fields, 2, ".sens")
         return SensAnalysis(output_node=_parse_voltage_probe(fields[1], ".sens"))
+    if directive == ".mc":
+        _require_min_fields(fields, 3, ".mc")
+        _require_max_fields(fields, 6, ".mc")
+        distribution = fields[4].lower() if len(fields) >= 5 else "gaussian"
+        if distribution not in ("gaussian", "uniform"):
+            raise NetlistParseError(
+                f".mc distribution must be 'gaussian' or 'uniform', got {fields[4]!r}"
+            )
+        return McAnalysis(
+            output_node=_parse_voltage_probe(fields[1], ".mc"),
+            n_trials=int(parse_value(fields[2])),
+            tolerance=parse_value(fields[3]) if len(fields) >= 4 else 0.05,
+            distribution=distribution,
+            seed=int(parse_value(fields[5])) if len(fields) >= 6 else None,
+        )
     raise NetlistParseError(f"unsupported directive {fields[0]!r}")
 
 
@@ -695,6 +732,11 @@ def _require_fields(fields: list[str], count: int, label: str) -> None:
 def _require_min_fields(fields: list[str], count: int, label: str) -> None:
     if len(fields) < count:
         raise NetlistParseError(f"{label} expects at least {count} fields, got {len(fields)}")
+
+
+def _require_max_fields(fields: list[str], count: int, label: str) -> None:
+    if len(fields) > count:
+        raise NetlistParseError(f"{label} expects at most {count} fields, got {len(fields)}")
 
 
 def _pad(values: list[float], count: int, default: float) -> list[float]:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -18,6 +18,7 @@ from spice_engine import (
     VoltageSource,
     ac_sweep,
     dc_op,
+    mc_dc,
     sens_dc,
     tf,
 )
@@ -25,6 +26,7 @@ from spice_engine import (
 from spice_netlist_parser import (
     AcAnalysis,
     DcAnalysis,
+    McAnalysis,
     ModelCard,
     NetlistParseError,
     OpAnalysis,
@@ -146,6 +148,51 @@ def test_sens_analysis_card_rejects_non_voltage_output_probe() -> None:
 Vin in 0 DC 1
 R1 in out 1k
 .sens out
+"""
+        )
+
+
+def test_parse_mc_analysis_card_and_run_monte_carlo() -> None:
+    parsed = parse_netlist(
+        """
+Vin in 0 DC 1
+Rtop in out 1k
+Rbot out 0 1k
+.mc V(out) 6 0 uniform 7
+"""
+    )
+
+    assert parsed.analyses == [
+        McAnalysis(
+            output_node="out",
+            n_trials=6,
+            tolerance=0.0,
+            distribution="uniform",
+            seed=7,
+        )
+    ]
+    assert parsed.mc_cards() == parsed.analyses
+    card = parsed.mc_cards()[0]
+    result = mc_dc(
+        parsed.circuit,
+        card.output_node,
+        n_trials=card.n_trials,
+        tolerance=card.tolerance,
+        distribution=card.distribution,
+        seed=card.seed,
+    )
+    assert result.n_trials == 6
+    assert isclose(result.mean, 0.5, abs_tol=1e-9)
+    assert isclose(result.std_dev, 0.0, abs_tol=1e-12)
+
+
+def test_mc_analysis_card_rejects_non_voltage_output_probe() -> None:
+    with pytest.raises(NetlistParseError, match=r"\.mc output must be a voltage probe"):
+        parse_netlist(
+            """
+Vin in 0 DC 1
+R1 in out 1k
+.mc out 10
 """
         )
 

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Parse SPICE `.tf V(output_node) input_source` transfer-function analysis
   cards.
 - Parse SPICE `.sens V(output_node)` DC sensitivity analysis cards.
+- Parse SPICE `.mc V(output_node) n_trials [tolerance] [distribution] [seed]`
+  Monte Carlo DC analysis cards.
 
 ## 0.1.7
 

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -25,4 +25,4 @@ cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering
 suffixes, independent-source `AC <magnitude> [phase]` forms, PWL/PULSE/SIN/EXP
 source forms, comments, `.end`, `.subckt` / `X` instance expansion, and
-`.op`, `.tran`, `.dc`, `.ac`, `.tf`, and `.sens` analysis cards.
+`.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, and `.mc` analysis cards.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -64,6 +64,15 @@ pub struct SensAnalysis {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct McAnalysis {
+    pub output_node: String,
+    pub n_trials: usize,
+    pub tolerance: f64,
+    pub distribution: String,
+    pub seed: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Analysis {
     Op(OpAnalysis),
     Tran(TranAnalysis),
@@ -71,6 +80,7 @@ pub enum Analysis {
     Ac(AcAnalysis),
     Tf(TfAnalysis),
     Sens(SensAnalysis),
+    Mc(McAnalysis),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -144,6 +154,16 @@ impl ParsedNetlist {
             .iter()
             .filter_map(|analysis| match analysis {
                 Analysis::Sens(card) => Some(card),
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn mc_cards(&self) -> Vec<&McAnalysis> {
+        self.analyses
+            .iter()
+            .filter_map(|analysis| match analysis {
+                Analysis::Mc(card) => Some(card),
                 _ => None,
             })
             .collect()
@@ -983,6 +1003,35 @@ fn parse_directive(fields: &[String]) -> Result<Analysis, NetlistParseError> {
                 output_node: parse_voltage_probe(&fields[1], ".sens")?,
             }))
         }
+        ".mc" => {
+            require_min_fields(fields, 3, ".mc")?;
+            require_max_fields(fields, 6, ".mc")?;
+            let distribution = fields
+                .get(4)
+                .map(|field| field.to_ascii_lowercase())
+                .unwrap_or_else(|| "gaussian".to_string());
+            if distribution != "gaussian" && distribution != "uniform" {
+                return Err(NetlistParseError::new(format!(
+                    ".mc distribution must be \"gaussian\" or \"uniform\", got {:?}",
+                    fields[4]
+                )));
+            }
+            Ok(Analysis::Mc(McAnalysis {
+                output_node: parse_voltage_probe(&fields[1], ".mc")?,
+                n_trials: parse_value(&fields[2])? as usize,
+                tolerance: if fields.len() >= 4 {
+                    parse_value(&fields[3])?
+                } else {
+                    0.05
+                },
+                distribution,
+                seed: if fields.len() >= 6 {
+                    Some(parse_value(&fields[5])? as u64)
+                } else {
+                    None
+                },
+            }))
+        }
         _ => Err(NetlistParseError::new(format!(
             "unsupported directive {:?}",
             fields[0]
@@ -1085,6 +1134,20 @@ fn require_min_fields(
     if fields.len() < count {
         return Err(NetlistParseError::new(format!(
             "{label} expects at least {count} fields, got {}",
+            fields.len()
+        )));
+    }
+    Ok(())
+}
+
+fn require_max_fields(
+    fields: &[String],
+    count: usize,
+    label: &str,
+) -> Result<(), NetlistParseError> {
+    if fields.len() > count {
+        return Err(NetlistParseError::new(format!(
+            "{label} expects at most {count} fields, got {}",
             fields.len()
         )));
     }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1,7 +1,10 @@
-use spice_engine::{ac_sweep, dc_op, sens_dc, tf, BjtPolarity, Element, MosfetType};
+use spice_engine::{
+    ac_sweep, dc_op, mc_dc, sens_dc, tf, BjtPolarity, Element, McDistribution, McOptions,
+    MosfetType,
+};
 use spice_netlist_parser::{
     parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, NetlistParseError, OpAnalysis,
-    SensAnalysis, TfAnalysis, TranAnalysis,
+    McAnalysis, SensAnalysis, TfAnalysis, TranAnalysis,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -187,6 +190,70 @@ R1 in out 1k
     assert!(error
         .to_string()
         .contains(".sens output must be a voltage probe"));
+}
+
+#[test]
+fn parses_mc_monte_carlo_dc_analysis_cards() {
+    let parsed = parse_netlist(
+        r#"
+Vin in 0 DC 1
+Rtop in out 1k
+Rbot out 0 1k
+.mc V(out) 6 0 uniform 7
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        parsed.analyses,
+        vec![Analysis::Mc(McAnalysis {
+            output_node: "out".to_string(),
+            n_trials: 6,
+            tolerance: 0.0,
+            distribution: "uniform".to_string(),
+            seed: Some(7),
+        })]
+    );
+    assert_eq!(parsed.mc_cards(), vec![match &parsed.analyses[0] {
+        Analysis::Mc(card) => card,
+        _ => panic!("expected mc card"),
+    }]);
+    let card = parsed.mc_cards()[0];
+    let distribution = match card.distribution.as_str() {
+        "gaussian" => McDistribution::Gaussian,
+        "uniform" => McDistribution::Uniform,
+        other => panic!("unexpected distribution {other}"),
+    };
+    let result = mc_dc(
+        &parsed.circuit,
+        &card.output_node,
+        card.n_trials,
+        McOptions {
+            tolerance: card.tolerance,
+            distribution,
+            seed: card.seed,
+        },
+    )
+    .unwrap();
+    assert_eq!(result.n_trials, 6);
+    assert_close(result.mean, 0.5);
+    assert_close(result.std_dev, 0.0);
+}
+
+#[test]
+fn rejects_mc_cards_without_voltage_output_probe() {
+    let error = parse_netlist(
+        r#"
+Vin in 0 DC 1
+R1 in out 1k
+.mc out 10
+"#,
+    )
+    .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains(".mc output must be a voltage probe"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Parse SPICE `.tf V(output_node) input_source` transfer-function analysis
   cards.
 - Parse SPICE `.sens V(output_node)` DC sensitivity analysis cards.
+- Parse SPICE `.mc V(output_node) n_trials [tolerance] [distribution] [seed]`
+  Monte Carlo DC analysis cards.
 
 ## 0.1.6
 

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -28,4 +28,4 @@ elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 `TNOM` parameters,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, `.ac`, and
-`.tf` and `.sens` analysis cards.
+`.tf`, `.sens`, and `.mc` analysis cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -70,13 +70,23 @@ export interface SensAnalysis {
   readonly outputNode: string;
 }
 
+export interface McAnalysis {
+  readonly kind: "mc";
+  readonly outputNode: string;
+  readonly nTrials: number;
+  readonly tolerance: number;
+  readonly distribution: "gaussian" | "uniform";
+  readonly seed?: number;
+}
+
 export type Analysis =
   | OpAnalysis
   | TranAnalysis
   | DcAnalysis
   | AcAnalysis
   | TfAnalysis
-  | SensAnalysis;
+  | SensAnalysis
+  | McAnalysis;
 
 export interface ModelCard {
   readonly name: string;
@@ -114,6 +124,10 @@ export class ParsedNetlist {
 
   sensCards(): SensAnalysis[] {
     return this.analyses.filter((analysis): analysis is SensAnalysis => analysis.kind === "sens");
+  }
+
+  mcCards(): McAnalysis[] {
+    return this.analyses.filter((analysis): analysis is McAnalysis => analysis.kind === "mc");
   }
 }
 
@@ -803,6 +817,24 @@ function parseDirective(fields: readonly string[]): Analysis {
       outputNode: parseVoltageProbe(fields[1], ".sens"),
     };
   }
+  if (directive === ".mc") {
+    requireMinFields(fields, 3, ".mc");
+    requireMaxFields(fields, 6, ".mc");
+    const distribution = fields.length >= 5 ? fields[4].toLowerCase() : "gaussian";
+    if (distribution !== "gaussian" && distribution !== "uniform") {
+      throw new NetlistParseError(
+        `.mc distribution must be "gaussian" or "uniform", got ${JSON.stringify(fields[4])}`,
+      );
+    }
+    return {
+      kind: "mc",
+      outputNode: parseVoltageProbe(fields[1], ".mc"),
+      nTrials: Math.trunc(parseValue(fields[2])),
+      tolerance: fields.length >= 4 ? parseValue(fields[3]) : 0.05,
+      distribution,
+      seed: fields.length >= 6 ? Math.trunc(parseValue(fields[5])) : undefined,
+    };
+  }
   throw new NetlistParseError(`unsupported directive ${JSON.stringify(fields[0])}`);
 }
 
@@ -867,6 +899,12 @@ function requireMinFields(fields: readonly string[], count: number, label: strin
     throw new NetlistParseError(
       `${label} expects at least ${count} fields, got ${fields.length}`,
     );
+  }
+}
+
+function requireMaxFields(fields: readonly string[], count: number, label: string): void {
+  if (fields.length > count) {
+    throw new NetlistParseError(`${label} expects at most ${count} fields, got ${fields.length}`);
   }
 }
 

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1,4 +1,4 @@
-import { acSweep, dcOp, sensDc, tf } from "@coding-adventures/spice-engine";
+import { acSweep, dcOp, mcDc, sensDc, tf } from "@coding-adventures/spice-engine";
 import { describe, expect, it } from "vitest";
 import {
   NetlistParseError,
@@ -141,6 +141,46 @@ R1 in out 1k
 .sens out
 `),
     ).toThrow(/\.sens output must be a voltage probe/);
+  });
+
+  it("parses .mc Monte Carlo DC analysis cards", () => {
+    const parsed = parseNetlist(`
+Vin in 0 DC 1
+Rtop in out 1k
+Rbot out 0 1k
+.mc V(out) 6 0 uniform 7
+`);
+
+    expect(parsed.analyses).toEqual([
+      {
+        kind: "mc",
+        outputNode: "out",
+        nTrials: 6,
+        tolerance: 0.0,
+        distribution: "uniform",
+        seed: 7,
+      },
+    ]);
+    expect(parsed.mcCards()).toEqual(parsed.analyses);
+    const [card] = parsed.mcCards();
+    const result = mcDc(parsed.circuit, card.outputNode, card.nTrials, {
+      tolerance: card.tolerance,
+      distribution: card.distribution,
+      seed: card.seed,
+    });
+    expect(result.nTrials).toBe(6);
+    expect(result.mean).toBeCloseTo(0.5, 9);
+    expect(result.stdDev).toBeCloseTo(0.0, 12);
+  });
+
+  it("rejects .mc cards without a voltage output probe", () => {
+    expect(() =>
+      parseNetlist(`
+Vin in 0 DC 1
+R1 in out 1k
+.mc out 10
+`),
+    ).toThrow(/\.mc output must be a voltage probe/);
   });
 
   it("parses VCVS elements into operating-point circuits", () => {


### PR DESCRIPTION
## Summary

- add `.mc V(output_node) n_trials [tolerance] [distribution] [seed]` analysis-card parsing to the Python, TypeScript, and Rust SPICE netlist parsers
- expose typed Monte Carlo card accessors on parsed netlists in all three implementations
- add parser tests that feed the parsed card into the existing engine Monte Carlo DC APIs

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-mc-cards sh BUILD` (`code/packages/python/spice-netlist-parser`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-mc-cards sh BUILD` (`code/packages/typescript/spice-netlist-parser`)
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-netlist-mc-cards cargo test -p spice-netlist-parser -- --nocapture` (`code/packages/rust`)
- `git diff --check`