### PR TITLE
feat(text-core): Phase 1 implementation

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -525,6 +525,7 @@ members = [
     "window-win32",
     "window-c",
     "tcp-runtime",
+    "text-core",
     "text-interfaces",
     "text-native",
     "text-native-coretext",

--- a/code/packages/rust/text-core/Cargo.toml
+++ b/code/packages/rust/text-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "text-core"
+version = "0.1.0"
+edition = "2021"
+description = "Canonical Rust text manipulation core — Excel/Lotus/R string functions for any spreadsheet or text-processing frontend."
+
+[dependencies]
+numeric-tower = { path = "../numeric-tower" }
+r-vector = { path = "../r-vector" }

--- a/code/packages/rust/text-core/src/case.rs
+++ b/code/packages/rust/text-core/src/case.rs
@@ -1,0 +1,154 @@
+//! UPPER / LOWER / PROPER — case conversion.
+//!
+//! - `UPPER` and `LOWER` use Rust's Unicode-aware default case folding.
+//!   Note that some characters *grow* (e.g. `"ß".to_uppercase() == "SS"`), so
+//!   the output may have a different `char` count than the input.
+//! - `PROPER` capitalises the first letter of each *word*. A word is defined
+//!   as a maximal run of `char::is_alphabetic` characters. All other
+//!   characters reset the word-start flag. Apostrophes count as
+//!   non-alphabetic (matches Excel: `proper("o'brien") == "O'Brien"`).
+//!
+//! ```text
+//! upper("hello") == "HELLO"
+//! lower("HELLO") == "hello"
+//! upper("straße") == "STRASSE"
+//! proper("the quick brown fox") == "The Quick Brown Fox"
+//! proper("o'brien")             == "O'Brien"
+//! proper("html5 is cool")       == "Html5 Is Cool"
+//! ```
+
+use crate::iter_character;
+use r_vector::Character;
+
+/// `UPPER(text)` — Unicode-aware uppercase.
+pub fn upper(s: &str) -> String {
+    s.to_uppercase()
+}
+
+/// `LOWER(text)` — Unicode-aware lowercase.
+pub fn lower(s: &str) -> String {
+    s.to_lowercase()
+}
+
+/// `PROPER(text)` — capitalise the first letter of each word; everything else
+/// lowercase. A "word" is a run of `is_alphabetic` characters.
+pub fn proper(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    // `at_word_start` tracks whether the next alphabetic char should be made
+    // uppercase. It is true at the very start and after every non-alphabetic
+    // character.
+    let mut at_word_start = true;
+    for c in s.chars() {
+        if c.is_alphabetic() {
+            if at_word_start {
+                // Push the uppercase form (may be multi-char).
+                for u in c.to_uppercase() {
+                    out.push(u);
+                }
+            } else {
+                for l in c.to_lowercase() {
+                    out.push(l);
+                }
+            }
+            at_word_start = false;
+        } else {
+            out.push(c);
+            at_word_start = true;
+        }
+    }
+    out
+}
+
+/// Vector `UPPER`. NA in / NA out.
+pub fn upper_vec(x: &Character) -> Character {
+    let out: Vec<Option<String>> = iter_character(x).map(|cell| cell.map(upper)).collect();
+    Character::from_options(out)
+}
+
+/// Vector `LOWER`. NA in / NA out.
+pub fn lower_vec(x: &Character) -> Character {
+    let out: Vec<Option<String>> = iter_character(x).map(|cell| cell.map(lower)).collect();
+    Character::from_options(out)
+}
+
+/// Vector `PROPER`. NA in / NA out.
+pub fn proper_vec(x: &Character) -> Character {
+    let out: Vec<Option<String>> = iter_character(x).map(|cell| cell.map(proper)).collect();
+    Character::from_options(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use r_vector::Vector;
+
+    #[test]
+    fn upper_basic() {
+        assert_eq!(upper("hello"), "HELLO");
+        assert_eq!(upper(""), "");
+        assert_eq!(upper("HeLLo"), "HELLO");
+    }
+
+    #[test]
+    fn upper_unicode_growth() {
+        assert_eq!(upper("straße"), "STRASSE");
+        assert_eq!(upper("ﬃ"), "FFI"); // U+FB03 ligature
+    }
+
+    #[test]
+    fn lower_basic() {
+        assert_eq!(lower("HELLO"), "hello");
+        assert_eq!(lower("Mixed Case"), "mixed case");
+    }
+
+    #[test]
+    fn lower_unicode() {
+        assert_eq!(lower("ÉTÉ"), "été");
+    }
+
+    #[test]
+    fn proper_basic() {
+        assert_eq!(proper("hello world"), "Hello World");
+        assert_eq!(proper("HELLO WORLD"), "Hello World");
+        assert_eq!(proper(""), "");
+    }
+
+    #[test]
+    fn proper_apostrophes_count_as_breaks() {
+        // Excel parity: each letter cluster gets its own capitalisation.
+        assert_eq!(proper("o'brien"), "O'Brien");
+    }
+
+    #[test]
+    fn proper_digits_and_punct_break_words() {
+        assert_eq!(proper("html5 is cool"), "Html5 Is Cool");
+        assert_eq!(proper("anne-marie"), "Anne-Marie");
+    }
+
+    #[test]
+    fn proper_unicode_words() {
+        assert_eq!(proper("école normale"), "École Normale");
+    }
+
+    #[test]
+    fn vec_variants_propagate_na() {
+        let x = Character::from_options(vec![
+            Some("hello".into()),
+            None,
+            Some("WORLD".into()),
+            Some("a b c".into()),
+        ]);
+        let up = upper_vec(&x);
+        assert_eq!(up.get(0), Some(&Some("HELLO".into())));
+        assert!(up.is_na(1));
+        assert_eq!(up.get(2), Some(&Some("WORLD".into())));
+
+        let lo = lower_vec(&x);
+        assert_eq!(lo.get(2), Some(&Some("world".into())));
+        assert!(lo.is_na(1));
+
+        let pr = proper_vec(&x);
+        assert_eq!(pr.get(3), Some(&Some("A B C".into())));
+        assert!(pr.is_na(1));
+    }
+}

--- a/code/packages/rust/text-core/src/chars.rs
+++ b/code/packages/rust/text-core/src/chars.rs
@@ -1,0 +1,152 @@
+//! CODE / CHAR / UNICODE / UNICHAR — character code conversion.
+//!
+//! | function     | input                | output                        |
+//! |--------------|----------------------|-------------------------------|
+//! | `CODE(s)`    | string               | first char as Latin-1 / lower byte (`0..=255`) |
+//! | `CHAR(n)`    | integer 1..=255      | Latin-1 char as 1-char string |
+//! | `UNICODE(s)` | string               | first char as Unicode scalar  |
+//! | `UNICHAR(n)` | integer 1..=0x10FFFF | Unicode char as 1-char string |
+//!
+//! Empty input → `BadParameter`. Out-of-range `CHAR` (e.g. 256) is also
+//! `BadParameter` (Excel's `#VALUE!`). `UNICHAR` accepts any valid scalar
+//! value but rejects surrogates (U+D800..=U+DFFF).
+
+use crate::{iter_character, TextError};
+use r_vector::Character;
+
+/// `CODE(text)` — returns the first character as its Latin-1 code (or lower
+/// byte for non-Latin-1 chars). For pure ASCII this matches Excel exactly.
+/// For non-ASCII we return the lower byte of the Unicode code point as a
+/// best-effort match to Excel's legacy behaviour.
+pub fn code(s: &str) -> Result<u32, TextError> {
+    let c = s.chars().next().ok_or(TextError::BadParameter {
+        name: "text",
+        value: String::new(),
+    })?;
+    Ok(c as u32 & 0xff)
+}
+
+/// `CHAR(n)` — Latin-1 character. Requires `1 <= n <= 255`.
+pub fn char_at(n: i64) -> Result<String, TextError> {
+    if !(1..=255).contains(&n) {
+        return Err(TextError::BadParameter {
+            name: "number",
+            value: n.to_string(),
+        });
+    }
+    Ok(char::from(n as u8).to_string())
+}
+
+/// `UNICODE(text)` — full Unicode scalar value of the first character.
+pub fn unicode(s: &str) -> Result<u32, TextError> {
+    let c = s.chars().next().ok_or(TextError::BadParameter {
+        name: "text",
+        value: String::new(),
+    })?;
+    Ok(c as u32)
+}
+
+/// `UNICHAR(n)` — Unicode scalar value as a single-char string.
+///
+/// Rejects values outside `1..=0x10FFFF` and surrogate code points.
+pub fn unichar(n: i64) -> Result<String, TextError> {
+    if !(1..=0x0010_FFFF).contains(&n) {
+        return Err(TextError::BadParameter {
+            name: "number",
+            value: n.to_string(),
+        });
+    }
+    let scalar = n as u32;
+    // Reject surrogate range.
+    if (0xD800..=0xDFFF).contains(&scalar) {
+        return Err(TextError::BadParameter {
+            name: "number",
+            value: format!("surrogate {n}"),
+        });
+    }
+    char::from_u32(scalar)
+        .map(|c| c.to_string())
+        .ok_or(TextError::BadParameter {
+            name: "number",
+            value: n.to_string(),
+        })
+}
+
+/// Vector `CODE`. NA in / NA out; errors collapse to NA.
+pub fn code_vec(x: &Character) -> Vec<Option<u32>> {
+    iter_character(x)
+        .map(|cell| cell.and_then(|s| code(s).ok()))
+        .collect()
+}
+
+/// Vector `UNICODE`. NA in / NA out.
+pub fn unicode_vec(x: &Character) -> Vec<Option<u32>> {
+    iter_character(x)
+        .map(|cell| cell.and_then(|s| unicode(s).ok()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_ascii() {
+        assert_eq!(code("A").unwrap(), 65);
+        assert_eq!(code("a").unwrap(), 97);
+        // Only first char matters
+        assert_eq!(code("Apple").unwrap(), 65);
+        assert_eq!(code(" ").unwrap(), 32);
+    }
+
+    #[test]
+    fn code_empty_errors() {
+        assert!(code("").is_err());
+    }
+
+    #[test]
+    fn char_at_basic() {
+        assert_eq!(char_at(65).unwrap(), "A");
+        assert_eq!(char_at(32).unwrap(), " ");
+        assert_eq!(char_at(255).unwrap(), char::from(255u8).to_string());
+        assert!(char_at(0).is_err());
+        assert!(char_at(256).is_err());
+        assert!(char_at(-1).is_err());
+    }
+
+    #[test]
+    fn unicode_handles_full_range() {
+        assert_eq!(unicode("A").unwrap(), 65);
+        assert_eq!(unicode("漢").unwrap(), 0x6f22);
+        assert_eq!(unicode("🙂").unwrap(), 0x1f642);
+    }
+
+    #[test]
+    fn unicode_empty_errors() {
+        assert!(unicode("").is_err());
+    }
+
+    #[test]
+    fn unichar_full_range() {
+        assert_eq!(unichar(65).unwrap(), "A");
+        assert_eq!(unichar(0x6f22).unwrap(), "漢");
+        assert_eq!(unichar(0x1f642).unwrap(), "🙂");
+    }
+
+    #[test]
+    fn unichar_rejects_out_of_range() {
+        assert!(unichar(0).is_err());
+        assert!(unichar(-1).is_err());
+        assert!(unichar(0x11_0000).is_err());
+        // Surrogates
+        assert!(unichar(0xD800).is_err());
+        assert!(unichar(0xDFFF).is_err());
+    }
+
+    #[test]
+    fn vec_variants() {
+        let x = Character::from_options(vec![Some("A".into()), None, Some("漢".into())]);
+        assert_eq!(code_vec(&x), vec![Some(65), None, Some(0x6f22 & 0xff)]);
+        assert_eq!(unicode_vec(&x), vec![Some(65), None, Some(0x6f22)]);
+    }
+}

--- a/code/packages/rust/text-core/src/compare.rs
+++ b/code/packages/rust/text-core/src/compare.rs
@@ -1,0 +1,81 @@
+//! EXACT — case-sensitive string equality.
+//!
+//! `EXACT(a, b)` returns `true` iff the two strings are byte-for-byte equal.
+//! This is the standard Excel semantics: `EXACT("HELLO", "hello") == false`.
+
+use r_vector::{Character, Vector};
+
+/// `EXACT(a, b)` — case-sensitive equality.
+pub fn exact(a: &str, b: &str) -> bool {
+    a == b
+}
+
+/// Vector `EXACT`. Pairs `Character` vectors element-wise. Mismatched lengths
+/// pad with NA results. NA-vs-anything yields `None` (NA boolean).
+pub fn exact_vec(a: &Character, b: &Character) -> Vec<Option<bool>> {
+    let n = a.len().max(b.len());
+    let mut out: Vec<Option<bool>> = Vec::with_capacity(n);
+    for i in 0..n {
+        let ai = match a.get(i) {
+            Some(Some(s)) => Some(s.as_str()),
+            _ => None,
+        };
+        let bi = match b.get(i) {
+            Some(Some(s)) => Some(s.as_str()),
+            _ => None,
+        };
+        match (ai, bi) {
+            (Some(x), Some(y)) => out.push(Some(exact(x, y))),
+            _ => out.push(None),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_basic() {
+        assert!(exact("hello", "hello"));
+        assert!(!exact("hello", "Hello"));
+        assert!(!exact("hello", "hello "));
+        assert!(exact("", ""));
+    }
+
+    #[test]
+    fn exact_unicode() {
+        assert!(exact("漢字", "漢字"));
+        assert!(!exact("漢", "字"));
+        // Different code-points that *look* the same are not equal.
+        assert!(!exact("e\u{0301}", "é")); // combining accent vs composed
+    }
+
+    #[test]
+    fn exact_vec_pairs_elementwise() {
+        let a = Character::from_options(vec![
+            Some("a".into()),
+            Some("B".into()),
+            None,
+            Some("d".into()),
+        ]);
+        let b = Character::from_options(vec![
+            Some("a".into()),
+            Some("b".into()),
+            Some("c".into()),
+            None,
+        ]);
+        assert_eq!(
+            exact_vec(&a, &b),
+            vec![Some(true), Some(false), None, None]
+        );
+    }
+
+    #[test]
+    fn exact_vec_uneven_lengths() {
+        let a = Character::from_strings(["a", "b"]);
+        let b = Character::from_strings(["a"]);
+        assert_eq!(exact_vec(&a, &b), vec![Some(true), None]);
+    }
+}

--- a/code/packages/rust/text-core/src/concat.rs
+++ b/code/packages/rust/text-core/src/concat.rs
@@ -1,0 +1,161 @@
+//! CONCAT / CONCATENATE / TEXTJOIN — string composition.
+//!
+//! - `concatenate(strs)` — joins all strings with empty separator. This is
+//!   the venerable Excel `CONCATENATE`.
+//! - `concat(strs)` — modern Excel `CONCAT`. Same as `CONCATENATE` for our
+//!   purposes (we don't model spreadsheet ranges here; the caller flattens).
+//! - `textjoin(delim, ignore_empty, parts)` — joins with `delim`. If
+//!   `ignore_empty` is true, empty strings are skipped (no extra delimiter).
+//!
+//! NA handling: at this layer, all inputs are `&str` slices. NA is handled by
+//! the bridge: a NA element should be passed as either an empty string (when
+//! the caller wants "blank" semantics) or surfaced upstream as `#N/A`. The
+//! `*_options` variants below take `Option<&str>` slices to make the choice
+//! explicit:
+//!
+//! - `concat_options(parts)` — `None` becomes empty string (Excel CONCAT
+//!   behaviour for blank cells).
+//! - `textjoin_options(delim, ignore_empty, parts)` — `None` is treated like
+//!   an empty string when `ignore_empty` is true.
+
+use crate::iter_character;
+use r_vector::Character;
+
+/// `CONCATENATE(s1, s2, ...)`.
+pub fn concatenate(parts: &[&str]) -> String {
+    let mut total = 0;
+    for p in parts {
+        total += p.len();
+    }
+    let mut out = String::with_capacity(total);
+    for p in parts {
+        out.push_str(p);
+    }
+    out
+}
+
+/// `CONCAT(s1, s2, ...)` — same as `CONCATENATE` at this layer.
+pub fn concat(parts: &[&str]) -> String {
+    concatenate(parts)
+}
+
+/// `CONCAT` over `Option<&str>` parts. `None` -> empty.
+pub fn concat_options(parts: &[Option<&str>]) -> String {
+    let mut out = String::new();
+    for p in parts {
+        if let Some(s) = p {
+            out.push_str(s);
+        }
+    }
+    out
+}
+
+/// `TEXTJOIN(delim, ignore_empty, parts)`.
+pub fn textjoin(delim: &str, ignore_empty: bool, parts: &[&str]) -> String {
+    let mut first = true;
+    let mut out = String::new();
+    for p in parts {
+        if ignore_empty && p.is_empty() {
+            continue;
+        }
+        if first {
+            first = false;
+        } else {
+            out.push_str(delim);
+        }
+        out.push_str(p);
+    }
+    out
+}
+
+/// `TEXTJOIN` over `Option<&str>` parts. `None` is treated as empty: skipped
+/// when `ignore_empty` is true, included as nothing (causing back-to-back
+/// delimiters) when false.
+pub fn textjoin_options(delim: &str, ignore_empty: bool, parts: &[Option<&str>]) -> String {
+    let mut first = true;
+    let mut out = String::new();
+    for p in parts {
+        let s = p.unwrap_or("");
+        if ignore_empty && s.is_empty() {
+            continue;
+        }
+        if first {
+            first = false;
+        } else {
+            out.push_str(delim);
+        }
+        out.push_str(s);
+    }
+    out
+}
+
+/// Concatenate a `Character` vector with the given delimiter.
+///
+/// `None` (NA) elements are skipped iff `ignore_empty` is true; otherwise
+/// they contribute an empty slot. Convenience wrapper over
+/// `textjoin_options`.
+pub fn textjoin_vec(delim: &str, ignore_empty: bool, x: &Character) -> String {
+    let parts: Vec<Option<&str>> = iter_character(x).collect();
+    textjoin_options(delim, ignore_empty, &parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concatenate_basic() {
+        assert_eq!(concatenate(&["a", "b", "c"]), "abc");
+        assert_eq!(concatenate(&[]), "");
+        assert_eq!(concatenate(&[""]), "");
+        assert_eq!(concatenate(&["hello", " ", "world"]), "hello world");
+    }
+
+    #[test]
+    fn concat_is_concatenate() {
+        assert_eq!(concat(&["x", "y"]), "xy");
+    }
+
+    #[test]
+    fn concat_options_treats_none_as_empty() {
+        assert_eq!(concat_options(&[Some("a"), None, Some("b")]), "ab");
+        assert_eq!(concat_options(&[]), "");
+    }
+
+    #[test]
+    fn textjoin_basic() {
+        assert_eq!(textjoin(", ", true, &["a", "b", "c"]), "a, b, c");
+        assert_eq!(textjoin(", ", true, &["a", "", "c"]), "a, c");
+        assert_eq!(textjoin(", ", false, &["a", "", "c"]), "a, , c");
+        assert_eq!(textjoin("-", true, &[]), "");
+    }
+
+    #[test]
+    fn textjoin_empty_delim() {
+        assert_eq!(textjoin("", true, &["a", "b", "c"]), "abc");
+    }
+
+    #[test]
+    fn textjoin_options_skips_none_when_ignoring() {
+        let parts = vec![Some("a"), None, Some("b")];
+        assert_eq!(textjoin_options(",", true, &parts), "a,b");
+        assert_eq!(textjoin_options(",", false, &parts), "a,,b");
+    }
+
+    #[test]
+    fn textjoin_vec_walks_character() {
+        let x = Character::from_options(vec![
+            Some("a".into()),
+            None,
+            Some("".into()),
+            Some("c".into()),
+        ]);
+        assert_eq!(textjoin_vec(",", true, &x), "a,c");
+        assert_eq!(textjoin_vec(",", false, &x), "a,,,c");
+    }
+
+    #[test]
+    fn concat_unicode() {
+        assert_eq!(concatenate(&["漢", "字"]), "漢字");
+    }
+}

--- a/code/packages/rust/text-core/src/convert.rs
+++ b/code/packages/rust/text-core/src/convert.rs
@@ -1,0 +1,393 @@
+//! TEXT / VALUE / NUMBERVALUE / FIXED / DOLLAR — number ↔ string conversion.
+//!
+//! These functions cover the Excel surface of "number formatting" and
+//! "string-to-number parsing". Full Excel format strings (with `[Red]`,
+//! conditional sections, date/time, etc.) are out of scope; that work lives
+//! in the future `cell-format` crate. Here we implement only the **basic
+//! format codes** listed in the spec:
+//!
+//! | code         | meaning                                  | example         |
+//! |--------------|------------------------------------------|-----------------|
+//! | `0`          | integer, at least 1 digit                | `5` → `"5"`     |
+//! | `0.00`       | exactly 2 fractional digits              | `5` → `"5.00"`  |
+//! | `#,##0`      | integer with comma thousands             | `12345` → `"12,345"` |
+//! | `#,##0.00`   | as above with 2 fractional digits        | `12345` → `"12,345.00"` |
+//! | `0%`         | integer percentage                       | `0.5` → `"50%"` |
+//! | `0.00E+00`   | scientific, 2 fractional + 2-digit exp   | `12345` → `"1.23E+04"` |
+//!
+//! Anything else is `FormatError`.
+
+use crate::{iter_character, TextError};
+use r_vector::Character;
+
+/// `TEXT(value, format_code)` for the six basic codes above.
+///
+/// Numbers are rounded half-away-from-zero (Excel's default behaviour for
+/// display rounding).
+pub fn text(value: f64, format_code: &str) -> Result<String, TextError> {
+    match format_code {
+        "0" => Ok(format_integer(value, false)),
+        "0.00" => Ok(format_fixed(value, 2, false)),
+        "#,##0" => Ok(format_integer(value, true)),
+        "#,##0.00" => Ok(format_fixed(value, 2, true)),
+        "0%" => Ok(format_percent(value)),
+        "0.00E+00" => Ok(format_scientific(value)),
+        other => Err(TextError::FormatError {
+            function: "TEXT",
+            format: other.to_string(),
+        }),
+    }
+}
+
+/// `VALUE(text)` — best-effort parse to `f64`.
+///
+/// - Surrounding whitespace is ignored.
+/// - A trailing `%` divides by 100.
+/// - A leading `+` is accepted.
+/// - Internal commas are ignored (Excel: `VALUE("1,234.56") == 1234.56`).
+/// - Scientific notation is accepted via `f64::from_str`.
+/// - Empty input or unparseable input → `ParseError`.
+pub fn value(text: &str) -> Result<f64, TextError> {
+    let raw = text.trim();
+    if raw.is_empty() {
+        return Err(TextError::ParseError {
+            function: "VALUE",
+            input: text.to_string(),
+        });
+    }
+    let (body, percent) = if let Some(stripped) = raw.strip_suffix('%') {
+        (stripped.trim_end(), true)
+    } else {
+        (raw, false)
+    };
+
+    // Strip commas (thousands separators in en-US locale).
+    let cleaned: String = body.chars().filter(|c| *c != ',').collect();
+    match cleaned.parse::<f64>() {
+        Ok(n) => Ok(if percent { n / 100.0 } else { n }),
+        Err(_) => Err(TextError::ParseError {
+            function: "VALUE",
+            input: text.to_string(),
+        }),
+    }
+}
+
+/// `NUMBERVALUE(text, [decimal], [group])` — locale-aware variant of `VALUE`.
+///
+/// - `decimal` is the decimal separator char (defaults to `'.'`).
+/// - `group` is the thousands separator char (defaults to `','`).
+/// - A trailing `%` divides by 100 (and may be repeated — `NUMBERVALUE("5%%")
+///   == 0.0005`, matching Excel).
+pub fn numbervalue(
+    text: &str,
+    decimal: Option<char>,
+    group: Option<char>,
+) -> Result<f64, TextError> {
+    let dec = decimal.unwrap_or('.');
+    let grp = group.unwrap_or(',');
+    if dec == grp {
+        return Err(TextError::BadParameter {
+            name: "decimal/group",
+            value: format!("{dec}={grp}"),
+        });
+    }
+    let raw = text.trim();
+    if raw.is_empty() {
+        return Err(TextError::ParseError {
+            function: "NUMBERVALUE",
+            input: text.to_string(),
+        });
+    }
+
+    // Strip and count trailing % chars.
+    let mut percent_count = 0;
+    let mut body: String = raw.to_string();
+    while let Some(stripped) = body.strip_suffix('%') {
+        percent_count += 1;
+        body = stripped.trim_end().to_string();
+    }
+
+    // Replace group separator with nothing, decimal with '.'.
+    let mut buf = String::with_capacity(body.len());
+    for c in body.chars() {
+        if c == grp {
+            continue;
+        }
+        if c == dec {
+            buf.push('.');
+        } else {
+            buf.push(c);
+        }
+    }
+    let parsed: f64 = buf.parse().map_err(|_| TextError::ParseError {
+        function: "NUMBERVALUE",
+        input: text.to_string(),
+    })?;
+    Ok(parsed / 100f64.powi(percent_count as i32))
+}
+
+/// `FIXED(number, decimals, [no_commas])` — format `number` with exactly
+/// `decimals` fractional digits.
+///
+/// - `decimals` can be negative; that rounds to the left of the decimal point
+///   (`FIXED(12345, -2) == "12,300"`).
+/// - `no_commas == true` suppresses the thousands separator.
+pub fn fixed(number: f64, decimals: i64, no_commas: bool) -> Result<String, TextError> {
+    if decimals >= 0 {
+        Ok(format_fixed(number, decimals as usize, !no_commas))
+    } else {
+        // Round to the left of the decimal.
+        let factor = 10f64.powi(-(decimals as i32));
+        let rounded = (number / factor).round() * factor;
+        Ok(format_integer(rounded, !no_commas))
+    }
+}
+
+/// `DOLLAR(number, [decimals])` — currency string with `$` prefix and
+/// configurable fractional digits. Negative numbers use the parenthesised
+/// `($1,234.56)` accounting style, matching Excel's default en-US locale.
+pub fn dollar(number: f64, decimals: i64) -> Result<String, TextError> {
+    let body = fixed(number.abs(), decimals, false)?;
+    if number < 0.0 {
+        Ok(format!("(${body})"))
+    } else {
+        Ok(format!("${body}"))
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Vector variants.
+// ----------------------------------------------------------------------------
+
+/// Vector `VALUE`. NA in / NA out; parse errors collapse to NA.
+pub fn value_vec(x: &Character) -> Vec<Option<f64>> {
+    iter_character(x)
+        .map(|cell| cell.and_then(|s| value(s).ok()))
+        .collect()
+}
+
+// ----------------------------------------------------------------------------
+// Internal formatting helpers.
+// ----------------------------------------------------------------------------
+
+/// Insert thousands separators into the integer portion of an already-printed
+/// number. Operates on the part **before** the decimal point.
+fn add_thousands(int_part: &str) -> String {
+    let (sign, digits) = if let Some(rest) = int_part.strip_prefix('-') {
+        ("-", rest)
+    } else {
+        ("", int_part)
+    };
+    let bytes = digits.as_bytes();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3 + sign.len());
+    out.push_str(sign);
+    let n = bytes.len();
+    for (i, b) in bytes.iter().enumerate() {
+        let remaining = n - i;
+        if i > 0 && remaining % 3 == 0 {
+            out.push(',');
+        }
+        out.push(*b as char);
+    }
+    out
+}
+
+/// Format `value` rounded to integer. `commas` controls thousands separators.
+fn format_integer(value: f64, commas: bool) -> String {
+    // Half-away-from-zero rounding.
+    let rounded = value.round();
+    let s = format!("{rounded:.0}");
+    if commas {
+        add_thousands(&s)
+    } else {
+        s
+    }
+}
+
+/// Format `value` with exactly `decimals` fractional digits, rounded
+/// half-away-from-zero to match Excel's display rounding. `commas` controls
+/// thousands separators in the integer part.
+///
+/// We can't rely on Rust's `{:.N}` format because it uses round-half-to-even
+/// (banker's rounding), so e.g. `format!("{:.0}", 1234.5)` gives `"1234"`.
+/// Excel users expect `"1235"`. We therefore pre-round at the requested
+/// scale, then format with `{:.N}` to pad zeros.
+fn format_fixed(value: f64, decimals: usize, commas: bool) -> String {
+    let factor = 10f64.powi(decimals as i32);
+    // `(x * factor).round()` is half-away-from-zero in Rust (`f64::round`).
+    let rounded = (value * factor).round() / factor;
+    let s = format!("{rounded:.*}", decimals);
+    if !commas {
+        return s;
+    }
+    if let Some(dot) = s.find('.') {
+        let (head, tail) = s.split_at(dot);
+        format!("{}{}", add_thousands(head), tail)
+    } else {
+        add_thousands(&s)
+    }
+}
+
+/// Format as integer percent (e.g. 0.5 -> "50%").
+fn format_percent(value: f64) -> String {
+    let scaled = value * 100.0;
+    format!("{}%", format_integer(scaled, false))
+}
+
+/// Format as `0.00E+00` (one leading digit, two fractional, signed
+/// two-digit exponent).
+fn format_scientific(value: f64) -> String {
+    if value == 0.0 {
+        return "0.00E+00".to_string();
+    }
+    let abs = value.abs();
+    let exp = abs.log10().floor() as i32;
+    let mantissa = value / 10f64.powi(exp);
+    // Re-round in case mantissa landed at exactly 10.0 after fractional
+    // rounding (e.g. 9.999 -> "10.00"). If so, bump exponent.
+    let mantissa_str = format!("{mantissa:.2}");
+    if mantissa_str.starts_with("10") || mantissa_str.starts_with("-10") {
+        let bumped_exp = exp + 1;
+        let bumped_mantissa = value / 10f64.powi(bumped_exp);
+        return format!(
+            "{:.2}E{}{:02}",
+            bumped_mantissa,
+            if bumped_exp >= 0 { '+' } else { '-' },
+            bumped_exp.abs()
+        );
+    }
+    format!(
+        "{}E{}{:02}",
+        mantissa_str,
+        if exp >= 0 { '+' } else { '-' },
+        exp.abs()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_basic_codes() {
+        assert_eq!(text(5.0, "0").unwrap(), "5");
+        assert_eq!(text(5.4, "0").unwrap(), "5");
+        assert_eq!(text(5.6, "0").unwrap(), "6");
+        assert_eq!(text(-3.2, "0").unwrap(), "-3");
+
+        assert_eq!(text(5.0, "0.00").unwrap(), "5.00");
+        assert_eq!(text(1234.567, "0.00").unwrap(), "1234.57");
+
+        assert_eq!(text(12345.0, "#,##0").unwrap(), "12,345");
+        assert_eq!(text(12345.678, "#,##0.00").unwrap(), "12,345.68");
+        assert_eq!(text(-12345.0, "#,##0").unwrap(), "-12,345");
+        assert_eq!(text(0.0, "#,##0").unwrap(), "0");
+    }
+
+    #[test]
+    fn text_percent() {
+        assert_eq!(text(0.5, "0%").unwrap(), "50%");
+        assert_eq!(text(0.0, "0%").unwrap(), "0%");
+        assert_eq!(text(1.234, "0%").unwrap(), "123%");
+    }
+
+    #[test]
+    fn text_scientific() {
+        assert_eq!(text(12345.0, "0.00E+00").unwrap(), "1.23E+04");
+        assert_eq!(text(0.0001234, "0.00E+00").unwrap(), "1.23E-04");
+        assert_eq!(text(0.0, "0.00E+00").unwrap(), "0.00E+00");
+        assert_eq!(text(-12345.0, "0.00E+00").unwrap(), "-1.23E+04");
+    }
+
+    #[test]
+    fn text_bad_format() {
+        let e = text(1.0, "@@bad@@").unwrap_err();
+        assert!(matches!(e, TextError::FormatError { function: "TEXT", .. }));
+    }
+
+    #[test]
+    fn value_basic() {
+        assert_eq!(value("123").unwrap(), 123.0);
+        assert_eq!(value("3.14").unwrap(), 3.14);
+        assert_eq!(value("-7.5").unwrap(), -7.5);
+        assert_eq!(value("+1.5").unwrap(), 1.5);
+    }
+
+    #[test]
+    fn value_whitespace_and_commas() {
+        assert_eq!(value("   42  ").unwrap(), 42.0);
+        assert_eq!(value("1,234.56").unwrap(), 1234.56);
+    }
+
+    #[test]
+    fn value_percent() {
+        assert_eq!(value("50%").unwrap(), 0.5);
+        assert_eq!(value("100%").unwrap(), 1.0);
+    }
+
+    #[test]
+    fn value_scientific() {
+        assert_eq!(value("1.23e4").unwrap(), 12300.0);
+        assert_eq!(value("1.5E-2").unwrap(), 0.015);
+    }
+
+    #[test]
+    fn value_failures() {
+        assert!(value("").is_err());
+        assert!(value("abc").is_err());
+        assert!(value("12abc").is_err());
+    }
+
+    #[test]
+    fn numbervalue_default_is_value() {
+        assert_eq!(numbervalue("1,234.56", None, None).unwrap(), 1234.56);
+        assert_eq!(numbervalue("50%", None, None).unwrap(), 0.5);
+        // Multiple % stacks.
+        assert!((numbervalue("5%%", None, None).unwrap() - 0.0005).abs() < 1e-12);
+    }
+
+    #[test]
+    fn numbervalue_eu_locale() {
+        // German style: '.' for thousands, ',' for decimal.
+        assert_eq!(
+            numbervalue("1.234,56", Some(','), Some('.')).unwrap(),
+            1234.56
+        );
+    }
+
+    #[test]
+    fn numbervalue_same_separators_errors() {
+        assert!(numbervalue("1.234", Some('.'), Some('.')).is_err());
+    }
+
+    #[test]
+    fn fixed_basic() {
+        assert_eq!(fixed(1234.567, 2, false).unwrap(), "1,234.57");
+        assert_eq!(fixed(1234.567, 2, true).unwrap(), "1234.57");
+        // `decimals == 0` uses `format_integer`, which calls `f64::round`
+        // (half-away-from-zero), so 1234.5 -> "1,235".
+        assert_eq!(fixed(1234.5, 0, false).unwrap(), "1,235");
+        // 1234.6 unambiguous up-round.
+        assert_eq!(fixed(1234.6, 0, false).unwrap(), "1,235");
+    }
+
+    #[test]
+    fn fixed_negative_decimals() {
+        assert_eq!(fixed(12345.0, -2, false).unwrap(), "12,300");
+        assert_eq!(fixed(12345.0, -2, true).unwrap(), "12300");
+    }
+
+    #[test]
+    fn dollar_basic() {
+        assert_eq!(dollar(1234.5, 2).unwrap(), "$1,234.50");
+        assert_eq!(dollar(0.0, 2).unwrap(), "$0.00");
+        assert_eq!(dollar(-1234.5, 2).unwrap(), "($1,234.50)");
+        assert_eq!(dollar(99.0, 0).unwrap(), "$99");
+    }
+
+    #[test]
+    fn value_vec_propagates_na() {
+        let x = Character::from_options(vec![Some("12".into()), None, Some("nope".into())]);
+        assert_eq!(value_vec(&x), vec![Some(12.0), None, None]);
+    }
+}

--- a/code/packages/rust/text-core/src/extract.rs
+++ b/code/packages/rust/text-core/src/extract.rs
@@ -1,0 +1,204 @@
+//! LEFT / RIGHT / MID — substring extraction.
+//!
+//! All three operate on **Unicode scalar values** (Rust `char`s), not bytes.
+//! Positions are **1-based** to match the Excel / VisiCalc API.
+//!
+//! | function          | semantics                                          |
+//! |-------------------|----------------------------------------------------|
+//! | `LEFT(s, n)`      | first `n` chars; if `n > len(s)`, returns `s`      |
+//! | `RIGHT(s, n)`     | last `n` chars; if `n > len(s)`, returns `s`       |
+//! | `MID(s, p, n)`    | `n` chars starting at 1-based position `p`         |
+//!
+//! Edge cases (Excel parity):
+//!
+//! - `LEFT("abc", 0) == ""`; `RIGHT("abc", 0) == ""`.
+//! - `LEFT("abc", -1)` → `TextError::BadParameter` (Excel `#VALUE!`).
+//! - `MID("abc", 0, ...)` → `BadParameter`. Excel disallows `start_num < 1`.
+//! - `MID("abc", 5, 2) == ""` — start past end yields empty.
+//! - `MID("abc", 2, 10) == "bc"` — length clamps to what's available.
+
+use crate::{iter_character, TextError};
+use r_vector::Character;
+
+/// `LEFT(text, n)` — first `n` characters (Unicode scalars).
+///
+/// Returns `BadParameter` if `n < 0`.
+pub fn left(s: &str, n: i64) -> Result<String, TextError> {
+    if n < 0 {
+        return Err(TextError::BadParameter {
+            name: "num_chars",
+            value: n.to_string(),
+        });
+    }
+    Ok(s.chars().take(n as usize).collect())
+}
+
+/// `RIGHT(text, n)` — last `n` characters (Unicode scalars).
+///
+/// Returns `BadParameter` if `n < 0`.
+pub fn right(s: &str, n: i64) -> Result<String, TextError> {
+    if n < 0 {
+        return Err(TextError::BadParameter {
+            name: "num_chars",
+            value: n.to_string(),
+        });
+    }
+    let n = n as usize;
+    let total = s.chars().count();
+    if n >= total {
+        return Ok(s.to_string());
+    }
+    // Skip total - n chars from the front.
+    Ok(s.chars().skip(total - n).collect())
+}
+
+/// `MID(text, start, length)` — `length` characters starting at 1-based
+/// `start`.
+///
+/// - `start < 1` → `BadParameter`
+/// - `length < 0` → `BadParameter`
+/// - `start > len(s)` → empty string
+/// - `length` longer than remaining chars → clamps
+pub fn mid(s: &str, start: i64, length: i64) -> Result<String, TextError> {
+    if start < 1 {
+        return Err(TextError::BadParameter {
+            name: "start_num",
+            value: start.to_string(),
+        });
+    }
+    if length < 0 {
+        return Err(TextError::BadParameter {
+            name: "num_chars",
+            value: length.to_string(),
+        });
+    }
+    let start0 = (start - 1) as usize;
+    Ok(s.chars().skip(start0).take(length as usize).collect())
+}
+
+/// Vector `LEFT`. NA in / NA out; errors collapse to NA.
+pub fn left_vec(x: &Character, n: i64) -> Character {
+    let out: Vec<Option<String>> = iter_character(x)
+        .map(|cell| cell.and_then(|s| left(s, n).ok()))
+        .collect();
+    Character::from_options(out)
+}
+
+/// Vector `RIGHT`. NA in / NA out; errors collapse to NA.
+pub fn right_vec(x: &Character, n: i64) -> Character {
+    let out: Vec<Option<String>> = iter_character(x)
+        .map(|cell| cell.and_then(|s| right(s, n).ok()))
+        .collect();
+    Character::from_options(out)
+}
+
+/// Vector `MID`. NA in / NA out; errors collapse to NA.
+pub fn mid_vec(x: &Character, start: i64, length: i64) -> Character {
+    let out: Vec<Option<String>> = iter_character(x)
+        .map(|cell| cell.and_then(|s| mid(s, start, length).ok()))
+        .collect();
+    Character::from_options(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use r_vector::Vector;
+
+    #[test]
+    fn left_basic() {
+        assert_eq!(left("hello", 3).unwrap(), "hel");
+        assert_eq!(left("hello", 0).unwrap(), "");
+        assert_eq!(left("hello", 99).unwrap(), "hello");
+        assert_eq!(left("", 3).unwrap(), "");
+    }
+
+    #[test]
+    fn left_unicode() {
+        assert_eq!(left("héllo", 2).unwrap(), "hé");
+        assert_eq!(left("漢字日本", 2).unwrap(), "漢字");
+        assert_eq!(left("🙂🎉a", 2).unwrap(), "🙂🎉");
+    }
+
+    #[test]
+    fn left_negative_errors() {
+        let e = left("hi", -1).unwrap_err();
+        assert!(matches!(e, TextError::BadParameter { name: "num_chars", .. }));
+    }
+
+    #[test]
+    fn right_basic() {
+        assert_eq!(right("hello", 3).unwrap(), "llo");
+        assert_eq!(right("hello", 0).unwrap(), "");
+        assert_eq!(right("hello", 99).unwrap(), "hello");
+    }
+
+    #[test]
+    fn right_unicode() {
+        assert_eq!(right("héllo", 3).unwrap(), "llo");
+        assert_eq!(right("漢字日本", 2).unwrap(), "日本");
+    }
+
+    #[test]
+    fn right_negative_errors() {
+        assert!(right("hi", -1).is_err());
+    }
+
+    #[test]
+    fn mid_basic() {
+        assert_eq!(mid("hello", 1, 3).unwrap(), "hel");
+        assert_eq!(mid("hello", 2, 3).unwrap(), "ell");
+        assert_eq!(mid("hello", 5, 1).unwrap(), "o");
+        // start past end
+        assert_eq!(mid("hello", 100, 3).unwrap(), "");
+        // length past end clamps
+        assert_eq!(mid("hello", 3, 100).unwrap(), "llo");
+        // zero length
+        assert_eq!(mid("hello", 3, 0).unwrap(), "");
+    }
+
+    #[test]
+    fn mid_unicode() {
+        assert_eq!(mid("漢字日本", 2, 2).unwrap(), "字日");
+        assert_eq!(mid("a🙂b", 2, 1).unwrap(), "🙂");
+    }
+
+    #[test]
+    fn mid_bad_start() {
+        assert!(mid("hi", 0, 1).is_err());
+        assert!(mid("hi", -3, 1).is_err());
+    }
+
+    #[test]
+    fn mid_bad_length() {
+        assert!(mid("hi", 1, -1).is_err());
+    }
+
+    #[test]
+    fn vec_variants_propagate_na() {
+        let x = Character::from_options(vec![
+            Some("hello".into()),
+            None,
+            Some("漢字".into()),
+        ]);
+        let got = left_vec(&x, 2);
+        assert_eq!(got.get(0), Some(&Some("he".into())));
+        assert_eq!(got.get(1), Some(&None));
+        assert_eq!(got.get(2), Some(&Some("漢字".into())));
+
+        let got = right_vec(&x, 2);
+        assert_eq!(got.get(0), Some(&Some("lo".into())));
+        assert!(got.is_na(1));
+
+        let got = mid_vec(&x, 2, 2);
+        assert_eq!(got.get(0), Some(&Some("el".into())));
+        assert!(got.is_na(1));
+    }
+
+    #[test]
+    fn vec_variants_collapse_errors_to_na() {
+        let x = Character::from_strings(["hi"]);
+        let got = left_vec(&x, -1);
+        assert!(got.is_na(0));
+    }
+}

--- a/code/packages/rust/text-core/src/find.rs
+++ b/code/packages/rust/text-core/src/find.rs
@@ -1,0 +1,274 @@
+//! FIND / SEARCH — substring lookup.
+//!
+//! Both functions return a 1-based *character* (not byte) position. They
+//! differ in:
+//!
+//! | feature             | FIND          | SEARCH                 |
+//! |---------------------|---------------|------------------------|
+//! | case-sensitive      | yes           | no                     |
+//! | wildcards (`*` `?`) | no            | yes                    |
+//!
+//! Both return `TextError::NotFound` (Excel `#VALUE!`) if the needle is
+//! absent from the haystack starting at `start`.
+//!
+//! ## Wildcard glob matcher
+//!
+//! SEARCH's wildcards are *not* regex. They are:
+//!
+//! - `?` matches exactly one character (any character).
+//! - `*` matches zero or more characters (any characters).
+//! - Everything else matches itself (case-insensitively).
+//!
+//! No anchoring, no character classes, no escapes. Hand-rolled matcher with
+//! backtracking on `*`. Returns the *char index* at which the match begins.
+
+use crate::{iter_character, TextError};
+use r_vector::Character;
+
+/// `FIND(needle, haystack, [start])` — case-sensitive, no wildcards.
+///
+/// `start` is 1-based; defaults to 1. Returns the 1-based char position of
+/// the first match, or `NotFound` if absent.
+pub fn find(needle: &str, haystack: &str, start: Option<usize>) -> Result<usize, TextError> {
+    let start = start.unwrap_or(1);
+    if start < 1 {
+        return Err(TextError::BadParameter {
+            name: "start_num",
+            value: start.to_string(),
+        });
+    }
+    let start0 = start - 1;
+    let hay: Vec<char> = haystack.chars().collect();
+    if start0 > hay.len() {
+        return Err(TextError::NotFound {
+            function: "FIND",
+            needle: needle.to_string(),
+        });
+    }
+    let needle_chars: Vec<char> = needle.chars().collect();
+    if needle_chars.is_empty() {
+        // Excel: FIND("", ...) returns start.
+        return Ok(start);
+    }
+    for i in start0..=hay.len().saturating_sub(needle_chars.len()) {
+        if hay[i..i + needle_chars.len()] == needle_chars[..] {
+            return Ok(i + 1);
+        }
+    }
+    Err(TextError::NotFound {
+        function: "FIND",
+        needle: needle.to_string(),
+    })
+}
+
+/// `SEARCH(needle, haystack, [start])` — case-insensitive; `*` and `?`
+/// wildcards. Returns 1-based char position of the first match.
+pub fn search(needle: &str, haystack: &str, start: Option<usize>) -> Result<usize, TextError> {
+    let start = start.unwrap_or(1);
+    if start < 1 {
+        return Err(TextError::BadParameter {
+            name: "start_num",
+            value: start.to_string(),
+        });
+    }
+    let start0 = start - 1;
+    // Case-fold haystack and needle to lowercase for comparison.
+    let hay: Vec<char> = haystack.to_lowercase().chars().collect();
+    let pat: Vec<char> = needle.to_lowercase().chars().collect();
+
+    if pat.is_empty() {
+        return Ok(start);
+    }
+    if start0 > hay.len() {
+        return Err(TextError::NotFound {
+            function: "SEARCH",
+            needle: needle.to_string(),
+        });
+    }
+    for i in start0..=hay.len() {
+        if glob_match_at(&pat, &hay, i) {
+            return Ok(i + 1);
+        }
+    }
+    Err(TextError::NotFound {
+        function: "SEARCH",
+        needle: needle.to_string(),
+    })
+}
+
+/// Glob matcher. Returns true iff `pat` matches a prefix of `hay[start..]`
+/// (or all of `hay[start..]` if the pattern ends without `*`). Supports `?`
+/// (any one char) and `*` (any zero or more chars). Both `pat` and `hay`
+/// are pre-lowercased.
+///
+/// We implement the classic two-pointer algorithm with a single backtrack
+/// point: when `*` is encountered, remember the position in pattern and the
+/// current position in the haystack; on mismatch later, rewind pattern to
+/// just after the `*` and advance the haystack by one.
+fn glob_match_at(pat: &[char], hay: &[char], start: usize) -> bool {
+    let mut h = start;
+    let mut p = 0usize;
+    let mut star_p: Option<usize> = None;
+    let mut star_h: usize = 0;
+
+    while h <= hay.len() {
+        if p < pat.len() && pat[p] == '*' {
+            // Record backtrack point and advance past the `*`.
+            star_p = Some(p);
+            star_h = h;
+            p += 1;
+        } else if p < pat.len()
+            && h < hay.len()
+            && (pat[p] == '?' || pat[p] == hay[h])
+        {
+            p += 1;
+            h += 1;
+        } else if let Some(sp) = star_p {
+            // Mismatch (or pattern exhausted but hay isn't): try matching
+            // one more char with the last `*`.
+            p = sp + 1;
+            star_h += 1;
+            h = star_h;
+            if h > hay.len() {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        // Once the pattern is exhausted, we've matched whatever the haystack
+        // consumed: a search "starts at i" is satisfied as long as the
+        // pattern is fully consumed, regardless of remaining haystack chars.
+        if p == pat.len() {
+            return true;
+        }
+    }
+    // p == pat.len() handled inside loop. Reaching here means we ran out of
+    // haystack with pattern unfinished.
+    false
+}
+
+/// Vector `FIND`. NA in / NA out; not-found collapses to NA.
+pub fn find_vec(needle: &str, haystacks: &Character, start: Option<usize>) -> Vec<Option<usize>> {
+    iter_character(haystacks)
+        .map(|cell| cell.and_then(|s| find(needle, s, start).ok()))
+        .collect()
+}
+
+/// Vector `SEARCH`. NA in / NA out; not-found collapses to NA.
+pub fn search_vec(needle: &str, haystacks: &Character, start: Option<usize>) -> Vec<Option<usize>> {
+    iter_character(haystacks)
+        .map(|cell| cell.and_then(|s| search(needle, s, start).ok()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_basic() {
+        assert_eq!(find("world", "hello world", None).unwrap(), 7);
+        assert_eq!(find("h", "hello", None).unwrap(), 1);
+        assert_eq!(find("o", "hello world", None).unwrap(), 5);
+    }
+
+    #[test]
+    fn find_is_case_sensitive() {
+        assert!(find("WORLD", "hello world", None).is_err());
+    }
+
+    #[test]
+    fn find_with_start() {
+        // Skip the first "o"
+        assert_eq!(find("o", "hello world", Some(6)).unwrap(), 8);
+    }
+
+    #[test]
+    fn find_not_found() {
+        let e = find("xyz", "hello", None).unwrap_err();
+        assert!(matches!(e, TextError::NotFound { function: "FIND", .. }));
+    }
+
+    #[test]
+    fn find_empty_needle() {
+        assert_eq!(find("", "hello", None).unwrap(), 1);
+        assert_eq!(find("", "hello", Some(3)).unwrap(), 3);
+    }
+
+    #[test]
+    fn find_unicode_1based_chars() {
+        // "漢" at char position 1, "字" at 2. FIND must NOT report byte
+        // offsets.
+        assert_eq!(find("字", "漢字日本", None).unwrap(), 2);
+        assert_eq!(find("日本", "漢字日本", None).unwrap(), 3);
+    }
+
+    #[test]
+    fn search_is_case_insensitive() {
+        assert_eq!(search("WORLD", "hello world", None).unwrap(), 7);
+        assert_eq!(search("HeLLo", "hello world", None).unwrap(), 1);
+    }
+
+    #[test]
+    fn search_wildcard_question() {
+        // ? matches exactly one char
+        assert_eq!(search("h?llo", "hello", None).unwrap(), 1);
+        assert_eq!(search("h?l", "well hello", None).unwrap(), 6);
+        assert!(search("h??llo", "hello", None).is_err()); // too many ?
+    }
+
+    #[test]
+    fn search_wildcard_star() {
+        // * matches zero or more
+        assert_eq!(search("h*o", "hello", None).unwrap(), 1);
+        assert_eq!(search("h*o", "ho", None).unwrap(), 1);
+        assert_eq!(search("*world", "hello world", None).unwrap(), 1);
+        assert_eq!(search("hello*", "hello world", None).unwrap(), 1);
+    }
+
+    #[test]
+    fn search_combined_wildcards() {
+        assert_eq!(search("h?l*o", "hello world", None).unwrap(), 1);
+        assert_eq!(search("?or*", "hello world", None).unwrap(), 7);
+    }
+
+    #[test]
+    fn search_not_found() {
+        assert!(search("xyz*", "hello", None).is_err());
+    }
+
+    #[test]
+    fn search_with_start() {
+        // Two "hellos"; second one starts at char position 7 (counting space).
+        assert_eq!(search("hello", "hello hello", Some(3)).unwrap(), 7);
+    }
+
+    #[test]
+    fn search_unicode() {
+        assert_eq!(search("字", "漢字日本", None).unwrap(), 2);
+    }
+
+    #[test]
+    fn find_vec_propagates_na_and_misses() {
+        let hay = Character::from_options(vec![
+            Some("hello world".into()),
+            None,
+            Some("foo".into()),
+        ]);
+        let got = find_vec("o", &hay, None);
+        assert_eq!(got, vec![Some(5), None, Some(2)]);
+    }
+
+    #[test]
+    fn search_vec_propagates_na() {
+        let hay = Character::from_options(vec![Some("Hello".into()), None]);
+        let got = search_vec("h*o", &hay, None);
+        assert_eq!(got, vec![Some(1), None]);
+    }
+
+    #[test]
+    fn find_start_past_end_is_not_found() {
+        assert!(find("x", "abc", Some(100)).is_err());
+    }
+}

--- a/code/packages/rust/text-core/src/length.rs
+++ b/code/packages/rust/text-core/src/length.rs
@@ -1,0 +1,91 @@
+//! LEN / LENB — string length.
+//!
+//! - `LEN` returns the number of Unicode scalar values (Rust `char`s).
+//! - `LENB` returns the number of UTF-8 bytes.
+//!
+//! In Excel on a Latin-1 build, LEN and LENB are equivalent. On a DBCS build,
+//! `LENB("é")` is 1 and `LENB("漢")` is 2. We model the latter behaviour using
+//! UTF-8 byte counts, which is the modern equivalent and matches the open
+//! spreadsheet (e.g. LibreOffice) convention.
+//!
+//! ```text
+//! len("hello")  == 5
+//! len("héllo")  == 5   (5 scalar values)
+//! lenb("héllo") == 6   (the 'é' is 2 UTF-8 bytes)
+//! len("漢字")   == 2
+//! lenb("漢字")  == 6   (each CJK ideograph is 3 UTF-8 bytes)
+//! ```
+
+use crate::iter_character;
+use r_vector::Character;
+
+/// `LEN(text)` — number of Unicode scalar values.
+pub fn len(s: &str) -> usize {
+    s.chars().count()
+}
+
+/// `LENB(text)` — number of bytes in the UTF-8 encoding.
+pub fn lenb(s: &str) -> usize {
+    s.len()
+}
+
+/// Vector `LEN` over a `Character`. NA propagates: an NA element produces an
+/// NA-coded length value here represented as `None`.
+///
+/// The output is a parallel `Vec<Option<usize>>` rather than a `Double`
+/// because keeping the integer flavour avoids forcing a numeric crate
+/// dependency on the caller side. The bridge layer can convert this to
+/// whichever spreadsheet-numeric vector its frontend wants.
+pub fn len_vec(x: &Character) -> Vec<Option<usize>> {
+    iter_character(x).map(|cell| cell.map(len)).collect()
+}
+
+/// Vector `LENB`. NA propagates.
+pub fn lenb_vec(x: &Character) -> Vec<Option<usize>> {
+    iter_character(x).map(|cell| cell.map(lenb)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn len_counts_ascii() {
+        assert_eq!(len("hello"), 5);
+        assert_eq!(len(""), 0);
+        assert_eq!(len("a"), 1);
+    }
+
+    #[test]
+    fn len_counts_scalars_not_bytes() {
+        assert_eq!(len("héllo"), 5);
+        assert_eq!(len("漢字"), 2);
+        // emoji is one scalar value
+        assert_eq!(len("🙂"), 1);
+    }
+
+    #[test]
+    fn lenb_counts_bytes() {
+        assert_eq!(lenb("hello"), 5);
+        assert_eq!(lenb("héllo"), 6);
+        assert_eq!(lenb("漢字"), 6);
+        assert_eq!(lenb("🙂"), 4);
+    }
+
+    #[test]
+    fn len_vec_propagates_na() {
+        let x = Character::from_options(vec![
+            Some("hi".into()),
+            None,
+            Some("".into()),
+            Some("漢".into()),
+        ]);
+        assert_eq!(len_vec(&x), vec![Some(2), None, Some(0), Some(1)]);
+    }
+
+    #[test]
+    fn lenb_vec_propagates_na() {
+        let x = Character::from_options(vec![Some("a".into()), None, Some("é".into())]);
+        assert_eq!(lenb_vec(&x), vec![Some(1), None, Some(2)]);
+    }
+}

--- a/code/packages/rust/text-core/src/lib.rs
+++ b/code/packages/rust/text-core/src/lib.rs
@@ -1,0 +1,131 @@
+//! Text Core
+//!
+//! Phase 1 implementation of `code/specs/backend-crate-catalog.md`'s
+//! `text-core` Layer-1 crate: a pure-Rust, no-I/O, WASM-compatible library of
+//! Excel / Lotus 1-2-3 / R string functions used by any spreadsheet or
+//! text-processing frontend (VisiCalc, Multiplan, modern reconstruction,
+//! Macsyma, Twig, etc).
+//!
+//! # Design notes
+//!
+//! ## Positions are 1-based
+//!
+//! Excel and VisiCalc both use 1-based string indexing: `MID("hello", 1, 3)`
+//! is `"hel"`, not `"ell"`. Functions in this crate translate to Rust's
+//! 0-based world at the boundary so the *public* API matches the spreadsheet
+//! semantics that calling code expects.
+//!
+//! ## Unicode handling
+//!
+//! - `LEN`, `LEFT`, `RIGHT`, `MID` count **Unicode scalar values** (Rust
+//!   `char`s). This matches modern Excel.
+//! - `LENB` counts UTF-8 bytes.
+//! - `UPPER` / `LOWER` use Rust's default case-folding (which is Unicode-aware
+//!   and may produce multi-char outputs, e.g. `"ß".to_uppercase() == "SS"`).
+//! - `PROPER` segments words using `char::is_alphabetic`; everything else is a
+//!   word-break.
+//!
+//! ## NA propagation
+//!
+//! Each function exposes two variants where vector inputs matter:
+//!
+//! - `foo(s: &str, ...) -> Result<..., TextError>` — the scalar form.
+//! - `foo_vec(x: &Character, ...) -> Character` — vector form that propagates
+//!   NA element-wise. An NA input produces an NA output. Errors on a single
+//!   element are rendered as NA in the vector form (the scalar form is the
+//!   place to surface `#VALUE!`).
+//!
+//! ## No regex, no external crates
+//!
+//! `numeric-tower` and `r-vector` are the only dependencies. The SEARCH
+//! wildcard matcher is hand-rolled (~30 lines, no captures).
+
+pub mod case;
+pub mod chars;
+pub mod compare;
+pub mod concat;
+pub mod convert;
+pub mod extract;
+pub mod find;
+pub mod length;
+pub mod predicates;
+pub mod repeat;
+pub mod split;
+pub mod substitute;
+pub mod trim;
+
+pub use numeric_tower::Number;
+pub use r_vector::{Character, Vector};
+
+/// Errors produced by `text-core` functions.
+///
+/// These map onto Excel's `#VALUE!`, `#NUM!`, and `#N/A` conditions. The
+/// bridge layer that wraps this crate for a particular frontend is responsible
+/// for translating `TextError` into the right cell error.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TextError {
+    /// A parameter was outside its legal domain (e.g. `LEFT(s, -1)`,
+    /// `MID(s, 0, ...)`). Equivalent to Excel `#VALUE!`.
+    BadParameter {
+        name: &'static str,
+        value: String,
+    },
+    /// A substring lookup that the caller requested to be strict (e.g.
+    /// `FIND`) failed to find its needle. Equivalent to Excel `#VALUE!`.
+    NotFound {
+        function: &'static str,
+        needle: String,
+    },
+    /// A string failed to parse as the requested numeric / typed value.
+    /// Equivalent to Excel `#VALUE!`.
+    ParseError {
+        function: &'static str,
+        input: String,
+    },
+    /// A format code was not recognised or was malformed.
+    /// Equivalent to Excel `#VALUE!`.
+    FormatError {
+        function: &'static str,
+        format: String,
+    },
+}
+
+impl std::fmt::Display for TextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TextError::BadParameter { name, value } => {
+                write!(f, "bad parameter {name}={value}")
+            }
+            TextError::NotFound { function, needle } => {
+                write!(f, "{function}: could not find {needle:?}")
+            }
+            TextError::ParseError { function, input } => {
+                write!(f, "{function}: cannot parse {input:?}")
+            }
+            TextError::FormatError { function, format } => {
+                write!(f, "{function}: bad format code {format:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TextError {}
+
+// ----------------------------------------------------------------------------
+// Helpers shared across modules.
+// ----------------------------------------------------------------------------
+
+/// Iterate the elements of a `Character` vector as `Option<&str>`.
+///
+/// This is the canonical access pattern: NA is `None`, present strings are
+/// `Some(&str)`. We do not expose this in `r-vector` itself because the public
+/// vector contract there returns `Option<&Element>` (the outer option being
+/// "in-range vs out-of-range"), so callers need a small adapter to flatten
+/// that into the NA-aware view we want here.
+pub(crate) fn iter_character(x: &Character) -> impl Iterator<Item = Option<&str>> + '_ {
+    (0..x.len()).map(move |i| match x.get(i) {
+        Some(Some(s)) => Some(s.as_str()),
+        _ => None,
+    })
+}
+

--- a/code/packages/rust/text-core/src/predicates.rs
+++ b/code/packages/rust/text-core/src/predicates.rs
@@ -1,0 +1,45 @@
+//! T / N — type predicates.
+//!
+//! These are tiny Excel adapters. In a spreadsheet:
+//!
+//! - `T(value)` returns the value unchanged if it's text, else `""`.
+//! - `N(value)` returns the value unchanged if it's a number, else `0`.
+//!
+//! In Rust, the cell's *type* is encoded by which function the bridge layer
+//! calls. We implement two thin helpers:
+//!
+//! - `t_text(Some("hi")) == "hi"`; `t_text(None) == ""`.
+//! - `n_number(Some(3.14)) == 3.14`; `n_number(None) == 0.0`.
+//!
+//! These look trivial in isolation but the bridge needs canonical names so
+//! that `=T(A1)` and `=N(A1)` always reach the same implementation.
+
+/// `T(value)`. Returns the text if present, empty string if not.
+pub fn t_text(value: Option<&str>) -> String {
+    value.unwrap_or("").to_string()
+}
+
+/// `N(value)`. Returns the number if present, `0.0` if not.
+pub fn n_number(value: Option<f64>) -> f64 {
+    value.unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn t_basic() {
+        assert_eq!(t_text(Some("hello")), "hello");
+        assert_eq!(t_text(None), "");
+        assert_eq!(t_text(Some("")), "");
+    }
+
+    #[test]
+    fn n_basic() {
+        assert_eq!(n_number(Some(3.14)), 3.14);
+        assert_eq!(n_number(None), 0.0);
+        assert_eq!(n_number(Some(0.0)), 0.0);
+        assert_eq!(n_number(Some(-7.0)), -7.0);
+    }
+}

--- a/code/packages/rust/text-core/src/repeat.rs
+++ b/code/packages/rust/text-core/src/repeat.rs
@@ -1,0 +1,88 @@
+//! REPT — string repetition.
+//!
+//! `REPT(text, count)` repeats `text` `count` times. `count == 0` returns an
+//! empty string; negative `count` is `BadParameter`. Excel additionally caps
+//! the total output length at 32,767 characters; we enforce the same cap
+//! since spreadsheets that consume our output expect it. Larger requests
+//! return `BadParameter`.
+
+use crate::{iter_character, TextError};
+use r_vector::Character;
+
+/// Excel's cell-content length cap. Used as the REPT output ceiling.
+pub const REPT_MAX_LEN: usize = 32_767;
+
+/// `REPT(text, count)`.
+pub fn rept(text: &str, count: i64) -> Result<String, TextError> {
+    if count < 0 {
+        return Err(TextError::BadParameter {
+            name: "number_times",
+            value: count.to_string(),
+        });
+    }
+    let count = count as usize;
+    // Compute final size in *chars* for the cap. (Excel uses chars, not bytes.)
+    let unit_chars = text.chars().count();
+    let total_chars = unit_chars.saturating_mul(count);
+    if total_chars > REPT_MAX_LEN {
+        return Err(TextError::BadParameter {
+            name: "number_times",
+            value: format!("would exceed {REPT_MAX_LEN} chars"),
+        });
+    }
+    Ok(text.repeat(count))
+}
+
+/// Vector `REPT`. NA in / NA out; errors collapse to NA.
+pub fn rept_vec(x: &Character, count: i64) -> Character {
+    let out: Vec<Option<String>> = iter_character(x)
+        .map(|cell| cell.and_then(|s| rept(s, count).ok()))
+        .collect();
+    Character::from_options(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use r_vector::Vector;
+
+    #[test]
+    fn rept_basic() {
+        assert_eq!(rept("ab", 3).unwrap(), "ababab");
+        assert_eq!(rept("x", 0).unwrap(), "");
+        assert_eq!(rept("", 5).unwrap(), "");
+    }
+
+    #[test]
+    fn rept_unicode() {
+        assert_eq!(rept("漢", 3).unwrap(), "漢漢漢");
+        assert_eq!(rept("🙂", 2).unwrap(), "🙂🙂");
+    }
+
+    #[test]
+    fn rept_negative_errors() {
+        assert!(rept("a", -1).is_err());
+    }
+
+    #[test]
+    fn rept_overflow_cap() {
+        // 100 chars * 1000 = 100,000 > REPT_MAX_LEN
+        let s = "x".repeat(100);
+        assert!(rept(&s, 1000).is_err());
+    }
+
+    #[test]
+    fn rept_vec_propagates_na() {
+        let x = Character::from_options(vec![Some("a".into()), None]);
+        let r = rept_vec(&x, 3);
+        assert_eq!(r.get(0), Some(&Some("aaa".into())));
+        assert!(r.is_na(1));
+    }
+
+    #[test]
+    fn rept_vec_collapses_errors_to_na() {
+        let x = Character::from_strings(["a"]);
+        let r = rept_vec(&x, -1);
+        assert!(r.is_na(0));
+    }
+}

--- a/code/packages/rust/text-core/src/split.rs
+++ b/code/packages/rust/text-core/src/split.rs
@@ -1,0 +1,226 @@
+//! TEXTSPLIT / TEXTBEFORE / TEXTAFTER — text segmentation.
+//!
+//! These mirror Excel 365's split family:
+//!
+//! - `TEXTSPLIT(text, col_delim)` — split into substrings on each occurrence
+//!   of `col_delim`. (We expose the column-split flavour only; row-splitting
+//!   is the caller's job since we don't model 2-D shapes here.)
+//! - `TEXTBEFORE(text, delim, [instance])` — substring before the `instance`-th
+//!   occurrence of `delim`. Instance defaults to 1. Negative instance counts
+//!   from the right (Excel parity).
+//! - `TEXTAFTER(text, delim, [instance])` — substring after the `instance`-th
+//!   occurrence.
+//!
+//! If `delim` is empty, all three return `BadParameter`. If the requested
+//! `instance` doesn't exist, `TEXTBEFORE` / `TEXTAFTER` return `NotFound`.
+
+use crate::TextError;
+use r_vector::Character;
+
+/// `TEXTSPLIT(text, delim)`. Splits on every occurrence of `delim`. Empty
+/// `delim` yields `BadParameter`.
+pub fn textsplit(text: &str, delim: &str) -> Result<Character, TextError> {
+    if delim.is_empty() {
+        return Err(TextError::BadParameter {
+            name: "delimiter",
+            value: String::new(),
+        });
+    }
+    let pieces: Vec<Option<String>> = text.split(delim).map(|p| Some(p.to_string())).collect();
+    Ok(Character::from_options(pieces))
+}
+
+/// `TEXTBEFORE(text, delim, [instance])`.
+///
+/// `instance` is 1-based. A negative `instance` counts from the right
+/// (e.g. -1 means the last occurrence). `instance == 0` is `BadParameter`.
+pub fn textbefore(text: &str, delim: &str, instance: i64) -> Result<String, TextError> {
+    if delim.is_empty() {
+        return Err(TextError::BadParameter {
+            name: "delimiter",
+            value: String::new(),
+        });
+    }
+    if instance == 0 {
+        return Err(TextError::BadParameter {
+            name: "instance_num",
+            value: "0".to_string(),
+        });
+    }
+    let positions = find_all(text, delim);
+    if positions.is_empty() {
+        return Err(TextError::NotFound {
+            function: "TEXTBEFORE",
+            needle: delim.to_string(),
+        });
+    }
+    let idx = resolve_instance(instance, positions.len())?;
+    let cut = positions[idx];
+    Ok(text[..cut].to_string())
+}
+
+/// `TEXTAFTER(text, delim, [instance])`. See `textbefore` for instance
+/// semantics.
+pub fn textafter(text: &str, delim: &str, instance: i64) -> Result<String, TextError> {
+    if delim.is_empty() {
+        return Err(TextError::BadParameter {
+            name: "delimiter",
+            value: String::new(),
+        });
+    }
+    if instance == 0 {
+        return Err(TextError::BadParameter {
+            name: "instance_num",
+            value: "0".to_string(),
+        });
+    }
+    let positions = find_all(text, delim);
+    if positions.is_empty() {
+        return Err(TextError::NotFound {
+            function: "TEXTAFTER",
+            needle: delim.to_string(),
+        });
+    }
+    let idx = resolve_instance(instance, positions.len())?;
+    let cut = positions[idx] + delim.len();
+    Ok(text[cut..].to_string())
+}
+
+/// Return the byte offsets of every non-overlapping occurrence of `needle`
+/// in `haystack`.
+fn find_all(haystack: &str, needle: &str) -> Vec<usize> {
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while let Some(rel) = haystack[i..].find(needle) {
+        let abs = i + rel;
+        out.push(abs);
+        i = abs + needle.len();
+    }
+    out
+}
+
+/// Translate a 1-based `instance` (possibly negative) into a 0-based index
+/// into a list of `total` positions.
+fn resolve_instance(instance: i64, total: usize) -> Result<usize, TextError> {
+    if instance > 0 {
+        let idx = (instance - 1) as usize;
+        if idx >= total {
+            return Err(TextError::NotFound {
+                function: "TEXTBEFORE/AFTER",
+                needle: format!("instance {instance}"),
+            });
+        }
+        Ok(idx)
+    } else {
+        // -1 = last, -2 = second-to-last, ...
+        let from_end = (-instance) as usize;
+        if from_end > total {
+            return Err(TextError::NotFound {
+                function: "TEXTBEFORE/AFTER",
+                needle: format!("instance {instance}"),
+            });
+        }
+        Ok(total - from_end)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use r_vector::Vector;
+
+    #[test]
+    fn textsplit_basic() {
+        let parts = textsplit("a,b,c", ",").unwrap();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts.get(0), Some(&Some("a".into())));
+        assert_eq!(parts.get(1), Some(&Some("b".into())));
+        assert_eq!(parts.get(2), Some(&Some("c".into())));
+    }
+
+    #[test]
+    fn textsplit_keeps_empty_segments() {
+        let parts = textsplit("a,,b", ",").unwrap();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts.get(1), Some(&Some("".into())));
+    }
+
+    #[test]
+    fn textsplit_multichar_delim() {
+        let parts = textsplit("aXXbXXc", "XX").unwrap();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts.get(1), Some(&Some("b".into())));
+    }
+
+    #[test]
+    fn textsplit_no_match() {
+        // No delim found: returns the whole string as a single element.
+        let parts = textsplit("hello", ",").unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts.get(0), Some(&Some("hello".into())));
+    }
+
+    #[test]
+    fn textsplit_empty_delim_errors() {
+        assert!(textsplit("abc", "").is_err());
+    }
+
+    #[test]
+    fn textbefore_positive_instance() {
+        assert_eq!(textbefore("a-b-c-d", "-", 1).unwrap(), "a");
+        assert_eq!(textbefore("a-b-c-d", "-", 2).unwrap(), "a-b");
+        assert_eq!(textbefore("a-b-c-d", "-", 3).unwrap(), "a-b-c");
+    }
+
+    #[test]
+    fn textbefore_negative_instance() {
+        // -1 == last delim
+        assert_eq!(textbefore("a-b-c-d", "-", -1).unwrap(), "a-b-c");
+        assert_eq!(textbefore("a-b-c-d", "-", -2).unwrap(), "a-b");
+    }
+
+    #[test]
+    fn textbefore_missing() {
+        assert!(textbefore("abc", "-", 1).is_err());
+        assert!(textbefore("a-b", "-", 5).is_err());
+        assert!(textbefore("a-b", "-", -5).is_err());
+    }
+
+    #[test]
+    fn textbefore_instance_zero_errors() {
+        assert!(textbefore("a-b", "-", 0).is_err());
+    }
+
+    #[test]
+    fn textafter_positive_instance() {
+        assert_eq!(textafter("a-b-c-d", "-", 1).unwrap(), "b-c-d");
+        assert_eq!(textafter("a-b-c-d", "-", 3).unwrap(), "d");
+    }
+
+    #[test]
+    fn textafter_negative_instance() {
+        assert_eq!(textafter("a-b-c-d", "-", -1).unwrap(), "d");
+        assert_eq!(textafter("a-b-c-d", "-", -2).unwrap(), "c-d");
+    }
+
+    #[test]
+    fn textafter_missing() {
+        assert!(textafter("abc", "-", 1).is_err());
+        assert!(textafter("a-b", "-", 0).is_err());
+    }
+
+    #[test]
+    fn textsplit_unicode() {
+        let parts = textsplit("漢-字-日", "-").unwrap();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts.get(0), Some(&Some("漢".into())));
+        assert_eq!(parts.get(2), Some(&Some("日".into())));
+    }
+
+    #[test]
+    fn textbefore_unicode_delim() {
+        assert_eq!(textbefore("aXb", "X", 1).unwrap(), "a");
+        assert_eq!(textbefore("a→b→c", "→", 1).unwrap(), "a");
+        assert_eq!(textafter("a→b→c", "→", 1).unwrap(), "b→c");
+    }
+}

--- a/code/packages/rust/text-core/src/substitute.rs
+++ b/code/packages/rust/text-core/src/substitute.rs
@@ -1,0 +1,230 @@
+//! SUBSTITUTE / REPLACE — string substitution.
+//!
+//! ## SUBSTITUTE
+//!
+//! `SUBSTITUTE(text, old, new, [instance])`:
+//!
+//! - If `instance` is `None`, every occurrence of `old` is replaced with
+//!   `new`. (Equivalent to R's `gsub` with a fixed pattern.)
+//! - If `instance` is `Some(k)`, only the *k*-th occurrence (1-based) is
+//!   replaced; if there are fewer than `k` occurrences the original is
+//!   returned unchanged.
+//! - If `old` is empty, the input is returned unchanged. This matches Excel:
+//!   substituting the empty string is a no-op (it never recurses infinitely).
+//!
+//! ## REPLACE
+//!
+//! `REPLACE(text, start, length, new)`:
+//!
+//! - 1-based `start`. Excel allows `start_num > len(text)`, in which case the
+//!   new text is appended. We do the same: out-of-range `start` clamps to the
+//!   end and inserts `new` there.
+//! - `start < 1` → `BadParameter`.
+//! - `length < 0` → `BadParameter`.
+//! - Operates on **Unicode scalar values** (chars).
+
+use crate::{iter_character, TextError};
+use r_vector::Character;
+
+/// `SUBSTITUTE(text, old, new, [instance])`.
+pub fn substitute(text: &str, old: &str, new: &str, instance: Option<usize>) -> String {
+    if old.is_empty() {
+        // Excel: substituting the empty string is a no-op.
+        return text.to_string();
+    }
+    match instance {
+        None => text.replace(old, new),
+        Some(k) if k == 0 => {
+            // 1-based; instance 0 is meaningless. Match Excel's behaviour of
+            // returning text unchanged (Excel returns #VALUE!, but in the
+            // typical Rust API style we treat 0 as "no match wanted").
+            // Callers wanting strict Excel behaviour can validate at the
+            // boundary.
+            text.to_string()
+        }
+        Some(k) => {
+            // Find the kth occurrence and replace only that.
+            let mut out = String::with_capacity(text.len());
+            let mut seen = 0usize;
+            // We walk byte-by-byte but check substring matches via
+            // `text[i..].starts_with(old)` to handle UTF-8 safely (any byte
+            // index where a multi-byte char starts is a char boundary).
+            let bytes = text.as_bytes();
+            let mut i = 0usize;
+            while i < bytes.len() {
+                if text.is_char_boundary(i) && text[i..].starts_with(old) {
+                    seen += 1;
+                    if seen == k {
+                        out.push_str(new);
+                        i += old.len();
+                        // Copy the rest verbatim.
+                        out.push_str(&text[i..]);
+                        return out;
+                    } else {
+                        // Not the right instance: copy this old as-is.
+                        out.push_str(&text[i..i + old.len()]);
+                        i += old.len();
+                        continue;
+                    }
+                }
+                // Push a single character.
+                // Find the next char boundary so we don't break UTF-8.
+                let mut j = i + 1;
+                while j <= bytes.len() && !text.is_char_boundary(j) {
+                    j += 1;
+                }
+                out.push_str(&text[i..j]);
+                i = j;
+            }
+            out
+        }
+    }
+}
+
+/// `REPLACE(text, start, length, new)`.
+///
+/// `start` is 1-based, in **chars**, not bytes.
+pub fn replace(text: &str, start: i64, length: i64, new: &str) -> Result<String, TextError> {
+    if start < 1 {
+        return Err(TextError::BadParameter {
+            name: "start_num",
+            value: start.to_string(),
+        });
+    }
+    if length < 0 {
+        return Err(TextError::BadParameter {
+            name: "num_chars",
+            value: length.to_string(),
+        });
+    }
+    let start0 = (start - 1) as usize;
+    let length = length as usize;
+
+    // Walk char-by-char accumulating the prefix, drop `length` chars, then
+    // emit `new` and the suffix.
+    let chars: Vec<char> = text.chars().collect();
+    let total = chars.len();
+    let head_end = start0.min(total);
+    let drop_end = (start0 + length).min(total);
+
+    let mut out = String::with_capacity(text.len() + new.len());
+    out.extend(&chars[..head_end]);
+    out.push_str(new);
+    out.extend(&chars[drop_end..]);
+    Ok(out)
+}
+
+/// Vector `SUBSTITUTE`. NA in / NA out.
+pub fn substitute_vec(
+    x: &Character,
+    old: &str,
+    new: &str,
+    instance: Option<usize>,
+) -> Character {
+    let out: Vec<Option<String>> = iter_character(x)
+        .map(|cell| cell.map(|s| substitute(s, old, new, instance)))
+        .collect();
+    Character::from_options(out)
+}
+
+/// Vector `REPLACE`. NA in / NA out; errors collapse to NA.
+pub fn replace_vec(x: &Character, start: i64, length: i64, new: &str) -> Character {
+    let out: Vec<Option<String>> = iter_character(x)
+        .map(|cell| cell.and_then(|s| replace(s, start, length, new).ok()))
+        .collect();
+    Character::from_options(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use r_vector::Vector;
+
+    #[test]
+    fn substitute_replaces_all_by_default() {
+        assert_eq!(substitute("foo bar foo", "foo", "baz", None), "baz bar baz");
+        assert_eq!(substitute("aaaa", "a", "bb", None), "bbbbbbbb");
+        assert_eq!(substitute("hello", "world", "x", None), "hello");
+    }
+
+    #[test]
+    fn substitute_replaces_nth_only() {
+        assert_eq!(
+            substitute("foo bar foo bar foo", "foo", "X", Some(2)),
+            "foo bar X bar foo"
+        );
+        assert_eq!(
+            substitute("aaaa", "a", "Z", Some(3)),
+            "aaZa"
+        );
+        // k > number of occurrences -> unchanged
+        assert_eq!(substitute("a a", "a", "X", Some(5)), "a a");
+    }
+
+    #[test]
+    fn substitute_empty_old_is_noop() {
+        assert_eq!(substitute("hello", "", "X", None), "hello");
+        assert_eq!(substitute("hello", "", "X", Some(1)), "hello");
+    }
+
+    #[test]
+    fn substitute_unicode() {
+        assert_eq!(substitute("漢字漢字", "漢", "金", None), "金字金字");
+        assert_eq!(substitute("漢字漢字", "漢", "金", Some(2)), "漢字金字");
+        assert_eq!(substitute("a🙂b🙂c", "🙂", "_", None), "a_b_c");
+    }
+
+    #[test]
+    fn substitute_instance_zero_is_noop() {
+        // Implementation choice documented in module docs.
+        assert_eq!(substitute("aaa", "a", "X", Some(0)), "aaa");
+    }
+
+    #[test]
+    fn replace_basic() {
+        // REPLACE("abcdef", 2, 3, "XY") -> "aXYef"
+        assert_eq!(replace("abcdef", 2, 3, "XY").unwrap(), "aXYef");
+        // Insert at start
+        assert_eq!(replace("abc", 1, 0, "Z").unwrap(), "Zabc");
+        // Replace nothing in middle (length=0 inserts)
+        assert_eq!(replace("abc", 2, 0, "Z").unwrap(), "aZbc");
+        // Replace whole string
+        assert_eq!(replace("abc", 1, 3, "WXYZ").unwrap(), "WXYZ");
+        // Empty new
+        assert_eq!(replace("abcdef", 2, 3, "").unwrap(), "aef");
+    }
+
+    #[test]
+    fn replace_clamps_past_end() {
+        // Excel: start past end appends.
+        assert_eq!(replace("abc", 10, 5, "Z").unwrap(), "abcZ");
+        // Length past end clamps.
+        assert_eq!(replace("abc", 2, 100, "Z").unwrap(), "aZ");
+    }
+
+    #[test]
+    fn replace_unicode() {
+        assert_eq!(replace("漢字日本", 2, 2, "X").unwrap(), "漢X本");
+        assert_eq!(replace("a🙂b", 2, 1, "*").unwrap(), "a*b");
+    }
+
+    #[test]
+    fn replace_bad_params() {
+        assert!(replace("abc", 0, 1, "Z").is_err());
+        assert!(replace("abc", -1, 1, "Z").is_err());
+        assert!(replace("abc", 1, -1, "Z").is_err());
+    }
+
+    #[test]
+    fn vec_variants_propagate_na() {
+        let x = Character::from_options(vec![Some("foo foo".into()), None, Some("bar".into())]);
+        let got = substitute_vec(&x, "foo", "X", None);
+        assert_eq!(got.get(0), Some(&Some("X X".into())));
+        assert!(got.is_na(1));
+        assert_eq!(got.get(2), Some(&Some("bar".into())));
+
+        let got = replace_vec(&x, 1, 2, "ZZ");
+        assert_eq!(got.get(0), Some(&Some("ZZo foo".into())));
+        assert!(got.is_na(1));
+    }
+}

--- a/code/packages/rust/text-core/src/trim.rs
+++ b/code/packages/rust/text-core/src/trim.rs
@@ -1,0 +1,125 @@
+//! TRIM / CLEAN — whitespace and control-character normalisation.
+//!
+//! ## TRIM — Excel semantics
+//!
+//! `TRIM` in Excel is *not* the same as Rust's `str::trim`. It:
+//!
+//! 1. Removes leading and trailing ASCII space (U+0020) characters.
+//! 2. Collapses each internal run of multiple spaces into a single space.
+//!
+//! It only operates on `' '` (U+0020). Tabs and newlines are left alone.
+//! (Modern Excel also leaves non-breaking spaces U+00A0 alone; we match
+//! that.)
+//!
+//! ```text
+//! trim("  hello   world  ") == "hello world"
+//! trim("a   b   c")         == "a b c"
+//! trim("\t a \t")           == "\t a \t"      (tabs preserved)
+//! ```
+//!
+//! ## CLEAN
+//!
+//! `CLEAN` removes all characters whose code-point is in `0..=31` (the C0
+//! control range, including newline / tab / null). Higher-range control
+//! characters (DEL, C1) are left alone to match Excel.
+
+use crate::iter_character;
+use r_vector::Character;
+
+/// `TRIM(text)` — collapse runs of spaces; remove leading/trailing spaces.
+pub fn trim(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_run_of_space = false;
+    let mut emitted_any = false;
+    for c in s.chars() {
+        if c == ' ' {
+            // Defer the space; we only emit it when we know there's
+            // non-space content to follow.
+            in_run_of_space = true;
+        } else {
+            if in_run_of_space && emitted_any {
+                out.push(' ');
+            }
+            out.push(c);
+            emitted_any = true;
+            in_run_of_space = false;
+        }
+    }
+    out
+}
+
+/// `CLEAN(text)` — drop characters with code points 0..=31.
+pub fn clean(s: &str) -> String {
+    s.chars().filter(|c| (*c as u32) > 31).collect()
+}
+
+/// Vector `TRIM`. NA in / NA out.
+pub fn trim_vec(x: &Character) -> Character {
+    let out: Vec<Option<String>> = iter_character(x).map(|cell| cell.map(trim)).collect();
+    Character::from_options(out)
+}
+
+/// Vector `CLEAN`. NA in / NA out.
+pub fn clean_vec(x: &Character) -> Character {
+    let out: Vec<Option<String>> = iter_character(x).map(|cell| cell.map(clean)).collect();
+    Character::from_options(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use r_vector::Vector;
+
+    #[test]
+    fn trim_collapses_internal_runs() {
+        assert_eq!(trim("  hello   world  "), "hello world");
+        assert_eq!(trim("a   b   c"), "a b c");
+        assert_eq!(trim("   "), "");
+        assert_eq!(trim(""), "");
+        assert_eq!(trim("nospace"), "nospace");
+    }
+
+    #[test]
+    fn trim_preserves_non_space_whitespace() {
+        // Tabs and newlines are preserved.
+        assert_eq!(trim("\t a \t"), "\t a \t");
+        assert_eq!(trim("a\nb"), "a\nb");
+        // Non-breaking space is left alone.
+        assert_eq!(trim("a\u{00A0}\u{00A0}b"), "a\u{00A0}\u{00A0}b");
+    }
+
+    #[test]
+    fn trim_unicode_passthrough() {
+        assert_eq!(trim("  漢  字  "), "漢 字");
+        assert_eq!(trim("🙂   🎉"), "🙂 🎉");
+    }
+
+    #[test]
+    fn clean_drops_c0_controls() {
+        assert_eq!(clean("hello\nworld"), "helloworld");
+        assert_eq!(clean("a\tb\rc"), "abc");
+        assert_eq!(clean("\0\x01abc\x1f"), "abc");
+        assert_eq!(clean(""), "");
+    }
+
+    #[test]
+    fn clean_keeps_higher_chars() {
+        // Space (U+0020) is kept; we only strip 0..=31.
+        assert_eq!(clean(" a b "), " a b ");
+        // DEL (U+007F) is intentionally left alone (Excel parity).
+        assert_eq!(clean("a\x7fb"), "a\x7fb");
+        assert_eq!(clean("漢字"), "漢字");
+    }
+
+    #[test]
+    fn vec_variants_propagate_na() {
+        let x = Character::from_options(vec![Some("  a  b  ".into()), None]);
+        let t = trim_vec(&x);
+        assert_eq!(t.get(0), Some(&Some("a b".into())));
+        assert!(t.is_na(1));
+
+        let c = clean_vec(&Character::from_options(vec![Some("x\ty".into()), None]));
+        assert_eq!(c.get(0), Some(&Some("xy".into())));
+        assert!(c.is_na(1));
+    }
+}

--- a/code/packages/rust/text-core/tests/text_tests.rs
+++ b/code/packages/rust/text-core/tests/text_tests.rs
@@ -1,0 +1,184 @@
+//! Integration tests for `text-core`.
+//!
+//! Each unit module also has rustdoc-adjacent `#[cfg(test)]` tests that
+//! cover the function-level cases. The integration tests here exercise
+//! **interactions** across modules — the kind of thing a frontend would
+//! actually do — plus full-coverage round-trips for `TEXT`/`VALUE`.
+
+use r_vector::{Character, Vector};
+use text_core::{
+    case, chars, compare, concat, convert, extract, find, length, predicates, repeat, split,
+    substitute, trim, TextError,
+};
+
+#[test]
+fn end_to_end_typical_workflow() {
+    // Imagine: take "  hello, WORLD  " and produce "Hello World".
+    let raw = "  hello, WORLD  ";
+    let stripped = trim::trim(raw);
+    assert_eq!(stripped, "hello, WORLD");
+    // Drop the comma, then proper-case.
+    let no_comma = substitute::substitute(&stripped, ",", "", None);
+    let titled = case::proper(&no_comma);
+    assert_eq!(titled, "Hello World");
+}
+
+#[test]
+fn text_value_round_trip() {
+    // Round-tripping should preserve integers exactly through "0".
+    for n in [0i64, 1, -7, 42, 12345, -999] {
+        let s = convert::text(n as f64, "0").unwrap();
+        let back = convert::value(&s).unwrap();
+        assert_eq!(back, n as f64);
+    }
+    // 2-decimal round trip.
+    let s = convert::text(3.14, "0.00").unwrap();
+    assert_eq!(s, "3.14");
+    assert!((convert::value(&s).unwrap() - 3.14).abs() < 1e-9);
+}
+
+#[test]
+fn search_then_mid_extracts_substring() {
+    let s = "name: Alice; age: 30";
+    let pos = find::search("name: ", s, None).unwrap();
+    // After "name: " (6 chars), grab up to ";".
+    let semi = find::find(";", s, Some(pos)).unwrap();
+    let extracted = extract::mid(s, (pos + 6) as i64, (semi - pos - 6) as i64).unwrap();
+    assert_eq!(extracted, "Alice");
+}
+
+#[test]
+fn split_then_textjoin_is_roundtrip_with_known_delimiter() {
+    let parts = split::textsplit("a,b,c,d", ",").unwrap();
+    let joined = concat::textjoin_vec(",", false, &parts);
+    assert_eq!(joined, "a,b,c,d");
+}
+
+#[test]
+fn vector_na_propagation_through_pipeline() {
+    let raw = Character::from_options(vec![
+        Some("  hello  ".into()),
+        None,
+        Some("WORLD".into()),
+    ]);
+    let trimmed = trim::trim_vec(&raw);
+    let lowered = case::lower_vec(&trimmed);
+    assert_eq!(lowered.get(0), Some(&Some("hello".into())));
+    assert!(lowered.is_na(1));
+    assert_eq!(lowered.get(2), Some(&Some("world".into())));
+}
+
+#[test]
+fn unicode_indexing_is_consistent_across_functions() {
+    let s = "漢字日本";
+    assert_eq!(length::len(s), 4);
+    assert_eq!(extract::left(s, 2).unwrap(), "漢字");
+    assert_eq!(extract::right(s, 2).unwrap(), "日本");
+    assert_eq!(extract::mid(s, 2, 2).unwrap(), "字日");
+    assert_eq!(find::find("日", s, None).unwrap(), 3);
+    assert_eq!(find::search("日", s, None).unwrap(), 3);
+}
+
+#[test]
+fn emoji_indexing() {
+    let s = "a🙂b🎉c";
+    assert_eq!(length::len(s), 5);
+    assert_eq!(extract::mid(s, 2, 1).unwrap(), "🙂");
+    assert_eq!(extract::mid(s, 4, 1).unwrap(), "🎉");
+    assert_eq!(find::find("🎉", s, None).unwrap(), 4);
+}
+
+#[test]
+fn combining_marks_count_as_separate_chars() {
+    // 'e' + combining acute accent = 2 scalar values.
+    let s = "e\u{0301}llo";
+    assert_eq!(length::len(s), 5);
+    // First char is bare 'e'.
+    assert_eq!(extract::left(s, 1).unwrap(), "e");
+    // Second char is the combining accent on its own.
+    assert_eq!(extract::mid(s, 2, 1).unwrap(), "\u{0301}");
+}
+
+#[test]
+fn dollar_and_fixed_match_excel_style() {
+    assert_eq!(convert::dollar(0.0, 2).unwrap(), "$0.00");
+    assert_eq!(convert::dollar(-2.5, 2).unwrap(), "($2.50)");
+    assert_eq!(convert::fixed(1.005, 2, false).unwrap(), "1.00");
+    // FIXED with no commas.
+    assert_eq!(convert::fixed(1234567.0, 0, true).unwrap(), "1234567");
+}
+
+#[test]
+fn chars_round_trip_ascii() {
+    for n in 1u8..=127 {
+        let s = chars::char_at(n as i64).unwrap();
+        let back = chars::code(&s).unwrap();
+        assert_eq!(back, n as u32);
+    }
+}
+
+#[test]
+fn unichar_round_trip_full_range() {
+    for n in [65i64, 0x6f22, 0x1f642] {
+        let s = chars::unichar(n).unwrap();
+        assert_eq!(chars::unicode(&s).unwrap(), n as u32);
+    }
+}
+
+#[test]
+fn exact_distinguishes_case() {
+    assert!(compare::exact("HELLO", "HELLO"));
+    assert!(!compare::exact("HELLO", "hello"));
+}
+
+#[test]
+fn predicates_pass_through_or_default() {
+    assert_eq!(predicates::t_text(Some("data")), "data");
+    assert_eq!(predicates::t_text(None), "");
+    assert_eq!(predicates::n_number(Some(2.5)), 2.5);
+    assert_eq!(predicates::n_number(None), 0.0);
+}
+
+#[test]
+fn repeat_caps_at_excel_limit() {
+    // Boundary: exactly at limit is fine.
+    assert!(repeat::rept("a", repeat::REPT_MAX_LEN as i64).is_ok());
+    // One over the limit fails.
+    assert!(repeat::rept("a", (repeat::REPT_MAX_LEN + 1) as i64).is_err());
+}
+
+#[test]
+fn substitute_handles_overlapping_potentials() {
+    // Substituting "aa" in "aaaa" should match positions 1 and 3 (Excel
+    // behaviour: non-overlapping left-to-right).
+    assert_eq!(substitute::substitute("aaaa", "aa", "X", None), "XX");
+    // Nth-only on overlapping potentials.
+    assert_eq!(substitute::substitute("aaaa", "aa", "X", Some(1)), "Xaa");
+    assert_eq!(substitute::substitute("aaaa", "aa", "X", Some(2)), "aaX");
+}
+
+#[test]
+fn search_wildcards_dont_leak_into_find() {
+    // FIND treats `*` and `?` literally.
+    assert!(find::find("h*o", "hello", None).is_err());
+    assert!(find::find("h?o", "hello", None).is_err());
+    assert!(find::find("*", "a*b", None).is_ok());
+}
+
+#[test]
+fn textbefore_after_compose() {
+    let s = "user@example.com";
+    assert_eq!(split::textbefore(s, "@", 1).unwrap(), "user");
+    assert_eq!(split::textafter(s, "@", 1).unwrap(), "example.com");
+}
+
+#[test]
+fn errors_have_useful_display() {
+    let e = TextError::BadParameter {
+        name: "num_chars",
+        value: "-1".to_string(),
+    };
+    let rendered = format!("{e}");
+    assert!(rendered.contains("num_chars"));
+    assert!(rendered.contains("-1"));
+}


### PR DESCRIPTION
## Summary

Implements the `text-core` Layer-1 crate from `code/specs/backend-crate-catalog.md`: a pure-Rust, no-I/O, WASM-compatible library of Excel / Lotus 1-2-3 / R string functions for any spreadsheet or text-processing frontend (VisiCalc, Multiplan, modern reconstruction, Macsyma, Twig, ...).

## Function inventory

| Module       | Functions                                                                  |
|--------------|----------------------------------------------------------------------------|
| `length`     | `LEN`, `LENB`                                                              |
| `extract`    | `LEFT`, `RIGHT`, `MID`                                                     |
| `case`       | `UPPER`, `LOWER`, `PROPER`                                                 |
| `trim`       | `TRIM` (Excel internal-space collapse), `CLEAN`                            |
| `substitute` | `SUBSTITUTE` (all / nth), `REPLACE`                                        |
| `find`       | `FIND` (case-sensitive, no wildcards), `SEARCH` (case-insensitive, `*`/`?`)|
| `convert`    | `TEXT` (6 basic codes), `VALUE`, `NUMBERVALUE`, `FIXED`, `DOLLAR`          |
| `repeat`     | `REPT`                                                                     |
| `chars`      | `CODE`, `CHAR` (Latin-1), `UNICODE`, `UNICHAR`                             |
| `concat`     | `CONCAT`, `CONCATENATE`, `TEXTJOIN`                                        |
| `compare`    | `EXACT`                                                                    |
| `split`      | `TEXTSPLIT`, `TEXTBEFORE`, `TEXTAFTER`                                     |
| `predicates` | `T`, `N`                                                                   |

## Unicode handling

- `LEN`, `LEFT`, `RIGHT`, `MID`, `FIND`, `SEARCH`, `REPLACE` operate on Unicode scalar values (Rust `char`s), not bytes. `LENB` is the byte-counting variant.
- `UPPER` / `LOWER` use Rust's Unicode default case folding (e.g. `straße` → `STRASSE`).
- `PROPER` segments words using `char::is_alphabetic`; apostrophes and digits break words (`o'brien` → `O'Brien`, `html5 is cool` → `Html5 Is Cool`).
- All position-returning APIs (`FIND`, `SEARCH`) return 1-based char positions, never byte offsets.

## 1-based indexing

All public functions translate to Rust's 0-based world at the boundary. `MID("hello", 1, 3)` returns `"hel"`. `MID(..., 0, ...)` is `BadParameter`. `start` past end → empty; `length` past end → clamps.

## NA propagation

Following the `statistics-core` pattern, each function offering a vector variant exposes both `foo(s: &str, ...)` and `foo_vec(x: &Character, ...)`. NA elements (`None` in `Character`) propagate element-wise; per-element errors collapse to NA in the vector variant so they don't poison the whole column.

## Excel parity choices (documented inline)

- `TRIM` collapses runs of ASCII space (U+0020) only — tabs, newlines, NBSP preserved (modern Excel behaviour).
- `CLEAN` strips C0 controls (0..=31) only; DEL (U+007F) preserved.
- `SUBSTITUTE` with empty `old` is a no-op (avoids infinite expansion).
- `DOLLAR` uses parenthesised negatives `($1,234.50)` for en-US.
- `TEXT` / `FIXED` round half-away-from-zero (pre-scale then format) so `FIXED(1234.5, 0)` → `"1,235"` matching Excel, not Rust's `{:.0}` banker's rounding which gives `"1234"`.
- `SEARCH` wildcards are `*` (zero-or-more) and `?` (one-of-any) only — no regex, no escapes; hand-rolled ~25-line matcher with single-backtrack on `*`.

## Constraints

- No external crates beyond `numeric-tower` and `r-vector`. No `regex`, no `unicase`, no `itertools`.
- No `unsafe`, no `#[cfg(target_os)]`, no file I/O, no globals.
- WASM-compatible: `cargo build -p text-core --target wasm32-unknown-unknown` succeeds.

## Workspace

Added `text-core` to `code/packages/rust/Cargo.toml` in alphabetical position (between `tcp-runtime` and `text-interfaces`).

## Test plan

- [x] `cargo test -p text-core` — 116 unit + 18 integration tests, all green.
- [x] `cargo build -p text-core --target wasm32-unknown-unknown` — clean WASM build.
- [x] Coverage: ASCII / CJK / emoji / combining marks.
- [x] 1-based indexing edge cases (`MID(s, 0, ...)`, `start > len`, `length > remaining`).
- [x] `SEARCH` wildcards: `*` zero/many, `?` exactly-one, combinations, `start` offset.
- [x] All six `TEXT` format codes (`0`, `0.00`, `#,##0`, `#,##0.00`, `0%`, `0.00E+00`).
- [x] `VALUE` parsing of `"1,234.56"`, `"50%"`, scientific, leading/trailing whitespace.
- [x] `NUMBERVALUE` EU-locale (`'.'` thousands, `','` decimal) and stacked `%%`.
- [x] `REPT` length cap (32,767-char Excel limit).
- [x] `SUBSTITUTE` `n`-th instance, non-overlapping matches, Unicode delimiters.
- [x] `REPLACE` positional clamping past end.
- [x] `TEXTBEFORE` / `TEXTAFTER` with negative instance (count from right).
- [x] NA propagation through every `_vec` variant.
- [x] Error paths: negative `LEFT`, malformed `FIND`, bad `TEXT` format, `CHAR`/`UNICHAR` out-of-range, surrogate rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)