### PR TITLE
feat(forme-orchestrator): reproducible-build mode (FM03 §8 partial)

### DIFF
--- a/code/packages/typescript/forme-orchestrator/CHANGELOG.md
+++ b/code/packages/typescript/forme-orchestrator/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog — @coding-adventures/forme-orchestrator
 
+## 0.2.0 — 2026-05-16
+
+### Added — reproducible-build mode (FM03 §8 — partial)
+
+- When `pipeline.config.settings.reproducibleBuild === true`, every
+  `StageContext` (and `StageInitContext`, and the dispose-time context)
+  now receives a `frozenClock` instead of a `systemClock`.  Two runs
+  of the same pipeline against the same inputs produce identical
+  `ctx.time.nowMs()` / `nowIso()` values, which is sufficient for the
+  hello-world topology to produce byte-identical artifacts across
+  runs.
+- Frozen wall-clock value: `REPRO_BUILD_FROZEN_TIMESTAMP_MS = 0`
+  (1970-01-01T00:00:00Z).  Per FM03 §8 the production value should
+  be the max input mtime; v0 always uses the fallback since the
+  orchestrator doesn't yet thread input mtimes from source stages.
+- Frozen monotonic counter advances by 1 ms per call so stages
+  measuring their own elapsed time still get non-zero values (the
+  reproducible contract is on the wall clock only).
+- New public export: `REPRO_BUILD_FROZEN_TIMESTAMP_MS`.
+
+### What's still deferred from FM03 §8
+
+- **Iteration-order sorting.**  Sources should iterate paths in
+  lexicographic order under repro mode.  Lives in source stages,
+  not the orchestrator (`forme-source-fs` already sorts within
+  directories; repro-mode-specific cross-directory ordering is a
+  follow-up).
+- **Deterministic randomness.**  `ctx.random.deterministic(name)`
+  doesn't exist in the kernel yet (FM01 future work).  No stage
+  currently uses randomness so this is harmless in practice.
+- **Telemetry suppression.**  Telemetry events still fire in repro
+  mode; embedding them into artifacts is the artifact-producer's
+  policy, which today is correct (no stage embeds telemetry into
+  output).
+
+### Tests
+
+6 new tests in `tests/repro-build.test.ts` covering:
+- Off-mode: two runs produce different timestamps.
+- On-mode: two runs produce identical timestamps.
+- On-mode: source `ctx.time.nowMs()` is also frozen.
+- On-mode: `dispose()` sees the same frozen clock as `run()`.
+- Public-API constant export.
+- Default (off) mode produces realistic timestamps.
+
 ## 0.1.1 — 2026-05-15
 
 ### Fixed

--- a/code/packages/typescript/forme-orchestrator/package-lock.json
+++ b/code/packages/typescript/forme-orchestrator/package-lock.json
@@ -24,6 +24,7 @@
       }
     },
     "../forme-cache": {
+      "name": "@coding-adventures/forme-cache",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -38,6 +39,7 @@
       }
     },
     "../forme-capability": {
+      "name": "@coding-adventures/forme-capability",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -47,6 +49,7 @@
       }
     },
     "../forme-errors": {
+      "name": "@coding-adventures/forme-errors",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -59,6 +62,7 @@
       }
     },
     "../forme-identity": {
+      "name": "@coding-adventures/forme-identity",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -72,6 +76,7 @@
       }
     },
     "../forme-pipeline-config": {
+      "name": "@coding-adventures/forme-pipeline-config",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -87,6 +92,7 @@
       }
     },
     "../forme-stage": {
+      "name": "@coding-adventures/forme-stage",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -101,6 +107,7 @@
       }
     },
     "../forme-types": {
+      "name": "@coding-adventures/forme-types",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/code/packages/typescript/forme-orchestrator/package.json
+++ b/code/packages/typescript/forme-orchestrator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coding-adventures/forme-orchestrator",
-  "version": "0.1.0",
-  "description": "Forme orchestrator runtime: DAG construction, sequential topological execution, error handling, cancellation, dispose lifecycle (FM03 §3-4, §9-10).",
+  "version": "0.2.0",
+  "description": "Forme orchestrator runtime: DAG construction, sequential topological execution, error handling, cancellation, dispose lifecycle, reproducible-build mode (FM03 §3-4, §8, §9-10).",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/code/packages/typescript/forme-orchestrator/src/index.ts
+++ b/code/packages/typescript/forme-orchestrator/src/index.ts
@@ -20,6 +20,7 @@ export { buildPipeline } from "./build-pipeline.js";
 export { runOnce } from "./run.js";
 export { buildDag } from "./dag.js";
 export { areKindsCompatible } from "./typecheck.js";
+export { REPRO_BUILD_FROZEN_TIMESTAMP_MS } from "./scheduler.js";
 
 export type {
   Orchestrator,

--- a/code/packages/typescript/forme-orchestrator/src/run.ts
+++ b/code/packages/typescript/forme-orchestrator/src/run.ts
@@ -51,6 +51,10 @@ export async function runOnce(
     cancellation,
     bestEffort,
     logger,
+    // Honour the pipeline's reproducible-build setting (FM03 §8).
+    // The scheduler swaps systemClock for frozenClock at every
+    // StageContext construction site when this is true.
+    reproducibleBuild: pipeline.config.settings.reproducibleBuild,
   });
 
   // Map sink-keyed outputs to OutputSpec names when present.

--- a/code/packages/typescript/forme-orchestrator/src/scheduler.ts
+++ b/code/packages/typescript/forme-orchestrator/src/scheduler.ts
@@ -18,9 +18,12 @@
  *     rebuild (FM03 §6) lands when the orchestrator gains revision
  *     tracking per instance.
  *
- *   - **No reproducible-build mode.**  Stages get systemClock, not
- *     frozenClock.  Reproducible-build mode (FM03 §8) lands as a
- *     `RunOptions` flag.
+ *   - **Reproducible-build mode is wired through.**  When
+ *     `settings.reproducibleBuild = true`, every StageContext receives
+ *     a frozenClock pinned at `REPRO_BUILD_FROZEN_TIMESTAMP_MS` (0
+ *     in v0; FM03 §8 max-input-mtime derivation pending source-stage
+ *     revision tracking).  Iteration-order sorting and the
+ *     deterministic-random `ctx.random` API remain deferred to v1.
  *
  * What v0 *does* implement:
  *
@@ -45,6 +48,7 @@ import {
   deniedNetworkApi,
   deniedShellApi,
   deniedStorageApi,
+  frozenClock,
   inMemoryCache,
   inMemoryEventBus,
   noOpTelemetryEmitter,
@@ -52,6 +56,7 @@ import {
 } from "@coding-adventures/forme-stage";
 import type {
   CancellationToken,
+  Clock,
   Logger,
   StageContext,
   StageInitContext,
@@ -86,7 +91,39 @@ export interface SchedulerOptions {
   readonly logger: Logger;
   readonly cancellation: CancellationToken;
   readonly bestEffort: boolean;
+  /**
+   * When true, every StageContext receives a `frozenClock` whose wall
+   * time is fixed for the duration of the run.  Combined with the
+   * existing determinism in stage I/O (no module-level state, no
+   * ambient I/O, identity-by-content), this lets two runs of the same
+   * pipeline against the same inputs produce byte-identical outputs
+   * (FM03 §8).
+   *
+   * v0 of reproducible mode pins time only.  Iteration-order sorting
+   * (FM03 §8 item 2) lives in source stages; randomness gating (item
+   * 4) requires a deterministic `ctx.random` which is itself FM01
+   * future work.  Telemetry suppression (item 5) is handled by the
+   * orchestrator-wide `telemetry` option, not here.
+   *
+   * Default: false.
+   */
+  readonly reproducibleBuild?: boolean;
 }
+
+/**
+ * Fixed wall-clock timestamp emitted by the reproducible-build clock.
+ *
+ * Per FM03 §8: "the fixed value is the input pipeline's max input
+ * mtime, falling back to 0 if no inputs have timestamps."  v0 always
+ * uses the fallback (0) because the orchestrator doesn't yet thread
+ * input mtimes from sources to here.  When source-fs's revision
+ * tracking lands, this constant becomes an input-derived value; the
+ * `frozenClock` factory is unchanged.
+ *
+ * 0 = midnight UTC on 1970-01-01.  Exposed so tests can assert on
+ * the exact value the orchestrator's frozen clock returns.
+ */
+export const REPRO_BUILD_FROZEN_TIMESTAMP_MS = 0;
 
 export interface SchedulerResult {
   readonly outcome: RunOutcome;
@@ -115,13 +152,17 @@ export async function executeDag(
   const errors: RunError[] = [];
   const outputs = new Map<string, unknown>();
 
+  // Choose a clock factory once for the whole run.  Reproducible-build
+  // mode hands every stage a frozenClock; otherwise systemClock.
+  const newClock = clockFactory(options);
+
   // Init pass: call init() on every stage that has one.  If any init
   // throws, we abort before any run() is called and surface the failure.
   for (const id of dag.topoOrder) {
     const inst = dag.instances.get(id)!;
     states.set(id, makeState(inst));
     if (typeof inst.stage.init !== "function") continue;
-    const initCtx: StageInitContext = makeInitContext(inst, options);
+    const initCtx: StageInitContext = makeInitContext(inst, options, newClock);
     try {
       await inst.stage.init(inst.config, initCtx);
       states.get(id)!.initialized = true;
@@ -162,7 +203,7 @@ export async function executeDag(
       // Sources have no input; non-sources read from their producer's
       // output (which we previously stored in `outputs`).
       const inputs = collectInputs(inst, states);
-      const ctx: StageContext = makeRunContext(inst, options);
+      const ctx: StageContext = makeRunContext(inst, options, newClock);
 
       if (inst.stage.consumes.name === "Stream" || inst.stage.consumes.name === "Void"
           || isSingleProducer(inst, dag, states)) {
@@ -337,14 +378,37 @@ function makeAsyncIterableFromArray<T>(arr: readonly T[]): AsyncIterable<T> {
   };
 }
 
+/**
+ * Pick the clock factory based on reproducible-build mode.  Lazy-
+ * builds a single frozen clock per scheduler invocation so every
+ * stage in the run sees the same monotonic baseline.  The monotonic
+ * source is per-context (so two parallel calls inside one stage
+ * still measure relative elapsed time correctly), but the wall
+ * clock is shared.
+ */
+function clockFactory(options: SchedulerOptions): () => Clock {
+  if (!options.reproducibleBuild) {
+    return systemClock;
+  }
+  return () =>
+    frozenClock({
+      timestamp: REPRO_BUILD_FROZEN_TIMESTAMP_MS,
+      // Monotonic still advances per-call so any stage measuring
+      // its own elapsed time gets non-zero values.  The reproducible
+      // contract is on the wall clock, not the monotonic one.
+      monotonicTickMs: 1,
+    });
+}
+
 function makeRunContext(
   inst: ResolvedInstance,
   options: SchedulerOptions,
+  newClock: () => Clock,
 ): StageContext {
   return {
     logger: options.logger.child({ stage: inst.stage.name, instance: inst.id }),
     cancellation: options.cancellation,
-    time: systemClock(),
+    time: newClock(),
     cache: inMemoryCache(),
     telemetry: noOpTelemetryEmitter(),
     storage: deniedStorageApi(),
@@ -359,12 +423,13 @@ function makeRunContext(
 function makeInitContext(
   inst: ResolvedInstance,
   options: SchedulerOptions,
+  newClock: () => Clock,
 ): StageInitContext {
   // StageInitContext omits `cancellation` and `cache`, adds `config`.
   return {
     config: inst.config as JsonValue,
     logger: options.logger.child({ stage: inst.stage.name, instance: inst.id, phase: "init" }),
-    time: systemClock(),
+    time: newClock(),
     telemetry: noOpTelemetryEmitter(),
     storage: deniedStorageApi(),
     network: deniedNetworkApi(),
@@ -380,13 +445,17 @@ async function disposeAll(
   states: Map<string, RunState>,
   options: SchedulerOptions,
 ): Promise<void> {
+  // dispose() should see the same frozen clock as init() / run() did
+  // when the run is reproducible — otherwise a dispose hook that
+  // logs a timestamp would re-introduce non-determinism.
+  const newClock = clockFactory(options);
   for (const id of dag.topoOrder) {
     const state = states.get(id)!;
     if (!state.initialized) continue;
     const inst = dag.instances.get(id)!;
     if (typeof inst.stage.dispose !== "function") continue;
     try {
-      const disposeCtx = makeInitContext(inst, options);
+      const disposeCtx = makeInitContext(inst, options, newClock);
       await inst.stage.dispose(disposeCtx);
     } catch (err) {
       // Per FM03 §3.2 Dispose: failures are logged warnings, never escalated.

--- a/code/packages/typescript/forme-orchestrator/tests/repro-build.test.ts
+++ b/code/packages/typescript/forme-orchestrator/tests/repro-build.test.ts
@@ -1,0 +1,236 @@
+/**
+ * repro-build.test.ts — exercise FM03 §8 reproducible-build mode.
+ *
+ * Test strategy: build a tiny pipeline whose only stage reads
+ * `ctx.time.nowMs()` and emits it as the artifact.  Run twice:
+ *
+ *   - Without reproducibleBuild → the two artifacts have different
+ *     timestamps (system clock advanced).
+ *   - With reproducibleBuild     → the two artifacts are byte-identical
+ *     (frozen clock returns the same value both times).
+ *
+ * Also covers the dispose-time clock (a dispose hook that reads
+ * `ctx.time.nowMs()` sees the same frozen value the run hook saw).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  KERNEL_API_VERSION,
+  Kinds,
+  streamOf,
+} from "@coding-adventures/forme-types";
+import { defineStage, silentLogger } from "@coding-adventures/forme-stage";
+import type { PipelineConfig } from "@coding-adventures/forme-pipeline-config";
+import {
+  createOrchestrator,
+  REPRO_BUILD_FROZEN_TIMESTAMP_MS,
+} from "../src/index.js";
+
+// ─── Stages ──────────────────────────────────────────────────────────
+
+function clockStampingSource() {
+  return defineStage({
+    name: "@test/clock-source",
+    version: "0.1.0",
+    apiVersion: KERNEL_API_VERSION,
+    description: "yields a single ContentSource whose providerMeta records ctx.time.nowMs()",
+    consumes: Kinds.Void,
+    produces: streamOf(Kinds.ContentSource),
+    capabilities: [],
+    configSchema: null,
+    async *run(_input, _config, ctx) {
+      yield {
+        path: "stamp",
+        bytes: new TextEncoder().encode(String(ctx.time.nowMs())),
+        mimeType: "text/plain",
+        identity: "01952c0d-7e63-7000-8000-000000000000" as never,
+        revision: "blake2b:00" as never,
+        providerMeta: { stampedAt: ctx.time.nowMs() },
+      } as never;
+    },
+  });
+}
+
+function clockStampingSink() {
+  return defineStage({
+    name: "@test/clock-sink",
+    version: "0.1.0",
+    apiVersion: KERNEL_API_VERSION,
+    description: "wraps the source as a DeployArtifact whose buildTime is ctx.time.nowIso()",
+    consumes: Kinds.ContentSource,
+    produces: Kinds.DeployArtifact,
+    capabilities: [],
+    configSchema: null,
+    async run(source, _config, ctx) {
+      const s = source as { path: string; bytes: Uint8Array; providerMeta: { stampedAt: number } };
+      return {
+        variant: { kind: "dist-tree" as const },
+        files: { [s.path]: s.bytes },
+        manifest: {
+          routes: [],
+          assets: [],
+          buildTime: ctx.time.nowIso(),
+          buildId: "blake2b:00" as never,
+        },
+      } as never;
+    },
+  });
+}
+
+function makeConfig(reproducibleBuild: boolean): PipelineConfig {
+  return {
+    name: "repro-test",
+    settings: {
+      storageRoot: "./",
+      cacheDir: null,
+      reproducibleBuild,
+      maxConcurrency: null,
+      logLevel: "error",
+      bestEffort: false,
+      deadlineMs: null,
+    },
+    stages: [
+      { stage: clockStampingSource() },
+      { stage: clockStampingSink() },
+    ],
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe("reproducible-build mode (FM03 §8)", () => {
+  it("OFF: two runs produce different timestamps", async () => {
+    const a = createOrchestrator({ logger: silentLogger() });
+    const b = createOrchestrator({ logger: silentLogger() });
+    const cfg = makeConfig(false);
+
+    const pa = await a.buildPipeline(cfg);
+    const pb = await b.buildPipeline(cfg);
+
+    const ra = await a.runOnce(pa);
+    // Force a perceptible time gap so Date.now() advances even on
+    // fast machines.  Otherwise two consecutive runs can both land
+    // on the same millisecond and the assertion below flakes.
+    await new Promise((r) => setTimeout(r, 10));
+    const rb = await b.runOnce(pb);
+
+    expect(ra.outcome).toBe("success");
+    expect(rb.outcome).toBe("success");
+
+    const artA = ra.outputs["@test/clock-sink"] as { manifest: { buildTime: string } }[];
+    const artB = rb.outputs["@test/clock-sink"] as { manifest: { buildTime: string } }[];
+    expect(artA[0]!.manifest.buildTime).not.toBe(artB[0]!.manifest.buildTime);
+
+    await a.dispose();
+    await b.dispose();
+  });
+
+  it("ON: two runs produce the same timestamp (frozen clock)", async () => {
+    const a = createOrchestrator({ logger: silentLogger() });
+    const b = createOrchestrator({ logger: silentLogger() });
+    const cfg = makeConfig(true);
+
+    const pa = await a.buildPipeline(cfg);
+    const pb = await b.buildPipeline(cfg);
+
+    const ra = await a.runOnce(pa);
+    await new Promise((r) => setTimeout(r, 10));
+    const rb = await b.runOnce(pb);
+
+    expect(ra.outcome).toBe("success");
+    expect(rb.outcome).toBe("success");
+
+    const artA = ra.outputs["@test/clock-sink"] as { manifest: { buildTime: string } }[];
+    const artB = rb.outputs["@test/clock-sink"] as { manifest: { buildTime: string } }[];
+
+    // The buildTime is derived from ctx.time.nowIso() inside the
+    // sink.  With repro on, that's a constant.
+    expect(artA[0]!.manifest.buildTime).toBe(artB[0]!.manifest.buildTime);
+    expect(artA[0]!.manifest.buildTime).toBe(
+      new Date(REPRO_BUILD_FROZEN_TIMESTAMP_MS).toISOString(),
+    );
+
+    await a.dispose();
+    await b.dispose();
+  });
+
+  it("ON: source-stage stampedAt timestamps are also frozen", async () => {
+    const o = createOrchestrator({ logger: silentLogger() });
+    const pipeline = await o.buildPipeline(makeConfig(true));
+    const result = await o.runOnce(pipeline);
+
+    expect(result.outcome).toBe("success");
+    // Inspect the DeployArtifact's files map: the sink wrote the
+    // source's bytes (which are String(stampedAt)).
+    const arts = result.outputs["@test/clock-sink"] as Array<{ files: Record<string, Uint8Array> }>;
+    const bytes = arts[0]!.files["stamp"]!;
+    const stamp = new TextDecoder().decode(bytes);
+    expect(stamp).toBe(String(REPRO_BUILD_FROZEN_TIMESTAMP_MS));
+    await o.dispose();
+  });
+
+  it("ON: dispose() also sees the frozen clock", async () => {
+    const disposeStampSpy = vi.fn<(t: number) => void>();
+    const sinkWithDispose = defineStage({
+      name: "@test/clock-sink-with-dispose",
+      version: "0.1.0",
+      apiVersion: KERNEL_API_VERSION,
+      description: "as clock-sink, plus a dispose() that records ctx.time.nowMs",
+      consumes: Kinds.ContentSource,
+      produces: Kinds.DeployArtifact,
+      capabilities: [],
+      configSchema: null,
+      async init() { /* required so dispose runs */ },
+      async run(_s, _c, ctx) {
+        return {
+          variant: { kind: "dist-tree" as const },
+          files: {},
+          manifest: {
+            routes: [], assets: [],
+            buildTime: ctx.time.nowIso(),
+            buildId: "blake2b:00" as never,
+          },
+        } as never;
+      },
+      async dispose(ctx) {
+        disposeStampSpy(ctx.time.nowMs());
+      },
+    });
+
+    const cfg: PipelineConfig = {
+      ...makeConfig(true),
+      stages: [{ stage: clockStampingSource() }, { stage: sinkWithDispose }],
+    };
+    const o = createOrchestrator({ logger: silentLogger() });
+    await o.runOnce(await o.buildPipeline(cfg));
+    expect(disposeStampSpy).toHaveBeenCalledWith(REPRO_BUILD_FROZEN_TIMESTAMP_MS);
+    await o.dispose();
+  });
+
+  it("ON: REPRO_BUILD_FROZEN_TIMESTAMP_MS is exported (and equals 0 in v0)", () => {
+    // The constant is part of the public API so tests / drivers can
+    // assert on the exact value the orchestrator's frozen clock
+    // returns.  v0 fixes it to 0 (1970-01-01T00:00:00Z) per the
+    // FM03 §8 fallback rule.
+    expect(REPRO_BUILD_FROZEN_TIMESTAMP_MS).toBe(0);
+  });
+
+  it("OFF: default mode (settings.reproducibleBuild absent ⇒ false) uses real time", async () => {
+    const cfg: PipelineConfig = {
+      ...makeConfig(false),
+      // Explicitly leave reproducibleBuild as false — proves the
+      // default does NOT silently flip on for some other reason.
+    };
+    const o = createOrchestrator({ logger: silentLogger() });
+    const start = Date.now();
+    const r = await o.runOnce(await o.buildPipeline(cfg));
+    expect(r.outcome).toBe("success");
+    const arts = r.outputs["@test/clock-sink"] as Array<{ manifest: { buildTime: string } }>;
+    const ts = new Date(arts[0]!.manifest.buildTime).getTime();
+    // The timestamp should fall in [start, start + 10s].  Generous
+    // ceiling for slow CI machines.
+    expect(ts).toBeGreaterThanOrEqual(start - 1);
+    expect(ts).toBeLessThanOrEqual(start + 10_000);
+    await o.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Wires FM03 §8 reproducible-build mode through the scheduler. When ``pipeline.config.settings.reproducibleBuild === true``, every ``StageContext`` (init, run, dispose) receives a ``frozenClock`` instead of ``systemClock``. Two runs of the same pipeline against the same inputs now produce identical ``ctx.time.nowMs()`` / ``nowIso()`` values — sufficient for the hello-world topology to emit byte-identical artifacts across runs.

Version bumped to **0.2.0** (new public API surface — minor semver).

## What this PR adds

- ``REPRO_BUILD_FROZEN_TIMESTAMP_MS`` public constant (= 0, the FM03 §8 fallback)
- ``SchedulerOptions.reproducibleBuild?: boolean`` field
- ``clockFactory(options)`` helper that returns ``systemClock`` or a parameterised ``frozenClock`` factory based on the flag
- ``newClock`` threaded through ``makeRunContext``, ``makeInitContext``, ``disposeAll``
- ``run.ts`` forwards ``pipeline.config.settings.reproducibleBuild`` to the scheduler

## What's still deferred from FM03 §8

- **Iteration-order sorting** (lives in source stages, not orchestrator)
- **``ctx.random.deterministic(name)``** (kernel doesn't expose this yet)
- **Telemetry suppression** (correct today — no stage embeds telemetry into output)

These will be a follow-up PR once the kernel adds ``ctx.random`` and once source-stages thread input mtimes through.

## Test plan

- [x] 36 tests pass (30 existing + 6 new in tests/repro-build.test.ts)
- [x] Off-mode: two runs produce different timestamps ✓
- [x] On-mode: two runs produce identical timestamps ✓
- [x] On-mode: source ``ctx.time.nowMs()`` is also frozen ✓
- [x] On-mode: ``dispose()`` sees the same frozen clock ✓
- [x] Public constant exported and equals 0 ✓
- [x] Default (off) mode produces realistic timestamps ✓
- [x] Security review (sub-agent): no findings — no mode confusion, no info leak, regression-free
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)