### PR TITLE
spice: parse capacitor initial conditions

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Parse capacitor `IC=<voltage>` initial-voltage parameters.
 - Parse SPICE independent source `AC <magnitude> [phase]` specifications for
   voltage and current sources, including `DC <value> AC ...` mixed bias/input
   forms.

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -22,7 +22,8 @@ This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`,
 `F`, and `H` elements, `.model` cards for Shockley diode parameters (`IS`,
 `VT`), BJT parameters (`NPN`/`PNP`, `IS`, `BF`/`BETA_F`, `VT`), and Level-1
 MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
-`W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`), SPICE engineering suffixes,
+`W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`), capacitor `IC=<voltage>`
+initial conditions, SPICE engineering suffixes,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
 expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, and `.noise`
 analysis cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -298,8 +298,20 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
         _require_fields(fields, 4, "resistor")
         return Resistor(name, fields[1], fields[2], parse_value(fields[3]))
     if prefix == "C":
-        _require_fields(fields, 4, "capacitor")
-        return Capacitor(name, fields[1], fields[2], parse_value(fields[3]))
+        _require_min_fields(fields, 4, "capacitor")
+        params = _parse_element_params(fields[4:], "capacitor")
+        unsupported = set(params) - {"IC"}
+        if unsupported:
+            raise NetlistParseError(
+                f"unsupported capacitor parameter {sorted(unsupported)[0]!r}"
+            )
+        return Capacitor(
+            name,
+            fields[1],
+            fields[2],
+            parse_value(fields[3]),
+            initial_voltage=params.get("IC", 0.0),
+        )
     if prefix == "L":
         _require_fields(fields, 4, "inductor")
         return Inductor(name, fields[1], fields[2], parse_value(fields[3]))

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -71,7 +71,7 @@ def test_parse_reactive_elements_and_analysis_cards() -> None:
 Vstep in 0 PULSE(0 1 0 1n 1n 10n 20n)
 I1 out 0 1m
 Rload in out 2.2k
-Cload out 0 10p
+Cload out 0 10p IC=2.5
 L1 out 0 1u
 G1 out 0 in 0 2m
 .tran 1n 20n
@@ -84,6 +84,7 @@ G1 out 0 in 0 2m
     assert parsed.circuit.elements[0].waveform is not None
     assert isinstance(parsed.circuit.elements[1], CurrentSource)
     assert isinstance(parsed.circuit.elements[3], Capacitor)
+    assert parsed.circuit.elements[3].initial_voltage == 2.5
     assert isinstance(parsed.circuit.elements[4], Inductor)
     assert isinstance(parsed.circuit.elements[5], VCCS)
     assert parsed.analyses == [
@@ -91,6 +92,11 @@ G1 out 0 in 0 2m
         DcAnalysis(source_name="Vstep", start=0.0, stop=1.0, step=0.5),
         AcAnalysis(mode="dec", points=10, start_hz=1.0e3, stop_hz=1.0e6),
     ]
+
+
+def test_capacitor_rejects_unsupported_element_params() -> None:
+    with pytest.raises(NetlistParseError, match="unsupported capacitor parameter"):
+        parse_netlist("C1 in 0 1u FOO=1")
 
 
 def test_parse_tf_analysis_card_and_run_transfer_function() -> None:

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Parse capacitor `IC=<voltage>` initial-voltage parameters.
 - Parse SPICE `.tf V(output_node) input_source` transfer-function analysis
   cards.
 - Parse SPICE `.sens V(output_node)` DC sensitivity analysis cards.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -23,6 +23,7 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `BETA_F`, and `VT` parameters, `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering
-suffixes, independent-source `AC <magnitude> [phase]` forms, PWL/PULSE/SIN/EXP
-source forms, comments, `.end`, `.subckt` / `X` instance expansion, and
+suffixes, capacitor `IC=<voltage>` initial conditions, independent-source
+`AC <magnitude> [phase]` forms, PWL/PULSE/SIN/EXP source forms, comments,
+`.end`, `.subckt` / `X` instance expansion, and
 `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, and `.noise` analysis cards.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -497,12 +497,19 @@ fn parse_element(
             )))
         }
         'C' => {
-            require_fields(fields, 4, "capacitor")?;
-            Ok(Element::Capacitor(Capacitor::new(
+            require_min_fields(fields, 4, "capacitor")?;
+            let params = parse_element_params(&fields[4..], "capacitor")?;
+            if let Some(param_name) = params.keys().find(|name| name.as_str() != "IC") {
+                return Err(NetlistParseError::new(format!(
+                    "unsupported capacitor parameter {param_name:?}"
+                )));
+            }
+            Ok(Element::Capacitor(Capacitor::with_initial_voltage(
                 name,
                 &fields[1],
                 &fields[2],
                 parse_value(&fields[3])?,
+                *params.get("IC").unwrap_or(&0.0),
             )))
         }
         'L' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -50,7 +50,7 @@ fn parses_reactive_elements_vccs_source_waveforms_and_analysis_cards() {
 Vstep in 0 PULSE(0 1 0 1n 1n 10n 20n)
 I1 out 0 1m
 Rload in out 2.2k
-Cload out 0 10p
+Cload out 0 10p IC=2.5
 L1 out 0 1u
 G1 out 0 in 0 2m
 .tran 1n 20n
@@ -75,6 +75,10 @@ G1 out 0 in 0 2m
         panic!("expected voltage source");
     };
     assert!(voltage.waveform.is_some());
+    let Element::Capacitor(capacitor) = &parsed.circuit.elements()[3] else {
+        panic!("expected capacitor");
+    };
+    assert_close(capacitor.initial_voltage, 2.5);
 
     assert_eq!(
         parsed.analyses,
@@ -97,6 +101,15 @@ G1 out 0 in 0 2m
             }),
         ]
     );
+}
+
+#[test]
+fn rejects_unsupported_capacitor_element_params() {
+    let error = parse_netlist("C1 in 0 1u FOO=1").unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("unsupported capacitor parameter"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Parse capacitor `IC=<voltage>` initial-voltage parameters.
 - Parse independent-source `AC <magnitude> [phase]` specs, including combined
   `DC <bias> AC <magnitude> [phase]` forms, and pass the AC phasor through to
   TypeScript SPICE engine AC analysis while preserving DC bias.

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -25,7 +25,7 @@ elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 `BF` / `BETA_F`, and `VT` parameters, `.model <name> NMOS(...)` /
 `.model <name> PMOS(...)` MOSFET cards with Level-1 `VT0` / `VTO`, `KP`,
 `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` /
-`TNOM` parameters,
+`TNOM` parameters, capacitor `IC=<voltage>` initial conditions,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, `.ac`, and
 `.tf`, `.sens`, `.mc`, and `.noise` analysis cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -5,7 +5,7 @@ import {
   PwlWaveform,
   SinWaveform,
   bjt,
-  capacitor,
+  capacitorWithInitialVoltage,
   cccs,
   ccvs,
   currentSource,
@@ -402,8 +402,22 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
     return resistor(name, fields[1], fields[2], parseValue(fields[3]));
   }
   if (prefix === "C") {
-    requireFields(fields, 4, "capacitor");
-    return capacitor(name, fields[1], fields[2], parseValue(fields[3]));
+    requireMinFields(fields, 4, "capacitor");
+    const params = parseElementParams(fields.slice(4), "capacitor");
+    for (const paramName of params.keys()) {
+      if (paramName !== "IC") {
+        throw new NetlistParseError(
+          `unsupported capacitor parameter ${JSON.stringify(paramName)}`,
+        );
+      }
+    }
+    return capacitorWithInitialVoltage(
+      name,
+      fields[1],
+      fields[2],
+      parseValue(fields[3]),
+      params.get("IC") ?? 0.0,
+    );
   }
   if (prefix === "L") {
     requireFields(fields, 4, "inductor");

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -34,7 +34,7 @@ R2 mid 0 1k
 Vstep in 0 PULSE(0 1 0 1n 1n 10n 20n)
 I1 out 0 1m
 Rload in out 2.2k
-Cload out 0 10p
+Cload out 0 10p IC=2.5
 L1 out 0 1u
 G1 out 0 in 0 2m
 .tran 1n 20n
@@ -52,11 +52,18 @@ G1 out 0 in 0 2m
       "vccs",
     ]);
     expect(elements[0]).toMatchObject({ kind: "voltage-source", waveform: expect.any(Object) });
+    expect(elements[3]).toMatchObject({ kind: "capacitor", initialVoltage: 2.5 });
     expect(parsed.analyses).toEqual([
       { kind: "tran", timeStep: 1.0e-9, stopTime: 20.0e-9 },
       { kind: "dc", sourceName: "Vstep", start: 0.0, stop: 1.0, step: 0.5 },
       { kind: "ac", mode: "dec", points: 10, startHz: 1.0e3, stopHz: 1.0e6 },
     ]);
+  });
+
+  it("rejects unsupported capacitor element parameters", () => {
+    expect(() => parseNetlist("C1 in 0 1u FOO=1")).toThrow(
+      /unsupported capacitor parameter/,
+    );
   });
 
   it("parses independent-source AC specs separately from DC bias", () => {


### PR DESCRIPTION

## Summary
- parse capacitor IC=<voltage> parameters in the Python, TypeScript, and Rust SPICE netlist parsers
- route parsed initial voltages into the existing engine capacitor constructors/fields
- add acceptance and unsupported-parameter tests across all three parser packages

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-capacitor-ic-cards sh BUILD (code/packages/python/spice-netlist-parser)
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-capacitor-ic-cards sh BUILD (code/packages/typescript/spice-netlist-parser)
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-capacitor-ic-cards cargo test -p spice-netlist-parser -- --nocapture (code/packages/rust)
- git diff --check
