### PR TITLE
spice: parse inductor initial conditions

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- **Inductor initial current** — `Inductor` now accepts an `initial_current`
+  value that seeds transient analysis companion models.
+
 - **Explicit AC source phasors** — `VoltageSource` and `CurrentSource` now
   accept an optional `AcSource(magnitude, phase_degrees=0.0)` value.  AC
   analysis uses those phasors independently from the DC bias value, and zeros

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -31,7 +31,7 @@ print(result.converged)            # True
 |-------|-------|-------------|
 | `Resistor` | R | Ohmic resistor |
 | `Capacitor` | C | Linear capacitor (with optional initial voltage) |
-| `Inductor` | L | Linear inductor |
+| `Inductor` | L | Linear inductor (with optional initial current) |
 | `VoltageSource` | V | Independent voltage source |
 | `CurrentSource` | I | Independent current source |
 | `Diode` | D | Shockley diode model |

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -275,6 +275,7 @@ class Inductor:
     n_plus: str
     n_minus: str
     inductance: float  # henries
+    initial_current: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -1570,6 +1570,13 @@ def transient(
                 n_minus=el.n_minus,
                 resistance=r_init,
             ))
+            if el.initial_current != 0.0:
+                init_circuit.add(CurrentSource(
+                    name=f"_L_{el.name}_I0",
+                    n_plus=el.n_plus,
+                    n_minus=el.n_minus,
+                    current=el.initial_current,
+                ))
     op = dc_op(init_circuit, max_iterations=max_iterations, tol=tol)
     if not op.converged:
         return TransientResult(points=[], converged=False, method=method)
@@ -1588,7 +1595,7 @@ def transient(
         for el in circuit.elements if isinstance(el, Capacitor)
     }
     ind_currents: dict[str, float] = {
-        el.name: 0.0
+        el.name: el.initial_current
         for el in circuit.elements if isinstance(el, Inductor)
     }
     ind_voltages: dict[str, float] = {

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -492,6 +492,19 @@ def test_transient_inductor_starts_at_zero_current():
     assert v0 >= 0.0
 
 
+def test_transient_inductor_respects_initial_current():
+    c = Circuit()
+    c.add(Resistor("R1", "out", "0", 1000.0))
+    c.add(Inductor("L1", "out", "0", 1.0, initial_current=1.0e-3))
+
+    result = transient(c, t_stop=2.0e-3, t_step=1.0e-3, method="euler")
+
+    assert result.converged
+    assert isclose(result.points[0].node_voltages["out"], -0.5, abs_tol=1e-9)
+    assert isclose(result.points[1].node_voltages["out"], -0.5, abs_tol=1e-9)
+    assert isclose(result.points[2].node_voltages["out"], -0.25, abs_tol=1e-9)
+
+
 # ---- Transient: TransientResult metadata ----
 
 

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Parse capacitor `IC=<voltage>` initial-voltage parameters.
+- Parse inductor `IC=<current>` initial-current parameters.
 - Parse SPICE independent source `AC <magnitude> [phase]` specifications for
   voltage and current sources, including `DC <value> AC ...` mixed bias/input
   forms.

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -23,7 +23,7 @@ This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`,
 `VT`), BJT parameters (`NPN`/`PNP`, `IS`, `BF`/`BETA_F`, `VT`), and Level-1
 MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`), capacitor `IC=<voltage>`
-initial conditions, SPICE engineering suffixes,
+and inductor `IC=<current>` initial conditions, SPICE engineering suffixes,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
 expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, and `.noise`
 analysis cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -313,8 +313,20 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             initial_voltage=params.get("IC", 0.0),
         )
     if prefix == "L":
-        _require_fields(fields, 4, "inductor")
-        return Inductor(name, fields[1], fields[2], parse_value(fields[3]))
+        _require_min_fields(fields, 4, "inductor")
+        params = _parse_element_params(fields[4:], "inductor")
+        unsupported = set(params) - {"IC"}
+        if unsupported:
+            raise NetlistParseError(
+                f"unsupported inductor parameter {sorted(unsupported)[0]!r}"
+            )
+        return Inductor(
+            name,
+            fields[1],
+            fields[2],
+            parse_value(fields[3]),
+            initial_current=params.get("IC", 0.0),
+        )
     if prefix == "V":
         _require_min_fields(fields, 4, "voltage source")
         source = _parse_source_value(fields[3:])

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -72,7 +72,7 @@ Vstep in 0 PULSE(0 1 0 1n 1n 10n 20n)
 I1 out 0 1m
 Rload in out 2.2k
 Cload out 0 10p IC=2.5
-L1 out 0 1u
+L1 out 0 1u IC=3m
 G1 out 0 in 0 2m
 .tran 1n 20n
 .dc Vstep 0 1 0.5
@@ -86,6 +86,7 @@ G1 out 0 in 0 2m
     assert isinstance(parsed.circuit.elements[3], Capacitor)
     assert parsed.circuit.elements[3].initial_voltage == 2.5
     assert isinstance(parsed.circuit.elements[4], Inductor)
+    assert parsed.circuit.elements[4].initial_current == 3.0e-3
     assert isinstance(parsed.circuit.elements[5], VCCS)
     assert parsed.analyses == [
         TranAnalysis(t_step=1.0e-9, t_stop=20.0e-9),
@@ -97,6 +98,11 @@ G1 out 0 in 0 2m
 def test_capacitor_rejects_unsupported_element_params() -> None:
     with pytest.raises(NetlistParseError, match="unsupported capacitor parameter"):
         parse_netlist("C1 in 0 1u FOO=1")
+
+
+def test_inductor_rejects_unsupported_element_params() -> None:
+    with pytest.raises(NetlistParseError, match="unsupported inductor parameter"):
+        parse_netlist("L1 in 0 1u FOO=1")
 
 
 def test_parse_tf_analysis_card_and_run_transfer_function() -> None:

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Parse capacitor `IC=<voltage>` initial-voltage parameters.
+- Parse inductor `IC=<current>` initial-current parameters.
 - Parse SPICE `.tf V(output_node) input_source` transfer-function analysis
   cards.
 - Parse SPICE `.sens V(output_node)` DC sensitivity analysis cards.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -23,7 +23,7 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `BETA_F`, and `VT` parameters, `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering
-suffixes, capacitor `IC=<voltage>` initial conditions, independent-source
-`AC <magnitude> [phase]` forms, PWL/PULSE/SIN/EXP source forms, comments,
-`.end`, `.subckt` / `X` instance expansion, and
+suffixes, capacitor `IC=<voltage>` and inductor `IC=<current>` initial
+conditions, independent-source `AC <magnitude> [phase]` forms,
+PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance expansion, and
 `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, and `.noise` analysis cards.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -513,12 +513,19 @@ fn parse_element(
             )))
         }
         'L' => {
-            require_fields(fields, 4, "inductor")?;
-            Ok(Element::Inductor(Inductor::new(
+            require_min_fields(fields, 4, "inductor")?;
+            let params = parse_element_params(&fields[4..], "inductor")?;
+            if let Some(param_name) = params.keys().find(|name| name.as_str() != "IC") {
+                return Err(NetlistParseError::new(format!(
+                    "unsupported inductor parameter {param_name:?}"
+                )));
+            }
+            Ok(Element::Inductor(Inductor::with_initial_current(
                 name,
                 &fields[1],
                 &fields[2],
                 parse_value(&fields[3])?,
+                *params.get("IC").unwrap_or(&0.0),
             )))
         }
         'V' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -51,7 +51,7 @@ Vstep in 0 PULSE(0 1 0 1n 1n 10n 20n)
 I1 out 0 1m
 Rload in out 2.2k
 Cload out 0 10p IC=2.5
-L1 out 0 1u
+L1 out 0 1u IC=3m
 G1 out 0 in 0 2m
 .tran 1n 20n
 .dc Vstep 0 1 0.5
@@ -79,6 +79,10 @@ G1 out 0 in 0 2m
         panic!("expected capacitor");
     };
     assert_close(capacitor.initial_voltage, 2.5);
+    let Element::Inductor(inductor) = &parsed.circuit.elements()[4] else {
+        panic!("expected inductor");
+    };
+    assert_close(inductor.initial_current, 3.0e-3);
 
     assert_eq!(
         parsed.analyses,
@@ -110,6 +114,13 @@ fn rejects_unsupported_capacitor_element_params() {
     assert!(error
         .to_string()
         .contains("unsupported capacitor parameter"));
+}
+
+#[test]
+fn rejects_unsupported_inductor_element_params() {
+    let error = parse_netlist("L1 in 0 1u FOO=1").unwrap_err();
+
+    assert!(error.to_string().contains("unsupported inductor parameter"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Parse capacitor `IC=<voltage>` initial-voltage parameters.
+- Parse inductor `IC=<current>` initial-current parameters.
 - Parse independent-source `AC <magnitude> [phase]` specs, including combined
   `DC <bias> AC <magnitude> [phase]` forms, and pass the AC phasor through to
   TypeScript SPICE engine AC analysis while preserving DC bias.

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -25,7 +25,8 @@ elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 `BF` / `BETA_F`, and `VT` parameters, `.model <name> NMOS(...)` /
 `.model <name> PMOS(...)` MOSFET cards with Level-1 `VT0` / `VTO`, `KP`,
 `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` /
-`TNOM` parameters, capacitor `IC=<voltage>` initial conditions,
+`TNOM` parameters, capacitor `IC=<voltage>` and inductor `IC=<current>`
+initial conditions,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, `.ac`, and
 `.tf`, `.sens`, `.mc`, and `.noise` analysis cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -13,7 +13,7 @@ import {
   currentSourceWithWaveform,
   diode,
   dcOp,
-  inductor,
+  inductorWithInitialCurrent,
   mosfet,
   resistor,
   vccs,
@@ -420,8 +420,22 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
     );
   }
   if (prefix === "L") {
-    requireFields(fields, 4, "inductor");
-    return inductor(name, fields[1], fields[2], parseValue(fields[3]));
+    requireMinFields(fields, 4, "inductor");
+    const params = parseElementParams(fields.slice(4), "inductor");
+    for (const paramName of params.keys()) {
+      if (paramName !== "IC") {
+        throw new NetlistParseError(
+          `unsupported inductor parameter ${JSON.stringify(paramName)}`,
+        );
+      }
+    }
+    return inductorWithInitialCurrent(
+      name,
+      fields[1],
+      fields[2],
+      parseValue(fields[3]),
+      params.get("IC") ?? 0.0,
+    );
   }
   if (prefix === "V") {
     requireMinFields(fields, 4, "voltage source");

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -35,7 +35,7 @@ Vstep in 0 PULSE(0 1 0 1n 1n 10n 20n)
 I1 out 0 1m
 Rload in out 2.2k
 Cload out 0 10p IC=2.5
-L1 out 0 1u
+L1 out 0 1u IC=3m
 G1 out 0 in 0 2m
 .tran 1n 20n
 .dc Vstep 0 1 0.5
@@ -53,6 +53,7 @@ G1 out 0 in 0 2m
     ]);
     expect(elements[0]).toMatchObject({ kind: "voltage-source", waveform: expect.any(Object) });
     expect(elements[3]).toMatchObject({ kind: "capacitor", initialVoltage: 2.5 });
+    expect(elements[4]).toMatchObject({ kind: "inductor", initialCurrent: 3.0e-3 });
     expect(parsed.analyses).toEqual([
       { kind: "tran", timeStep: 1.0e-9, stopTime: 20.0e-9 },
       { kind: "dc", sourceName: "Vstep", start: 0.0, stop: 1.0, step: 0.5 },
@@ -63,6 +64,12 @@ G1 out 0 in 0 2m
   it("rejects unsupported capacitor element parameters", () => {
     expect(() => parseNetlist("C1 in 0 1u FOO=1")).toThrow(
       /unsupported capacitor parameter/,
+    );
+  });
+
+  it("rejects unsupported inductor element parameters", () => {
+    expect(() => parseNetlist("L1 in 0 1u FOO=1")).toThrow(
+      /unsupported inductor parameter/,
     );
   });
 


### PR DESCRIPTION
Summary:
- add Python Inductor.initial_current seeding for transient analysis
- parse L... IC=<current> in Python, TypeScript, and Rust netlist parsers
- add parser acceptance/rejection tests and Python engine transient coverage

Validation:
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-inductor-ic-cards sh BUILD (code/packages/python/spice-engine)
- sh BUILD (code/packages/python/spice-netlist-parser)
- sh BUILD (code/packages/typescript/spice-netlist-parser)
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-inductor-ic-cards cargo test -p spice-netlist-parser -- --nocapture (code/packages/rust)
- git diff --check