### PR TITLE
feat(dsp-fft): DSP01 Phase 4a — scalar Bluestein for arbitrary lengths

### DIFF
--- a/code/packages/rust/dsp-fft/CHANGELOG.md
+++ b/code/packages/rust/dsp-fft/CHANGELOG.md
@@ -1,5 +1,101 @@
 # Changelog — dsp-fft
 
+## 0.5.0 — 2026-05-15
+
+### Added — DSP01 Phase 4a (scalar Bluestein for arbitrary lengths)
+
+The public `fft` / `ifft` API now accepts **arbitrary `N ≥ 1`**.
+Previously, non-power-of-two lengths returned
+`FftError::NotPowerOfTwo`; now they fall back to a scalar
+Bluestein (chirp z-transform) implementation that handles every
+length with one code path.
+
+#### New module: `dsp_fft::bluestein`
+
+```rust
+pub fn bluestein_scalar(
+    signal: &[f32],
+    direction: Direction,
+) -> Result<Vec<f32>, FftError>;
+```
+
+Operates on the same interleaved `[re, im]` `f32` convention
+as `fft_scalar`.  Algorithm:
+
+1. Pick `M = next_pow2(2N - 1)` — the smallest power of two
+   that fits a linear convolution of two length-`N` sequences.
+2. Build the pre-chirp `a[n] = x[n] · exp(-iπ · n² / N)`,
+   zero-padded to length `M`.
+3. Build the bilateral anti-chirp `b[n] = exp(+iπ · n² / N)`
+   wrapped onto `[0, M)`.
+4. Convolve via three length-`M` FFTs: `c = IFFT(FFT(a) · FFT(b))`.
+5. Multiply by the post-chirp: `X[k] = exp(-iπ · k² / N) · c[k]`.
+
+The chirp uses `k² mod 2N` reduction inside the floating-point
+exponent so very large `N` doesn't bleed precision.  Inverse
+direction flips the chirp sign and applies the `1/N` backward
+normalization.
+
+`bluestein_scalar` is exposed at the crate root as
+`dsp_fft::bluestein_scalar` for callers that want to bypass
+`fft` / `ifft`.
+
+#### Public API integration
+
+| Input shape                     | `complex` | N parity        | Path                |
+| ------------------------------- | --------- | --------------- | ------------------- |
+| `[N]` real, `N ≥ 2` pow2        | `false`   | pow2            | matrix-ir → runtime |
+| `[N]` real, `N ≥ 2` non-pow2    | `false`   | non-pow2 (new)  | scalar Bluestein    |
+| `[N]` real, `N = 1`             | `false`   | degenerate      | scalar (identity)   |
+| `[2N]` interleaved, `N` pow2    | `true`    | pow2            | scalar radix-2      |
+| `[2N]` interleaved, `N` non-pow2 | `true`    | non-pow2 (new) | scalar Bluestein    |
+| `ifft` on `[N, 2]`, `N` pow2    | —         | pow2            | scalar radix-2      |
+| `ifft` on `[N, 2]`, `N` non-pow2 | —         | non-pow2 (new) | scalar Bluestein    |
+
+#### New unit tests
+
+**`bluestein` module — 15 tests:**
+
+- Error paths: odd-length buffer, empty buffer.
+- N = 1 identity (forward + inverse).
+- Sanity vs radix-2 at N = 8 (cross-check the chirp).
+- vs naive O(N²) DFT for N ∈ {3, 5, 6, 7, 12}.
+- Round-trip for N ∈ {3, 7} + a stress test sweeping every
+  N ∈ 1..=32.
+- Closed-form impulse at N = 5, DC at N = 7.
+
+**`lib` public API — 3 new tests:**
+
+- `public_fft_real_non_pow2_routes_through_bluestein` —
+  verifies N = 3 against an inline naive DFT.
+- `public_ifft_round_trip_non_pow2_n5` — `ifft(fft(x)) ≈ x` for
+  N = 5 (where both directions go through Bluestein).
+- `public_fft_complex_non_pow2_routes_through_bluestein` —
+  complex-input round-trip at N = 3.
+
+All 45 unit tests pass.
+
+#### Behavior changes
+
+- `fft(&[1.0, 2.0, 3.0], false)` previously returned
+  `Err(FftError::NotPowerOfTwo(3))`; now returns the correct
+  3-point DFT.
+- `fft_scalar` and `ifft_scalar` retain their power-of-two-only
+  behavior — they're the radix-2 oracle and stay that way.
+  Use `bluestein_scalar` or the public `fft` / `ifft` for
+  arbitrary lengths.
+
+### What this phase does NOT include
+
+- **Phase 4b**: `rfft` / `irfft`.  Real-input half-spectrum APIs
+  that exploit conjugate symmetry to return only `N/2 + 1` bins.
+- **Phase 4c**: matrix-ir-lowered Bluestein.  The convolution
+  inside `bluestein_scalar` currently calls `fft_scalar` /
+  `ifft_scalar` directly; lifting it onto the matrix execution
+  layer is its own (significant) chunk of work.
+- Performance benchmarking.  Bluestein has ~3× the constant
+  factor of an in-place radix-2; perf is Phase 5.
+
 ## 0.4.0 — 2026-05-15
 
 ### Changed — DSP01 Phase 3b.iv (public `fft()` real-input path runs on the matrix execution layer)

--- a/code/packages/rust/dsp-fft/Cargo.toml
+++ b/code/packages/rust/dsp-fft/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dsp-fft"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "DSP01 Phases 2-3b.iv: pure-Rust scalar reference + matrix-ir-lowered radix-2 Cooley-Tukey FFT for the DSP layer. The public fft() for real inputs runs end-to-end through matrix-runtime + matrix-cpu; complex inputs and ifft still go through the scalar oracle. Operates on interleaved [re, im] f32 buffers. Power-of-2 N only in V1; Bluestein for arbitrary N is DSP01 Phase 4."
+description = "DSP01 Phases 2-4a: pure-Rust scalar reference + matrix-ir-lowered radix-2 Cooley-Tukey FFT + scalar Bluestein for arbitrary lengths. Power-of-2 real inputs run end-to-end on matrix-runtime + matrix-cpu; non-power-of-2 lengths use a scalar Bluestein fallback. Operates on interleaved [re, im] f32 buffers. rfft/irfft (Phase 4b) and matrix-ir-lowered Bluestein (Phase 4c) are still pending."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/dsp-fft/README.md
+++ b/code/packages/rust/dsp-fft/README.md
@@ -1,17 +1,24 @@
 # dsp-fft
 
-Pure-Rust radix-2 Cooley-Tukey FFT / IFFT for the DSP layer on
-interleaved `[re, im]` f32 buffers — same layout as
+Pure-Rust FFT / IFFT for the DSP layer on interleaved `[re, im]`
+f32 buffers — same layout as
 [`dsp-complex::ComplexTensor`](../dsp-complex/README.md).
 
-As of **0.4.0 (DSP01 Phase 3b.iv)** the public `fft()` for
-real-valued, power-of-two inputs runs end-to-end through
-`matrix-runtime` + `matrix-cpu` — i.e. the FFT actually executes
-on the matrix execution layer.  Complex inputs and `ifft` still
-call the scalar reference (the matrix-ir graph builder is
-real-input only for now).  The scalar reference stays available
-as `fft_scalar` / `ifft_scalar`; it's also the oracle every other
-path is tested against.
+As of **0.5.0 (DSP01 Phase 4a)** the public `fft()` / `ifft()`
+accepts **arbitrary `N ≥ 1`**:
+
+- Power-of-two real inputs run end-to-end on the matrix execution
+  layer (`matrix-runtime` + `matrix-cpu`, GPU once Metal / CUDA
+  claim Slice + Concat) via the radix-2 graph.
+- Non-power-of-two lengths fall back to a scalar Bluestein
+  (chirp z-transform) implementation — every length works with
+  one code path.
+- Complex-input transforms (`complex = true`) stay on the scalar
+  oracle for now (radix-2 for pow2, Bluestein for non-pow2).
+
+The scalar radix-2 reference (`fft_scalar` / `ifft_scalar`) stays
+available as the test oracle.  Bluestein is exposed as
+`bluestein_scalar` for callers that want it directly.
 
 ```rust
 use dsp_fft::{fft, ifft};
@@ -58,8 +65,10 @@ pseudorandom round-trip up to `N = 1024`.
 | 3b.i   | `Op::Concat` in matrix-ir                             | landed |
 | 3b.ii  | matrix-ir-lowered FFT graph builder                   | landed (0.2.0) |
 | 3b.iii | End-to-end execution via `matrix-runtime` + `matrix-cpu` | landed (0.3.0) |
-| **3b.iv** | **Public `fft()` real-input path routes through `fft_via_runtime`** | **this PR (0.4.0)** |
-| 4      | Bluestein for arbitrary lengths; rfft / irfft        | pending |
+| 3b.iv  | Public `fft()` real-input path routes through `fft_via_runtime` | landed (0.4.0) |
+| **4a** | **Scalar Bluestein for arbitrary lengths**          | **this PR (0.5.0)** |
+| 4b     | `rfft` / `irfft` (half-spectrum API)                 | pending |
+| 4c     | Matrix-ir-lowered Bluestein                          | pending |
 | 5      | MX05 specialised emitters (folded twiddles)          | pending |
 
 ## Matrix-IR graph build (Phase 3b.ii)
@@ -103,29 +112,57 @@ The Phase 3b.iii test suite verifies the matrix-ir-lowered FFT
 matches the scalar oracle within 1e-4 relative tolerance for
 N ∈ {2, 4, 8, 16} — including a `ifft(fft(x)) ≈ x` round-trip.
 
-## Public-API routing (Phase 3b.iv)
+## Public-API routing (as of Phase 4a / 0.5.0)
 
-| Call                                  | Path                        |
-| ------------------------------------- | --------------------------- |
-| `fft(&real, false)`, `N ≥ 2` pow2     | matrix-ir → `fft_via_runtime` |
-| `fft(&real, false)`, `N = 1`          | scalar (degenerate)          |
-| `fft(&interleaved, true)`             | scalar                       |
-| `ifft(&spectrum)`                     | scalar                       |
+| Call                                       | Path                          |
+| ------------------------------------------ | ----------------------------- |
+| `fft(&real, false)`, `N ≥ 2` pow2          | matrix-ir → `fft_via_runtime` |
+| `fft(&real, false)`, `N ≥ 2` non-pow2      | scalar Bluestein              |
+| `fft(&real, false)`, `N = 1`               | scalar (identity)             |
+| `fft(&interleaved, true)`, `N` pow2        | scalar radix-2                |
+| `fft(&interleaved, true)`, `N` non-pow2    | scalar Bluestein              |
+| `ifft(&spectrum)`, `N` pow2                | scalar radix-2                |
+| `ifft(&spectrum)`, `N` non-pow2            | scalar Bluestein              |
 
 The complex-input and `ifft` paths stay scalar because the
 matrix-ir graph builder's input shape is `[N]` real (it Concats
-a zero imaginary lane internally).  A future phase will add a
-complex-input graph variant; until then `fft_scalar` /
-`ifft_scalar` remain the canonical entry points for those cases
-and the test oracle for everything.
+a zero imaginary lane internally).  Phase 4c will lift the
+Bluestein path onto matrix-ir; a later phase will add a
+complex-input radix-2 graph variant.  Until then `fft_scalar` /
+`ifft_scalar` remain the canonical radix-2 oracle, and
+`bluestein_scalar` is the canonical arbitrary-N oracle.
+
+## Bluestein's algorithm (Phase 4a, scalar)
+
+For non-power-of-two `N`, `bluestein_scalar(signal, direction)`
+computes the DFT as a length-`M` linear convolution, where
+`M = next_pow2(2N - 1)`.  The three internal FFTs all run on
+the radix-2 path (`fft_scalar`).  The chirp construction uses
+`k² mod 2N` reduction to keep the floating-point exponent
+bounded for large `N`.
+
+```rust
+use dsp_fft::{bluestein_scalar, Direction};
+
+// 7-point DFT — prime length, can't use radix-2 directly.
+let signal = vec![1.0_f32, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0,
+                  5.0, 0.0, 6.0, 0.0, 7.0, 0.0];
+let spectrum = bluestein_scalar(&signal, Direction::Forward).unwrap();
+```
 
 ## Tests
 
-`cargo test -p dsp-fft` — 28 unit tests:
+`cargo test -p dsp-fft` — 45 unit tests:
 
-- 12 from Phase 2 — error paths, closed-form known vectors, scalar round-trips.
+- 12 from Phase 2 — error paths, closed-form known vectors, scalar radix-2 round-trips.
 - 5 from Phase 3b.ii — graph build / validation.
 - 5 from Phase 3b.iii — `fft_via_runtime` matches scalar for N ∈ {2, 4, 8, 16}.
-- 6 from Phase 3b.iv (this release) — public API routes through
-  the runtime, complex-input contract preserved bit-for-bit
-  against scalar.
+- 6 from Phase 3b.iv — public API routes through the runtime,
+  complex-input contract preserved bit-for-bit against scalar.
+- 15 from Phase 4a (this release) — Bluestein: error paths,
+  N = 1 identity, radix-2 sanity check at N = 8, naive-DFT
+  cross-checks at N ∈ {3, 5, 6, 7, 12}, round-trips at
+  N = 3, 7, and every N ∈ 1..=32, plus closed-form impulse /
+  DC known vectors at non-pow2 sizes.
+- 2 new at the public-API layer — `fft` / `ifft` routing
+  through Bluestein for non-pow2 real and complex inputs.

--- a/code/packages/rust/dsp-fft/src/bluestein.rs
+++ b/code/packages/rust/dsp-fft/src/bluestein.rs
@@ -1,0 +1,548 @@
+//! # Bluestein's algorithm — FFT for arbitrary lengths
+//!
+//! **DSP01 Phase 4a (scalar reference).**  Computes the discrete
+//! Fourier transform of a length-`N` sequence for *any* `N ≥ 1`,
+//! including non-power-of-two lengths the radix-2 path can't
+//! touch.  This phase ships the scalar reference only;
+//! later phases (4b: rfft/irfft, 4c: matrix-ir lowered Bluestein)
+//! build on top.
+//!
+//! ## Why Bluestein?
+//!
+//! The matrix-ir-lowered FFT in [`crate::radix2`] requires `N` to
+//! be a power of two — the butterfly tree's depth is `log₂(N)`
+//! and the bit-reversal permutation is a power-of-two identity.
+//! Real-world signal lengths are usually *not* powers of two
+//! (think 1000 samples, 882 samples for audio resampling, etc.).
+//!
+//! Bluestein's algorithm — also called the chirp z-transform —
+//! recasts the length-`N` DFT as a length-`M` *linear convolution*,
+//! where `M ≥ 2N - 1` and we pick the next power of two.  The
+//! length-`M` convolution is then computed via three length-`M`
+//! FFTs (which the radix-2 path handles natively).  The price is
+//! one extra FFT-pair worth of memory traffic and three times the
+//! arithmetic of a same-size radix-2 FFT; the win is that *every*
+//! `N` works with one code path.
+//!
+//! ## Algorithm
+//!
+//! The chirp-z identity reorganizes `n · k` as a difference of
+//! squares (a "chirp"):
+//!
+//! ```text
+//!     n · k = ( n² + k² - (k - n)² ) / 2
+//! ```
+//!
+//! Substituting into the forward DFT:
+//!
+//! ```text
+//!     X[k] = Σ_n  x[n] · exp(-2πi · n · k / N)
+//!          = exp(-iπ · k² / N) · Σ_n  ( x[n] · exp(-iπ · n² / N) )
+//!                                      · exp(+iπ · (k - n)² / N)
+//! ```
+//!
+//! Define:
+//!
+//! - `a[n] = x[n] · exp(-iπ · n² / N)`   ("pre-chirp"; length `N`)
+//! - `b[n] = exp(+iπ · n² / N)`           ("anti-chirp"; length
+//!   `2N - 1` if indexed from `-(N - 1)` to `N - 1`)
+//!
+//! Then `X[k] = exp(-iπ · k² / N) · (a ⋆ b)[k]` for `k = 0..N-1`,
+//! where `⋆` is linear convolution.
+//!
+//! To compute the convolution we pick `M = next_pow2(2N - 1)` and:
+//!
+//! 1. Zero-pad `a` from length `N` to length `M`.
+//! 2. Build `b'` of length `M` by wrapping the bilateral chirp:
+//!    `b'[k] = exp(+iπ · k² / N)` for `k = 0..N-1`,
+//!    `b'[k] = exp(+iπ · (k - M)² / N)` for `k = M - N + 1..M-1`,
+//!    `b'[k] = 0` elsewhere.
+//!    The "wrap" gives us the negative-index half of `b`.
+//! 3. Compute `A = FFT(a)`, `B = FFT(b')`, `C[k] = A[k] · B[k]`
+//!    (elementwise complex multiply).
+//! 4. `c = IFFT(C)`.  The first `N` samples of `c` are the
+//!    linear convolution `(a ⋆ b)[0..N]`.
+//! 5. `X[k] = exp(-iπ · k² / N) · c[k]` for `k = 0..N-1`.
+//!
+//! Inverse FFT is the same algorithm with the chirp sign flipped
+//! and a final `1/N` scaling (backward normalization, matching
+//! the radix-2 path).
+//!
+//! ## Complexity
+//!
+//! - **Time**: three length-`M` FFTs at `M · log₂(M)` ops each,
+//!   plus three length-`M` pointwise complex multiplies — i.e.
+//!   `O(M log M) = O(N log N)` since `M < 4N`.
+//! - **Memory**: `O(M) = O(N)` working storage.
+//! - **Numerical accuracy**: the chirp computation involves
+//!   floating-point modular arithmetic on `n²`, which loses
+//!   precision for very large `N` (`n²` for `n = 65535` is
+//!   `2³²`-scale and the residue mod `2N` loses bits).  This
+//!   matters past `N ≈ 1M` in `f32`; below that, the round-trip
+//!   stays within `1e-4` like the radix-2 path.
+//!
+//! ## What this module does NOT do (Phase 4a)
+//!
+//! - Matrix-ir lowering.  The convolution uses `fft_scalar` /
+//!   `ifft_scalar` internally so it runs on CPU only.  Phase 4c
+//!   will replace those calls with [`crate::radix2::fft_via_runtime`]
+//!   (or a `bluestein_via_runtime` wrapper) so the whole thing
+//!   lifts onto the matrix execution layer.
+//! - `rfft` / `irfft` half-spectrum APIs.  Phase 4b.
+//! - Real-input optimisation.  Bluestein on a real signal still
+//!   does the full complex convolution; the half-spectrum win
+//!   comes from `rfft`.
+
+use crate::{fft_scalar, ifft_scalar, Direction, FftError};
+
+/// Forward / inverse FFT via Bluestein's algorithm.  Accepts any
+/// `N ≥ 1`, including non-power-of-two lengths.  Operates on
+/// interleaved `[re, im, re, im, …]` `f32` buffers — same layout
+/// as [`fft_scalar`].
+///
+/// `signal` must have even length (one `[re, im]` pair per
+/// element).  Length is interpreted as `N = signal.len() / 2`.
+///
+/// The output has the same length and convention as the
+/// corresponding direction of [`fft_scalar`] / [`ifft_scalar`].
+/// In particular the inverse direction applies the same
+/// "backward" `1/N` normalization (matches numpy / scipy /
+/// MATLAB).
+///
+/// For power-of-two `N` the radix-2 path
+/// ([`fft_scalar`] / [`ifft_scalar`]) is faster.  This routine
+/// is the canonical fallback for everything else.
+pub fn bluestein_scalar(
+    signal: &[f32],
+    direction: Direction,
+) -> Result<Vec<f32>, FftError> {
+    if signal.len() % 2 != 0 {
+        return Err(FftError::InvalidInput(format!(
+            "interleaved buffer must have even length; got {}",
+            signal.len()
+        )));
+    }
+    let n = signal.len() / 2;
+    if n == 0 {
+        return Err(FftError::InvalidInput(
+            "FFT length must be at least 1".into(),
+        ));
+    }
+
+    // ── Trivial N = 1 case: the DFT is the identity.
+    //   Skip the chirp construction entirely.  We still apply the
+    //   inverse direction's `1/N` factor, but with N = 1 that's a
+    //   no-op too.
+    if n == 1 {
+        return Ok(signal.to_vec());
+    }
+
+    // ── Step 0: pick the convolution length M = next_pow2(2N - 1).
+    //   This is the smallest power of two that fits a linear
+    //   convolution of two length-N sequences (length 2N - 1).
+    let conv_len = 2 * n - 1;
+    let m = conv_len.next_power_of_two();
+
+    // ── Step 1: build the chirp.  The pre-chirp factor for index
+    //   `k` is `exp(sign · iπ · k² / N)` where `sign = -1` for
+    //   forward, `+1` for inverse.  We compute `k² mod 2N` to
+    //   stay precise — the chirp is periodic with period `2N`
+    //   (since `exp(±iπ · 2N / N) = exp(±2πi) = 1`).
+    //
+    //   We store the chirp interleaved `[re, im]` as a small
+    //   helper Vec.  `chirp[k] = exp(sign · iπ · k² / N)`.
+    let sign: f32 = match direction {
+        Direction::Forward => -1.0,
+        Direction::Inverse => 1.0,
+    };
+    let chirp = build_chirp(n, sign);
+
+    // ── Step 2: a[n] = x[n] · chirp[n], padded to length M with
+    //   zeros.  Output is interleaved length 2M.
+    let mut a = vec![0.0f32; 2 * m];
+    for k in 0..n {
+        let xr = signal[2 * k];
+        let xi = signal[2 * k + 1];
+        let cr = chirp[2 * k];
+        let ci = chirp[2 * k + 1];
+        // Complex multiply: (xr + i·xi) · (cr + i·ci)
+        //   = (xr·cr - xi·ci) + i(xr·ci + xi·cr)
+        a[2 * k]     = xr * cr - xi * ci;
+        a[2 * k + 1] = xr * ci + xi * cr;
+    }
+
+    // ── Step 3: build b' of length M.  This is the bilateral
+    //   chirp `exp(-sign · iπ · k² / N)` (note opposite sign from
+    //   the pre-chirp), indexed from -(N-1) to N-1 and wrapped
+    //   onto [0, M).
+    //
+    //   - b'[k] for k = 0..N         = chirp_conj[k]
+    //   - b'[k] for k = M-N+1..M     = chirp_conj[M - k]
+    //   - b'[k] for k = N..M-N       = 0
+    //
+    //   `chirp_conj` is `exp(-sign · iπ · k² / N)`, which is
+    //   the elementwise conjugate of `chirp` (sign-flipped imag).
+    let mut b = vec![0.0f32; 2 * m];
+    for k in 0..n {
+        b[2 * k]     =  chirp[2 * k];      // re unchanged
+        b[2 * k + 1] = -chirp[2 * k + 1];  // im negated (conjugate)
+    }
+    for k in 1..n {
+        // Index M - k wraps to the negative half of the bilateral
+        // chirp.  Since `(-k)² == k²`, `chirp_conj[M-k]` is just
+        // the same chirp_conj[k] value.
+        let idx = m - k;
+        b[2 * idx]     =  chirp[2 * k];
+        b[2 * idx + 1] = -chirp[2 * k + 1];
+    }
+
+    // ── Step 4: convolve via FFT.  A = FFT(a), B = FFT(b),
+    //   C[k] = A[k] · B[k], c = IFFT(C).
+    //
+    //   `m` is a power of two by construction so `fft_scalar`
+    //   accepts both calls.
+    let a_spec = fft_scalar(&a)?;
+    let b_spec = fft_scalar(&b)?;
+    let mut c_spec = vec![0.0f32; 2 * m];
+    for k in 0..m {
+        let ar = a_spec[2 * k];
+        let ai = a_spec[2 * k + 1];
+        let br = b_spec[2 * k];
+        let bi = b_spec[2 * k + 1];
+        c_spec[2 * k]     = ar * br - ai * bi;
+        c_spec[2 * k + 1] = ar * bi + ai * br;
+    }
+    let conv = ifft_scalar(&c_spec)?;
+
+    // ── Step 5: X[k] = chirp[k] · conv[k] for k = 0..N.
+    //
+    //   For inverse direction we additionally divide by N to
+    //   match the "backward" normalization convention.  The
+    //   `ifft_scalar` call above already divided by M (the
+    //   convolution length), but the outer DFT is length N, so
+    //   we need an extra `M / N` correction — except wait, no:
+    //   the chirp identity gives us *linear convolution*, and
+    //   `ifft_scalar(FFT(a) · FFT(b))` is *circular convolution*
+    //   of length M.  Linear ⊆ circular when M ≥ 2N - 1, which
+    //   we guaranteed in Step 0, so the first N samples are the
+    //   linear convolution we want.
+    //
+    //   Normalization: `ifft_scalar` divides by M.  But the
+    //   linear convolution we want has *no* such division — it's
+    //   `Σ_j a[j] · b[k-j]`.  The chirp identity for the
+    //   *forward* DFT comes out clean: `X[k] = chirp[k] · conv[k]`
+    //   with no extra factor.  For the *inverse* DFT we also need
+    //   a `1/N` factor to match the backward convention.
+    let mut out = vec![0.0f32; 2 * n];
+    let inv_n: f32 = if direction == Direction::Inverse {
+        1.0 / (n as f32)
+    } else {
+        1.0
+    };
+    for k in 0..n {
+        let cr = conv[2 * k];
+        let ci = conv[2 * k + 1];
+        let wr = chirp[2 * k];
+        let wi = chirp[2 * k + 1];
+        // (wr + i·wi) · (cr + i·ci)
+        let re = wr * cr - wi * ci;
+        let im = wr * ci + wi * cr;
+        out[2 * k]     = re * inv_n;
+        out[2 * k + 1] = im * inv_n;
+    }
+    Ok(out)
+}
+
+/// Build the chirp sequence `chirp[k] = exp(sign · iπ · k² / N)`
+/// for `k = 0..N`, returned as an interleaved `[re, im]` buffer.
+///
+/// The exponent argument is `sign · π · (k² mod 2N) / N` —
+/// reducing `k²` modulo `2N` before the floating-point divide
+/// keeps the value bounded to `(-π, π)` regardless of how large
+/// `k` gets, which is what saves us precision for large `N`.
+///
+/// Why `2N` and not `N`?  Because the chirp has period `2N`:
+/// `exp(iπ · (k + 2N)² / N)` differs from `exp(iπ · k² / N)`
+/// by `exp(iπ · (4kN + 4N²) / N) = exp(4πi · k + 4πi · N) = 1`.
+fn build_chirp(n: usize, sign: f32) -> Vec<f32> {
+    use std::f32::consts::PI;
+    let two_n = (2 * n) as u64;
+    let mut out = Vec::with_capacity(2 * n);
+    for k in 0..n {
+        // k² mod 2N — compute in u64 to handle large N without
+        // overflow.  N ≤ usize::MAX, k < N, k² could be up to
+        // N² which on 64-bit usize already fits, but using u64
+        // explicit is clearer.
+        let k_sq = (k as u64).wrapping_mul(k as u64);
+        let residue = (k_sq % two_n) as f32;
+        let theta = sign * PI * residue / (n as f32);
+        let (im, re) = theta.sin_cos();
+        out.push(re);
+        out.push(im);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::PI;
+
+    /// Loose float equality with a "scale-aware" tolerance — we
+    /// compare magnitudes, so `tol` is interpreted as a relative
+    /// epsilon for values above 1.0 and an absolute epsilon below.
+    fn approx_eq(a: f32, b: f32, tol: f32) -> bool {
+        let scale = a.abs().max(b.abs()).max(1.0);
+        (a - b).abs() <= scale * tol
+    }
+
+    fn assert_close(a: &[f32], b: &[f32], tol: f32) {
+        assert_eq!(a.len(), b.len(), "length mismatch");
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!(
+                approx_eq(*x, *y, tol),
+                "mismatch at {}: {} vs {} (tol {})",
+                i,
+                x,
+                y,
+                tol
+            );
+        }
+    }
+
+    /// Naive O(N²) DFT for use as a small-N test oracle.  We use
+    /// it to validate Bluestein against the textbook definition
+    /// at the non-power-of-two sizes the radix-2 path can't run.
+    fn naive_dft(signal: &[f32], direction: Direction) -> Vec<f32> {
+        let n = signal.len() / 2;
+        let sign: f32 = match direction {
+            Direction::Forward => -1.0,
+            Direction::Inverse => 1.0,
+        };
+        let scale: f32 = match direction {
+            Direction::Forward => 1.0,
+            Direction::Inverse => 1.0 / (n as f32),
+        };
+        let mut out = vec![0.0f32; 2 * n];
+        for k in 0..n {
+            let mut sr = 0.0f32;
+            let mut si = 0.0f32;
+            for nn in 0..n {
+                let theta = sign * 2.0 * PI * (k as f32) * (nn as f32) / (n as f32);
+                let (wi, wr) = theta.sin_cos();
+                let xr = signal[2 * nn];
+                let xi = signal[2 * nn + 1];
+                sr += wr * xr - wi * xi;
+                si += wr * xi + wi * xr;
+            }
+            out[2 * k]     = sr * scale;
+            out[2 * k + 1] = si * scale;
+        }
+        out
+    }
+
+    // ── error paths ────────────────────────────────────────────
+
+    #[test]
+    fn rejects_odd_length_buffer() {
+        let err = bluestein_scalar(&[1.0, 2.0, 3.0], Direction::Forward).unwrap_err();
+        assert!(matches!(err, FftError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn rejects_empty_buffer() {
+        let err = bluestein_scalar(&[], Direction::Forward).unwrap_err();
+        assert!(matches!(err, FftError::InvalidInput(_)));
+    }
+
+    // ── degenerate / power-of-two N ─────────────────────────────
+
+    #[test]
+    fn n1_is_identity_forward() {
+        let signal = vec![3.5f32, -1.25];
+        let spectrum = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        assert_close(&spectrum, &signal, 1e-7);
+    }
+
+    #[test]
+    fn n1_is_identity_inverse() {
+        let signal = vec![3.5f32, -1.25];
+        let recovered = bluestein_scalar(&signal, Direction::Inverse).unwrap();
+        assert_close(&recovered, &signal, 1e-7);
+    }
+
+    #[test]
+    fn bluestein_matches_radix2_for_power_of_two_n8() {
+        // Sanity check: at power-of-two N, Bluestein and the
+        // radix-2 path should agree to within numerical
+        // tolerance.  This is a cross-check that the chirp
+        // construction is correct.
+        let signal: Vec<f32> = (0..8)
+            .flat_map(|i| [(i as f32) * 0.3 - 0.7, ((i as f32) * 0.11).sin()])
+            .collect();
+        let via_radix2 = fft_scalar(&signal).unwrap();
+        let via_bluestein = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        assert_close(&via_bluestein, &via_radix2, 1e-4);
+    }
+
+    // ── non-power-of-two N (the whole point of Bluestein) ───────
+
+    #[test]
+    fn forward_n3_matches_naive_dft() {
+        // N = 3: smallest non-trivial non-pow2.  Convolution length
+        // M = next_pow2(2·3 - 1) = next_pow2(5) = 8.
+        let signal = vec![1.0f32, 0.0, 2.0, 0.0, 3.0, 0.0];
+        let via_bluestein = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        let via_naive = naive_dft(&signal, Direction::Forward);
+        assert_close(&via_bluestein, &via_naive, 1e-4);
+    }
+
+    #[test]
+    fn forward_n5_matches_naive_dft() {
+        // N = 5: M = next_pow2(9) = 16.
+        let signal: Vec<f32> = (0..5)
+            .flat_map(|i| [(i as f32) - 2.0, (i as f32) * 0.5])
+            .collect();
+        let via_bluestein = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        let via_naive = naive_dft(&signal, Direction::Forward);
+        assert_close(&via_bluestein, &via_naive, 1e-4);
+    }
+
+    #[test]
+    fn forward_n6_matches_naive_dft() {
+        // N = 6: M = next_pow2(11) = 16.
+        let signal: Vec<f32> = (0..6)
+            .flat_map(|i| {
+                let x = (2.0 * PI * (i as f32) / 6.0).cos();
+                [x, 0.0f32]
+            })
+            .collect();
+        let via_bluestein = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        let via_naive = naive_dft(&signal, Direction::Forward);
+        assert_close(&via_bluestein, &via_naive, 1e-4);
+    }
+
+    #[test]
+    fn forward_n7_matches_naive_dft() {
+        // N = 7 is a prime — the worst-case scenario for any
+        // mixed-radix FFT.  Bluestein still handles it at the
+        // same cost (M = next_pow2(13) = 16).
+        let signal: Vec<f32> = (0..7)
+            .flat_map(|i| [(i as f32).sin(), ((i as f32) * 0.3).cos()])
+            .collect();
+        let via_bluestein = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        let via_naive = naive_dft(&signal, Direction::Forward);
+        assert_close(&via_bluestein, &via_naive, 1e-4);
+    }
+
+    #[test]
+    fn forward_n12_matches_naive_dft() {
+        // N = 12 is composite but not a power of two.
+        // M = next_pow2(23) = 32.
+        let signal: Vec<f32> = (0..12)
+            .flat_map(|i| [((i as f32) * 0.1).sin(), ((i as f32) * 0.07).cos()])
+            .collect();
+        let via_bluestein = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        let via_naive = naive_dft(&signal, Direction::Forward);
+        assert_close(&via_bluestein, &via_naive, 1e-4);
+    }
+
+    // ── round-trip ─────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_n3() {
+        let original = vec![1.0f32, 0.0, 2.0, 0.0, 3.0, 0.0];
+        let spectrum = bluestein_scalar(&original, Direction::Forward).unwrap();
+        let recovered = bluestein_scalar(&spectrum, Direction::Inverse).unwrap();
+        assert_close(&original, &recovered, 1e-4);
+    }
+
+    #[test]
+    fn round_trip_n7_real_complex_mix() {
+        let n: usize = 7;
+        let original: Vec<f32> = (0..n)
+            .flat_map(|i| [(i as f32) * 0.3, ((i as f32) * 0.5).sin()])
+            .collect();
+        let spectrum = bluestein_scalar(&original, Direction::Forward).unwrap();
+        let recovered = bluestein_scalar(&spectrum, Direction::Inverse).unwrap();
+        assert_close(&original, &recovered, 1e-4);
+    }
+
+    #[test]
+    fn round_trip_works_for_many_sizes() {
+        // Stress test: round-trip every N from 1 to 32.
+        // Includes power-of-two N (where Bluestein and radix-2
+        // both work) and arbitrary N (Bluestein's home turf).
+        for n in 1..=32usize {
+            let original: Vec<f32> = (0..n)
+                .flat_map(|i| [((i as f32) * 0.15).sin(), 0.0f32])
+                .collect();
+            let spectrum =
+                bluestein_scalar(&original, Direction::Forward).unwrap();
+            let recovered =
+                bluestein_scalar(&spectrum, Direction::Inverse).unwrap();
+            // Tolerance scales loosely with N; 1e-3 covers N=32
+            // comfortably.
+            for (i, (a, b)) in original.iter().zip(recovered.iter()).enumerate() {
+                let scale = a.abs().max(b.abs()).max(1.0);
+                assert!(
+                    (a - b).abs() <= scale * 1e-3,
+                    "round-trip failed for N={}, index {}: {} vs {}",
+                    n,
+                    i,
+                    a,
+                    b
+                );
+            }
+        }
+    }
+
+    // ── closed-form known vectors ──────────────────────────────
+
+    #[test]
+    fn forward_impulse_n5_is_all_ones() {
+        // fft(impulse) = [1, 1, …, 1] regardless of N.
+        let n = 5;
+        let mut signal = vec![0.0f32; 2 * n];
+        signal[0] = 1.0;
+        let spectrum = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        for k in 0..n {
+            assert!(
+                approx_eq(spectrum[2 * k], 1.0, 1e-4),
+                "bin {} real = {}, expected 1.0",
+                k,
+                spectrum[2 * k]
+            );
+            assert!(
+                approx_eq(spectrum[2 * k + 1], 0.0, 1e-4),
+                "bin {} imag = {}, expected 0.0",
+                k,
+                spectrum[2 * k + 1]
+            );
+        }
+    }
+
+    #[test]
+    fn forward_dc_n7_is_single_bin() {
+        // fft(constant) = [N, 0, 0, …, 0].
+        let n = 7;
+        let signal: Vec<f32> = (0..n).flat_map(|_| [1.0f32, 0.0]).collect();
+        let spectrum = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        assert!(approx_eq(spectrum[0], n as f32, 1e-4));
+        assert!(approx_eq(spectrum[1], 0.0, 1e-4));
+        for k in 1..n {
+            assert!(
+                approx_eq(spectrum[2 * k], 0.0, 1e-3),
+                "bin {} real = {}, expected 0",
+                k,
+                spectrum[2 * k]
+            );
+            assert!(
+                approx_eq(spectrum[2 * k + 1], 0.0, 1e-3),
+                "bin {} imag = {}, expected 0",
+                k,
+                spectrum[2 * k + 1]
+            );
+        }
+    }
+}

--- a/code/packages/rust/dsp-fft/src/lib.rs
+++ b/code/packages/rust/dsp-fft/src/lib.rs
@@ -15,16 +15,19 @@
 //! - **Phase 3b.iii** — `fft_via_runtime` plans + dispatches that
 //!   graph through `matrix-runtime` + `matrix-cpu`, downloading the
 //!   spectrum.
-//! - **Phase 3b.iv (this release)** — the public [`fft`] entry
-//!   point routes real-valued power-of-two inputs through
-//!   `fft_via_runtime` instead of the scalar reference.  Complex
-//!   inputs (`complex = true`) and the public [`ifft`] still go
-//!   through the scalar code — the matrix-ir graph builder is
-//!   real-only for now.  The scalar reference stays available as
-//!   [`fft_scalar`] / [`ifft_scalar`] for callers that want it
-//!   directly (it's also the test oracle).
-//! - **Phase 4** — Bluestein for arbitrary lengths, plus
-//!   `rfft` / `irfft`.
+//! - **Phase 3b.iv** — the public [`fft`] entry point routes
+//!   real-valued power-of-two inputs through `fft_via_runtime`
+//!   instead of the scalar reference.
+//! - **Phase 4a (this release)** — scalar Bluestein
+//!   ([`bluestein_scalar`]) handles arbitrary (non-power-of-two)
+//!   lengths.  The public [`fft`] / [`ifft`] now accept any
+//!   `N ≥ 1`; non-pow2 inputs fall through to Bluestein.
+//!   Complex-input transforms also delegate to Bluestein for
+//!   non-pow2 `N`.
+//! - **Phase 4b** — `rfft` / `irfft` (real-input half-spectrum
+//!   API exploiting conjugate symmetry).
+//! - **Phase 4c** — Matrix-ir-lowered Bluestein so non-pow2
+//!   FFTs also lift onto the matrix execution layer.
 //! - **Phase 5** — MX05 specialised emitters (folded twiddles for
 //!   canonical sizes 8…1024).
 //!
@@ -53,7 +56,9 @@
 
 #![warn(rust_2018_idioms)]
 
+pub mod bluestein;
 pub mod radix2;
+pub use bluestein::bluestein_scalar;
 pub use radix2::{build_fft_graph, build_fft_graph_with_input, fft_via_runtime};
 
 use dsp_complex::ComplexTensor;
@@ -107,53 +112,71 @@ pub fn ifft_scalar(spectrum: &[f32]) -> Result<Vec<f32>, FftError> {
 /// Compute the forward 1-D FFT of a real-valued or already-complex
 /// `signal`.
 ///
-/// - If `signal` has length `N` (real input), it's routed through
-///   the matrix-ir-lowered FFT graph via
-///   [`fft_via_runtime`](crate::radix2::fft_via_runtime) — i.e.
-///   the FFT actually runs on the matrix execution layer.  When
-///   `matrix-metal` / `matrix-cuda` claim `Slice` + `Concat` in
-///   their `supported_ops` bitsets, the call lifts to GPU
-///   automatically with no `dsp-fft` change required.
+/// - If `signal` has length `N` (real input):
+///   - **Power-of-two `N ≥ 2`** routes through the matrix-ir-lowered
+///     FFT graph via
+///     [`fft_via_runtime`](crate::radix2::fft_via_runtime) — the
+///     FFT actually runs on the matrix execution layer.  When
+///     `matrix-metal` / `matrix-cuda` claim `Slice` + `Concat` in
+///     their `supported_ops` bitsets, the call lifts to GPU
+///     automatically with no `dsp-fft` change required.
+///   - **Non-power-of-two `N`** (new in Phase 4a) falls back to the
+///     scalar Bluestein algorithm
+///     ([`bluestein_scalar`](crate::bluestein::bluestein_scalar)).
+///     Still CPU-only; Phase 4c will lower it to matrix-ir.
+///   - **`N = 1`** is the identity, handled by the scalar path.
 /// - If `signal` has length `2N` (interleaved complex), pass
-///   `complex: true`.  Complex-input transforms still go through
-///   the scalar reference ([`fft_scalar`]) because the matrix-ir
-///   graph builder is real-only in Phase 3b.iv; a future phase
-///   will add a complex-input graph variant.
+///   `complex: true`.  Power-of-two `N` uses [`fft_scalar`];
+///   non-pow2 `N` (also new in Phase 4a) uses Bluestein.
 ///
 /// Returns a `ComplexTensor` of `N` complex elements.
 ///
-/// **Phase 3b.iv**: real-input path uses the matrix-ir-lowered
-/// graph end-to-end; complex-input path still calls the scalar
-/// oracle.
+/// **Phase 4a**: the public API now accepts arbitrary `N ≥ 1`.
+/// Previously non-power-of-two lengths returned
+/// `FftError::NotPowerOfTwo`.
 pub fn fft(signal: &[f32], complex: bool) -> Result<ComplexTensor, FftError> {
     let interleaved = if complex {
-        // Complex input: matrix-ir graph builder doesn't support
-        // complex inputs yet (the `build_fft_graph` real→complex
-        // step always Concats a zero imaginary lane), so fall back
-        // to the scalar oracle.  Length validation flows through
-        // `fft_scalar`.
-        fft_scalar(signal)?
+        // Complex input: route by N parity to either the radix-2
+        // scalar oracle (power-of-two) or Bluestein (anything else).
+        // Both share the interleaved `[re, im]` buffer convention so
+        // we can dispatch with no buffer rewrap.
+        if signal.len() % 2 != 0 {
+            return Err(FftError::InvalidInput(format!(
+                "interleaved complex buffer must have even length; got {}",
+                signal.len()
+            )));
+        }
+        let n = signal.len() / 2;
+        if n.is_power_of_two() && n >= 1 {
+            fft_scalar(signal)?
+        } else {
+            bluestein_scalar(signal, Direction::Forward)?
+        }
     } else if signal.len() < 2 {
-        // The matrix-ir graph builder requires N ≥ 2 (a single
-        // element has no butterfly stages and the Reshape +
-        // Concat plumbing assumes at least one stage).  Fall back
-        // to the scalar oracle so the public API still accepts
-        // the degenerate N = 1 case the way Phase 2 did, and
-        // preserves the exact `FftError` shape Phase 2 produced
-        // for empty input.
+        // Degenerate N < 2 case (empty or single real sample).
+        // The matrix-ir graph builder requires N ≥ 2; fall back to
+        // the scalar oracle so the public API behavior is unchanged
+        // for these edge cases — empty still returns `InvalidInput`,
+        // single-element passes through as the identity.
         let mut interleaved_real = Vec::with_capacity(signal.len() * 2);
         for &x in signal {
             interleaved_real.push(x);
             interleaved_real.push(0.0);
         }
         fft_scalar(&interleaved_real)?
-    } else {
-        // Real input, N ≥ 2: run the matrix-ir-lowered FFT graph
-        // end-to-end through `matrix-runtime` + `matrix-cpu`.
-        // Length validation flows through `fft_via_runtime`
-        // (`build_fft_graph_with_input` rejects non-power-of-two
-        // inputs the same way the scalar path does).
+    } else if signal.len().is_power_of_two() {
+        // Real input, N ≥ 2 power-of-two: matrix-ir-lowered path.
         fft_via_runtime(signal, Direction::Forward)?
+    } else {
+        // Real input, non-power-of-two N: wrap as interleaved
+        // complex with im = 0 then call Bluestein.  No matrix-ir
+        // path yet (Phase 4c).
+        let mut interleaved_real = Vec::with_capacity(signal.len() * 2);
+        for &x in signal {
+            interleaved_real.push(x);
+            interleaved_real.push(0.0);
+        }
+        bluestein_scalar(&interleaved_real, Direction::Forward)?
     };
     Ok(ComplexTensor::from_interleaved(interleaved).expect("fft output has even length"))
 }
@@ -163,13 +186,20 @@ pub fn fft(signal: &[f32], complex: bool) -> Result<ComplexTensor, FftError> {
 /// output is a complex `ComplexTensor` whose `real()` part is the
 /// recovered signal when the input was real-valued.
 ///
-/// **Phase 3b.iv**: still forwards to [`ifft_scalar`].  The
-/// matrix-ir graph builder's input is `[N]` real and its output
-/// is `[N, 2]` complex; an inverse from `[N, 2]` complex doesn't
-/// fit the same graph and is deferred to a follow-up.  Output
-/// matches the scalar oracle exactly.
+/// Power-of-two `N` runs through [`ifft_scalar`] (still the scalar
+/// oracle — the matrix-ir graph builder for inverse-from-complex
+/// is a future phase); non-power-of-two `N` (new in Phase 4a) runs
+/// through the scalar Bluestein algorithm with
+/// `Direction::Inverse`, applying the same `1/N` backward
+/// normalization.
 pub fn ifft(spectrum: &ComplexTensor) -> Result<ComplexTensor, FftError> {
-    let result = ifft_scalar(spectrum.as_interleaved())?;
+    let interleaved = spectrum.as_interleaved();
+    let n = spectrum.len();
+    let result = if n.is_power_of_two() && n >= 1 {
+        ifft_scalar(interleaved)?
+    } else {
+        bluestein_scalar(interleaved, Direction::Inverse)?
+    };
     Ok(ComplexTensor::from_interleaved(result).expect("ifft output has even length"))
 }
 
@@ -577,12 +607,78 @@ mod tests {
         assert_eq!(via_public.as_interleaved(), via_scalar.as_slice());
     }
 
+    // ── Phase 4a: public API now accepts arbitrary N ≥ 1 via
+    //    Bluestein on the non-power-of-two path.  These tests
+    //    pin that behavior — what used to return
+    //    `FftError::NotPowerOfTwo` now returns a correct spectrum.
+
     #[test]
-    fn public_fft_real_rejects_non_power_of_two() {
-        // Length validation flows through the matrix-ir graph's
-        // `NotPowerOfTwo` check (in `build_fft_graph_with_input`).
+    fn public_fft_real_non_pow2_routes_through_bluestein() {
+        // N = 3: the smallest non-trivial non-pow2.  Previously
+        // this returned NotPowerOfTwo(3); now Bluestein computes
+        // the actual DFT.  Compare against the naive O(N²) DFT.
         let real = vec![1.0f32, 2.0, 3.0];
-        let err = fft(&real, false).unwrap_err();
-        assert_eq!(err, FftError::NotPowerOfTwo(3));
+        let spectrum = fft(&real, false).unwrap();
+        assert_eq!(spectrum.len(), 3);
+        // Compare against naive_dft via the bluestein test
+        // module's reference — we duplicate it here inline.
+        let n = 3;
+        let mut interleaved = vec![0.0f32; 2 * n];
+        for (i, &x) in real.iter().enumerate() {
+            interleaved[2 * i] = x;
+        }
+        for k in 0..n {
+            let mut sr = 0.0f32;
+            let mut si = 0.0f32;
+            for nn in 0..n {
+                let theta =
+                    -2.0 * PI * (k as f32) * (nn as f32) / (n as f32);
+                let (wi, wr) = theta.sin_cos();
+                sr += wr * interleaved[2 * nn] - wi * interleaved[2 * nn + 1];
+                si += wr * interleaved[2 * nn + 1] + wi * interleaved[2 * nn];
+            }
+            let got_re = spectrum.as_interleaved()[2 * k];
+            let got_im = spectrum.as_interleaved()[2 * k + 1];
+            assert!(
+                approx_eq(got_re, sr, 1e-4),
+                "bin {} re: got {}, expected {}",
+                k,
+                got_re,
+                sr
+            );
+            assert!(
+                approx_eq(got_im, si, 1e-4),
+                "bin {} im: got {}, expected {}",
+                k,
+                got_im,
+                si
+            );
+        }
+    }
+
+    #[test]
+    fn public_ifft_round_trip_non_pow2_n5() {
+        // Round-trip through the public API for N = 5 (non-pow2).
+        // Forward goes through Bluestein (since 5 isn't a power
+        // of two), inverse also goes through Bluestein.
+        let real = vec![1.0f32, 2.0, 3.0, 4.0, 5.0];
+        let spectrum = fft(&real, false).unwrap();
+        assert_eq!(spectrum.len(), 5);
+        let recovered = ifft(&spectrum).unwrap();
+        let rec_real = recovered.real();
+        assert_close(&real, &rec_real, 1e-4);
+    }
+
+    #[test]
+    fn public_fft_complex_non_pow2_routes_through_bluestein() {
+        // Complex-input, N = 3 (non-pow2).  Previously returned
+        // NotPowerOfTwo(3) via fft_scalar; now goes through
+        // Bluestein.  We verify by round-trip — the cleanest
+        // check that doesn't require importing the naive DFT.
+        let interleaved = vec![1.0f32, 0.5, 2.0, -0.5, 3.0, 0.25];
+        let spectrum = fft(&interleaved, true).unwrap();
+        assert_eq!(spectrum.len(), 3);
+        let recovered = ifft(&spectrum).unwrap();
+        assert_close(recovered.as_interleaved(), &interleaved, 1e-4);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `dsp_fft::bluestein::bluestein_scalar(signal, direction)` — chirp z-transform FFT for arbitrary `N ≥ 1`. Handles every length with one code path; uses three length-`M` radix-2 FFTs internally where `M = next_pow2(2N - 1)`.
- Wires the public `fft()` and `ifft()` to delegate to Bluestein when `N` is non-power-of-two. `fft(&[1.0, 2.0, 3.0], false)` now returns the correct 3-point DFT instead of `Err(NotPowerOfTwo(3))`.
- `fft_scalar` / `ifft_scalar` retain their power-of-two-only contract — they remain the radix-2 test oracle.
- Bumps `dsp-fft` 0.4.0 → 0.5.0.

## Test plan

- [x] `cargo test -p dsp-fft` — 45 tests pass (28 prior + 15 new Bluestein module + 2 net new public-API)
- [x] Bluestein cross-checked against a naive O(N²) DFT for N ∈ {3, 5, 6, 7, 12}
- [x] Round-trip stress test sweeps every N ∈ 1..=32
- [x] Cross-check vs radix-2 at N = 8 (chirp construction sanity)
- [x] Security review passed
- [ ] CI green on origin

## What this phase does NOT include

- Phase 4b: `rfft` / `irfft` half-spectrum API exploiting conjugate symmetry.
- Phase 4c: matrix-ir-lowered Bluestein so non-pow2 FFTs also lift onto the matrix execution layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)