### PR TITLE
feat(array-core): Phase 1 implementation

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "actor",
     "arithmetic",
     "arm-simulator",
+    "array-core",
     "assembler",
     "aztec-code",
     "barcode-2d",

--- a/code/packages/rust/array-core/CHANGELOG.md
+++ b/code/packages/rust/array-core/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to `array-core` are documented in this file. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
+uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-05-16
+
+### Added
+
+- Initial Phase 1 implementation per `code/specs/backend-crate-catalog.md`'s
+  `array-core` row.
+- `Array2D<T>` 2-D row-major wrapper with `new`, `from_vector`, `filled`,
+  `get`, `set`, `row`, `col`, `is_empty`, and `is_na` (f64 specialization).
+- `ArrayError` enum (`ShapeMismatch`, `EmptyResult`, `BadParameter`,
+  `OutOfRange`) with `Display` and `std::error::Error` impls.
+- `generate::sequence` — Excel 365 `SEQUENCE(rows, cols, start, step)`.
+- `shape::take` / `shape::drop` / `shape::expand` — Excel 365 `TAKE`, `DROP`,
+  `EXPAND` with Excel-style negative-count "from the end" semantics and NA
+  padding for `EXPAND`.
+- `stack::hstack` / `stack::vstack` — Excel 365 `HSTACK` / `VSTACK` with NA
+  padding for mismatched shapes.
+- `reshape::to_row` / `reshape::to_col` — Excel 365 `TOROW` / `TOCOL` with the
+  4-mode `ignore` enum (`KeepAll`, `SkipBlanks`, `SkipErrors`, `SkipBoth`) and
+  optional column-major scan order.
+- `reshape::wrap_rows` / `reshape::wrap_cols` — Excel 365 `WRAPROWS` /
+  `WRAPCOLS` with caller-supplied or NA padding.
+- `pick::choose_rows` / `pick::choose_cols` — Excel 365 `CHOOSEROWS` /
+  `CHOOSECOLS` with 1-based indices, negative-from-end, repeats allowed.
+- `filter::filter` — Excel 365 `FILTER` with 1-D boolean mask, `if_empty`
+  fallback, and NA-as-FALSE mask semantics.
+- `sort::sort` / `sort::sort_by` — Excel 365 `SORT` / `SORTBY` with stable
+  ordering, NA-last-in-ascending convention, optional `by_col` axis, and
+  multi-key support (capped at 6 keys for Phase 1; Excel allows 128).
+- `unique::unique` — Excel 365 `UNIQUE` with `by_col` and `exactly_once`
+  options. NA values dedupe against each other.
+- Integration test suite (~50 tests) covering every function, NA propagation,
+  Excel edge cases, and error paths.
+
+### Notes / divergences from Excel 365
+
+- `TOROW` / `TOCOL` modes 2 (skip errors) and 3 (skip both) currently behave
+  identically to 0 / 1 respectively because `Array2D<f64>` has no error
+  encoding distinct from NA. Phase 2 (mixed text/error arrays) will revisit.
+- `SORTBY` is capped at 6 keys (Excel: 128). v1 callers should not hit this.
+- `RANDARRAY` is intentionally deferred — it routes through a separate RNG
+  crate per the catalog.

--- a/code/packages/rust/array-core/Cargo.toml
+++ b/code/packages/rust/array-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "array-core"
+version = "0.1.0"
+edition = "2021"
+description = "Canonical Rust dynamic-array helpers — Excel 365 array functions for any spreadsheet frontend."
+
+[dependencies]
+numeric-tower = { path = "../numeric-tower" }
+r-vector = { path = "../r-vector" }

--- a/code/packages/rust/array-core/README.md
+++ b/code/packages/rust/array-core/README.md
@@ -1,0 +1,52 @@
+# array-core
+
+Canonical Rust dynamic-array helpers — Excel 365 array functions for any spreadsheet frontend.
+
+## What this is
+
+`array-core` is a Layer-1 Rust crate in the spreadsheet/statistics stack. It implements the shape-mutating, generating, and selecting array helpers that Excel 365 surfaces as dynamic-array functions (`SEQUENCE`, `TAKE`, `SORT`, `UNIQUE`, etc.) so that any frontend (VisiCalc faithful, modern reconstruction, a Sheets-style host) can share a single, well-tested implementation.
+
+The crate is pure compute: no I/O, no platform code, no globals, WASM-compatible. The only dependencies are sibling Layer-0 crates `numeric-tower` and `r-vector`.
+
+## Where it fits
+
+See `code/specs/backend-crate-catalog.md` (Layer 1 row `array-core`) and `code/specs/statistics-core.md` for sibling conventions. Cell-level broadcast/spill logic lives in a higher layer (`spreadsheet-core`); this crate just provides the array math.
+
+## Functions (Phase 1)
+
+| Module      | Functions                                     |
+|-------------|-----------------------------------------------|
+| `generate`  | `sequence`                                    |
+| `shape`     | `take`, `drop`, `expand`                      |
+| `stack`     | `hstack`, `vstack`                            |
+| `reshape`   | `to_row`, `to_col`, `wrap_rows`, `wrap_cols`  |
+| `pick`      | `choose_rows`, `choose_cols`                  |
+| `filter`    | `filter`                                      |
+| `sort`      | `sort`, `sort_by`                             |
+| `unique`    | `unique`                                      |
+
+`RANDARRAY` is deferred — it requires a pluggable RNG (handled by a separate crate in the catalog).
+
+## Conventions
+
+- **1-based indexing at the public surface** (`CHOOSEROWS`, `SORT`'s `sort_index`). Negative indices count from the end, matching Excel.
+- **NA via the `r-vector` bit pattern**. `na_real()` is re-exported. NA in sort keys lands at the end (ascending) / beginning (descending); UNIQUE collapses duplicate NAs; FILTER treats NA-in-mask as `FALSE`.
+- **NA-padding for shape mismatches**: HSTACK / VSTACK / EXPAND / WRAPROWS / WRAPCOLS pad with NA when the inputs do not divide evenly.
+
+## Example
+
+```rust
+use array_core::{generate::sequence, sort::sort, shape::take};
+
+let a = sequence(5, None, Some(1.0), Some(1.0))?;  // 1,2,3,4,5 as a column
+let top3 = take(&a, 3, None)?;                       // 1,2,3
+let desc = sort(&a, None, Some(-1), None)?;          // 5,4,3,2,1
+```
+
+## Tests
+
+```sh
+cargo test -p array-core
+```
+
+Phase 1 ships ~50 integration tests covering happy paths, Excel-365 edge cases (negative indices, over-take/over-drop, NA-in-mask, NA-in-sort, exactly-once UNIQUE), and error paths.

--- a/code/packages/rust/array-core/src/filter.rs
+++ b/code/packages/rust/array-core/src/filter.rs
@@ -1,0 +1,70 @@
+//! FILTER — boolean-mask row filter.
+//!
+//! `FILTER(array, include, [if_empty])` returns the rows of `array` where
+//! `include[i]` is truthy (non-zero, not NA). The mask must have one entry
+//! per row of `array`. If nothing passes and `if_empty` is `None`, returns
+//! `ArrayError::EmptyResult` — which the cell layer maps to `#CALC!`.
+//!
+//! # NA-in-mask behavior
+//!
+//! NA in the mask is treated as `FALSE`. This matches Excel: a blank or
+//! `#N/A` in the include criteria excludes the corresponding row. (Modeling
+//! that as "propagate NA into the included rows" would surprise spreadsheet
+//! authors more than it would help; the included rows are a subset of the
+//! original, not arithmetically derived from the mask.)
+
+use crate::{is_na_real, Array2D, ArrayError};
+
+/// Coerce an f64 mask entry to a boolean. Returns `false` for NA, `false`
+/// for `0.0` (Excel convention), and `true` for everything else (including
+/// non-NA NaN, matching Excel's quirk of `=IF(NaN, "y", "n")` being truthy).
+fn mask_is_true(value: f64) -> bool {
+    if is_na_real(value) {
+        return false;
+    }
+    value != 0.0
+}
+
+/// `FILTER(array, include, [if_empty])` — Excel 365.
+///
+/// `include` must be an `Array2D<f64>` whose total cell count equals
+/// `array.rows`. We accept any shape (row vector, column vector, or even a
+/// single column with the right length) for ergonomic API surface. Excel
+/// itself accepts both row and column vector masks.
+///
+/// Output: a new array containing only rows where the mask is truthy. If
+/// the result is empty, returns `if_empty` (as a 1x1 array containing that
+/// single value, matching Excel's spill behavior) or `EmptyResult`.
+pub fn filter(
+    array: &Array2D<f64>,
+    include: &Array2D<f64>,
+    if_empty: Option<f64>,
+) -> Result<Array2D<f64>, ArrayError> {
+    if include.data.len() != array.rows {
+        return Err(ArrayError::ShapeMismatch {
+            expected: format!("{} mask values (one per row)", array.rows),
+            found: format!("{} mask values", include.data.len()),
+        });
+    }
+    let kept_rows: Vec<usize> = include
+        .data
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &v)| if mask_is_true(v) { Some(i) } else { None })
+        .collect();
+
+    if kept_rows.is_empty() {
+        return match if_empty {
+            Some(v) => Array2D::new(1, 1, vec![v]),
+            None => Err(ArrayError::EmptyResult { function: "FILTER" }),
+        };
+    }
+
+    let mut data = Vec::with_capacity(kept_rows.len() * array.cols);
+    for r in &kept_rows {
+        for c in 0..array.cols {
+            data.push(*array.get(*r, c));
+        }
+    }
+    Array2D::new(kept_rows.len(), array.cols, data)
+}

--- a/code/packages/rust/array-core/src/generate.rs
+++ b/code/packages/rust/array-core/src/generate.rs
@@ -1,0 +1,57 @@
+//! Array generators.
+//!
+//! Phase 1 covers SEQUENCE. RANDARRAY is intentionally deferred — it requires
+//! a pluggable RNG, which the catalog routes through a separate crate; see
+//! `code/specs/backend-crate-catalog.md`.
+
+use crate::{Array2D, ArrayError};
+
+/// `SEQUENCE(rows, [cols], [start], [step])` — Excel 365.
+///
+/// Produces a `(rows, cols)` array filled row-major from `start`, stepping
+/// by `step`. Defaults match Excel: `cols = 1`, `start = 1`, `step = 1`.
+///
+/// # Truth table for tiny inputs
+///
+/// | Call                              | Result                            |
+/// |-----------------------------------|-----------------------------------|
+/// | `sequence(3, None, None, None)`   | `[[1], [2], [3]]`                 |
+/// | `sequence(2, Some(3), None, None)`| `[[1, 2, 3], [4, 5, 6]]`          |
+/// | `sequence(3, None, Some(0.), Some(0.5))` | `[[0.0], [0.5], [1.0]]`    |
+/// | `sequence(3, None, Some(5.), Some(-1.))` | `[[5.0], [4.0], [3.0]]`    |
+///
+/// # Errors
+///
+/// `rows == 0` returns `BadParameter("rows", "0")` — Excel reports `#VALUE!`
+/// for non-positive row counts. Same for `cols == 0`.
+pub fn sequence(
+    rows: usize,
+    cols: Option<usize>,
+    start: Option<f64>,
+    step: Option<f64>,
+) -> Result<Array2D<f64>, ArrayError> {
+    if rows == 0 {
+        return Err(ArrayError::BadParameter {
+            name: "rows",
+            value: "0".into(),
+        });
+    }
+    let cols = cols.unwrap_or(1);
+    if cols == 0 {
+        return Err(ArrayError::BadParameter {
+            name: "cols",
+            value: "0".into(),
+        });
+    }
+    let start = start.unwrap_or(1.0);
+    let step = step.unwrap_or(1.0);
+
+    let n = rows * cols;
+    let mut data = Vec::with_capacity(n);
+    // We compute `start + i * step` (rather than accumulating) to avoid
+    // accumulating floating-point error across long sequences.
+    for i in 0..n {
+        data.push(start + (i as f64) * step);
+    }
+    Array2D::new(rows, cols, data)
+}

--- a/code/packages/rust/array-core/src/lib.rs
+++ b/code/packages/rust/array-core/src/lib.rs
@@ -1,0 +1,259 @@
+//! Array Core
+//!
+//! Phase 1 implementation of `code/specs/backend-crate-catalog.md`'s
+//! `array-core` row — Excel 365 dynamic-array helpers usable from any
+//! spreadsheet frontend (VisiCalc faithful, modern reconstruction, or a
+//! Numbers/Sheets-style host).
+//!
+//! # Design overview
+//!
+//! ## Why a dedicated `Array2D<T>`?
+//!
+//! Excel-365 dynamic-array functions are inherently 2-D: `SEQUENCE(3, 4)` is a
+//! 3-row, 4-column block, `HSTACK` glues blocks side by side, `SORT` reorders
+//! rows or columns. `r-vector::Double` only models a flat 1-D atomic vector
+//! plus an optional `dim` attribute. Threading a 2-D abstraction through
+//! callers of every function in this crate via that attribute would obscure
+//! intent and duplicate validation in every call site. So we wrap the storage
+//! in a small in-crate type:
+//!
+//! ```text
+//!   Array2D { rows, cols, data }   // row-major Vec<T>
+//! ```
+//!
+//! `data` is row-major: `data[r * cols + c]` is the cell at `(r, c)`. This is
+//! the same convention as `r-vector::Double`'s eventual matrix view and what
+//! most C/Rust callers expect. (R's column-major convention is a presentation
+//! detail; we convert at the language-binding edge, not here.)
+//!
+//! For numeric arrays we use `Array2D<f64>` and reuse `r-vector::na_real()`'s
+//! NA bit-pattern, so missing values flow through arithmetic and through every
+//! function in this crate without an additional `Option` layer. `Array2D<T>`
+//! is generic so future Phase-2 work (mixed text + numeric arrays) can layer
+//! on without rewriting the storage.
+//!
+//! ## 1-based indexing at the public surface
+//!
+//! Excel cell references and array-function arguments are 1-based. To keep
+//! the API readable from a spreadsheet engineer's perspective, all
+//! user-facing indices (`CHOOSEROWS`, `CHOOSECOLS`, `SORT`'s `sort_index`)
+//! are 1-based. Negative values count from the end, matching Excel:
+//! `CHOOSEROWS(arr, -1)` is the last row. We convert to 0-based right at the
+//! function entry; internal helpers stay 0-based.
+//!
+//! ## NA propagation rules (per-function notes are inline in each module)
+//!
+//! * SORT keeps NA values — they sort to the end in ascending order (matching
+//!   Excel's behavior of placing errors at the end).
+//! * UNIQUE treats two NA positions as equal — duplicates of NA collapse.
+//! * FILTER's boolean mask: NA in the mask is treated as `FALSE` (do not
+//!   include). This matches Excel where `=FILTER(A:A, B:B)` with an empty
+//!   cell in `B` excludes the corresponding row.
+//! * EXPAND / HSTACK / VSTACK / WRAPROWS / WRAPCOLS pad with NA (representing
+//!   Excel's `#N/A` error sentinel for "no value here") when shapes differ.
+
+pub mod filter;
+pub mod generate;
+pub mod pick;
+pub mod reshape;
+pub mod shape;
+pub mod sort;
+pub mod stack;
+pub mod unique;
+
+pub use r_vector::{is_na_real, na_real};
+
+/// Errors returned by `array-core` operations.
+///
+/// We deliberately keep this small and serializable-friendly (no boxed
+/// `dyn Error`). Each variant captures enough context for a frontend to
+/// translate into Excel error sentinels (`#VALUE!`, `#CALC!`, `#REF!`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ArrayError {
+    /// Two arrays whose shapes did not match for the requested operation.
+    ShapeMismatch {
+        expected: String,
+        found: String,
+    },
+    /// A function produced no rows / cols (FILTER with everything excluded
+    /// and no `if_empty`, for example). Maps to Excel `#CALC!`.
+    EmptyResult {
+        function: &'static str,
+    },
+    /// A caller-supplied parameter was outside its allowed range.
+    BadParameter {
+        name: &'static str,
+        value: String,
+    },
+    /// A 1-based index (possibly negative) resolved outside the array bounds.
+    /// `index` is the original 1-based value; `max` is the maximum absolute
+    /// 1-based value that would have been valid.
+    OutOfRange {
+        function: &'static str,
+        index: i64,
+        max: usize,
+    },
+}
+
+impl std::fmt::Display for ArrayError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArrayError::ShapeMismatch { expected, found } => {
+                write!(f, "shape mismatch: expected {expected}, found {found}")
+            }
+            ArrayError::EmptyResult { function } => {
+                write!(f, "{function}: empty result")
+            }
+            ArrayError::BadParameter { name, value } => {
+                write!(f, "bad parameter {name}={value}")
+            }
+            ArrayError::OutOfRange {
+                function,
+                index,
+                max,
+            } => write!(
+                f,
+                "{function}: index {index} out of range (|index| must be <= {max})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ArrayError {}
+
+/// 2-D row-major array used by every function in this crate.
+///
+/// # Invariants
+///
+/// * `data.len() == rows * cols`
+/// * If `rows == 0` or `cols == 0`, the array is considered empty and most
+///   functions short-circuit (returning empty, propagating NA, or erroring as
+///   the underlying Excel function does).
+///
+/// # Example
+/// ```text
+///   Array2D::new(2, 3, vec![1.0, 2.0, 3.0,    // row 0
+///                            4.0, 5.0, 6.0])  // row 1
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct Array2D<T: Clone> {
+    pub rows: usize,
+    pub cols: usize,
+    /// Row-major storage. `data[r * cols + c]` is the cell at `(r, c)`.
+    pub data: Vec<T>,
+}
+
+impl<T: Clone> Array2D<T> {
+    /// Construct from explicit dimensions and a row-major buffer.
+    ///
+    /// Returns `ShapeMismatch` if `data.len() != rows * cols`. We accept the
+    /// `0 x 0` empty array (with an empty `data` vec) since several functions
+    /// can legitimately produce an empty result (`DROP` past the end, for
+    /// example).
+    pub fn new(rows: usize, cols: usize, data: Vec<T>) -> Result<Self, ArrayError> {
+        if data.len() != rows.saturating_mul(cols) {
+            return Err(ArrayError::ShapeMismatch {
+                expected: format!("{} elements ({rows}x{cols})", rows.saturating_mul(cols)),
+                found: format!("{} elements", data.len()),
+            });
+        }
+        Ok(Self { rows, cols, data })
+    }
+
+    /// Wrap a 1-D vector as a single-column 2-D array `(n, 1)`.
+    ///
+    /// This is the canonical "lift" from `r-vector` shape to `Array2D` for
+    /// callers that receive a `Double` and want to pipe it through an
+    /// `array-core` helper. Length-zero produces a `(0, 1)` array (still
+    /// width 1; Excel treats a single-column empty range as 1 column wide).
+    pub fn from_vector(data: Vec<T>) -> Self {
+        let rows = data.len();
+        Self {
+            rows,
+            cols: 1,
+            data,
+        }
+    }
+
+    /// Construct an `Array2D` filled by repeating `value`.
+    pub fn filled(rows: usize, cols: usize, value: T) -> Self {
+        Self {
+            rows,
+            cols,
+            data: vec![value; rows * cols],
+        }
+    }
+
+    /// Borrow a cell by `(row, col)` (0-based). Panics if out of bounds — the
+    /// public-facing functions in this crate are responsible for bounds
+    /// checking before calling `get`.
+    pub fn get(&self, r: usize, c: usize) -> &T {
+        debug_assert!(r < self.rows && c < self.cols, "Array2D::get out of bounds");
+        &self.data[r * self.cols + c]
+    }
+
+    /// Set a cell. Intended only for in-place builders inside this crate.
+    pub fn set(&mut self, r: usize, c: usize, value: T) {
+        debug_assert!(r < self.rows && c < self.cols, "Array2D::set out of bounds");
+        self.data[r * self.cols + c] = value;
+    }
+
+    /// Materialize a row as a fresh `Vec<T>`.
+    pub fn row(&self, r: usize) -> Vec<T> {
+        debug_assert!(r < self.rows, "Array2D::row out of bounds");
+        let start = r * self.cols;
+        self.data[start..start + self.cols].to_vec()
+    }
+
+    /// Materialize a column as a fresh `Vec<T>`. (Row-major storage makes
+    /// this an O(rows) gather, which is fine for v1; callers operating on
+    /// many cols can use `data` directly.)
+    pub fn col(&self, c: usize) -> Vec<T> {
+        debug_assert!(c < self.cols, "Array2D::col out of bounds");
+        (0..self.rows).map(|r| self.data[r * self.cols + c].clone()).collect()
+    }
+
+    /// `true` iff the array has zero cells.
+    pub fn is_empty(&self) -> bool {
+        self.rows == 0 || self.cols == 0
+    }
+}
+
+impl Array2D<f64> {
+    /// `true` iff the cell holds the canonical NA bit pattern from
+    /// `r-vector`. (This is a no-cost wrapper that exists so callers do not
+    /// have to import `r_vector::is_na_real` for typical scans.)
+    pub fn is_na(&self, r: usize, c: usize) -> bool {
+        is_na_real(*self.get(r, c))
+    }
+}
+
+/// Resolve a 1-based, possibly-negative Excel-style index against a length.
+///
+/// Returns the 0-based offset, or `ArrayError::OutOfRange` if `index` is
+/// `0` (Excel rejects zero indices) or `|index| > max`.
+///
+/// # Examples
+/// * `resolve_index("CHOOSEROWS",  1, 5)` -> Ok(0) — first item.
+/// * `resolve_index("CHOOSEROWS", -1, 5)` -> Ok(4) — last item.
+/// * `resolve_index("CHOOSEROWS",  0, 5)` -> Err(OutOfRange)
+/// * `resolve_index("CHOOSEROWS",  6, 5)` -> Err(OutOfRange)
+pub(crate) fn resolve_index(
+    function: &'static str,
+    index: i64,
+    max: usize,
+) -> Result<usize, ArrayError> {
+    if index == 0 || (index.unsigned_abs() as usize) > max {
+        return Err(ArrayError::OutOfRange {
+            function,
+            index,
+            max,
+        });
+    }
+    if index > 0 {
+        Ok((index - 1) as usize)
+    } else {
+        // Negative: -1 means last, -2 second-to-last, etc.
+        Ok(max - (index.unsigned_abs() as usize))
+    }
+}

--- a/code/packages/rust/array-core/src/pick.rs
+++ b/code/packages/rust/array-core/src/pick.rs
@@ -1,0 +1,48 @@
+//! CHOOSEROWS / CHOOSECOLS — pick rows or columns by 1-based index.
+//!
+//! Indices are 1-based, possibly negative (count from end). Excel raises
+//! `#VALUE!` for `0` and `#REF!` for out-of-range; we map both to
+//! `ArrayError::OutOfRange` and let the cell layer decide which sentinel to
+//! surface.
+
+use crate::{resolve_index, Array2D, ArrayError};
+
+/// `CHOOSEROWS(array, indices...)` — Excel 365.
+///
+/// Returns a new array containing the specified rows in the order given.
+/// Repeating an index repeats the row. Negative indices count from the end.
+pub fn choose_rows(array: &Array2D<f64>, indices: &[i64]) -> Result<Array2D<f64>, ArrayError> {
+    if indices.is_empty() {
+        return Err(ArrayError::BadParameter {
+            name: "indices",
+            value: "(none)".into(),
+        });
+    }
+    let mut data = Vec::with_capacity(indices.len() * array.cols);
+    for &idx in indices {
+        let r = resolve_index("CHOOSEROWS", idx, array.rows)?;
+        for c in 0..array.cols {
+            data.push(*array.get(r, c));
+        }
+    }
+    Array2D::new(indices.len(), array.cols, data)
+}
+
+/// `CHOOSECOLS(array, indices...)` — Excel 365.
+pub fn choose_cols(array: &Array2D<f64>, indices: &[i64]) -> Result<Array2D<f64>, ArrayError> {
+    if indices.is_empty() {
+        return Err(ArrayError::BadParameter {
+            name: "indices",
+            value: "(none)".into(),
+        });
+    }
+    let out_cols = indices.len();
+    let mut data = vec![0.0; array.rows * out_cols];
+    for (out_c, &idx) in indices.iter().enumerate() {
+        let src_c = resolve_index("CHOOSECOLS", idx, array.cols)?;
+        for r in 0..array.rows {
+            data[r * out_cols + out_c] = *array.get(r, src_c);
+        }
+    }
+    Array2D::new(array.rows, out_cols, data)
+}

--- a/code/packages/rust/array-core/src/reshape.rs
+++ b/code/packages/rust/array-core/src/reshape.rs
@@ -1,0 +1,186 @@
+//! Reshape helpers: TOROW, TOCOL, WRAPROWS, WRAPCOLS.
+//!
+//! TOROW/TOCOL flatten an arbitrary 2-D array into a single row or column,
+//! optionally skipping blanks or errors. WRAPROWS/WRAPCOLS go the other
+//! direction, reshaping a 1-D vector into a 2-D grid with NA padding when
+//! the count does not divide evenly.
+
+use crate::{is_na_real, na_real, Array2D, ArrayError};
+
+/// `ignore` modes for TOROW / TOCOL, matching Excel 365's documented
+/// 4-value enum.
+///
+/// | Code | Meaning                              |
+/// |------|--------------------------------------|
+/// | 0    | Keep every cell (default).           |
+/// | 1    | Skip blanks (here: NA cells).        |
+/// | 2    | Skip errors. We currently have no    |
+/// |      | distinct error encoding apart from   |
+/// |      | NA, so this behaves like 0.          |
+/// | 3    | Skip both. Behaves like 1.           |
+///
+/// # Divergence from Excel 365
+///
+/// Excel distinguishes "blank" from `#N/A` and other error sentinels. In our
+/// `Array2D<f64>` storage there is only NA. When richer text/error arrays
+/// land in Phase 2 we will revisit modes 2 and 3 so they treat
+/// `#VALUE!`/`#DIV/0!`/etc. as the "error" bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ignore {
+    KeepAll,
+    SkipBlanks,
+    SkipErrors,
+    SkipBoth,
+}
+
+impl Ignore {
+    pub fn from_code(code: u8) -> Result<Self, ArrayError> {
+        match code {
+            0 => Ok(Ignore::KeepAll),
+            1 => Ok(Ignore::SkipBlanks),
+            2 => Ok(Ignore::SkipErrors),
+            3 => Ok(Ignore::SkipBoth),
+            _ => Err(ArrayError::BadParameter {
+                name: "ignore",
+                value: code.to_string(),
+            }),
+        }
+    }
+
+    fn keeps(self, value: f64) -> bool {
+        let is_na = is_na_real(value);
+        match self {
+            Ignore::KeepAll => true,
+            // We treat NA as "blank" for now (see module docstring).
+            Ignore::SkipBlanks => !is_na,
+            // No distinct error type yet; nothing to skip.
+            Ignore::SkipErrors => true,
+            // Same NA-as-blank treatment.
+            Ignore::SkipBoth => !is_na,
+        }
+    }
+}
+
+/// Walk an array, optionally row-major (default) or column-major, applying
+/// `ignore`. Returns a single flat `Vec<f64>` of the kept cells in scan
+/// order.
+fn flatten_with_ignore(
+    array: &Array2D<f64>,
+    ignore: Ignore,
+    scan_by_column: bool,
+) -> Vec<f64> {
+    let mut out = Vec::with_capacity(array.data.len());
+    if scan_by_column {
+        for c in 0..array.cols {
+            for r in 0..array.rows {
+                let value = *array.get(r, c);
+                if ignore.keeps(value) {
+                    out.push(value);
+                }
+            }
+        }
+    } else {
+        for r in 0..array.rows {
+            for c in 0..array.cols {
+                let value = *array.get(r, c);
+                if ignore.keeps(value) {
+                    out.push(value);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// `TOROW(array, [ignore], [scan_by_column])` — Excel 365.
+///
+/// Flattens to a `(1, n)` array. If all cells are skipped, returns a
+/// `(1, 0)` array (Excel emits `#CALC!`; we surface empty and let the cell
+/// layer decide).
+pub fn to_row(
+    array: &Array2D<f64>,
+    ignore: Option<u8>,
+    scan_by_column: Option<bool>,
+) -> Result<Array2D<f64>, ArrayError> {
+    let ignore = Ignore::from_code(ignore.unwrap_or(0))?;
+    let scan_by_column = scan_by_column.unwrap_or(false);
+    let flat = flatten_with_ignore(array, ignore, scan_by_column);
+    let len = flat.len();
+    Array2D::new(1, len, flat)
+}
+
+/// `TOCOL(array, [ignore], [scan_by_column])` — Excel 365.
+///
+/// Flattens to an `(n, 1)` array. See `to_row` for skip semantics.
+pub fn to_col(
+    array: &Array2D<f64>,
+    ignore: Option<u8>,
+    scan_by_column: Option<bool>,
+) -> Result<Array2D<f64>, ArrayError> {
+    let ignore = Ignore::from_code(ignore.unwrap_or(0))?;
+    let scan_by_column = scan_by_column.unwrap_or(false);
+    let flat = flatten_with_ignore(array, ignore, scan_by_column);
+    let len = flat.len();
+    Array2D::new(len, 1, flat)
+}
+
+/// `WRAPROWS(vector, wrap_count, [pad_with])` — Excel 365.
+///
+/// Reshapes a 1-D input (any `(r, c)` is allowed, but Excel documents this as
+/// a "vector") into a grid `wrap_count` columns wide. Reads input in
+/// row-major order. The last row is padded with `pad_with` (default NA) if
+/// the total cell count is not a multiple of `wrap_count`.
+pub fn wrap_rows(
+    vector: &Array2D<f64>,
+    wrap_count: usize,
+    pad_with: Option<f64>,
+) -> Result<Array2D<f64>, ArrayError> {
+    if wrap_count == 0 {
+        return Err(ArrayError::BadParameter {
+            name: "wrap_count",
+            value: "0".into(),
+        });
+    }
+    let pad = pad_with.unwrap_or_else(na_real);
+    let n = vector.data.len();
+    if n == 0 {
+        return Array2D::new(0, wrap_count, vec![]);
+    }
+    let rows = n.div_ceil(wrap_count);
+    let mut data = vec![pad; rows * wrap_count];
+    for (i, v) in vector.data.iter().enumerate() {
+        data[i] = *v;
+    }
+    Array2D::new(rows, wrap_count, data)
+}
+
+/// `WRAPCOLS(vector, wrap_count, [pad_with])` — Excel 365.
+///
+/// Like WRAPROWS but reshapes into a grid `wrap_count` rows tall. The output
+/// fills column-by-column, padding the last column with `pad_with`.
+pub fn wrap_cols(
+    vector: &Array2D<f64>,
+    wrap_count: usize,
+    pad_with: Option<f64>,
+) -> Result<Array2D<f64>, ArrayError> {
+    if wrap_count == 0 {
+        return Err(ArrayError::BadParameter {
+            name: "wrap_count",
+            value: "0".into(),
+        });
+    }
+    let pad = pad_with.unwrap_or_else(na_real);
+    let n = vector.data.len();
+    if n == 0 {
+        return Array2D::new(wrap_count, 0, vec![]);
+    }
+    let cols = n.div_ceil(wrap_count);
+    let mut data = vec![pad; wrap_count * cols];
+    // Fill column-by-column. Input is consumed in its row-major order.
+    for (i, v) in vector.data.iter().enumerate() {
+        let c = i / wrap_count;
+        let r = i % wrap_count;
+        data[r * cols + c] = *v;
+    }
+    Array2D::new(wrap_count, cols, data)
+}

--- a/code/packages/rust/array-core/src/shape.rs
+++ b/code/packages/rust/array-core/src/shape.rs
@@ -1,0 +1,142 @@
+//! Shape-mutating helpers: TAKE, DROP, EXPAND.
+//!
+//! All three accept negative arguments meaning "from the end" (Excel 365
+//! convention). The implementations factor through a small helper
+//! `slice_range` that turns Excel's signed length into a 0-based half-open
+//! range against an axis.
+
+use crate::{na_real, Array2D, ArrayError};
+
+/// Compute the 0-based half-open range that an Excel-style signed `n`
+/// selects for TAKE on an axis of length `len`.
+///
+/// * `n > 0`: take the first `min(n, len)` items -> `0..min(n, len)`.
+/// * `n < 0`: take the last `min(|n|, len)` items -> `len - min(|n|, len) .. len`.
+/// * `n == 0`: take zero items -> `0..0`.
+///
+/// This matches `=TAKE({1,2,3,4,5}, 2)` -> `{1,2}` and
+/// `=TAKE({1,2,3,4,5}, -2)` -> `{4,5}`. Over-taking is a no-op clamp: Excel
+/// does not error on `=TAKE({1,2,3}, 99)`.
+fn take_range(len: usize, n: i64) -> std::ops::Range<usize> {
+    if n == 0 {
+        return 0..0;
+    }
+    let take = std::cmp::min(n.unsigned_abs() as usize, len);
+    if n > 0 {
+        0..take
+    } else {
+        (len - take)..len
+    }
+}
+
+/// Compute the 0-based half-open range that survives DROP of an Excel-style
+/// signed `n` on an axis of length `len`.
+///
+/// * `n > 0`: drop the first `n` -> `min(n, len)..len`.
+/// * `n < 0`: drop the last `|n|` -> `0..len - min(|n|, len)`.
+/// * `n == 0`: drop nothing -> `0..len`.
+///
+/// Over-dropping is again a clamp: `=DROP({1,2,3}, 99)` returns an empty
+/// array (Excel emits `#CALC!` in that case; for the host frontend we surface
+/// the empty result and let the cell layer translate).
+fn drop_range(len: usize, n: i64) -> std::ops::Range<usize> {
+    if n == 0 {
+        return 0..len;
+    }
+    let drop = std::cmp::min(n.unsigned_abs() as usize, len);
+    if n > 0 {
+        drop..len
+    } else {
+        0..(len - drop)
+    }
+}
+
+/// `TAKE(array, rows, [cols])` — Excel 365.
+///
+/// Returns the first `rows` rows and first `cols` cols. Negative counts take
+/// from the end. `cols = None` keeps all columns; passing `Some(0)` drops all
+/// columns (producing a `(rows, 0)` array). Same for `rows = 0`.
+pub fn take(
+    array: &Array2D<f64>,
+    rows: i64,
+    cols: Option<i64>,
+) -> Result<Array2D<f64>, ArrayError> {
+    let row_range = take_range(array.rows, rows);
+    let col_range = match cols {
+        Some(c) => take_range(array.cols, c),
+        None => 0..array.cols,
+    };
+    slice(array, row_range, col_range)
+}
+
+/// `DROP(array, rows, [cols])` — Excel 365.
+///
+/// Returns the array with the first `rows` rows and `cols` cols removed.
+/// Negative counts drop from the end. Over-dropping returns an empty array.
+pub fn drop(
+    array: &Array2D<f64>,
+    rows: i64,
+    cols: Option<i64>,
+) -> Result<Array2D<f64>, ArrayError> {
+    let row_range = drop_range(array.rows, rows);
+    let col_range = match cols {
+        Some(c) => drop_range(array.cols, c),
+        None => 0..array.cols,
+    };
+    slice(array, row_range, col_range)
+}
+
+/// Generic slice helper used by TAKE and DROP. Materializes a fresh
+/// row-major buffer for the sub-rectangle described by the two ranges.
+fn slice(
+    array: &Array2D<f64>,
+    row_range: std::ops::Range<usize>,
+    col_range: std::ops::Range<usize>,
+) -> Result<Array2D<f64>, ArrayError> {
+    let out_rows = row_range.end.saturating_sub(row_range.start);
+    let out_cols = col_range.end.saturating_sub(col_range.start);
+    let mut data = Vec::with_capacity(out_rows * out_cols);
+    for r in row_range {
+        for c in col_range.clone() {
+            data.push(*array.get(r, c));
+        }
+    }
+    Array2D::new(out_rows, out_cols, data)
+}
+
+/// `EXPAND(array, rows, [cols], [pad_with])` — Excel 365.
+///
+/// Grows `array` to exactly `(rows, cols)`, padding the new region with
+/// `pad_with` (default: NA — Excel emits `#N/A`). Shrinking is an error:
+/// Excel emits `#VALUE!` if the requested dimensions are smaller than the
+/// source. We translate that into `BadParameter`.
+pub fn expand(
+    array: &Array2D<f64>,
+    rows: usize,
+    cols: Option<usize>,
+    pad_with: Option<f64>,
+) -> Result<Array2D<f64>, ArrayError> {
+    let cols = cols.unwrap_or(array.cols);
+    if rows < array.rows {
+        return Err(ArrayError::BadParameter {
+            name: "rows",
+            value: format!("{rows} (smaller than source {})", array.rows),
+        });
+    }
+    if cols < array.cols {
+        return Err(ArrayError::BadParameter {
+            name: "cols",
+            value: format!("{cols} (smaller than source {})", array.cols),
+        });
+    }
+    let pad = pad_with.unwrap_or_else(na_real);
+    let mut data = vec![pad; rows * cols];
+    // Copy the source into the top-left corner. We intentionally do not
+    // center or right-align — Excel always anchors at the top-left.
+    for r in 0..array.rows {
+        for c in 0..array.cols {
+            data[r * cols + c] = *array.get(r, c);
+        }
+    }
+    Array2D::new(rows, cols, data)
+}

--- a/code/packages/rust/array-core/src/sort.rs
+++ b/code/packages/rust/array-core/src/sort.rs
@@ -1,0 +1,162 @@
+//! SORT / SORTBY — order rows or columns by one or more keys.
+//!
+//! Both functions are stable: equal keys preserve original order. NA values
+//! sort to the end in ascending order and to the beginning in descending
+//! order — equivalent to "errors always last in ascending direction", which
+//! matches Excel's documented behavior.
+
+use crate::{is_na_real, resolve_index, Array2D, ArrayError};
+
+/// Sort direction. `+1` = ascending (default), `-1` = descending.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Order {
+    Ascending,
+    Descending,
+}
+
+impl Order {
+    pub fn from_code(code: i32) -> Result<Self, ArrayError> {
+        match code {
+            1 => Ok(Order::Ascending),
+            -1 => Ok(Order::Descending),
+            _ => Err(ArrayError::BadParameter {
+                name: "sort_order",
+                value: code.to_string(),
+            }),
+        }
+    }
+}
+
+/// Comparison that puts NA at the "end" of ascending order. We use
+/// `f64::total_cmp` for the non-NA case (a total order over all f64s
+/// including NaN), so subnormals and signed zeros behave deterministically.
+fn cmp_key(a: f64, b: f64, order: Order) -> std::cmp::Ordering {
+    let a_na = is_na_real(a);
+    let b_na = is_na_real(b);
+    // NA always sorts last in ascending; flip for descending so that NA
+    // appears first there. This matches Excel's "errors last" convention
+    // for ascending, mirrored.
+    let cmp = match (a_na, b_na) {
+        (true, true) => std::cmp::Ordering::Equal,
+        (true, false) => std::cmp::Ordering::Greater,
+        (false, true) => std::cmp::Ordering::Less,
+        (false, false) => a.total_cmp(&b),
+    };
+    match order {
+        Order::Ascending => cmp,
+        Order::Descending => cmp.reverse(),
+    }
+}
+
+/// `SORT(array, [sort_index], [sort_order], [by_col])` — Excel 365.
+///
+/// Default sorts rows ascending by the first column. `by_col = true` flips
+/// the axis: sort columns by a row's values.
+///
+/// `sort_index` is 1-based and refers to a column (when sorting rows) or a
+/// row (when sorting columns). Out-of-range values raise `OutOfRange`.
+pub fn sort(
+    array: &Array2D<f64>,
+    sort_index: Option<i64>,
+    sort_order: Option<i32>,
+    by_col: Option<bool>,
+) -> Result<Array2D<f64>, ArrayError> {
+    let by_col = by_col.unwrap_or(false);
+    let order = Order::from_code(sort_order.unwrap_or(1))?;
+    let sort_index_1b = sort_index.unwrap_or(1);
+
+    if array.is_empty() {
+        return Ok(array.clone());
+    }
+
+    if !by_col {
+        // Sort rows by `array[*, sort_index_1b - 1]`.
+        let key_col = resolve_index("SORT", sort_index_1b, array.cols)?;
+        let mut row_order: Vec<usize> = (0..array.rows).collect();
+        // Stable sort preserves input order among equal keys.
+        row_order.sort_by(|&i, &j| {
+            cmp_key(*array.get(i, key_col), *array.get(j, key_col), order)
+        });
+        let mut data = Vec::with_capacity(array.rows * array.cols);
+        for r in row_order {
+            for c in 0..array.cols {
+                data.push(*array.get(r, c));
+            }
+        }
+        Array2D::new(array.rows, array.cols, data)
+    } else {
+        // Sort columns by `array[sort_index_1b - 1, *]`.
+        let key_row = resolve_index("SORT", sort_index_1b, array.rows)?;
+        let mut col_order: Vec<usize> = (0..array.cols).collect();
+        col_order.sort_by(|&i, &j| {
+            cmp_key(*array.get(key_row, i), *array.get(key_row, j), order)
+        });
+        let mut data = vec![0.0; array.rows * array.cols];
+        for (out_c, src_c) in col_order.iter().enumerate() {
+            for r in 0..array.rows {
+                data[r * array.cols + out_c] = *array.get(r, *src_c);
+            }
+        }
+        Array2D::new(array.rows, array.cols, data)
+    }
+}
+
+/// A single (key array, order) pair for `sort_by`.
+pub struct SortKey<'a> {
+    pub by: &'a Array2D<f64>,
+    pub order: Order,
+}
+
+/// `SORTBY(array, by_array1, [order1], by_array2, [order2], ...)` — Excel 365.
+///
+/// Sorts rows of `array` by one or more separate key arrays. Each key array
+/// must have exactly `array.rows` cells. Sort is stable across keys, so
+/// earlier keys are dominant and later keys break ties (lexicographic order).
+///
+/// We cap at 6 keys for Phase 1 (Excel allows up to 128); spreadsheet
+/// frontends almost never use more than a handful.
+pub fn sort_by(array: &Array2D<f64>, keys: &[SortKey<'_>]) -> Result<Array2D<f64>, ArrayError> {
+    if keys.is_empty() {
+        return Err(ArrayError::BadParameter {
+            name: "keys",
+            value: "(none)".into(),
+        });
+    }
+    if keys.len() > 6 {
+        return Err(ArrayError::BadParameter {
+            name: "keys",
+            value: format!("{} (max 6 for Phase 1)", keys.len()),
+        });
+    }
+    for (i, k) in keys.iter().enumerate() {
+        if k.by.data.len() != array.rows {
+            return Err(ArrayError::ShapeMismatch {
+                expected: format!("key {i} length = {}", array.rows),
+                found: format!("{}", k.by.data.len()),
+            });
+        }
+    }
+    if array.is_empty() {
+        return Ok(array.clone());
+    }
+
+    let mut row_order: Vec<usize> = (0..array.rows).collect();
+    row_order.sort_by(|&i, &j| {
+        for key in keys {
+            let cmp = cmp_key(key.by.data[i], key.by.data[j], key.order);
+            if cmp != std::cmp::Ordering::Equal {
+                return cmp;
+            }
+        }
+        // All keys equal — stable, so report Equal and let sort preserve
+        // the original index order.
+        std::cmp::Ordering::Equal
+    });
+    let mut data = Vec::with_capacity(array.rows * array.cols);
+    for r in row_order {
+        for c in 0..array.cols {
+            data.push(*array.get(r, c));
+        }
+    }
+    Array2D::new(array.rows, array.cols, data)
+}

--- a/code/packages/rust/array-core/src/stack.rs
+++ b/code/packages/rust/array-core/src/stack.rs
@@ -1,0 +1,68 @@
+//! HSTACK / VSTACK — concatenation with NA padding when shapes differ.
+//!
+//! Excel 365 lets you stack arrays of mismatched shape; the shorter axis is
+//! padded with `#N/A` (we use `r-vector::na_real()`). HSTACK aligns rows
+//! (vertical axis), VSTACK aligns columns (horizontal axis).
+
+use crate::{na_real, Array2D, ArrayError};
+
+/// `HSTACK(arr1, arr2, ...)` — horizontal concat.
+///
+/// All inputs are placed side-by-side; the result has
+/// `cols = sum(arr_i.cols)` and `rows = max(arr_i.rows)`. Rows shorter than
+/// the max are padded with NA at the bottom.
+///
+/// Empty inputs are skipped. If no inputs (or all empty), returns an empty
+/// `(0, 0)` array.
+pub fn hstack(arrays: &[&Array2D<f64>]) -> Result<Array2D<f64>, ArrayError> {
+    if arrays.is_empty() {
+        return Array2D::new(0, 0, vec![]);
+    }
+    let total_cols: usize = arrays.iter().map(|a| a.cols).sum();
+    let max_rows: usize = arrays.iter().map(|a| a.rows).max().unwrap_or(0);
+
+    if total_cols == 0 || max_rows == 0 {
+        return Array2D::new(max_rows, total_cols, vec![na_real(); max_rows * total_cols]);
+    }
+
+    let mut data = vec![na_real(); max_rows * total_cols];
+    let mut col_offset = 0usize;
+    for a in arrays {
+        for r in 0..a.rows {
+            for c in 0..a.cols {
+                data[r * total_cols + (col_offset + c)] = *a.get(r, c);
+            }
+        }
+        col_offset += a.cols;
+    }
+    Array2D::new(max_rows, total_cols, data)
+}
+
+/// `VSTACK(arr1, arr2, ...)` — vertical concat.
+///
+/// All inputs are placed top-to-bottom; the result has
+/// `rows = sum(arr_i.rows)` and `cols = max(arr_i.cols)`. Columns shorter
+/// than the max are padded with NA on the right.
+pub fn vstack(arrays: &[&Array2D<f64>]) -> Result<Array2D<f64>, ArrayError> {
+    if arrays.is_empty() {
+        return Array2D::new(0, 0, vec![]);
+    }
+    let total_rows: usize = arrays.iter().map(|a| a.rows).sum();
+    let max_cols: usize = arrays.iter().map(|a| a.cols).max().unwrap_or(0);
+
+    if total_rows == 0 || max_cols == 0 {
+        return Array2D::new(total_rows, max_cols, vec![na_real(); total_rows * max_cols]);
+    }
+
+    let mut data = vec![na_real(); total_rows * max_cols];
+    let mut row_offset = 0usize;
+    for a in arrays {
+        for r in 0..a.rows {
+            for c in 0..a.cols {
+                data[(row_offset + r) * max_cols + c] = *a.get(r, c);
+            }
+        }
+        row_offset += a.rows;
+    }
+    Array2D::new(total_rows, max_cols, data)
+}

--- a/code/packages/rust/array-core/src/unique.rs
+++ b/code/packages/rust/array-core/src/unique.rs
@@ -1,0 +1,121 @@
+//! UNIQUE — distinct rows (or columns) of an array.
+//!
+//! # NA handling
+//!
+//! Two NA values compare equal here (so duplicate NA rows collapse into
+//! one). This matches Excel: `=UNIQUE({#N/A; #N/A; 1})` -> `{#N/A; 1}`.
+//! For non-NA cells we compare bitwise via `f64::to_bits`, so `+0.0` and
+//! `-0.0` are considered distinct only if their bit patterns differ. This
+//! is a deliberate trade: bit-level equality is the only definition that
+//! makes NaN deduplication well-behaved.
+//!
+//! # exactly_once
+//!
+//! With `exactly_once = true` we return only items that appear in the input
+//! exactly once. Items appearing 2+ times are dropped entirely (not even one
+//! representative). This matches Excel's documented behavior.
+
+use crate::{is_na_real, Array2D, ArrayError};
+use std::collections::HashMap;
+
+/// Hash key for a row (or column): a Vec<u64> of bit patterns, with NA
+/// normalized to a single canonical value so all NAs collide in the table.
+fn key_of(values: &[f64]) -> Vec<u64> {
+    const NA_CANON: u64 = u64::MAX; // sentinel distinct from any real f64
+    values
+        .iter()
+        .map(|&v| if is_na_real(v) { NA_CANON } else { v.to_bits() })
+        .collect()
+}
+
+/// `UNIQUE(array, [by_col], [exactly_once])` — Excel 365.
+///
+/// * `by_col = false` (default): return unique rows.
+/// * `by_col = true`: return unique columns.
+/// * `exactly_once = true`: only items appearing exactly once survive.
+pub fn unique(
+    array: &Array2D<f64>,
+    by_col: Option<bool>,
+    exactly_once: Option<bool>,
+) -> Result<Array2D<f64>, ArrayError> {
+    let by_col = by_col.unwrap_or(false);
+    let exactly_once = exactly_once.unwrap_or(false);
+
+    if array.is_empty() {
+        return Ok(array.clone());
+    }
+
+    if !by_col {
+        // Iterate rows, keep first occurrences, count to support
+        // `exactly_once`.
+        let mut order: Vec<usize> = Vec::new();
+        let mut counts: HashMap<Vec<u64>, usize> = HashMap::new();
+        let mut first_pos: HashMap<Vec<u64>, usize> = HashMap::new();
+        for r in 0..array.rows {
+            let row = array.row(r);
+            let k = key_of(&row);
+            *counts.entry(k.clone()).or_insert(0) += 1;
+            first_pos.entry(k.clone()).or_insert_with(|| {
+                order.push(r);
+                r
+            });
+        }
+        let kept_rows: Vec<usize> = order
+            .into_iter()
+            .filter(|r| {
+                let k = key_of(&array.row(*r));
+                if exactly_once {
+                    counts.get(&k) == Some(&1)
+                } else {
+                    true
+                }
+            })
+            .collect();
+        if kept_rows.is_empty() {
+            return Array2D::new(0, array.cols, vec![]);
+        }
+        let mut data = Vec::with_capacity(kept_rows.len() * array.cols);
+        for r in &kept_rows {
+            for c in 0..array.cols {
+                data.push(*array.get(*r, c));
+            }
+        }
+        Array2D::new(kept_rows.len(), array.cols, data)
+    } else {
+        // Same logic mirrored for columns.
+        let mut order: Vec<usize> = Vec::new();
+        let mut counts: HashMap<Vec<u64>, usize> = HashMap::new();
+        let mut first_pos: HashMap<Vec<u64>, usize> = HashMap::new();
+        for c in 0..array.cols {
+            let col = array.col(c);
+            let k = key_of(&col);
+            *counts.entry(k.clone()).or_insert(0) += 1;
+            first_pos.entry(k.clone()).or_insert_with(|| {
+                order.push(c);
+                c
+            });
+        }
+        let kept_cols: Vec<usize> = order
+            .into_iter()
+            .filter(|c| {
+                let k = key_of(&array.col(*c));
+                if exactly_once {
+                    counts.get(&k) == Some(&1)
+                } else {
+                    true
+                }
+            })
+            .collect();
+        if kept_cols.is_empty() {
+            return Array2D::new(array.rows, 0, vec![]);
+        }
+        let out_cols = kept_cols.len();
+        let mut data = vec![0.0; array.rows * out_cols];
+        for (out_c, src_c) in kept_cols.iter().enumerate() {
+            for r in 0..array.rows {
+                data[r * out_cols + out_c] = *array.get(r, *src_c);
+            }
+        }
+        Array2D::new(array.rows, out_cols, data)
+    }
+}

--- a/code/packages/rust/array-core/tests/array_tests.rs
+++ b/code/packages/rust/array-core/tests/array_tests.rs
@@ -1,0 +1,622 @@
+//! Integration tests for `array-core` Phase 1. Each function is exercised
+//! with at least: a happy path, an Excel-365 edge case (negative indices,
+//! over-take/over-drop, etc.), an NA case where applicable, and one or two
+//! error paths.
+
+use array_core::filter::filter;
+use array_core::generate::sequence;
+use array_core::na_real;
+use array_core::pick::{choose_cols, choose_rows};
+use array_core::reshape::{to_col, to_row, wrap_cols, wrap_rows};
+use array_core::shape::{drop, expand, take};
+use array_core::sort::{sort, sort_by, Order, SortKey};
+use array_core::stack::{hstack, vstack};
+use array_core::unique::unique;
+use array_core::{is_na_real, Array2D, ArrayError};
+
+// ---- helpers ----
+
+fn arr(rows: usize, cols: usize, data: Vec<f64>) -> Array2D<f64> {
+    Array2D::new(rows, cols, data).unwrap()
+}
+
+/// Assert that `a` and `b` are bit-identical, treating NA cells as equal.
+/// (We can't just compare with PartialEq for cell-wise equality because
+/// `na_real()` is a NaN bit pattern and `NaN != NaN`.)
+fn assert_arr_eq(a: &Array2D<f64>, b: &Array2D<f64>) {
+    assert_eq!(a.rows, b.rows, "row count: left={:?} right={:?}", a, b);
+    assert_eq!(a.cols, b.cols, "col count: left={:?} right={:?}", a, b);
+    for (i, (x, y)) in a.data.iter().zip(b.data.iter()).enumerate() {
+        let both_na = is_na_real(*x) && is_na_real(*y);
+        assert!(
+            both_na || x == y,
+            "cell {i}: {x:?} vs {y:?} (rows={}, cols={})",
+            a.rows,
+            a.cols
+        );
+    }
+}
+
+// ---- Array2D ----
+
+#[test]
+fn array2d_new_rejects_shape_mismatch() {
+    let err = Array2D::new(2, 3, vec![1.0, 2.0]).unwrap_err();
+    matches!(err, ArrayError::ShapeMismatch { .. });
+}
+
+#[test]
+fn array2d_from_vector_makes_column() {
+    let a = Array2D::from_vector(vec![1.0, 2.0, 3.0]);
+    assert_eq!(a.rows, 3);
+    assert_eq!(a.cols, 1);
+}
+
+#[test]
+fn array2d_row_and_col() {
+    let a = arr(2, 3, vec![1., 2., 3., 4., 5., 6.]);
+    assert_eq!(a.row(0), vec![1., 2., 3.]);
+    assert_eq!(a.row(1), vec![4., 5., 6.]);
+    assert_eq!(a.col(0), vec![1., 4.]);
+    assert_eq!(a.col(2), vec![3., 6.]);
+}
+
+#[test]
+fn array2d_is_na() {
+    let a = arr(1, 2, vec![1.0, na_real()]);
+    assert!(!a.is_na(0, 0));
+    assert!(a.is_na(0, 1));
+}
+
+#[test]
+fn array2d_empty_is_empty() {
+    let a = Array2D::<f64>::new(0, 0, vec![]).unwrap();
+    assert!(a.is_empty());
+    let b = Array2D::<f64>::new(0, 3, vec![]).unwrap();
+    assert!(b.is_empty());
+}
+
+// ---- SEQUENCE ----
+
+#[test]
+fn sequence_default_1d() {
+    let out = sequence(3, None, None, None).unwrap();
+    assert_arr_eq(&out, &arr(3, 1, vec![1., 2., 3.]));
+}
+
+#[test]
+fn sequence_2d() {
+    let out = sequence(2, Some(3), None, None).unwrap();
+    assert_arr_eq(&out, &arr(2, 3, vec![1., 2., 3., 4., 5., 6.]));
+}
+
+#[test]
+fn sequence_custom_start_step() {
+    let out = sequence(3, None, Some(0.0), Some(0.5)).unwrap();
+    assert_arr_eq(&out, &arr(3, 1, vec![0.0, 0.5, 1.0]));
+}
+
+#[test]
+fn sequence_negative_step() {
+    let out = sequence(3, None, Some(5.0), Some(-1.0)).unwrap();
+    assert_arr_eq(&out, &arr(3, 1, vec![5.0, 4.0, 3.0]));
+}
+
+#[test]
+fn sequence_zero_rows_rejected() {
+    let err = sequence(0, None, None, None).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { name: "rows", .. }));
+}
+
+#[test]
+fn sequence_zero_cols_rejected() {
+    let err = sequence(3, Some(0), None, None).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { name: "cols", .. }));
+}
+
+// ---- TAKE ----
+
+#[test]
+fn take_positive_rows() {
+    let a = arr(3, 2, vec![1., 2., 3., 4., 5., 6.]);
+    let out = take(&a, 2, None).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![1., 2., 3., 4.]));
+}
+
+#[test]
+fn take_negative_rows() {
+    let a = arr(3, 2, vec![1., 2., 3., 4., 5., 6.]);
+    let out = take(&a, -2, None).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![3., 4., 5., 6.]));
+}
+
+#[test]
+fn take_rows_and_cols() {
+    let a = arr(3, 3, vec![1., 2., 3., 4., 5., 6., 7., 8., 9.]);
+    let out = take(&a, 2, Some(2)).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![1., 2., 4., 5.]));
+}
+
+#[test]
+fn take_negative_cols() {
+    let a = arr(2, 3, vec![1., 2., 3., 4., 5., 6.]);
+    let out = take(&a, 2, Some(-1)).unwrap();
+    assert_arr_eq(&out, &arr(2, 1, vec![3., 6.]));
+}
+
+#[test]
+fn take_exceeds_clamps() {
+    let a = arr(2, 2, vec![1., 2., 3., 4.]);
+    let out = take(&a, 99, Some(99)).unwrap();
+    assert_arr_eq(&out, &a);
+}
+
+#[test]
+fn take_zero_yields_empty() {
+    let a = arr(2, 2, vec![1., 2., 3., 4.]);
+    let out = take(&a, 0, None).unwrap();
+    assert_eq!(out.rows, 0);
+    assert_eq!(out.cols, 2);
+}
+
+// ---- DROP ----
+
+#[test]
+fn drop_positive() {
+    let a = arr(3, 2, vec![1., 2., 3., 4., 5., 6.]);
+    let out = drop(&a, 1, None).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![3., 4., 5., 6.]));
+}
+
+#[test]
+fn drop_negative() {
+    let a = arr(3, 2, vec![1., 2., 3., 4., 5., 6.]);
+    let out = drop(&a, -1, None).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![1., 2., 3., 4.]));
+}
+
+#[test]
+fn drop_cols() {
+    let a = arr(2, 3, vec![1., 2., 3., 4., 5., 6.]);
+    let out = drop(&a, 0, Some(1)).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![2., 3., 5., 6.]));
+}
+
+#[test]
+fn drop_over_yields_empty() {
+    let a = arr(3, 2, vec![1., 2., 3., 4., 5., 6.]);
+    let out = drop(&a, 99, None).unwrap();
+    assert_eq!(out.rows, 0);
+    assert_eq!(out.cols, 2);
+}
+
+// ---- EXPAND ----
+
+#[test]
+fn expand_pads_with_na_by_default() {
+    let a = arr(1, 1, vec![7.0]);
+    let out = expand(&a, 2, Some(2), None).unwrap();
+    assert!(!is_na_real(*out.get(0, 0)));
+    assert_eq!(*out.get(0, 0), 7.0);
+    assert!(is_na_real(*out.get(0, 1)));
+    assert!(is_na_real(*out.get(1, 0)));
+    assert!(is_na_real(*out.get(1, 1)));
+}
+
+#[test]
+fn expand_with_custom_pad() {
+    let a = arr(1, 1, vec![7.0]);
+    let out = expand(&a, 2, Some(2), Some(-1.0)).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![7.0, -1.0, -1.0, -1.0]));
+}
+
+#[test]
+fn expand_noop_if_already_sized() {
+    let a = arr(2, 2, vec![1., 2., 3., 4.]);
+    let out = expand(&a, 2, Some(2), None).unwrap();
+    assert_arr_eq(&out, &a);
+}
+
+#[test]
+fn expand_shrink_rejected() {
+    let a = arr(2, 2, vec![1., 2., 3., 4.]);
+    let err = expand(&a, 1, Some(1), None).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { .. }));
+}
+
+// ---- HSTACK / VSTACK ----
+
+#[test]
+fn hstack_equal_rows() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let b = arr(2, 2, vec![10., 20., 30., 40.]);
+    let out = hstack(&[&a, &b]).unwrap();
+    assert_arr_eq(&out, &arr(2, 3, vec![1., 10., 20., 2., 30., 40.]));
+}
+
+#[test]
+fn hstack_mismatched_rows_pads_na() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let b = arr(3, 1, vec![10., 20., 30.]);
+    let out = hstack(&[&a, &b]).unwrap();
+    assert_eq!(out.rows, 3);
+    assert_eq!(out.cols, 2);
+    assert_eq!(*out.get(0, 0), 1.0);
+    assert_eq!(*out.get(1, 0), 2.0);
+    assert!(is_na_real(*out.get(2, 0)));
+    assert_eq!(*out.get(2, 1), 30.0);
+}
+
+#[test]
+fn hstack_empty_input_returns_empty() {
+    let out = hstack(&[]).unwrap();
+    assert!(out.is_empty());
+}
+
+#[test]
+fn vstack_equal_cols() {
+    let a = arr(1, 2, vec![1., 2.]);
+    let b = arr(2, 2, vec![10., 20., 30., 40.]);
+    let out = vstack(&[&a, &b]).unwrap();
+    assert_arr_eq(&out, &arr(3, 2, vec![1., 2., 10., 20., 30., 40.]));
+}
+
+#[test]
+fn vstack_mismatched_cols_pads_na() {
+    let a = arr(1, 2, vec![1., 2.]);
+    let b = arr(1, 3, vec![10., 20., 30.]);
+    let out = vstack(&[&a, &b]).unwrap();
+    assert_eq!(out.rows, 2);
+    assert_eq!(out.cols, 3);
+    assert!(is_na_real(*out.get(0, 2)));
+    assert_eq!(*out.get(1, 2), 30.0);
+}
+
+// ---- TOROW / TOCOL ----
+
+#[test]
+fn to_row_flattens_row_major() {
+    let a = arr(2, 3, vec![1., 2., 3., 4., 5., 6.]);
+    let out = to_row(&a, None, None).unwrap();
+    assert_arr_eq(&out, &arr(1, 6, vec![1., 2., 3., 4., 5., 6.]));
+}
+
+#[test]
+fn to_row_scan_by_column() {
+    let a = arr(2, 3, vec![1., 2., 3., 4., 5., 6.]);
+    let out = to_row(&a, None, Some(true)).unwrap();
+    assert_arr_eq(&out, &arr(1, 6, vec![1., 4., 2., 5., 3., 6.]));
+}
+
+#[test]
+fn to_row_ignore_blanks_drops_na() {
+    let a = arr(1, 3, vec![1.0, na_real(), 3.0]);
+    let out = to_row(&a, Some(1), None).unwrap();
+    assert_arr_eq(&out, &arr(1, 2, vec![1.0, 3.0]));
+}
+
+#[test]
+fn to_col_flattens() {
+    let a = arr(2, 2, vec![1., 2., 3., 4.]);
+    let out = to_col(&a, None, None).unwrap();
+    assert_arr_eq(&out, &arr(4, 1, vec![1., 2., 3., 4.]));
+}
+
+#[test]
+fn to_col_ignore_skip_both() {
+    let a = arr(2, 2, vec![1.0, na_real(), na_real(), 4.0]);
+    let out = to_col(&a, Some(3), None).unwrap();
+    assert_arr_eq(&out, &arr(2, 1, vec![1.0, 4.0]));
+}
+
+#[test]
+fn to_row_invalid_ignore_code() {
+    let a = arr(1, 1, vec![1.0]);
+    let err = to_row(&a, Some(9), None).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { name: "ignore", .. }));
+}
+
+// ---- WRAPROWS / WRAPCOLS ----
+
+#[test]
+fn wrap_rows_even() {
+    let v = arr(1, 6, vec![1., 2., 3., 4., 5., 6.]);
+    let out = wrap_rows(&v, 3, None).unwrap();
+    assert_arr_eq(&out, &arr(2, 3, vec![1., 2., 3., 4., 5., 6.]));
+}
+
+#[test]
+fn wrap_rows_pads() {
+    let v = arr(1, 5, vec![1., 2., 3., 4., 5.]);
+    let out = wrap_rows(&v, 3, Some(0.0)).unwrap();
+    assert_arr_eq(&out, &arr(2, 3, vec![1., 2., 3., 4., 5., 0.0]));
+}
+
+#[test]
+fn wrap_rows_zero_count_rejected() {
+    let v = arr(1, 3, vec![1., 2., 3.]);
+    let err = wrap_rows(&v, 0, None).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { name: "wrap_count", .. }));
+}
+
+#[test]
+fn wrap_cols_even() {
+    let v = arr(1, 6, vec![1., 2., 3., 4., 5., 6.]);
+    let out = wrap_cols(&v, 3, None).unwrap();
+    // 3 rows tall, 2 cols. Column-by-column fill: col0 = 1,2,3; col1 = 4,5,6.
+    assert_arr_eq(&out, &arr(3, 2, vec![1., 4., 2., 5., 3., 6.]));
+}
+
+#[test]
+fn wrap_cols_pads() {
+    let v = arr(1, 5, vec![1., 2., 3., 4., 5.]);
+    let out = wrap_cols(&v, 3, Some(0.0)).unwrap();
+    // 3 rows, 2 cols. col0 = 1,2,3; col1 = 4,5,pad.
+    assert_arr_eq(&out, &arr(3, 2, vec![1., 4., 2., 5., 3., 0.0]));
+}
+
+// ---- CHOOSEROWS / CHOOSECOLS ----
+
+#[test]
+fn choose_rows_positive_and_negative() {
+    let a = arr(3, 2, vec![1., 2., 3., 4., 5., 6.]);
+    let out = choose_rows(&a, &[1, -1]).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![1., 2., 5., 6.]));
+}
+
+#[test]
+fn choose_rows_repeats() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let out = choose_rows(&a, &[1, 1, 2]).unwrap();
+    assert_arr_eq(&out, &arr(3, 1, vec![1., 1., 2.]));
+}
+
+#[test]
+fn choose_rows_zero_index_errors() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let err = choose_rows(&a, &[0]).unwrap_err();
+    assert!(matches!(err, ArrayError::OutOfRange { index: 0, .. }));
+}
+
+#[test]
+fn choose_rows_out_of_range() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let err = choose_rows(&a, &[3]).unwrap_err();
+    assert!(matches!(err, ArrayError::OutOfRange { .. }));
+}
+
+#[test]
+fn choose_cols_positive_and_negative() {
+    let a = arr(2, 3, vec![1., 2., 3., 4., 5., 6.]);
+    let out = choose_cols(&a, &[3, -3]).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![3., 1., 6., 4.]));
+}
+
+#[test]
+fn choose_cols_empty_indices_errors() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let err = choose_cols(&a, &[]).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { .. }));
+}
+
+// ---- FILTER ----
+
+#[test]
+fn filter_matching_rows() {
+    let a = arr(3, 2, vec![1., 2., 3., 4., 5., 6.]);
+    let mask = Array2D::from_vector(vec![1.0, 0.0, 1.0]);
+    let out = filter(&a, &mask, None).unwrap();
+    assert_arr_eq(&out, &arr(2, 2, vec![1., 2., 5., 6.]));
+}
+
+#[test]
+fn filter_no_match_with_if_empty() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let mask = Array2D::from_vector(vec![0.0, 0.0]);
+    let out = filter(&a, &mask, Some(-1.0)).unwrap();
+    assert_arr_eq(&out, &arr(1, 1, vec![-1.0]));
+}
+
+#[test]
+fn filter_no_match_without_if_empty_errors() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let mask = Array2D::from_vector(vec![0.0, 0.0]);
+    let err = filter(&a, &mask, None).unwrap_err();
+    assert!(matches!(err, ArrayError::EmptyResult { function: "FILTER" }));
+}
+
+#[test]
+fn filter_na_in_mask_treated_as_false() {
+    let a = arr(2, 1, vec![10., 20.]);
+    let mask = Array2D::from_vector(vec![1.0, na_real()]);
+    let out = filter(&a, &mask, None).unwrap();
+    assert_arr_eq(&out, &arr(1, 1, vec![10.]));
+}
+
+#[test]
+fn filter_mask_wrong_length() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let mask = Array2D::from_vector(vec![1.0]);
+    let err = filter(&a, &mask, None).unwrap_err();
+    assert!(matches!(err, ArrayError::ShapeMismatch { .. }));
+}
+
+// ---- SORT ----
+
+#[test]
+fn sort_rows_ascending() {
+    let a = arr(3, 2, vec![3., 1., 1., 2., 2., 3.]);
+    let out = sort(&a, None, None, None).unwrap();
+    // Sort by column 1 (default): keys = 3,1,2 -> order 1,2,3.
+    assert_arr_eq(&out, &arr(3, 2, vec![1., 2., 2., 3., 3., 1.]));
+}
+
+#[test]
+fn sort_rows_descending() {
+    let a = arr(3, 2, vec![3., 1., 1., 2., 2., 3.]);
+    let out = sort(&a, None, Some(-1), None).unwrap();
+    assert_arr_eq(&out, &arr(3, 2, vec![3., 1., 2., 3., 1., 2.]));
+}
+
+#[test]
+fn sort_by_col_axis() {
+    let a = arr(2, 3, vec![3., 1., 2., 30., 10., 20.]);
+    let out = sort(&a, Some(1), None, Some(true)).unwrap();
+    // Sort columns by row 1: keys = 3,1,2 -> col order 1,2,0.
+    assert_arr_eq(&out, &arr(2, 3, vec![1., 2., 3., 10., 20., 30.]));
+}
+
+#[test]
+fn sort_na_sorts_to_end_asc() {
+    let a = arr(3, 1, vec![2.0, na_real(), 1.0]);
+    let out = sort(&a, None, None, None).unwrap();
+    assert_eq!(*out.get(0, 0), 1.0);
+    assert_eq!(*out.get(1, 0), 2.0);
+    assert!(is_na_real(*out.get(2, 0)));
+}
+
+#[test]
+fn sort_bad_order_rejected() {
+    let a = arr(1, 1, vec![1.0]);
+    let err = sort(&a, None, Some(5), None).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { name: "sort_order", .. }));
+}
+
+#[test]
+fn sort_empty_is_empty() {
+    let a = Array2D::<f64>::new(0, 0, vec![]).unwrap();
+    let out = sort(&a, None, None, None).unwrap();
+    assert!(out.is_empty());
+}
+
+// ---- SORTBY ----
+
+#[test]
+fn sort_by_two_keys() {
+    let a = arr(4, 1, vec![10., 20., 30., 40.]);
+    // Primary: A,B,A,B -> after asc on letters, A's then B's.
+    // We encode A=1, B=2.
+    let primary = Array2D::from_vector(vec![1.0, 2.0, 1.0, 2.0]);
+    // Secondary: 2,1,1,2 -> within group, ascending.
+    let secondary = Array2D::from_vector(vec![2.0, 1.0, 1.0, 2.0]);
+    let keys = vec![
+        SortKey {
+            by: &primary,
+            order: Order::Ascending,
+        },
+        SortKey {
+            by: &secondary,
+            order: Order::Ascending,
+        },
+    ];
+    let out = sort_by(&a, &keys).unwrap();
+    // Groups: A={row0(2), row2(1)} -> sorted: row2(1), row0(2) -> 30, 10.
+    //         B={row1(1), row3(2)} -> sorted: row1(1), row3(2) -> 20, 40.
+    assert_arr_eq(&out, &arr(4, 1, vec![30., 10., 20., 40.]));
+}
+
+#[test]
+fn sort_by_rejects_empty_keys() {
+    let a = arr(1, 1, vec![1.0]);
+    let err = sort_by(&a, &[]).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { name: "keys", .. }));
+}
+
+#[test]
+fn sort_by_wrong_key_length() {
+    let a = arr(2, 1, vec![1., 2.]);
+    let bad_key = Array2D::from_vector(vec![1.0]);
+    let keys = vec![SortKey {
+        by: &bad_key,
+        order: Order::Ascending,
+    }];
+    let err = sort_by(&a, &keys).unwrap_err();
+    assert!(matches!(err, ArrayError::ShapeMismatch { .. }));
+}
+
+#[test]
+fn sort_by_caps_at_six_keys() {
+    let a = arr(1, 1, vec![1.0]);
+    let k = Array2D::from_vector(vec![1.0]);
+    let keys: Vec<SortKey> = (0..7)
+        .map(|_| SortKey {
+            by: &k,
+            order: Order::Ascending,
+        })
+        .collect();
+    let err = sort_by(&a, &keys).unwrap_err();
+    assert!(matches!(err, ArrayError::BadParameter { name: "keys", .. }));
+}
+
+// ---- UNIQUE ----
+
+#[test]
+fn unique_rows_dedupe() {
+    let a = arr(4, 2, vec![1., 2., 3., 4., 1., 2., 5., 6.]);
+    let out = unique(&a, None, None).unwrap();
+    assert_arr_eq(&out, &arr(3, 2, vec![1., 2., 3., 4., 5., 6.]));
+}
+
+#[test]
+fn unique_na_collapses() {
+    let a = arr(3, 1, vec![na_real(), 1.0, na_real()]);
+    let out = unique(&a, None, None).unwrap();
+    // NA appears once (first), then 1.0.
+    assert_eq!(out.rows, 2);
+    assert!(is_na_real(*out.get(0, 0)));
+    assert_eq!(*out.get(1, 0), 1.0);
+}
+
+#[test]
+fn unique_exactly_once() {
+    let a = arr(4, 1, vec![1., 2., 1., 3.]);
+    let out = unique(&a, None, Some(true)).unwrap();
+    // 1 appears twice -> dropped. 2 and 3 appear once.
+    assert_arr_eq(&out, &arr(2, 1, vec![2., 3.]));
+}
+
+#[test]
+fn unique_by_col() {
+    let a = arr(2, 3, vec![1., 2., 1., 3., 4., 3.]);
+    let out = unique(&a, Some(true), None).unwrap();
+    // Cols: [1;3], [2;4], [1;3] -> unique: col0, col1.
+    assert_arr_eq(&out, &arr(2, 2, vec![1., 2., 3., 4.]));
+}
+
+#[test]
+fn unique_exactly_once_all_dupes() {
+    let a = arr(2, 1, vec![1., 1.]);
+    let out = unique(&a, None, Some(true)).unwrap();
+    assert_eq!(out.rows, 0);
+    assert_eq!(out.cols, 1);
+}
+
+// ---- Edge cases ----
+
+#[test]
+fn all_na_array_sorts_unchanged() {
+    let a = arr(2, 1, vec![na_real(), na_real()]);
+    let out = sort(&a, None, None, None).unwrap();
+    assert!(is_na_real(*out.get(0, 0)));
+    assert!(is_na_real(*out.get(1, 0)));
+}
+
+#[test]
+fn single_element_round_trip() {
+    let a = arr(1, 1, vec![42.0]);
+    let out = take(&a, 1, Some(1)).unwrap();
+    assert_arr_eq(&out, &a);
+}
+
+#[test]
+fn error_display_is_informative() {
+    let e = ArrayError::OutOfRange {
+        function: "X",
+        index: -5,
+        max: 2,
+    };
+    let s = format!("{e}");
+    assert!(s.contains("X"));
+    assert!(s.contains("-5"));
+    assert!(s.contains("2"));
+}


### PR DESCRIPTION
## Summary

Initial implementation of the Layer-1 `array-core` crate per `code/specs/backend-crate-catalog.md`. Ships Excel 365 dynamic-array helpers (`SEQUENCE`, `TAKE`, `DROP`, `EXPAND`, `HSTACK`, `VSTACK`, `TOROW`, `TOCOL`, `WRAPROWS`, `WRAPCOLS`, `CHOOSEROWS`, `CHOOSECOLS`, `FILTER`, `SORT`, `SORTBY`, `UNIQUE`) on top of a small in-crate `Array2D<T>` 2-D row-major wrapper.

## Function inventory

| Module      | Functions                                     |
|-------------|-----------------------------------------------|
| `generate`  | `sequence`                                    |
| `shape`     | `take`, `drop`, `expand`                      |
| `stack`     | `hstack`, `vstack`                            |
| `reshape`   | `to_row`, `to_col`, `wrap_rows`, `wrap_cols`  |
| `pick`      | `choose_rows`, `choose_cols`                  |
| `filter`    | `filter`                                      |
| `sort`      | `sort`, `sort_by`                             |
| `unique`    | `unique`                                      |

`RANDARRAY` is intentionally deferred — it routes through a separate RNG crate per the catalog.

## `Array2D` design rationale

Excel-365 dynamic-array functions are inherently 2-D, but `r-vector::Double` only models a flat 1-D atomic vector with an optional `dim` attribute. Threading 2-D shape through every caller via that attribute would obscure intent and duplicate validation everywhere. So `array-core` wraps storage in a small `Array2D<T>` type with explicit `rows`, `cols`, and row-major `data`. Numeric work uses `Array2D<f64>` with NA encoded via `r-vector::na_real()`; the type stays generic so Phase 2 (mixed text + numeric arrays) can layer on without rewriting storage.

## NA / padding behavior

- **HSTACK / VSTACK / EXPAND / WRAPROWS / WRAPCOLS**: pad mismatched shapes with NA (mapping to Excel `#N/A`).
- **SORT**: NA sorts to the end in ascending order, beginning in descending — matches Excel's "errors last in ascending direction" convention.
- **UNIQUE**: NA values compare equal, so duplicate NAs collapse.
- **FILTER**: NA in the boolean mask is treated as `FALSE` (do not include the corresponding row).

## Excel-365 parity notes

- 1-based indexing at the public surface (`CHOOSEROWS`, `SORT`'s `sort_index`); negative indices count from the end.
- Over-take / over-drop clamps to a valid range rather than erroring (Excel semantics).
- `EXPAND` to a smaller size errors with `BadParameter` (Excel emits `#VALUE!`).
- `FILTER` with no matches and no `if_empty` returns `EmptyResult` (Excel emits `#CALC!`).
- `TOROW` / `TOCOL` `ignore` modes 2 (skip errors) and 3 (skip both) currently behave identically to 0 / 1 respectively — Phase 1 has no error encoding distinct from NA. Documented inline.
- `SORTBY` is capped at 6 keys (Excel: 128); v1 callers should not hit this.

## Test plan

- [x] `cargo build -p array-core` (native)
- [x] `cargo build -p array-core --target wasm32-unknown-unknown` (WASM-compatible verified)
- [x] `cargo test -p array-core` (70 integration tests, all passing)
- [x] `cargo clippy -p array-core --all-targets -- -D warnings` (clean)
- [x] Test coverage: every function has a happy-path test, Excel edge-case tests (negative indices, over-take/drop, NA-in-mask, NA-in-sort, `exactly_once` UNIQUE), and at least one error-path test.

Dependencies: `numeric-tower` and `r-vector` only. No external crates, no `unsafe`, no `cfg(target_os)`, no I/O, no globals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)