### PR TITLE
feat(rust/twig-aot): --target CLI flag for multi-platform dispatch

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog — `twig-aot`
 
+## 0.4.0 — 2026-05-16 (`--target` CLI flag)
+
+**Expose the LANG46 multi-target driver to end users via a `--target`
+CLI flag on the `twig-aot` binary.**
+
+Previously the CLI only invoked `compile_file_macos_arm64`; the
+Linux/Windows entry points existed but were unreachable from the
+command line.  This release adds a `--target` flag and host-aware
+dispatch:
+
+```
+twig-aot foo.twig                      # auto-picks the host target
+twig-aot foo.twig --target=linux-x86_64
+twig-aot foo.twig --target=windows-x86_64
+twig-aot foo.twig --target=macos-arm64
+```
+
+Accepted values (and full target-triple aliases):
+| Short | Triple |
+|---|---|
+| `auto` (default) | (build host) |
+| `macos-arm64` | `aarch64-apple-darwin` |
+| `linux-x86_64` | `x86_64-unknown-linux-gnu` |
+| `windows-x86_64` | `x86_64-pc-windows-msvc` |
+
+Cross-OS dispatch (e.g. `--target=linux-x86_64` on a Windows host)
+errors out cleanly:
+
+```
+$ twig-aot --target=linux-x86_64 foo.twig    # on Windows
+twig-aot: --target=linux-x86_64 requires a Linux x86-64 host in V1
+         (cross-OS compilation is a separate follow-up)
+```
+
+Unknown targets produce an enumerated error:
+
+```
+$ twig-aot --target=bogus foo.twig
+twig-aot: unknown target "bogus"; expected one of: auto, macos-arm64,
+         linux-x86_64, windows-x86_64
+```
+
 ## 0.3.1 — 2026-05-16 (multi-function x86_64 cross-fn patching)
 
 **Patch cross-function `call` sites in place during the x86_64

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source."
 

--- a/code/packages/rust/twig-aot/bin/twig_aot.rs
+++ b/code/packages/rust/twig-aot/bin/twig_aot.rs
@@ -1,29 +1,77 @@
-//! `twig-aot` CLI — compile a Twig source file to a native ARM64
-//! Mach-O executable.
+//! `twig-aot` CLI — compile a Twig source file to a native executable.
 //!
 //! ## Usage
 //!
 //! ```text
-//! twig-aot <FILE.twig> [-o <OUT>]
+//! twig-aot <FILE.twig> [-o <OUT>] [--target <TRIPLE>]
 //! twig-aot --help
 //! twig-aot --version
 //! ```
 //!
+//! `--target` selects the output platform:
+//! - `auto` (default) — picks the build host's platform.
+//! - `macos-arm64` — Apple Silicon Mach-O executable (requires macOS host).
+//! - `linux-x86_64` — Linux ELF64 executable (requires Linux host in V1).
+//! - `windows-x86_64` — Windows PE executable (requires Windows host in V1).
+//!
 //! Argument parsing is driven by [`cli_builder`] — the JSON spec lives
-//! in `twig_aot.cli.json` next to this binary's source.  Keeping the
-//! shape declarative means `--help` / `--version` / error messages are
-//! generated for free, and we don't roll yet another argv parser.
+//! in `twig_aot.cli.json` next to this binary's source.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use cli_builder::parser::Parser;
 use cli_builder::spec_loader::load_spec_from_str;
 use cli_builder::types::ParserOutput;
 
-/// CLI specification embedded at compile time.  The same file ships
-/// next to the source so editor tooling can pick it up.
+/// CLI specification embedded at compile time.
 static CLI_SPEC: &str = include_str!("../twig_aot.cli.json");
+
+/// Output target the CLI dispatches to.
+///
+/// Resolution order:
+/// 1. If `--target <triple>` is given, use it.
+/// 2. Otherwise (or with `--target auto`), pick the build host's
+///    triple via `cfg(target_os)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Target {
+    MacosArm64,
+    LinuxX86_64,
+    WindowsX86_64,
+}
+
+impl Target {
+    /// Parse a `--target` value.  `auto` (or unspecified) picks the host.
+    fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "auto" => Ok(Self::host()),
+            "macos-arm64"    | "aarch64-apple-darwin"     => Ok(Self::MacosArm64),
+            "linux-x86_64"   | "x86_64-unknown-linux-gnu" => Ok(Self::LinuxX86_64),
+            "windows-x86_64" | "x86_64-pc-windows-msvc"   => Ok(Self::WindowsX86_64),
+            other => Err(format!(
+                "unknown target {other:?}; expected one of: auto, \
+                 macos-arm64, linux-x86_64, windows-x86_64")),
+        }
+    }
+
+    /// Resolve to the build host's target.  Unsupported hosts fall
+    /// through to `MacosArm64` so we don't fail to compile the CLI
+    /// itself; the actual dispatch below errors with a clear message.
+    fn host() -> Self {
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        { Self::MacosArm64 }
+        #[cfg(target_os = "linux")]
+        { Self::LinuxX86_64 }
+        #[cfg(target_os = "windows")]
+        { Self::WindowsX86_64 }
+        #[cfg(not(any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            target_os = "linux",
+            target_os = "windows",
+        )))]
+        { Self::MacosArm64 }
+    }
+}
 
 fn main() -> ExitCode {
     let spec = match load_spec_from_str(CLI_SPEC) {
@@ -59,8 +107,56 @@ fn main() -> ExitCode {
         .map(PathBuf::from)
         .unwrap_or_else(|| input.with_extension(""));
 
-    match twig_aot::compile_file_macos_arm64(&input, &output) {
+    let target_str = result.flags.get("target")
+        .and_then(|v| v.as_str())
+        .unwrap_or("auto");
+    let target = match Target::parse(target_str) {
+        Ok(t) => t,
+        Err(e) => { eprintln!("twig-aot: {e}"); return ExitCode::from(2); }
+    };
+
+    let result = dispatch(target, &input, &output);
+    match result {
         Ok(())   => ExitCode::SUCCESS,
-        Err(e) => { eprintln!("twig-aot: {e}"); ExitCode::from(1) }
+        Err(msg) => { eprintln!("twig-aot: {msg}"); ExitCode::from(1) }
+    }
+}
+
+/// Route to the right `compile_file_*` entry point for `target`.
+///
+/// Each branch is cfg-gated to the matching host OS — `twig-aot`'s V1
+/// supports only host-targets-host AOT.  On a non-matching host the
+/// branch returns a clear error.  Cross-OS compilation is tracked as
+/// a separate follow-up.
+fn dispatch(target: Target, input: &Path, output: &Path) -> Result<(), String> {
+    match target {
+        Target::MacosArm64 => {
+            #[cfg(unix)]
+            { twig_aot::compile_file_macos_arm64(input, output)
+                  .map_err(|e| format!("{e}")) }
+            #[cfg(not(unix))]
+            { let _ = (input, output);
+              Err("--target=macos-arm64 requires a Unix host (macOS or \
+                   Linux with cross-toolchain — cross-toolchain not yet \
+                   supported)".into()) }
+        }
+        Target::LinuxX86_64 => {
+            #[cfg(target_os = "linux")]
+            { twig_aot::compile_file_linux_x86_64(input, output)
+                  .map_err(|e| format!("{e}")) }
+            #[cfg(not(target_os = "linux"))]
+            { let _ = (input, output);
+              Err("--target=linux-x86_64 requires a Linux x86-64 host \
+                   in V1 (cross-OS compilation is a separate follow-up)".into()) }
+        }
+        Target::WindowsX86_64 => {
+            #[cfg(target_os = "windows")]
+            { twig_aot::compile_file_windows_x86_64(input, output)
+                  .map_err(|e| format!("{e}")) }
+            #[cfg(not(target_os = "windows"))]
+            { let _ = (input, output);
+              Err("--target=windows-x86_64 requires a Windows x86-64 host \
+                   in V1 (cross-OS compilation is a separate follow-up)".into()) }
+        }
     }
 }

--- a/code/packages/rust/twig-aot/twig_aot.cli.json
+++ b/code/packages/rust/twig-aot/twig_aot.cli.json
@@ -1,14 +1,21 @@
 {
   "cli_builder_spec_version": "1.0",
   "name": "twig-aot",
-  "description": "Compile a Twig source file to a native ARM64 Mach-O executable.",
-  "version": "0.1.0",
+  "description": "Compile a Twig source file to a native executable on Linux x86-64, Windows x86-64, or macOS ARM64.",
+  "version": "0.4.0",
   "flags": [
     {
       "id": "output",
       "short": "o",
       "long": "output",
       "description": "Output path for the executable (default: input file with no extension).",
+      "type": "string"
+    },
+    {
+      "id": "target",
+      "short": "t",
+      "long": "target",
+      "description": "Target platform: auto (default, picks the host), macos-arm64, linux-x86_64, or windows-x86_64. Cross-OS compilation requires a host that can provide the target's linker; on V1 hosts the runtime archive must also have been built for the target at twig-aot crate build time.",
       "type": "string"
     }
   ],


### PR DESCRIPTION
## Follow-up 2/3 from PR #3203

Exposes the LANG46 multi-target driver via a `--target` CLI flag on the `twig-aot` binary. Previously the binary only invoked `compile_file_macos_arm64` regardless of host; the Linux/Windows entry points existed but were unreachable from the command line.

## CLI surface

```
twig-aot foo.twig                      # auto (host)
twig-aot foo.twig --target=linux-x86_64
twig-aot foo.twig --target=windows-x86_64
twig-aot foo.twig --target=macos-arm64
```

Both short forms (`linux-x86_64`) and full target triples (`x86_64-unknown-linux-gnu`) are accepted.

## Dispatch

| `--target=…` | Routes to | When host differs |
|---|---|---|
| `auto` (default) | host's `compile_file_*` | — |
| `macos-arm64` | `compile_file_macos_arm64` (Unix) | clear error on Windows |
| `linux-x86_64` | `compile_file_linux_x86_64` (Linux) | clear error elsewhere |
| `windows-x86_64` | `compile_file_windows_x86_64` (Windows) | clear error elsewhere |

Cross-OS dispatch is explicitly out of scope for V1 (tracked as the third follow-up — PR C); each branch returns a clean "requires X host" error instead of attempting to compile.

## Test plan

- [x] `twig-aot --help` displays the new flag with both short (`-t`) and long (`--target`) forms
- [x] `twig-aot --target=bogus foo.twig` produces enumerated error listing valid targets
- [x] `twig-aot --target=linux-x86_64 foo.twig` on Windows host produces "requires Linux host" error
- [x] `twig-aot foo.twig` (auto) routes to the host's compiler unchanged
- [x] All existing tests still pass (10 lib + 2 macOS smoke + 3 Windows smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)