### PR TITLE
feat(rust/twig-aot): --emit-object flag for cross-OS workflows

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog — `twig-aot`
 
+## 0.5.0 — 2026-05-16 (`--emit-object` for cross-OS workflows)
+
+**Cross-OS object emission via a new `--emit-object` flag.**
+
+The third follow-up from PR #3203.  The `.o` / `.obj` object format
+is fully portable — only the *link step* is bound to the target
+host's toolchain.  This release exposes that asymmetry: produce the
+object file on any host, then copy it to a target machine and link
+it there.
+
+```
+# On Windows: produce a Linux ELF .o
+twig-aot foo.twig --target=linux-x86_64 --emit-object -o out/foo
+
+# Output:
+# twig-aot: emitted object: out/foo.o
+# twig-aot: NOTE: runtime archive for LinuxX86_64 was not built on
+#           this host (1-byte stub).  Build twig-aot on a
+#           LinuxX86_64 host or rebuild the runtime from
+#           `twig-aot/runtime/twig_runtime.c` on the target machine.
+```
+
+When the runtime archive *is* available for the target (i.e. the
+twig-aot binary was built on a matching host), `--emit-object` also
+writes the archive alongside and prints the exact link command:
+
+```
+# On Windows: produce a Windows .obj + .lib (host == target)
+twig-aot foo.twig --target=windows-x86_64 --emit-object -o out/bar
+
+# Output:
+# twig-aot: emitted object: out/bar.obj
+# twig-aot: emitted runtime archive: out/bar_runtime.lib
+# twig-aot: link on the target host with:
+#   link.exe /OUT:<exe>.exe /ENTRY:main /SUBSYSTEM:CONSOLE \
+#            out/bar.obj out/bar_runtime.lib libcmt.lib legacy_stdio_definitions.lib
+```
+
+### New API
+
+- **`EmitObjectTarget`** enum — `MacosArm64`, `LinuxX86_64`,
+  `WindowsX86_64`.  Selects which object format and runtime archive
+  the helper produces.
+- **`EmittedObject`** struct — `{ object_path, runtime_archive_path,
+  target }` returned from `emit_object_to_disk`.  Callers (e.g. the
+  CLI) print human-readable paths.
+- **`emit_object_to_disk(src, out_base, target) -> EmittedObject`**
+  — writes the relocatable object and (if available on this build
+  host) the runtime archive next to it.  Works from any (host,
+  target) combination because object emission doesn't need the
+  target's toolchain.
+
+### CLI changes
+
+- New `-c` / `--emit-object` boolean flag.  When set, the binary
+  writes the object + (optional) runtime archive instead of
+  invoking the system linker.  Combines with `--target` so the
+  user can write a Linux `.o` on a Windows host (or vice versa).
+
+### Tests
+
+- `emit_object_to_disk_writes_linux_o`: verifies the `.o` extension
+  and ELF magic.
+- `emit_object_to_disk_writes_windows_obj`: verifies the `.obj`
+  extension and `IMAGE_FILE_MACHINE_AMD64` (0x8664) at byte 0.
+- `emit_object_runtime_path_is_none_when_archive_is_stub`: iterates
+  the three targets and asserts at least one yields a real archive
+  (the host) and at least one yields a stub.
+
+### Out of scope (deferred to V2)
+
+Full cross-OS *linking* — taking a Linux ELF source on a Windows
+host all the way to a runnable `<exe>` without copying — would need
+either a bundled `clang+lld` + sysroot toolchain, or a `zig cc`
+dependency.  Both are substantial.  `--emit-object` covers the
+common case (build farm produces objects, target machine links)
+without that complexity.
+
 ## 0.4.0 — 2026-05-16 (`--target` CLI flag)
 
 **Expose the LANG46 multi-target driver to end users via a `--target`

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source."
 

--- a/code/packages/rust/twig-aot/bin/twig_aot.rs
+++ b/code/packages/rust/twig-aot/bin/twig_aot.rs
@@ -115,11 +115,67 @@ fn main() -> ExitCode {
         Err(e) => { eprintln!("twig-aot: {e}"); return ExitCode::from(2); }
     };
 
-    let result = dispatch(target, &input, &output);
-    match result {
+    let emit_object = result.flags.get("emit_object")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let outcome = if emit_object {
+        emit_object_dispatch(target, &input, &output)
+    } else {
+        dispatch(target, &input, &output)
+    };
+    match outcome {
         Ok(())   => ExitCode::SUCCESS,
         Err(msg) => { eprintln!("twig-aot: {msg}"); ExitCode::from(1) }
     }
+}
+
+/// `--emit-object` path: writes the relocatable object file + runtime
+/// archive to disk without invoking a linker.  Works from any host
+/// regardless of `target` because object emission doesn't need the
+/// target's toolchain; only linking does.
+fn emit_object_dispatch(target: Target, input: &Path, output: &Path) -> Result<(), String> {
+    use twig_aot::EmitObjectTarget;
+    let emit_target = match target {
+        Target::MacosArm64    => EmitObjectTarget::MacosArm64,
+        Target::LinuxX86_64   => EmitObjectTarget::LinuxX86_64,
+        Target::WindowsX86_64 => EmitObjectTarget::WindowsX86_64,
+    };
+    let emitted = twig_aot::emit_object_to_disk(input, output, emit_target)
+        .map_err(|e| format!("{e}"))?;
+
+    // Tell the user what landed and how to link it on the target host.
+    eprintln!("twig-aot: emitted object: {}", emitted.object_path.display());
+    match emitted.runtime_archive_path {
+        Some(p) => {
+            eprintln!("twig-aot: emitted runtime archive: {}", p.display());
+            eprintln!("twig-aot: link on the target host with:");
+            match emit_target {
+                EmitObjectTarget::LinuxX86_64 => {
+                    eprintln!("  cc -o <exe> {} {} -lc -lm",
+                        emitted.object_path.display(), p.display());
+                }
+                EmitObjectTarget::WindowsX86_64 => {
+                    eprintln!("  link.exe /OUT:<exe>.exe /ENTRY:main /SUBSYSTEM:CONSOLE \\");
+                    eprintln!("           {} {} libcmt.lib legacy_stdio_definitions.lib",
+                        emitted.object_path.display(), p.display());
+                }
+                EmitObjectTarget::MacosArm64 => {
+                    eprintln!("  ld -arch arm64 -platform_version macos 15.0 15.0 -e _main \\");
+                    eprintln!("     -lSystem -o <exe> {} {}",
+                        emitted.object_path.display(), p.display());
+                }
+            }
+        }
+        None => {
+            eprintln!("twig-aot: NOTE: runtime archive for {emit_target:?} \
+                       was not built on this host (1-byte stub).  Build \
+                       twig-aot on a {emit_target:?} host or rebuild the \
+                       runtime from `twig-aot/runtime/twig_runtime.c` on \
+                       the target machine.");
+        }
+    }
+    Ok(())
 }
 
 /// Route to the right `compile_file_*` entry point for `target`.

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -797,6 +797,148 @@ pub fn compile_windows_x86_64_object(source: &str, module_name: &str) -> Result<
 }
 
 // ---------------------------------------------------------------------------
+// Cross-OS object emission (works from any host — no linking step)
+// ---------------------------------------------------------------------------
+
+/// Logical target the `emit_object_to_disk` helper writes for.
+///
+/// `MacosArm64` is included for completeness; the macOS pipeline goes
+/// through `aarch64-backend` + `macho_object` rather than the x86_64
+/// path, but we still expose object emission so all three targets have
+/// a consistent --emit-object surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmitObjectTarget {
+    /// macOS ARM64 (`.o` Mach-O object — same as `compile_module_macos_arm64_object`).
+    MacosArm64,
+    /// Linux x86-64 (`.o` ELF64 object — works on any host).
+    LinuxX86_64,
+    /// Windows x86-64 (`.obj` PE/COFF object — works on any host).
+    WindowsX86_64,
+}
+
+impl EmitObjectTarget {
+    fn object_extension(self) -> &'static str {
+        match self {
+            EmitObjectTarget::MacosArm64    => "o",
+            EmitObjectTarget::LinuxX86_64   => "o",
+            EmitObjectTarget::WindowsX86_64 => "obj",
+        }
+    }
+    fn runtime_extension(self) -> &'static str {
+        match self {
+            EmitObjectTarget::MacosArm64    => "a",
+            EmitObjectTarget::LinuxX86_64   => "a",
+            EmitObjectTarget::WindowsX86_64 => "lib",
+        }
+    }
+    fn runtime_bytes(self) -> &'static [u8] {
+        match self {
+            EmitObjectTarget::MacosArm64    => RUNTIME_ARCHIVE,
+            EmitObjectTarget::LinuxX86_64   => RUNTIME_LINUX_X86_64,
+            EmitObjectTarget::WindowsX86_64 => RUNTIME_WINDOWS_X86_64,
+        }
+    }
+}
+
+/// Outputs produced by `emit_object_to_disk`.
+///
+/// `runtime_archive_path` is `None` when the target's runtime archive
+/// is a stub on this build host (i.e. the host couldn't build it at
+/// `twig-aot` crate compile time).  In that case the caller must
+/// provide their own runtime when linking; the message printed by the
+/// CLI says exactly that.
+#[derive(Debug, Clone)]
+pub struct EmittedObject {
+    /// Where the object file was written.
+    pub object_path: PathBuf,
+    /// Where the runtime archive was written, if available on this host.
+    pub runtime_archive_path: Option<PathBuf>,
+    /// The target this object was produced for.
+    pub target: EmitObjectTarget,
+}
+
+/// Emit a Twig program as a relocatable object file (`.o` / `.obj`) on
+/// disk, plus the matching runtime archive if available on this build
+/// host.  Works for any (host, target) combination — the only host-
+/// dependent piece is whether the runtime archive was built at
+/// `twig-aot` crate compile time.
+///
+/// The caller writes a separate link command (`cc`, `link.exe`, etc.)
+/// against the resulting files on a machine that can host the target.
+///
+/// `out_base` is the path *without* an extension — `.o`/`.obj` and
+/// `_runtime.a`/`_runtime.lib` are appended.  E.g. passing
+/// `out_base = "build/foo"` for a Linux target writes:
+/// - `build/foo.o`         (the object file)
+/// - `build/foo_runtime.a` (the runtime archive, if available)
+pub fn emit_object_to_disk(
+    src: &Path,
+    out_base: &Path,
+    target: EmitObjectTarget,
+) -> Result<EmittedObject, AotError> {
+    use std::io::Write as _;
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("twig");
+
+    // Produce the object bytes (no linking).
+    let object_bytes = match target {
+        EmitObjectTarget::MacosArm64    => compile_macos_arm64_object(&source, stem)?,
+        EmitObjectTarget::LinuxX86_64   => compile_linux_x86_64_object(&source, stem)?,
+        EmitObjectTarget::WindowsX86_64 => compile_windows_x86_64_object(&source, stem)?,
+    };
+
+    let object_path = with_extension(out_base, target.object_extension());
+    if let Some(parent) = object_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let mut f = std::fs::File::create(&object_path)?;
+    f.write_all(&object_bytes)?;
+    drop(f);
+
+    // Write the runtime archive when this host produced a real one at
+    // build time.  Stub archives (one byte) are skipped — the caller
+    // gets a clear message via the CLI.
+    let rt_bytes = target.runtime_bytes();
+    let runtime_archive_path = if rt_bytes.len() > 4 {
+        let rt_path = {
+            let mut p = out_base.to_path_buf();
+            let name = p.file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("twig")
+                .to_owned();
+            p.set_file_name(format!("{name}_runtime.{}", target.runtime_extension()));
+            p
+        };
+        let mut f = std::fs::File::create(&rt_path)?;
+        f.write_all(rt_bytes)?;
+        Some(rt_path)
+    } else {
+        None
+    };
+
+    Ok(EmittedObject {
+        object_path,
+        runtime_archive_path,
+        target,
+    })
+}
+
+/// Helper: produce `<base>.<ext>` regardless of whether `base` already
+/// has an extension.  (`Path::with_extension` *replaces* the extension,
+/// which surprises a user who passes `out_base = "foo.exe"`.)
+fn with_extension(base: &Path, ext: &str) -> PathBuf {
+    let mut p = base.to_path_buf();
+    let new_name = match p.file_name().and_then(|s| s.to_str()) {
+        Some(name) => format!("{name}.{ext}"),
+        None       => format!("twig.{ext}"),
+    };
+    p.set_file_name(new_name);
+    p
+}
+
+// ---------------------------------------------------------------------------
 // End-to-end pipelines: Twig source → object → system linker → executable
 // ---------------------------------------------------------------------------
 
@@ -1810,5 +1952,75 @@ mod tests {
             .filter(|r| r.symbol == "__twig_print_i64").collect();
         assert_eq!(plt.len(), 1,
             "expected one external reloc for __twig_print_i64, got {ext:?}");
+    }
+
+    // ---- --emit-object cross-OS object emission ----
+
+    #[test]
+    fn emit_object_to_disk_writes_linux_o() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("hello.twig");
+        std::fs::write(&src, "42").unwrap();
+        let base = dir.path().join("out");
+
+        let emitted = emit_object_to_disk(&src, &base, EmitObjectTarget::LinuxX86_64)
+            .expect("emit ok");
+
+        assert!(emitted.object_path.exists());
+        assert_eq!(
+            emitted.object_path.extension().and_then(|s| s.to_str()),
+            Some("o"),
+            "Linux objects use .o extension",
+        );
+
+        // ELF magic at byte 0.
+        let bytes = std::fs::read(&emitted.object_path).unwrap();
+        assert_eq!(&bytes[0..4], &[0x7F, b'E', b'L', b'F']);
+    }
+
+    #[test]
+    fn emit_object_to_disk_writes_windows_obj() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("hello.twig");
+        std::fs::write(&src, "42").unwrap();
+        let base = dir.path().join("out");
+
+        let emitted = emit_object_to_disk(&src, &base, EmitObjectTarget::WindowsX86_64)
+            .expect("emit ok");
+
+        assert!(emitted.object_path.exists());
+        assert_eq!(
+            emitted.object_path.extension().and_then(|s| s.to_str()),
+            Some("obj"),
+            "Windows objects use .obj extension",
+        );
+
+        // IMAGE_FILE_MACHINE_AMD64 (0x8664) LE at byte 0.
+        let bytes = std::fs::read(&emitted.object_path).unwrap();
+        assert_eq!(&bytes[0..2], &[0x64, 0x86]);
+    }
+
+    #[test]
+    fn emit_object_runtime_path_is_none_when_archive_is_stub() {
+        // Iterate the three targets.  Each host produces a real runtime
+        // archive for its own target and stubs for the others; emit_object
+        // should write a real `_runtime.*` file only when the bytes are
+        // a real archive (>4 bytes).  Verify both branches are exercised.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("hello.twig");
+        std::fs::write(&src, "42").unwrap();
+
+        let mut had_real = false;
+        let mut had_stub = false;
+        for tgt in [EmitObjectTarget::MacosArm64,
+                    EmitObjectTarget::LinuxX86_64,
+                    EmitObjectTarget::WindowsX86_64] {
+            let base = dir.path().join(format!("out_{tgt:?}"));
+            let e = emit_object_to_disk(&src, &base, tgt).expect("emit ok");
+            if e.runtime_archive_path.is_some() { had_real = true; }
+            else { had_stub = true; }
+        }
+        assert!(had_real, "at least one target must have a real runtime archive on the host");
+        assert!(had_stub, "at least one target should be a stub on this host");
     }
 }

--- a/code/packages/rust/twig-aot/twig_aot.cli.json
+++ b/code/packages/rust/twig-aot/twig_aot.cli.json
@@ -15,8 +15,15 @@
       "id": "target",
       "short": "t",
       "long": "target",
-      "description": "Target platform: auto (default, picks the host), macos-arm64, linux-x86_64, or windows-x86_64. Cross-OS compilation requires a host that can provide the target's linker; on V1 hosts the runtime archive must also have been built for the target at twig-aot crate build time.",
+      "description": "Target platform: auto (default, picks the host), macos-arm64, linux-x86_64, or windows-x86_64.",
       "type": "string"
+    },
+    {
+      "id": "emit_object",
+      "short": "c",
+      "long": "emit-object",
+      "description": "Emit the object file (.o on Linux/macOS, .obj on Windows) and runtime archive instead of producing a runnable executable. Works from any host regardless of --target — the object format is fully portable; only the link step is host/target-bound. Use this for cross-OS workflows: produce the .o on any host, copy it to the target machine, and link there with `cc -o exe foo.o runtime.a -lc` (Linux) or `link.exe /OUT:exe.exe foo.obj runtime.lib libcmt.lib legacy_stdio_definitions.lib` (Windows).",
+      "type": "boolean"
     }
   ],
   "arguments": [


### PR DESCRIPTION
## Follow-up 3/3 from PR #3203

Lifts the cross-OS limitation pragmatically: produce a relocatable object file (`.o` on Linux/macOS, `.obj` on Windows) and the matching runtime archive without invoking a linker. The object format is fully portable — only the link step is bound to the target host's toolchain — so this lets users compile a Twig source on any host and link the result on the target machine.

⚠️ **Stacks on PR #3332** (`feat/x86_64-target-flag`) for the `--target` plumbing; if merging this before #3332, rebase first.

## CLI surface

```
twig-aot foo.twig --target=linux-x86_64 --emit-object -o out/foo
```

### Cross-OS example (Windows host → Linux ELF object)

```
$ twig-aot foo.twig --target=linux-x86_64 --emit-object -o out/foo
twig-aot: emitted object: out/foo.o
twig-aot: NOTE: runtime archive for LinuxX86_64 was not built on this
         host (1-byte stub).  Build twig-aot on a LinuxX86_64 host or
         rebuild the runtime from `twig-aot/runtime/twig_runtime.c` on
         the target machine.
```

The `.o` is a fully valid Linux ELF64 ET_REL object — user copies to Linux machine and links there.

### Host == target example (Windows host → Windows .obj + .lib)

```
$ twig-aot foo.twig --target=windows-x86_64 --emit-object -o out/bar
twig-aot: emitted object: out/bar.obj
twig-aot: emitted runtime archive: out/bar_runtime.lib
twig-aot: link on the target host with:
  link.exe /OUT:<exe>.exe /ENTRY:main /SUBSYSTEM:CONSOLE \
           out/bar.obj out/bar_runtime.lib libcmt.lib legacy_stdio_definitions.lib
```

## New API

- `EmitObjectTarget` enum (`MacosArm64`, `LinuxX86_64`, `WindowsX86_64`)
- `EmittedObject` struct with `object_path`, optional `runtime_archive_path`, `target`
- `emit_object_to_disk(src, out_base, target) -> EmittedObject` — works from any (host, target) combination

## Test plan

- [x] 11 lib tests pass (3 new: `.o` extension + ELF magic; `.obj` extension + AMD64 magic; runtime-stub handling)
- [x] CLI: `--emit-object --target=linux-x86_64` on Windows writes a valid ELF `.o` and prints the runtime-stub note
- [x] CLI: `--emit-object --target=windows-x86_64` on Windows writes `.obj` + `.lib` and prints the `link.exe` command
- [x] All previous tests (2 macOS smoke + 3 Windows smoke) still pass

## Out of scope (deferred to V2)

Full cross-OS *linking* — taking a Linux ELF source on a Windows host all the way to a runnable `<exe>` without copying — would need either a bundled `clang+lld+sysroot` toolchain or a `zig cc` dependency. Both are substantial. `--emit-object` covers the common case (build farm produces objects, target machine links) without that complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)