### PR TITLE
fix(forme-orchestrator): DAG typecheck agrees with scheduler on stream iteration

### DIFF
--- a/code/packages/typescript/forme-orchestrator/CHANGELOG.md
+++ b/code/packages/typescript/forme-orchestrator/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog — @coding-adventures/forme-orchestrator
 
+## 0.1.1 — 2026-05-15
+
+### Fixed
+
+- **DAG typecheck now agrees with the scheduler on stream-iteration
+  promotion.**  When a per-item stage (consumes X, produces Y) sits
+  between a stream source (Stream<X>) and a stream sink
+  (Stream<Y>), the scheduler iterates the source and invokes the
+  per-item stage N times — yielding N Y values that downstream
+  consumers see as Stream<Y>.  The DAG builder used to reject the
+  wire before scheduling ever ran (it compared the per-item stage's
+  declared `produces: Y` against the consumer's `consumes:
+  Stream<Y>` and failed).  `buildDag` now tracks an `effectiveProduces`
+  per instance — when an instance's input is a stream and its declared
+  consumes/produces are single values, its effective downstream output
+  is promoted to `Stream<produces>`.  Two new integration tests pin
+  the behaviour (Stream → per-item → Stream builds; pure stream-stream
+  chains aren't double-wrapped).
+
+  This was discovered while wiring the blog site (FM00 §5 demo): the
+  natural shape — source-fs (Stream) → parse-markdown (per-item) →
+  render-static (Stream) → emit-fs (Stream) — couldn't be built.
+
 ## 0.1.0 — 2026-05-15
 
 Initial release.  FM03 §3-4, §9-10 — the runtime that takes a

--- a/code/packages/typescript/forme-orchestrator/src/dag.ts
+++ b/code/packages/typescript/forme-orchestrator/src/dag.ts
@@ -77,9 +77,23 @@ export function buildDag(resolved: ResolvedPipelineConfig): PipelineDag {
   // Second pass: resolve producers by walking earlier instances and
   // finding the most-recent compatible kind.  Track which producers
   // are consumed so we can identify sinks.
+  //
+  // The compatibility check uses each prior instance's *effective*
+  // produces kind — which can differ from its declared produces when
+  // the orchestrator iterates a stream input on its behalf.  Example:
+  //   sourceFs               produces Stream<ContentSource>
+  //   parseMarkdown          consumes ContentSource, declares produces ContentNode
+  //   renderStatic           consumes Stream<ContentNode>
+  // The scheduler iterates sourceFs's stream and invokes parseMarkdown
+  // once per ContentSource, yielding a Stream<ContentNode> downstream
+  // (forme-orchestrator/scheduler.ts marks state.isStreamOutput=true in
+  // that branch).  The DAG builder must agree, or it rejects the wire
+  // before scheduling ever runs.  `effectiveProduces` captures that
+  // promotion so the typecheck and the runtime stay in sync.
   const consumedAsProducer = new Set<string>();
   const ids = resolved.resolvedIds;
   const updated: ResolvedInstance[] = [];
+  const effectiveProduces = new Map<string, KindDescriptor>();
   for (let i = 0; i < ids.length; i++) {
     const id = ids[i]!;
     const inst = instances.get(id)!;
@@ -87,17 +101,22 @@ export function buildDag(resolved: ResolvedPipelineConfig): PipelineDag {
 
     // Sources: consumes: Void (or void).
     if (consumes.name === "Void") {
+      effectiveProduces.set(id, inst.stage.produces);
       sources.push(id);
       updated.push(inst);
       continue;
     }
 
-    // Walk earlier instances in declaration order from most-recent backwards.
+    // Walk earlier instances in declaration order from most-recent
+    // backwards.  Compare against each prior's effective produces.
     let producerId: string | null = null;
+    let producerEffective: KindDescriptor | null = null;
     for (let j = i - 1; j >= 0; j--) {
       const prior = instances.get(ids[j]!)!;
-      if (areKindsCompatible(prior.stage.produces, consumes)) {
+      const priorEffective = effectiveProduces.get(prior.id) ?? prior.stage.produces;
+      if (areKindsCompatible(priorEffective, consumes)) {
         producerId = prior.id;
+        producerEffective = priorEffective;
         break;
       }
     }
@@ -113,6 +132,29 @@ export function buildDag(resolved: ResolvedPipelineConfig): PipelineDag {
     }
     consumedAsProducer.add(producerId);
     updated.push({ ...inst, producer: producerId });
+
+    // Compute this instance's effective produces, considering the
+    // stream-iteration promotion described above.
+    //
+    //   producerEffective = Stream<X>  AND  consumes = X           ⇒
+    //     orchestrator invokes inst per-yielded-X.  Each invocation
+    //     produces stage.produces.  Downstream sees Stream<stage.produces>.
+    //
+    //   producerEffective = Stream<stage.produces>                 ⇒ keep as-is.
+    //
+    //   producerEffective is Stream<X> and consumes is Stream<X>   ⇒ keep declared produces
+    //     (instance is itself a stream-stream stage).
+    //
+    //   Otherwise                                                  ⇒ keep declared produces.
+    const declared = inst.stage.produces;
+    const isPerItemIteration =
+      producerEffective.name === "Stream" &&
+      consumes.name !== "Stream" &&
+      declared.name !== "Stream";
+    const promoted: KindDescriptor = isPerItemIteration
+      ? { name: "Stream", version: declared.version, inner: declared }
+      : declared;
+    effectiveProduces.set(id, promoted);
   }
 
   // Replace map with updated instances (now carrying producer info).

--- a/code/packages/typescript/forme-orchestrator/tests/integration.test.ts
+++ b/code/packages/typescript/forme-orchestrator/tests/integration.test.ts
@@ -356,6 +356,83 @@ describe("buildDag — direct API", () => {
   });
 });
 
+describe("buildDag — stream-iteration typecheck promotion", () => {
+  // When a per-item stage sits between a stream source and a stream
+  // sink, the orchestrator iterates the stream and invokes the per-
+  // item stage once per yielded value.  The per-item stage's
+  // declared `produces` is a single value, but its effective output
+  // downstream is Stream<that value> — because the orchestrator
+  // collects N invocations into a stream.  The DAG builder must
+  // agree with that runtime semantics or it rejects the wire.
+
+  it("Stream<X> → (X→Y per-item) → Stream<Y> builds without error", () => {
+    const source = tinySource(["a", "b"]);
+    // per-item: ContentSource → ContentNode
+    const parse = defineStage({
+      name: "@test/parse",
+      version: "0.1.0", apiVersion: KERNEL_API_VERSION,
+      description: "per-item ContentSource → ContentNode",
+      consumes: Kinds.ContentSource,
+      produces: Kinds.ContentNode,
+      capabilities: [], configSchema: null,
+      async run() { return {} as never; },
+    });
+    // stream-stream: Stream<ContentNode> → Stream<RenderedPage>
+    const render = defineStage({
+      name: "@test/render",
+      version: "0.1.0", apiVersion: KERNEL_API_VERSION,
+      description: "Stream<ContentNode> → Stream<RenderedPage>",
+      consumes: streamOf(Kinds.ContentNode),
+      produces: streamOf(Kinds.RenderedPage),
+      capabilities: [], configSchema: null,
+      // eslint-disable-next-line require-yield
+      async *run() { /* no-op for typecheck */ },
+    });
+    const config = makeConfig([
+      { stage: source }, { stage: parse }, { stage: render },
+    ]);
+    const resolved = validateConfig(config);
+    // Before the fix: this throws "no earlier instance produces a
+    // compatible kind" because parse declares produces=ContentNode
+    // and render consumes Stream<ContentNode>.  After: parse's
+    // effective output is Stream<ContentNode> because it's wired
+    // from a stream, so the typecheck accepts.
+    expect(() => buildDag(resolved)).not.toThrow();
+    const dag = buildDag(resolved);
+    expect(dag.topoOrder).toEqual(["@test/source", "@test/parse", "@test/render"]);
+    expect(dag.instances.get("@test/render")!.producer).toBe("@test/parse");
+  });
+
+  it("a stream-stream stage's effective output is its declared Stream produces (no double-wrap)", () => {
+    // sourceA -> streamStage(Stream<X> -> Stream<Y>) -> sink(Stream<Y>)
+    const source = tinySource(["x"]);
+    const streamStage = defineStage({
+      name: "@test/stream-stage",
+      version: "0.1.0", apiVersion: KERNEL_API_VERSION,
+      description: "stream → stream pass-through",
+      consumes: streamOf(Kinds.ContentSource),
+      produces: streamOf(Kinds.ContentSource),
+      capabilities: [], configSchema: null,
+      // eslint-disable-next-line require-yield
+      async *run() { /* no-op */ },
+    });
+    const streamSink = defineStage({
+      name: "@test/stream-sink",
+      version: "0.1.0", apiVersion: KERNEL_API_VERSION,
+      description: "consumes Stream<X>, emits artifact",
+      consumes: streamOf(Kinds.ContentSource),
+      produces: Kinds.DeployArtifact,
+      capabilities: [], configSchema: null,
+      async run() { return null as never; },
+    });
+    const config = makeConfig([
+      { stage: source }, { stage: streamStage }, { stage: streamSink },
+    ]);
+    const resolved = validateConfig(config);
+    expect(() => buildDag(resolved)).not.toThrow();
+  });
+});
+
 describe("runOnce direct (without the orchestrator wrapper)", () => {
   it("returns a result with elapsedMs and buildId", async () => {
     const source = tinySource(["a"]);


### PR DESCRIPTION
## Summary

Small focused fix: **the DAG typecheck now agrees with the scheduler** on stream-iteration promotion.

### The problem

When a per-item stage (`consumes: X, produces: Y`) sits between a stream source (`Stream<X>`) and a stream sink (`Stream<Y>`), the scheduler iterates the source and invokes the per-item stage N times — yielding N `Y` values that downstream consumers see as `Stream<Y>`. The scheduler already handles this (sets `state.isStreamOutput = true` in the per-item-iteration branch). The DAG builder did not.

Result: the natural Markdown-blog pipeline shape couldn't be built:

```
sourceFs              produces Stream<ContentSource>
parseMarkdown         consumes ContentSource → produces ContentNode
renderStatic          consumes Stream<ContentNode>     ← rejected here
emitFs                consumes Stream<RenderedPage> → produces DeployArtifact
```

`buildDag` would throw:

```
Error: buildDag: instance "@coding-adventures/forme-render-static" consumes Stream<ContentNode> but no earlier instance produces a compatible kind
```

…even though the scheduler would have handled it just fine.

### The fix

`buildDag` now tracks `effectiveProduces` per instance. When an instance's input is a stream and its declared `consumes` / `produces` are single values, its effective downstream output is promoted to `Stream<produces>`. Stream-stream stages are **not** double-wrapped (a stage that declares `Stream<Y>` keeps `Stream<Y>` regardless of whether its own input was a stream).

The promotion mirrors the scheduler's runtime behaviour, so type-time and run-time stay in sync.

### Discovered while

…wiring the **blog site** (FM00 §5 end-to-end demo). The blog site PR is queued behind this one.

## Test plan

- [x] `npx vitest run` — **30 tests pass** (15 existing typecheck + 13 existing integration + **2 new integration** for the promotion behaviour)
- [x] New test 1: `Stream<X> → (X→Y per-item) → Stream<Y>` builds without error
- [x] New test 2: a stream-stream stage's effective output is its declared `Stream<Y>` (not double-wrapped to `Stream<Stream<Y>>`)
- [x] No changes to runtime semantics — the scheduler already did the right thing; only the typecheck was wrong
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)