### PR TITLE
feat(dsp-fft): DSP01 Phase 4c — matrix-ir-lowered Bluestein

### DIFF
--- a/code/packages/rust/dsp-fft/CHANGELOG.md
+++ b/code/packages/rust/dsp-fft/CHANGELOG.md
@@ -1,5 +1,105 @@
 # Changelog — dsp-fft
 
+## 0.7.0 — 2026-05-15
+
+### Added — DSP01 Phase 4c (matrix-ir-lowered Bluestein)
+
+The Bluestein chirp-z algorithm now has a matrix-ir-lowered
+implementation alongside the scalar one.  Non-power-of-two FFTs
+can now run end-to-end on the matrix execution layer, exactly
+like power-of-two FFTs have since Phase 3b.iii.  When
+`matrix-metal` / `matrix-cuda` claim Slice + Concat in their
+`supported_ops` bitsets, *every* `N ≥ 2` lifts onto GPU
+automatically — that's the whole point.
+
+#### New public API
+
+- `pub fn build_bluestein_graph_with_input(signal: &[f32], direction: Direction) -> Result<(Graph, TensorId), FftError>`
+  — emits a `matrix_ir::Graph` that computes Bluestein for any
+  `N ≥ 2`.  Signal embedded as `Const`; chirps + bilateral `b'`
+  precomputed in Rust and embedded as `Const`s too.  Output is
+  `[N, 2]` interleaved complex.
+- `pub fn bluestein_via_runtime(signal: &[f32], direction: Direction) -> Result<Vec<f32>, FftError>`
+  — end-to-end helper.  Builds the graph, plans through
+  `matrix-runtime`, dispatches on `matrix-cpu`, downloads the
+  spectrum.
+
+Both re-exported at the crate root.
+
+#### Graph structure
+
+For a length-`N` input the graph is:
+
+1. Signal as `Const` `[N, 2]` (interleaved complex; real-only
+   callers wrap with zero-imag before calling).
+2. Pre-chirp `Const` `[N, 2]` — `exp(sign · iπ · k² / N)`.
+3. Bilateral `b'` `Const` `[M, 2]` where `M = next_pow2(2N - 1)`.
+4. Complex-multiply signal × pre-chirp = `a`.
+5. Zero-pad `a` from `[N, 2]` to `[M, 2]` via `Concat` with
+   zeros.
+6. **Length-`M` FFT** of `a_padded` → `A`.  Composed in-place
+   via the new `radix2::add_radix2_fft_to_builder` helper.
+7. **Length-`M` FFT** of `b'` → `B`.  Same helper, same builder.
+8. Elementwise complex-multiply `A × B` = `C`.
+9. **Length-`M` inverse FFT** of `C` → `c`.  The radix-2 inverse
+   already divides by `M`, which is what the linear-convolution
+   identity wants.
+10. `Slice` first `N` rows of `c`.
+11. Complex-multiply by post-chirp (reuses the pre-chirp Const).
+12. For inverse direction, multiply by `1/N` (the backward
+    normalisation factor; the intermediate `1/M` from step 9 is
+    already applied).
+
+Three full length-`M` FFT subgraphs are spliced into a single
+graph through the new `add_radix2_fft_to_builder(builder,
+input_tensor, n, direction)` helper.  No `unsafe`, no FFI.
+
+#### Refactor — `radix2.rs`
+
+The radix-2 FFT graph code is now factored as:
+
+- `wrap_real_as_complex(builder, real_tensor, n) -> Tensor` —
+  reshape `[N]` to `[N, 1]` and concat a zero imaginary lane.
+- `add_radix2_fft_to_builder(builder, complex_tensor, n, direction) -> Result<Tensor, _>`
+  — appends bit-reverse + butterfly stages + optional `1/N`
+  scaling to an existing builder.
+
+`build_fft_graph` and `build_fft_graph_with_input` are now thin
+wrappers around these two helpers.  No behavior change — all
+prior tests still pass.
+
+`add_radix2_fft_to_builder` is `pub(crate)` so the `bluestein`
+module can splice three FFTs into its convolution graph without
+copy-pasting butterfly code.
+
+#### New unit tests (8)
+
+- `matrix_ir_bluestein_rejects_n1` — N = 1 degenerate case.
+- `matrix_ir_bluestein_rejects_odd_buffer` — error path.
+- `graph_validates_for_small_non_pow2_sizes` — builds + validates
+  the graph for N ∈ {2, 3, 5, 6, 7, 8, 12} in both directions
+  and checks the output shape is `[N, 2]`.
+- `bluestein_via_runtime_matches_scalar_n3_forward`
+- `bluestein_via_runtime_matches_scalar_n5_forward`
+- `bluestein_via_runtime_matches_scalar_n7_forward` — prime N.
+- `bluestein_via_runtime_matches_scalar_n6_inverse` — exercises
+  the chirp-sign flip and outer `1/N` scaling.
+- `bluestein_via_runtime_round_trip_n5` — `inv(fwd(x)) ≈ x`
+  end-to-end through the matrix-ir graph.
+
+All 71 unit tests pass.
+
+### What this phase does NOT include
+
+- Wiring the public `fft` / `ifft` to use `bluestein_via_runtime`
+  for non-pow2 inputs.  The matrix-ir Bluestein graph is more
+  expensive than the scalar one when running on CPU (three full
+  length-`M` FFTs of length up to `4N`), so leaving the scalar
+  path as the default until GPU backends actually claim Slice +
+  Concat is the right call.  A follow-up phase will add a
+  routing knob.
+- Phase 5: MX05 specialised emitters (folded twiddles).
+
 ## 0.6.0 — 2026-05-15
 
 ### Added — DSP01 Phase 4b (rfft / irfft, half-spectrum API for real inputs)

--- a/code/packages/rust/dsp-fft/Cargo.toml
+++ b/code/packages/rust/dsp-fft/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dsp-fft"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
-description = "DSP01 Phases 2-4b: pure-Rust scalar reference + matrix-ir-lowered radix-2 Cooley-Tukey FFT + scalar Bluestein for arbitrary lengths + rfft/irfft half-spectrum API for real inputs. Power-of-2 real inputs run end-to-end on matrix-runtime + matrix-cpu; non-power-of-2 lengths use a scalar Bluestein fallback. Operates on interleaved [re, im] f32 buffers. Matrix-ir-lowered Bluestein (Phase 4c) is still pending."
+description = "DSP01 Phases 2-4c: pure-Rust scalar reference + matrix-ir-lowered radix-2 Cooley-Tukey FFT + scalar AND matrix-ir-lowered Bluestein for arbitrary lengths + rfft/irfft. Both power-of-2 AND non-power-of-2 FFTs can now run end-to-end on the matrix execution layer via build_bluestein_graph_with_input / bluestein_via_runtime. The scalar oracles (fft_scalar, ifft_scalar, bluestein_scalar) remain as the test oracle and as the public-API fallback. Operates on interleaved [re, im] f32 buffers."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/dsp-fft/README.md
+++ b/code/packages/rust/dsp-fft/README.md
@@ -4,16 +4,20 @@ Pure-Rust FFT / IFFT for the DSP layer on interleaved `[re, im]`
 f32 buffers — same layout as
 [`dsp-complex::ComplexTensor`](../dsp-complex/README.md).
 
-As of **0.6.0 (DSP01 Phase 4b)** the crate offers the full
-NumPy-style FFT surface:
+As of **0.7.0 (DSP01 Phase 4c)** the crate offers the full
+NumPy-style FFT surface, with **every length `N ≥ 2` lowerable
+to the matrix execution layer**:
 
 - `fft` / `ifft` accept **arbitrary `N ≥ 1`** (radix-2 for
   power-of-two, scalar Bluestein for everything else).
 - Power-of-two real inputs run end-to-end on the matrix
-  execution layer (`matrix-runtime` + `matrix-cpu`, GPU once
-  Metal / CUDA claim Slice + Concat) via the radix-2 graph.
-- `rfft` / `irfft` (new in 0.6.0) exploit conjugate symmetry of
-  real-input spectra to return only `⌊N / 2⌋ + 1` bins.
+  execution layer via `fft_via_runtime` (radix-2 graph).
+- Non-power-of-two inputs can now run end-to-end on the matrix
+  execution layer too, via `bluestein_via_runtime` (new in
+  0.7.0).  Both paths lift to GPU automatically once Metal /
+  CUDA claim Slice + Concat.
+- `rfft` / `irfft` exploit conjugate symmetry of real-input
+  spectra to return only `⌊N / 2⌋ + 1` bins.
 - `fft_scalar` / `ifft_scalar` (radix-2, pow2-only) and
   `bluestein_scalar` remain available as the canonical oracles.
 
@@ -64,8 +68,8 @@ pseudorandom round-trip up to `N = 1024`.
 | 3b.iii | End-to-end execution via `matrix-runtime` + `matrix-cpu` | landed (0.3.0) |
 | 3b.iv  | Public `fft()` real-input path routes through `fft_via_runtime` | landed (0.4.0) |
 | 4a     | Scalar Bluestein for arbitrary lengths               | landed (0.5.0) |
-| **4b** | **`rfft` / `irfft` (half-spectrum API)**             | **this PR (0.6.0)** |
-| 4c     | Matrix-ir-lowered Bluestein                          | pending |
+| 4b     | `rfft` / `irfft` (half-spectrum API)                 | landed (0.6.0) |
+| **4c** | **Matrix-ir-lowered Bluestein**                      | **this PR (0.7.0)** |
 | 5      | MX05 specialised emitters (folded twiddles)          | pending |
 
 ## Matrix-IR graph build (Phase 3b.ii)
@@ -129,27 +133,36 @@ complex-input radix-2 graph variant.  Until then `fft_scalar` /
 `ifft_scalar` remain the canonical radix-2 oracle, and
 `bluestein_scalar` is the canonical arbitrary-N oracle.
 
-## Bluestein's algorithm (Phase 4a, scalar)
+## Bluestein's algorithm (Phases 4a + 4c)
 
-For non-power-of-two `N`, `bluestein_scalar(signal, direction)`
-computes the DFT as a length-`M` linear convolution, where
-`M = next_pow2(2N - 1)`.  The three internal FFTs all run on
-the radix-2 path (`fft_scalar`).  The chirp construction uses
-`k² mod 2N` reduction to keep the floating-point exponent
-bounded for large `N`.
+For non-power-of-two `N`, Bluestein computes the DFT as a
+length-`M` linear convolution where `M = next_pow2(2N - 1)`.
+Three internal length-`M` FFTs do the heavy lifting.
+
+Two equivalent entry points:
 
 ```rust
-use dsp_fft::{bluestein_scalar, Direction};
+use dsp_fft::{bluestein_scalar, bluestein_via_runtime, Direction};
 
 // 7-point DFT — prime length, can't use radix-2 directly.
 let signal = vec![1.0_f32, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0,
                   5.0, 0.0, 6.0, 0.0, 7.0, 0.0];
-let spectrum = bluestein_scalar(&signal, Direction::Forward).unwrap();
+
+// Scalar oracle — pure-Rust, CPU-only, fastest on small N.
+let s1 = bluestein_scalar(&signal, Direction::Forward).unwrap();
+
+// Matrix-ir-lowered — runs through matrix-runtime + matrix-cpu.
+// Lifts to GPU automatically once Metal / CUDA claim Slice +
+// Concat in their `supported_ops` bitsets.
+let s2 = bluestein_via_runtime(&signal, Direction::Forward).unwrap();
 ```
+
+The chirp construction uses `k² mod 2N` reduction to keep the
+floating-point exponent bounded for large `N`.
 
 ## Tests
 
-`cargo test -p dsp-fft` — 63 unit tests:
+`cargo test -p dsp-fft` — 71 unit tests:
 
 - 12 from Phase 2 — error paths, closed-form known vectors, scalar radix-2 round-trips.
 - 5 from Phase 3b.ii — graph build / validation.
@@ -157,7 +170,9 @@ let spectrum = bluestein_scalar(&signal, Direction::Forward).unwrap();
 - 8 from Phase 3b.iv — public API routes through the runtime.
 - 15 from Phase 4a — Bluestein: error paths, naive-DFT
   cross-checks, round-trip sweep 1..=32.
-- 18 from Phase 4b (this release) — `rfft` / `irfft`: error
-  paths, closed-form impulse / DC / single-bin at N = 8, 16,
-  round-trip at N ∈ {1, 8, 16, 64, 3, 7, 12} plus a 1..=20
-  sweep, and 3 public-API tests.
+- 18 from Phase 4b — `rfft` / `irfft`: error paths, closed-form,
+  round-trips for pow2 and non-pow2 N, public API.
+- 8 from Phase 4c (this release) — matrix-ir Bluestein: error
+  paths, graph validation for N ∈ {2, 3, 5, 6, 7, 8, 12},
+  end-to-end vs scalar oracle at N ∈ {3, 5, 7} forward, N = 6
+  inverse, plus a round-trip at N = 5.

--- a/code/packages/rust/dsp-fft/src/bluestein.rs
+++ b/code/packages/rust/dsp-fft/src/bluestein.rs
@@ -81,19 +81,21 @@
 //!   matters past `N ≈ 1M` in `f32`; below that, the round-trip
 //!   stays within `1e-4` like the radix-2 path.
 //!
-//! ## What this module does NOT do (Phase 4a)
+//! ## What this module did NOT include in Phase 4a
 //!
-//! - Matrix-ir lowering.  The convolution uses `fft_scalar` /
-//!   `ifft_scalar` internally so it runs on CPU only.  Phase 4c
-//!   will replace those calls with [`crate::radix2::fft_via_runtime`]
-//!   (or a `bluestein_via_runtime` wrapper) so the whole thing
-//!   lifts onto the matrix execution layer.
-//! - `rfft` / `irfft` half-spectrum APIs.  Phase 4b.
+//! - ~Matrix-ir lowering~ — Phase 4c (this release) adds
+//!   [`build_bluestein_graph`] and [`bluestein_via_runtime`] so
+//!   the whole convolution lifts onto the matrix execution
+//!   layer.  The scalar `bluestein_scalar` stays as the oracle.
+//! - `rfft` / `irfft` half-spectrum APIs.  Phase 4b (already
+//!   shipped in 0.6.0).
 //! - Real-input optimisation.  Bluestein on a real signal still
 //!   does the full complex convolution; the half-spectrum win
 //!   comes from `rfft`.
 
+use crate::radix2::add_radix2_fft_to_builder;
 use crate::{fft_scalar, ifft_scalar, Direction, FftError};
+use matrix_ir::{DType, Graph, GraphBuilder, Shape, Tensor, TensorId};
 
 /// Forward / inverse FFT via Bluestein's algorithm.  Accepts any
 /// `N ≥ 1`, including non-power-of-two lengths.  Operates on
@@ -279,6 +281,278 @@ fn build_chirp(n: usize, sign: f32) -> Vec<f32> {
         let (im, re) = theta.sin_cos();
         out.push(re);
         out.push(im);
+    }
+    out
+}
+
+/// **DSP01 Phase 4c.**  Build a `matrix_ir::Graph` that computes
+/// the Bluestein FFT of a length-`N` signal (interleaved
+/// `[re, im]` complex, length `2N` `f32`).  The signal is
+/// embedded as a `Const` — no runtime inputs are declared — and
+/// the returned `TensorId` identifies the output buffer to
+/// download.
+///
+/// This is the matrix-ir analogue of [`bluestein_scalar`].  The
+/// chirp Consts and the bilateral `b'` Const are precomputed in
+/// Rust at graph-build time; the three length-`M` FFTs run as
+/// composed radix-2 subgraphs (via
+/// [`crate::radix2::add_radix2_fft_to_builder`]).  When
+/// `matrix-metal` / `matrix-cuda` claim Slice + Concat in their
+/// `supported_ops` bitsets, the whole graph lifts onto the GPU
+/// — exactly what Phase 4c was meant to unlock.
+///
+/// Output shape is `[N, 2]` interleaved complex.
+///
+/// Returns `Err` if `signal` has odd length, is empty, or
+/// represents a single complex element (`N = 1` is degenerate;
+/// callers should route it through the scalar path).
+pub fn build_bluestein_graph_with_input(
+    signal: &[f32],
+    direction: Direction,
+) -> Result<(Graph, TensorId), FftError> {
+    if signal.len() % 2 != 0 {
+        return Err(FftError::InvalidInput(format!(
+            "interleaved buffer must have even length; got {}",
+            signal.len()
+        )));
+    }
+    let n_usize = signal.len() / 2;
+    if n_usize < 2 {
+        // N = 0 or 1 are degenerate.  N = 0 has no Const to
+        // embed; N = 1 has no FFT structure to lower (M = 1
+        // would underflow `add_radix2_fft_to_builder`'s N ≥ 2
+        // contract).  Callers should handle these via the
+        // scalar path.
+        return Err(FftError::InvalidInput(format!(
+            "matrix-ir Bluestein requires N ≥ 2; got N = {}",
+            n_usize
+        )));
+    }
+    let n = n_usize as u32;
+
+    // ── Step 0: pick the convolution length M = next_pow2(2N - 1).
+    let conv_len = 2 * n_usize - 1;
+    let m_usize = conv_len.next_power_of_two();
+    let m = m_usize as u32;
+
+    // ── Precompute chirp + bilateral-chirp values in Rust.
+    let sign: f32 = match direction {
+        Direction::Forward => -1.0,
+        Direction::Inverse => 1.0,
+    };
+    let chirp = build_chirp(n_usize, sign);
+    //   `b_full[k]` = conj(chirp[k]) for k ∈ 0..N,
+    //   `b_full[M-k]` = conj(chirp[k]) for k ∈ 1..N,
+    //   zeros otherwise (the linear-convolution zero pad).
+    let mut b_full = vec![0.0f32; 2 * m_usize];
+    for k in 0..n_usize {
+        b_full[2 * k]     =  chirp[2 * k];
+        b_full[2 * k + 1] = -chirp[2 * k + 1];
+    }
+    for k in 1..n_usize {
+        let idx = m_usize - k;
+        b_full[2 * idx]     =  chirp[2 * k];
+        b_full[2 * idx + 1] = -chirp[2 * k + 1];
+    }
+
+    // Pack chirp / b_full into little-endian byte buffers for Consts.
+    let chirp_bytes = floats_to_le_bytes(&chirp);
+    let b_full_bytes = floats_to_le_bytes(&b_full);
+
+    let mut bb = GraphBuilder::new();
+
+    // ── Step 1: embed the signal as a `Const` shaped `[N, 2]`.
+    //   The input arrives interleaved, so this is a direct
+    //   reinterpret — no Concat/Reshape needed unlike the radix-2
+    //   real-only path.
+    let signal_bytes = floats_to_le_bytes(signal);
+    let signal_const = bb.constant(DType::F32, Shape::from(&[n, 2]), signal_bytes);
+    let chirp_const = bb.constant(DType::F32, Shape::from(&[n, 2]), chirp_bytes);
+    let b_full_const = bb.constant(DType::F32, Shape::from(&[m, 2]), b_full_bytes);
+
+    // ── Step 2: a = signal · chirp  (elementwise complex multiply).
+    let a_n2 = complex_multiply_n2(&mut bb, &signal_const, &chirp_const, n);
+
+    // ── Step 3: pad a from [N, 2] to [M, 2] with zeros.
+    let zeros_pad = bb.constant(
+        DType::F32,
+        Shape::from(&[m - n, 2]),
+        vec![0u8; (m - n) as usize * 8],
+    );
+    let a_padded = bb.concat(&[&a_n2, &zeros_pad], 0);
+
+    // ── Step 4: A = FFT(a_padded).
+    let cap_a = add_radix2_fft_to_builder(&mut bb, a_padded, m, Direction::Forward)?;
+
+    // ── Step 5: B = FFT(b_full_const).
+    let cap_b =
+        add_radix2_fft_to_builder(&mut bb, b_full_const, m, Direction::Forward)?;
+
+    // ── Step 6: C = A · B  (elementwise complex multiply on [M, 2]).
+    let cap_c = complex_multiply_n2(&mut bb, &cap_a, &cap_b, m);
+
+    // ── Step 7: c = IFFT(C).  The radix-2 inverse divides by M.
+    let c_m = add_radix2_fft_to_builder(&mut bb, cap_c, m, Direction::Inverse)?;
+
+    // ── Step 8: take the first N samples of c.
+    let c_n = bb.slice(&c_m, 0, 0, n, 1);
+
+    // ── Step 9: x = c_n · chirp  (post-chirp; reuses the same Const).
+    let mut x_n2 = complex_multiply_n2(&mut bb, &c_n, &chirp_const, n);
+
+    // ── Step 10 (inverse direction only): scale by 1/N.
+    //   The intermediate IFFT already divided by M, so this gives
+    //   the final backward-normalised inverse.
+    if direction == Direction::Inverse {
+        let inv_n = 1.0_f32 / (n as f32);
+        let scale = bb.constant(
+            DType::F32,
+            Shape::from(&[1, 1]),
+            inv_n.to_le_bytes().to_vec(),
+        );
+        let scale_b = bb.broadcast(&scale, Shape::from(&[n, 2]));
+        x_n2 = bb.mul(&x_n2, &scale_b);
+    }
+
+    let out_id = x_n2.id;
+    bb.output(&x_n2);
+    let graph = bb
+        .build()
+        .map_err(|e| FftError::InvalidInput(format!("graph build/validate: {:?}", e)))?;
+    Ok((graph, out_id))
+}
+
+/// **DSP01 Phase 4c.**  End-to-end execution of the matrix-ir
+/// lowered Bluestein FFT.  Builds the graph via
+/// [`build_bluestein_graph_with_input`], plans it through
+/// `matrix-runtime`, dispatches on a fresh `matrix-cpu`
+/// executor, downloads the spectrum, and returns it as an
+/// interleaved `[re, im, …, re, im]` `Vec<f32>` of length `2N`.
+///
+/// Same output convention and `direction` semantics as
+/// [`bluestein_scalar`].  This is the canonical "Bluestein
+/// actually runs on the matrix execution layer" entry point;
+/// once Metal / CUDA claim Slice + Concat the call lifts to GPU
+/// with no `dsp-fft` change.
+pub fn bluestein_via_runtime(
+    signal: &[f32],
+    direction: Direction,
+) -> Result<Vec<f32>, FftError> {
+    use compute_ir::ComputeGraph;
+    use executor_protocol::{ExecutorRequest, ExecutorResponse};
+    use matrix_cpu::CpuExecutor;
+    use matrix_runtime::Runtime;
+
+    let (graph, output_id) = build_bluestein_graph_with_input(signal, direction)?;
+    let n = signal.len() / 2;
+    let output_byte_count = n * 2 * 4;
+
+    let runtime = Runtime::new(matrix_cpu::profile());
+    let placed: ComputeGraph = runtime
+        .plan(&graph)
+        .map_err(|e| FftError::InvalidInput(format!("plan: {:?}", e)))?;
+
+    // Find the output residency the same way `fft_via_runtime` does.
+    let output_residency = placed
+        .outputs
+        .iter()
+        .find(|t| t.id == output_id)
+        .map(|t| t.residency)
+        .or_else(|| placed.tensors.get(output_id.0 as usize).map(|t| t.residency))
+        .ok_or_else(|| {
+            FftError::InvalidInput(format!(
+                "output tensor {} not in placed graph",
+                output_id.0
+            ))
+        })?;
+
+    let executor = CpuExecutor::new();
+
+    match executor.handle(ExecutorRequest::Dispatch {
+        job_id: 1,
+        graph: placed,
+    }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        ExecutorResponse::Error { code, message, .. } => {
+            return Err(FftError::InvalidInput(format!(
+                "dispatch error 0x{:04X}: {}",
+                code.0, message
+            )));
+        }
+        other => {
+            return Err(FftError::InvalidInput(format!(
+                "unexpected response to Dispatch: {:?}",
+                other
+            )));
+        }
+    }
+
+    let download = executor.handle(ExecutorRequest::DownloadBuffer {
+        buffer: output_residency.buffer,
+        offset: 0,
+        len: output_byte_count as u64,
+    });
+    let bytes = match download {
+        ExecutorResponse::BufferData { data, .. } => data,
+        ExecutorResponse::Error { code, message, .. } => {
+            return Err(FftError::InvalidInput(format!(
+                "download error 0x{:04X}: {}",
+                code.0, message
+            )));
+        }
+        other => {
+            return Err(FftError::InvalidInput(format!(
+                "unexpected response to DownloadBuffer: {:?}",
+                other
+            )));
+        }
+    };
+
+    let mut out: Vec<f32> = Vec::with_capacity(bytes.len() / 4);
+    for chunk in bytes.chunks_exact(4) {
+        let arr: [u8; 4] = chunk.try_into().unwrap();
+        out.push(f32::from_le_bytes(arr));
+    }
+    Ok(out)
+}
+
+/// Helper: elementwise complex multiply on two `[N, 2]` tensors.
+/// `(ar + i ai)(br + i bi) = (ar br - ai bi) + i (ar bi + ai br)`.
+/// Returns a `[N, 2]` tensor.
+///
+/// The `_n` parameter (number of rows) is currently unused inside
+/// the body — matrix-ir's Mul / Slice / Concat infer the shape
+/// from the operand metadata — but it's kept in the signature to
+/// document the caller's contract and to keep the call site
+/// self-explanatory at the use point.
+fn complex_multiply_n2(
+    b: &mut GraphBuilder,
+    lhs: &Tensor,
+    rhs: &Tensor,
+    _n: u32,
+) -> Tensor {
+    let lhs_re = b.slice(lhs, 1, 0, 1, 1);
+    let lhs_im = b.slice(lhs, 1, 1, 2, 1);
+    let rhs_re = b.slice(rhs, 1, 0, 1, 1);
+    let rhs_im = b.slice(rhs, 1, 1, 2, 1);
+
+    let ac = b.mul(&lhs_re, &rhs_re);
+    let bd = b.mul(&lhs_im, &rhs_im);
+    let ad = b.mul(&lhs_re, &rhs_im);
+    let bc = b.mul(&lhs_im, &rhs_re);
+
+    let out_re = b.sub(&ac, &bd);
+    let out_im = b.add(&ad, &bc);
+    b.concat(&[&out_re, &out_im], 1)
+}
+
+/// Helper: pack a slice of `f32`s into little-endian bytes for a
+/// `Const` tensor.  Used by `build_bluestein_graph_with_input`
+/// to construct chirp / signal Consts.
+fn floats_to_le_bytes(floats: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(floats.len() * 4);
+    for &x in floats {
+        out.extend_from_slice(&x.to_le_bytes());
     }
     out
 }
@@ -521,6 +795,112 @@ mod tests {
             );
         }
     }
+
+    // ── Phase 4c: matrix-ir-lowered Bluestein ──────────────────
+
+    #[test]
+    fn matrix_ir_bluestein_rejects_n1() {
+        // N = 1 is degenerate; the matrix-ir builder requires N ≥ 2.
+        let signal = vec![3.5f32, -1.25];
+        let err =
+            build_bluestein_graph_with_input(&signal, Direction::Forward).unwrap_err();
+        assert!(matches!(err, FftError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn matrix_ir_bluestein_rejects_odd_buffer() {
+        let err = build_bluestein_graph_with_input(&[1.0, 2.0, 3.0], Direction::Forward)
+            .unwrap_err();
+        assert!(matches!(err, FftError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn graph_validates_for_small_non_pow2_sizes() {
+        // The graph builder should produce a well-formed graph
+        // for the canonical "non-pow2" sizes our scalar tests
+        // cover.
+        for &n in &[2usize, 3, 5, 6, 7, 8, 12] {
+            let signal: Vec<f32> = (0..n).flat_map(|i| [(i as f32) * 0.5, 0.0]).collect();
+            for &dir in &[Direction::Forward, Direction::Inverse] {
+                let (graph, _id) =
+                    build_bluestein_graph_with_input(&signal, dir).unwrap_or_else(
+                        |e| panic!("graph build failed for N={}, dir={:?}: {:?}", n, dir, e),
+                    );
+                // `build` already validates internally, so reaching
+                // here means the graph passed validate().  The
+                // assertion is implicit; we also check the output
+                // shape is the expected [N, 2].
+                let out_id = *graph
+                    .outputs
+                    .first()
+                    .expect("graph has at least one output");
+                let out_tensor = &graph.tensors[out_id.0 as usize];
+                assert_eq!(
+                    out_tensor.shape.dims,
+                    vec![n as u32, 2],
+                    "wrong output shape for N={}, dir={:?}",
+                    n,
+                    dir
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bluestein_via_runtime_matches_scalar_n3_forward() {
+        let signal = vec![1.0f32, 0.0, 2.0, 0.0, 3.0, 0.0];
+        let via_runtime = bluestein_via_runtime(&signal, Direction::Forward).unwrap();
+        let via_scalar = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        assert_close(&via_runtime, &via_scalar, 1e-4);
+    }
+
+    #[test]
+    fn bluestein_via_runtime_matches_scalar_n5_forward() {
+        let signal: Vec<f32> = (0..5)
+            .flat_map(|i| [(i as f32) - 2.0, (i as f32) * 0.5])
+            .collect();
+        let via_runtime = bluestein_via_runtime(&signal, Direction::Forward).unwrap();
+        let via_scalar = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        assert_close(&via_runtime, &via_scalar, 1e-4);
+    }
+
+    #[test]
+    fn bluestein_via_runtime_matches_scalar_n7_forward() {
+        // N = 7 prime — Bluestein's whole reason to exist.
+        let signal: Vec<f32> = (0..7)
+            .flat_map(|i| [(i as f32).sin(), ((i as f32) * 0.3).cos()])
+            .collect();
+        let via_runtime = bluestein_via_runtime(&signal, Direction::Forward).unwrap();
+        let via_scalar = bluestein_scalar(&signal, Direction::Forward).unwrap();
+        assert_close(&via_runtime, &via_scalar, 1e-4);
+    }
+
+    #[test]
+    fn bluestein_via_runtime_matches_scalar_n6_inverse() {
+        // Inverse direction exercises the chirp-sign flip and the
+        // outer 1/N scaling in the matrix-ir graph.
+        let signal: Vec<f32> = (0..6)
+            .flat_map(|i| [((i as f32) * 0.4).cos(), 0.0f32])
+            .collect();
+        let via_runtime = bluestein_via_runtime(&signal, Direction::Inverse).unwrap();
+        let via_scalar = bluestein_scalar(&signal, Direction::Inverse).unwrap();
+        assert_close(&via_runtime, &via_scalar, 1e-4);
+    }
+
+    #[test]
+    fn bluestein_via_runtime_round_trip_n5() {
+        // Round-trip: forward then inverse through the runtime,
+        // and expect to recover the input.  Tests both directions
+        // of the matrix-ir graph in sequence.
+        let original: Vec<f32> = (0..5)
+            .flat_map(|i| [(i as f32), (i as f32) * 0.5])
+            .collect();
+        let spectrum = bluestein_via_runtime(&original, Direction::Forward).unwrap();
+        let recovered = bluestein_via_runtime(&spectrum, Direction::Inverse).unwrap();
+        assert_close(&original, &recovered, 1e-4);
+    }
+
+    // ── original closed-form tests (Phase 4a) continue below ──
 
     #[test]
     fn forward_dc_n7_is_single_bin() {

--- a/code/packages/rust/dsp-fft/src/lib.rs
+++ b/code/packages/rust/dsp-fft/src/lib.rs
@@ -21,12 +21,14 @@
 //! - **Phase 4a** — scalar Bluestein ([`bluestein_scalar`])
 //!   handles arbitrary (non-power-of-two) lengths.  The public
 //!   [`fft`] / [`ifft`] now accept any `N ≥ 1`.
-//! - **Phase 4b (this release)** — [`rfft`] / [`irfft`]
-//!   half-spectrum API for real inputs.  Returns only the first
-//!   `⌊N / 2⌋ + 1` complex bins (the rest are determined by
-//!   conjugate symmetry).  Works for any `N ≥ 1`.
-//! - **Phase 4c** — Matrix-ir-lowered Bluestein so non-pow2
-//!   FFTs also lift onto the matrix execution layer.
+//! - **Phase 4b** — [`rfft`] / [`irfft`] half-spectrum API for
+//!   real inputs (returns `⌊N / 2⌋ + 1` complex bins via
+//!   conjugate symmetry).
+//! - **Phase 4c (this release)** — matrix-ir-lowered Bluestein
+//!   ([`build_bluestein_graph_with_input`] /
+//!   [`bluestein_via_runtime`]).  Non-pow2 FFTs now lift onto
+//!   the matrix execution layer end-to-end, exactly like pow2
+//!   FFTs have since Phase 3b.iii.
 //! - **Phase 5** — MX05 specialised emitters (folded twiddles for
 //!   canonical sizes 8…1024).
 //!
@@ -58,7 +60,9 @@
 pub mod bluestein;
 pub mod radix2;
 pub mod rfft;
-pub use bluestein::bluestein_scalar;
+pub use bluestein::{
+    bluestein_scalar, bluestein_via_runtime, build_bluestein_graph_with_input,
+};
 pub use radix2::{build_fft_graph, build_fft_graph_with_input, fft_via_runtime};
 pub use rfft::{irfft, irfft_scalar, rfft, rfft_scalar};
 

--- a/code/packages/rust/dsp-fft/src/radix2.rs
+++ b/code/packages/rust/dsp-fft/src/radix2.rs
@@ -75,17 +75,57 @@ pub fn build_fft_graph(n: u32, direction: Direction) -> Result<Graph, FftError> 
     if n < 2 || !n.is_power_of_two() {
         return Err(FftError::NotPowerOfTwo(n as usize));
     }
-    let log_n = n.trailing_zeros() as usize;
     let mut b = GraphBuilder::new();
 
     // ── Step 1: real → complex.  [N] → [N, 1] → [N, 2] (concat with zeros).
     let input = b.input(DType::F32, Shape::from(&[n]));
-    let zeros_bytes = vec![0u8; (n as usize) * 4];
-    let zeros = b.constant(DType::F32, Shape::from(&[n, 1]), zeros_bytes);
-    let input_2d = b.reshape(&input, Shape::from(&[n, 1]));
-    let mut x = b.concat(&[&input_2d, &zeros], 1);
+    let x = wrap_real_as_complex(&mut b, &input, n);
 
-    // ── Step 2: bit-reversal permutation.
+    // ── Steps 2-4: bit-reverse + butterflies + optional /N scaling.
+    let spectrum = add_radix2_fft_to_builder(&mut b, x, n, direction)?;
+
+    b.output(&spectrum);
+    b.build()
+        .map_err(|e| FftError::InvalidInput(format!("graph build/validate: {:?}", e)))
+}
+
+/// **Phase 4c helper.**  Wrap a `[N]` real-valued tensor as a
+/// `[N, 2]` complex tensor with zero imaginary lane.  Used by
+/// both `build_fft_graph` (where the input arrives as a declared
+/// graph input) and `build_fft_graph_with_input` (where the
+/// input is a `Const`), as well as by `build_bluestein_graph`
+/// which wraps its own `Const`-embedded signal the same way.
+fn wrap_real_as_complex(b: &mut GraphBuilder, real_1d: &Tensor, n: u32) -> Tensor {
+    let zeros = b.constant(DType::F32, Shape::from(&[n, 1]), vec![0u8; n as usize * 4]);
+    let real_2d = b.reshape(real_1d, Shape::from(&[n, 1]));
+    b.concat(&[&real_2d, &zeros], 1)
+}
+
+/// **Phase 4c helper.**  Append the radix-2 Cooley-Tukey FFT
+/// (or inverse, per `direction`) to an existing `GraphBuilder`.
+/// Takes an `[N, 2]` complex tensor (interleaved `[re, im]`) and
+/// returns the corresponding `[N, 2]` spectrum tensor.
+///
+/// `n` must be `≥ 2` and a power of two — same contract as the
+/// public `build_fft_graph` builder; that builder is now a thin
+/// wrapper around `wrap_real_as_complex` + this helper.
+///
+/// Exposed at module scope (but `pub(crate)`) so the Bluestein
+/// graph builder in `crate::bluestein` can splice three length-`M`
+/// FFTs into a single composite graph without copy-pasting the
+/// butterfly code.
+pub(crate) fn add_radix2_fft_to_builder(
+    b: &mut GraphBuilder,
+    mut x: Tensor,
+    n: u32,
+    direction: Direction,
+) -> Result<Tensor, FftError> {
+    if n < 2 || !n.is_power_of_two() {
+        return Err(FftError::NotPowerOfTwo(n as usize));
+    }
+    let log_n = n.trailing_zeros() as usize;
+
+    // ── Bit-reversal permutation.
     //
     // For N=2 this is the identity, so we skip.  For larger N we
     // generate `N` width-1 slices and one Concat.  This produces a
@@ -102,7 +142,7 @@ pub fn build_fft_graph(n: u32, direction: Direction) -> Result<Graph, FftError> 
         x = b.concat(&refs, 0);
     }
 
-    // ── Step 3: butterfly stages.
+    // ── Butterfly stages.
     let sign: f32 = match direction {
         Direction::Forward => -1.0,
         Direction::Inverse => 1.0,
@@ -170,9 +210,7 @@ pub fn build_fft_graph(n: u32, direction: Direction) -> Result<Graph, FftError> 
         x = b.mul(&x, &scale_b);
     }
 
-    b.output(&x);
-    b.build()
-        .map_err(|e| FftError::InvalidInput(format!("graph build/validate: {:?}", e)))
+    Ok(x)
 }
 
 /// Like [`build_fft_graph`] but embeds `signal` as a `Const` in the
@@ -191,7 +229,6 @@ pub fn build_fft_graph_with_input(
     if n < 2 || !n.is_power_of_two() {
         return Err(FftError::NotPowerOfTwo(signal.len()));
     }
-    let log_n = n.trailing_zeros() as usize;
     let mut b = GraphBuilder::new();
 
     // ── Step 1: real → complex with the signal baked in as a Const.
@@ -200,81 +237,13 @@ pub fn build_fft_graph_with_input(
         input_bytes.extend_from_slice(&x.to_le_bytes());
     }
     let signal_const = b.constant(DType::F32, Shape::from(&[n]), input_bytes);
-    let zeros = b.constant(DType::F32, Shape::from(&[n, 1]), vec![0u8; n as usize * 4]);
-    let input_2d = b.reshape(&signal_const, Shape::from(&[n, 1]));
-    let mut x = b.concat(&[&input_2d, &zeros], 1);
+    let x_complex = wrap_real_as_complex(&mut b, &signal_const, n);
 
-    // ── Step 2: bit-reversal permutation.
-    if n > 2 {
-        let mut slices: Vec<Tensor> = Vec::with_capacity(n as usize);
-        for i in 0..n {
-            let bri = bit_reverse(i as usize, log_n) as u32;
-            let s = b.slice(&x, 0, bri, bri + 1, 1);
-            slices.push(s);
-        }
-        let refs: Vec<&Tensor> = slices.iter().collect();
-        x = b.concat(&refs, 0);
-    }
+    // ── Steps 2-4: bit-reverse + butterflies + optional /N scaling.
+    let spectrum = add_radix2_fft_to_builder(&mut b, x_complex, n, direction)?;
 
-    // ── Step 3: butterfly stages.
-    let sign: f32 = match direction {
-        Direction::Forward => -1.0,
-        Direction::Inverse => 1.0,
-    };
-    let mut full: u32 = 2;
-    while full <= n {
-        let half = full / 2;
-        let n_groups = n / full;
-
-        x = b.reshape(&x, Shape::from(&[n_groups, full, 2]));
-        let even = b.slice(&x, 1, 0, half, 1);
-        let odd = b.slice(&x, 1, half, full, 1);
-
-        let mut tw_bytes = Vec::with_capacity((half as usize) * 8);
-        for j in 0..half {
-            let theta = sign * 2.0 * std::f32::consts::PI * (j as f32) / (full as f32);
-            tw_bytes.extend_from_slice(&theta.cos().to_le_bytes());
-            tw_bytes.extend_from_slice(&theta.sin().to_le_bytes());
-        }
-        let tw = b.constant(DType::F32, Shape::from(&[half, 2]), tw_bytes);
-        let tw_3d = b.reshape(&tw, Shape::from(&[1, half, 2]));
-        let tw_b = b.broadcast(&tw_3d, Shape::from(&[n_groups, half, 2]));
-
-        let odd_re = b.slice(&odd, 2, 0, 1, 1);
-        let odd_im = b.slice(&odd, 2, 1, 2, 1);
-        let tw_re = b.slice(&tw_b, 2, 0, 1, 1);
-        let tw_im = b.slice(&tw_b, 2, 1, 2, 1);
-
-        let ac = b.mul(&odd_re, &tw_re);
-        let bd = b.mul(&odd_im, &tw_im);
-        let ad = b.mul(&odd_re, &tw_im);
-        let bc = b.mul(&odd_im, &tw_re);
-
-        let tw_odd_re = b.sub(&ac, &bd);
-        let tw_odd_im = b.add(&ad, &bc);
-        let tw_odd = b.concat(&[&tw_odd_re, &tw_odd_im], 2);
-
-        let next_first = b.add(&even, &tw_odd);
-        let next_second = b.sub(&even, &tw_odd);
-        x = b.concat(&[&next_first, &next_second], 1);
-        x = b.reshape(&x, Shape::from(&[n, 2]));
-
-        full *= 2;
-    }
-
-    if direction == Direction::Inverse {
-        let inv_n = 1.0_f32 / (n as f32);
-        let scale = b.constant(
-            DType::F32,
-            Shape::from(&[1, 1]),
-            inv_n.to_le_bytes().to_vec(),
-        );
-        let scale_b = b.broadcast(&scale, Shape::from(&[n, 2]));
-        x = b.mul(&x, &scale_b);
-    }
-
-    let out_id = x.id;
-    b.output(&x);
+    let out_id = spectrum.id;
+    b.output(&spectrum);
     let graph = b
         .build()
         .map_err(|e| FftError::InvalidInput(format!("graph build/validate: {:?}", e)))?;
@@ -282,8 +251,8 @@ pub fn build_fft_graph_with_input(
 }
 
 /// Reverse the bottom `bits` bits of `x`.  Used by the bit-reversal
-/// permutation step of build_fft_graph.
-fn bit_reverse(mut x: usize, bits: usize) -> usize {
+/// permutation step of `add_radix2_fft_to_builder`.
+pub(crate) fn bit_reverse(mut x: usize, bits: usize) -> usize {
     let mut r = 0usize;
     for _ in 0..bits {
         r = (r << 1) | (x & 1);


### PR DESCRIPTION
## Summary

- Closes the remaining gap in DSP01: non-power-of-two FFTs can now run end-to-end on the matrix execution layer via `bluestein_via_runtime`. Every `N ≥ 2` lifts to GPU automatically once Metal / CUDA claim Slice + Concat.
- New `build_bluestein_graph_with_input(signal, direction)` builder emits a single matrix-ir Graph composing three length-`M` radix-2 FFTs (`M = next_pow2(2N - 1)`) with chirp Consts.
- Refactors `radix2.rs` to expose `add_radix2_fft_to_builder(builder, x, n, direction)` so the Bluestein graph can splice in three FFT subgraphs without copy-pasting butterfly code. `build_fft_graph` / `build_fft_graph_with_input` become thin wrappers — pure refactor, no behavior change.
- Bumps `dsp-fft` 0.6.0 → 0.7.0.

## Test plan

- [x] `cargo test -p dsp-fft` — 71 tests pass (63 prior + 8 new Phase 4c)
- [x] Graph validates for N ∈ {2, 3, 5, 6, 7, 8, 12} both directions
- [x] `bluestein_via_runtime` matches scalar oracle at N ∈ {3, 5, 7} forward, N = 6 inverse, plus a round-trip at N = 5
- [x] Security review passed
- [ ] CI green on origin

## What this phase does NOT include

- Wiring public `fft` / `ifft` to use `bluestein_via_runtime` for non-pow2. The matrix-ir Bluestein graph is heavier than the scalar one on CPU (three length-M radix-2 subgraphs); leaving scalar as the default until GPU backends claim Slice + Concat is the right call. A follow-up phase will add routing.
- Phase 5: MX05 specialised emitters (folded twiddles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)