### PR TITLE
feat(lookup-core): Phase 1 implementation

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -177,6 +177,7 @@ members = [
     "macsyma-wasm",
     "logic-gates",
     "logic-core",
+    "lookup-core",
     "logic-engine",
     "adjudication-ir",
     "llm-cache",

--- a/code/packages/rust/lookup-core/CHANGELOG.md
+++ b/code/packages/rust/lookup-core/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to `lookup-core` are recorded here.  Format follows
+Keep a Changelog; the project uses semantic versioning starting at `0.1.0`.
+
+## [0.1.0] — Phase 1
+
+### Added
+- `LookupValue` frontend-agnostic value enum (`Empty` / `Boolean` /
+  `Number` / `Text`) with NA encoded via `r_vector::na_real`.
+- `LookupError` enum with `Display` + `std::error::Error` impls.
+- `vlookup` and `hlookup` with exact and approximate (binary-search) modes.
+- `index_1d` and `index_2d` (1-based; supports whole-row/whole-column
+  results when `row=0` or `col=0`).
+- `match` (`Exact` / `LessOrEqual` / `GreaterOrEqual`).
+- `xlookup` and `xmatch` covering all Excel `match_mode` × `search_mode`
+  combinations, including wildcard match and `if_not_found` fallback.
+- `offset` for range arithmetic over a 2-D table.
+- `choose` variadic pick.
+- `row` / `column` / `rows` / `columns` shape-introspection helpers.
+- Centralised Excel-compatible equality, ordering, and `?`/`*`/`~`
+  wildcard matchers.
+- Unit tests in every module plus integration tests in
+  `tests/lookup_tests.rs`.

--- a/code/packages/rust/lookup-core/Cargo.toml
+++ b/code/packages/rust/lookup-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lookup-core"
+version = "0.1.0"
+edition = "2021"
+description = "Canonical Rust lookup/reference core — Excel/Lotus/R lookup functions for any spreadsheet frontend."
+
+[dependencies]
+numeric-tower = { path = "../numeric-tower" }
+r-vector = { path = "../r-vector" }

--- a/code/packages/rust/lookup-core/README.md
+++ b/code/packages/rust/lookup-core/README.md
@@ -1,0 +1,51 @@
+# lookup-core
+
+Canonical Rust lookup/reference core for VisiCalc, spreadsheet, R, and S
+frontends.  Implements the classic Excel lookup-family functions over a
+frontend-agnostic value type.
+
+## Where this fits in the stack
+
+`lookup-core` is one of the Layer-1 backend crates described in
+`code/specs/backend-crate-catalog.md`.  Like the rest of Layer 1 it is:
+
+- Pure Rust, no platform code.
+- WASM-compatible (no I/O, no globals, no `unsafe`).
+- Depends only on `numeric-tower` and `r-vector`.
+
+A future `spreadsheet-core` will own the canonical `CellValue` and call into
+`lookup-core` by adapting `CellValue → LookupValue` at the dispatch
+boundary.
+
+## Functions implemented (Phase 1)
+
+| Function                 | Notes                                              |
+|--------------------------|----------------------------------------------------|
+| `vlookup` / `hlookup`    | Exact + approximate (binary search) match.         |
+| `index_1d` / `index_2d`  | 1-based; `row=0` or `col=0` selects whole strip.   |
+| `match`                  | `Exact` / `LessOrEqual` / `GreaterOrEqual`.        |
+| `xlookup` / `xmatch`     | All Excel `match_mode` × `search_mode` combos.     |
+| `offset`                 | Sub-table extraction with bounds checking.         |
+| `choose`                 | 1-based variadic pick.                             |
+| `row` / `column` / `rows` / `columns` | Shape-introspection helpers.          |
+
+## NA propagation
+
+- NA in the *probe* → output is NA.
+- NA in the *lookup array* is skipped — those cells never match.
+
+This matches `code/specs/na-semantics.md` and Excel's observable behaviour.
+
+## Example
+
+```rust
+use lookup_core::vlookup::vlookup;
+use lookup_core::LookupValue;
+
+let table = vec![
+    vec![LookupValue::Text("apple".into()),  LookupValue::Number(1.0)],
+    vec![LookupValue::Text("banana".into()), LookupValue::Number(2.0)],
+];
+let r = vlookup(&LookupValue::Text("banana".into()), &table, 2, false).unwrap();
+assert_eq!(r, LookupValue::Number(2.0));
+```

--- a/code/packages/rust/lookup-core/src/choose.rs
+++ b/code/packages/rust/lookup-core/src/choose.rs
@@ -1,0 +1,59 @@
+//! CHOOSE — pick the n-th argument from a variadic list.
+//!
+//! In Excel: `CHOOSE(index, value1, value2, ..., value254)` returns the
+//! `index`-th value (1-based).  We model the variadic list as a slice.
+
+use crate::{one_based_to_zero, LookupResult, LookupValue};
+
+/// `CHOOSE(index, values...)`.  Returns `#VALUE!` (mapped to
+/// `LookupError::OutOfRange`) when `index` is outside `1..=values.len()`.
+pub fn choose(index: i64, values: &[LookupValue]) -> LookupResult<LookupValue> {
+    let zero = one_based_to_zero("CHOOSE", index, values.len())?;
+    Ok(values[zero].clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LookupError;
+
+    fn t(s: &str) -> LookupValue {
+        LookupValue::Text(s.into())
+    }
+
+    #[test]
+    fn choose_first_value() {
+        let r = choose(1, &[t("a"), t("b"), t("c")]).unwrap();
+        assert_eq!(r, t("a"));
+    }
+
+    #[test]
+    fn choose_middle_value() {
+        let r = choose(2, &[t("a"), t("b"), t("c")]).unwrap();
+        assert_eq!(r, t("b"));
+    }
+
+    #[test]
+    fn choose_last_value() {
+        let r = choose(3, &[t("a"), t("b"), t("c")]).unwrap();
+        assert_eq!(r, t("c"));
+    }
+
+    #[test]
+    fn choose_zero_is_out_of_range() {
+        let err = choose(0, &[t("a")]).unwrap_err();
+        assert!(matches!(err, LookupError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn choose_too_large_is_out_of_range() {
+        let err = choose(10, &[t("a")]).unwrap_err();
+        assert!(matches!(err, LookupError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn choose_empty_values_is_out_of_range() {
+        let err = choose(1, &[]).unwrap_err();
+        assert!(matches!(err, LookupError::OutOfRange { .. }));
+    }
+}

--- a/code/packages/rust/lookup-core/src/index_match.rs
+++ b/code/packages/rust/lookup-core/src/index_match.rs
@@ -1,0 +1,350 @@
+//! INDEX and MATCH — the building blocks behind every modern lookup
+//! formula.  INDEX returns a value (or whole row/column) from an array by
+//! coordinate; MATCH returns the position of a probe within a 1-D array.
+//!
+//! Together they replace VLOOKUP for arbitrary-direction lookups: the
+//! canonical idiom is `INDEX(return_col, MATCH(probe, key_col, 0))`.
+
+use crate::{cmp_excel, equal_excel, is_na_real, one_based_to_zero, LookupError, LookupResult, LookupValue};
+
+/// MATCH variants — Excel's `match_type` integer rewritten as an enum so
+/// callers can't accidentally pass an unsupported value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchType {
+    /// `match_type = 0`: exact match, no sort assumption (linear scan).
+    Exact,
+    /// `match_type = 1`: largest value `<=` probe; lookup array must be
+    /// sorted ascending.
+    LessOrEqual,
+    /// `match_type = -1`: smallest value `>=` probe; lookup array must be
+    /// sorted descending.
+    GreaterOrEqual,
+}
+
+impl MatchType {
+    /// Build a `MatchType` from Excel's integer code, surfacing bad values
+    /// as `LookupError::BadParameter`.
+    pub fn from_excel_code(code: i64) -> LookupResult<Self> {
+        match code {
+            0 => Ok(MatchType::Exact),
+            1 => Ok(MatchType::LessOrEqual),
+            -1 => Ok(MatchType::GreaterOrEqual),
+            _ => Err(LookupError::BadParameter {
+                name: "match_type",
+                value: code.to_string(),
+            }),
+        }
+    }
+}
+
+/// `INDEX(array, n)` over a 1-D vector.  `n` is 1-based.
+pub fn index_1d(array: &[LookupValue], n: i64) -> LookupResult<LookupValue> {
+    let zero = one_based_to_zero("INDEX", n, array.len())?;
+    Ok(array[zero].clone())
+}
+
+/// `INDEX(array, row, col)` over a 2-D row-major matrix.
+///
+/// Special cases (Excel parity):
+/// - `row = 0`  → return the whole column `col` as a vector.
+/// - `col = 0`  → return the whole row `row` as a vector.
+/// - both zero  → error (Excel returns the entire array; we surface as
+///   `BadParameter` since this crate's return type is a single value or a
+///   single vector, not a matrix).
+///
+/// The "whole row" / "whole column" results are returned as a separate
+/// [`IndexResult`] discriminant so the caller can tell them apart from a
+/// scalar.
+pub fn index_2d(array: &[Vec<LookupValue>], row: i64, col: i64) -> LookupResult<IndexResult> {
+    if array.is_empty() {
+        return Err(LookupError::OutOfRange {
+            function: "INDEX",
+            index: row,
+            max: 0,
+        });
+    }
+    let n_rows = array.len();
+    let n_cols = array[0].len();
+
+    match (row, col) {
+        (0, 0) => Err(LookupError::BadParameter {
+            name: "row,col",
+            value: "0,0 (whole-array result not supported in scalar API)".to_string(),
+        }),
+        (0, c) => {
+            let cz = one_based_to_zero("INDEX", c, n_cols)?;
+            let column: Vec<LookupValue> = array.iter().map(|r| r[cz].clone()).collect();
+            Ok(IndexResult::Vector(column))
+        }
+        (r, 0) => {
+            let rz = one_based_to_zero("INDEX", r, n_rows)?;
+            Ok(IndexResult::Vector(array[rz].clone()))
+        }
+        (r, c) => {
+            let rz = one_based_to_zero("INDEX", r, n_rows)?;
+            let cz = one_based_to_zero("INDEX", c, n_cols)?;
+            Ok(IndexResult::Scalar(array[rz][cz].clone()))
+        }
+    }
+}
+
+/// Result of [`index_2d`] — either a single value or a whole row/column.
+#[derive(Debug, Clone, PartialEq)]
+pub enum IndexResult {
+    Scalar(LookupValue),
+    Vector(Vec<LookupValue>),
+}
+
+/// `MATCH(lookup_value, lookup_array, match_type)`.  Returns a 1-based
+/// position.  NA in the probe propagates as `#N/A`; NA in the array is
+/// skipped.
+pub fn r#match(
+    lookup_value: &LookupValue,
+    lookup_array: &[LookupValue],
+    match_type: MatchType,
+) -> LookupResult<i64> {
+    if lookup_value.is_na() {
+        return Err(LookupError::NotFound { function: "MATCH" });
+    }
+    match match_type {
+        MatchType::Exact => match_exact(lookup_value, lookup_array),
+        MatchType::LessOrEqual => match_le_sorted_asc(lookup_value, lookup_array),
+        MatchType::GreaterOrEqual => match_ge_sorted_desc(lookup_value, lookup_array),
+    }
+}
+
+fn match_exact(probe: &LookupValue, array: &[LookupValue]) -> LookupResult<i64> {
+    for (i, value) in array.iter().enumerate() {
+        if matches!(value, LookupValue::Number(n) if is_na_real(*n)) {
+            continue;
+        }
+        if equal_excel(probe, value) {
+            return Ok((i + 1) as i64);
+        }
+    }
+    Err(LookupError::NotFound { function: "MATCH" })
+}
+
+fn match_le_sorted_asc(probe: &LookupValue, array: &[LookupValue]) -> LookupResult<i64> {
+    // Largest value <= probe.  Array assumed sorted ascending.
+    let compact: Vec<(usize, &LookupValue)> = array
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !is_na_value(v))
+        .collect();
+    if compact.is_empty() {
+        return Err(LookupError::NotFound { function: "MATCH" });
+    }
+    if cmp_excel("MATCH", probe, compact[0].1)?.is_lt() {
+        return Err(LookupError::NotFound { function: "MATCH" });
+    }
+    let mut lo = 0usize;
+    let mut hi = compact.len();
+    while lo + 1 < hi {
+        let mid = lo + (hi - lo) / 2;
+        match cmp_excel("MATCH", compact[mid].1, probe)? {
+            std::cmp::Ordering::Greater => hi = mid,
+            _ => lo = mid,
+        }
+    }
+    Ok((compact[lo].0 + 1) as i64)
+}
+
+fn match_ge_sorted_desc(probe: &LookupValue, array: &[LookupValue]) -> LookupResult<i64> {
+    // Smallest value >= probe.  Array assumed sorted descending.
+    let compact: Vec<(usize, &LookupValue)> = array
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !is_na_value(v))
+        .collect();
+    if compact.is_empty() {
+        return Err(LookupError::NotFound { function: "MATCH" });
+    }
+    // Descending: first element is the max.  If probe > first element,
+    // nothing in the array is >= probe → #N/A.
+    if cmp_excel("MATCH", probe, compact[0].1)?.is_gt() {
+        return Err(LookupError::NotFound { function: "MATCH" });
+    }
+    // Linear scan from start: pick the LAST index whose value is still
+    // >= probe.  Sticking to a linear scan keeps the logic simple; the
+    // typical lookup array is small enough that this is not a hotspot.
+    let mut answer: Option<usize> = None;
+    for (i, v) in &compact {
+        if cmp_excel("MATCH", v, probe)?.is_ge() {
+            answer = Some(*i);
+        } else {
+            break;
+        }
+    }
+    answer
+        .map(|i| (i + 1) as i64)
+        .ok_or(LookupError::NotFound { function: "MATCH" })
+}
+
+fn is_na_value(v: &LookupValue) -> bool {
+    matches!(v, LookupValue::Number(n) if is_na_real(*n))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> LookupValue {
+        LookupValue::Text(s.into())
+    }
+    fn n(x: f64) -> LookupValue {
+        LookupValue::Number(x)
+    }
+
+    #[test]
+    fn index_1d_basic() {
+        let arr = vec![t("a"), t("b"), t("c")];
+        assert_eq!(index_1d(&arr, 1).unwrap(), t("a"));
+        assert_eq!(index_1d(&arr, 3).unwrap(), t("c"));
+    }
+
+    #[test]
+    fn index_1d_out_of_range() {
+        let arr = vec![t("a")];
+        assert!(matches!(
+            index_1d(&arr, 5).unwrap_err(),
+            LookupError::OutOfRange { .. }
+        ));
+        assert!(matches!(
+            index_1d(&arr, 0).unwrap_err(),
+            LookupError::OutOfRange { .. }
+        ));
+    }
+
+    #[test]
+    fn index_2d_scalar_pick() {
+        let m = vec![vec![n(1.0), n(2.0)], vec![n(3.0), n(4.0)]];
+        match index_2d(&m, 2, 1).unwrap() {
+            IndexResult::Scalar(v) => assert_eq!(v, n(3.0)),
+            _ => panic!("expected scalar"),
+        }
+    }
+
+    #[test]
+    fn index_2d_whole_row() {
+        let m = vec![vec![n(1.0), n(2.0)], vec![n(3.0), n(4.0)]];
+        match index_2d(&m, 1, 0).unwrap() {
+            IndexResult::Vector(v) => assert_eq!(v, vec![n(1.0), n(2.0)]),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn index_2d_whole_column() {
+        let m = vec![vec![n(1.0), n(2.0)], vec![n(3.0), n(4.0)]];
+        match index_2d(&m, 0, 2).unwrap() {
+            IndexResult::Vector(v) => assert_eq!(v, vec![n(2.0), n(4.0)]),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn index_2d_both_zero_is_bad_param() {
+        let m = vec![vec![n(1.0)]];
+        assert!(matches!(
+            index_2d(&m, 0, 0).unwrap_err(),
+            LookupError::BadParameter { .. }
+        ));
+    }
+
+    #[test]
+    fn match_exact_returns_one_based_position() {
+        let arr = vec![t("a"), t("b"), t("c")];
+        assert_eq!(r#match(&t("b"), &arr, MatchType::Exact).unwrap(), 2);
+    }
+
+    #[test]
+    fn match_exact_miss_is_not_found() {
+        let arr = vec![t("a"), t("b")];
+        assert!(matches!(
+            r#match(&t("z"), &arr, MatchType::Exact).unwrap_err(),
+            LookupError::NotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn match_le_sorted_asc_picks_largest_le() {
+        let arr = vec![n(1.0), n(3.0), n(5.0), n(7.0)];
+        assert_eq!(r#match(&n(4.0), &arr, MatchType::LessOrEqual).unwrap(), 2);
+        assert_eq!(r#match(&n(7.0), &arr, MatchType::LessOrEqual).unwrap(), 4);
+        assert_eq!(r#match(&n(1.0), &arr, MatchType::LessOrEqual).unwrap(), 1);
+    }
+
+    #[test]
+    fn match_le_below_min_not_found() {
+        let arr = vec![n(10.0), n(20.0)];
+        assert!(matches!(
+            r#match(&n(5.0), &arr, MatchType::LessOrEqual).unwrap_err(),
+            LookupError::NotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn match_ge_sorted_desc_picks_smallest_ge() {
+        let arr = vec![n(9.0), n(7.0), n(5.0), n(3.0), n(1.0)];
+        assert_eq!(
+            r#match(&n(4.0), &arr, MatchType::GreaterOrEqual).unwrap(),
+            3
+        );
+        assert_eq!(
+            r#match(&n(9.0), &arr, MatchType::GreaterOrEqual).unwrap(),
+            1
+        );
+        assert_eq!(
+            r#match(&n(1.0), &arr, MatchType::GreaterOrEqual).unwrap(),
+            5
+        );
+    }
+
+    #[test]
+    fn match_ge_above_max_not_found() {
+        let arr = vec![n(9.0), n(7.0)];
+        assert!(matches!(
+            r#match(&n(100.0), &arr, MatchType::GreaterOrEqual).unwrap_err(),
+            LookupError::NotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn match_excel_code_parser_round_trips() {
+        assert_eq!(MatchType::from_excel_code(0).unwrap(), MatchType::Exact);
+        assert_eq!(MatchType::from_excel_code(1).unwrap(), MatchType::LessOrEqual);
+        assert_eq!(
+            MatchType::from_excel_code(-1).unwrap(),
+            MatchType::GreaterOrEqual
+        );
+        assert!(matches!(
+            MatchType::from_excel_code(7).unwrap_err(),
+            LookupError::BadParameter { .. }
+        ));
+    }
+
+    #[test]
+    fn match_skips_na_array_entries() {
+        let arr = vec![LookupValue::na(), t("a"), t("b")];
+        assert_eq!(r#match(&t("a"), &arr, MatchType::Exact).unwrap(), 2);
+    }
+
+    #[test]
+    fn match_na_probe_is_not_found() {
+        let arr = vec![t("a")];
+        assert!(matches!(
+            r#match(&LookupValue::na(), &arr, MatchType::Exact).unwrap_err(),
+            LookupError::NotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn match_mixed_types_in_array_with_exact() {
+        // Mixed numbers and text — exact match still works because we only
+        // compare same-type pairs and return the first equal entry.
+        let arr = vec![t("apple"), n(1.0), t("banana"), n(2.0)];
+        assert_eq!(r#match(&n(2.0), &arr, MatchType::Exact).unwrap(), 4);
+        assert_eq!(r#match(&t("banana"), &arr, MatchType::Exact).unwrap(), 3);
+    }
+}

--- a/code/packages/rust/lookup-core/src/lib.rs
+++ b/code/packages/rust/lookup-core/src/lib.rs
@@ -1,0 +1,424 @@
+//! Lookup Core
+//!
+//! Phase 1 implementation for `code/specs/backend-crate-catalog.md` (the
+//! `lookup-core` Layer-1 crate).  This crate provides Excel/Lotus/R-style
+//! lookup and reference functions over a frontend-agnostic value type
+//! [`LookupValue`].
+//!
+//! # Why a local value enum?
+//!
+//! The eventual `spreadsheet-core` crate will own the canonical `CellValue`
+//! type, but that crate does not yet exist.  To keep `lookup-core` honest
+//! about its data dependencies, this crate carries its own minimal value
+//! enum.  When `spreadsheet-core` lands, a small `From<CellValue> for
+//! LookupValue` adapter at the dispatch boundary will route values into this
+//! crate without forcing it to depend on the full spreadsheet stack.
+//!
+//! # NA propagation
+//!
+//! NA in the *lookup_value* causes the function output to be NA (matches
+//! Excel's `=VLOOKUP(NA(),…)` behaviour).  NA in the lookup *array* is
+//! skipped — those cells never match a probe.  These rules come from
+//! `code/specs/na-semantics.md`.
+//!
+//! # Numeric NA bit pattern
+//!
+//! Numeric NA inside `LookupValue::Number` is encoded via
+//! [`r_vector::na_real`] / [`r_vector::is_na_real`], a quiet-NaN payload
+//! distinct from plain `NaN`.  This lets us round-trip NA through
+//! `LookupValue::Number` without inventing a separate variant.
+//!
+//! # Indexing convention
+//!
+//! All public APIs use **1-based** indexing (Excel's surface convention).
+//! Internally we convert to 0-based at the function boundary so the rest of
+//! the implementation is plain Rust.
+
+pub mod choose;
+pub mod index_match;
+pub mod offset;
+pub mod position;
+pub mod vlookup;
+pub mod xlookup;
+
+pub use r_vector::{is_na_real, na_real};
+
+/// A frontend-agnostic value used by every lookup function in this crate.
+///
+/// `Number` carries floating-point values; an NA is encoded by the
+/// `r_vector::na_real()` bit pattern, so callers do not need a separate
+/// variant.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LookupValue {
+    /// An empty cell.  Treated as "not a value" in comparisons — never
+    /// matches a non-empty probe, matches another `Empty`.
+    Empty,
+    /// `TRUE`/`FALSE`.  Booleans only compare equal to other booleans.
+    Boolean(bool),
+    /// IEEE-754 double.  NA is encoded as the `na_real()` payload.
+    Number(f64),
+    /// UTF-8 text.  Approximate-match comparisons are ASCII case-insensitive.
+    Text(String),
+}
+
+impl LookupValue {
+    /// Convenience constructor for an NA number.
+    pub fn na() -> Self {
+        LookupValue::Number(na_real())
+    }
+
+    /// True iff this value is `Number(NA)` (the `na_real` bit pattern).
+    pub fn is_na(&self) -> bool {
+        match self {
+            LookupValue::Number(value) => is_na_real(*value),
+            _ => false,
+        }
+    }
+
+    /// Short tag describing the variant, used in error messages.
+    pub(crate) fn type_tag(&self) -> &'static str {
+        match self {
+            LookupValue::Empty => "empty",
+            LookupValue::Boolean(_) => "boolean",
+            LookupValue::Number(_) => "number",
+            LookupValue::Text(_) => "text",
+        }
+    }
+}
+
+/// Errors emitted by lookup functions.  Each variant maps cleanly to an
+/// Excel `#…!` error code at the dispatch boundary:
+///
+/// | `LookupError`         | Excel error | Notes                           |
+/// |-----------------------|-------------|---------------------------------|
+/// | `NotFound`            | `#N/A`      | Probe not present               |
+/// | `OutOfRange`          | `#REF!`     | Index past end of array         |
+/// | `BadParameter`        | `#VALUE!`   | E.g. negative height in OFFSET  |
+/// | `ShapeMismatch`       | `#VALUE!`   | Arrays of incompatible length   |
+/// | `TypeMismatch`        | `#VALUE!`   | Number vs text in approx match  |
+#[derive(Debug, Clone, PartialEq)]
+pub enum LookupError {
+    /// The probe value is absent from the lookup array.
+    NotFound { function: &'static str },
+    /// A 1-based index is outside the valid range `1..=max`.
+    OutOfRange {
+        function: &'static str,
+        index: i64,
+        max: usize,
+    },
+    /// A parameter (e.g. `match_type`) had an invalid value.
+    BadParameter {
+        name: &'static str,
+        value: String,
+    },
+    /// Two arrays disagree on length / shape.
+    ShapeMismatch {
+        expected: String,
+        found: String,
+    },
+    /// Two values are of incompatible types for the requested comparison.
+    TypeMismatch {
+        function: &'static str,
+        what: String,
+    },
+}
+
+impl std::fmt::Display for LookupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LookupError::NotFound { function } => write!(f, "{function}: no matching value (#N/A)"),
+            LookupError::OutOfRange {
+                function,
+                index,
+                max,
+            } => write!(
+                f,
+                "{function}: index {index} is outside 1..={max} (#REF!)"
+            ),
+            LookupError::BadParameter { name, value } => {
+                write!(f, "bad parameter {name}={value} (#VALUE!)")
+            }
+            LookupError::ShapeMismatch { expected, found } => {
+                write!(f, "shape mismatch: expected {expected}, found {found}")
+            }
+            LookupError::TypeMismatch { function, what } => {
+                write!(f, "{function}: type mismatch ({what}) (#VALUE!)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LookupError {}
+
+/// Convenience alias for fallible lookup results.
+pub type LookupResult<T> = Result<T, LookupError>;
+
+// -----------------------------------------------------------------------
+// Internal comparison helpers shared by all submodules.
+//
+// We centralise the comparison logic here so that VLOOKUP, MATCH, XLOOKUP
+// and friends agree on what "equal" and "less than" mean — there is exactly
+// one place in the crate where Excel parity lives.
+// -----------------------------------------------------------------------
+
+/// Exact equality comparison used by VLOOKUP-exact, MATCH-type-0, etc.
+///
+/// Numbers compare by IEEE equality (NA never compares equal to anything,
+/// including itself — Excel's `=NA()=NA()` returns `#N/A`).  Text is
+/// **case-insensitive ASCII** to match Excel's default.  Booleans only equal
+/// other booleans; empties only equal other empties.
+pub(crate) fn equal_excel(left: &LookupValue, right: &LookupValue) -> bool {
+    match (left, right) {
+        (LookupValue::Empty, LookupValue::Empty) => true,
+        (LookupValue::Boolean(a), LookupValue::Boolean(b)) => a == b,
+        (LookupValue::Number(a), LookupValue::Number(b)) => {
+            if is_na_real(*a) || is_na_real(*b) {
+                false
+            } else {
+                a == b
+            }
+        }
+        (LookupValue::Text(a), LookupValue::Text(b)) => a.eq_ignore_ascii_case(b),
+        _ => false,
+    }
+}
+
+/// Ordering used for *approximate* lookups (VLOOKUP-TRUE, MATCH-1, MATCH--1,
+/// XLOOKUP exact-or-next-*).  Returns:
+///
+/// - `Ok(Ordering)` when both values are comparable.
+/// - `Err(TypeMismatch)` when the variants differ (Excel rule: approximate
+///   match across types is `#N/A` in practice; we surface it as a typed
+///   error and let the dispatcher map it back).
+pub(crate) fn cmp_excel(
+    function: &'static str,
+    left: &LookupValue,
+    right: &LookupValue,
+) -> Result<std::cmp::Ordering, LookupError> {
+    use std::cmp::Ordering;
+    match (left, right) {
+        (LookupValue::Empty, LookupValue::Empty) => Ok(Ordering::Equal),
+        (LookupValue::Boolean(a), LookupValue::Boolean(b)) => Ok(a.cmp(b)),
+        (LookupValue::Number(a), LookupValue::Number(b)) => {
+            if is_na_real(*a) || is_na_real(*b) {
+                Err(LookupError::TypeMismatch {
+                    function,
+                    what: "NA in approximate comparison".to_string(),
+                })
+            } else {
+                // `total_cmp` keeps the function total even for ±0 and NaN.
+                Ok(a.total_cmp(b))
+            }
+        }
+        (LookupValue::Text(a), LookupValue::Text(b)) => {
+            // ASCII case-insensitive ordering for parity with Excel sort.
+            Ok(a.to_ascii_lowercase().cmp(&b.to_ascii_lowercase()))
+        }
+        (l, r) => Err(LookupError::TypeMismatch {
+            function,
+            what: format!("{} vs {}", l.type_tag(), r.type_tag()),
+        }),
+    }
+}
+
+/// Match a probe against a candidate using Excel-style wildcards:
+///   `?` matches exactly one character (no Unicode awareness),
+///   `*` matches zero or more characters,
+///   `~?` and `~*` are literal `?`/`*`,
+///   `~~` is a literal `~`.
+///
+/// Only applied when *both* sides are `Text`; for non-text the function
+/// falls back to [`equal_excel`].
+pub(crate) fn matches_wildcard(probe: &LookupValue, candidate: &LookupValue) -> bool {
+    match (probe, candidate) {
+        (LookupValue::Text(pattern), LookupValue::Text(target)) => {
+            wildcard_match_ascii(pattern, target)
+        }
+        _ => equal_excel(probe, candidate),
+    }
+}
+
+/// Recursive descent ASCII wildcard matcher.  We avoid regex / external
+/// crates per the Layer-1 "no external deps" rule, and ASCII-fold both sides
+/// to match Excel's case-insensitive behaviour.
+fn wildcard_match_ascii(pattern: &str, target: &str) -> bool {
+    // Tokenise the pattern into a stream of (LiteralChar | AnyChar | AnyRun)
+    // tokens.  Building the token list once is `O(p)` and lets the matcher
+    // collapse runs of `*` automatically.
+    enum Tok {
+        Lit(u8),
+        AnyChar,
+        AnyRun,
+    }
+    let bytes = pattern.as_bytes();
+    let mut tokens: Vec<Tok> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b'~' if i + 1 < bytes.len() => {
+                tokens.push(Tok::Lit(bytes[i + 1].to_ascii_lowercase()));
+                i += 2;
+            }
+            b'?' => {
+                tokens.push(Tok::AnyChar);
+                i += 1;
+            }
+            b'*' => {
+                // Collapse consecutive `*` since `**` == `*`.
+                if !matches!(tokens.last(), Some(Tok::AnyRun)) {
+                    tokens.push(Tok::AnyRun);
+                }
+                i += 1;
+            }
+            _ => {
+                tokens.push(Tok::Lit(b.to_ascii_lowercase()));
+                i += 1;
+            }
+        }
+    }
+
+    let target_bytes: Vec<u8> = target.bytes().map(|b| b.to_ascii_lowercase()).collect();
+
+    fn rec(toks: &[Tok], target: &[u8]) -> bool {
+        match toks.first() {
+            None => target.is_empty(),
+            Some(Tok::Lit(c)) => !target.is_empty() && target[0] == *c && rec(&toks[1..], &target[1..]),
+            Some(Tok::AnyChar) => !target.is_empty() && rec(&toks[1..], &target[1..]),
+            Some(Tok::AnyRun) => {
+                // Try matching zero characters first, then progressively
+                // longer prefixes.  This is the standard backtracking
+                // wildcard.  Worst case `O(p*t)`; fine for our use.
+                if rec(&toks[1..], target) {
+                    return true;
+                }
+                for k in 1..=target.len() {
+                    if rec(&toks[1..], &target[k..]) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    rec(&tokens, &target_bytes)
+}
+
+/// Convert a 1-based index to 0-based, validating the bound.  Centralised so
+/// that every "index outside 1..=n" error message reads the same.
+pub(crate) fn one_based_to_zero(
+    function: &'static str,
+    index: i64,
+    max: usize,
+) -> Result<usize, LookupError> {
+    if index < 1 || (index as usize) > max {
+        return Err(LookupError::OutOfRange {
+            function,
+            index,
+            max,
+        });
+    }
+    Ok((index as usize) - 1)
+}
+
+// -----------------------------------------------------------------------
+// Tests for helpers.
+// -----------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equality_is_case_insensitive_for_text() {
+        let a = LookupValue::Text("Apple".to_string());
+        let b = LookupValue::Text("apple".to_string());
+        assert!(equal_excel(&a, &b));
+    }
+
+    #[test]
+    fn na_never_equals_itself() {
+        let a = LookupValue::na();
+        let b = LookupValue::na();
+        assert!(!equal_excel(&a, &b));
+    }
+
+    #[test]
+    fn wildcard_question_mark_matches_single_char() {
+        let p = LookupValue::Text("a?c".to_string());
+        let t = LookupValue::Text("abc".to_string());
+        assert!(matches_wildcard(&p, &t));
+        let t2 = LookupValue::Text("ac".to_string());
+        assert!(!matches_wildcard(&p, &t2));
+    }
+
+    #[test]
+    fn wildcard_star_matches_run() {
+        let p = LookupValue::Text("a*c".to_string());
+        assert!(matches_wildcard(
+            &p,
+            &LookupValue::Text("abc".to_string())
+        ));
+        assert!(matches_wildcard(
+            &p,
+            &LookupValue::Text("abbbbc".to_string())
+        ));
+        assert!(matches_wildcard(&p, &LookupValue::Text("ac".to_string())));
+        assert!(!matches_wildcard(
+            &p,
+            &LookupValue::Text("abz".to_string())
+        ));
+    }
+
+    #[test]
+    fn wildcard_tilde_escapes_specials() {
+        let p = LookupValue::Text("a~*c".to_string());
+        assert!(matches_wildcard(
+            &p,
+            &LookupValue::Text("a*c".to_string())
+        ));
+        assert!(!matches_wildcard(
+            &p,
+            &LookupValue::Text("abc".to_string())
+        ));
+    }
+
+    #[test]
+    fn one_based_conversion_rejects_zero() {
+        let err = one_based_to_zero("f", 0, 5).unwrap_err();
+        match err {
+            LookupError::OutOfRange { index, max, .. } => {
+                assert_eq!(index, 0);
+                assert_eq!(max, 5);
+            }
+            _ => panic!("wrong error"),
+        }
+    }
+
+    #[test]
+    fn one_based_conversion_accepts_in_range() {
+        assert_eq!(one_based_to_zero("f", 1, 5).unwrap(), 0);
+        assert_eq!(one_based_to_zero("f", 5, 5).unwrap(), 4);
+    }
+
+    #[test]
+    fn display_strings_mention_excel_codes() {
+        let e = LookupError::NotFound { function: "VLOOKUP" };
+        assert!(format!("{e}").contains("#N/A"));
+        let e = LookupError::OutOfRange {
+            function: "INDEX",
+            index: 9,
+            max: 3,
+        };
+        assert!(format!("{e}").contains("#REF!"));
+    }
+
+    #[test]
+    fn type_tag_is_stable() {
+        assert_eq!(LookupValue::Empty.type_tag(), "empty");
+        assert_eq!(LookupValue::Boolean(true).type_tag(), "boolean");
+        assert_eq!(LookupValue::Number(1.0).type_tag(), "number");
+        assert_eq!(LookupValue::Text("x".into()).type_tag(), "text");
+    }
+}

--- a/code/packages/rust/lookup-core/src/offset.rs
+++ b/code/packages/rust/lookup-core/src/offset.rs
@@ -1,0 +1,163 @@
+//! OFFSET — range arithmetic.
+//!
+//! # Simplification vs Excel
+//!
+//! In Excel, `OFFSET` returns a **reference** to a shifted range.  We don't
+//! have a `Reference` / `RangeRef` type in this Layer-1 crate (those live in
+//! `spreadsheet-core`, which doesn't exist yet), so we model OFFSET as a
+//! function that:
+//!
+//! 1. Takes a 2-D table (the implicit workbook patch surrounding the
+//!    anchor) plus an `anchor_row` / `anchor_col` (1-based) pointing at the
+//!    top-left of the *reference*.
+//! 2. Applies the row / column offsets and optional height / width to
+//!    extract a sub-table from that 2-D table.
+//!
+//! Callers that have richer reference types can wrap this function easily.
+
+use crate::{LookupError, LookupResult, LookupValue};
+
+/// `OFFSET(reference, rows, cols, height, width)` — extract a rectangular
+/// sub-table.
+///
+/// `anchor_row` / `anchor_col` are 1-based, identifying the top-left of the
+/// original reference inside `table`.  `height` / `width` default to the
+/// reference's own height/width when `None`; for our purposes the original
+/// reference is exactly one cell, so the defaults are 1×1.
+pub fn offset(
+    table: &[Vec<LookupValue>],
+    anchor_row: i64,
+    anchor_col: i64,
+    rows: i64,
+    cols: i64,
+    height: Option<i64>,
+    width: Option<i64>,
+) -> LookupResult<Vec<Vec<LookupValue>>> {
+    let n_rows = table.len() as i64;
+    let n_cols = if n_rows == 0 { 0 } else { table[0].len() as i64 };
+
+    let h = height.unwrap_or(1);
+    let w = width.unwrap_or(1);
+    if h <= 0 {
+        return Err(LookupError::BadParameter {
+            name: "height",
+            value: h.to_string(),
+        });
+    }
+    if w <= 0 {
+        return Err(LookupError::BadParameter {
+            name: "width",
+            value: w.to_string(),
+        });
+    }
+
+    // New 1-based top-left after applying offsets.
+    let new_top_1 = anchor_row + rows;
+    let new_left_1 = anchor_col + cols;
+    // 1-based inclusive bottom-right.
+    let new_bot_1 = new_top_1 + h - 1;
+    let new_right_1 = new_left_1 + w - 1;
+
+    if new_top_1 < 1 || new_left_1 < 1 || new_bot_1 > n_rows || new_right_1 > n_cols {
+        return Err(LookupError::OutOfRange {
+            function: "OFFSET",
+            index: new_top_1,
+            max: n_rows.max(0) as usize,
+        });
+    }
+
+    let mut out: Vec<Vec<LookupValue>> = Vec::with_capacity(h as usize);
+    for r in new_top_1..=new_bot_1 {
+        let row = &table[(r - 1) as usize];
+        let slice: Vec<LookupValue> = row[(new_left_1 - 1) as usize..new_right_1 as usize]
+            .to_vec();
+        out.push(slice);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn n(x: f64) -> LookupValue {
+        LookupValue::Number(x)
+    }
+
+    fn small_table() -> Vec<Vec<LookupValue>> {
+        // 3x3 grid:
+        //   1 2 3
+        //   4 5 6
+        //   7 8 9
+        vec![
+            vec![n(1.0), n(2.0), n(3.0)],
+            vec![n(4.0), n(5.0), n(6.0)],
+            vec![n(7.0), n(8.0), n(9.0)],
+        ]
+    }
+
+    #[test]
+    fn offset_zero_zero_returns_anchor_cell() {
+        let t = small_table();
+        let r = offset(&t, 2, 2, 0, 0, None, None).unwrap();
+        assert_eq!(r, vec![vec![n(5.0)]]);
+    }
+
+    #[test]
+    fn offset_positive_offsets_pick_new_cell() {
+        let t = small_table();
+        let r = offset(&t, 1, 1, 1, 1, None, None).unwrap();
+        assert_eq!(r, vec![vec![n(5.0)]]);
+    }
+
+    #[test]
+    fn offset_with_height_and_width_returns_block() {
+        let t = small_table();
+        // From anchor (1,1), shift 1 down 1 right, then take 2x2.
+        let r = offset(&t, 1, 1, 1, 1, Some(2), Some(2)).unwrap();
+        assert_eq!(r, vec![vec![n(5.0), n(6.0)], vec![n(8.0), n(9.0)]]);
+    }
+
+    #[test]
+    fn offset_negative_offsets() {
+        let t = small_table();
+        // Anchor at (3,3), offset by (-2,-2) → (1,1).
+        let r = offset(&t, 3, 3, -2, -2, None, None).unwrap();
+        assert_eq!(r, vec![vec![n(1.0)]]);
+    }
+
+    #[test]
+    fn offset_out_of_bounds_top() {
+        let t = small_table();
+        let err = offset(&t, 1, 1, -1, 0, None, None).unwrap_err();
+        assert!(matches!(err, LookupError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn offset_out_of_bounds_height() {
+        let t = small_table();
+        let err = offset(&t, 1, 1, 0, 0, Some(5), Some(1)).unwrap_err();
+        assert!(matches!(err, LookupError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn offset_zero_height_is_bad_parameter() {
+        let t = small_table();
+        let err = offset(&t, 1, 1, 0, 0, Some(0), Some(1)).unwrap_err();
+        assert!(matches!(err, LookupError::BadParameter { name: "height", .. }));
+    }
+
+    #[test]
+    fn offset_negative_width_is_bad_parameter() {
+        let t = small_table();
+        let err = offset(&t, 1, 1, 0, 0, Some(1), Some(-2)).unwrap_err();
+        assert!(matches!(err, LookupError::BadParameter { name: "width", .. }));
+    }
+
+    #[test]
+    fn offset_full_row_extraction() {
+        let t = small_table();
+        let r = offset(&t, 1, 1, 1, 0, Some(1), Some(3)).unwrap();
+        assert_eq!(r, vec![vec![n(4.0), n(5.0), n(6.0)]]);
+    }
+}

--- a/code/packages/rust/lookup-core/src/position.rs
+++ b/code/packages/rust/lookup-core/src/position.rs
@@ -1,0 +1,105 @@
+//! ROW / COLUMN / ROWS / COLUMNS — dimension introspection.
+//!
+//! # Simplification vs Excel
+//!
+//! In Excel, `ROW(A3)` returns the absolute worksheet row number (`3`).
+//! That requires a workbook reference type, which we don't have at Layer 1.
+//! Instead, given an *array shape*, `row`/`column` return the **1-based
+//! index sequence within that shape**:
+//!
+//! - `row(Vector(n))` → `[1, 2, ..., n]`
+//! - `column(Vector(n))` → `[1]`   (a column-vector has one column)
+//! - `row(Matrix(r×c))` → `[1, 2, ..., r]`
+//! - `column(Matrix(r×c))` → `[1, 2, ..., c]`
+//!
+//! `ROWS` / `COLUMNS` return scalar counts.
+//!
+//! When `spreadsheet-core` introduces real references, a thin adapter can
+//! pick which API to call.
+
+/// Shape passed to the position helpers — either a 1-D vector or a 2-D
+/// row-major matrix.  This lets a caller introspect either kind of array
+/// without forcing them to inflate a vector into a 1×n matrix.
+#[derive(Debug, Clone, Copy)]
+pub enum Shape {
+    Vector(usize),
+    Matrix { rows: usize, cols: usize },
+}
+
+/// `ROW(array)`.  See module docs for the simplified semantics.
+pub fn row(shape: Shape) -> Vec<i64> {
+    match shape {
+        Shape::Vector(n) => (1..=(n as i64)).collect(),
+        Shape::Matrix { rows, .. } => (1..=(rows as i64)).collect(),
+    }
+}
+
+/// `COLUMN(array)`.
+pub fn column(shape: Shape) -> Vec<i64> {
+    match shape {
+        Shape::Vector(_) => vec![1],
+        Shape::Matrix { cols, .. } => (1..=(cols as i64)).collect(),
+    }
+}
+
+/// `ROWS(array)`.
+pub fn rows(shape: Shape) -> usize {
+    match shape {
+        Shape::Vector(n) => n,
+        Shape::Matrix { rows, .. } => rows,
+    }
+}
+
+/// `COLUMNS(array)`.
+pub fn columns(shape: Shape) -> usize {
+    match shape {
+        Shape::Vector(_) => 1,
+        Shape::Matrix { cols, .. } => cols,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_on_vector_is_one_to_n() {
+        assert_eq!(row(Shape::Vector(4)), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn column_on_vector_is_just_one() {
+        assert_eq!(column(Shape::Vector(4)), vec![1]);
+    }
+
+    #[test]
+    fn row_on_matrix_uses_row_count() {
+        assert_eq!(
+            row(Shape::Matrix { rows: 3, cols: 5 }),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn column_on_matrix_uses_col_count() {
+        assert_eq!(
+            column(Shape::Matrix { rows: 3, cols: 5 }),
+            vec![1, 2, 3, 4, 5]
+        );
+    }
+
+    #[test]
+    fn rows_columns_scalars() {
+        assert_eq!(rows(Shape::Vector(7)), 7);
+        assert_eq!(columns(Shape::Vector(7)), 1);
+        assert_eq!(rows(Shape::Matrix { rows: 3, cols: 5 }), 3);
+        assert_eq!(columns(Shape::Matrix { rows: 3, cols: 5 }), 5);
+    }
+
+    #[test]
+    fn rows_columns_on_empty_vector() {
+        assert_eq!(rows(Shape::Vector(0)), 0);
+        assert_eq!(columns(Shape::Vector(0)), 1);
+        assert_eq!(row(Shape::Vector(0)), Vec::<i64>::new());
+    }
+}

--- a/code/packages/rust/lookup-core/src/vlookup.rs
+++ b/code/packages/rust/lookup-core/src/vlookup.rs
@@ -1,0 +1,275 @@
+//! VLOOKUP / HLOOKUP — the two original "lookup in a table by key" functions.
+//!
+//! Both functions search a row or column for a probe and return a value from
+//! a parallel column or row.  They differ only in axis orientation, so the
+//! implementation factors through a shared "search a 1-D key column" helper.
+//!
+//! # Excel parity notes
+//!
+//! - Excel's `range_lookup` parameter defaults to `TRUE` (approximate
+//!   match).  We make `range_lookup` a *required* parameter at the Rust
+//!   surface because silent approximate-match is a famous source of
+//!   spreadsheet bugs.  The dispatcher that wraps this crate is responsible
+//!   for filling in the default when emulating Excel's call shape.
+//! - Approximate match requires the key column to be sorted ascending.  We
+//!   trust the caller and binary-search; this matches Excel's documented
+//!   contract.
+//! - NA in the probe → NA result (returned as `Ok(LookupValue::na())`).
+//! - NA cells in the key column are *skipped* — they never match.
+
+use crate::{
+    cmp_excel, equal_excel, is_na_real, one_based_to_zero, LookupError, LookupResult, LookupValue,
+};
+
+/// Excel `VLOOKUP(lookup_value, table, col_index, range_lookup)`.
+///
+/// - `table`: row-major 2-D array.  The *first* column is the key column.
+/// - `col_index`: 1-based column index into `table`.
+/// - `range_lookup = true`: approximate match (sorted ascending).
+/// - `range_lookup = false`: exact match (case-insensitive ASCII for text).
+pub fn vlookup(
+    lookup_value: &LookupValue,
+    table: &[Vec<LookupValue>],
+    col_index: i64,
+    range_lookup: bool,
+) -> LookupResult<LookupValue> {
+    if table.is_empty() {
+        return Err(LookupError::NotFound { function: "VLOOKUP" });
+    }
+    // NA probe propagates regardless of match mode.
+    if lookup_value.is_na() {
+        return Ok(LookupValue::na());
+    }
+    let n_cols = table[0].len();
+    let col_zero = one_based_to_zero("VLOOKUP", col_index, n_cols)?;
+    let keys: Vec<&LookupValue> = table.iter().map(|row| &row[0]).collect();
+
+    let row = search_key_column("VLOOKUP", lookup_value, &keys, range_lookup)?;
+    Ok(table[row][col_zero].clone())
+}
+
+/// Excel `HLOOKUP(lookup_value, table, row_index, range_lookup)`.
+///
+/// Mirrors [`vlookup`], but the *first row* of `table` is the key row and we
+/// return from column-aligned cells in `row_index`.
+pub fn hlookup(
+    lookup_value: &LookupValue,
+    table: &[Vec<LookupValue>],
+    row_index: i64,
+    range_lookup: bool,
+) -> LookupResult<LookupValue> {
+    if table.is_empty() || table[0].is_empty() {
+        return Err(LookupError::NotFound { function: "HLOOKUP" });
+    }
+    if lookup_value.is_na() {
+        return Ok(LookupValue::na());
+    }
+    let n_rows = table.len();
+    let row_zero = one_based_to_zero("HLOOKUP", row_index, n_rows)?;
+    let keys: Vec<&LookupValue> = table[0].iter().collect();
+
+    let col = search_key_column("HLOOKUP", lookup_value, &keys, range_lookup)?;
+    Ok(table[row_zero][col].clone())
+}
+
+/// Shared key-column search.  Skips NA entries (Excel semantics) and either
+/// performs exact equality (`range_lookup=false`) or an approximate-match
+/// binary search (`range_lookup=true`).
+fn search_key_column(
+    function: &'static str,
+    probe: &LookupValue,
+    keys: &[&LookupValue],
+    range_lookup: bool,
+) -> LookupResult<usize> {
+    if !range_lookup {
+        // Linear exact-match scan.  We must use a linear scan rather than
+        // binary search because exact-match VLOOKUP does NOT require the key
+        // column to be sorted.
+        for (i, key) in keys.iter().enumerate() {
+            if key_is_na(key) {
+                continue;
+            }
+            if equal_excel(probe, key) {
+                return Ok(i);
+            }
+        }
+        return Err(LookupError::NotFound { function });
+    }
+
+    // Approximate match: binary search for the *largest* key ≤ probe.
+    //
+    // The key column is assumed sorted ascending with NAs skipped.  We work
+    // on a compacted (no-NA) view to keep the binary search invariant clean,
+    // then map back to original indices at the end.
+    let compact: Vec<(usize, &LookupValue)> = keys
+        .iter()
+        .enumerate()
+        .filter(|(_, k)| !key_is_na(k))
+        .map(|(i, k)| (i, *k))
+        .collect();
+
+    if compact.is_empty() {
+        return Err(LookupError::NotFound { function });
+    }
+
+    // Reject if probe is smaller than the smallest key — Excel returns #N/A
+    // in this case rather than returning the first row.
+    if cmp_excel(function, probe, compact[0].1)?.is_lt() {
+        return Err(LookupError::NotFound { function });
+    }
+
+    let mut lo = 0usize;
+    let mut hi = compact.len();
+    while lo + 1 < hi {
+        let mid = lo + (hi - lo) / 2;
+        // We want the largest index with key ≤ probe.  If keys[mid] > probe,
+        // shrink the high end; otherwise the answer is at mid or further.
+        match cmp_excel(function, compact[mid].1, probe)? {
+            std::cmp::Ordering::Greater => hi = mid,
+            _ => lo = mid,
+        }
+    }
+    Ok(compact[lo].0)
+}
+
+fn key_is_na(v: &LookupValue) -> bool {
+    matches!(v, LookupValue::Number(n) if is_na_real(*n))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> LookupValue {
+        LookupValue::Text(s.into())
+    }
+    fn n(x: f64) -> LookupValue {
+        LookupValue::Number(x)
+    }
+
+    #[test]
+    fn vlookup_exact_hit_returns_aligned_value() {
+        // Two-column lookup table: (fruit, price)
+        let table = vec![
+            vec![t("apple"), n(1.0)],
+            vec![t("banana"), n(2.0)],
+            vec![t("cherry"), n(3.0)],
+        ];
+        let r = vlookup(&t("banana"), &table, 2, false).unwrap();
+        assert_eq!(r, n(2.0));
+    }
+
+    #[test]
+    fn vlookup_exact_miss_is_not_found() {
+        let table = vec![vec![t("a"), n(1.0)], vec![t("b"), n(2.0)]];
+        let err = vlookup(&t("z"), &table, 2, false).unwrap_err();
+        assert!(matches!(err, LookupError::NotFound { function: "VLOOKUP" }));
+    }
+
+    #[test]
+    fn vlookup_text_is_case_insensitive() {
+        let table = vec![vec![t("Apple"), n(1.0)]];
+        let r = vlookup(&t("apple"), &table, 2, false).unwrap();
+        assert_eq!(r, n(1.0));
+    }
+
+    #[test]
+    fn vlookup_col_index_out_of_range() {
+        let table = vec![vec![t("a"), n(1.0)]];
+        let err = vlookup(&t("a"), &table, 5, false).unwrap_err();
+        assert!(matches!(err, LookupError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn vlookup_approximate_picks_largest_le_probe() {
+        // Bracketed tax table.
+        let table = vec![
+            vec![n(0.0), t("0%")],
+            vec![n(10.0), t("10%")],
+            vec![n(20.0), t("20%")],
+            vec![n(50.0), t("50%")],
+        ];
+        assert_eq!(vlookup(&n(15.0), &table, 2, true).unwrap(), t("10%"));
+        assert_eq!(vlookup(&n(50.0), &table, 2, true).unwrap(), t("50%"));
+        assert_eq!(vlookup(&n(0.0), &table, 2, true).unwrap(), t("0%"));
+        assert_eq!(vlookup(&n(1000.0), &table, 2, true).unwrap(), t("50%"));
+    }
+
+    #[test]
+    fn vlookup_approximate_below_min_is_not_found() {
+        let table = vec![vec![n(10.0), t("10%")], vec![n(20.0), t("20%")]];
+        let err = vlookup(&n(5.0), &table, 2, true).unwrap_err();
+        assert!(matches!(err, LookupError::NotFound { .. }));
+    }
+
+    #[test]
+    fn vlookup_skips_na_keys() {
+        let table = vec![
+            vec![LookupValue::na(), t("ghost")],
+            vec![t("apple"), t("a")],
+        ];
+        let r = vlookup(&t("apple"), &table, 2, false).unwrap();
+        assert_eq!(r, t("a"));
+    }
+
+    #[test]
+    fn vlookup_na_probe_propagates() {
+        let table = vec![vec![n(1.0), n(10.0)]];
+        let r = vlookup(&LookupValue::na(), &table, 2, false).unwrap();
+        assert!(r.is_na());
+    }
+
+    #[test]
+    fn vlookup_type_mismatch_in_approx_is_error() {
+        // Approximate match on a text probe against numeric keys.
+        let table = vec![vec![n(1.0), t("a")], vec![n(2.0), t("b")]];
+        let err = vlookup(&t("x"), &table, 2, true).unwrap_err();
+        assert!(matches!(err, LookupError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn hlookup_exact_hit_returns_aligned_value() {
+        // First row is keys, second row is values.
+        let table = vec![vec![t("a"), t("b"), t("c")], vec![n(1.0), n(2.0), n(3.0)]];
+        assert_eq!(hlookup(&t("b"), &table, 2, false).unwrap(), n(2.0));
+    }
+
+    #[test]
+    fn hlookup_approximate() {
+        let table = vec![vec![n(0.0), n(10.0), n(20.0)], vec![t("low"), t("mid"), t("hi")]];
+        assert_eq!(hlookup(&n(15.0), &table, 2, true).unwrap(), t("mid"));
+        assert_eq!(hlookup(&n(100.0), &table, 2, true).unwrap(), t("hi"));
+    }
+
+    #[test]
+    fn hlookup_row_index_out_of_range() {
+        let table = vec![vec![t("a")]];
+        let err = hlookup(&t("a"), &table, 99, false).unwrap_err();
+        assert!(matches!(err, LookupError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn hlookup_empty_table_not_found() {
+        let table: Vec<Vec<LookupValue>> = vec![];
+        let err = hlookup(&t("a"), &table, 1, false).unwrap_err();
+        assert!(matches!(err, LookupError::NotFound { .. }));
+    }
+
+    #[test]
+    fn vlookup_approximate_edge_cases_min_max_between() {
+        // Verify binary-search behaviour at exact min, exact max, and a
+        // value between two existing keys.
+        let table = vec![
+            vec![n(1.0), t("a")],
+            vec![n(3.0), t("b")],
+            vec![n(5.0), t("c")],
+            vec![n(7.0), t("d")],
+            vec![n(9.0), t("e")],
+        ];
+        assert_eq!(vlookup(&n(1.0), &table, 2, true).unwrap(), t("a")); // exact min
+        assert_eq!(vlookup(&n(9.0), &table, 2, true).unwrap(), t("e")); // exact max
+        assert_eq!(vlookup(&n(4.0), &table, 2, true).unwrap(), t("b")); // between
+        assert_eq!(vlookup(&n(6.0), &table, 2, true).unwrap(), t("c"));
+        assert_eq!(vlookup(&n(8.0), &table, 2, true).unwrap(), t("d"));
+    }
+}

--- a/code/packages/rust/lookup-core/src/xlookup.rs
+++ b/code/packages/rust/lookup-core/src/xlookup.rs
@@ -1,0 +1,568 @@
+//! XLOOKUP / XMATCH — Excel's modern lookup primitives.  Compared to
+//! VLOOKUP, XLOOKUP:
+//!
+//! - Defaults to **exact match** (no silent approximate-match foot-gun).
+//! - Returns from an independent return array, so the lookup column does
+//!   not have to be left of the result column.
+//! - Lets callers supply a fallback (`if_not_found`) instead of an error.
+//! - Supports wildcard and binary-search modes.
+
+use crate::{
+    cmp_excel, equal_excel, is_na_real, matches_wildcard, LookupError, LookupResult, LookupValue,
+};
+
+/// `match_mode` for XLOOKUP / XMATCH.  Matches Excel's integer codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum XMatchMode {
+    /// `0`: exact match (default in Excel).
+    Exact,
+    /// `-1`: exact, or next smaller item.
+    ExactOrNextSmaller,
+    /// `1`: exact, or next larger item.
+    ExactOrNextLarger,
+    /// `2`: wildcard match (`*` and `?` with `~` as escape).
+    Wildcard,
+}
+
+impl XMatchMode {
+    pub fn from_excel_code(code: i64) -> LookupResult<Self> {
+        match code {
+            0 => Ok(XMatchMode::Exact),
+            -1 => Ok(XMatchMode::ExactOrNextSmaller),
+            1 => Ok(XMatchMode::ExactOrNextLarger),
+            2 => Ok(XMatchMode::Wildcard),
+            _ => Err(LookupError::BadParameter {
+                name: "match_mode",
+                value: code.to_string(),
+            }),
+        }
+    }
+}
+
+/// `search_mode` for XLOOKUP / XMATCH.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum XSearchMode {
+    /// `1`: scan from first to last (default).
+    FirstToLast,
+    /// `-1`: scan from last to first.
+    LastToFirst,
+    /// `2`: binary search assuming ascending order.
+    BinarySortedAsc,
+    /// `-2`: binary search assuming descending order.
+    BinarySortedDesc,
+}
+
+impl XSearchMode {
+    pub fn from_excel_code(code: i64) -> LookupResult<Self> {
+        match code {
+            1 => Ok(XSearchMode::FirstToLast),
+            -1 => Ok(XSearchMode::LastToFirst),
+            2 => Ok(XSearchMode::BinarySortedAsc),
+            -2 => Ok(XSearchMode::BinarySortedDesc),
+            _ => Err(LookupError::BadParameter {
+                name: "search_mode",
+                value: code.to_string(),
+            }),
+        }
+    }
+}
+
+/// `XLOOKUP(lookup_value, lookup_array, return_array, if_not_found,
+/// match_mode, search_mode)`.
+///
+/// `if_not_found` is `Some(value)` to suppress the `NotFound` error and
+/// return `value` instead — exactly Excel's behaviour when the optional
+/// fallback argument is supplied.
+pub fn xlookup(
+    lookup_value: &LookupValue,
+    lookup_array: &[LookupValue],
+    return_array: &[LookupValue],
+    if_not_found: Option<LookupValue>,
+    match_mode: XMatchMode,
+    search_mode: XSearchMode,
+) -> LookupResult<LookupValue> {
+    if lookup_array.len() != return_array.len() {
+        return Err(LookupError::ShapeMismatch {
+            expected: format!("return_array.len = {}", lookup_array.len()),
+            found: format!("{}", return_array.len()),
+        });
+    }
+    if lookup_value.is_na() {
+        return Ok(LookupValue::na());
+    }
+    match xmatch(lookup_value, lookup_array, match_mode, search_mode) {
+        Ok(pos) => {
+            // xmatch returns 1-based; convert to 0-based to index return_array.
+            Ok(return_array[(pos - 1) as usize].clone())
+        }
+        Err(LookupError::NotFound { .. }) => match if_not_found {
+            Some(v) => Ok(v),
+            None => Err(LookupError::NotFound { function: "XLOOKUP" }),
+        },
+        Err(e) => Err(e),
+    }
+}
+
+/// `XMATCH(lookup_value, lookup_array, match_mode, search_mode)`.
+/// Returns a 1-based position.
+pub fn xmatch(
+    lookup_value: &LookupValue,
+    lookup_array: &[LookupValue],
+    match_mode: XMatchMode,
+    search_mode: XSearchMode,
+) -> LookupResult<i64> {
+    if lookup_value.is_na() {
+        return Err(LookupError::NotFound { function: "XMATCH" });
+    }
+    if lookup_array.is_empty() {
+        return Err(LookupError::NotFound { function: "XMATCH" });
+    }
+
+    // Build an iteration order based on `search_mode`.  Binary search modes
+    // get their own fast path below; the linear modes share a generic
+    // "iterate + test" loop.
+    match search_mode {
+        XSearchMode::FirstToLast => linear_scan(lookup_value, lookup_array, match_mode, false),
+        XSearchMode::LastToFirst => linear_scan(lookup_value, lookup_array, match_mode, true),
+        XSearchMode::BinarySortedAsc => {
+            binary_search_lookup(lookup_value, lookup_array, match_mode, true)
+        }
+        XSearchMode::BinarySortedDesc => {
+            binary_search_lookup(lookup_value, lookup_array, match_mode, false)
+        }
+    }
+}
+
+fn linear_scan(
+    probe: &LookupValue,
+    array: &[LookupValue],
+    mode: XMatchMode,
+    reverse: bool,
+) -> LookupResult<i64> {
+    // For ExactOrNextSmaller / ExactOrNextLarger we need to track the best
+    // candidate so far in addition to a possible exact hit, because the
+    // first exact match wins immediately but otherwise we have to scan all
+    // elements to find the closest one in the requested direction.
+    let n = array.len();
+    let order: Box<dyn Iterator<Item = usize>> = if reverse {
+        Box::new((0..n).rev())
+    } else {
+        Box::new(0..n)
+    };
+
+    let mut best: Option<(usize, &LookupValue)> = None;
+    for i in order {
+        let value = &array[i];
+        if matches!(value, LookupValue::Number(n) if is_na_real(*n)) {
+            continue;
+        }
+        match mode {
+            XMatchMode::Exact => {
+                if equal_excel(probe, value) {
+                    return Ok((i + 1) as i64);
+                }
+            }
+            XMatchMode::Wildcard => {
+                if matches_wildcard(probe, value) {
+                    return Ok((i + 1) as i64);
+                }
+            }
+            XMatchMode::ExactOrNextSmaller => {
+                if equal_excel(probe, value) {
+                    return Ok((i + 1) as i64);
+                }
+                let ord = cmp_excel("XMATCH", value, probe)?;
+                if ord.is_lt() {
+                    // Track the *largest* such value.
+                    if let Some((_, b)) = best {
+                        if cmp_excel("XMATCH", value, b)?.is_gt() {
+                            best = Some((i, value));
+                        }
+                    } else {
+                        best = Some((i, value));
+                    }
+                }
+            }
+            XMatchMode::ExactOrNextLarger => {
+                if equal_excel(probe, value) {
+                    return Ok((i + 1) as i64);
+                }
+                let ord = cmp_excel("XMATCH", value, probe)?;
+                if ord.is_gt() {
+                    // Track the *smallest* such value.
+                    if let Some((_, b)) = best {
+                        if cmp_excel("XMATCH", value, b)?.is_lt() {
+                            best = Some((i, value));
+                        }
+                    } else {
+                        best = Some((i, value));
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some((i, _)) = best {
+        return Ok((i + 1) as i64);
+    }
+    Err(LookupError::NotFound { function: "XMATCH" })
+}
+
+fn binary_search_lookup(
+    probe: &LookupValue,
+    array: &[LookupValue],
+    mode: XMatchMode,
+    ascending: bool,
+) -> LookupResult<i64> {
+    // Binary search modes assume no NAs in the array; Excel does too — NA
+    // would break the sort order.  We still skip NAs defensively, but doing
+    // so degrades to a compacted view rather than tripping over them.
+    let compact: Vec<(usize, &LookupValue)> = array
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !matches!(v, LookupValue::Number(n) if is_na_real(*n)))
+        .collect();
+    if compact.is_empty() {
+        return Err(LookupError::NotFound { function: "XMATCH" });
+    }
+
+    // Classic binary search for equality.  Falls back to the directional
+    // "next-smaller"/"next-larger" rules if no exact hit.
+    let mut lo = 0usize;
+    let mut hi = compact.len();
+    let cmp = |a: &LookupValue, b: &LookupValue| cmp_excel("XMATCH", a, b);
+
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let ord = cmp(compact[mid].1, probe)?;
+        match (ord, ascending) {
+            (std::cmp::Ordering::Equal, _) => return Ok((compact[mid].0 + 1) as i64),
+            (std::cmp::Ordering::Less, true) | (std::cmp::Ordering::Greater, false) => {
+                lo = mid + 1;
+            }
+            _ => hi = mid,
+        }
+    }
+
+    // Not found exactly.  Apply directional fallback.  After the loop, `lo`
+    // is the insertion point in the compacted, *iteration-direction-sorted*
+    // view: everything before `lo` is "less-than-probe-in-iteration-order"
+    // and everything from `lo` onward is "greater-than-probe-in-iteration-order".
+    match mode {
+        XMatchMode::Exact | XMatchMode::Wildcard => {
+            Err(LookupError::NotFound { function: "XMATCH" })
+        }
+        XMatchMode::ExactOrNextSmaller => {
+            if ascending {
+                // The element right before `lo` is the largest value strictly
+                // less than the probe.
+                if lo == 0 {
+                    return Err(LookupError::NotFound { function: "XMATCH" });
+                }
+                Ok((compact[lo - 1].0 + 1) as i64)
+            } else {
+                // In descending order, "less than probe" sits at index `lo`
+                // (everything past lo is smaller-than-probe in true value).
+                if lo >= compact.len() {
+                    return Err(LookupError::NotFound { function: "XMATCH" });
+                }
+                Ok((compact[lo].0 + 1) as i64)
+            }
+        }
+        XMatchMode::ExactOrNextLarger => {
+            if ascending {
+                if lo >= compact.len() {
+                    return Err(LookupError::NotFound { function: "XMATCH" });
+                }
+                Ok((compact[lo].0 + 1) as i64)
+            } else {
+                if lo == 0 {
+                    return Err(LookupError::NotFound { function: "XMATCH" });
+                }
+                Ok((compact[lo - 1].0 + 1) as i64)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> LookupValue {
+        LookupValue::Text(s.into())
+    }
+    fn n(x: f64) -> LookupValue {
+        LookupValue::Number(x)
+    }
+
+    #[test]
+    fn xlookup_default_exact_hit() {
+        let keys = vec![t("a"), t("b"), t("c")];
+        let vals = vec![n(1.0), n(2.0), n(3.0)];
+        let r = xlookup(
+            &t("b"),
+            &keys,
+            &vals,
+            None,
+            XMatchMode::Exact,
+            XSearchMode::FirstToLast,
+        )
+        .unwrap();
+        assert_eq!(r, n(2.0));
+    }
+
+    #[test]
+    fn xlookup_default_exact_miss_uses_fallback() {
+        let keys = vec![t("a"), t("b")];
+        let vals = vec![n(1.0), n(2.0)];
+        let r = xlookup(
+            &t("z"),
+            &keys,
+            &vals,
+            Some(t("missing")),
+            XMatchMode::Exact,
+            XSearchMode::FirstToLast,
+        )
+        .unwrap();
+        assert_eq!(r, t("missing"));
+    }
+
+    #[test]
+    fn xlookup_default_exact_miss_no_fallback_errors() {
+        let keys = vec![t("a")];
+        let vals = vec![n(1.0)];
+        let err = xlookup(
+            &t("z"),
+            &keys,
+            &vals,
+            None,
+            XMatchMode::Exact,
+            XSearchMode::FirstToLast,
+        )
+        .unwrap_err();
+        assert!(matches!(err, LookupError::NotFound { .. }));
+    }
+
+    #[test]
+    fn xlookup_shape_mismatch() {
+        let keys = vec![t("a")];
+        let vals = vec![n(1.0), n(2.0)];
+        let err = xlookup(
+            &t("a"),
+            &keys,
+            &vals,
+            None,
+            XMatchMode::Exact,
+            XSearchMode::FirstToLast,
+        )
+        .unwrap_err();
+        assert!(matches!(err, LookupError::ShapeMismatch { .. }));
+    }
+
+    #[test]
+    fn xmatch_last_to_first_finds_rightmost() {
+        let arr = vec![t("a"), t("b"), t("a"), t("c")];
+        // First-to-last finds index 1, last-to-first finds 3.
+        assert_eq!(
+            xmatch(&t("a"), &arr, XMatchMode::Exact, XSearchMode::FirstToLast).unwrap(),
+            1
+        );
+        assert_eq!(
+            xmatch(&t("a"), &arr, XMatchMode::Exact, XSearchMode::LastToFirst).unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn xmatch_next_smaller_linear() {
+        let arr = vec![n(10.0), n(20.0), n(30.0)];
+        // probe=25, nearest smaller=20 at position 2
+        assert_eq!(
+            xmatch(
+                &n(25.0),
+                &arr,
+                XMatchMode::ExactOrNextSmaller,
+                XSearchMode::FirstToLast,
+            )
+            .unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn xmatch_next_larger_linear() {
+        let arr = vec![n(10.0), n(20.0), n(30.0)];
+        // probe=25, nearest larger=30 at position 3
+        assert_eq!(
+            xmatch(
+                &n(25.0),
+                &arr,
+                XMatchMode::ExactOrNextLarger,
+                XSearchMode::FirstToLast,
+            )
+            .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn xmatch_wildcard_matches_pattern() {
+        let arr = vec![t("apple"), t("banana"), t("apricot")];
+        assert_eq!(
+            xmatch(
+                &t("ap*"),
+                &arr,
+                XMatchMode::Wildcard,
+                XSearchMode::FirstToLast,
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(
+            xmatch(
+                &t("a?ri*"),
+                &arr,
+                XMatchMode::Wildcard,
+                XSearchMode::FirstToLast,
+            )
+            .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn xmatch_binary_asc_exact_hit() {
+        let arr = vec![n(1.0), n(3.0), n(5.0), n(7.0), n(9.0)];
+        assert_eq!(
+            xmatch(
+                &n(5.0),
+                &arr,
+                XMatchMode::Exact,
+                XSearchMode::BinarySortedAsc,
+            )
+            .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn xmatch_binary_asc_next_smaller() {
+        let arr = vec![n(1.0), n(3.0), n(5.0), n(7.0), n(9.0)];
+        assert_eq!(
+            xmatch(
+                &n(6.0),
+                &arr,
+                XMatchMode::ExactOrNextSmaller,
+                XSearchMode::BinarySortedAsc,
+            )
+            .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn xmatch_binary_asc_next_larger() {
+        let arr = vec![n(1.0), n(3.0), n(5.0), n(7.0), n(9.0)];
+        assert_eq!(
+            xmatch(
+                &n(6.0),
+                &arr,
+                XMatchMode::ExactOrNextLarger,
+                XSearchMode::BinarySortedAsc,
+            )
+            .unwrap(),
+            4
+        );
+    }
+
+    #[test]
+    fn xmatch_binary_desc_exact_hit() {
+        let arr = vec![n(9.0), n(7.0), n(5.0), n(3.0), n(1.0)];
+        assert_eq!(
+            xmatch(
+                &n(5.0),
+                &arr,
+                XMatchMode::Exact,
+                XSearchMode::BinarySortedDesc,
+            )
+            .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn xmatch_binary_desc_next_smaller() {
+        let arr = vec![n(9.0), n(7.0), n(5.0), n(3.0), n(1.0)];
+        // 4.0 → next smaller is 3.0 at descending-position 4.
+        assert_eq!(
+            xmatch(
+                &n(4.0),
+                &arr,
+                XMatchMode::ExactOrNextSmaller,
+                XSearchMode::BinarySortedDesc,
+            )
+            .unwrap(),
+            4
+        );
+    }
+
+    #[test]
+    fn xmatch_excel_code_parsers() {
+        assert_eq!(XMatchMode::from_excel_code(0).unwrap(), XMatchMode::Exact);
+        assert_eq!(
+            XMatchMode::from_excel_code(-1).unwrap(),
+            XMatchMode::ExactOrNextSmaller
+        );
+        assert_eq!(
+            XMatchMode::from_excel_code(1).unwrap(),
+            XMatchMode::ExactOrNextLarger
+        );
+        assert_eq!(
+            XMatchMode::from_excel_code(2).unwrap(),
+            XMatchMode::Wildcard
+        );
+        assert!(XMatchMode::from_excel_code(9).is_err());
+
+        assert_eq!(
+            XSearchMode::from_excel_code(1).unwrap(),
+            XSearchMode::FirstToLast
+        );
+        assert_eq!(
+            XSearchMode::from_excel_code(-1).unwrap(),
+            XSearchMode::LastToFirst
+        );
+        assert_eq!(
+            XSearchMode::from_excel_code(2).unwrap(),
+            XSearchMode::BinarySortedAsc
+        );
+        assert_eq!(
+            XSearchMode::from_excel_code(-2).unwrap(),
+            XSearchMode::BinarySortedDesc
+        );
+        assert!(XSearchMode::from_excel_code(99).is_err());
+    }
+
+    #[test]
+    fn xlookup_na_probe_propagates() {
+        let keys = vec![n(1.0)];
+        let vals = vec![n(10.0)];
+        let r = xlookup(
+            &LookupValue::na(),
+            &keys,
+            &vals,
+            None,
+            XMatchMode::Exact,
+            XSearchMode::FirstToLast,
+        )
+        .unwrap();
+        assert!(r.is_na());
+    }
+
+    #[test]
+    fn xmatch_empty_array_is_not_found() {
+        let arr: Vec<LookupValue> = vec![];
+        let err = xmatch(&t("a"), &arr, XMatchMode::Exact, XSearchMode::FirstToLast).unwrap_err();
+        assert!(matches!(err, LookupError::NotFound { .. }));
+    }
+}

--- a/code/packages/rust/lookup-core/tests/lookup_tests.rs
+++ b/code/packages/rust/lookup-core/tests/lookup_tests.rs
@@ -1,0 +1,172 @@
+//! Integration tests for `lookup-core`.  These exercise public APIs end to
+//! end and cross-check that the various lookup paths agree with each other
+//! and with documented Excel behaviour.
+
+use lookup_core::choose::choose;
+use lookup_core::index_match::{index_1d, index_2d, r#match, IndexResult, MatchType};
+use lookup_core::offset::offset;
+use lookup_core::position::{column, columns, row, rows, Shape};
+use lookup_core::vlookup::{hlookup, vlookup};
+use lookup_core::xlookup::{xlookup, xmatch, XMatchMode, XSearchMode};
+use lookup_core::{LookupError, LookupValue};
+
+fn t(s: &str) -> LookupValue {
+    LookupValue::Text(s.into())
+}
+fn n(x: f64) -> LookupValue {
+    LookupValue::Number(x)
+}
+
+#[test]
+fn vlookup_index_match_agree_on_simple_hit() {
+    // A canonical Excel parity check: VLOOKUP and INDEX/MATCH should
+    // return the same answer for the same problem.
+    let table = vec![
+        vec![t("apple"), n(1.0)],
+        vec![t("banana"), n(2.0)],
+        vec![t("cherry"), n(3.0)],
+    ];
+    let keys: Vec<LookupValue> = table.iter().map(|r| r[0].clone()).collect();
+    let vals: Vec<LookupValue> = table.iter().map(|r| r[1].clone()).collect();
+
+    let vlk = vlookup(&t("banana"), &table, 2, false).unwrap();
+    let pos = r#match(&t("banana"), &keys, MatchType::Exact).unwrap();
+    let idx = index_1d(&vals, pos).unwrap();
+    assert_eq!(vlk, idx);
+}
+
+#[test]
+fn xlookup_matches_vlookup_on_exact() {
+    let table = vec![vec![t("a"), n(10.0)], vec![t("b"), n(20.0)]];
+    let keys: Vec<LookupValue> = table.iter().map(|r| r[0].clone()).collect();
+    let vals: Vec<LookupValue> = table.iter().map(|r| r[1].clone()).collect();
+    let v = vlookup(&t("b"), &table, 2, false).unwrap();
+    let x = xlookup(
+        &t("b"),
+        &keys,
+        &vals,
+        None,
+        XMatchMode::Exact,
+        XSearchMode::FirstToLast,
+    )
+    .unwrap();
+    assert_eq!(v, x);
+}
+
+#[test]
+fn full_grid_navigation_with_offset_and_index() {
+    // 3x3 grid; OFFSET extracts middle cell, INDEX agrees.
+    let grid = vec![
+        vec![n(1.0), n(2.0), n(3.0)],
+        vec![n(4.0), n(5.0), n(6.0)],
+        vec![n(7.0), n(8.0), n(9.0)],
+    ];
+    let off = offset(&grid, 1, 1, 1, 1, None, None).unwrap();
+    match index_2d(&grid, 2, 2).unwrap() {
+        IndexResult::Scalar(v) => assert_eq!(off, vec![vec![v]]),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn position_helpers_round_trip() {
+    let shape = Shape::Matrix { rows: 4, cols: 6 };
+    assert_eq!(rows(shape), 4);
+    assert_eq!(columns(shape), 6);
+    assert_eq!(row(shape).len(), 4);
+    assert_eq!(column(shape).len(), 6);
+}
+
+#[test]
+fn choose_dispatches_to_correct_argument() {
+    let values = vec![t("alpha"), t("beta"), t("gamma")];
+    assert_eq!(choose(2, &values).unwrap(), t("beta"));
+}
+
+#[test]
+fn hlookup_and_vlookup_are_axis_symmetric() {
+    let row_oriented = vec![
+        vec![t("a"), t("b"), t("c")],
+        vec![n(1.0), n(2.0), n(3.0)],
+    ];
+    let col_oriented = vec![
+        vec![t("a"), n(1.0)],
+        vec![t("b"), n(2.0)],
+        vec![t("c"), n(3.0)],
+    ];
+    assert_eq!(
+        hlookup(&t("c"), &row_oriented, 2, false).unwrap(),
+        vlookup(&t("c"), &col_oriented, 2, false).unwrap()
+    );
+}
+
+#[test]
+fn xmatch_wildcard_then_index_resolves_to_value() {
+    let keys = vec![t("alpha"), t("beta"), t("gamma")];
+    let vals = vec![n(1.0), n(2.0), n(3.0)];
+    let pos = xmatch(
+        &t("be*"),
+        &keys,
+        XMatchMode::Wildcard,
+        XSearchMode::FirstToLast,
+    )
+    .unwrap();
+    let v = index_1d(&vals, pos).unwrap();
+    assert_eq!(v, n(2.0));
+}
+
+#[test]
+fn type_mismatch_during_approx_lookup() {
+    let table = vec![vec![n(1.0), t("a")], vec![n(2.0), t("b")]];
+    let err = vlookup(&t("x"), &table, 2, true).unwrap_err();
+    assert!(matches!(err, LookupError::TypeMismatch { .. }));
+}
+
+#[test]
+fn na_in_lookup_value_returns_na() {
+    let table = vec![vec![n(1.0), t("a")]];
+    let r = vlookup(&LookupValue::na(), &table, 2, false).unwrap();
+    assert!(r.is_na());
+}
+
+#[test]
+fn na_in_lookup_array_is_skipped() {
+    let keys = vec![LookupValue::na(), t("b"), LookupValue::na(), t("c")];
+    let pos = r#match(&t("c"), &keys, MatchType::Exact).unwrap();
+    // Original index: 'c' is at position 4 (1-based).
+    assert_eq!(pos, 4);
+}
+
+#[test]
+fn mixed_types_lookup_column() {
+    // VLOOKUP exact match across a column with both numbers and text.
+    let table = vec![
+        vec![t("apple"), t("fruit")],
+        vec![n(42.0), t("answer")],
+        vec![t("banana"), t("yellow")],
+    ];
+    assert_eq!(
+        vlookup(&n(42.0), &table, 2, false).unwrap(),
+        t("answer")
+    );
+    assert_eq!(
+        vlookup(&t("banana"), &table, 2, false).unwrap(),
+        t("yellow")
+    );
+}
+
+#[test]
+fn xlookup_if_not_found_fallback() {
+    let keys = vec![t("a"), t("b")];
+    let vals = vec![n(1.0), n(2.0)];
+    let r = xlookup(
+        &t("z"),
+        &keys,
+        &vals,
+        Some(n(-1.0)),
+        XMatchMode::Exact,
+        XSearchMode::FirstToLast,
+    )
+    .unwrap();
+    assert_eq!(r, n(-1.0));
+}


### PR DESCRIPTION
## Summary

Implements the `lookup-core` Layer-1 backend crate per
`code/specs/backend-crate-catalog.md`. Pure Rust, no platform code, no
external crates beyond `numeric-tower` and `r-vector`. Builds for
`wasm32-unknown-unknown`.

## Function inventory

| Function | Notes |
|---|---|
| `vlookup` / `hlookup` | Exact and approximate (binary-search) match |
| `index_1d` / `index_2d` | 1-based; `row=0` / `col=0` selects whole strip |
| `r#match` | `Exact` / `LessOrEqual` / `GreaterOrEqual` |
| `xlookup` / `xmatch` | All Excel `match_mode` x `search_mode` combos, wildcard |
| `offset` | Sub-table extraction with bounds checking |
| `choose` | 1-based variadic pick |
| `row` / `column` / `rows` / `columns` | Shape-introspection helpers |

## Excel parity notes

- `VLOOKUP` `range_lookup` is *required* in the Rust API rather than
  defaulting to `TRUE` — silent approximate-match is a famous bug source.
  The dispatcher (when it lands) is responsible for filling in Excel's
  default at the call boundary.
- Approximate match assumes the lookup array is sorted ascending and uses
  binary search to find the largest key `<=` probe.
- Text comparison is **ASCII case-insensitive** in both exact and
  approximate modes (matches Excel's documented default).
- `INDEX` with `row=0` or `col=0` returns a whole row/column vector via
  a separate `IndexResult` variant; `row=0,col=0` is rejected because the
  scalar API cannot return a whole matrix.
- `OFFSET` is simplified to operate on an explicit 2-D table plus a 1-based
  anchor, since we don't have a `RangeRef` type at Layer 1. Documented in
  the module docs and `README.md`.
- `ROW` / `COLUMN` return 1-based index sequences over a shape rather than
  workbook coordinates, again because we lack reference types at Layer 1.

## `LookupValue` placeholder rationale

`spreadsheet-core` (which will own the canonical `CellValue`) does not yet
exist. To avoid forcing this crate to depend on the full spreadsheet stack,
`lookup-core` carries its own minimal value enum:

```rust
pub enum LookupValue { Empty, Boolean(bool), Number(f64), Text(String) }
```

Numeric NA is encoded via `r_vector::na_real()` so we do not need a separate
variant. When `spreadsheet-core` lands, a `From<CellValue> for LookupValue`
adapter at the dispatch boundary will route values without disturbing this
crate's API.

## NA propagation

Per `code/specs/na-semantics.md`:
- NA in the *probe* → output is NA (returned as `Ok(LookupValue::na())`).
- NA in the *lookup array* is skipped — those cells never match.

## Test plan

- [x] `cargo test -p lookup-core` (88 tests pass: 76 unit + 12 integration)
- [x] `cargo build -p lookup-core --target wasm32-unknown-unknown` (clean)
- [x] `cargo clippy -p lookup-core --all-targets` (clean)
- [x] VLOOKUP exact match (hit + miss)
- [x] VLOOKUP approximate (sorted) — binary-search edges at min, max, between values, below-min, above-max
- [x] HLOOKUP symmetric to VLOOKUP
- [x] INDEX 1-D and 2-D (row, col, whole-row, whole-col)
- [x] MATCH all three match_types
- [x] XLOOKUP all modes including wildcard, first-to-last and last-to-first, binary-asc and binary-desc
- [x] OFFSET with positive, negative, zero offsets; bounds errors; bad height/width
- [x] CHOOSE with valid + invalid indices
- [x] ROW/COLUMN/ROWS/COLUMNS over vectors and matrices
- [x] Errors: not-found, out-of-range, type-mismatch, shape-mismatch
- [x] Mixed types in lookup column (numbers + text)
- [x] NA propagation rules

## Constraints checklist

- [x] Only `numeric-tower` + `r-vector` deps (no external crates)
- [x] No `unsafe`
- [x] No `cfg(target_os)`, no I/O, no globals
- [x] 1-based indexing at the public surface; converted to 0-based internally
- [x] Every divergence from Excel documented in code comments

Generated with [Claude Code](https://claude.com/claude-code)