### PR TITLE
feat(dsp-conv): DSP04 Phase 4+5 — sep_conv2d + image filter design helpers

### DIFF
--- a/code/packages/rust/dsp-conv/CHANGELOG.md
+++ b/code/packages/rust/dsp-conv/CHANGELOG.md
@@ -1,5 +1,109 @@
 # Changelog — dsp-conv
 
+## 0.3.0 — 2026-05-16
+
+### Added — DSP04 Phase 4 + 5 (separable conv + image filter design helpers)
+
+The image-filter toolbox lands.  Adds:
+
+- `sep_conv2d` — separable 2-D convolution (row-then-column).
+  Asymptotically faster than `conv2d` when the 2-D kernel
+  factors: `O(H·W·(KH+KW))` vs `O(H·W·KH·KW)`.
+- Image filter design helpers — `gaussian_blur_kernel`,
+  `box_blur_kernel`, `sobel_x_kernel`, `sobel_y_kernel`,
+  `laplacian_kernel`, `sharpen_kernel`.  The canonical
+  OpenCV / scipy.ndimage primitives.
+
+This makes `dsp-conv` a one-stop-shop for the standard image
+preprocessing pipeline: blur, sharpen, edge-detect, denoise.
+
+#### New module — `dsp_conv::sep`
+
+```rust
+pub fn sep_conv2d(
+    image: &[f32],
+    horizontal_kernel: &[f32],
+    vertical_kernel: &[f32],
+    image_height: u32, image_width: u32,
+    mode: BoundaryMode,
+) -> Result<Vec<f32>, ConvError>;
+```
+
+Two passes: `conv1d` along each row with `horizontal_kernel`,
+then `conv1d` along each column with `vertical_kernel`.  Each
+pass uses the same `BoundaryMode` along its corresponding
+axis.
+
+#### New module — `dsp_conv::kernels`
+
+```rust
+pub fn gaussian_blur_kernel(sigma: f32, size: u32) -> Vec<f32>;
+pub fn box_blur_kernel(size: u32) -> Vec<f32>;
+pub fn sobel_x_kernel() -> Vec<f32>;     // 3x3, 9 floats
+pub fn sobel_y_kernel() -> Vec<f32>;     // 3x3
+pub fn laplacian_kernel() -> Vec<f32>;   // 3x3
+pub fn sharpen_kernel(amount: f32) -> Vec<f32>;  // 3x3
+```
+
+- `gaussian_blur_kernel(σ, size)` — 1-D Gaussian normalised to
+  sum=1.  Pass to `sep_conv2d` as both horizontal + vertical
+  for a separable 2-D Gaussian blur.  Requires odd `size > 0`
+  and `σ > 0`.
+- `box_blur_kernel(size)` — 1-D uniform, each tap = 1/size.
+- `sobel_x_kernel()` / `sobel_y_kernel()` — directional 3×3
+  edge detectors.  Sum to 0 (reject DC).  Pass to `conv2d`
+  with `kernel_height = kernel_width = 3`.
+- `laplacian_kernel()` — 4-connected discrete `∇²` (`[0,1,0; 1,-4,1; 0,1,0]`).
+- `sharpen_kernel(amount)` — identity + `amount` × (-Laplacian).
+  Sums to 1 regardless of `amount` (preserves average
+  brightness).  Common values: `amount ∈ [0.5, 2.0]`.
+
+All re-exported at the crate root.
+
+#### New unit tests — 21
+
+`sep` module (6):
+- 4 error paths: zero dims, empty horizontal kernel, empty
+  vertical kernel, image size mismatch.
+- 1 matches conv2d with outer-product kernel for 3×3 under
+  all 4 boundary modes.
+- 1 matches conv2d for a 5×5 Gaussian-like
+  `[1,4,6,4,1]/16 ⊗ [1,4,6,4,1]/16` under Replicate.
+- 1 identity kernels pass image through unchanged.
+- 1 constant image + normalised separable kernel passes
+  through under Replicate.
+
+`kernels` module (15):
+- Gaussian: sums to 1 across σ ∈ {0.5, 1, 2, 3}; symmetric;
+  peak at centre.
+- Box: sums to 1; all taps uniform.
+- Sobel x/y: sum to 0; Sobel-X applied to a vertical edge
+  produces strong horizontal response (≥ 3× the flat-region
+  response).
+- Laplacian: sums to 0; applied to a constant image produces
+  zero (∇² of constant = 0).
+- Sharpen: amount=0 gives identity kernel; sums to 1 across
+  amounts; constant image passes through.
+
+All 47 unit tests + 1 doctest pass (15 conv1d + 11 conv2d +
+6 sep + 15 kernels).
+
+#### Validation conventions
+
+- `gaussian_blur_kernel` and `box_blur_kernel` panic via
+  `assert!` on invalid input (even/zero size, non-positive
+  σ).  Matches `dsp-filters::design` convention.
+- `sep_conv2d` returns `ConvError` for empty kernels, zero
+  dims, size mismatch, or kernel-larger-than-image.
+
+### What this phase does NOT include
+
+- Phase 6: matrix-ir-lowered `conv1d` / `conv2d` via dsp-fft.
+- Strided / dilated convolution.
+- Multi-channel `[B, H, W, C]` images.
+- Kaiser-window / Lanczos / bilateral / non-linear filters
+  (median, morphological).  DSP05+ territory.
+
 ## 0.2.0 — 2026-05-16
 
 ### Added — DSP04 Phase 3 (scalar conv2d for [H, W] images)

--- a/code/packages/rust/dsp-conv/Cargo.toml
+++ b/code/packages/rust/dsp-conv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dsp-conv"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "DSP04 Phases 1-3: scalar reference same-size 1-D and 2-D convolution with 4 boundary modes (Zero, Replicate, Reflect, Wrap). conv1d for signal filtering, conv2d for image filtering on row-major [H, W] f32 images. Complements dsp-filters::fir's full-mode output by providing the same-size image-processing API. Phase 4 adds sep_conv2d for separable kernels; Phase 5 adds Gaussian / Sobel / box / Laplacian / sharpen design helpers."
+description = "DSP04 Phases 1-5: scalar reference same-size 1-D and 2-D convolution with 4 boundary modes (Zero, Replicate, Reflect, Wrap). conv1d / conv2d for direct convolution, sep_conv2d for the row-then-column fast path on separable kernels (O(H·W·(KH+KW)) vs O(H·W·KH·KW)). Plus image filter design helpers: Gaussian blur, box blur, Sobel x/y, Laplacian, sharpen — the canonical OpenCV-equivalent primitives. Phase 6 (matrix-ir-lowered) is still pending."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/dsp-conv/README.md
+++ b/code/packages/rust/dsp-conv/README.md
@@ -1,19 +1,20 @@
 # dsp-conv
 
-Scalar reference 1-D and 2-D convolution for the DSP layer.
+Scalar reference 1-D and 2-D convolution + image filter
+design helpers for the DSP layer.
 
-As of **0.2.0 (DSP04 Phase 3)** this crate ships:
+As of **0.3.0 (DSP04 Phase 4+5)** this crate ships:
 
 - **1-D** (`conv1d`) — same-size signal convolution.
-- **2-D** (`conv2d`) — same-size image convolution on
-  row-major `[H, W]` real `f32` buffers.
+- **2-D** (`conv2d`) — direct 2-D convolution on `[H, W]`.
+- **2-D separable** (`sep_conv2d`) — row-then-column fast
+  path, `O(H·W·(KH+KW))` instead of `O(H·W·KH·KW)`.
+- **Image filter design** — Gaussian blur, box blur,
+  Sobel x/y, Laplacian, sharpen.  The canonical OpenCV /
+  scipy.ndimage primitives.
 
-Complements `dsp-filters::fir` (which produces the full
-`N + K - 1` linear-convolution output) by providing the
-**same-size** output that image processing and filter chains
-usually want, plus explicit control over the boundary
-extension at the edges (`Zero` / `Replicate` / `Reflect` /
-`Wrap`).
+All four boundary modes (`Zero`, `Replicate`, `Reflect`,
+`Wrap`) are supported throughout.
 
 ```rust
 use dsp_conv::{conv1d, BoundaryMode};
@@ -80,9 +81,8 @@ pub enum ConvError {
 | ------ | ---------------------------------------------------- | ------ |
 | 0      | Spec (`code/specs/DSP04-convolution.md`)             | landed |
 | 1+2    | Crate skeleton + scalar `conv1d` with 4 boundary modes | landed (0.1.0) |
-| **3**  | **Scalar `conv2d` for row-major `[H, W]` images**    | **this PR (0.2.0)** |
-| 4      | `sep_conv2d` for separable kernels                   | pending |
-| 5      | Image filter design helpers (Gaussian / Sobel / box / Laplacian / sharpen) | pending |
+| 3      | Scalar `conv2d` for row-major `[H, W]` images        | landed (0.2.0) |
+| **4+5** | **`sep_conv2d` + image filter design helpers (Gaussian / Sobel / etc)** | **this PR (0.3.0)** |
 | 6      | Matrix-ir-lowered `conv1d` / `conv2d`                | pending |
 
 ## 2-D conv example (Phase 3)

--- a/code/packages/rust/dsp-conv/src/kernels.rs
+++ b/code/packages/rust/dsp-conv/src/kernels.rs
@@ -1,0 +1,361 @@
+//! # Image filter design helpers (DSP04 Phase 5)
+//!
+//! The canonical image-processing kernels you reach for
+//! every time you write `cv2.GaussianBlur`, `cv2.Sobel`, or
+//! `scipy.ndimage.laplace`.
+//!
+//! ## Separable kernels (length-N 1-D)
+//!
+//! These return a 1-D Vec ready to pass to [`crate::sep_conv2d`]
+//! with the same kernel along both axes for symmetric blurs:
+//!
+//! - [`gaussian_blur_kernel`] — Gaussian with given σ and size.
+//! - [`box_blur_kernel`] — uniform box.
+//!
+//! ## Non-separable 3×3 kernels
+//!
+//! These return a 9-element row-major 3×3 Vec ready for
+//! [`crate::conv2d`] (with `kernel_height = kernel_width = 3`):
+//!
+//! - [`sobel_x_kernel`] / [`sobel_y_kernel`] — directional edge
+//!   detection.
+//! - [`laplacian_kernel`] — second-derivative / edge magnitude.
+//! - [`sharpen_kernel`] — identity + scaled negative Laplacian.
+
+use std::f32::consts::PI;
+
+// ─────────────────────────── Separable 1-D ───────────────────────────
+
+/// 1-D Gaussian blur kernel with standard deviation `sigma`
+/// and length `size`.  Normalised so the sum is `1.0`.
+///
+/// `size` must be **odd** so the Gaussian's centre lands on
+/// an integer index.  The function panics if either `size` is
+/// even / zero or `sigma <= 0`.
+///
+/// For separable 2-D Gaussian blur, pass the returned kernel
+/// as both `horizontal_kernel` and `vertical_kernel` to
+/// [`crate::sep_conv2d`].
+///
+/// # Panics
+///
+/// Panics if `size == 0`, `size` is even, or `sigma <= 0.0`.
+pub fn gaussian_blur_kernel(sigma: f32, size: u32) -> Vec<f32> {
+    assert!(size > 0 && size % 2 == 1, "size must be odd and > 0; got {}", size);
+    assert!(sigma > 0.0, "sigma must be > 0; got {}", sigma);
+
+    let n = size as usize;
+    let centre = (n - 1) as f32 / 2.0;
+    let two_sigma_sq = 2.0 * sigma * sigma;
+    let norm_pdf = 1.0 / (sigma * (2.0 * PI).sqrt());
+
+    let mut k = Vec::with_capacity(n);
+    for i in 0..n {
+        let x = (i as f32) - centre;
+        let v = norm_pdf * (-(x * x) / two_sigma_sq).exp();
+        k.push(v);
+    }
+    // Re-normalise so sum = 1 exactly (the discrete truncation
+    // perturbs the analytic 1.0).
+    let sum: f32 = k.iter().sum();
+    if sum > 0.0 {
+        for v in &mut k {
+            *v /= sum;
+        }
+    }
+    k
+}
+
+/// 1-D box blur (uniform) kernel of length `size`.  Each tap
+/// is `1.0 / size` so the kernel sums to `1.0`.
+///
+/// For separable 2-D box blur, pass the returned kernel as
+/// both `horizontal_kernel` and `vertical_kernel` to
+/// [`crate::sep_conv2d`].
+///
+/// # Panics
+///
+/// Panics if `size == 0`.
+pub fn box_blur_kernel(size: u32) -> Vec<f32> {
+    assert!(size > 0, "size must be > 0");
+    let n = size as usize;
+    let v = 1.0 / (n as f32);
+    vec![v; n]
+}
+
+// ─────────────────────────── Non-separable 3×3 ───────────────────────────
+
+/// 3×3 Sobel kernel for horizontal-gradient (edge) detection.
+///
+/// Layout (row-major, length 9):
+///
+/// ```text
+///     [-1,  0,  1,
+///      -2,  0,  2,
+///      -1,  0,  1]
+/// ```
+///
+/// Pass to [`crate::conv2d`] with `kernel_height = 3, kernel_width = 3`.
+/// Sums to 0 (rejects DC) — output is the rate of change in
+/// the horizontal direction at each pixel.
+pub fn sobel_x_kernel() -> Vec<f32> {
+    vec![-1.0, 0.0, 1.0, -2.0, 0.0, 2.0, -1.0, 0.0, 1.0]
+}
+
+/// 3×3 Sobel kernel for vertical-gradient (edge) detection.
+///
+/// Layout (row-major):
+///
+/// ```text
+///     [-1, -2, -1,
+///       0,  0,  0,
+///       1,  2,  1]
+/// ```
+///
+/// Sums to 0.  Output is the vertical gradient — large
+/// positive values where intensity increases downward.
+pub fn sobel_y_kernel() -> Vec<f32> {
+    vec![-1.0, -2.0, -1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 1.0]
+}
+
+/// 3×3 Laplacian kernel — 4-connected discrete approximation
+/// of `∇²`.
+///
+/// ```text
+///     [0,  1, 0,
+///      1, -4, 1,
+///      0,  1, 0]
+/// ```
+///
+/// Sums to 0.  Highlights second-derivative features: edges
+/// and corners stand out.  Often used inside unsharp masking.
+pub fn laplacian_kernel() -> Vec<f32> {
+    vec![0.0, 1.0, 0.0, 1.0, -4.0, 1.0, 0.0, 1.0, 0.0]
+}
+
+/// 3×3 sharpen kernel: identity + `amount` × (-Laplacian).
+///
+/// With `amount = 0.0` you get the identity (kernel does
+/// nothing).  Increasing `amount` increasingly accentuates
+/// edges / high-frequency detail:
+///
+/// ```text
+///     [0,         -amount, 0,
+///     -amount, 1+4·amount, -amount,
+///      0,         -amount, 0]
+/// ```
+///
+/// The kernel sums to `1.0` for any `amount`, so the average
+/// brightness of the image is preserved.  Common values are
+/// `amount ∈ [0.5, 2.0]`.
+pub fn sharpen_kernel(amount: f32) -> Vec<f32> {
+    let c = 1.0 + 4.0 * amount;
+    vec![
+        0.0, -amount, 0.0,
+        -amount, c, -amount,
+        0.0, -amount, 0.0,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{conv2d, BoundaryMode};
+
+    fn approx_eq(a: f32, b: f32, tol: f32) -> bool {
+        let scale = a.abs().max(b.abs()).max(1.0);
+        (a - b).abs() <= scale * tol
+    }
+
+    // ── Gaussian ───────────────────────────────────────────────
+
+    #[test]
+    fn gaussian_kernel_sums_to_one() {
+        for &(sigma, size) in &[(0.5_f32, 3u32), (1.0, 5), (2.0, 9), (3.0, 15)] {
+            let k = gaussian_blur_kernel(sigma, size);
+            let sum: f32 = k.iter().sum();
+            assert!(
+                approx_eq(sum, 1.0, 1e-6),
+                "Gaussian σ={} size={}: sum = {}",
+                sigma,
+                size,
+                sum
+            );
+        }
+    }
+
+    #[test]
+    fn gaussian_kernel_is_symmetric() {
+        let k = gaussian_blur_kernel(1.5, 11);
+        let n = k.len();
+        for i in 0..(n / 2) {
+            assert!(
+                approx_eq(k[i], k[n - 1 - i], 1e-6),
+                "asymmetry at i={}: {} vs {}",
+                i,
+                k[i],
+                k[n - 1 - i]
+            );
+        }
+    }
+
+    #[test]
+    fn gaussian_kernel_peak_at_centre() {
+        let k = gaussian_blur_kernel(1.0, 7);
+        let centre = k.len() / 2;
+        let max = k.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(
+            approx_eq(k[centre], max, 1e-7),
+            "centre {} not max {}",
+            k[centre],
+            max
+        );
+    }
+
+    // ── Box ────────────────────────────────────────────────────
+
+    #[test]
+    fn box_kernel_sums_to_one() {
+        for size in [1u32, 3, 5, 9] {
+            let k = box_blur_kernel(size);
+            let sum: f32 = k.iter().sum();
+            assert!(
+                approx_eq(sum, 1.0, 1e-6),
+                "Box size={}: sum = {}",
+                size,
+                sum
+            );
+        }
+    }
+
+    #[test]
+    fn box_kernel_is_uniform() {
+        let k = box_blur_kernel(7);
+        let expected = 1.0 / 7.0;
+        for &v in &k {
+            assert!(
+                approx_eq(v, expected, 1e-7),
+                "non-uniform tap: {} vs {}",
+                v,
+                expected
+            );
+        }
+    }
+
+    // ── Sobel ──────────────────────────────────────────────────
+
+    #[test]
+    fn sobel_x_kernel_sums_to_zero() {
+        let k = sobel_x_kernel();
+        assert_eq!(k.len(), 9);
+        let sum: f32 = k.iter().sum();
+        assert!(approx_eq(sum, 0.0, 1e-7), "Sobel-X sum = {}", sum);
+    }
+
+    #[test]
+    fn sobel_y_kernel_sums_to_zero() {
+        let k = sobel_y_kernel();
+        assert_eq!(k.len(), 9);
+        let sum: f32 = k.iter().sum();
+        assert!(approx_eq(sum, 0.0, 1e-7), "Sobel-Y sum = {}", sum);
+    }
+
+    #[test]
+    fn sobel_x_responds_to_vertical_edge() {
+        // 5×5 image with a vertical edge: left half = 0, right
+        // half = 1.  Sobel-X should produce a strong response
+        // along the edge column (column 2).
+        let image: Vec<f32> = (0..25)
+            .map(|i| {
+                let c = i % 5;
+                if c >= 3 {
+                    1.0
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        let k = sobel_x_kernel();
+        let out = conv2d(&image, &k, 5, 5, 3, 3, BoundaryMode::Replicate).unwrap();
+
+        // Column 2 (the edge) should have a strong response (≈ ±4).
+        // Verify the magnitude is much higher than at the edges
+        // away from the discontinuity (column 0 or 4).
+        let edge_resp = out[2 * 5 + 2].abs();
+        let flat_resp = out[2 * 5 + 0].abs();
+        assert!(
+            edge_resp > 2.0,
+            "edge response too small: {}",
+            edge_resp
+        );
+        assert!(
+            edge_resp > 3.0 * flat_resp.max(0.1),
+            "edge {} not much bigger than flat {}",
+            edge_resp,
+            flat_resp
+        );
+    }
+
+    // ── Laplacian ──────────────────────────────────────────────
+
+    #[test]
+    fn laplacian_kernel_sums_to_zero() {
+        let k = laplacian_kernel();
+        assert_eq!(k.len(), 9);
+        let sum: f32 = k.iter().sum();
+        assert!(approx_eq(sum, 0.0, 1e-7), "Laplacian sum = {}", sum);
+    }
+
+    #[test]
+    fn laplacian_on_constant_image_is_zero() {
+        // ∇² of a constant is 0.
+        let image = vec![5.0f32; 25];
+        let k = laplacian_kernel();
+        let out = conv2d(&image, &k, 5, 5, 3, 3, BoundaryMode::Replicate).unwrap();
+        for &v in &out {
+            assert!(
+                approx_eq(v, 0.0, 1e-5),
+                "Laplacian on constant = {} (expected 0)",
+                v
+            );
+        }
+    }
+
+    // ── Sharpen ────────────────────────────────────────────────
+
+    #[test]
+    fn sharpen_with_amount_zero_is_identity() {
+        let k = sharpen_kernel(0.0);
+        assert_eq!(k.len(), 9);
+        let expected = vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0];
+        for (i, (a, b)) in k.iter().zip(expected.iter()).enumerate() {
+            assert!(approx_eq(*a, *b, 1e-7), "tap {}: {} vs {}", i, a, b);
+        }
+    }
+
+    #[test]
+    fn sharpen_kernel_sums_to_one() {
+        for &amount in &[0.0_f32, 0.5, 1.0, 2.0] {
+            let k = sharpen_kernel(amount);
+            let sum: f32 = k.iter().sum();
+            assert!(
+                approx_eq(sum, 1.0, 1e-6),
+                "sharpen amount={}: sum = {}",
+                amount,
+                sum
+            );
+        }
+    }
+
+    #[test]
+    fn sharpen_on_constant_image_passes_through() {
+        // Sharpen kernel sums to 1, so constant input → same
+        // constant output (no high-frequency content to amplify).
+        let image = vec![3.0f32; 25];
+        let k = sharpen_kernel(1.5);
+        let out = conv2d(&image, &k, 5, 5, 3, 3, BoundaryMode::Replicate).unwrap();
+        for &v in &out {
+            assert!(approx_eq(v, 3.0, 1e-5), "got {}", v);
+        }
+    }
+}

--- a/code/packages/rust/dsp-conv/src/lib.rs
+++ b/code/packages/rust/dsp-conv/src/lib.rs
@@ -47,7 +47,14 @@
 
 #![warn(rust_2018_idioms)]
 
+pub mod kernels;
+pub mod sep;
 pub mod two_d;
+pub use kernels::{
+    box_blur_kernel, gaussian_blur_kernel, laplacian_kernel, sharpen_kernel,
+    sobel_x_kernel, sobel_y_kernel,
+};
+pub use sep::sep_conv2d;
 pub use two_d::conv2d;
 
 use std::fmt;

--- a/code/packages/rust/dsp-conv/src/sep.rs
+++ b/code/packages/rust/dsp-conv/src/sep.rs
@@ -1,0 +1,325 @@
+//! # Separable 2-D convolution (DSP04 Phase 4)
+//!
+//! Most useful image filter kernels — Gaussian, box blur,
+//! Sobel, anything built from `[1, 2, 1] ⊗ [1, 2, 1]` style
+//! constructions — are **separable**: the 2-D kernel can be
+//! written as the outer product of two 1-D kernels.  When
+//! that's true, computing the 2-D convolution as one row-pass
+//! followed by one column-pass cuts the work from
+//! `O(H · W · KH · KW)` down to `O(H · W · (KH + KW))` —
+//! a big win for typical 3×3, 5×5, 7×7, … kernels.
+//!
+//! ## Algorithm
+//!
+//! ```text
+//!   intermediate[r, c] = Σ_k  horizontal_kernel[k]
+//!                            · image_ext[r, c + cw - k]
+//!
+//!   out[r, c]          = Σ_k  vertical_kernel[k]
+//!                            · intermediate_ext[r + ch - k, c]
+//! ```
+//!
+//! Each pass is a call to [`crate::conv1d`] under the hood
+//! (row pass takes a length-`W` slice and outputs a length-`W`
+//! slice; column pass gathers a length-`H` column, runs
+//! `conv1d`, scatters back).
+//!
+//! The boundary mode is applied along the corresponding axis
+//! in each pass.
+
+use crate::{conv1d, BoundaryMode, ConvError};
+
+/// Same-size separable 2-D convolution.  Applies
+/// `horizontal_kernel` along each row of `image`, then
+/// `vertical_kernel` down each column of the result.  Output
+/// is the same `[H, W]` row-major buffer as the input.
+///
+/// Asymptotically faster than [`crate::conv2d`] when the
+/// 2-D kernel factors as `vertical_kernel ⊗ horizontal_kernel`:
+///
+/// - Direct 2-D: `O(H · W · KH · KW)`
+/// - Separable:  `O(H · W · (KH + KW))`
+///
+/// For a 5×5 Gaussian on a 1080p image that's the difference
+/// between 50M and 20M multiplies — 2.5× faster.
+///
+/// Both kernels are independently subject to the empty-kernel
+/// check; either being empty returns `ConvError::EmptyKernel`.
+/// Image-dimension checks match [`crate::conv2d`].
+///
+/// The boundary mode is applied along the horizontal axis
+/// during the row pass and along the vertical axis during
+/// the column pass.
+pub fn sep_conv2d(
+    image: &[f32],
+    horizontal_kernel: &[f32],
+    vertical_kernel: &[f32],
+    image_height: u32,
+    image_width: u32,
+    mode: BoundaryMode,
+) -> Result<Vec<f32>, ConvError> {
+    if image_height == 0 || image_width == 0 {
+        return Err(ConvError::ImageSizeMismatch(format!(
+            "image dimensions must be non-zero; got {}×{}",
+            image_height, image_width
+        )));
+    }
+    if horizontal_kernel.is_empty() || vertical_kernel.is_empty() {
+        return Err(ConvError::EmptyKernel);
+    }
+    let h = image_height as usize;
+    let w = image_width as usize;
+    let expected_image_len = h.checked_mul(w).ok_or_else(|| {
+        ConvError::ImageSizeMismatch(format!(
+            "image dimensions overflow: {}×{}",
+            h, w
+        ))
+    })?;
+    if image.len() != expected_image_len {
+        return Err(ConvError::ImageSizeMismatch(format!(
+            "image length {} does not match {}×{} = {}",
+            image.len(),
+            h,
+            w,
+            expected_image_len
+        )));
+    }
+    if horizontal_kernel.len() > w {
+        return Err(ConvError::KernelTooLarge(format!(
+            "horizontal kernel length {} > image width {}",
+            horizontal_kernel.len(),
+            w
+        )));
+    }
+    if vertical_kernel.len() > h {
+        return Err(ConvError::KernelTooLarge(format!(
+            "vertical kernel length {} > image height {}",
+            vertical_kernel.len(),
+            h
+        )));
+    }
+
+    // ── Step 1: row pass.  For each row r ∈ [0, H), run
+    //   conv1d(image[r * W..(r+1) * W], horizontal_kernel)
+    //   and store into intermediate[r * W..(r+1) * W].
+    let mut intermediate = vec![0.0f32; expected_image_len];
+    for r in 0..h {
+        let row = &image[r * w..(r + 1) * w];
+        let row_out = conv1d(row, horizontal_kernel, mode)?;
+        intermediate[r * w..(r + 1) * w].copy_from_slice(&row_out);
+    }
+
+    // ── Step 2: column pass.  For each column c ∈ [0, W),
+    //   gather intermediate[:, c] into a temp vec, run
+    //   conv1d(.., vertical_kernel), scatter back.
+    let mut out = vec![0.0f32; expected_image_len];
+    let mut col_buf = vec![0.0f32; h];
+    for c in 0..w {
+        for r in 0..h {
+            col_buf[r] = intermediate[r * w + c];
+        }
+        let col_out = conv1d(&col_buf, vertical_kernel, mode)?;
+        for r in 0..h {
+            out[r * w + c] = col_out[r];
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conv2d;
+
+    fn approx_eq(a: f32, b: f32, tol: f32) -> bool {
+        let scale = a.abs().max(b.abs()).max(1.0);
+        (a - b).abs() <= scale * tol
+    }
+
+    fn assert_close(a: &[f32], b: &[f32], tol: f32) {
+        assert_eq!(a.len(), b.len(), "length mismatch");
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!(
+                approx_eq(*x, *y, tol),
+                "mismatch at {}: {} vs {} (tol {})",
+                i,
+                x,
+                y,
+                tol
+            );
+        }
+    }
+
+    /// Build the outer product of `v_kernel` (length KH) and
+    /// `h_kernel` (length KW) as a row-major flattened
+    /// `[KH, KW]` buffer of length KH * KW.
+    ///
+    /// `outer[r * KW + c] = v_kernel[r] * h_kernel[c]`.
+    fn outer_product(v_kernel: &[f32], h_kernel: &[f32]) -> Vec<f32> {
+        let kh = v_kernel.len();
+        let kw = h_kernel.len();
+        let mut k = vec![0.0f32; kh * kw];
+        for r in 0..kh {
+            for c in 0..kw {
+                k[r * kw + c] = v_kernel[r] * h_kernel[c];
+            }
+        }
+        k
+    }
+
+    // ── error paths ────────────────────────────────────────────
+
+    #[test]
+    fn sep_conv2d_rejects_zero_dims() {
+        let err =
+            sep_conv2d(&[], &[1.0], &[1.0], 0, 8, BoundaryMode::Zero).unwrap_err();
+        assert!(matches!(err, ConvError::ImageSizeMismatch(_)));
+    }
+
+    #[test]
+    fn sep_conv2d_rejects_empty_horizontal_kernel() {
+        let img = vec![0.0f32; 16];
+        let err = sep_conv2d(&img, &[], &[1.0], 4, 4, BoundaryMode::Zero)
+            .unwrap_err();
+        assert!(matches!(err, ConvError::EmptyKernel));
+    }
+
+    #[test]
+    fn sep_conv2d_rejects_empty_vertical_kernel() {
+        let img = vec![0.0f32; 16];
+        let err = sep_conv2d(&img, &[1.0], &[], 4, 4, BoundaryMode::Zero)
+            .unwrap_err();
+        assert!(matches!(err, ConvError::EmptyKernel));
+    }
+
+    #[test]
+    fn sep_conv2d_rejects_image_size_mismatch() {
+        let img = vec![0.0f32; 8];
+        let err =
+            sep_conv2d(&img, &[1.0], &[1.0], 4, 4, BoundaryMode::Zero).unwrap_err();
+        assert!(matches!(err, ConvError::ImageSizeMismatch(_)));
+    }
+
+    // ── matches conv2d with outer-product kernel ───────────────
+
+    #[test]
+    fn sep_conv2d_matches_outer_product_for_3x3() {
+        // Separable kernel: v = [1, 2, 1] / 4, h = [1, 2, 1] / 4.
+        // The 2-D kernel is the outer product.
+        let v = vec![0.25f32, 0.5, 0.25];
+        let h = vec![0.25f32, 0.5, 0.25];
+        let kernel_2d = outer_product(&v, &h);
+
+        let height = 7;
+        let width = 5;
+        let image: Vec<f32> = (0..(height * width))
+            .map(|i| ((i as f32) * 0.13).sin() + 0.4)
+            .collect();
+
+        for &mode in &[
+            BoundaryMode::Zero,
+            BoundaryMode::Replicate,
+            BoundaryMode::Reflect,
+            BoundaryMode::Wrap,
+        ] {
+            let via_sep = sep_conv2d(
+                &image,
+                &h,
+                &v,
+                height as u32,
+                width as u32,
+                mode,
+            )
+            .unwrap();
+            let via_2d = conv2d(
+                &image,
+                &kernel_2d,
+                height as u32,
+                width as u32,
+                3,
+                3,
+                mode,
+            )
+            .unwrap();
+            assert_close(&via_sep, &via_2d, 1e-5);
+        }
+    }
+
+    #[test]
+    fn sep_conv2d_matches_outer_product_5x5_gaussian_under_replicate() {
+        // 5×5 Gaussian-like kernel via outer product of
+        // [1, 4, 6, 4, 1] / 16 with itself.  This is the
+        // binomial approximation to a Gaussian and is
+        // exactly separable.
+        let g = vec![
+            1.0f32 / 16.0,
+            4.0 / 16.0,
+            6.0 / 16.0,
+            4.0 / 16.0,
+            1.0 / 16.0,
+        ];
+        let kernel_2d = outer_product(&g, &g);
+
+        let height = 9;
+        let width = 11;
+        let image: Vec<f32> = (0..(height * width))
+            .map(|i| ((i as f32) * 0.07 + 0.3).sin())
+            .collect();
+
+        let via_sep = sep_conv2d(
+            &image,
+            &g,
+            &g,
+            height as u32,
+            width as u32,
+            BoundaryMode::Replicate,
+        )
+        .unwrap();
+        let via_2d = conv2d(
+            &image,
+            &kernel_2d,
+            height as u32,
+            width as u32,
+            5,
+            5,
+            BoundaryMode::Replicate,
+        )
+        .unwrap();
+        assert_close(&via_sep, &via_2d, 1e-5);
+    }
+
+    #[test]
+    fn sep_conv2d_identity_kernels_pass_through() {
+        // [1.0] × [1.0] is the convolutional identity (1×1
+        // kernel).  Image should pass through unchanged.
+        let image: Vec<f32> = (0..30).map(|i| (i as f32) * 0.1).collect();
+        let out = sep_conv2d(
+            &image,
+            &[1.0],
+            &[1.0],
+            5,
+            6,
+            BoundaryMode::Replicate,
+        )
+        .unwrap();
+        assert_close(&out, &image, 1e-7);
+    }
+
+    #[test]
+    fn sep_conv2d_constant_image_passes_through() {
+        // Constant image + normalised separable kernel +
+        // Replicate should give the same constant.
+        let h = vec![1.0f32 / 3.0; 3];
+        let v = vec![1.0f32 / 3.0; 3];
+        let image = vec![3.5f32; 25];
+        let out = sep_conv2d(&image, &h, &v, 5, 5, BoundaryMode::Replicate)
+            .unwrap();
+        for &val in &out {
+            assert!(
+                approx_eq(val, 3.5, 1e-5),
+                "constant 2-D yielded {}",
+                val
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds \`sep_conv2d(image, h_kernel, v_kernel, h, w, mode)\` for separable 2-D convolution. Asymptotically faster than \`conv2d\` when the kernel factors: \`O(H·W·(KH+KW))\` vs \`O(H·W·KH·KW)\`. For a 5×5 Gaussian on a 1080p image, ~2.5× faster.
- Adds the canonical image filter design helpers: \`gaussian_blur_kernel\`, \`box_blur_kernel\`, \`sobel_x_kernel\`, \`sobel_y_kernel\`, \`laplacian_kernel\`, \`sharpen_kernel\`. The OpenCV / scipy.ndimage primitives every image-processing pipeline reaches for.
- 47 unit tests + 1 doctest pass (21 new). Cross-validation: separable matches direct conv2d via outer-product kernels for 3×3 (all 4 modes) and 5×5 Gaussian. Functional tests: Sobel-X on a vertical edge gives ≥ 3× stronger response than flat regions; Laplacian of constant = 0; sharpen with amount=0 = identity.
- Bumps \`dsp-conv\` 0.2.0 → 0.3.0.

## Test plan

- [x] \`cargo test -p dsp-conv\` — 47 + 1 doctest pass (15 conv1d + 11 conv2d + 6 sep + 15 kernels)
- [x] \`sep_conv2d\` matches \`conv2d\` with outer-product kernel for 3×3 under all 4 boundary modes
- [x] 5×5 Gaussian via separable matches direct \`conv2d\` to 1e-5
- [x] Gaussian kernel sums to 1, is symmetric, peaks at centre
- [x] Sobel-X applied to vertical edge produces strong response (≥ 3× flat regions)
- [x] Laplacian of constant image = 0; sharpen with amount=0 = identity
- [x] Security review passed
- [ ] CI green on origin

## What this phase does NOT include

- Phase 6: matrix-ir-lowered \`conv1d\` / \`conv2d\` via dsp-fft.
- Strided / dilated convolution.
- Multi-channel \`[B, H, W, C]\` images.
- Kaiser / Lanczos / bilateral / non-linear filters (median, morphological) — DSP05+ territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)