### PR TITLE
chore: version housekeeping — clean up empty Unreleased sections, bump spice-engine 0.13.0 and Rust macsyma-runtime 0.3.0

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ## 1.26.0 — 2026-05-14
 
 **MACSYMA stress-test parity: limit L'Hôpital, multivariate expand, Taylor for transcendentals,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.13.0] — 2026-05-16
 
 ### Added
 

--- a/code/packages/python/spice-engine/pyproject.toml
+++ b/code/packages/python/spice-engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-engine"
-version = "0.12.0"
+version = "0.13.0"
 description = "SPICE-compatible analog circuit simulator with MNA + Newton-Raphson DC + Gmin/source-stepping convergence aids + transient + AC small-signal sweep + DC transfer function (.TF) + DC parameter sweep (.DC) + DC sensitivity analysis (.SENS) + Monte Carlo (.MC) + noise analysis (.NOISE) + controlled sources (VCVS, VCCS, CCCS, CCVS) + time-varying source waveforms (PWL, SIN, PULSE, EXP)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ## 0.55.0 — 2026-05-14
 
 **Phase 26 — MACSYMA stress-test parity fixes: differentiation order, pattern matching,

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
-## Unreleased
+## [0.3.0] — 2026-05-16
+
+**EllipticE (2nd kind) and EllipticPi (3rd kind) integration pipeline tests.**
+
+Added pipeline-level tests verifying that the complete and incomplete elliptic
+integrals of the second and third kind round-trip correctly through the
+macsyma-runtime dispatcher:
+
+- `recognizes_elliptic_second_kind_integrals_through_runtime` — incomplete
+  EllipticE: `∫ √(1−k²sin²θ) dθ` → `EllipticE(θ, k)`
+- `recognizes_complete_elliptic_second_kind_integrals_through_runtime` —
+  complete EllipticE: `∫₀^(π/2) √(1−k²sin²θ) dθ` → `EllipticE(k)`
+- `recognizes_complete_elliptic_third_kind_integrals_through_runtime` —
+  complete EllipticPi: `∫₀^(π/2) 1/((1+n·sin²θ)√(1−k²sin²θ)) dθ` → `EllipticPi(n, k)`
+- `elliptic_first_kind_regression_still_works` — regression guard confirming
+  EllipticK recognition is unaffected
 
 ## [0.2.0] — 2026-05-14
 

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-macsyma-runtime"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "MACSYMA runtime session facade over the Rust symbolic VM"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog — symbolic-vm (Rust)
 
-## Unreleased
-
 ## [0.3.0] — 2026-05-14
 
 ### Added
@@ -14,8 +12,6 @@
 - New helper functions: `elliptic_second_kind_radicand`, `complete_elliptic_second_kind`,
   `incomplete_elliptic_second_kind`, `extract_characteristic_n`,
   `elliptic_third_kind_params`, `complete_elliptic_third_kind`
-
-## [0.1.1] — 2026-04-28
 
 ## [0.2.0] — 2026-05-14
 
@@ -52,6 +48,8 @@
 - Numeric and symbolic handlers for reciprocal hyperbolic heads `Coth`,
   `Sech`, and `Csch`, including `sech(0) = 1` and undefined-at-zero checks for
   `coth`/`csch`.
+
+## [0.1.1] — 2026-04-28
 
 ## [0.1.0] — 2026-04-27
 

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -1,11 +1,13 @@
 # SPICE Engine & MACSYMA Pipeline — Status and Pending Work
 
 > **Living document.** Updated each time a PR lands or new work is planned.
-> Last updated: 2026-05-14. Sprint complete: TypeScript 0.2.0 releases (PR #3170 ✅
+> Last updated: 2026-05-16. Sprint complete: TypeScript 0.2.0 releases (PR #3170 ✅
 > merged), Rust 0.2.0 releases (PR #3171 ✅ merged), Python EllipticE/Pi —
-> `symbolic-vm` 0.54.0 (PR #3173 ✅ merged), TypeScript EllipticE/Pi —
+> `symbolic-vm` 0.55.0 (PR #3173 ✅ merged), TypeScript EllipticE/Pi —
 > `symbolic-vm` 0.3.0 (PR #3179 ✅ merged), Rust EllipticE/Pi —
-> `symbolic-vm` 0.3.0 (PR #3178 ✅ merged).
+> `symbolic-vm` 0.3.0 (PR #3178 ✅ merged), Python `macsyma-runtime` 1.26.0,
+> `spice-engine` 0.13.0 (inductor IC, AcSource phasors, waveforms already implemented),
+> `rust/macsyma-runtime` 0.3.0 (EllipticE/Pi pipeline tests).
 
 This document is the canonical reference for resuming work on either project.
 It records exactly what is on `main`, what is in flight, and what has not been
@@ -62,6 +64,9 @@ files.
 |---|---|---|
 | v0.1.0 | #1353 | MNA core, DC operating point (Newton-Raphson), forward-Euler transient, `Diode`, `Mosfet` |
 | v0.10.0 | #2901 ✅ | All four SPICE controlled sources: `VCVS` (E), `VCCS` (G), `CCCS` (F), `CCVS` (H). Correct MNA stamps (DC + AC). `TfResult.gain`. Fixed CCCS stamp sign. |
+| v0.11.0 | — | Time-varying source waveforms: `PwlWaveform`, `SinWaveform`, `PulseWaveform`, `ExpWaveform`; waveform evaluation at each transient timestep |
+| v0.12.0 | — | DC convergence aids: Gmin stepping + source stepping fallback chain; `_dc_newton` / `_x_from_result` helpers |
+| v0.13.0 | — | Inductor `initial_current` for transient seeding; explicit AC source phasors (`AcSource`) on `VoltageSource`/`CurrentSource` |
 | v0.2.0 | #2339 | Trapezoidal + Backward Euler integration, LTE-based adaptive timestep |
 | v0.3.0 | #2342 | `BJT` element (Ebers-Moll, NPN/PNP) |
 | v0.4.0 | #2344 | AC small-signal frequency sweep (`.AC`) |
@@ -76,6 +81,8 @@ files.
 
 **Analyses on main:** `dc_op`, `transient`, `ac_sweep`, `tf`, `dc_sweep`,
 `sens_dc`, `mc_dc`, `noise_ac`
+
+**Waveforms on main:** `PwlWaveform`, `SinWaveform`, `PulseWaveform`, `ExpWaveform`
 
 ---
 
@@ -93,9 +100,7 @@ Items are listed in priority order within each group.
 
 | Feature | Why it matters | Design notes |
 |---|---|---|
-| **Time-varying source waveforms** | Every realistic transient simulation — step response, oscillator startup, filter characterisation — needs non-static sources. Currently `VoltageSource` and `CurrentSource` are DC-constant only. | Add a `waveform` field (optional) to `VoltageSource` / `CurrentSource` accepting a callable `(t: float) -> float` or one of `PwlWaveform`, `SinWaveform`, `PulseWaveform`, `ExpWaveform`. The transient engine already calls `_stamp_vsource` at each timestep; it just needs to pass the current `t`. SPICE spec in `spice-engine.md` section "Source Waveforms" (conformance target: PWL, PULSE, SIN, EXP). |
 | **SPICE3 netlist parser** | Lets you run existing `.cir` / `.sp` files directly. Huge usability leap — you can grab any NGSPICE example and feed it in. | New package `spice-netlist-parser`. Grammar-driven (reuse `grammar-tools`). Conformance matrix in `spice-engine.md`: R, C, L, V, I, M (MOSFET), D, Q (BJT), E/G/F/H (controlled sources), X (subcircuit), `.tran`, `.dc`, `.ac`, `.op`, `.include`, `.subckt`, `.model`, `.param`. Returns a `Circuit` object identical to what you'd build in Python. |
-| **Convergence aids** | Necessary for power electronics, startup transients, and any circuit with strongly coupled nonlinear devices (e.g. bandgap references). Newton-Raphson alone fails on these. | Three strategies described in `spice-engine.md`: (1) **Gmin stepping** — add small conductance across every node to ground, gradually reduce to zero. (2) **Source stepping** — scale all independent source voltages from 0 to full value. (3) **Pseudo-transient continuation** — add capacitors to ground and integrate to DC. Try in order; each is a fallback. |
 
 #### Group 2 — Medium value
 
@@ -128,11 +133,11 @@ Every item below is wired end-to-end: surface syntax → compile → VM → corr
 | Package | Version | What it provides |
 |---|---|---|
 | `symbolic-ir` | latest | `IRSymbol`, `IRInteger`, `IRRational`, `IRFloat`, `IRString`, `IRApply` node types |
-| `symbolic-vm` | 0.54.0 | Pluggable VM, `SymbolicBackend`, arithmetic, Risch integration (phases 1–14+, Phase 25 EllipticF/K/E/Pi), numeric folding, 100+ handlers |
+| `symbolic-vm` | 0.55.0 | Pluggable VM, `SymbolicBackend`, arithmetic, Risch integration (phases 1–14+, Phase 25 EllipticF/K/E/Pi), numeric folding, 100+ handlers |
 | `macsyma-lexer` | 0.1.0 | Grammar-driven tokenizer |
 | `macsyma-parser` | 0.1.0 | Grammar-driven parser |
 | `macsyma-compiler` | 0.9.0 | AST → IR; 60+ MACSYMA identifier mappings in name table |
-| `macsyma-runtime` | 1.25.0 | History (`%`, `%i1`, `%o1`, …), `;`/`$` terminators, `kill`, `ev`, `MacsymaBackend` |
+| `macsyma-runtime` | 1.26.0 | History (`%`, `%i1`, `%o1`, …), `;`/`$` terminators, `kill`, `ev`, `MacsymaBackend` |
 
 #### TypeScript port version releases (PR #3170 ✅ merged)
 


### PR DESCRIPTION
## Summary

- **spice-engine 0.12.0 → 0.13.0**: waveforms (PWL/SIN/PULSE/EXP), inductor IC, AcSource already implemented and tested — formalizes the release
- **rust/macsyma-runtime 0.2.0 → 0.3.0**: EllipticE/Pi pipeline tests already in the test suite — adds proper CHANGELOG entry
- **python/symbolic-vm, python/macsyma-runtime, rust/symbolic-vm**: Remove stray empty `## Unreleased` sections that accumulated above latest version headings
- **rust/symbolic-vm**: Fix `## [0.1.1]` ordering (was misplaced between 0.3.0 and 0.2.0; moved to its correct place between 0.1.0 and 0.2.0)
- **specs/spice-macsyma-pending-work.md**: Update version table to reflect 0.55.0/1.26.0/0.13.0; mark waveforms as shipped

## Test plan

- [ ] No code changes — all tests were already passing on `main`
- [ ] Python symbolic-vm, macsyma-runtime: existing test suites unchanged
- [ ] Rust symbolic-vm, macsyma-runtime: existing test suites unchanged  
- [ ] spice-engine: existing 66-test suite unchanged (waveforms already covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)