### PR TITLE
feat(dsp-conv): DSP04 Phase 3 — scalar conv2d for [H, W] images

### DIFF
--- a/code/packages/rust/dsp-conv/CHANGELOG.md
+++ b/code/packages/rust/dsp-conv/CHANGELOG.md
@@ -1,5 +1,111 @@
 # Changelog — dsp-conv
 
+## 0.2.0 — 2026-05-16
+
+### Added — DSP04 Phase 3 (scalar conv2d for [H, W] images)
+
+Adds same-size 2-D convolution on row-major `[H, W]` real
+`f32` images.  Uses the same four boundary modes as `conv1d`,
+applied independently along each axis.
+
+#### Public API
+
+```rust
+pub fn conv2d(
+    image: &[f32],
+    kernel: &[f32],
+    image_height: u32, image_width: u32,
+    kernel_height: u32, kernel_width: u32,
+    mode: BoundaryMode,
+) -> Result<Vec<f32>, ConvError>;
+```
+
+Re-exported at the crate root.
+
+#### Algorithm
+
+Direct 2-D convolution with kernel centred at `(KH/2, KW/2)`:
+
+```text
+    out[r, c] = Σ_{kr, kc}  kernel[kr, kc]
+                           · image_ext[r + ch - kr, c + cw - kc]
+```
+
+Boundary extension is applied per axis via the shared
+`extend_index` helper (extracted from `conv1d`'s `sample`
+during this PR — pure refactor, all prior tests still pass).
+
+`O(H · W · KH · KW)` time, `O(H · W)` memory.  Phase 4 will
+add `sep_conv2d` for separable kernels with `O(H · W · (KH + KW))`.
+
+#### Validation
+
+- `image_height == 0 || image_width == 0` → `ImageSizeMismatch`
+- `image.len() != H · W` → `ImageSizeMismatch`
+- `kernel_height == 0 || kernel_width == 0` → `EmptyKernel`
+- `kernel.len() != KH · KW` → `ImageSizeMismatch`
+- `kernel_height > image_height || kernel_width > image_width`
+  → `KernelTooLarge` (V1 simplification; Reflect mode's
+  formula assumes the kernel fits)
+- `checked_mul` on `H · W` and `KH · KW` guards against
+  overflow on huge u32 inputs.
+
+#### New unit tests — 11
+
+Error paths (6):
+- `conv2d_rejects_zero_height`, `conv2d_rejects_zero_width`
+- `conv2d_rejects_image_size_mismatch`,
+  `conv2d_rejects_kernel_size_mismatch`
+- `conv2d_rejects_kernel_too_large`
+- `conv2d_rejects_empty_kernel`
+
+Closed-form (2):
+- `conv2d_identity_kernel_returns_image` — 1×1 kernel = identity
+  under all modes.
+- `conv2d_centred_delta_preserves_image` — 3×3 centred delta
+  = identity under all modes.
+
+Invariants (1):
+- `conv2d_box_kernel_on_constant_image_passes_through` —
+  3×3 normalised box on constant 5×5 image yields the same
+  constant under Replicate (and at the interior under all
+  modes).
+
+Separability cross-check (1):
+- `conv2d_outer_product_matches_sequential_conv1d` — a 3×3
+  separable kernel `[1,2,1] ⊗ [1,2,1]` (normalised) computed
+  via `conv2d` matches the row-then-column composition via
+  `conv1d` along each axis with the same boundary mode.
+
+Boundary modes spot-check (1):
+- `conv2d_boundary_modes_differ_at_corner` — corner pixel
+  (0, 0) of a 3×3 image with a 3×3 uniform kernel yields a
+  distinct value under each of the 4 boundary modes
+  (Zero=12, Replicate=21, Reflect and Wrap also distinct).
+
+All 26 unit tests + 1 doctest pass (15 conv1d + 11 conv2d).
+
+#### Internal refactor
+
+The 1-D `sample()` helper has been split:
+- `extend_index(idx, n, mode) -> Option<usize>` — maps an
+  index to its valid source position via boundary extension,
+  or returns `None` for Zero-mode out-of-bounds.  `pub(crate)`
+  so 2-D conv2d can call it twice (once per axis).
+- `sample` is now a thin wrapper around `extend_index`.
+
+Pure refactor — all prior conv1d tests still pass.
+
+### What this phase does NOT include
+
+- Phase 4: `sep_conv2d` (separable 2-D convolution — much faster
+  for blurs/Gaussians where the kernel factors).
+- Phase 5: image filter design helpers (Gaussian, Sobel, box,
+  Laplacian, sharpen).
+- Phase 6: matrix-ir-lowered `conv1d` / `conv2d` via dsp-fft.
+- Strided / dilated convolution.
+- Multi-channel `[B, H, W, C]` images.
+
 ## 0.1.0 — 2026-05-16
 
 ### Added — DSP04 Phase 1 + 2 (crate skeleton + scalar conv1d with 4 boundary modes)

--- a/code/packages/rust/dsp-conv/Cargo.toml
+++ b/code/packages/rust/dsp-conv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dsp-conv"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "DSP04 Phase 1+2: scalar reference same-size 1-D convolution with 4 boundary modes (Zero, Replicate, Reflect, Wrap). Complements dsp-filters::fir (which is full-mode N+K-1 output) by providing the same-size N output image-processing API. Phase 3 adds 2-D conv2d for images; Phase 5 adds Gaussian / Sobel / box / Laplacian / sharpen design helpers."
+description = "DSP04 Phases 1-3: scalar reference same-size 1-D and 2-D convolution with 4 boundary modes (Zero, Replicate, Reflect, Wrap). conv1d for signal filtering, conv2d for image filtering on row-major [H, W] f32 images. Complements dsp-filters::fir's full-mode output by providing the same-size image-processing API. Phase 4 adds sep_conv2d for separable kernels; Phase 5 adds Gaussian / Sobel / box / Laplacian / sharpen design helpers."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/dsp-conv/README.md
+++ b/code/packages/rust/dsp-conv/README.md
@@ -1,13 +1,19 @@
 # dsp-conv
 
-**DSP04 Phase 1+2** — scalar reference same-size 1-D
-convolution for the DSP layer.
+Scalar reference 1-D and 2-D convolution for the DSP layer.
 
-`dsp-conv` complements `dsp-filters::fir` (which produces the
-full `N + K - 1` linear-convolution output) by providing the
-**same-size** `N`-length output that image processing and
-filter chains usually want, plus explicit control over the
-boundary extension at the edges.
+As of **0.2.0 (DSP04 Phase 3)** this crate ships:
+
+- **1-D** (`conv1d`) — same-size signal convolution.
+- **2-D** (`conv2d`) — same-size image convolution on
+  row-major `[H, W]` real `f32` buffers.
+
+Complements `dsp-filters::fir` (which produces the full
+`N + K - 1` linear-convolution output) by providing the
+**same-size** output that image processing and filter chains
+usually want, plus explicit control over the boundary
+extension at the edges (`Zero` / `Replicate` / `Reflect` /
+`Wrap`).
 
 ```rust
 use dsp_conv::{conv1d, BoundaryMode};
@@ -73,21 +79,39 @@ pub enum ConvError {
 | Phase  | Lands                                                | Status |
 | ------ | ---------------------------------------------------- | ------ |
 | 0      | Spec (`code/specs/DSP04-convolution.md`)             | landed |
-| **1+2** | **Crate skeleton + scalar `conv1d` with 4 boundary modes** | **this PR (0.1.0)** |
-| 3      | Scalar `conv2d` for row-major `[H, W]` images        | pending |
+| 1+2    | Crate skeleton + scalar `conv1d` with 4 boundary modes | landed (0.1.0) |
+| **3**  | **Scalar `conv2d` for row-major `[H, W]` images**    | **this PR (0.2.0)** |
 | 4      | `sep_conv2d` for separable kernels                   | pending |
 | 5      | Image filter design helpers (Gaussian / Sobel / box / Laplacian / sharpen) | pending |
 | 6      | Matrix-ir-lowered `conv1d` / `conv2d`                | pending |
 
+## 2-D conv example (Phase 3)
+
+```rust
+use dsp_conv::{conv2d, BoundaryMode};
+
+// 3×3 box-blur kernel (normalised).
+let kernel = vec![1.0_f32 / 9.0; 9];
+
+// 5×5 row-major image.
+let image: Vec<f32> = (0..25).map(|i| i as f32).collect();
+
+let blurred = conv2d(&image, &kernel, 5, 5, 3, 3, BoundaryMode::Replicate)
+    .unwrap();
+assert_eq!(blurred.len(), 25);
+```
+
 ## Tests
 
-`cargo test -p dsp-conv` exercises:
+`cargo test -p dsp-conv` — 26 unit tests + 1 doctest:
 
-- Error paths: empty signal, empty kernel.
-- Closed-form: identity kernel `[1.0]` is identity; centred
-  delta kernel preserves the signal.
-- Output length contract: `output.len() == signal.len()`.
-- All 4 boundary modes verified with handwritten expected
-  outputs.
-- `conv1d(_, _, Zero)` matches the centre slice of
-  `dsp_filters::fir(_, _)`.
+- 15 from Phase 1+2 (1-D): error paths, identity / centred-delta,
+  output length contract, all 4 boundary modes with handwritten
+  expected outputs, fir cross-check, periodicity / replicate /
+  symmetry / integral invariants.
+- 11 from Phase 3 (2-D, this release): error paths (zero dims,
+  size mismatch, kernel-too-large), 1×1 + 3×3 identity, constant
+  image + box kernel = constant, 3×3 outer-product matches
+  sequential conv1d (separability cross-check), boundary modes
+  produce distinct corner values for a 3×3 image / 3×3 uniform
+  kernel.

--- a/code/packages/rust/dsp-conv/src/lib.rs
+++ b/code/packages/rust/dsp-conv/src/lib.rs
@@ -34,15 +34,21 @@
 //! ## Phase scope
 //!
 //! - **Phase 0** — spec (`code/specs/DSP04-convolution.md`).
-//! - **Phase 1+2 (this release)** — crate skeleton + scalar
-//!   `conv1d` with 4 boundary modes.
-//! - **Phase 3** — scalar `conv2d` for `[H, W]` images.
-//! - **Phase 4** — `sep_conv2d` (separable 2-D conv).
+//! - **Phase 1+2** — crate skeleton + scalar `conv1d` with
+//!   4 boundary modes.  Landed as 0.1.0.
+//! - **Phase 3 (this release)** — scalar [`conv2d`] for
+//!   `[H, W]` images.  Row-major, same-size output, boundary
+//!   extension applied independently along each axis.
+//! - **Phase 4** — `sep_conv2d` (separable 2-D conv — much
+//!   faster for blurs / Gaussians where the kernel factors).
 //! - **Phase 5** — image filter design helpers (Gaussian,
 //!   Sobel, box, Laplacian, sharpen).
 //! - **Phase 6** — matrix-ir-lowered `conv1d` / `conv2d`.
 
 #![warn(rust_2018_idioms)]
+
+pub mod two_d;
+pub use two_d::conv2d;
 
 use std::fmt;
 
@@ -120,16 +126,28 @@ pub fn conv1d(
 /// Helper: read `signal` at a possibly-out-of-bounds index,
 /// extending via the chosen `mode`.
 fn sample(signal: &[f32], idx: isize, mode: BoundaryMode) -> f32 {
-    let n = signal.len() as isize;
+    match extend_index(idx, signal.len() as isize, mode) {
+        Some(i) => signal[i],
+        None => 0.0,
+    }
+}
+
+/// **Phase 3 helper.**  Map a possibly-out-of-bounds index `idx`
+/// into a valid source index in `[0, n)` per the boundary `mode`,
+/// or return `None` when the mode is `Zero` and the index falls
+/// outside the support (i.e. the convolution should accumulate
+/// `0` for that tap).
+///
+/// `n` must be `≥ 1`.  This is used by both the 1-D `sample`
+/// here and the 2-D conv2d in the [`crate::two_d`] module, which
+/// applies the extension along each axis independently.
+pub(crate) fn extend_index(idx: isize, n: isize, mode: BoundaryMode) -> Option<usize> {
     if idx >= 0 && idx < n {
-        return signal[idx as usize];
+        return Some(idx as usize);
     }
     match mode {
-        BoundaryMode::Zero => 0.0,
-        BoundaryMode::Replicate => {
-            let clamped = idx.clamp(0, n - 1) as usize;
-            signal[clamped]
-        }
+        BoundaryMode::Zero => None,
+        BoundaryMode::Replicate => Some(idx.clamp(0, n - 1) as usize),
         BoundaryMode::Reflect => {
             // Mirror about both boundaries.  Works for arbitrarily
             // far indices via the "fold into [-N+1, N) twice"
@@ -141,20 +159,19 @@ fn sample(signal: &[f32], idx: isize, mode: BoundaryMode) -> f32 {
             //
             // For N = 1 the period collapses; we special-case it.
             if n == 1 {
-                return signal[0];
+                return Some(0);
             }
             let period = 2 * (n - 1);
             let mut m = idx.rem_euclid(period);
             if m >= n {
                 m = 2 * (n - 1) - m;
             }
-            signal[m as usize]
+            Some(m as usize)
         }
         BoundaryMode::Wrap => {
             // Modular index — `rem_euclid` handles negatives
             // correctly.
-            let m = idx.rem_euclid(n) as usize;
-            signal[m]
+            Some(idx.rem_euclid(n) as usize)
         }
     }
 }

--- a/code/packages/rust/dsp-conv/src/two_d.rs
+++ b/code/packages/rust/dsp-conv/src/two_d.rs
@@ -1,0 +1,400 @@
+//! # 2-D convolution for image filtering (DSP04 Phase 3)
+//!
+//! Adds [`conv2d`] for same-size 2-D convolution on row-major
+//! `[H, W]` real `f32` images.  Uses the same four boundary
+//! modes as 1-D conv ([`crate::BoundaryMode`]).
+//!
+//! ## Algorithm
+//!
+//! Direct 2-D convolution.  For each output `(r, c)`:
+//!
+//! ```text
+//!     out[r, c] = Σ_{kr, kc}  kernel[kr, kc]
+//!                            · image_ext[r + ch - kr, c + cw - kc]
+//! ```
+//!
+//! where `ch = KH / 2` and `cw = KW / 2` (integer division for
+//! upper-centre on even kernel sizes), and `image_ext` extends
+//! the image past `[0, H) × [0, W)` per the chosen boundary
+//! mode along each axis independently.
+//!
+//! `O(H · W · KH · KW)` time, `O(H · W)` memory.  Phase 4 will
+//! add `sep_conv2d` for the row-then-column fast path on
+//! separable kernels (`O(H · W · (KH + KW))`).
+//!
+//! ## Use cases
+//!
+//! - Gaussian blur, box blur — separable kernels (faster via
+//!   `sep_conv2d` in Phase 4, but `conv2d` works too).
+//! - Sobel / Prewitt / Scharr edge detection — directional 3×3
+//!   kernels.
+//! - Laplacian, sharpen, emboss — short non-separable kernels
+//!   where `conv2d` is the natural API.
+
+use crate::{extend_index, BoundaryMode, ConvError};
+
+/// Same-size 2-D convolution on a row-major `[H, W]` real
+/// image.
+///
+/// - `image` must have `image.len() == H · W`, row-major
+///   (`image[r * W + c]` is the pixel at row `r`, col `c`).
+/// - `kernel` must have `kernel.len() == KH · KW`, row-major.
+/// - Output is a same-size `[H, W]` row-major `Vec<f32>`.
+/// - Kernel is centred at `(KH / 2, KW / 2)` — matches
+///   `scipy.ndimage.convolve`.
+pub fn conv2d(
+    image: &[f32],
+    kernel: &[f32],
+    image_height: u32,
+    image_width: u32,
+    kernel_height: u32,
+    kernel_width: u32,
+    mode: BoundaryMode,
+) -> Result<Vec<f32>, ConvError> {
+    if image_height == 0 || image_width == 0 {
+        return Err(ConvError::ImageSizeMismatch(format!(
+            "image dimensions must be non-zero; got {}×{}",
+            image_height, image_width
+        )));
+    }
+    if kernel_height == 0 || kernel_width == 0 {
+        return Err(ConvError::EmptyKernel);
+    }
+    let h = image_height as usize;
+    let w = image_width as usize;
+    let kh = kernel_height as usize;
+    let kw = kernel_width as usize;
+
+    let expected_image_len = h.checked_mul(w).ok_or_else(|| {
+        ConvError::ImageSizeMismatch(format!(
+            "image dimensions overflow: {}×{}",
+            h, w
+        ))
+    })?;
+    if image.len() != expected_image_len {
+        return Err(ConvError::ImageSizeMismatch(format!(
+            "image length {} does not match {}×{} = {}",
+            image.len(),
+            h,
+            w,
+            expected_image_len
+        )));
+    }
+    let expected_kernel_len = kh.checked_mul(kw).ok_or_else(|| {
+        ConvError::ImageSizeMismatch(format!(
+            "kernel dimensions overflow: {}×{}",
+            kh, kw
+        ))
+    })?;
+    if kernel.len() != expected_kernel_len {
+        return Err(ConvError::ImageSizeMismatch(format!(
+            "kernel length {} does not match {}×{} = {}",
+            kernel.len(),
+            kh,
+            kw,
+            expected_kernel_len
+        )));
+    }
+    // V1 simplification: require kernel to fit inside the image.
+    // Reflect mode's boundary extension formula assumes
+    // `kernel_height ≤ image_height` (and similarly for width)
+    // so it never reflects past the image's other edge.
+    if kh > h || kw > w {
+        return Err(ConvError::KernelTooLarge(format!(
+            "kernel {}×{} exceeds image {}×{}",
+            kh, kw, h, w
+        )));
+    }
+
+    let ch = (kh / 2) as isize; // kernel centre row
+    let cw = (kw / 2) as isize; // kernel centre col
+    let h_isize = h as isize;
+    let w_isize = w as isize;
+
+    // ── Main convolution loop.
+    //
+    // For each output (r, c) in [0, H) × [0, W), sum over
+    // kernel taps (kr, kc) in [0, KH) × [0, KW).  Source row is
+    // `r + ch - kr`, source col is `c + cw - kc`.  Boundary
+    // extension is applied independently along each axis via
+    // the shared `extend_index` helper from lib.rs.
+    let mut out = vec![0.0f32; expected_image_len];
+    for r in 0..h {
+        for c in 0..w {
+            let mut acc = 0.0f32;
+            for kr in 0..kh {
+                let src_r = (r as isize) + ch - (kr as isize);
+                let row = match extend_index(src_r, h_isize, mode) {
+                    Some(rr) => rr,
+                    None => continue, // Zero mode, row out of bounds
+                };
+                for kc in 0..kw {
+                    let src_c = (c as isize) + cw - (kc as isize);
+                    let col = match extend_index(src_c, w_isize, mode) {
+                        Some(cc) => cc,
+                        None => continue,
+                    };
+                    let img_v = image[row * w + col];
+                    let ker_v = kernel[kr * kw + kc];
+                    acc += img_v * ker_v;
+                }
+            }
+            out[r * w + c] = acc;
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conv1d;
+
+    fn approx_eq(a: f32, b: f32, tol: f32) -> bool {
+        let scale = a.abs().max(b.abs()).max(1.0);
+        (a - b).abs() <= scale * tol
+    }
+
+    fn assert_close(a: &[f32], b: &[f32], tol: f32) {
+        assert_eq!(a.len(), b.len(), "length mismatch");
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!(
+                approx_eq(*x, *y, tol),
+                "mismatch at {}: {} vs {} (tol {})",
+                i,
+                x,
+                y,
+                tol
+            );
+        }
+    }
+
+    // ── error paths ────────────────────────────────────────────
+
+    #[test]
+    fn conv2d_rejects_zero_height() {
+        let err = conv2d(&[], &[1.0], 0, 8, 1, 1, BoundaryMode::Zero).unwrap_err();
+        assert!(matches!(err, ConvError::ImageSizeMismatch(_)));
+    }
+
+    #[test]
+    fn conv2d_rejects_zero_width() {
+        let err = conv2d(&[], &[1.0], 8, 0, 1, 1, BoundaryMode::Zero).unwrap_err();
+        assert!(matches!(err, ConvError::ImageSizeMismatch(_)));
+    }
+
+    #[test]
+    fn conv2d_rejects_image_size_mismatch() {
+        // 4×4 image expects 16 floats; we pass 8.
+        let img = vec![0.0f32; 8];
+        let err =
+            conv2d(&img, &[1.0], 4, 4, 1, 1, BoundaryMode::Zero).unwrap_err();
+        assert!(matches!(err, ConvError::ImageSizeMismatch(_)));
+    }
+
+    #[test]
+    fn conv2d_rejects_kernel_size_mismatch() {
+        // 3×3 kernel expects 9 floats; we pass 4.
+        let img = vec![0.0f32; 16];
+        let err =
+            conv2d(&img, &[1.0; 4], 4, 4, 3, 3, BoundaryMode::Zero).unwrap_err();
+        assert!(matches!(err, ConvError::ImageSizeMismatch(_)));
+    }
+
+    #[test]
+    fn conv2d_rejects_kernel_too_large() {
+        // 5×5 kernel on a 3×3 image.
+        let img = vec![0.0f32; 9];
+        let kernel = vec![0.0f32; 25];
+        let err =
+            conv2d(&img, &kernel, 3, 3, 5, 5, BoundaryMode::Zero).unwrap_err();
+        assert!(matches!(err, ConvError::KernelTooLarge(_)));
+    }
+
+    #[test]
+    fn conv2d_rejects_empty_kernel() {
+        let img = vec![0.0f32; 9];
+        let err = conv2d(&img, &[], 3, 3, 0, 0, BoundaryMode::Zero).unwrap_err();
+        assert!(matches!(err, ConvError::EmptyKernel));
+    }
+
+    // ── closed-form ────────────────────────────────────────────
+
+    #[test]
+    fn conv2d_identity_kernel_returns_image() {
+        // 1×1 kernel = [1.0] is the convolutional identity.
+        let img: Vec<f32> = (0..16).map(|i| i as f32).collect();
+        for &mode in &[
+            BoundaryMode::Zero,
+            BoundaryMode::Replicate,
+            BoundaryMode::Reflect,
+            BoundaryMode::Wrap,
+        ] {
+            let out = conv2d(&img, &[1.0], 4, 4, 1, 1, mode).unwrap();
+            assert_close(&out, &img, 1e-7);
+        }
+    }
+
+    #[test]
+    fn conv2d_centred_delta_preserves_image() {
+        // 3×3 kernel with 1 at the centre, zeros elsewhere is
+        // also the convolutional identity in conv terms.
+        let img: Vec<f32> = (0..16).map(|i| (i as f32) * 0.5).collect();
+        let mut kernel = vec![0.0f32; 9];
+        kernel[4] = 1.0; // centre of 3×3
+        for &mode in &[
+            BoundaryMode::Zero,
+            BoundaryMode::Replicate,
+            BoundaryMode::Reflect,
+            BoundaryMode::Wrap,
+        ] {
+            let out = conv2d(&img, &kernel, 4, 4, 3, 3, mode).unwrap();
+            assert_close(&out, &img, 1e-7);
+        }
+    }
+
+    #[test]
+    fn conv2d_box_kernel_on_constant_image_passes_through() {
+        // 3×3 box kernel (normalised to sum=1) on a constant 5×5
+        // image should yield the same constant — under Replicate
+        // there are no edge artefacts; under all modes the
+        // interior is fine.
+        let img = vec![3.5f32; 25];
+        let kernel = vec![1.0 / 9.0; 9];
+        let out =
+            conv2d(&img, &kernel, 5, 5, 3, 3, BoundaryMode::Replicate).unwrap();
+        for &v in &out {
+            assert!(
+                approx_eq(v, 3.5, 1e-5),
+                "constant 2-D yielded {}, expected 3.5",
+                v
+            );
+        }
+        // Also check the interior under all four modes.
+        for &mode in &[
+            BoundaryMode::Zero,
+            BoundaryMode::Replicate,
+            BoundaryMode::Reflect,
+            BoundaryMode::Wrap,
+        ] {
+            let out2 = conv2d(&img, &kernel, 5, 5, 3, 3, mode).unwrap();
+            // Interior pixels: (r, c) in [1..4) × [1..4) — every
+            // mode is identical here since no boundary samples
+            // enter the sum.
+            for r in 1..4 {
+                for c in 1..4 {
+                    let v = out2[r * 5 + c];
+                    assert!(
+                        approx_eq(v, 3.5, 1e-5),
+                        "interior pixel ({},{}) under {:?} = {}",
+                        r,
+                        c,
+                        mode,
+                        v
+                    );
+                }
+            }
+        }
+    }
+
+    // ── separability cross-check ───────────────────────────────
+
+    #[test]
+    fn conv2d_outer_product_matches_sequential_conv1d() {
+        // A separable 3×3 kernel:
+        //   [[1, 2, 1],
+        //    [2, 4, 2],     = [1, 2, 1] ⊗ [1, 2, 1]  (normalised)
+        //    [1, 2, 1]]
+        //
+        // Applying it via conv2d should match applying
+        // conv1d horizontally to each row, then conv1d
+        // vertically to each column (same boundary mode).
+        let h = 5;
+        let w = 7;
+        let img: Vec<f32> = (0..(h * w))
+            .map(|i| ((i as f32) * 0.13).sin() + 0.4)
+            .collect();
+        let h1d = vec![1.0f32 / 4.0, 2.0 / 4.0, 1.0 / 4.0];
+        let kernel_2d: Vec<f32> = {
+            let mut k = vec![0.0f32; 9];
+            for r in 0..3 {
+                for c in 0..3 {
+                    k[r * 3 + c] = h1d[r] * h1d[c];
+                }
+            }
+            k
+        };
+        let mode = BoundaryMode::Replicate;
+        let via_2d =
+            conv2d(&img, &kernel_2d, h as u32, w as u32, 3, 3, mode).unwrap();
+
+        // Row pass: conv1d along each row.
+        let mut intermediate = vec![0.0f32; h * w];
+        for r in 0..h {
+            let row = &img[r * w..(r + 1) * w];
+            let row_out = conv1d(row, &h1d, mode).unwrap();
+            intermediate[r * w..(r + 1) * w].copy_from_slice(&row_out);
+        }
+        // Column pass: gather column, conv1d, scatter back.
+        let mut via_separable = vec![0.0f32; h * w];
+        let mut col_buf = vec![0.0f32; h];
+        for c in 0..w {
+            for r in 0..h {
+                col_buf[r] = intermediate[r * w + c];
+            }
+            let col_out = conv1d(&col_buf, &h1d, mode).unwrap();
+            for r in 0..h {
+                via_separable[r * w + c] = col_out[r];
+            }
+        }
+        assert_close(&via_2d, &via_separable, 1e-5);
+    }
+
+    // ── boundary mode spot-check ───────────────────────────────
+
+    #[test]
+    fn conv2d_boundary_modes_differ_at_corner() {
+        // 3×3 image of [1, 2, 3; 4, 5, 6; 7, 8, 9] with a 3×3
+        // uniform kernel.  Corner output (0, 0) depends on
+        // boundary extension; verify each mode gives a distinct
+        // value.
+        let img = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let kernel = vec![1.0f32; 9];
+
+        // Zero: corner (0,0) sees image at (-1,-1)=(0), (-1,0)=(0),
+        // (-1,1)=(0), (0,-1)=(0), (0,0)=1, (0,1)=2, (1,-1)=(0),
+        // (1,0)=4, (1,1)=5.  Sum = 1+2+4+5 = 12.
+        let out_zero =
+            conv2d(&img, &kernel, 3, 3, 3, 3, BoundaryMode::Zero).unwrap();
+        assert!(approx_eq(out_zero[0], 12.0, 1e-5), "Zero corner = {}", out_zero[0]);
+
+        // Replicate: corner (0,0) sees (-1,-1)=image[0,0]=1,
+        // (-1,0)=image[0,0]=1, (-1,1)=image[0,1]=2,
+        // (0,-1)=image[0,0]=1, (0,0)=1, (0,1)=2,
+        // (1,-1)=image[1,0]=4, (1,0)=4, (1,1)=5.
+        // Sum = 1+1+2+1+1+2+4+4+5 = 21.
+        let out_rep =
+            conv2d(&img, &kernel, 3, 3, 3, 3, BoundaryMode::Replicate).unwrap();
+        assert!(approx_eq(out_rep[0], 21.0, 1e-5), "Replicate corner = {}", out_rep[0]);
+
+        // All four should give different corner values.  We've
+        // verified two; the other two are well-defined by the
+        // boundary formulas — just check they're all distinct.
+        let out_ref =
+            conv2d(&img, &kernel, 3, 3, 3, 3, BoundaryMode::Reflect).unwrap();
+        let out_wrap =
+            conv2d(&img, &kernel, 3, 3, 3, 3, BoundaryMode::Wrap).unwrap();
+        let corners = [out_zero[0], out_rep[0], out_ref[0], out_wrap[0]];
+        for i in 0..corners.len() {
+            for j in (i + 1)..corners.len() {
+                assert!(
+                    !approx_eq(corners[i], corners[j], 1e-4),
+                    "modes {} and {} both gave corner = {}",
+                    i,
+                    j,
+                    corners[i]
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds \`conv2d(image, kernel, h, w, kh, kw, mode)\` to \`dsp-conv\`. Same-size 2-D convolution on row-major \`[H, W]\` real f32 images with 4 boundary modes applied independently along each axis.
- Direct \`O(H·W·KH·KW)\` algorithm with kernel centered at \`(KH/2, KW/2)\`. Phase 4 will add separable conv for the row-then-column fast path.
- Refactors the 1-D \`sample()\` helper into a \`pub(crate) extend_index()\` so both 1-D and 2-D paths share the same boundary extension code. Pure refactor — all 15 prior \`conv1d\` tests still pass.
- Bumps \`dsp-conv\` 0.1.0 → 0.2.0.

## Test plan

- [x] \`cargo test -p dsp-conv\` — 26 + 1 doctest pass (15 conv1d + 11 conv2d)
- [x] Closed-form: 1×1 identity and 3×3 centered delta preserve image under all modes
- [x] Constant image + 3×3 box kernel = constant under Replicate (and interior under all modes)
- [x] 3×3 outer-product kernel via \`conv2d\` matches sequential \`conv1d\` row-then-column (separability cross-check)
- [x] Corner of 3×3 image / 3×3 uniform kernel produces distinct values per mode (Zero=12, Replicate=21, Reflect and Wrap also distinct)
- [x] Security review passed
- [ ] CI green on origin

## What this phase does NOT include

- Phase 4: \`sep_conv2d\` (separable 2-D conv — much faster for blurs/Gaussians).
- Phase 5: image filter design helpers (Gaussian, Sobel, box, Laplacian, sharpen).
- Phase 6: matrix-ir-lowered \`conv1d\` / \`conv2d\`.
- Strided / dilated convolution.
- Multi-channel \`[B, H, W, C]\` images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)