### PR TITLE
feat(cas-laplace): extend ILT engine and forward table in Python, TypeScript, Rust

### DIFF
--- a/code/packages/python/cas-laplace/CHANGELOG.md
+++ b/code/packages/python/cas-laplace/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 0.2.0 — 2026-05-16
+
+**Extended ILT engine: complex conjugate poles, repeated poles, improper fractions.
+Extended forward table: t^n·sin(ωt) and t^n·cos(ωt) for n = 2, 3.**
+
+### `inverse_table.py` — extended partial-fraction engine
+
+`_ilt_via_partial_fractions` was previously limited to proper fractions whose
+denominators factored completely over the rationals into distinct simple poles.
+Three new capabilities were added:
+
+1. **Improper fractions** — polynomial long division extracts the quotient `P(s)`.
+   A constant quotient contributes a `DiracDelta(t)` term; higher-degree quotients
+   return unevaluated (δ-derivatives are rare in practice).
+
+2. **Repeated rational poles** — instead of the derivative formula that fails when
+   `Q'(r) = 0`, the engine now uses a formal power-series expansion around the
+   pole: shift `s → r + t`, divide out `t^m`, and read off the first `m` Taylor
+   coefficients of the reduced function.  These become the `A_m, …, A_1`
+   coefficients for the `A_k/(s−r)^k` terms.  All arithmetic is exact Fraction.
+
+3. **Irreducible quadratic factor** — after extracting all rational-root factors,
+   a remaining degree-2 denominator with `b²−4c < 0` is handled by completing
+   the square `(s+α)²+β²` and matching each partial-fraction term against
+   `A*(s+α)/((s+α)²+β²)` and `β/((s+α)²+β²)`, yielding `exp(−αt)·cos(βt)`
+   and `exp(−αt)·sin(βt)` respectively.  When `β` is irrational, a symbolic
+   `Sqrt(β²)` node is built so the output remains exact.
+
+New helper functions: `_is_zero_poly`, `_poly_shift`, `_power_series_coeffs`,
+`_compute_repeated_residues`, `_ilt_poly_term`, `_ilt_irreducible_quad`.
+
+Examples now evaluating:
+- `ilt(1/(s^2+2*s+2), s, t)` → `exp(-t)*sin(t)`
+- `ilt(s/(s^2+2*s+2), s, t)` → `exp(-t)*(cos(t) - sin(t))`
+- `ilt(1/(s-2)^2, s, t)` → `t*exp(2*t)`
+- `ilt(1/(s*(s^2+1)), s, t)` → `UnitStep(t) - cos(t)`
+
+### `table.py` — t^n·trig forward transforms for n = 2, 3
+
+Added `_match_tn_sin` / `_tf_tn_sin` and `_match_tn_cos` / `_tf_tn_cos` to the
+forward transform table for `t^n·sin(ωt)` and `t^n·cos(ωt)` with n ≥ 2.
+
+Closed-form formulas (derived from L{sin/cos} by repeated differentiation):
+
+| f(t)             | F(s) = L{f}(s)                      |
+|------------------|-------------------------------------|
+| t²·sin(ωt)       | 2ω(3s²−ω²) / (s²+ω²)³              |
+| t²·cos(ωt)       | 2s(s²−3ω²) / (s²+ω²)³              |
+| t³·sin(ωt)       | 24ωs(s²−ω²) / (s²+ω²)⁴             |
+| t³·cos(ωt)       | 6(s⁴−6s²ω²+ω⁴) / (s²+ω²)⁴         |
+
+For n ≥ 4 the pattern matches but the builder returns `None`, falling through
+to unevaluated `Laplace(f, t, s)`.
+
 ## 0.1.1 — 2026-05-14
 
 **Bug fixes: infinite recursion guard in `laplace_handler` and `exp(-t)` pattern recognition.**

--- a/code/packages/python/cas-laplace/pyproject.toml
+++ b/code/packages/python/cas-laplace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-laplace"
-version = "0.1.1"
+version = "0.2.0"
 description = "Laplace transform and inverse Laplace transform for the symbolic VM."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-laplace/src/cas_laplace/inverse_table.py
+++ b/code/packages/python/cas-laplace/src/cas_laplace/inverse_table.py
@@ -10,44 +10,47 @@ The inverse Laplace transform (ILT) recovers f(t) from F(s) by:
 
 Inverse table
 -------------
-| F(s)                     | f(t) = L⁻¹{F}(s)          |
-|--------------------------|----------------------------|
-| 1/s                      | UnitStep(t)                |
-| 1/(s-a)                  | exp(a·t)                   |
-| 1/(s-a)^n  (n ≥ 2)       | t^{n-1}·exp(a·t) / (n-1)! |
-| ω/(s²+ω²)                | sin(ω·t)                   |
-| s/(s²+ω²)                | cos(ω·t)                   |
-| ω/((s-a)²+ω²)            | exp(a·t)·sin(ω·t)          |
-| (s-a)/((s-a)²+ω²)        | exp(a·t)·cos(ω·t)          |
-| a/(s²-a²)                | sinh(a·t)                  |
-| s/(s²-a²)                | cosh(a·t)                  |
+| F(s)                       | f(t) = L⁻¹{F}(s)              |
+|----------------------------|--------------------------------|
+| 1/s                        | UnitStep(t)                    |
+| 1/(s-a)                    | exp(a·t)                       |
+| 1/(s-a)^n  (n ≥ 2)         | t^{n-1}·exp(a·t) / (n-1)!     |
+| ω/(s²+ω²)                  | sin(ω·t)                       |
+| s/(s²+ω²)                  | cos(ω·t)                       |
+| ω/((s-a)²+ω²)              | exp(a·t)·sin(ω·t)              |
+| (s-a)/((s-a)²+ω²)          | exp(a·t)·cos(ω·t)              |
+| a/(s²-a²)                  | sinh(a·t)                      |
+| s/(s²-a²)                  | cosh(a·t)                      |
+| c  (constant)              | c·δ(t)   [polynomial part]    |
 
 Partial-fraction decomposition
 -------------------------------
-For a proper rational function P(s)/Q(s) with distinct rational poles
-r_1, ..., r_n, the residue formula gives:
+For a rational function P(s)/Q(s) the engine performs:
 
-    A_i = P(r_i) / Q'(r_i)
+1. **Polynomial long division** (improper fractions): if deg P ≥ deg Q,
+   extract the polynomial quotient.  A degree-0 quotient contributes a
+   DiracDelta(t) term; higher-degree terms are left symbolic.
 
-where Q'(s) is the derivative of Q(s). This is implemented using Python's
-``fractions.Fraction`` for exact rational arithmetic.
+2. **Rational root extraction**: uses the rational root theorem to find
+   all rational roots r_i of Q(s) with their multiplicities m_i.
 
-For the special case of a denominator that contains a simple pole at s=0
-(contributing a UnitStep term) plus other poles, the decomposition is
-applied uniformly.
+3. **Residue computation for repeated rational poles**: uses a formal
+   power-series expansion (shift to s=r, divide out the t^m factor,
+   compute m Taylor coefficients) to find A_{m}, …, A_1 for each
+   multiplicity-m pole without requiring symbolic differentiation.
 
-Limitations (Phase 1)
----------------------
-This implementation handles:
-- Proper fractions (deg P < deg Q)
-- Denominators with all distinct rational roots (simple poles only)
-- The special irreducible quadratic s²+ω² → sin/cos pairs
-- The s·/(s²+ω²) → cos form
+4. **Irreducible quadratic factor**: after extracting all rational-root
+   factors, if the remaining denominator is a degree-2 polynomial with
+   negative discriminant b²-4c < 0 (complex conjugate poles), it is
+   decomposed by completing the square:
 
-It does NOT yet handle:
-- Repeated complex poles
-- Higher-order irreducible quadratics
-- Improper fractions (partial polynomial part)
+       (As+B) / ((s+α)²+β²)  →
+         A·exp(-αt)·cos(βt)  +  (B-Aα)/β · exp(-αt)·sin(βt)
+
+   When β is not a perfect rational square, a symbolic ``Sqrt`` node is
+   built so the answer is still exact.
+
+All exact arithmetic uses Python's ``fractions.Fraction``.
 """
 
 from __future__ import annotations
@@ -60,11 +63,15 @@ from symbolic_ir import (
     ADD,
     COS,
     COSH,
+    DIV,
     EXP,
     MUL,
+    NEG,
     POW,
     SIN,
     SINH,
+    SQRT,
+    SUB,
     IRApply,
     IRInteger,
     IRNode,
@@ -72,7 +79,7 @@ from symbolic_ir import (
     IRSymbol,
 )
 
-from cas_laplace.heads import UNIT_STEP
+from cas_laplace.heads import DIRAC_DELTA, UNIT_STEP
 
 # ---------------------------------------------------------------------------
 # Polynomial arithmetic over Fraction (rational coefficients)
@@ -282,7 +289,6 @@ def _ilt_simple_pole(
     if A == 1:
         return exp_term
     if A == -1:
-        from symbolic_ir import NEG
         return IRApply(NEG, (exp_term,))
     return IRApply(MUL, (_frac_to_ir(A), exp_term))
 
@@ -610,6 +616,256 @@ def _isqrt_exact(n: int) -> int | None:
 
 
 # ---------------------------------------------------------------------------
+# Extended partial-fraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_zero_poly(p: Poly) -> bool:
+    """Return True if p is the zero polynomial (after normalization)."""
+    n = _poly_normalize(p)
+    return len(n) == 1 and n[0] == Fraction(0)
+
+
+def _poly_shift(p: Poly, r: Fraction) -> Poly:
+    """Compute p(s + r) as a polynomial in s.
+
+    Substitutes s → s + r using the binomial expansion.  The result is
+    a polynomial whose k-th coefficient is the coefficient of (s+r)^k
+    in p(s+r).
+
+    Examples::
+
+        p = (c_0, c_1, c_2)  represents  c_0 + c_1·s + c_2·s²
+        _poly_shift(p, 1)  →  p(s+1) = c_0 + c_1(s+1) + c_2(s+1)²
+    """
+    result: Poly = _ZERO_POLY
+    for i, coeff in enumerate(p):
+        if coeff == 0:
+            continue
+        if i == 0:
+            term: Poly = (coeff,)
+        else:
+            # (s + r)^i in ascending-coefficient order
+            s_plus_r: Poly = (r, Fraction(1))
+            term = _poly_scale(_poly_pow(s_plus_r, i), coeff)
+        result = _poly_add(result, term)
+    return _poly_normalize(result)
+
+
+def _power_series_coeffs(num: Poly, den: Poly, terms: int) -> list[Fraction]:
+    """First ``terms`` coefficients of the formal power series N(t)/D(t).
+
+    Requires ``den[0] != 0`` (D(0) ≠ 0).  Uses the recurrence::
+
+        g_0 = N[0] / D[0]
+        g_k = (N[k] - Σ_{j=0}^{k-1} D[k-j] · g_j) / D[0]
+
+    This is the standard long-division algorithm for formal power series
+    over a field.  All arithmetic uses exact ``Fraction`` values.
+    """
+    q0 = den[0]
+    # Caller guarantees q0 != 0
+    g: list[Fraction] = []
+    for k in range(terms):
+        nk = num[k] if k < len(num) else Fraction(0)
+        subtract = sum(
+            (den[k - j] if (k - j) < len(den) else Fraction(0)) * g[j]
+            for j in range(k)
+        )
+        g.append((nk - subtract) / q0)
+    return g
+
+
+def _compute_repeated_residues(
+    num: Poly,
+    den: Poly,
+    r: Fraction,
+    m: int,
+) -> list[Fraction] | None:
+    """Compute Laurent coefficients [A_m, A_{m-1}, …, A_1] for a repeated pole.
+
+    For F(s) = N(s)/D(s) with D having a zero of order exactly ``m`` at
+    ``r``, the partial-fraction expansion near s=r is::
+
+        F(s) = A_m/(s-r)^m + A_{m-1}/(s-r)^{m-1} + … + A_1/(s-r) + …
+
+    Algorithm:
+
+    1. Shift: let t = s − r and compute N_t(t) = N(r+t), D_t(t) = D(r+t).
+    2. Since r has multiplicity m in D, D_t = t^m · Q_other(t) where
+       Q_other(0) ≠ 0.  The first m coefficients of D_t must be zero.
+    3. H(t) = N_t(t) / Q_other(t) is analytic at t=0.  Its first m
+       Taylor coefficients are [A_m, A_{m-1}, …, A_1] in that order.
+    4. Compute via ``_power_series_coeffs``.
+
+    Returns ``None`` if the claimed multiplicity is incorrect.
+    """
+    N_t = _poly_shift(num, r)
+    D_t = _poly_shift(den, r)
+
+    # Verify the first m coefficients of D_t are zero
+    for i in range(m):
+        val = D_t[i] if i < len(D_t) else Fraction(0)
+        if val != 0:
+            return None  # multiplicity claim is wrong
+
+    # Q_other: drop the leading m zero coefficients of D_t
+    if len(D_t) <= m:
+        return None  # degenerate (denominator is exactly t^m)
+    Q_other = tuple(D_t[m:])
+    if Q_other[0] == 0:
+        return None  # higher multiplicity than claimed
+
+    return _power_series_coeffs(N_t, Q_other, m)
+
+
+def _ilt_poly_term(
+    coeff: Fraction, degree: int, t_sym: IRSymbol
+) -> IRNode | None:
+    """L⁻¹{coeff · sⁿ}.
+
+    The inverse Laplace transform of sⁿ is the n-th distributional
+    derivative of the Dirac delta, δ^{(n)}(t).  We only handle:
+
+    - degree 0: L⁻¹{coeff} = coeff · δ(t)
+
+    For degree ≥ 1 we return ``None`` (the caller will propagate it as
+    unevaluated), since δ-derivatives are rarely needed in practice.
+    """
+    if degree == 0:
+        delta = IRApply(DIRAC_DELTA, (t_sym,))
+        if coeff == 1:
+            return delta
+        return IRApply(MUL, (_frac_to_ir(coeff), delta))
+    # δ^{(n)}(t) for n ≥ 1 not supported yet
+    return None
+
+
+def _ilt_irreducible_quad(
+    lin_num: Poly,
+    quad_den: Poly,
+    t_sym: IRSymbol,
+) -> list[IRNode] | None:
+    """Invert (A·s + B) / (s² + b·s + c)  with discriminant b²−4c < 0.
+
+    Completes the square: s² + b·s + c = (s + α)² + β²
+    where α = b/2 and β = √(c − α²).
+
+    Decomposition::
+
+        (A·s + B) / ((s+α)²+β²)
+        = A·(s+α)/((s+α)²+β²)  +  (B−A·α)/β · β/((s+α)²+β²)
+
+    Inverse transform::
+
+        A·exp(−αt)·cos(βt)  +  (B−Aα)/β · exp(−αt)·sin(βt)
+
+    When β is an irrational rational (non-perfect-square numerator/denominator),
+    a ``Sqrt(β²)`` IR node is used so the output is still exact.
+
+    Returns a list of IR term nodes (may be empty if all coefficients are
+    zero), or ``None`` if the quadratic is not irreducible.
+    """
+    if _poly_degree(quad_den) != 2:
+        return None
+
+    # Make the denominator monic: divide numerator and denominator by the
+    # leading coefficient so we have s² + b·s + c form.
+    leading = quad_den[2]
+    if leading == 0:
+        return None
+    if leading != 1:
+        quad_den = _poly_scale(quad_den, Fraction(1) / leading)
+        lin_num = _poly_scale(lin_num, Fraction(1) / leading)
+
+    c: Fraction = quad_den[0]
+    b: Fraction = quad_den[1]
+    # quad_den[2] == 1 after normalisation
+
+    # Discriminant check: b² − 4c < 0 (complex conjugate poles)
+    disc = b * b - 4 * c
+    if disc >= 0:
+        return None  # Real roots — not an irreducible quadratic
+
+    # Extract A, B from linear numerator (A*s + B, ascending order B, A)
+    B: Fraction = lin_num[0] if len(lin_num) > 0 else Fraction(0)
+    A: Fraction = lin_num[1] if len(lin_num) > 1 else Fraction(0)
+
+    # Complete the square: α = b/2, β² = c − α²
+    alpha: Fraction = b / 2
+    beta_sq: Fraction = c - alpha * alpha
+
+    if beta_sq <= 0:
+        return None
+
+    # Try exact rational β first; fall back to Sqrt IR node
+    beta_rat = _rational_sqrt(beta_sq)
+    beta_ir: IRNode
+    if beta_rat is not None:
+        beta_ir = _frac_to_ir(beta_rat)
+        beta_frac: Fraction | None = beta_rat
+    else:
+        # β is irrational — use Sqrt(β²) as an IR node
+        beta_ir = IRApply(SQRT, (_frac_to_ir(beta_sq),))
+        beta_frac = None  # signals we cannot do Fraction arithmetic for beta
+
+    # neg_alpha for the exponent: exp(−α·t) = exp(neg_alpha · t)
+    neg_alpha: Fraction = -alpha
+
+    def _make_exp_trig(coeff_ir: IRNode, is_cos: bool) -> IRNode:
+        """Build coeff · exp(−α·t) · trig(β·t)."""
+        # trig argument: β · t
+        if beta_rat == 1:
+            trig_arg: IRNode = t_sym
+        else:
+            trig_arg = IRApply(MUL, (beta_ir, t_sym))
+
+        trig_fn = COS if is_cos else SIN
+        trig_term = IRApply(trig_fn, (trig_arg,))
+
+        # exp factor: exp(−α·t)  [omitted when α = 0]
+        if alpha == 0:
+            oscillator: IRNode = trig_term
+        else:
+            exp_arg: IRNode
+            if neg_alpha == 1:
+                exp_arg = t_sym
+            elif neg_alpha == -1:
+                exp_arg = IRApply(NEG, (t_sym,))
+            else:
+                exp_arg = IRApply(MUL, (_frac_to_ir(neg_alpha), t_sym))
+            oscillator = IRApply(MUL, (IRApply(EXP, (exp_arg,)), trig_term))
+
+        # Scale by coefficient
+        if isinstance(coeff_ir, IRInteger) and coeff_ir.value == 1:
+            return oscillator
+        if isinstance(coeff_ir, IRInteger) and coeff_ir.value == 0:
+            raise ValueError("zero coeff should be filtered before calling")
+        return IRApply(MUL, (coeff_ir, oscillator))
+
+    terms: list[IRNode] = []
+
+    # Term 1: A · exp(−α·t) · cos(β·t)
+    if A != 0:
+        terms.append(_make_exp_trig(_frac_to_ir(A), is_cos=True))
+
+    # Term 2: (B − A·α) / β · exp(−α·t) · sin(β·t)
+    # Coefficient is (B − A·α) / β
+    baa: Fraction = B - A * alpha  # B − A·α (exact Fraction)
+    if baa != 0:
+        if beta_frac is not None:
+            # Exact rational: divide baa / beta
+            coeff2 = baa / beta_frac
+            coeff2_ir: IRNode = _frac_to_ir(coeff2)
+        else:
+            # Irrational β: build Div(baa, Sqrt(beta_sq))
+            coeff2_ir = IRApply(DIV, (_frac_to_ir(baa), beta_ir))
+        terms.append(_make_exp_trig(coeff2_ir, is_cos=False))
+
+    return terms
+
+
+# ---------------------------------------------------------------------------
 # Main inverse transform routine
 # ---------------------------------------------------------------------------
 
@@ -891,78 +1147,169 @@ def _poly_scale(p: Poly, c: Fraction) -> Poly:
 
 
 # ---------------------------------------------------------------------------
-# Partial-fraction decomposition
+# Partial-fraction decomposition (extended)
 # ---------------------------------------------------------------------------
-
-
-def _partial_fractions_simple_poles(
-    num: Poly, den: Poly, roots: list[Fraction]
-) -> list[tuple[Fraction, Fraction, int]] | None:
-    """Compute partial-fraction residues for a proper rational function.
-
-    All poles must be simple (distinct roots). Returns a list of
-    (A_i, r_i, 1) tuples meaning A_i / (s - r_i).
-
-    Uses the residue formula:  A_i = P(r_i) / Q'(r_i).
-    """
-    den_deriv = _poly_deriv(den)
-    terms: list[tuple[Fraction, Fraction, int]] = []
-    for r in roots:
-        p_at_r = _poly_evaluate(num, r)
-        qd_at_r = _poly_evaluate(den_deriv, r)
-        if qd_at_r == 0:
-            return None  # repeated root
-        A = p_at_r / qd_at_r
-        terms.append((A, r, 1))
-    return terms
 
 
 def _ilt_via_partial_fractions(
     F_ir: IRNode, s_sym: IRSymbol, t_sym: IRSymbol
 ) -> IRNode | None:
-    """Attempt ILT via partial-fraction decomposition.
+    """Attempt ILT via partial-fraction decomposition (full engine).
 
-    Returns the sum of inverse transforms, or None if decomposition fails.
+    Handles:
+
+    - **Improper fractions**: polynomial long division extracts the
+      polynomial part; each constant term yields a DiracDelta(t).
+    - **Repeated rational poles**: Laurent expansion via formal power
+      series (no symbolic differentiation needed).
+    - **Irreducible quadratic factors**: complex-conjugate poles produce
+      exp(−αt)·sin/cos(βt) pairs via completing the square.
+
+    Returns the IR for f(t), or ``None`` if decomposition fails.
     """
     rational = _ir_to_rational(F_ir, s_sym)
     if rational is None:
         return None
 
-    num, den = rational
-    num = _poly_normalize(num)
-    den = _poly_normalize(den)
+    num, den = _poly_normalize(rational[0]), _poly_normalize(rational[1])
 
-    # Must be a proper fraction
+    # ── Step 1: Handle improper fractions via polynomial long division ─────────
+    # If deg(N) ≥ deg(D), extract a polynomial quotient P(s).
+    # L⁻¹{P(s)} = P[0]·δ(t) + P[1]·δ'(t) + …  (we handle P[0] only).
+    poly_part: Poly = _ZERO_POLY
     if _poly_degree(num) >= _poly_degree(den):
-        return None
+        poly_part, num = _poly_divmod(num, den)
+        poly_part = _poly_normalize(poly_part)
+        num = _poly_normalize(num)
 
-    # Find all rational roots of the denominator
+    # ── Step 2: Find all rational roots of denominator (with multiplicity) ─────
     roots = _extract_all_rational_roots(den)
 
-    # Roots must account for ALL factors (i.e., we need exactly deg(den) roots)
-    if len(roots) != _poly_degree(den):
-        return None  # Irreducible factors remain
+    # Build Q_rat = Π(s − r_i)^{m_i} from the rational roots
+    Q_rat: Poly = _ONE_POLY
+    for r in roots:
+        Q_rat = _poly_mul(Q_rat, (-r, Fraction(1)))
+    Q_rat = _poly_normalize(Q_rat)
 
-    # Compute residues
-    terms = _partial_fractions_simple_poles(num, den, roots)
-    if terms is None:
-        return None
+    # Irreducible factor: Q_irred = D / Q_rat
+    Q_irred, rem = _poly_divmod(den, Q_rat)
+    Q_irred = _poly_normalize(Q_irred)
 
-    # Build inverse transform for each term
+    if not _is_zero_poly(rem):
+        return None  # Division was not exact (should not happen)
+
+    irred_deg = _poly_degree(Q_irred)
+
+    if irred_deg > 2:
+        return None  # Cannot handle irreducible cubic or higher factors yet
+
+    # ── Step 3: Collect IR terms ───────────────────────────────────────────────
     ir_terms: list[IRNode] = []
-    for A, r, mult in terms:
-        if mult == 1:
+
+    # Polynomial part → DiracDelta terms
+    for deg, coeff in enumerate(poly_part):
+        if coeff == 0:
+            continue
+        pterm = _ilt_poly_term(coeff, deg, t_sym)
+        if pterm is None:
+            return None  # DiracDelta derivative not supported
+        ir_terms.append(pterm)
+
+    # ── Step 4: Rational poles ─────────────────────────────────────────────────
+    # Group roots by value and count multiplicity
+    distinct_roots: dict[Fraction, int] = {}
+    for r in roots:
+        distinct_roots[r] = distinct_roots.get(r, 0) + 1
+
+    # Store residues for reuse in the quadratic-numerator step below
+    # residues_map[r] = list of [A_m, A_{m-1}, …, A_1] for root r
+    residues_map: dict[Fraction, list[Fraction]] = {}
+
+    for r, m in distinct_roots.items():
+        linear_pow_m: Poly = _poly_pow((-r, Fraction(1)), m)
+        Q_rat_no_rm, _ = _poly_divmod(Q_rat, linear_pow_m)
+        Q_rat_no_rm = _poly_normalize(Q_rat_no_rm)
+        # Q_other = (Q_rat / (s−r)^m) · Q_irred — the non-(s−r) part of D
+        Q_other = _poly_normalize(_poly_mul(Q_rat_no_rm, Q_irred))
+
+        if m == 1:
+            q_other_r = _poly_evaluate(Q_other, r)
+            if q_other_r == 0:
+                return None  # Degenerate (should not happen with correct roots)
+            A = _poly_evaluate(num, r) / q_other_r
+            residues_map[r] = [A]
             ir_terms.append(_ilt_simple_pole(A, r, t_sym))
         else:
-            ir_terms.append(_ilt_repeated_pole(A, r, mult, t_sym))
+            residues = _compute_repeated_residues(num, den, r, m)
+            if residues is None:
+                return None
+            residues_map[r] = residues
+            for k, A in enumerate(residues):
+                if A == 0:
+                    continue
+                pole_order = m - k  # m, m−1, …, 1
+                if pole_order == 1:
+                    ir_terms.append(_ilt_simple_pole(A, r, t_sym))
+                else:
+                    ir_terms.append(_ilt_repeated_pole(A, r, pole_order, t_sym))
 
+    # ── Step 5: Irreducible quadratic factor ───────────────────────────────────
+    if irred_deg == 2:
+        # Find the linear numerator (A·s + B) for the term (A·s+B)/Q_irred.
+        #
+        # The partial-fraction identity (multiplied out by D = Q_rat·Q_irred)
+        # is:
+        #
+        #   N(s) = [rational pole contributions] + (A·s+B)·Q_rat(s)
+        #
+        # "Rational pole contribution" of root r with multiplicity m at pole
+        # order k is:  A_{m−k+1} · D(s)/(s−r)^k
+        #            = A_{m−k+1} · Q_irred(s) · Q_rat(s)/(s−r)^k
+        #
+        # Summing all rational contributions in polynomial form:
+        #   rat_poly = Q_irred · Σ_{r,k} A_k · (Q_rat/(s−r)^k)
+        #
+        # Then:
+        #   (A·s+B) = [N − rat_poly] / Q_rat         (exact polynomial division)
+
+        rat_poly: Poly = _ZERO_POLY
+        for r, m in distinct_roots.items():
+            residues = residues_map[r]
+            for k_idx, A in enumerate(residues):
+                if A == 0:
+                    continue
+                pole_order = m - k_idx          # order of this partial-fraction term
+                linear_pow_k: Poly = _poly_pow((-r, Fraction(1)), pole_order)
+                Q_rat_div_k, _ = _poly_divmod(Q_rat, linear_pow_k)
+                Q_rat_div_k = _poly_normalize(Q_rat_div_k)
+                contrib = _poly_scale(
+                    _poly_mul(Q_irred, Q_rat_div_k), A
+                )
+                rat_poly = _poly_add(rat_poly, contrib)
+
+        # irred_times_qrat = N − rat_poly  should be exactly divisible by Q_rat
+        irred_times_qrat = _poly_normalize(
+            _poly_add(num, _poly_neg(rat_poly))
+        )
+        lin_num, rem2 = _poly_divmod(irred_times_qrat, Q_rat)
+        lin_num = _poly_normalize(lin_num)
+
+        if not _is_zero_poly(rem2):
+            return None  # Numerator computation failed (rounding / structure)
+
+        # Invert (A·s + B) / Q_irred(s)
+        irred_terms = _ilt_irreducible_quad(lin_num, Q_irred, t_sym)
+        if irred_terms is None:
+            return None
+        ir_terms.extend(irred_terms)
+
+    # ── Step 6: Assemble result ────────────────────────────────────────────────
     if not ir_terms:
         return IRInteger(0)
     if len(ir_terms) == 1:
         return ir_terms[0]
 
-    # Sum all terms
-    result = ir_terms[0]
+    result: IRNode = ir_terms[0]
     for term in ir_terms[1:]:
         result = IRApply(ADD, (result, term))
     return result

--- a/code/packages/python/cas-laplace/src/cas_laplace/table.py
+++ b/code/packages/python/cas-laplace/src/cas_laplace/table.py
@@ -42,10 +42,14 @@ Standard transforms implemented
 | t^n·exp(a·t)          | n! / (s-a)^(n+1)       |
 | sinh(a·t)             | a / (s² - a²)          |
 | cosh(a·t)             | s / (s² - a²)          |
-| t·sin(ω·t)            | 2ωs / (s² + ω²)²       |
-| t·cos(ω·t)            | (s² - ω²) / (s² + ω²)² |
-| DiracDelta(t)         | 1                      |
-| UnitStep(t)           | 1/s                    |
+| t·sin(ω·t)            | 2ωs / (s² + ω²)²                        |
+| t·cos(ω·t)            | (s² - ω²) / (s² + ω²)²                  |
+| t²·sin(ω·t)           | 2ω(3s² − ω²) / (s² + ω²)³               |
+| t²·cos(ω·t)           | 2s(s² − 3ω²) / (s² + ω²)³               |
+| t³·sin(ω·t)           | 24ωs(s² − ω²) / (s² + ω²)⁴              |
+| t³·cos(ω·t)           | 6(s⁴ − 6s²ω² + ω⁴) / (s² + ω²)⁴        |
+| DiracDelta(t)         | 1                                        |
+| UnitStep(t)           | 1/s                                      |
 """
 
 from __future__ import annotations
@@ -617,6 +621,67 @@ def _match_t_cos(
     return None
 
 
+def _match_tn_sin(
+    f: IRNode, t_sym: IRSymbol
+) -> dict[str, Any] | None:
+    """Match ``f = t^n * sin(ω*t)`` for integer n ≥ 2 (either Mul order).
+
+    Returns ``{"n": n, "omega": omega_node}``.
+
+    Transform: L{t^n·sin(ωt)} derived by differentiating L{sin(ωt)} n
+    times with respect to −s:
+
+        L{t^n·sin(ωt)} = (−1)^n · dⁿ/dsⁿ [ω/(s²+ω²)]
+
+    Closed-form results for n = 2 and n = 3 are implemented in
+    ``_tf_tn_sin``; for n ≥ 4 the pattern matches but the transform
+    builder returns ``None`` (falls through to unevaluated).
+    """
+    if not (
+        isinstance(f, IRApply)
+        and isinstance(f.head, IRSymbol)
+        and f.head.name == "Mul"
+        and len(f.args) == 2
+    ):
+        return None
+    left, right = f.args
+    for pow_node, sin_node in [(left, right), (right, left)]:
+        pow_match = _match_power_of_t(pow_node, t_sym)
+        if pow_match is not None and pow_match.get("n", 0) >= 2:
+            s = _match_sin(sin_node, t_sym)
+            if s is not None:
+                return {"n": pow_match["n"], "omega": s["omega"]}
+    return None
+
+
+def _match_tn_cos(
+    f: IRNode, t_sym: IRSymbol
+) -> dict[str, Any] | None:
+    """Match ``f = t^n * cos(ω*t)`` for integer n ≥ 2 (either Mul order).
+
+    Returns ``{"n": n, "omega": omega_node}``.
+
+    Transform: L{t^n·cos(ωt)} derived by differentiating L{cos(ωt)} n
+    times with respect to −s.  Closed-form results for n = 2 and n = 3
+    are implemented in ``_tf_tn_cos``.
+    """
+    if not (
+        isinstance(f, IRApply)
+        and isinstance(f.head, IRSymbol)
+        and f.head.name == "Mul"
+        and len(f.args) == 2
+    ):
+        return None
+    left, right = f.args
+    for pow_node, cos_node in [(left, right), (right, left)]:
+        pow_match = _match_power_of_t(pow_node, t_sym)
+        if pow_match is not None and pow_match.get("n", 0) >= 2:
+            c = _match_cos(cos_node, t_sym)
+            if c is not None:
+                return {"n": pow_match["n"], "omega": c["omega"]}
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Transform builders (take extracted params, return F(s) IR)
 # ---------------------------------------------------------------------------
@@ -796,6 +861,115 @@ def _tf_t_cos(params: dict[str, Any], s: IRSymbol) -> IRNode:
     return _make_div(num, denom)
 
 
+def _tf_tn_sin(params: dict[str, Any], s: IRSymbol) -> IRNode | None:
+    """L{t^n·sin(ωt)} for n = 2, 3.
+
+    Closed forms derived from L{sin(ωt)} = ω/(s²+ω²) via repeated
+    differentiation with respect to −s:
+
+    n = 2:  L{t²·sin(ωt)} = 2ω(3s² − ω²) / (s² + ω²)³
+
+        Derivation: F(s) = ω/(s²+ω²).  F''(s) = (6ωs² − 2ω³)/(s²+ω²)³
+        and L{t²·sin(ωt)} = F''(s) (second derivative of F).
+
+    n = 3:  L{t³·sin(ωt)} = 24ωs(s² − ω²) / (s² + ω²)⁴
+
+        Derivation: L{t³f} = −F'''(s); computing F''' gives the result.
+
+    Returns ``None`` for n ≥ 4 (left unevaluated for now).
+    """
+    from symbolic_ir import SUB  # noqa: PLC0415
+
+    n: int = params["n"]
+    omega = params["omega"]
+    s2 = _make_pow(s, 2)
+    w2 = _make_pow(omega, 2)
+    s2_plus_w2 = _make_add(s2, w2)
+
+    if n == 2:
+        # 2ω(3s² − ω²) / (s²+ω²)³
+        num = _make_mul(
+            _make_mul(IRInteger(2), omega),
+            IRApply(SUB, (_make_mul(IRInteger(3), s2), w2)),
+        )
+        denom = _make_pow(s2_plus_w2, 3)
+        return _make_div(num, denom)
+
+    if n == 3:
+        # 24ωs(s² − ω²) / (s²+ω²)⁴
+        num = _make_mul(
+            _make_mul(IRInteger(24), omega),
+            _make_mul(s, IRApply(SUB, (s2, w2))),
+        )
+        denom = _make_pow(s2_plus_w2, 4)
+        return _make_div(num, denom)
+
+    return None  # n ≥ 4: fall through to unevaluated
+
+
+def _tf_tn_cos(params: dict[str, Any], s: IRSymbol) -> IRNode | None:
+    """L{t^n·cos(ωt)} for n = 2, 3.
+
+    Closed forms derived from L{cos(ωt)} = s/(s²+ω²) via repeated
+    differentiation with respect to −s:
+
+    n = 2:  L{t²·cos(ωt)} = 2s(s² − 3ω²) / (s² + ω²)³
+
+        Derivation: G(s) = s/(s²+ω²).  G''(s) = 2s(s²−3ω²)/(s²+ω²)³.
+
+    n = 3:  L{t³·cos(ωt)} = 6(s⁴ − 6s²ω² + ω⁴) / (s² + ω²)⁴
+
+        Derivation: L{t³f} = −G'''(s); computing G''' gives the result.
+
+    Returns ``None`` for n ≥ 4 (left unevaluated for now).
+    """
+    from symbolic_ir import SUB  # noqa: PLC0415
+
+    n: int = params["n"]
+    omega = params["omega"]
+    s2 = _make_pow(s, 2)
+    w2 = _make_pow(omega, 2)
+    s2_plus_w2 = _make_add(s2, w2)
+
+    if n == 2:
+        # 2s(s² − 3ω²) / (s²+ω²)³
+        num = _make_mul(
+            _make_mul(IRInteger(2), s),
+            IRApply(SUB, (s2, _make_mul(IRInteger(3), w2))),
+        )
+        denom = _make_pow(s2_plus_w2, 3)
+        return _make_div(num, denom)
+
+    if n == 3:
+        # 6(s⁴ − 6s²ω² + ω⁴) / (s²+ω²)⁴
+        s4 = _make_pow(s, 4)
+        w4 = _make_pow(omega, 4)
+        num = _make_mul(
+            IRInteger(6),
+            IRApply(
+                SUB,
+                (
+                    IRApply(SUB, (s4, _make_mul(IRInteger(6), _make_mul(s2, w2)))),
+                    _make_mul(IRInteger(-1), w4),  # + ω⁴  (SUB negates, so −(−ω⁴))
+                ),
+            ),
+        )
+        # s⁴ − 6s²ω² + ω⁴ = (s⁴ − 6s²ω²) − (−ω⁴) ... cleaner as Add
+        from symbolic_ir import ADD as _ADD  # noqa: PLC0415
+        inner = IRApply(
+            _ADD,
+            (
+                IRApply(SUB, (s4, _make_mul(IRInteger(6), _make_mul(s2, w2)))),
+                w4,
+            ),
+        )
+        num = _make_mul(IRInteger(6), inner)
+        denom = _make_pow(s2_plus_w2, 4)
+        return _make_div(num, denom)
+
+    return None  # n ≥ 4: fall through to unevaluated
+
+
 # ---------------------------------------------------------------------------
 # The transform table: ordered from most specific to least specific.
 #
@@ -816,6 +990,9 @@ TRANSFORM_TABLE: list[
     (_match_exp_cos, _tf_exp_cos),
     (_match_tn_exp, _tf_tn_exp),   # t^n * exp(at), n>=2 — must precede t*exp
     (_match_t_exp, _tf_t_exp),     # t * exp(at)
+    # t^n * trig: n>=2 must precede t*trig so t²*sin matches before t*sin strips t
+    (_match_tn_sin, _tf_tn_sin),   # t^n * sin(wt), n>=2
+    (_match_tn_cos, _tf_tn_cos),   # t^n * cos(wt), n>=2
     (_match_t_sin, _tf_t_sin),     # t * sin(wt)
     (_match_t_cos, _tf_t_cos),     # t * cos(wt)
     # --- Elementary transforms ---

--- a/code/packages/python/cas-laplace/tests/test_laplace.py
+++ b/code/packages/python/cas-laplace/tests/test_laplace.py
@@ -733,3 +733,280 @@ class TestLaplaceEdgeCases:
         result = laplace_transform(f, T, S)
         assert isinstance(result, IRApply)
         assert result.head.name == "Div"
+
+
+# ===========================================================================
+# New gap-closure tests: t^n·trig (forward) and extended ILT
+# ===========================================================================
+
+
+class TestLaplaceTnTrig:
+    """L{t^n·sin(ωt)} and L{t^n·cos(ωt)} for n = 2, 3."""
+
+    def test_t2_sin_t(self):
+        # L{t^2·sin(t)} = 2·1·(3s²−1)/(s²+1)³ = 2(3s²−1)/(s²+1)³
+        f = IRApply(MUL, (IRApply(POW, (T, IRInteger(2))), IRApply(SIN, (T,))))
+        result = laplace_transform(f, T, S)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Div"
+        # denominator is (s²+1)^3
+        denom = result.args[1]
+        assert isinstance(denom, IRApply) and denom.head.name == "Pow"
+        assert isinstance(denom.args[1], IRInteger) and denom.args[1].value == 3
+
+    def test_t2_sin_2t(self):
+        # L{t²·sin(2t)} = 2·2·(3s²−4)/(s²+4)³ = 4(3s²−4)/(s²+4)³
+        inner = IRApply(MUL, (IRInteger(2), T))
+        f = IRApply(MUL, (IRApply(POW, (T, IRInteger(2))), IRApply(SIN, (inner,))))
+        result = laplace_transform(f, T, S)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Div"
+
+    def test_t2_cos_t(self):
+        # L{t²·cos(t)} = 2s(s²−3)/(s²+1)³
+        f = IRApply(MUL, (IRApply(POW, (T, IRInteger(2))), IRApply(COS, (T,))))
+        result = laplace_transform(f, T, S)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Div"
+        denom = result.args[1]
+        assert isinstance(denom, IRApply) and denom.head.name == "Pow"
+        assert isinstance(denom.args[1], IRInteger) and denom.args[1].value == 3
+
+    def test_t2_cos_3t(self):
+        # L{t²·cos(3t)} = 2s(s²−27)/(s²+9)³
+        inner = IRApply(MUL, (IRInteger(3), T))
+        f = IRApply(MUL, (IRApply(POW, (T, IRInteger(2))), IRApply(COS, (inner,))))
+        result = laplace_transform(f, T, S)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Div"
+
+    def test_t3_sin_t(self):
+        # L{t³·sin(t)} = 24s(s²−1)/(s²+1)⁴
+        f = IRApply(MUL, (IRApply(POW, (T, IRInteger(3))), IRApply(SIN, (T,))))
+        result = laplace_transform(f, T, S)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Div"
+        denom = result.args[1]
+        assert isinstance(denom, IRApply) and denom.head.name == "Pow"
+        assert isinstance(denom.args[1], IRInteger) and denom.args[1].value == 4
+
+    def test_t3_cos_t(self):
+        # L{t³·cos(t)} = 6(s⁴−6s²+1)/(s²+1)⁴
+        f = IRApply(MUL, (IRApply(POW, (T, IRInteger(3))), IRApply(COS, (T,))))
+        result = laplace_transform(f, T, S)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Div"
+        denom = result.args[1]
+        assert isinstance(denom, IRApply) and denom.head.name == "Pow"
+        assert isinstance(denom.args[1], IRInteger) and denom.args[1].value == 4
+
+    def test_t2_sin_reversed_order(self):
+        # sin(t) * t^2 — sin first, power second
+        f = IRApply(MUL, (IRApply(SIN, (T,)), IRApply(POW, (T, IRInteger(2)))))
+        result = laplace_transform(f, T, S)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Div"
+
+    def test_t4_sin_falls_through(self):
+        # L{t⁴·sin(t)} — not in table for n≥4, falls through to unevaluated
+        from cas_laplace.heads import LAPLACE
+        f = IRApply(MUL, (IRApply(POW, (T, IRInteger(4))), IRApply(SIN, (T,))))
+        result = laplace_transform(f, T, S)
+        # Should fall through (since tn_sin builder returns None for n>=4)
+        # The table will miss it, returning Laplace(f, t, s)
+        assert isinstance(result, IRApply)
+
+
+class TestILTComplexPoles:
+    """ILT for irreducible quadratic denominators (complex conjugate poles)."""
+
+    def test_ilt_1_over_s2_plus_2s_plus_2(self):
+        # L^{-1}{1/(s²+2s+2)} = exp(-t)·sin(t)
+        # Denominator: s²+2s+2 = (s+1)²+1  →  α=1, β=1
+        den = IRApply(
+            ADD,
+            (
+                IRApply(ADD, (IRApply(POW, (S, IRInteger(2))), IRApply(MUL, (IRInteger(2), S)))),
+                IRInteger(2),
+            ),
+        )
+        F = IRApply(DIV, (IRInteger(1), den))
+        result = inverse_laplace(F, S, T)
+        # Result should be Mul(Exp(-t), Sin(t))
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Mul"
+        # One factor is Exp, other is Sin
+        heads = {result.args[0].head.name, result.args[1].head.name}
+        assert "Exp" in heads
+        assert "Sin" in heads
+
+    def test_ilt_s_over_s2_plus_2s_plus_2(self):
+        # L^{-1}{s/(s²+2s+2)} = exp(-t)·cos(t) + something
+        den = IRApply(
+            ADD,
+            (
+                IRApply(ADD, (IRApply(POW, (S, IRInteger(2))), IRApply(MUL, (IRInteger(2), S)))),
+                IRInteger(2),
+            ),
+        )
+        F = IRApply(DIV, (S, den))
+        result = inverse_laplace(F, S, T)
+        # Result should be a sum involving exp(-t)*cos(t) and exp(-t)*sin(t)
+        assert isinstance(result, IRApply)
+        # Should not be unevaluated ILT
+        from cas_laplace.heads import ILT
+        assert result.head.name != "ILT"
+
+    def test_ilt_1_over_s2_plus_4(self):
+        # L^{-1}{1/(s²+4)} = (1/2)·sin(2t)
+        # This is already handled by direct pattern but should also work via
+        # partial fractions when expressed differently
+        den = IRApply(ADD, (IRApply(POW, (S, IRInteger(2))), IRInteger(4)))
+        F = IRApply(DIV, (IRInteger(1), den))
+        result = inverse_laplace(F, S, T)
+        assert isinstance(result, IRApply)
+        # Should be sin_scaled form from direct pattern: (1/2)*sin(2t)
+        from cas_laplace.heads import ILT
+        assert result.head.name != "ILT"
+
+    def test_ilt_mixed_rational_and_quad(self):
+        # L^{-1}{1/(s·(s²+1))} = UnitStep(t) − cos(t)
+        den = IRApply(MUL, (S, IRApply(ADD, (IRApply(POW, (S, IRInteger(2))), IRInteger(1)))))
+        F = IRApply(DIV, (IRInteger(1), den))
+        result = inverse_laplace(F, S, T)
+        # Should be a sum of two terms
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Add"
+
+
+class TestILTRepeatedPoles:
+    """ILT for repeated rational poles."""
+
+    def test_ilt_1_over_s_squared(self):
+        # L^{-1}{1/s²} = t
+        F = IRApply(DIV, (IRInteger(1), IRApply(POW, (S, IRInteger(2)))))
+        result = inverse_laplace(F, S, T)
+        assert result == T  # t (bare symbol)
+
+    def test_ilt_1_over_s_minus_2_squared(self):
+        # L^{-1}{1/(s-2)²} = t·exp(2t)
+        F = IRApply(
+            DIV,
+            (
+                IRInteger(1),
+                IRApply(POW, (IRApply(SUB, (S, IRInteger(2))), IRInteger(2))),
+            ),
+        )
+        result = inverse_laplace(F, S, T)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Mul"
+        heads = {result.args[0].head.name if isinstance(result.args[0], IRApply) else "sym",
+                 result.args[1].head.name if isinstance(result.args[1], IRApply) else "sym"}
+        assert "Exp" in heads
+
+    def test_ilt_repeated_pole_at_neg1(self):
+        # L^{-1}{1/(s+1)²} = t·exp(-t)
+        F = IRApply(
+            DIV,
+            (
+                IRInteger(1),
+                IRApply(POW, (IRApply(ADD, (S, IRInteger(1))), IRInteger(2))),
+            ),
+        )
+        result = inverse_laplace(F, S, T)
+        assert isinstance(result, IRApply)
+        assert result.head.name == "Mul"
+        # One factor should be t, the other exp(-t)
+        factor_heads = set()
+        for arg in result.args:
+            if isinstance(arg, IRApply):
+                factor_heads.add(arg.head.name)
+            elif isinstance(arg, IRSymbol):
+                factor_heads.add("Symbol")
+        assert "Exp" in factor_heads
+
+    def test_ilt_improper_fraction_constant_quotient(self):
+        # L^{-1}{(s²+3s+3)/(s²+3s+2)}
+        # = L^{-1}{1 + 1/(s²+3s+2)} = DiracDelta(t) + partial_fracs
+        # s²+3s+2 = (s+1)(s+2), roots -1, -2
+        # 1/((s+1)(s+2)) = 1/(s+1) - 1/(s+2) → exp(-t) - exp(-2t)
+        from symbolic_ir import IRRational as _IRR
+        # (s²+3s+3) in poly form ascending: (3, 3, 1)
+        # We can't build this as a simple IR literal easily — use Add forms
+        # Numerator: s² + 3s + 3
+        num_ir = IRApply(
+            ADD,
+            (
+                IRApply(ADD, (IRApply(POW, (S, IRInteger(2))), IRApply(MUL, (IRInteger(3), S)))),
+                IRInteger(3),
+            ),
+        )
+        # Denominator: s² + 3s + 2 = (s+1)(s+2)
+        den_ir = IRApply(MUL, (IRApply(ADD, (S, IRInteger(1))), IRApply(ADD, (S, IRInteger(2)))))
+        F = IRApply(DIV, (num_ir, den_ir))
+        result = inverse_laplace(F, S, T)
+        assert isinstance(result, IRApply)
+        # Should include DiracDelta from the constant-1 polynomial part
+        from cas_laplace.heads import DIRAC_DELTA
+        # Flatten result to find all node types
+        def _find_heads(node: IRNode, found: set) -> None:
+            if isinstance(node, IRApply):
+                found.add(node.head.name)
+                for a in node.args:
+                    _find_heads(a, found)
+        all_heads: set = set()
+        _find_heads(result, all_heads)
+        assert "DiracDelta" in all_heads
+
+
+class TestILTPolynomialHelpers:
+    """Unit tests for the polynomial helper functions."""
+
+    def test_poly_shift_constant(self):
+        from fractions import Fraction
+        from cas_laplace.inverse_table import _poly_shift
+        # Shifting a constant is a no-op
+        p = (Fraction(5),)
+        assert _poly_shift(p, Fraction(3)) == p
+
+    def test_poly_shift_linear(self):
+        from fractions import Fraction
+        from cas_laplace.inverse_table import _poly_shift
+        # (s + 2) shifted by r=1 → ((1+2) + 1·s) = (3 + s)
+        p = (Fraction(2), Fraction(1))  # 2 + s
+        shifted = _poly_shift(p, Fraction(1))
+        # Expected: 2 + (s+1) = 3 + s → (3, 1)
+        from fractions import Fraction
+        assert shifted == (Fraction(3), Fraction(1))
+
+    def test_poly_shift_quadratic_around_root(self):
+        from fractions import Fraction
+        from cas_laplace.inverse_table import _poly_shift, _poly_evaluate
+        # (s-2)^2 = s²−4s+4.  Shifted by r=2: t^2 → (0, 0, 1)
+        p = (Fraction(4), Fraction(-4), Fraction(1))  # 4 - 4s + s²
+        shifted = _poly_shift(p, Fraction(2))
+        # p(t+2) = (t+2-2)^2 = t^2 → (0, 0, 1)
+        from cas_laplace.inverse_table import _poly_normalize
+        assert _poly_normalize(shifted) == (Fraction(0), Fraction(0), Fraction(1))
+
+    def test_power_series_coeffs_simple(self):
+        from fractions import Fraction
+        from cas_laplace.inverse_table import _power_series_coeffs
+        # 1/1 → [1, 0, 0] (Taylor coefficients of constant 1)
+        g = _power_series_coeffs((Fraction(1),), (Fraction(1),), 3)
+        assert g == [Fraction(1), Fraction(0), Fraction(0)]
+
+    def test_power_series_coeffs_linear(self):
+        from fractions import Fraction
+        from cas_laplace.inverse_table import _power_series_coeffs
+        # (1 + t) / 1 → Taylor coefficients [1, 1]
+        g = _power_series_coeffs((Fraction(1), Fraction(1)), (Fraction(1),), 2)
+        assert g == [Fraction(1), Fraction(1)]
+
+    def test_is_zero_poly(self):
+        from fractions import Fraction
+        from cas_laplace.inverse_table import _is_zero_poly
+        assert _is_zero_poly((Fraction(0),))
+        assert _is_zero_poly((Fraction(0), Fraction(0)))
+        assert not _is_zero_poly((Fraction(1),))
+        assert not _is_zero_poly((Fraction(0), Fraction(1)))

--- a/code/packages/rust/cas-laplace/CHANGELOG.md
+++ b/code/packages/rust/cas-laplace/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## 0.2.0 — 2026-05-16
+
+**Extended ILT engine: complex conjugate poles, repeated poles, improper
+fractions.  Extended forward table: t^n·sin(ωt) and t^n·cos(ωt) for n = 2, 3.**
+
+### `lib.rs` — partial-fraction decomposition engine
+
+`inverse_lookup` now falls through to a full partial-fraction engine
+`inverse_pf` when direct pattern matching fails.  Three new capabilities:
+
+1. **Improper fractions** — polynomial long division extracts the quotient
+   `P(s)`.  A constant quotient contributes a `DiracDelta(t)` term.
+
+2. **Repeated rational poles** — formal power-series expansion around the
+   pole: shift `s → r + t`, divide out `t^m`, and read off the first `m`
+   Taylor coefficients.  All arithmetic is exact, using a `Frac` struct
+   backed by `i64`.
+
+3. **Irreducible quadratic factor** — after extracting all rational-root
+   factors, a remaining degree-2 denominator with `b²−4c < 0` is handled
+   by completing the square `(s+α)²+β²`, yielding
+   `exp(−αt)·cos(βt)` and `exp(−αt)·sin(βt)`.  When β is irrational a
+   `Sqrt(β²)` IR node keeps the result exact.
+
+New internal infrastructure: `Frac` struct with i64 arithmetic;
+`Poly = Vec<Frac>`; `ir_to_rational`; `poly_shift`; `power_series_coeffs`;
+`compute_repeated_residues`; `ilt_irreducible_quad`; `inverse_pf`;
+`rational_roots`; `extract_all_rational_roots`.
+
+Examples now evaluating:
+- `ilt(1/(s^2+2*s+2), s, t)` → `Mul(Exp(Neg(t)), Sin(t))`
+- `ilt(1/(s-2)^2, s, t)` → `Mul(t, Exp(Mul(2, t)))`
+- `ilt(1/(s*(s^2+1)), s, t)` → `Add(UnitStep(t), Mul(-1, Cos(t)))`
+
+### `lib.rs` — t^n·trig forward transforms for n = 2, 3
+
+Added `match_tn_times_trig` pattern matcher and inline transform builders
+for `t^n·sin(ωt)` and `t^n·cos(ωt)` with n = 2, 3.
+
+| f(t)        | F(s) = L{f}(s)                  |
+|-------------|----------------------------------|
+| t²·sin(ωt)  | 2ω(3s²−ω²) / (s²+ω²)³           |
+| t²·cos(ωt)  | 2s(s²−3ω²) / (s²+ω²)³           |
+| t³·sin(ωt)  | 24ωs(s²−ω²) / (s²+ω²)⁴          |
+| t³·cos(ωt)  | 6(s⁴−6s²ω²+ω⁴) / (s²+ω²)⁴      |
+
+For n ≥ 4 the pattern matches but returns `None`, falling through to
+unevaluated `Laplace(f, t, s)`.
+
+### Test count
+
+Tests expanded from 6 to 15.
+
 ## 0.1.0
 
 - Added a pure Rust table-driven Laplace and inverse Laplace transform package.

--- a/code/packages/rust/cas-laplace/Cargo.toml
+++ b/code/packages/rust/cas-laplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-laplace"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Table-driven symbolic Laplace and inverse Laplace transforms over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-laplace/src/lib.rs
+++ b/code/packages/rust/cas-laplace/src/lib.rs
@@ -1,7 +1,33 @@
+//! Laplace and inverse Laplace transforms over symbolic IR.
+//!
+//! This crate provides:
+//!
+//! - [`laplace_transform`] — forward Laplace transform via table lookup and
+//!   linearity rules.
+//! - [`inverse_laplace`] — inverse Laplace transform via a two-stage pipeline:
+//!   direct table matching followed by a full partial-fraction decomposition
+//!   engine.
+//!
+//! ## Partial-fraction engine
+//!
+//! The engine handles three classes that the direct table cannot:
+//!
+//! 1. **Improper fractions** — polynomial long division extracts the quotient
+//!    P(s); a constant quotient contributes a DiracDelta(t) term.
+//!
+//! 2. **Repeated rational poles** — formal power-series expansion around the
+//!    pole (no symbolic differentiation needed).  All arithmetic is exact,
+//!    using a `Frac` struct backed by `i64`.
+//!
+//! 3. **Irreducible quadratic factors** — complex-conjugate poles produce
+//!    `exp(−αt)·cos(βt)` / `exp(−αt)·sin(βt)` pairs by completing the
+//!    square.  When β is irrational a `Sqrt(β²)` IR node keeps the result
+//!    exact.
+
 use std::collections::BTreeMap;
 
 use symbolic_ir::{
-    apply, int, rat, sym, IRNode, ADD, COS, COSH, DIV, EXP, MUL, NEG, POW, SIN, SINH, SUB,
+    apply, int, rat, sym, IRNode, ADD, COS, COSH, DIV, EXP, MUL, NEG, POW, SIN, SINH, SQRT, SUB,
 };
 
 pub const LAPLACE: &str = "Laplace";
@@ -12,7 +38,12 @@ pub const UNIT_STEP: &str = "UnitStep";
 pub type EvalFn = dyn Fn(IRNode) -> IRNode;
 pub type Handler = fn(&IRNode, &EvalFn) -> IRNode;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
 pub fn laplace_transform(f: IRNode, t: IRNode, s: IRNode) -> IRNode {
+    // Linearity: L{f + g} = L{f} + L{g}
     if let Some((a, b)) = binary_args(&f, ADD) {
         return binary(
             ADD,
@@ -21,6 +52,7 @@ pub fn laplace_transform(f: IRNode, t: IRNode, s: IRNode) -> IRNode {
         );
     }
 
+    // Linearity: L{c·f} = c·L{f}
     if let Some((coeff, body)) = extract_coeff_and_fn(&f, &t) {
         if !is_int(&coeff, 1) {
             return binary(MUL, coeff, laplace_transform(body, t, s));
@@ -111,10 +143,20 @@ fn unit_step_eval_handler(expr: &IRNode, _eval: &EvalFn) -> IRNode {
     unit_step_handler(expr)
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Forward transform table
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Entries are checked in order; the first match wins.  The t^n·trig entries
+// for n ≥ 2 must appear before the n=1 entry.
+
 fn table_lookup(f: &IRNode, t: &IRNode, s: &IRNode) -> Option<IRNode> {
+    // L{1} = 1/s
     if is_one(f) {
         return Some(binary(DIV, int(1), s.clone()));
     }
+
+    // L{t^n} = n! / s^{n+1}
     if let Some(n) = match_power_of_t(f, t) {
         return Some(binary(
             DIV,
@@ -122,27 +164,41 @@ fn table_lookup(f: &IRNode, t: &IRNode, s: &IRNode) -> Option<IRNode> {
             binary(POW, s.clone(), int(n + 1)),
         ));
     }
+
+    // L{exp(at)} = 1/(s-a)
     if let Some(a) = match_unary_linear(f, EXP, t) {
         return Some(binary(DIV, int(1), binary(SUB, s.clone(), a)));
     }
+
+    // L{sin(ωt)} = ω/(s²+ω²)
     if let Some(w) = match_unary_linear(f, SIN, t) {
         return Some(binary(DIV, w.clone(), sum_s_sq_param_sq(s, &w)));
     }
+
+    // L{cos(ωt)} = s/(s²+ω²)
     if let Some(w) = match_unary_linear(f, COS, t) {
         return Some(binary(DIV, s.clone(), sum_s_sq_param_sq(s, &w)));
     }
+
+    // L{sinh(at)} = a/(s²-a²)
     if let Some(a) = match_unary_linear(f, SINH, t) {
         return Some(binary(DIV, a.clone(), sub_s_sq_param_sq(s, &a)));
     }
+
+    // L{cosh(at)} = s/(s²-a²)
     if let Some(a) = match_unary_linear(f, COSH, t) {
         return Some(binary(DIV, s.clone(), sub_s_sq_param_sq(s, &a)));
     }
+
+    // L{DiracDelta(t)} = 1,  L{UnitStep(t)} = 1/s
     if is_apply_of_var(f, DIRAC_DELTA, t) {
         return Some(int(1));
     }
     if is_apply_of_var(f, UNIT_STEP, t) {
         return Some(binary(DIV, int(1), s.clone()));
     }
+
+    // L{exp(at)·trig(ωt)}: shifted oscillator pair
     if let Some((a, trig_head, w)) = match_exp_times_trig(f, t) {
         let shifted = binary(SUB, s.clone(), a);
         let denom = binary(
@@ -156,6 +212,8 @@ fn table_lookup(f: &IRNode, t: &IRNode, s: &IRNode) -> Option<IRNode> {
             binary(DIV, shifted, denom)
         });
     }
+
+    // L{t^n·exp(at)}: n! / (s-a)^{n+1}
     if let Some((n, a)) = match_t_power_times_exp(f, t) {
         let shifted = binary(SUB, s.clone(), a);
         return Some(binary(
@@ -164,6 +222,72 @@ fn table_lookup(f: &IRNode, t: &IRNode, s: &IRNode) -> Option<IRNode> {
             binary(POW, shifted, int(n + 1)),
         ));
     }
+
+    // L{t^n·sin(ωt)} / L{t^n·cos(ωt)} for n ≥ 2
+    //
+    // Must appear BEFORE the n=1 trig case below.  Formulas derived by
+    // repeated differentiation of L{sin/cos}:
+    //
+    //   L{t²·sin(ωt)} = 2ω(3s²−ω²) / (s²+ω²)³
+    //   L{t²·cos(ωt)} = 2s(s²−3ω²) / (s²+ω²)³
+    //   L{t³·sin(ωt)} = 24ωs(s²−ω²) / (s²+ω²)⁴
+    //   L{t³·cos(ωt)} = 6(s⁴−6s²ω²+ω⁴) / (s²+ω²)⁴
+    if let Some((n, trig_head, w)) = match_tn_times_trig(f, t) {
+        let s2 = binary(POW, s.clone(), int(2));
+        let w2 = binary(POW, w.clone(), int(2));
+        let s2pw2 = binary(ADD, s2.clone(), w2.clone());
+
+        if trig_head == SIN {
+            match n {
+                2 => {
+                    // Numerator: 2ω · (3s² − ω²)
+                    let num = binary(
+                        MUL,
+                        binary(MUL, int(2), w.clone()),
+                        binary(SUB, binary(MUL, int(3), s2), w2),
+                    );
+                    return Some(binary(DIV, num, binary(POW, s2pw2, int(3))));
+                }
+                3 => {
+                    // Numerator: 24ω · s · (s² − ω²)
+                    let num = binary(
+                        MUL,
+                        binary(MUL, int(24), w),
+                        binary(MUL, s.clone(), binary(SUB, s2, w2)),
+                    );
+                    return Some(binary(DIV, num, binary(POW, s2pw2, int(4))));
+                }
+                _ => return None, // n ≥ 4: fall through to unevaluated
+            }
+        } else {
+            // COS
+            match n {
+                2 => {
+                    // Numerator: 2s · (s² − 3ω²)
+                    let num = binary(
+                        MUL,
+                        binary(MUL, int(2), s.clone()),
+                        binary(SUB, s2, binary(MUL, int(3), w2)),
+                    );
+                    return Some(binary(DIV, num, binary(POW, s2pw2, int(3))));
+                }
+                3 => {
+                    // Numerator: 6 · (s⁴ − 6s²ω² + ω⁴)
+                    let s4 = binary(POW, s.clone(), int(4));
+                    let w4 = binary(POW, w, int(4));
+                    let inner = binary(
+                        ADD,
+                        binary(SUB, s4, binary(MUL, int(6), binary(MUL, s2, w2))),
+                        w4,
+                    );
+                    return Some(binary(DIV, binary(MUL, int(6), inner), binary(POW, s2pw2, int(4))));
+                }
+                _ => return None, // n ≥ 4: fall through to unevaluated
+            }
+        }
+    }
+
+    // L{t·sin(ωt)} = 2ωs / (s²+ω²)²,  L{t·cos(ωt)} = (s²−ω²) / (s²+ω²)²
     if let Some((trig_head, w)) = match_t_times_trig(f, t) {
         let denom_base = sum_s_sq_param_sq(s, &w);
         let denom = binary(POW, denom_base, int(2));
@@ -177,18 +301,29 @@ fn table_lookup(f: &IRNode, t: &IRNode, s: &IRNode) -> Option<IRNode> {
             )
         });
     }
+
     None
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Inverse transform: direct table then partial-fraction engine
+// ─────────────────────────────────────────────────────────────────────────────
+
 fn inverse_lookup(f: &IRNode, s: &IRNode, t: &IRNode) -> Option<IRNode> {
+    // ── Direct pattern matching ──────────────────────────────────────────────
     let (num, den) = binary_args(f, DIV)?;
+
+    // 1/s → UnitStep(t)
     if is_int(num, 1) && same(den, s) {
         return Some(unary(UNIT_STEP, t.clone()));
     }
+
     if is_int(num, 1) {
+        // 1/(s-a) → exp(at)
         if let Some(a) = match_s_minus_a(den, s) {
             return Some(unary(EXP, binary(MUL, a, t.clone())));
         }
+        // 1/s^n  (n ≥ 2) → t^{n-1} / (n-1)!
         if let Some(n) = match_pow_of(den, s) {
             if n >= 2 {
                 let power = if n == 2 {
@@ -205,6 +340,8 @@ fn inverse_lookup(f: &IRNode, s: &IRNode, t: &IRNode) -> Option<IRNode> {
             }
         }
     }
+
+    // ω/(s²+ω²) → sin(ωt),  s/(s²+ω²) → cos(ωt)
     if let Some(w) = match_s_sq_plus_param_sq(den, s) {
         if same(num, &w) {
             return Some(unary(SIN, binary(MUL, w, t.clone())));
@@ -213,12 +350,791 @@ fn inverse_lookup(f: &IRNode, s: &IRNode, t: &IRNode) -> Option<IRNode> {
             return Some(unary(COS, binary(MUL, w, t.clone())));
         }
     }
+
+    // a/(s²-a²) → sinh(at),  s/(s²-a²) → cosh(at)
     if let Some(a) = match_s_sq_minus_param_sq(den, s) {
         if same(num, &a) {
             return Some(unary(SINH, binary(MUL, a, t.clone())));
         }
         if same(num, s) {
             return Some(unary(COSH, binary(MUL, a, t.clone())));
+        }
+    }
+
+    // ── Partial-fraction decomposition engine ────────────────────────────────
+    inverse_pf(f, s, t)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fraction arithmetic over i64
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `Frac` is always stored with d > 0 and gcd(|n|, d) = 1.
+// The `Frac::new` constructor enforces this invariant.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Frac {
+    n: i64,
+    d: i64,
+}
+
+impl Frac {
+    /// Construct a reduced Frac.  Panics if d = 0.
+    fn new(n: i64, d: i64) -> Self {
+        assert!(d != 0, "Frac::new: division by zero");
+        let (n, d) = if d < 0 { (-n, -d) } else { (n, d) };
+        let g = gcd_u64(n.unsigned_abs(), d.unsigned_abs()) as i64;
+        if g == 0 {
+            return Self { n: 0, d: 1 };
+        }
+        Self { n: n / g, d: d / g }
+    }
+
+    fn zero() -> Self {
+        Self { n: 0, d: 1 }
+    }
+    fn one() -> Self {
+        Self { n: 1, d: 1 }
+    }
+    fn is_zero(self) -> bool {
+        self.n == 0
+    }
+    fn is_neg(self) -> bool {
+        self.n < 0
+    }
+}
+
+fn gcd_u64(a: u64, b: u64) -> u64 {
+    if b == 0 { a } else { gcd_u64(b, a % b) }
+}
+
+fn f_add(a: Frac, b: Frac) -> Frac {
+    Frac::new(a.n * b.d + b.n * a.d, a.d * b.d)
+}
+fn f_sub(a: Frac, b: Frac) -> Frac {
+    Frac::new(a.n * b.d - b.n * a.d, a.d * b.d)
+}
+fn f_mul(a: Frac, b: Frac) -> Frac {
+    Frac::new(a.n * b.n, a.d * b.d)
+}
+fn f_div(a: Frac, b: Frac) -> Frac {
+    Frac::new(a.n * b.d, a.d * b.n)
+}
+fn f_neg(a: Frac) -> Frac {
+    Frac { n: -a.n, d: a.d }
+}
+
+/// Convert a Frac to an IRNode (Integer when d=1, Rational otherwise).
+fn frac_to_ir(f: Frac) -> IRNode {
+    if f.d == 1 {
+        int(f.n)
+    } else {
+        rat(f.n, f.d)
+    }
+}
+
+/// Return √f as a Frac if f is a perfect rational square, else None.
+fn frac_rational_sqrt(f: Frac) -> Option<Frac> {
+    let sn = isqrt_exact(f.n)?;
+    let sd = isqrt_exact(f.d)?;
+    Some(Frac::new(sn, sd))
+}
+
+fn isqrt_exact(n: i64) -> Option<i64> {
+    if n < 0 {
+        return None;
+    }
+    if n == 0 {
+        return Some(0);
+    }
+    let r = (n as f64).sqrt() as i64;
+    for candidate in [r - 1, r, r + 1] {
+        if candidate >= 0 && candidate * candidate == n {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Polynomial arithmetic over Frac
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `Poly = Vec<Frac>` in ascending degree order: poly[i] is the coefficient
+// of s^i.
+
+type Poly = Vec<Frac>;
+
+fn poly_normalize(p: Poly) -> Poly {
+    let mut r = p;
+    while r.len() > 1 && r.last().map_or(false, |c| c.is_zero()) {
+        r.pop();
+    }
+    if r.is_empty() {
+        r.push(Frac::zero());
+    }
+    r
+}
+
+fn poly_degree(p: &[Frac]) -> usize {
+    let n = poly_normalize(p.to_vec());
+    n.len() - 1
+}
+
+fn poly_is_zero(p: &[Frac]) -> bool {
+    let n = poly_normalize(p.to_vec());
+    n.len() == 1 && n[0].is_zero()
+}
+
+fn poly_add(a: &[Frac], b: &[Frac]) -> Poly {
+    let len = a.len().max(b.len());
+    let result: Poly = (0..len)
+        .map(|i| {
+            let ca = a.get(i).copied().unwrap_or(Frac::zero());
+            let cb = b.get(i).copied().unwrap_or(Frac::zero());
+            f_add(ca, cb)
+        })
+        .collect();
+    poly_normalize(result)
+}
+
+fn poly_neg(p: &[Frac]) -> Poly {
+    p.iter().map(|&c| f_neg(c)).collect()
+}
+
+fn poly_mul(a: &[Frac], b: &[Frac]) -> Poly {
+    let mut result = vec![Frac::zero(); a.len() + b.len() - 1];
+    for (i, &ca) in a.iter().enumerate() {
+        for (j, &cb) in b.iter().enumerate() {
+            result[i + j] = f_add(result[i + j], f_mul(ca, cb));
+        }
+    }
+    poly_normalize(result)
+}
+
+fn poly_scale(p: &[Frac], c: Frac) -> Poly {
+    p.iter().map(|&x| f_mul(x, c)).collect()
+}
+
+/// Raise polynomial p to the non-negative integer power n.
+fn poly_pow(p: &[Frac], n: i64) -> Poly {
+    if n == 0 {
+        return vec![Frac::one()];
+    }
+    if n == 1 {
+        return p.to_vec();
+    }
+    let mut result = vec![Frac::one()];
+    let mut base = p.to_vec();
+    let mut k = n;
+    while k > 0 {
+        if k & 1 == 1 {
+            result = poly_mul(&result, &base);
+        }
+        base = poly_mul(&base, &base);
+        k >>= 1;
+    }
+    result
+}
+
+/// Evaluate polynomial at x using Horner's method.
+fn poly_eval(p: &[Frac], x: Frac) -> Frac {
+    let mut result = Frac::zero();
+    for &coeff in p.iter().rev() {
+        result = f_add(f_mul(result, x), coeff);
+    }
+    result
+}
+
+/// Polynomial long division: returns (quotient, remainder).
+fn poly_divmod(num: &[Frac], den: &[Frac]) -> (Poly, Poly) {
+    let n = poly_normalize(num.to_vec());
+    let d = poly_normalize(den.to_vec());
+    let deg_n = poly_degree(&n);
+    let deg_d = poly_degree(&d);
+
+    if deg_n < deg_d {
+        return (vec![Frac::zero()], n);
+    }
+
+    let mut q = vec![Frac::zero(); deg_n - deg_d + 1];
+    let mut rem = n.clone();
+
+    for i in (0..=(deg_n - deg_d)).rev() {
+        if i + deg_d < rem.len() && !d[deg_d].is_zero() {
+            let coeff = f_div(rem[i + deg_d], d[deg_d]);
+            q[i] = coeff;
+            for j in 0..=deg_d {
+                if i + j < rem.len() {
+                    rem[i + j] = f_sub(rem[i + j], f_mul(coeff, d[j]));
+                }
+            }
+        }
+    }
+    (poly_normalize(q), poly_normalize(rem))
+}
+
+/// Compute p(s + r) as a polynomial in s via binomial expansion.
+fn poly_shift(p: &[Frac], r: Frac) -> Poly {
+    let mut result = vec![Frac::zero()];
+    for (i, &coeff) in p.iter().enumerate() {
+        if coeff.is_zero() {
+            continue;
+        }
+        let term: Poly = if i == 0 {
+            vec![coeff]
+        } else {
+            let s_plus_r = vec![r, Frac::one()];
+            poly_scale(&poly_pow(&s_plus_r, i as i64), coeff)
+        };
+        result = poly_add(&result, &term);
+    }
+    poly_normalize(result)
+}
+
+/// First `terms` Taylor coefficients of the formal power series N(t)/D(t).
+/// Requires D[0] ≠ 0.
+fn power_series_coeffs(num: &[Frac], den: &[Frac], terms: usize) -> Vec<Frac> {
+    let q0 = den[0];
+    let mut g: Vec<Frac> = Vec::with_capacity(terms);
+    for k in 0..terms {
+        let nk = num.get(k).copied().unwrap_or(Frac::zero());
+        let mut subtract = Frac::zero();
+        for j in 0..k {
+            let dkj = den.get(k - j).copied().unwrap_or(Frac::zero());
+            subtract = f_add(subtract, f_mul(dkj, g[j]));
+        }
+        g.push(f_div(f_sub(nk, subtract), q0));
+    }
+    g
+}
+
+/// Compute Laurent coefficients [A_m, …, A_1] for a pole of order m at r.
+fn compute_repeated_residues(num: &[Frac], den: &[Frac], r: Frac, m: usize) -> Option<Vec<Frac>> {
+    let nt = poly_shift(num, r);
+    let dt = poly_shift(den, r);
+
+    // Verify first m coefficients of dt are zero
+    for i in 0..m {
+        let val = dt.get(i).copied().unwrap_or(Frac::zero());
+        if !val.is_zero() {
+            return None; // wrong multiplicity
+        }
+    }
+    if dt.len() <= m {
+        return None; // degenerate
+    }
+    let q_other = dt[m..].to_vec();
+    if q_other[0].is_zero() {
+        return None; // higher multiplicity
+    }
+
+    Some(power_series_coeffs(&nt, &q_other, m))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rational root finding
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn rational_roots(p: &[Frac]) -> Vec<Frac> {
+    let p = poly_normalize(p.to_vec());
+    if p.len() <= 1 {
+        return vec![];
+    }
+
+    // s = 0 is a root iff constant term is zero
+    if p[0].is_zero() {
+        return vec![Frac::zero()];
+    }
+
+    // Clear denominators to get integer coefficients
+    let mut lcm: i64 = 1;
+    for c in &p {
+        let g = gcd_u64(lcm.unsigned_abs(), c.d.unsigned_abs()) as i64;
+        lcm = (lcm / g) * c.d;
+    }
+    let int_coeffs: Vec<i64> = p.iter().map(|c| c.n * (lcm / c.d)).collect();
+
+    let constant_term = int_coeffs[0].unsigned_abs();
+    let lead_coeff = int_coeffs.last().unwrap().unsigned_abs();
+
+    let p_divs = divisors(constant_term);
+    let q_divs = divisors(lead_coeff);
+
+    let mut roots = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for &pv in &p_divs {
+        for &qv in &q_divs {
+            for &sign in &[1i64, -1i64] {
+                let candidate = Frac::new(sign * pv as i64, qv as i64);
+                let key = (candidate.n, candidate.d);
+                if seen.contains(&key) {
+                    continue;
+                }
+                seen.insert(key);
+                if poly_eval(&p, candidate).is_zero() {
+                    roots.push(candidate);
+                }
+            }
+        }
+    }
+    roots
+}
+
+fn divisors(n: u64) -> Vec<u64> {
+    if n == 0 {
+        return vec![0];
+    }
+    let mut divs = Vec::new();
+    let mut i = 1u64;
+    while i * i <= n {
+        if n % i == 0 {
+            divs.push(i);
+            if i != n / i {
+                divs.push(n / i);
+            }
+        }
+        i += 1;
+    }
+    divs
+}
+
+/// Extract all rational roots with multiplicity (each root repeated).
+fn extract_all_rational_roots(p: &[Frac]) -> Vec<Frac> {
+    let mut p = poly_normalize(p.to_vec());
+    let mut roots = Vec::new();
+
+    while poly_degree(&p) >= 1 {
+        let found = rational_roots(&p);
+        if found.is_empty() {
+            break;
+        }
+        let root = found[0];
+        let mut progress = false;
+        while poly_degree(&p) >= 1 && poly_eval(&p, root).is_zero() {
+            roots.push(root);
+            let linear = vec![f_neg(root), Frac::one()];
+            let (q, _) = poly_divmod(&p, &linear);
+            p = poly_normalize(q);
+            progress = true;
+        }
+        if !progress {
+            break;
+        }
+    }
+    roots
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IR ↔ rational function conversion
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Convert an IR node to a rational function (num/den pair of Poly).
+/// Returns None if the node is not a polynomial in s or ratio of two.
+fn ir_to_rational(node: &IRNode, s: &IRNode) -> Option<(Poly, Poly)> {
+    match node {
+        IRNode::Integer(n) => Some((vec![Frac::new(*n, 1)], vec![Frac::one()])),
+        IRNode::Rational(n, d) => Some((vec![Frac::new(*n, *d)], vec![Frac::one()])),
+        IRNode::Symbol(_) => {
+            if same(node, s) {
+                // s = 0 + 1·s
+                Some((vec![Frac::zero(), Frac::one()], vec![Frac::one()]))
+            } else {
+                None // unknown symbol
+            }
+        }
+        IRNode::Apply(app_node) => {
+            let h = &app_node.head;
+            let args = &app_node.args;
+
+            if h == &sym(ADD) && args.len() == 2 {
+                let (n1, d1) = ir_to_rational(&args[0], s)?;
+                let (n2, d2) = ir_to_rational(&args[1], s)?;
+                // (n1/d1) + (n2/d2) = (n1·d2 + n2·d1) / (d1·d2)
+                let num = poly_normalize(poly_add(&poly_mul(&n1, &d2), &poly_mul(&n2, &d1)));
+                let den = poly_normalize(poly_mul(&d1, &d2));
+                return Some((num, den));
+            }
+
+            if h == &sym(SUB) && args.len() == 2 {
+                let (n1, d1) = ir_to_rational(&args[0], s)?;
+                let (n2, d2) = ir_to_rational(&args[1], s)?;
+                let num = poly_normalize(poly_add(
+                    &poly_mul(&n1, &d2),
+                    &poly_mul(&poly_neg(&n2), &d1),
+                ));
+                let den = poly_normalize(poly_mul(&d1, &d2));
+                return Some((num, den));
+            }
+
+            if h == &sym(MUL) && args.len() == 2 {
+                let (n1, d1) = ir_to_rational(&args[0], s)?;
+                let (n2, d2) = ir_to_rational(&args[1], s)?;
+                return Some((
+                    poly_normalize(poly_mul(&n1, &n2)),
+                    poly_normalize(poly_mul(&d1, &d2)),
+                ));
+            }
+
+            if h == &sym(DIV) && args.len() == 2 {
+                let (n1, d1) = ir_to_rational(&args[0], s)?;
+                let (n2, d2) = ir_to_rational(&args[1], s)?;
+                // (n1/d1) / (n2/d2) = (n1·d2) / (d1·n2)
+                return Some((
+                    poly_normalize(poly_mul(&n1, &d2)),
+                    poly_normalize(poly_mul(&d1, &n2)),
+                ));
+            }
+
+            if h == &sym(NEG) && args.len() == 1 {
+                let (n1, d1) = ir_to_rational(&args[0], s)?;
+                return Some((poly_normalize(poly_neg(&n1)), d1));
+            }
+
+            if h == &sym(POW) && args.len() == 2 {
+                let exp_node = &args[1];
+                let n_exp = match exp_node {
+                    IRNode::Integer(n) => *n,
+                    _ => return None,
+                };
+                let (n1, d1) = ir_to_rational(&args[0], s)?;
+                if n_exp < 0 {
+                    let pos_n = (-n_exp) as i64;
+                    return Some((
+                        poly_normalize(poly_pow(&d1, pos_n)),
+                        poly_normalize(poly_pow(&n1, pos_n)),
+                    ));
+                }
+                return Some((
+                    poly_normalize(poly_pow(&n1, n_exp)),
+                    poly_normalize(poly_pow(&d1, n_exp)),
+                ));
+            }
+
+            None
+        }
+        _ => None,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inverse transform builders (pole → time-domain term)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// L⁻¹{A/(s−a)}: returns A·exp(at).  If a=0, returns A·UnitStep(t).
+fn ilt_simple_pole(big_a: Frac, a: Frac, t: &IRNode) -> IRNode {
+    if a.is_zero() {
+        let step = unary(UNIT_STEP, t.clone());
+        return if big_a == Frac::one() {
+            step
+        } else {
+            binary(MUL, frac_to_ir(big_a), step)
+        };
+    }
+    let exp_term = if a == Frac::one() {
+        unary(EXP, t.clone())
+    } else {
+        unary(EXP, binary(MUL, frac_to_ir(a), t.clone()))
+    };
+    if big_a == Frac::one() {
+        exp_term
+    } else if big_a == Frac::new(-1, 1) {
+        unary(NEG, exp_term)
+    } else {
+        binary(MUL, frac_to_ir(big_a), exp_term)
+    }
+}
+
+/// L⁻¹{A/(s−a)^n}  (n ≥ 2):  A·t^{n-1}·exp(at) / (n-1)!
+fn ilt_repeated_pole(big_a: Frac, a: Frac, n: usize, t: &IRNode) -> IRNode {
+    let fact_nm1 = factorial((n - 1) as i64);
+    let coeff = f_div(big_a, Frac::new(fact_nm1, 1));
+    let coeff_node = frac_to_ir(coeff);
+
+    // t^{n-1}  (n-1=1 → just t)
+    let t_pow: IRNode = if n - 1 == 1 {
+        t.clone()
+    } else {
+        binary(POW, t.clone(), int((n - 1) as i64))
+    };
+
+    if a.is_zero() {
+        return if coeff == Frac::one() {
+            t_pow
+        } else {
+            binary(MUL, coeff_node, t_pow)
+        };
+    }
+
+    let exp_term = if a == Frac::one() {
+        unary(EXP, t.clone())
+    } else {
+        unary(EXP, binary(MUL, frac_to_ir(a), t.clone()))
+    };
+    let inner = binary(MUL, t_pow, exp_term);
+    if coeff == Frac::one() {
+        inner
+    } else {
+        binary(MUL, coeff_node, inner)
+    }
+}
+
+/// Invert (A·s + B) / (s² + b·s + c) with discriminant b²−4c < 0.
+fn ilt_irreducible_quad(lin_num: &[Frac], quad_den: &[Frac], t: &IRNode) -> Option<Vec<IRNode>> {
+    if poly_degree(quad_den) != 2 {
+        return None;
+    }
+
+    let leading = quad_den.get(2).copied().unwrap_or(Frac::zero());
+    if leading.is_zero() {
+        return None;
+    }
+
+    // Make monic
+    let inv_leading = f_div(Frac::one(), leading);
+    let c = f_mul(quad_den.first().copied().unwrap_or(Frac::zero()), inv_leading);
+    let b = f_mul(
+        quad_den.get(1).copied().unwrap_or(Frac::zero()),
+        inv_leading,
+    );
+    let big_b = f_mul(
+        lin_num.first().copied().unwrap_or(Frac::zero()),
+        inv_leading,
+    );
+    let big_a = f_mul(
+        lin_num.get(1).copied().unwrap_or(Frac::zero()),
+        inv_leading,
+    );
+
+    // Discriminant check: b²−4c < 0
+    let disc = f_sub(f_mul(b, b), f_mul(Frac::new(4, 1), c));
+    if !disc.is_neg() {
+        return None; // real roots
+    }
+
+    // Complete the square: α = b/2, β² = c − α²
+    let alpha = f_div(b, Frac::new(2, 1));
+    let beta_sq = f_sub(c, f_mul(alpha, alpha));
+    if beta_sq.is_zero() || beta_sq.is_neg() {
+        return None;
+    }
+
+    let beta_rat = frac_rational_sqrt(beta_sq);
+    let beta_ir: IRNode = match beta_rat {
+        Some(br) => frac_to_ir(br),
+        None => unary(SQRT, frac_to_ir(beta_sq)),
+    };
+    let neg_alpha = f_neg(alpha);
+
+    let beta_is_one = beta_rat.map_or(false, |b| b == Frac::one());
+    let alpha_is_zero = alpha.is_zero();
+
+    // Build coeff · exp(−α·t) · trig(β·t)
+    let make_exp_trig = |coeff_ir: IRNode, is_cos: bool| -> IRNode {
+        let trig_arg: IRNode = if beta_is_one {
+            t.clone()
+        } else {
+            binary(MUL, beta_ir.clone(), t.clone())
+        };
+        let trig_fn = if is_cos { COS } else { SIN };
+        let trig_term = unary(trig_fn, trig_arg);
+
+        let oscillator: IRNode = if alpha_is_zero {
+            trig_term
+        } else {
+            let exp_arg: IRNode = if neg_alpha == Frac::one() {
+                t.clone()
+            } else if neg_alpha == Frac::new(-1, 1) {
+                unary(NEG, t.clone())
+            } else {
+                binary(MUL, frac_to_ir(neg_alpha), t.clone())
+            };
+            binary(MUL, unary(EXP, exp_arg), trig_term)
+        };
+
+        if is_one(&coeff_ir) {
+            oscillator
+        } else {
+            binary(MUL, coeff_ir, oscillator)
+        }
+    };
+
+    let mut terms = Vec::new();
+
+    // Term 1: A · exp(−αt) · cos(βt)
+    if !big_a.is_zero() {
+        terms.push(make_exp_trig(frac_to_ir(big_a), true));
+    }
+
+    // Term 2: (B − A·α) / β · exp(−αt) · sin(βt)
+    let baa = f_sub(big_b, f_mul(big_a, alpha));
+    if !baa.is_zero() {
+        let coeff2: IRNode = match beta_rat {
+            Some(br) => frac_to_ir(f_div(baa, br)),
+            None => binary(DIV, frac_to_ir(baa), beta_ir.clone()),
+        };
+        terms.push(make_exp_trig(coeff2, false));
+    }
+
+    Some(terms)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Full partial-fraction decomposition engine
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn inverse_pf(f_ir: &IRNode, s: &IRNode, t: &IRNode) -> Option<IRNode> {
+    let (num_raw, den_raw) = ir_to_rational(f_ir, s)?;
+    let mut num = poly_normalize(num_raw);
+    let den = poly_normalize(den_raw);
+
+    // ── Step 1: Improper fractions ─────────────────────────────────────────
+    let mut poly_part = vec![Frac::zero()];
+    if poly_degree(&num) >= poly_degree(&den) {
+        let (q, r) = poly_divmod(&num, &den);
+        poly_part = poly_normalize(q);
+        num = poly_normalize(r);
+    }
+
+    // ── Step 2: Extract rational roots ────────────────────────────────────
+    let roots = extract_all_rational_roots(&den);
+
+    let mut q_rat: Poly = vec![Frac::one()];
+    for &r in &roots {
+        q_rat = poly_mul(&q_rat, &[f_neg(r), Frac::one()]);
+    }
+    q_rat = poly_normalize(q_rat);
+
+    let (q_irred, rem_check) = poly_divmod(&den, &q_rat);
+    if !poly_is_zero(&rem_check) {
+        return None;
+    }
+
+    let irred_deg = poly_degree(&q_irred);
+    if irred_deg > 2 {
+        return None;
+    }
+
+    // ── Step 3: Polynomial-part terms ─────────────────────────────────────
+    let mut ir_terms: Vec<IRNode> = Vec::new();
+
+    for (deg, &coeff) in poly_part.iter().enumerate() {
+        if coeff.is_zero() {
+            continue;
+        }
+        if deg == 0 {
+            let delta = unary(DIRAC_DELTA, t.clone());
+            ir_terms.push(if coeff == Frac::one() {
+                delta
+            } else {
+                binary(MUL, frac_to_ir(coeff), delta)
+            });
+        } else {
+            return None; // DiracDelta derivatives not supported
+        }
+    }
+
+    // ── Step 4: Rational pole terms ────────────────────────────────────────
+    // Group roots by value and count multiplicity
+    let mut distinct_roots: std::collections::BTreeMap<(i64, i64), (Frac, usize)> =
+        std::collections::BTreeMap::new();
+    for &r in &roots {
+        let key = (r.n, r.d);
+        distinct_roots.entry(key).and_modify(|(_, cnt)| *cnt += 1).or_insert((r, 1));
+    }
+
+    let mut residues_map: std::collections::BTreeMap<(i64, i64), Vec<Frac>> =
+        std::collections::BTreeMap::new();
+
+    for (&key, &(r, m)) in &distinct_roots {
+        let linear_pow_m = poly_pow(&[f_neg(r), Frac::one()], m as i64);
+        let (q_rat_no_rm, _) = poly_divmod(&q_rat, &linear_pow_m);
+        let q_other = poly_normalize(poly_mul(&q_rat_no_rm, &q_irred));
+
+        if m == 1 {
+            let q_other_r = poly_eval(&q_other, r);
+            if q_other_r.is_zero() {
+                return None;
+            }
+            let res_a = f_div(poly_eval(&num, r), q_other_r);
+            residues_map.insert(key, vec![res_a]);
+            ir_terms.push(ilt_simple_pole(res_a, r, t));
+        } else {
+            let residues = compute_repeated_residues(&num, &den, r, m)?;
+            residues_map.insert(key, residues.clone());
+            for (k, &res_a) in residues.iter().enumerate() {
+                if res_a.is_zero() {
+                    continue;
+                }
+                let pole_order = m - k;
+                ir_terms.push(if pole_order == 1 {
+                    ilt_simple_pole(res_a, r, t)
+                } else {
+                    ilt_repeated_pole(res_a, r, pole_order, t)
+                });
+            }
+        }
+    }
+
+    // ── Step 5: Irreducible quadratic term ─────────────────────────────────
+    if irred_deg == 2 {
+        let mut rat_poly: Poly = vec![Frac::zero()];
+        for (&key, &(r, m)) in &distinct_roots {
+            let residues = residues_map.get(&key).unwrap();
+            for (k_idx, &res_a) in residues.iter().enumerate() {
+                if res_a.is_zero() {
+                    continue;
+                }
+                let pole_order = m - k_idx;
+                let linear_pow_k = poly_pow(&[f_neg(r), Frac::one()], pole_order as i64);
+                let (q_rat_div_k, _) = poly_divmod(&q_rat, &linear_pow_k);
+                let contrib = poly_scale(&poly_mul(&q_irred, &q_rat_div_k), res_a);
+                rat_poly = poly_add(&rat_poly, &contrib);
+            }
+        }
+
+        let irred_times_qrat = poly_normalize(poly_add(&num, &poly_neg(&rat_poly)));
+        let (lin_num, rem2) = poly_divmod(&irred_times_qrat, &q_rat);
+        if !poly_is_zero(&rem2) {
+            return None;
+        }
+
+        let irred_terms = ilt_irreducible_quad(&poly_normalize(lin_num), &poly_normalize(q_irred), t)?;
+        ir_terms.extend(irred_terms);
+    }
+
+    // ── Step 6: Assemble ───────────────────────────────────────────────────
+    if ir_terms.is_empty() {
+        return Some(int(0));
+    }
+    if ir_terms.len() == 1 {
+        return Some(ir_terms.remove(0));
+    }
+    let mut result = ir_terms.remove(0);
+    for term in ir_terms {
+        result = binary(ADD, result, term);
+    }
+    Some(result)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pattern matchers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Match t^n · trig(ω·t) for n ≥ 2.
+fn match_tn_times_trig(f: &IRNode, t: &IRNode) -> Option<(i64, &'static str, IRNode)> {
+    let (a, b) = binary_args(f, MUL)?;
+    for (power_node, trig_node) in [(a, b), (b, a)] {
+        let n = match_power_of_t(power_node, t)?;
+        if n < 2 {
+            continue;
+        }
+        if let Some(w) = match_unary_linear(trig_node, SIN, t) {
+            return Some((n, SIN, w));
+        }
+        if let Some(w) = match_unary_linear(trig_node, COS, t) {
+            return Some((n, COS, w));
         }
     }
     None
@@ -362,10 +1278,7 @@ fn match_s_sq_param_sq(s_sq: &IRNode, param_sq: &IRNode, s: &IRNode) -> Option<I
     if !matches!(match_pow_of(s_sq, s), Some(2)) {
         return None;
     }
-    if let Some(param) = sqrt_param(param_sq) {
-        return Some(param);
-    }
-    None
+    sqrt_param(param_sq)
 }
 
 fn sqrt_param(node: &IRNode) -> Option<IRNode> {

--- a/code/packages/rust/cas-laplace/tests/tests.rs
+++ b/code/packages/rust/cas-laplace/tests/tests.rs
@@ -2,7 +2,7 @@ use cas_laplace::{
     build_laplace_handler_table, dirac_delta_handler, ilt_handler, inverse_laplace,
     laplace_handler, laplace_transform, unit_step_handler, DIRAC_DELTA, ILT, LAPLACE, UNIT_STEP,
 };
-use symbolic_ir::{apply, int, rat, sym, ADD, COS, COSH, DIV, EXP, MUL, POW, SIN, SINH, SUB};
+use symbolic_ir::{apply, int, rat, sym, ADD, COS, COSH, DIV, EXP, MUL, NEG, POW, SIN, SINH, SUB};
 
 fn t() -> symbolic_ir::IRNode {
     sym("t")
@@ -11,6 +11,26 @@ fn t() -> symbolic_ir::IRNode {
 fn s() -> symbolic_ir::IRNode {
     sym("s")
 }
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn mul(a: symbolic_ir::IRNode, b: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    apply(sym(MUL), vec![a, b])
+}
+fn add(a: symbolic_ir::IRNode, b: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    apply(sym(ADD), vec![a, b])
+}
+fn sub(a: symbolic_ir::IRNode, b: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    apply(sym(SUB), vec![a, b])
+}
+fn div(a: symbolic_ir::IRNode, b: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    apply(sym(DIV), vec![a, b])
+}
+fn pow(base: symbolic_ir::IRNode, exp: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    apply(sym(POW), vec![base, exp])
+}
+
+// ─── Existing forward transform tests ────────────────────────────────────────
 
 #[test]
 fn forward_constant_and_powers() {
@@ -133,6 +153,8 @@ fn special_heads_and_handlers() {
     );
 }
 
+// ─── Existing inverse table tests ────────────────────────────────────────────
+
 #[test]
 fn inverse_table_entries() {
     assert_eq!(
@@ -195,4 +217,143 @@ fn handler_eval_and_fallback() {
         laplace_transform(unknown.clone(), t(), s()),
         apply(sym(LAPLACE), vec![unknown, t(), s()])
     );
+}
+
+// ─── Forward: t^n·trig for n = 2, 3 ─────────────────────────────────────────
+
+#[test]
+fn forward_tn_sin_cos_n2() {
+    // L{t²·sin(2t)} = 2ω(3s²−ω²)/(s²+ω²)³  with ω=2
+    // Expected: Div(Mul(Mul(2,2), Sub(Mul(3,Pow(s,2)), Pow(2,2))), Pow(Add(Pow(s,2),Pow(2,2)),3))
+    let f = mul(pow(t(), int(2)), apply(sym(SIN), vec![mul(int(2), t())]));
+    let result = laplace_transform(f, t(), s());
+    let s2 = pow(s(), int(2));
+    let w2 = pow(int(2), int(2));
+    let s2pw2 = add(s2.clone(), w2.clone());
+    let expected_num = mul(mul(int(2), int(2)), sub(mul(int(3), s2), w2));
+    let expected = div(expected_num, pow(s2pw2, int(3)));
+    assert_eq!(result, expected);
+
+    // L{t²·cos(2t)} = 2s(s²−3ω²)/(s²+ω²)³
+    let f2 = mul(pow(t(), int(2)), apply(sym(COS), vec![mul(int(2), t())]));
+    let result2 = laplace_transform(f2, t(), s());
+    let s2b = pow(s(), int(2));
+    let w2b = pow(int(2), int(2));
+    let s2pw2b = add(s2b.clone(), w2b.clone());
+    let expected_num2 = mul(mul(int(2), s()), sub(s2b, mul(int(3), w2b)));
+    let expected2 = div(expected_num2, pow(s2pw2b, int(3)));
+    assert_eq!(result2, expected2);
+}
+
+#[test]
+fn forward_tn_sin_cos_n3() {
+    // L{t³·sin(t)} = 24ωs(s²−ω²)/(s²+ω²)⁴  with ω=1
+    let f = mul(pow(t(), int(3)), apply(sym(SIN), vec![t()]));
+    let result = laplace_transform(f, t(), s());
+    let s2 = pow(s(), int(2));
+    let w2 = pow(int(1), int(2));
+    let s2pw2 = add(s2.clone(), w2.clone());
+    let expected_num = mul(mul(int(24), int(1)), mul(s(), sub(s2, w2)));
+    let expected = div(expected_num, pow(s2pw2, int(4)));
+    assert_eq!(result, expected);
+
+    // L{t³·cos(t)} = 6(s⁴−6s²ω²+ω⁴)/(s²+ω²)⁴
+    let f2 = mul(pow(t(), int(3)), apply(sym(COS), vec![t()]));
+    let result2 = laplace_transform(f2, t(), s());
+    let s2c = pow(s(), int(2));
+    let w2c = pow(int(1), int(2));
+    let s2pw2c = add(s2c.clone(), w2c.clone());
+    let s4 = pow(s(), int(4));
+    let w4 = pow(int(1), int(4));
+    let inner = add(sub(s4, mul(int(6), mul(s2c, w2c))), w4);
+    let expected2 = div(mul(int(6), inner), pow(s2pw2c, int(4)));
+    assert_eq!(result2, expected2);
+}
+
+#[test]
+fn forward_tn_trig_n4_falls_through() {
+    // n=4 is unsupported; falls through to unevaluated Laplace(...)
+    let f = mul(pow(t(), int(4)), apply(sym(SIN), vec![t()]));
+    let result = laplace_transform(f, t(), s());
+    assert!(
+        matches!(result, symbolic_ir::IRNode::Apply(ref app) if app.head == sym(LAPLACE)),
+        "expected unevaluated Laplace, got {:?}",
+        result
+    );
+}
+
+// ─── Inverse: irreducible quadratic (complex conjugate poles) ────────────────
+
+#[test]
+fn inverse_complex_poles_1_over_s2_2s_2() {
+    // 1/(s²+2s+2) → exp(−t)·sin(t) = Mul(Exp(Neg(t)), Sin(t))
+    let denom = add(add(pow(s(), int(2)), mul(int(2), s())), int(2));
+    let f = div(int(1), denom);
+    let result = inverse_laplace(f, s(), t());
+    let expected = mul(
+        apply(sym(EXP), vec![apply(sym(NEG), vec![t()])]),
+        apply(sym(SIN), vec![t()]),
+    );
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn inverse_complex_poles_s_over_s2_2s_2() {
+    // s/(s²+2s+2) → exp(−t)·cos(t) + (−1)·exp(−t)·sin(t)
+    let denom = add(add(pow(s(), int(2)), mul(int(2), s())), int(2));
+    let f = div(s(), denom);
+    let result = inverse_laplace(f, s(), t());
+    let exp_neg_t = apply(sym(EXP), vec![apply(sym(NEG), vec![t()])]);
+    let t1 = mul(exp_neg_t.clone(), apply(sym(COS), vec![t()]));
+    let t2 = mul(int(-1), mul(exp_neg_t, apply(sym(SIN), vec![t()])));
+    let expected = add(t1, t2);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn inverse_complex_poles_mixed_1_over_s_s2_1() {
+    // 1/(s·(s²+1)) → Add(UnitStep(t), Mul(-1, Cos(t)))
+    let f = div(int(1), mul(s(), add(pow(s(), int(2)), int(1))));
+    let result = inverse_laplace(f, s(), t());
+    let expected = add(
+        apply(sym(UNIT_STEP), vec![t()]),
+        mul(int(-1), apply(sym(COS), vec![t()])),
+    );
+    assert_eq!(result, expected);
+}
+
+// ─── Inverse: repeated poles ─────────────────────────────────────────────────
+
+#[test]
+fn inverse_repeated_pole_1_over_s_minus_2_sq() {
+    // 1/(s−2)² → t·exp(2t) = Mul(t, Exp(Mul(2, t)))
+    let f = div(int(1), pow(sub(s(), int(2)), int(2)));
+    let result = inverse_laplace(f, s(), t());
+    let expected = mul(t(), apply(sym(EXP), vec![mul(int(2), t())]));
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn inverse_repeated_pole_s_over_s_minus_1_sq() {
+    // s/(s−1)² → t·exp(t) + exp(t)
+    // iltSimplePole/iltRepeatedPole with a=1 produce exp(t) not exp(1*t)
+    let f = div(s(), pow(sub(s(), int(1)), int(2)));
+    let result = inverse_laplace(f, s(), t());
+    let exp_t = apply(sym(EXP), vec![t()]);
+    let expected = add(mul(t(), exp_t.clone()), exp_t);
+    assert_eq!(result, expected);
+}
+
+// ─── Inverse: improper fractions ─────────────────────────────────────────────
+
+#[test]
+fn inverse_improper_s2_over_s2_plus_1() {
+    // s²/(s²+1) → DiracDelta(t) + (−1)·Sin(t)
+    let f = div(pow(s(), int(2)), add(pow(s(), int(2)), int(1)));
+    let result = inverse_laplace(f, s(), t());
+    let expected = add(
+        apply(sym(DIRAC_DELTA), vec![t()]),
+        mul(int(-1), apply(sym(SIN), vec![t()])),
+    );
+    assert_eq!(result, expected);
 }

--- a/code/packages/typescript/cas-laplace/CHANGELOG.md
+++ b/code/packages/typescript/cas-laplace/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 0.2.0 — 2026-05-16
+
+**Extended ILT engine: complex conjugate poles, repeated poles, improper
+fractions.  Extended forward table: t^n·sin(ωt) and t^n·cos(ωt) for n = 2, 3.**
+
+### `index.ts` — partial-fraction decomposition engine
+
+`inverseLookup` now falls through to a full partial-fraction engine
+`inversePF` when direct pattern matching fails.  Three new capabilities:
+
+1. **Improper fractions** — polynomial long division extracts the quotient
+   `P(s)`.  A constant quotient contributes a `DiracDelta(t)` term.
+
+2. **Repeated rational poles** — formal power-series expansion around the
+   pole: shift `s → r + t`, divide out `t^m`, and read off the first `m`
+   Taylor coefficients of the reduced function.  All arithmetic is exact,
+   using a `Frac` type backed by `bigint`.
+
+3. **Irreducible quadratic factor** — after extracting all rational-root
+   factors, a remaining degree-2 denominator with `b²−4c < 0` is handled
+   by completing the square `(s+α)²+β²` and matching against
+   `A*(s+α)/((s+α)²+β²)` and `β/((s+α)²+β²)`, yielding
+   `exp(−αt)·cos(βt)` and `exp(−αt)·sin(βt)` respectively.  When β is
+   irrational a `Sqrt(β²)` node is built so the output remains exact.
+
+New internal infrastructure: `Frac` type with exact bigint arithmetic;
+`Poly = Frac[]` polynomial arithmetic; `irToRational`; `polyShift`;
+`powerSeriesCoeffs`; `computeRepeatedResidues`; `iltIrreducibleQuad`;
+`inversePF`; `rationalRoots`; `extractAllRationalRoots`.
+
+Examples now evaluating:
+- `ilt(1/(s^2+2*s+2), s, t)` → `Mul(Exp(Neg(t)), Sin(t))`
+- `ilt(s/(s^2+2*s+2), s, t)` → `Add(Mul(Exp(Neg(t)),Cos(t)), Mul(-1,Mul(Exp(Neg(t)),Sin(t))))`
+- `ilt(1/(s-2)^2, s, t)` → `Mul(t, Exp(Mul(2, t)))`
+- `ilt(1/(s*(s^2+1)), s, t)` → `Add(UnitStep(t), Mul(-1, Cos(t)))`
+
+### `index.ts` — t^n·trig forward transforms for n = 2, 3
+
+Added `matchTnTimesTrig` pattern recognizer and inline transform builders
+for `t^n·sin(ωt)` and `t^n·cos(ωt)` with n ≥ 2.
+
+Closed-form formulas:
+
+| f(t)        | F(s) = L{f}(s)                  |
+|-------------|----------------------------------|
+| t²·sin(ωt)  | 2ω(3s²−ω²) / (s²+ω²)³           |
+| t²·cos(ωt)  | 2s(s²−3ω²) / (s²+ω²)³           |
+| t³·sin(ωt)  | 24ωs(s²−ω²) / (s²+ω²)⁴          |
+| t³·cos(ωt)  | 6(s⁴−6s²ω²+ω⁴) / (s²+ω²)⁴      |
+
+For n ≥ 4 the pattern matches but returns `undefined`, falling through to
+unevaluated `Laplace(f, t, s)`.
+
+### Test count
+
+Tests expanded from 10 to 35.
+
 ## 0.1.0
 
 - Added a pure TypeScript table-driven Laplace and inverse Laplace transform package.

--- a/code/packages/typescript/cas-laplace/package.json
+++ b/code/packages/typescript/cas-laplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-laplace",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pure TypeScript table-driven Laplace and inverse Laplace transforms over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-laplace/src/index.ts
+++ b/code/packages/typescript/cas-laplace/src/index.ts
@@ -1,3 +1,30 @@
+/**
+ * Laplace and inverse Laplace transforms over symbolic IR.
+ *
+ * This module provides:
+ *
+ * - `laplaceTransform(f, t, s)` — forward Laplace transform via table
+ *   lookup and linearity rules.
+ * - `inverseLaplace(F, s, t)` — inverse Laplace transform via a two-stage
+ *   pipeline: direct table matching followed by a full partial-fraction
+ *   decomposition engine.
+ *
+ * The partial-fraction engine handles three classes that the direct table
+ * cannot:
+ *
+ * 1. **Improper fractions** — polynomial long division extracts the
+ *    polynomial part; a constant quotient contributes a DiracDelta(t) term.
+ *
+ * 2. **Repeated rational poles** — Laurent expansion via formal power
+ *    series (no symbolic differentiation needed).
+ *
+ * 3. **Irreducible quadratic factors** — complex-conjugate poles produce
+ *    exp(−αt)·cos(βt) / exp(−αt)·sin(βt) pairs by completing the square.
+ *
+ * All arithmetic in the polynomial engine is exact, using a `Frac` type
+ * backed by arbitrary-precision `bigint`.
+ */
+
 import {
   ADD,
   COS,
@@ -9,6 +36,7 @@ import {
   POW,
   SIN,
   SINH,
+  SQRT,
   SUB,
   app,
   equals,
@@ -25,12 +53,18 @@ export const UNIT_STEP = sym("UnitStep");
 
 export type EvalFn = (node: IRNode) => IRNode;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function laplaceTransform(f: IRNode, t: IRNode, s: IRNode): IRNode {
+  // Linearity: L{f + g} = L{f} + L{g}
   const addArgs = binaryArgs(f, ADD);
   if (addArgs !== undefined) {
     return bin(ADD, laplaceTransform(addArgs[0], t, s), laplaceTransform(addArgs[1], t, s));
   }
 
+  // Linearity: L{c·f} = c·L{f}
   const extracted = extractCoeffAndFn(f, t);
   if (extracted !== undefined && !isInt(extracted.coeff, 1n)) {
     return bin(MUL, extracted.coeff, laplaceTransform(extracted.body, t, s));
@@ -77,29 +111,47 @@ export function buildLaplaceHandlerTable(): ReadonlyMap<string, (expr: IRNode, e
   ]);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Forward transform table
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The table is a sequential lookup: each pattern matcher returns the transform
+// result or undefined to fall through to the next entry.  Order matters —
+// t^n·trig patterns for n≥2 must appear before the n=1 entry.
+
 function tableLookup(f: IRNode, t: IRNode, s: IRNode): IRNode | undefined {
+  // L{1} = 1/s
   if (isOne(f)) return bin(DIV, int(1), s);
+
+  // L{t^n} = n! / s^{n+1}
   const n = matchPowerOfT(f, t);
   if (n !== undefined) return bin(DIV, int(factorial(n)), bin(POW, s, int(n + 1n)));
 
+  // L{exp(at)} = 1/(s-a)
   const expShift = matchUnaryLinear(f, EXP, t);
   if (expShift !== undefined) return bin(DIV, int(1), bin(SUB, s, expShift));
 
+  // L{sin(ωt)} = ω/(s²+ω²)
   const sinOmega = matchUnaryLinear(f, SIN, t);
   if (sinOmega !== undefined) return bin(DIV, sinOmega, sumSSqParamSq(s, sinOmega));
 
+  // L{cos(ωt)} = s/(s²+ω²)
   const cosOmega = matchUnaryLinear(f, COS, t);
   if (cosOmega !== undefined) return bin(DIV, s, sumSSqParamSq(s, cosOmega));
 
+  // L{sinh(at)} = a/(s²-a²)
   const sinhA = matchUnaryLinear(f, SINH, t);
   if (sinhA !== undefined) return bin(DIV, sinhA, subSSqParamSq(s, sinhA));
 
+  // L{cosh(at)} = s/(s²-a²)
   const coshA = matchUnaryLinear(f, COSH, t);
   if (coshA !== undefined) return bin(DIV, s, subSSqParamSq(s, coshA));
 
+  // L{DiracDelta(t)} = 1, L{UnitStep(t)} = 1/s
   if (isApplyOfVar(f, DIRAC_DELTA, t)) return int(1);
   if (isApplyOfVar(f, UNIT_STEP, t)) return bin(DIV, int(1), s);
 
+  // L{exp(at)·trig(ωt)}: shifted oscillator pairs
   const expTrig = matchExpTimesTrig(f, t);
   if (expTrig !== undefined) {
     const shifted = bin(SUB, s, expTrig.shift);
@@ -107,11 +159,56 @@ function tableLookup(f: IRNode, t: IRNode, s: IRNode): IRNode | undefined {
     return equals(expTrig.trigHead, SIN) ? bin(DIV, expTrig.omega, denom) : bin(DIV, shifted, denom);
   }
 
+  // L{t^n·exp(at)}: n! / (s-a)^{n+1}
   const tExp = matchTPowerTimesExp(f, t);
   if (tExp !== undefined) {
     return bin(DIV, int(factorial(tExp.power)), bin(POW, bin(SUB, s, tExp.shift), int(tExp.power + 1n)));
   }
 
+  // L{t^n·sin(ωt)} / L{t^n·cos(ωt)} for n ≥ 2 — must come BEFORE the n=1 case below.
+  // Formulas derived by repeated differentiation of L{sin/cos}:
+  //   L{t²·sin(ωt)} = 2ω(3s²−ω²) / (s²+ω²)³
+  //   L{t²·cos(ωt)} = 2s(s²−3ω²) / (s²+ω²)³
+  //   L{t³·sin(ωt)} = 24ωs(s²−ω²) / (s²+ω²)⁴
+  //   L{t³·cos(ωt)} = 6(s⁴−6s²ω²+ω⁴) / (s²+ω²)⁴
+  const tnTrig = matchTnTimesTrig(f, t);
+  if (tnTrig !== undefined) {
+    const { power: tn, trigHead, omega } = tnTrig;
+    const s2 = bin(POW, s, int(2));
+    const w2 = bin(POW, omega, int(2));
+    const s2pw2 = bin(ADD, s2, w2);
+
+    if (equals(trigHead, SIN)) {
+      if (tn === 2n) {
+        // Numerator: 2ω · (3s² − ω²)
+        const num = bin(MUL, bin(MUL, int(2), omega), bin(SUB, bin(MUL, int(3), s2), w2));
+        return bin(DIV, num, bin(POW, s2pw2, int(3)));
+      }
+      if (tn === 3n) {
+        // Numerator: 24ω · s · (s² − ω²)
+        const num = bin(MUL, bin(MUL, int(24), omega), bin(MUL, s, bin(SUB, s2, w2)));
+        return bin(DIV, num, bin(POW, s2pw2, int(4)));
+      }
+      return undefined; // n ≥ 4: fall through to unevaluated
+    } else {
+      // COS
+      if (tn === 2n) {
+        // Numerator: 2s · (s² − 3ω²)
+        const num = bin(MUL, bin(MUL, int(2), s), bin(SUB, s2, bin(MUL, int(3), w2)));
+        return bin(DIV, num, bin(POW, s2pw2, int(3)));
+      }
+      if (tn === 3n) {
+        // Numerator: 6 · (s⁴ − 6s²ω² + ω⁴)
+        const s4 = bin(POW, s, int(4));
+        const w4 = bin(POW, omega, int(4));
+        const inner = bin(ADD, bin(SUB, s4, bin(MUL, int(6), bin(MUL, s2, w2))), w4);
+        return bin(DIV, bin(MUL, int(6), inner), bin(POW, s2pw2, int(4)));
+      }
+      return undefined; // n ≥ 4: fall through to unevaluated
+    }
+  }
+
+  // L{t·sin(ωt)} = 2ωs / (s²+ω²)²,  L{t·cos(ωt)} = (s²−ω²) / (s²+ω²)²
   const tTrig = matchTTimesTrig(f, t);
   if (tTrig !== undefined) {
     const denom = bin(POW, sumSSqParamSq(s, tTrig.omega), int(2));
@@ -123,34 +220,819 @@ function tableLookup(f: IRNode, t: IRNode, s: IRNode): IRNode | undefined {
   return undefined;
 }
 
-function inverseLookup(f: IRNode, s: IRNode, t: IRNode): IRNode | undefined {
-  const div = binaryArgs(f, DIV);
-  if (div === undefined) return undefined;
-  const [num, den] = div;
+// ─────────────────────────────────────────────────────────────────────────────
+// Inverse transform: direct table then partial-fraction engine
+// ─────────────────────────────────────────────────────────────────────────────
 
-  if (isInt(num, 1n) && equals(den, s)) return app(UNIT_STEP, [t]);
-  if (isInt(num, 1n)) {
-    const shift = matchSMinusA(den, s);
-    if (shift !== undefined) return app(EXP, [bin(MUL, shift, t)]);
-    const pow = matchPowOf(den, s);
-    if (pow !== undefined && pow >= 2n) {
-      const power = pow === 2n ? t : bin(POW, t, int(pow - 1n));
-      return pow === 2n ? power : bin(DIV, power, int(factorial(pow - 1n)));
+function inverseLookup(f: IRNode, s: IRNode, t: IRNode): IRNode | undefined {
+  // ── Step 1: Direct pattern matching ─────────────────────────────────────
+  const div = binaryArgs(f, DIV);
+  if (div !== undefined) {
+    const [num, den] = div;
+
+    // 1/s → UnitStep(t)
+    if (isInt(num, 1n) && equals(den, s)) return app(UNIT_STEP, [t]);
+
+    if (isInt(num, 1n)) {
+      // 1/(s-a) → exp(at)
+      const shift = matchSMinusA(den, s);
+      if (shift !== undefined) return app(EXP, [bin(MUL, shift, t)]);
+
+      // 1/s^n  (n ≥ 2) → t^{n-1} / (n-1)!
+      const pow = matchPowOf(den, s);
+      if (pow !== undefined && pow >= 2n) {
+        const power = pow === 2n ? t : bin(POW, t, int(pow - 1n));
+        return pow === 2n ? power : bin(DIV, power, int(factorial(pow - 1n)));
+      }
+    }
+
+    // ω/(s²+ω²) → sin(ωt),  s/(s²+ω²) → cos(ωt)
+    const plusParam = matchSSqPlusParamSq(den, s);
+    if (plusParam !== undefined) {
+      if (equals(num, plusParam)) return app(SIN, [bin(MUL, plusParam, t)]);
+      if (equals(num, s)) return app(COS, [bin(MUL, plusParam, t)]);
+    }
+
+    // a/(s²-a²) → sinh(at),  s/(s²-a²) → cosh(at)
+    const minusParam = matchSSqMinusParamSq(den, s);
+    if (minusParam !== undefined) {
+      if (equals(num, minusParam)) return app(SINH, [bin(MUL, minusParam, t)]);
+      if (equals(num, s)) return app(COSH, [bin(MUL, minusParam, t)]);
     }
   }
 
-  const plusParam = matchSSqPlusParamSq(den, s);
-  if (plusParam !== undefined) {
-    if (equals(num, plusParam)) return app(SIN, [bin(MUL, plusParam, t)]);
-    if (equals(num, s)) return app(COS, [bin(MUL, plusParam, t)]);
+  // ── Step 2: Partial-fraction decomposition engine ────────────────────────
+  return inversePF(f, s, t);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fraction arithmetic (exact rational numbers over bigint)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// A `Frac` is always stored in reduced form with d > 0.
+// The `frac()` constructor enforces this invariant.
+
+type Frac = { readonly n: bigint; readonly d: bigint };
+
+/** Construct a reduced Frac. */
+function frac(n: bigint, d: bigint = 1n): Frac {
+  if (d === 0n) throw new Error("frac: division by zero");
+  if (d < 0n) {
+    n = -n;
+    d = -d;
+  }
+  const g = bigGcd(n < 0n ? -n : n, d);
+  if (g === 0n) return { n: 0n, d: 1n };
+  return { n: n / g, d: d / g };
+}
+
+function bigGcd(a: bigint, b: bigint): bigint {
+  while (b !== 0n) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+const ZERO_F: Frac = { n: 0n, d: 1n };
+const ONE_F: Frac = { n: 1n, d: 1n };
+
+function fracAdd(a: Frac, b: Frac): Frac {
+  return frac(a.n * b.d + b.n * a.d, a.d * b.d);
+}
+function fracSub(a: Frac, b: Frac): Frac {
+  return frac(a.n * b.d - b.n * a.d, a.d * b.d);
+}
+function fracMul(a: Frac, b: Frac): Frac {
+  return frac(a.n * b.n, a.d * b.d);
+}
+function fracDiv(a: Frac, b: Frac): Frac {
+  return frac(a.n * b.d, a.d * b.n);
+}
+function fracEq(a: Frac, b: Frac): boolean {
+  return a.n === b.n && a.d === b.d;
+}
+function fracNeg(a: Frac): Frac {
+  return { n: -a.n, d: a.d };
+}
+function fracIsZero(a: Frac): boolean {
+  return a.n === 0n;
+}
+function fracIsNeg(a: Frac): boolean {
+  return a.n < 0n;
+}
+
+/** Convert a Frac to an IRNode (integer if d=1, rational otherwise). */
+function fracToIR(f: Frac): IRNode {
+  return f.d === 1n ? int(f.n) : rational(f.n, f.d);
+}
+
+/**
+ * Return sqrt(f) as a Frac if f is a perfect rational square, else undefined.
+ *
+ * Examples:
+ *   fracRationalSqrt({n:4n,d:1n})  → {n:2n,d:1n}
+ *   fracRationalSqrt({n:1n,d:4n})  → {n:1n,d:2n}
+ *   fracRationalSqrt({n:2n,d:1n})  → undefined
+ */
+function fracRationalSqrt(f: Frac): Frac | undefined {
+  const sn = bigintSqrtExact(f.n);
+  const sd = bigintSqrtExact(f.d);
+  if (sn !== undefined && sd !== undefined) return frac(sn, sd);
+  return undefined;
+}
+
+function bigintSqrtExact(n: bigint): bigint | undefined {
+  if (n < 0n) return undefined;
+  if (n === 0n) return 0n;
+  const r = bigintSqrt(n);
+  return r * r === n ? r : undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Polynomial arithmetic over Frac
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Polynomials are represented as `Frac[]` in ascending degree order:
+//   poly[i]  is the coefficient of s^i.
+//
+// So (c0, c1, c2) represents  c0 + c1·s + c2·s².
+
+type Poly = Frac[];
+
+function polyNormalize(p: Poly): Poly {
+  const r = [...p];
+  while (r.length > 1 && fracIsZero(r[r.length - 1])) r.pop();
+  return r.length === 0 ? [ZERO_F] : r;
+}
+
+function polyDegree(p: Poly): number {
+  return polyNormalize(p).length - 1;
+}
+
+function polyIsZero(p: Poly): boolean {
+  const n = polyNormalize(p);
+  return n.length === 1 && fracIsZero(n[0]);
+}
+
+function polyAdd(a: Poly, b: Poly): Poly {
+  const len = Math.max(a.length, b.length);
+  const result: Poly = [];
+  for (let i = 0; i < len; i++) {
+    const ca = i < a.length ? a[i] : ZERO_F;
+    const cb = i < b.length ? b[i] : ZERO_F;
+    result.push(fracAdd(ca, cb));
+  }
+  return polyNormalize(result);
+}
+
+function polyNeg(p: Poly): Poly {
+  return p.map(fracNeg);
+}
+
+function polyMul(a: Poly, b: Poly): Poly {
+  const result: Poly = Array.from({ length: a.length + b.length - 1 }, () => ZERO_F);
+  for (let i = 0; i < a.length; i++) {
+    for (let j = 0; j < b.length; j++) {
+      result[i + j] = fracAdd(result[i + j], fracMul(a[i], b[j]));
+    }
+  }
+  return polyNormalize(result);
+}
+
+function polyScale(p: Poly, c: Frac): Poly {
+  return p.map((x) => fracMul(x, c));
+}
+
+/** Raise polynomial p to the non-negative integer power n (binary exponentiation). */
+function polyPow(p: Poly, n: bigint): Poly {
+  if (n === 0n) return [ONE_F];
+  if (n === 1n) return [...p];
+  let result: Poly = [ONE_F];
+  let base = [...p];
+  let k = n;
+  while (k > 0n) {
+    if (k & 1n) result = polyMul(result, base);
+    base = polyMul(base, base);
+    k >>= 1n;
+  }
+  return result;
+}
+
+/** Evaluate polynomial at x using Horner's method. */
+function polyEval(p: Poly, x: Frac): Frac {
+  let result = ZERO_F;
+  for (let i = p.length - 1; i >= 0; i--) {
+    result = fracAdd(fracMul(result, x), p[i]);
+  }
+  return result;
+}
+
+/** Polynomial long division: returns [quotient, remainder]. */
+function polyDivmod(num: Poly, den: Poly): [Poly, Poly] {
+  let n = polyNormalize(num);
+  const d = polyNormalize(den);
+  const degN = polyDegree(n);
+  const degD = polyDegree(d);
+  if (degN < degD) return [[ZERO_F], [...n]];
+
+  const q: Poly = Array.from({ length: degN - degD + 1 }, () => ZERO_F);
+  const rem = [...n];
+
+  for (let i = degN - degD; i >= 0; i--) {
+    if (i + degD < rem.length && !fracIsZero(d[degD])) {
+      const coeff = fracDiv(rem[i + degD], d[degD]);
+      q[i] = coeff;
+      for (let j = 0; j <= degD; j++) {
+        if (i + j < rem.length) {
+          rem[i + j] = fracSub(rem[i + j], fracMul(coeff, d[j]));
+        }
+      }
+    }
+  }
+  return [polyNormalize(q), polyNormalize(rem)];
+}
+
+/**
+ * Compute p(s + r) as a polynomial in s.
+ *
+ * Substitutes s → s + r via binomial expansion: each term c·s^i becomes
+ * c·(s+r)^i.  This is used to shift a polynomial so a given root r is
+ * moved to the origin, enabling the formal Laurent expansion for repeated
+ * poles.
+ */
+function polyShift(p: Poly, r: Frac): Poly {
+  let result: Poly = [ZERO_F];
+  for (let i = 0; i < p.length; i++) {
+    if (fracIsZero(p[i])) continue;
+    let term: Poly;
+    if (i === 0) {
+      term = [p[i]];
+    } else {
+      // (s + r)^i in ascending-coefficient form
+      const sPlusR: Poly = [r, ONE_F];
+      term = polyScale(polyPow(sPlusR, BigInt(i)), p[i]);
+    }
+    result = polyAdd(result, term);
+  }
+  return polyNormalize(result);
+}
+
+/**
+ * First `terms` Taylor coefficients of the formal power series N(t)/D(t).
+ *
+ * Requires D[0] ≠ 0.  Uses the recurrence:
+ *
+ *   g_0 = N[0] / D[0]
+ *   g_k = (N[k] − Σ_{j=0}^{k-1} D[k-j]·g_j) / D[0]
+ */
+function powerSeriesCoeffs(num: Poly, den: Poly, terms: number): Frac[] {
+  const q0 = den[0];
+  const g: Frac[] = [];
+  for (let k = 0; k < terms; k++) {
+    const nk = k < num.length ? num[k] : ZERO_F;
+    let subtract = ZERO_F;
+    for (let j = 0; j < k; j++) {
+      const dkj = k - j < den.length ? den[k - j] : ZERO_F;
+      subtract = fracAdd(subtract, fracMul(dkj, g[j]));
+    }
+    g.push(fracDiv(fracSub(nk, subtract), q0));
+  }
+  return g;
+}
+
+/**
+ * Compute Laurent coefficients [A_m, A_{m-1}, …, A_1] for a pole of
+ * multiplicity m at r.
+ *
+ * For F(s) = N(s)/D(s) with D having a zero of order m at r, we:
+ * 1. Shift: N_t(t) = N(r+t), D_t(t) = D(r+t).
+ * 2. Verify D_t[0..m-1] are zero (confirms multiplicity ≥ m).
+ * 3. Form Q_other = D_t[m:] (constant term nonzero).
+ * 4. Compute m Taylor coefficients of N_t / Q_other.
+ *
+ * Returns undefined if the claimed multiplicity is inconsistent.
+ */
+function computeRepeatedResidues(num: Poly, den: Poly, r: Frac, m: number): Frac[] | undefined {
+  const Nt = polyShift(num, r);
+  const Dt = polyShift(den, r);
+
+  for (let i = 0; i < m; i++) {
+    const val = i < Dt.length ? Dt[i] : ZERO_F;
+    if (!fracIsZero(val)) return undefined; // multiplicity claim is wrong
+  }
+  if (Dt.length <= m) return undefined; // degenerate
+  const Qother = Dt.slice(m);
+  if (fracIsZero(Qother[0])) return undefined; // higher multiplicity than claimed
+
+  return powerSeriesCoeffs(Nt, Qother, m);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rational root finding
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find rational roots of p using the rational root theorem.
+ *
+ * Any rational root p/q of an integer polynomial must have p | a_0 and
+ * q | a_n.  We clear denominators to reduce to the integer case.
+ */
+function rationalRoots(p: Poly): Frac[] {
+  p = polyNormalize(p);
+  if (p.length <= 1) return [];
+
+  // s = 0 is a root iff the constant term is zero
+  if (fracIsZero(p[0])) return [ZERO_F];
+
+  // Clear denominators: multiply by LCM of all denominators
+  let lcm = 1n;
+  for (const c of p) {
+    const g = bigGcd(lcm, c.d);
+    lcm = (lcm / g) * c.d;
+  }
+  const intCoeffs = p.map((c) => c.n * (lcm / c.d));
+
+  const constantTerm = intCoeffs[0] < 0n ? -intCoeffs[0] : intCoeffs[0];
+  const leadCoeff =
+    intCoeffs[intCoeffs.length - 1] < 0n
+      ? -intCoeffs[intCoeffs.length - 1]
+      : intCoeffs[intCoeffs.length - 1];
+
+  const pDivs = divisorsBigint(constantTerm);
+  const qDivs = divisorsBigint(leadCoeff);
+
+  const roots: Frac[] = [];
+  const seen = new Set<string>();
+
+  for (const pv of pDivs) {
+    for (const qv of qDivs) {
+      for (const sign of [1n, -1n]) {
+        const candidate = frac(sign * pv, qv);
+        const key = `${candidate.n}/${candidate.d}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        if (fracIsZero(polyEval(p, candidate))) {
+          roots.push(candidate);
+        }
+      }
+    }
+  }
+  return roots;
+}
+
+/** Positive divisors of n (bigint). */
+function divisorsBigint(n: bigint): bigint[] {
+  if (n === 0n) return [0n];
+  const divs: bigint[] = [];
+  for (let i = 1n; i * i <= n; i++) {
+    if (n % i === 0n) {
+      divs.push(i);
+      if (i !== n / i) divs.push(n / i);
+    }
+  }
+  return divs;
+}
+
+/**
+ * Extract all rational roots of p with multiplicity (each root repeated in
+ * the returned list according to its multiplicity).
+ *
+ * Uses repeated division: find a root, divide it out, repeat.
+ */
+function extractAllRationalRoots(p: Poly): Frac[] {
+  p = polyNormalize(p);
+  const roots: Frac[] = [];
+
+  while (polyDegree(p) >= 1) {
+    const found = rationalRoots(p);
+    if (found.length === 0) break;
+    const root = found[0];
+    // Extract all copies of this root
+    let progress = false;
+    while (polyDegree(p) >= 1 && fracIsZero(polyEval(p, root))) {
+      roots.push(root);
+      const [q] = polyDivmod(p, [fracNeg(root), ONE_F]);
+      p = polyNormalize(q);
+      progress = true;
+    }
+    if (!progress) break; // safety: root claim was wrong
+  }
+  return roots;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IR ↔ rational function conversion
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Convert an IR expression to a rational function (num/den pair of Poly).
+ *
+ * Returns undefined if the node is not a polynomial in s with rational
+ * coefficients, or not a ratio of two such polynomials.
+ *
+ * Handles: integer, rational, symbol (s only), Add, Sub, Mul, Div, Neg, Pow.
+ */
+function irToRational(node: IRNode, s: IRNode): { num: Poly; den: Poly } | undefined {
+  if (node.kind === "integer") {
+    return { num: [frac(node.value)], den: [ONE_F] };
+  }
+  if (node.kind === "rational") {
+    return { num: [frac(node.numer, node.denom)], den: [ONE_F] };
+  }
+  if (node.kind === "symbol") {
+    // Only the integration variable s is recognized; any other symbol is
+    // non-rational from this engine's perspective.
+    if (equals(node, s)) return { num: [ZERO_F, ONE_F], den: [ONE_F] };
+    return undefined;
+  }
+  if (node.kind !== "apply") return undefined;
+
+  const h = node.head;
+  const args = node.args;
+
+  if (equals(h, ADD) && args.length === 2) {
+    const r1 = irToRational(args[0], s);
+    const r2 = irToRational(args[1], s);
+    if (!r1 || !r2) return undefined;
+    // (n1/d1) + (n2/d2) = (n1·d2 + n2·d1) / (d1·d2)
+    return {
+      num: polyNormalize(polyAdd(polyMul(r1.num, r2.den), polyMul(r2.num, r1.den))),
+      den: polyNormalize(polyMul(r1.den, r2.den)),
+    };
   }
 
-  const minusParam = matchSSqMinusParamSq(den, s);
-  if (minusParam !== undefined) {
-    if (equals(num, minusParam)) return app(SINH, [bin(MUL, minusParam, t)]);
-    if (equals(num, s)) return app(COSH, [bin(MUL, minusParam, t)]);
+  if (equals(h, SUB) && args.length === 2) {
+    const r1 = irToRational(args[0], s);
+    const r2 = irToRational(args[1], s);
+    if (!r1 || !r2) return undefined;
+    return {
+      num: polyNormalize(polyAdd(polyMul(r1.num, r2.den), polyMul(polyNeg(r2.num), r1.den))),
+      den: polyNormalize(polyMul(r1.den, r2.den)),
+    };
   }
 
+  if (equals(h, MUL) && args.length === 2) {
+    const r1 = irToRational(args[0], s);
+    const r2 = irToRational(args[1], s);
+    if (!r1 || !r2) return undefined;
+    return {
+      num: polyNormalize(polyMul(r1.num, r2.num)),
+      den: polyNormalize(polyMul(r1.den, r2.den)),
+    };
+  }
+
+  if (equals(h, DIV) && args.length === 2) {
+    const r1 = irToRational(args[0], s);
+    const r2 = irToRational(args[1], s);
+    if (!r1 || !r2) return undefined;
+    // (n1/d1) / (n2/d2) = (n1·d2) / (d1·n2)
+    return {
+      num: polyNormalize(polyMul(r1.num, r2.den)),
+      den: polyNormalize(polyMul(r1.den, r2.num)),
+    };
+  }
+
+  if (equals(h, NEG) && args.length === 1) {
+    const r1 = irToRational(args[0], s);
+    if (!r1) return undefined;
+    return { num: polyNormalize(polyNeg(r1.num)), den: r1.den };
+  }
+
+  if (equals(h, POW) && args.length === 2) {
+    const expNode = args[1];
+    if (expNode.kind !== "integer") return undefined;
+    const nExp = expNode.value;
+    const r1 = irToRational(args[0], s);
+    if (!r1) return undefined;
+    if (nExp < 0n) {
+      // base^{-n} = 1 / base^n  →  num = den^n, den = num^n
+      const posN = -nExp;
+      return {
+        num: polyNormalize(polyPow(r1.den, posN)),
+        den: polyNormalize(polyPow(r1.num, posN)),
+      };
+    }
+    return {
+      num: polyNormalize(polyPow(r1.num, nExp)),
+      den: polyNormalize(polyPow(r1.den, nExp)),
+    };
+  }
+
+  return undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inverse transform builders (pole → time-domain term)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** L⁻¹{A/(s−a)}: returns A·exp(at).  If a=0, returns A·UnitStep(t). */
+function iltSimplePole(A: Frac, a: Frac, t: IRNode): IRNode {
+  if (fracIsZero(a)) {
+    const step = app(UNIT_STEP, [t]);
+    if (fracEq(A, ONE_F)) return step;
+    return bin(MUL, fracToIR(A), step);
+  }
+  const expTerm = fracEq(a, ONE_F) ? app(EXP, [t]) : app(EXP, [bin(MUL, fracToIR(a), t)]);
+  if (fracEq(A, ONE_F)) return expTerm;
+  if (fracEq(A, frac(-1n))) return app(NEG, [expTerm]);
+  return bin(MUL, fracToIR(A), expTerm);
+}
+
+/** L⁻¹{A/(s−a)^n}  (n ≥ 2):  A·t^{n-1}·exp(at) / (n-1)! */
+function iltRepeatedPole(A: Frac, a: Frac, n: number, t: IRNode): IRNode {
+  const factNm1 = factorial(BigInt(n - 1));
+  const coeff = fracDiv(A, frac(factNm1));
+  const coeffNode = fracToIR(coeff);
+
+  // t^{n-1}  (n-1=1 → just t)
+  const tPow: IRNode = n - 1 === 1 ? t : bin(POW, t, int(n - 1));
+
+  if (fracIsZero(a)) {
+    // exp(0) = 1; only the t^{n-1} factor remains
+    return fracEq(coeff, ONE_F) ? tPow : bin(MUL, coeffNode, tPow);
+  }
+
+  const expTerm = fracEq(a, ONE_F) ? app(EXP, [t]) : app(EXP, [bin(MUL, fracToIR(a), t)]);
+  const inner = bin(MUL, tPow, expTerm);
+  return fracEq(coeff, ONE_F) ? inner : bin(MUL, coeffNode, inner);
+}
+
+/**
+ * Invert (A·s + B) / (s² + b·s + c) with discriminant b²−4c < 0.
+ *
+ * Completes the square: s² + bs + c = (s + α)² + β²
+ * where α = b/2 and β = √(c − α²).
+ *
+ * Decomposition:
+ *
+ *   (A·s + B) / ((s+α)² + β²)
+ *   = A·(s+α)/((s+α)²+β²)  +  (B−Aα)/β · β/((s+α)²+β²)
+ *
+ * Inverse:
+ *
+ *   A·exp(−αt)·cos(βt)  +  (B−Aα)/β · exp(−αt)·sin(βt)
+ *
+ * When β is irrational, a Sqrt(β²) IR node is built to keep the result
+ * exact.
+ *
+ * Returns a list of terms (may be empty if all coefficients are zero),
+ * or undefined if the quadratic is not irreducible.
+ */
+function iltIrreducibleQuad(linNum: Poly, quadDen: Poly, t: IRNode): IRNode[] | undefined {
+  if (polyDegree(quadDen) !== 2) return undefined;
+
+  const leading = quadDen.length >= 3 ? quadDen[2] : ZERO_F;
+  if (fracIsZero(leading)) return undefined;
+
+  // Make monic: divide num and den by leading coefficient
+  const invLeading = fracDiv(ONE_F, leading);
+  const c = fracMul(quadDen[0] !== undefined ? quadDen[0] : ZERO_F, invLeading);
+  const b = fracMul(quadDen.length >= 2 ? quadDen[1] : ZERO_F, invLeading);
+  const B = fracMul(linNum.length >= 1 ? linNum[0] : ZERO_F, invLeading);
+  const A = fracMul(linNum.length >= 2 ? linNum[1] : ZERO_F, invLeading);
+
+  // Discriminant check: b² − 4c < 0 means complex conjugate poles
+  const disc = fracSub(fracMul(b, b), fracMul(frac(4n), c));
+  if (!fracIsNeg(disc)) return undefined; // real roots — not irreducible
+
+  // Complete the square: α = b/2, β² = c − α²
+  const alpha = fracDiv(b, frac(2n));
+  const betaSq = fracSub(c, fracMul(alpha, alpha));
+  if (!fracIsNeg(fracNeg(betaSq)) && fracIsZero(betaSq)) return undefined; // degenerate
+  if (fracIsNeg(betaSq)) return undefined;
+
+  const betaRat = fracRationalSqrt(betaSq);
+  const betaIR: IRNode =
+    betaRat !== undefined ? fracToIR(betaRat) : app(SQRT, [fracToIR(betaSq)]);
+  const negAlpha = fracNeg(alpha);
+
+  const betaIsOne = betaRat !== undefined && fracEq(betaRat, ONE_F);
+  const alphaIsZero = fracIsZero(alpha);
+
+  /** Build coeff · exp(−α·t) · trig(β·t). */
+  function makeExpTrig(coeff: IRNode, isCos: boolean): IRNode {
+    // Trig argument: β·t (simplified to t when β=1)
+    const trigArg: IRNode = betaIsOne ? t : bin(MUL, betaIR, t);
+    const trigFn = isCos ? COS : SIN;
+    const trigTerm = app(trigFn, [trigArg]);
+
+    // Exponential factor exp(−α·t) — omitted when α=0
+    let oscillator: IRNode;
+    if (alphaIsZero) {
+      oscillator = trigTerm;
+    } else {
+      const expArg: IRNode = fracEq(negAlpha, ONE_F)
+        ? t
+        : fracEq(negAlpha, frac(-1n))
+        ? app(NEG, [t])
+        : bin(MUL, fracToIR(negAlpha), t);
+      oscillator = bin(MUL, app(EXP, [expArg]), trigTerm);
+    }
+
+    // Scale by coefficient (skip mul-by-1)
+    return isOne(coeff) ? oscillator : bin(MUL, coeff, oscillator);
+  }
+
+  const terms: IRNode[] = [];
+
+  // Term 1: A · exp(−αt) · cos(βt)
+  if (!fracIsZero(A)) {
+    terms.push(makeExpTrig(fracToIR(A), true));
+  }
+
+  // Term 2: (B − A·α) / β · exp(−αt) · sin(βt)
+  const baa = fracSub(B, fracMul(A, alpha)); // B − A·α
+  if (!fracIsZero(baa)) {
+    const coeff2: IRNode =
+      betaRat !== undefined
+        ? fracToIR(fracDiv(baa, betaRat))
+        : bin(DIV, fracToIR(baa), betaIR);
+    terms.push(makeExpTrig(coeff2, false));
+  }
+
+  return terms;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Full partial-fraction decomposition engine
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Attempt inverse Laplace transform via partial-fraction decomposition.
+ *
+ * Pipeline:
+ *
+ * 1. Convert F(s) to a rational function (num, den) over Frac.
+ * 2. Polynomial long division for improper fractions.
+ * 3. Extract all rational roots of den with multiplicity.
+ * 4. Build residues for each pole (simple or repeated via power series).
+ * 5. Handle any irreducible quadratic factor.
+ * 6. Assemble terms into an ADD chain.
+ *
+ * Returns undefined if decomposition is not possible (e.g., irreducible
+ * cubic or non-rational coefficients).
+ */
+function inversePF(F: IRNode, s: IRNode, t: IRNode): IRNode | undefined {
+  const rf = irToRational(F, s);
+  if (!rf) return undefined;
+
+  let { num, den } = rf;
+  num = polyNormalize(num);
+  den = polyNormalize(den);
+
+  // ── Step 1: Improper fractions via polynomial long division ─────────────
+  // If deg(N) ≥ deg(D), extract the polynomial quotient P(s).
+  // L⁻¹{P(s)} = P[0]·δ(t) for deg-0 quotient; higher degrees return None.
+  let polyPart: Poly = [ZERO_F];
+  if (polyDegree(num) >= polyDegree(den)) {
+    const [q, r] = polyDivmod(num, den);
+    polyPart = polyNormalize(q);
+    num = polyNormalize(r);
+  }
+
+  // ── Step 2: Extract rational roots and factor denominator ────────────────
+  const roots = extractAllRationalRoots(den);
+
+  // Q_rat = Π(s − r_i) for each rational root r_i
+  let Q_rat: Poly = [ONE_F];
+  for (const r of roots) {
+    Q_rat = polyMul(Q_rat, [fracNeg(r), ONE_F]);
+  }
+  Q_rat = polyNormalize(Q_rat);
+
+  // Q_irred = den / Q_rat  (the irreducible remainder)
+  const [Q_irred, remCheck] = polyDivmod(den, Q_rat);
+  if (!polyIsZero(remCheck)) return undefined; // should be exact
+
+  const irredDeg = polyDegree(Q_irred);
+  if (irredDeg > 2) return undefined; // can't handle irreducible cubic+
+
+  // ── Step 3: Polynomial-part terms ────────────────────────────────────────
+  const irTerms: IRNode[] = [];
+
+  for (let deg = 0; deg < polyPart.length; deg++) {
+    const coeff = polyPart[deg];
+    if (fracIsZero(coeff)) continue;
+    if (deg === 0) {
+      const delta = app(DIRAC_DELTA, [t]);
+      irTerms.push(fracEq(coeff, ONE_F) ? delta : bin(MUL, fracToIR(coeff), delta));
+    } else {
+      return undefined; // DiracDelta derivatives not supported
+    }
+  }
+
+  // ── Step 4: Rational pole terms ──────────────────────────────────────────
+  // Group roots by distinct value (accumulating multiplicity count)
+  const distinctRoots = new Map<string, { root: Frac; count: number }>();
+  for (const r of roots) {
+    const key = `${r.n}/${r.d}`;
+    const existing = distinctRoots.get(key);
+    if (existing) existing.count++;
+    else distinctRoots.set(key, { root: r, count: 1 });
+  }
+
+  // residuesMap[key] = [A_m, A_{m-1}, …, A_1] for that root
+  const residuesMap = new Map<string, Frac[]>();
+
+  for (const [key, { root: r, count: m }] of distinctRoots) {
+    const linearPowM = polyPow([fracNeg(r), ONE_F], BigInt(m));
+    const [Q_rat_no_rm] = polyDivmod(Q_rat, linearPowM);
+    // Q_other = (Q_rat / (s−r)^m) · Q_irred — everything except the (s−r)^m factor
+    const Q_other = polyNormalize(polyMul(Q_rat_no_rm, Q_irred));
+
+    if (m === 1) {
+      // Simple pole: residue = N(r) / Q_other(r)
+      const q_other_r = polyEval(Q_other, r);
+      if (fracIsZero(q_other_r)) return undefined;
+      const resA = fracDiv(polyEval(num, r), q_other_r);
+      residuesMap.set(key, [resA]);
+      irTerms.push(iltSimplePole(resA, r, t));
+    } else {
+      // Repeated pole: Laurent expansion via power series
+      const residues = computeRepeatedResidues(num, den, r, m);
+      if (!residues) return undefined;
+      residuesMap.set(key, residues);
+      for (let k = 0; k < residues.length; k++) {
+        const resA = residues[k];
+        if (fracIsZero(resA)) continue;
+        const poleOrder = m - k; // m, m−1, …, 1
+        irTerms.push(
+          poleOrder === 1
+            ? iltSimplePole(resA, r, t)
+            : iltRepeatedPole(resA, r, poleOrder, t),
+        );
+      }
+    }
+  }
+
+  // ── Step 5: Irreducible quadratic term ───────────────────────────────────
+  if (irredDeg === 2) {
+    // Recover the linear numerator (A·s + B) for the term (A·s+B)/Q_irred.
+    //
+    // The partial-fraction identity (multiplied by D = Q_rat·Q_irred) is:
+    //
+    //   N(s) = [rational contributions] + (A·s+B)·Q_rat(s)
+    //
+    // where each rational contribution for root r with multiplicity m at
+    // pole order k is: A_k · Q_irred · Q_rat/(s−r)^k.
+    //
+    // Sum rational contributions into rat_poly, then:
+    //   A·s+B = [N − rat_poly] / Q_rat  (exact division)
+
+    let rat_poly: Poly = [ZERO_F];
+    for (const [key, { root: r, count: m }] of distinctRoots) {
+      const residues = residuesMap.get(key)!;
+      for (let kIdx = 0; kIdx < residues.length; kIdx++) {
+        const resA = residues[kIdx];
+        if (fracIsZero(resA)) continue;
+        const poleOrder = m - kIdx;
+        const linearPowK = polyPow([fracNeg(r), ONE_F], BigInt(poleOrder));
+        const [Q_rat_div_k] = polyDivmod(Q_rat, linearPowK);
+        const contrib = polyScale(polyMul(Q_irred, Q_rat_div_k), resA);
+        rat_poly = polyAdd(rat_poly, contrib);
+      }
+    }
+
+    const irred_times_qrat = polyNormalize(polyAdd(num, polyNeg(rat_poly)));
+    const [linNum, rem2] = polyDivmod(irred_times_qrat, Q_rat);
+    if (!polyIsZero(rem2)) return undefined; // numerator recovery failed
+
+    const irredTerms = iltIrreducibleQuad(polyNormalize(linNum), polyNormalize(Q_irred), t);
+    if (!irredTerms) return undefined;
+    irTerms.push(...irredTerms);
+  }
+
+  // ── Step 6: Assemble result ───────────────────────────────────────────────
+  if (irTerms.length === 0) return int(0);
+  if (irTerms.length === 1) return irTerms[0];
+  let result = irTerms[0];
+  for (let i = 1; i < irTerms.length; i++) {
+    result = bin(ADD, result, irTerms[i]);
+  }
+  return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pattern matchers for the forward table
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Match t^n · trig(ω·t) for n ≥ 2.  Used for forward table entries. */
+function matchTnTimesTrig(
+  f: IRNode,
+  t: IRNode,
+): { power: bigint; trigHead: IRNode; omega: IRNode } | undefined {
+  const args = binaryArgs(f, MUL);
+  if (!args) return undefined;
+  for (const [left, right] of [args, [args[1], args[0]]] as const) {
+    const n = matchPowerOfT(left, t);
+    if (n === undefined || n < 2n) continue;
+    const sinOmega = matchUnaryLinear(right, SIN, t);
+    if (sinOmega !== undefined) return { power: n, trigHead: SIN, omega: sinOmega };
+    const cosOmega = matchUnaryLinear(right, COS, t);
+    if (cosOmega !== undefined) return { power: n, trigHead: COS, omega: cosOmega };
+  }
   return undefined;
 }
 
@@ -195,7 +1077,8 @@ function matchTTimesTrig(f: IRNode, t: IRNode): { trigHead: IRNode; omega: IRNod
 function matchPowerOfT(f: IRNode, t: IRNode): bigint | undefined {
   if (equals(f, t)) return 1n;
   const pow = binaryArgs(f, POW);
-  if (pow !== undefined && equals(pow[0], t) && pow[1].kind === "integer" && pow[1].value >= 1n) return pow[1].value;
+  if (pow !== undefined && equals(pow[0], t) && pow[1].kind === "integer" && pow[1].value >= 1n)
+    return pow[1].value;
   return undefined;
 }
 
@@ -239,7 +1122,9 @@ function matchSMinusA(node: IRNode, s: IRNode): IRNode | undefined {
 
 function matchPowOf(node: IRNode, base: IRNode): bigint | undefined {
   const args = binaryArgs(node, POW);
-  return args !== undefined && equals(args[0], base) && args[1].kind === "integer" ? args[1].value : undefined;
+  return args !== undefined && equals(args[0], base) && args[1].kind === "integer"
+    ? args[1].value
+    : undefined;
 }
 
 function matchSSqPlusParamSq(node: IRNode, s: IRNode): IRNode | undefined {
@@ -279,6 +1164,10 @@ function sumSSqParamSq(s: IRNode, param: IRNode): IRNode {
 function subSSqParamSq(s: IRNode, param: IRNode): IRNode {
   return bin(SUB, bin(POW, s, int(2)), bin(POW, param, int(2)));
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Utility helpers
+// ─────────────────────────────────────────────────────────────────────────────
 
 function applyArgs(node: IRNode, head: IRNode): readonly IRNode[] | undefined {
   return node.kind === "apply" && equals(node.head, head) ? node.args : undefined;

--- a/code/packages/typescript/cas-laplace/tests/cas-laplace.test.ts
+++ b/code/packages/typescript/cas-laplace/tests/cas-laplace.test.ts
@@ -6,6 +6,7 @@ import {
   DIV,
   EXP,
   MUL,
+  NEG,
   POW,
   SIN,
   SUB,
@@ -33,49 +34,206 @@ import {
 const t = sym("t");
 const s = sym("s");
 
-describe("laplaceTransform", () => {
-  it("handles constants and powers", () => {
-    expect(laplaceTransform(int(1), t, s)).toEqual(app(DIV, [int(1), s]));
-    expect(laplaceTransform(t, t, s)).toEqual(app(DIV, [int(1), app(POW, [s, int(2)])]));
-    expect(laplaceTransform(app(POW, [t, int(3)]), t, s)).toEqual(app(DIV, [int(6), app(POW, [s, int(4)])]));
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function isHead(node: IRNode, head: IRNode): boolean {
+  return node.kind === "apply" && equals(node.head, head);
+}
+
+/** Build `Mul(a, b)`. */
+function mul(a: IRNode, b: IRNode): IRNode {
+  return app(MUL, [a, b]);
+}
+
+/** Build `Pow(base, exp)`. */
+function pow(base: IRNode, exponent: IRNode): IRNode {
+  return app(POW, [base, exponent]);
+}
+
+/** Build `Add(a, b)`. */
+function add(a: IRNode, b: IRNode): IRNode {
+  return app(ADD, [a, b]);
+}
+
+/** Build `Sub(a, b)`. */
+function sub(a: IRNode, b: IRNode): IRNode {
+  return app(SUB, [a, b]);
+}
+
+/** Build `Div(a, b)`. */
+function div(a: IRNode, b: IRNode): IRNode {
+  return app(DIV, [a, b]);
+}
+
+// ─── Forward transform: existing cases ───────────────────────────────────────
+
+describe("laplaceTransform — constants and powers", () => {
+  it("handles 1", () => {
+    expect(laplaceTransform(int(1), t, s)).toEqual(div(int(1), s));
   });
 
-  it("handles exp, trig, hyperbolic, and shifted trig products", () => {
-    expect(laplaceTransform(app(EXP, [app(MUL, [int(3), t])]), t, s)).toEqual(app(DIV, [int(1), app(SUB, [s, int(3)])]));
-    expect(laplaceTransform(app(SIN, [app(MUL, [int(2), t])]), t, s)).toEqual(
-      app(DIV, [int(2), app(ADD, [app(POW, [s, int(2)]), app(POW, [int(2), int(2)])])]),
+  it("handles t", () => {
+    expect(laplaceTransform(t, t, s)).toEqual(div(int(1), pow(s, int(2))));
+  });
+
+  it("handles t^3", () => {
+    expect(laplaceTransform(pow(t, int(3)), t, s)).toEqual(
+      div(int(6), pow(s, int(4))),
     );
-
-    const expSin = app(MUL, [app(EXP, [t]), app(SIN, [app(MUL, [int(2), t])])]);
-    expect(isHead(laplaceTransform(expSin, t, s), DIV)).toBe(true);
-    expect(isHead(laplaceTransform(app(COSH, [t]), t, s), DIV)).toBe(true);
-  });
-
-  it("applies linearity and falls through honestly", () => {
-    const sum = app(ADD, [app(SIN, [t]), app(COS, [t])]);
-    expect(isHead(laplaceTransform(sum, t, s), ADD)).toBe(true);
-    expect(isHead(laplaceTransform(app(MUL, [int(5), app(SIN, [t])]), t, s), MUL)).toBe(true);
-
-    const unknown = app(sym("Mystery"), [t]);
-    expect(laplaceTransform(unknown, t, s)).toEqual(app(LAPLACE, [unknown, t, s]));
-  });
-
-  it("handles special heads", () => {
-    expect(laplaceTransform(app(DIRAC_DELTA, [t]), t, s)).toEqual(int(1));
-    expect(laplaceTransform(app(UNIT_STEP, [t]), t, s)).toEqual(app(DIV, [int(1), s]));
   });
 });
 
-describe("inverseLaplace", () => {
-  it("handles standard inverse table entries", () => {
-    expect(inverseLaplace(app(DIV, [int(1), s]), s, t)).toEqual(app(UNIT_STEP, [t]));
-    expect(inverseLaplace(app(DIV, [int(1), app(SUB, [s, int(3)])]), s, t)).toEqual(app(EXP, [app(MUL, [int(3), t])]));
-    expect(inverseLaplace(app(DIV, [int(2), app(ADD, [app(POW, [s, int(2)]), int(4)])]), s, t)).toEqual(
-      app(SIN, [app(MUL, [int(2), t])]),
+describe("laplaceTransform — exp, trig, hyperbolic, shifted products", () => {
+  it("handles exp(3t)", () => {
+    expect(laplaceTransform(app(EXP, [mul(int(3), t)]), t, s)).toEqual(
+      div(int(1), sub(s, int(3))),
     );
-    expect(inverseLaplace(app(DIV, [s, app(SUB, [app(POW, [s, int(2)]), int(1)])]), s, t)).toEqual(
-      app(COSH, [app(MUL, [int(1), t])]),
+  });
+
+  it("handles sin(2t)", () => {
+    expect(laplaceTransform(app(SIN, [mul(int(2), t)]), t, s)).toEqual(
+      div(int(2), add(pow(s, int(2)), pow(int(2), int(2)))),
     );
+  });
+
+  it("handles exp(t)*sin(2t)", () => {
+    const expSin = mul(app(EXP, [t]), app(SIN, [mul(int(2), t)]));
+    expect(isHead(laplaceTransform(expSin, t, s), DIV)).toBe(true);
+  });
+
+  it("handles cosh(t)", () => {
+    expect(isHead(laplaceTransform(app(COSH, [t]), t, s), DIV)).toBe(true);
+  });
+});
+
+describe("laplaceTransform — linearity and fallthrough", () => {
+  it("applies linearity over Add", () => {
+    const sum = add(app(SIN, [t]), app(COS, [t]));
+    expect(isHead(laplaceTransform(sum, t, s), ADD)).toBe(true);
+  });
+
+  it("applies linearity over scalar multiple", () => {
+    expect(isHead(laplaceTransform(mul(int(5), app(SIN, [t])), t, s), MUL)).toBe(true);
+  });
+
+  it("falls through for unknown heads", () => {
+    const unknown = app(sym("Mystery"), [t]);
+    expect(laplaceTransform(unknown, t, s)).toEqual(app(LAPLACE, [unknown, t, s]));
+  });
+});
+
+describe("laplaceTransform — special heads", () => {
+  it("handles DiracDelta(t)", () => {
+    expect(laplaceTransform(app(DIRAC_DELTA, [t]), t, s)).toEqual(int(1));
+  });
+
+  it("handles UnitStep(t)", () => {
+    expect(laplaceTransform(app(UNIT_STEP, [t]), t, s)).toEqual(div(int(1), s));
+  });
+});
+
+// ─── Forward transform: t^n·trig (n ≥ 2) ────────────────────────────────────
+
+describe("laplaceTransform — t^n·trig for n = 2, 3", () => {
+  // ── n = 2 ──────────────────────────────────────────────────────────────
+  //
+  // L{t²·sin(ωt)} = 2ω(3s²−ω²) / (s²+ω²)³
+  // L{t²·cos(ωt)} = 2s(s²−3ω²) / (s²+ω²)³
+
+  it("L{t²·sin(2t)} = 4(3s²−4)/(s²+4)³", () => {
+    // f = Mul(Pow(t,2), Sin(Mul(2,t)))
+    const f = mul(pow(t, int(2)), app(SIN, [mul(int(2), t)]));
+    const result = laplaceTransform(f, t, s);
+    // Expected: Div(Mul(Mul(2,2), Sub(Mul(3,s²), Pow(2,2))), Pow(Add(s²,Pow(2,2)),3))
+    const s2 = pow(s, int(2));
+    const w2 = pow(int(2), int(2));
+    const s2pw2 = add(s2, w2);
+    const expectedNum = mul(mul(int(2), int(2)), sub(mul(int(3), s2), w2));
+    const expected = div(expectedNum, pow(s2pw2, int(3)));
+    expect(result).toEqual(expected);
+  });
+
+  it("L{t²·sin(2t)} matches reversed factor order too", () => {
+    // Mul(Sin(2t), Pow(t,2)) — commuted operands
+    const f = mul(app(SIN, [mul(int(2), t)]), pow(t, int(2)));
+    const result = laplaceTransform(f, t, s);
+    expect(isHead(result, DIV)).toBe(true);
+  });
+
+  it("L{t²·cos(2t)} = 2s(s²−12)/(s²+4)³", () => {
+    const f = mul(pow(t, int(2)), app(COS, [mul(int(2), t)]));
+    const result = laplaceTransform(f, t, s);
+    const s2 = pow(s, int(2));
+    const w2 = pow(int(2), int(2)); // 4
+    const s2pw2 = add(s2, w2);
+    const expectedNum = mul(mul(int(2), s), sub(s2, mul(int(3), w2)));
+    const expected = div(expectedNum, pow(s2pw2, int(3)));
+    expect(result).toEqual(expected);
+  });
+
+  // ── n = 3 ──────────────────────────────────────────────────────────────
+  //
+  // L{t³·sin(ωt)} = 24ωs(s²−ω²) / (s²+ω²)⁴
+  // L{t³·cos(ωt)} = 6(s⁴−6s²ω²+ω⁴) / (s²+ω²)⁴
+
+  it("L{t³·sin(t)} = 24s(s²−1)/(s²+1)⁴", () => {
+    const f = mul(pow(t, int(3)), app(SIN, [t]));
+    const result = laplaceTransform(f, t, s);
+    const s2 = pow(s, int(2));
+    const w2 = pow(int(1), int(2)); // 1
+    const s2pw2 = add(s2, w2);
+    // Num: Mul(Mul(24, 1), Mul(s, Sub(s², w²)))
+    const expectedNum = mul(mul(int(24), int(1)), mul(s, sub(s2, w2)));
+    const expected = div(expectedNum, pow(s2pw2, int(4)));
+    expect(result).toEqual(expected);
+  });
+
+  it("L{t³·cos(t)} = 6(s⁴−6s²+1)/(s²+1)⁴", () => {
+    const f = mul(pow(t, int(3)), app(COS, [t]));
+    const result = laplaceTransform(f, t, s);
+    const s2 = pow(s, int(2));
+    const w2 = pow(int(1), int(2));
+    const s2pw2 = add(s2, w2);
+    const s4 = pow(s, int(4));
+    const w4 = pow(int(1), int(4));
+    const inner = add(sub(s4, mul(int(6), mul(s2, w2))), w4);
+    const expected = div(mul(int(6), inner), pow(s2pw2, int(4)));
+    expect(result).toEqual(expected);
+  });
+
+  it("L{t⁴·sin(t)} falls through to unevaluated Laplace", () => {
+    const f = mul(pow(t, int(4)), app(SIN, [t]));
+    const result = laplaceTransform(f, t, s);
+    // n=4 is unsupported; the linearity rule extracts no coefficient,
+    // so the whole expression goes to the table which returns undefined,
+    // and the top-level wraps it in Laplace(...).
+    expect(isHead(result, LAPLACE)).toBe(true);
+  });
+});
+
+// ─── Inverse transform: existing direct table ────────────────────────────────
+
+describe("inverseLaplace — direct table entries", () => {
+  it("1/s → UnitStep(t)", () => {
+    expect(inverseLaplace(div(int(1), s), s, t)).toEqual(app(UNIT_STEP, [t]));
+  });
+
+  it("1/(s−3) → exp(3t)", () => {
+    expect(
+      inverseLaplace(div(int(1), sub(s, int(3))), s, t),
+    ).toEqual(app(EXP, [mul(int(3), t)]));
+  });
+
+  it("2/(s²+4) → sin(2t)", () => {
+    expect(
+      inverseLaplace(div(int(2), add(pow(s, int(2)), int(4))), s, t),
+    ).toEqual(app(SIN, [mul(int(2), t)]));
+  });
+
+  it("s/(s²−1) → cosh(1·t)", () => {
+    expect(
+      inverseLaplace(div(s, sub(pow(s, int(2)), int(1))), s, t),
+    ).toEqual(app(COSH, [mul(int(1), t)]));
   });
 
   it("returns unevaluated ILT for unknown forms", () => {
@@ -84,23 +242,143 @@ describe("inverseLaplace", () => {
   });
 });
 
+// ─── Inverse transform: complex conjugate poles (irreducible quadratic) ───────
+
+describe("inverseLaplace — irreducible quadratic (complex poles)", () => {
+  // 1/(s²+2s+2) = 1/((s+1)²+1²) → exp(−t)·sin(t)
+  // The denominator has no rational roots (discriminant = 4−8 = −4).
+  it("1/(s²+2s+2) → exp(−t)·sin(t)", () => {
+    // Build 1 / (s² + 2s + 2)
+    const denom = add(add(pow(s, int(2)), mul(int(2), s)), int(2));
+    const F = div(int(1), denom);
+    const result = inverseLaplace(F, s, t);
+    // Expected: Mul(Exp(Neg(t)), Sin(t))
+    const expected = mul(app(EXP, [app(NEG, [t])]), app(SIN, [t]));
+    expect(result).toEqual(expected);
+  });
+
+  // s/(s²+2s+2) → exp(−t)·cos(t) − exp(−t)·sin(t)
+  it("s/(s²+2s+2) → exp(−t)·cos(t) + (−1)·exp(−t)·sin(t)", () => {
+    const denom = add(add(pow(s, int(2)), mul(int(2), s)), int(2));
+    const F = div(s, denom);
+    const result = inverseLaplace(F, s, t);
+    // First term A=1: exp(-t)*cos(t)
+    // baa = B - A*alpha = 0 - 1*1 = -1 → coeff = -1/1 = -1
+    // Second term: Mul(-1, Mul(Exp(Neg(t)), Sin(t)))
+    const expNegT = app(EXP, [app(NEG, [t])]);
+    const t1 = mul(expNegT, app(COS, [t]));
+    const t2 = mul(int(-1), mul(expNegT, app(SIN, [t])));
+    const expected = add(t1, t2);
+    expect(result).toEqual(expected);
+  });
+
+  // 1/(s²+1) goes through direct table, not PF engine
+  // (matchSSqPlusParamSq matches it as omega=1)
+  it("1/(s²+1) → sin(1·t) [via direct table]", () => {
+    const F = div(int(1), add(pow(s, int(2)), int(1)));
+    const result = inverseLaplace(F, s, t);
+    expect(result).toEqual(app(SIN, [mul(int(1), t)]));
+  });
+
+  // 1/(s*(s²+1)) — mixed: simple pole at 0 + irreducible quadratic
+  it("1/(s·(s²+1)) → UnitStep(t) + (−1)·cos(t)", () => {
+    // Build 1 / (s * (s² + 1))
+    const F = div(int(1), mul(s, add(pow(s, int(2)), int(1))));
+    const result = inverseLaplace(F, s, t);
+    // UnitStep(t) from simple pole at 0,
+    // Mul(-1, Cos(t)) from the irreducible quadratic with A=-1, B=0
+    const expected = add(app(UNIT_STEP, [t]), mul(int(-1), app(COS, [t])));
+    expect(result).toEqual(expected);
+  });
+});
+
+// ─── Inverse transform: repeated poles ───────────────────────────────────────
+
+describe("inverseLaplace — repeated rational poles", () => {
+  // 1/(s−2)² → t·exp(2t)
+  it("1/(s−2)² → t·exp(2t)", () => {
+    // Build 1 / (s-2)²  = 1 / Pow(Sub(s,2), 2)
+    const F = div(int(1), pow(sub(s, int(2)), int(2)));
+    const result = inverseLaplace(F, s, t);
+    // iltRepeatedPole(1, 2, 2, t) = t * exp(2t)
+    const expected = mul(t, app(EXP, [mul(int(2), t)]));
+    expect(result).toEqual(expected);
+  });
+
+  // 1/s² → t  (repeated pole at 0; the direct table handles it before PF)
+  it("1/s² → t [via direct table]", () => {
+    const F = div(int(1), pow(s, int(2)));
+    const result = inverseLaplace(F, s, t);
+    expect(result).toEqual(t);
+  });
+
+  // s/(s−1)² — s in numerator, repeated pole at 1
+  // PF: s = A*(s-1) + B, but via PF engine...
+  // num=(0,1), den=(1,-2,1)=(s-1)^2, roots=[1,1]
+  // residues via power series: computeRepeatedResidues((0,1),(1,-2,1),1,2)
+  //   N_t = shift (0,1) by 1: (1,1) = 1 + t
+  //   D_t = shift (1,-2,1) by 1: t² = (0,0,1)
+  //   Qother = (1,) [from D_t[2:]]
+  //   ps coeffs of (1,1)/(1,): g0=1, g1=1 → [1,1] = [A2, A1]
+  // k=0: A=1, poleOrder=2 → iltRepeatedPole(1,1,2,t) = t*exp(t)
+  // k=1: A=1, poleOrder=1 → iltSimplePole(1,1,t) = exp(t)
+  // result = Add(t*exp(t), exp(t))
+  it("s/(s−1)² → t·exp(t) + exp(t)", () => {
+    const F = div(s, pow(sub(s, int(1)), int(2)));
+    const result = inverseLaplace(F, s, t);
+    // iltSimplePole and iltRepeatedPole both use exp(t) (not exp(1*t)) when a=1
+    const expT = app(EXP, [t]);
+    const expected = add(mul(t, expT), expT);
+    expect(result).toEqual(expected);
+  });
+});
+
+// ─── Inverse transform: improper fractions ───────────────────────────────────
+
+describe("inverseLaplace — improper fractions", () => {
+  // s²/(s²+1): polynomial part = 1 (quotient) with remainder = -1/(s²+1)
+  // L⁻¹{1} = DiracDelta(t), L⁻¹{-1/(s²+1)} = -sin(t)
+  it("s²/(s²+1) → DiracDelta(t) + (−1)·sin(t)", () => {
+    const F = div(pow(s, int(2)), add(pow(s, int(2)), int(1)));
+    const result = inverseLaplace(F, s, t);
+    // poly part: (1,), so DiracDelta(t)
+    // remainder: (-1,0) / (1,0,1) → but via irredQuad:
+    // linNum = (-1,), quadDen = (1,0,1), A=0, B=-1
+    // baa = -1 - 0 = -1, coeff2 = -1/1 = -1
+    // term2: Mul(-1, Sin(t))
+    const expected = add(app(DIRAC_DELTA, [t]), mul(int(-1), app(SIN, [t])));
+    expect(result).toEqual(expected);
+  });
+});
+
+// ─── Handlers ─────────────────────────────────────────────────────────────────
+
 describe("handlers", () => {
   const id = (node: IRNode): IRNode => node;
 
-  it("dispatches transform handlers", () => {
-    expect(laplaceHandler(app(LAPLACE, [int(1), t, s]), id)).toEqual(app(DIV, [int(1), s]));
-    expect(iltHandler(app(ILT, [app(DIV, [int(1), s]), s, t]), id)).toEqual(app(UNIT_STEP, [t]));
+  it("dispatches laplaceHandler", () => {
+    expect(laplaceHandler(app(LAPLACE, [int(1), t, s]), id)).toEqual(div(int(1), s));
   });
 
-  it("evaluates special functions and exposes table keys", () => {
+  it("dispatches iltHandler", () => {
+    expect(
+      iltHandler(app(ILT, [div(int(1), s), s, t]), id),
+    ).toEqual(app(UNIT_STEP, [t]));
+  });
+
+  it("evaluates DiracDelta and UnitStep special functions", () => {
     expect(diracDeltaHandler(app(DIRAC_DELTA, [int(0)]))).toEqual(int(1));
     expect(unitStepHandler(app(UNIT_STEP, [int(-1)]))).toEqual(int(0));
     expect(unitStepHandler(app(UNIT_STEP, [int(0)]))).toEqual(rational(1, 2));
     expect(unitStepHandler(app(UNIT_STEP, [int(2)]))).toEqual(int(1));
-    expect([...buildLaplaceHandlerTable().keys()]).toEqual(["Laplace", "ILT", "DiracDelta", "UnitStep"]);
+  });
+
+  it("exposes the four handler table keys", () => {
+    expect([...buildLaplaceHandlerTable().keys()]).toEqual([
+      "Laplace",
+      "ILT",
+      "DiracDelta",
+      "UnitStep",
+    ]);
   });
 });
-
-function isHead(node: IRNode, head: IRNode): boolean {
-  return node.kind === "apply" && equals(node.head, head);
-}


### PR DESCRIPTION
## Summary

- **Extended ILT engine** (all 3 languages): handles improper fractions (→ DiracDelta), repeated rational poles (via formal power series), and irreducible quadratic factors (complex conjugate poles, completing the square)
- **Extended forward table** (all 3 languages): added `L{t²·sin(ωt)}`, `L{t²·cos(ωt)}`, `L{t³·sin(ωt)}`, `L{t³·cos(ωt)}` with exact closed-form formulas; n≥4 falls through to unevaluated
- **Versions bumped**: Python `cas-laplace` → 0.2.0, TypeScript `cas-laplace` → 0.2.0, Rust `cas-laplace` → 0.2.0
- **Test counts**: Python 190 tests (90.42% coverage), TypeScript 35 tests, Rust 15 tests — all passing

## New capabilities

| Input | Output |
|---|---|
| `ilt(1/(s²+2s+2))` | `exp(−t)·sin(t)` |
| `ilt(s/(s²+2s+2))` | `exp(−t)·cos(t) + (−1)·exp(−t)·sin(t)` |
| `ilt(1/(s−2)²)` | `t·exp(2t)` |
| `ilt(1/(s·(s²+1)))` | `UnitStep(t) + (−1)·cos(t)` |
| `ilt(s²/(s²+1))` | `DiracDelta(t) + (−1)·sin(t)` |
| `L{t²·sin(ωt)}` | `2ω(3s²−ω²)/(s²+ω²)³` |
| `L{t³·cos(ωt)}` | `6(s⁴−6s²ω²+ω⁴)/(s²+ω²)⁴` |

## Test plan

- [x] Python: `cd code/packages/python/cas-laplace && ./BUILD` — 190 tests, 90.42% coverage
- [x] TypeScript: `cd code/packages/typescript/cas-laplace && npm test` — 35 tests pass
- [x] Rust: `cd code/packages/rust/cas-laplace && cargo test` — 15 tests pass
- [x] Security review: passed for all three languages (pure math computation, no I/O surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)