### PR TITLE
feat: Phase 21 named variable-coeff ODEs + symbolic-ir 0.14.0 + spice-netlist-parser 0.2.0

### DIFF
--- a/code/packages/python/cas-ode/CHANGELOG.md
+++ b/code/packages/python/cas-ode/CHANGELOG.md
@@ -2,6 +2,124 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] — 2026-05-16
+
+### Added
+
+- **Named variable-coefficient 2nd-order ODE recognition** — Phase 21
+  - Recognises four classical ODE families whose solutions are named
+    special functions.  Pattern matching is *numerical*: coefficients
+    are evaluated at four interior test points `(0.3, 0.6, −0.25, 0.85)`
+    and compared to the expected algebraic form.  This handles any
+    syntactically equivalent tree the MACSYMA compiler might generate
+    for the same equation without requiring structural tree normalisation.
+
+  - **Legendre ODE** (`_try_legendre_ode`)
+    `(1−x²)y'' − 2x·y' + n(n+1)·y = 0` → `Equal(y, %c1·LegendreP(n,x) + %c2·LegendreQ(n,x))`
+    - P≈1−x² and Q≈−2x checked numerically; R extracted as constant n(n+1).
+    - `_legendre_n_from_lambda(lam)` finds non-negative integer n with n(n+1)=λ
+      using the quadratic formula and a round-trip integer check.
+
+  - **Bessel ODE** (`_try_bessel_ode`)
+    `x²y'' + x·y' + (x²−ν²)·y = 0` → `Equal(y, %c1·BesselJ(ν,x) + %c2·BesselY(ν,x))`
+    - P≈x² and Q≈x checked numerically.
+    - ν extracted from R(x) = x²−ν² via `_nu_from_r_minus_xsq` which evaluates
+      R at x=1 and x=2, verifies R(2)−R(1)≈3 (confirms x²-offset structure),
+      then finds the positive rational ν=p/q (denominator ≤ 20) by trial.
+    - Integer ν represented as `IRInteger`; fractional ν as `IRRational`.
+      Half-integer orders ν = n+1/2 (spherical Bessel functions) fully supported.
+
+  - **Hermite ODE** (`_try_hermite_ode`)
+    `y'' − 2x·y' + 2n·y = 0` → `Equal(y, %c1·HermiteH(n,x) + %c2·HermiteH2(n,x))`
+    - P must be exactly 1 (constant leading coefficient); Q≈−2x.
+    - R is constant = 2n; n must be a non-negative integer (reject non-even R).
+
+  - **Chebyshev ODE** (`_try_chebyshev_ode`)
+    `(1−x²)y'' − x·y' + n²·y = 0` → `Equal(y, %c1·ChebyshevT(n,x) + %c2·ChebyshevU(n,x))`
+    - P≈1−x² and Q≈−x checked numerically; R = n² requires perfect-square check.
+    - **Tried before Legendre** in the dispatcher because both have P≈1−x² but
+      differ on Q (−x vs −2x). Priority ordering prevents misclassification.
+
+  - **Phase 21 dispatcher** (`_try_var_coeff_named_ode`)
+    - Tries Chebyshev → Legendre → Bessel → Hermite in order and returns the
+      first match, or `None` if none of the families match.
+    - Inserted in `solve_ode` after Euler-Cauchy (step 5 — see Changed).
+
+- **New helper functions** (Section 3b):
+  - `_split_out_factor(term, target) → IRNode | None` — extracts K from
+    K·target in a nested Mul tree.  Handles `Neg(...)` wrappers, three-level
+    nesting, and the identity case term == target (returns `IRInteger(1)`).
+  - `_collect_var2_coeffs(expr, y, x) → (P, Q, R) | None` — generalises
+    `_collect_second_order_coeffs` to allow polynomial/rational coefficient
+    functions P(x), Q(x), R(x).  Flattens the Add tree and uses
+    `_split_out_factor` to attribute each term to y'', y', or y.
+  - `_eval_ir_at_x(node, x, xv) → float | None` — numerically evaluates an
+    x-only IR expression at a scalar point using the existing `_eval_at_xy`
+    helper with a dummy y symbol.
+  - `_coeff_matches_func(node, x, expected, tol=1e-9) → bool` — checks whether
+    `node` agrees with `expected(xv)` at all four canonical test points.
+  - `_extract_const_val(node, x) → float | None` — returns the numeric value
+    of a constant-w.r.t.-x node (None if it contains x).
+  - `_legendre_n_from_lambda(lam) → int | None` — quadratic-formula root
+    finder for n(n+1) = lam.
+  - `_nu_from_r_minus_xsq(R_node, x) → (p, q) | None` — rational-ν extractor
+    for Bessel R(x) = x²−ν² (denominator search up to 20).
+  - `_build_named_solution(sym1, sym2, param_ir, y, x) → IRNode` — builds
+    `Equal(y, %c1·sym1(param,x) + %c2·sym2(param,x))`.
+
+### Changed
+
+- `solve_ode` dispatcher — Phase 21 step added after Euler-Cauchy:
+  1. `_try_second_order_nonhom` (undetermined coefficients, Phase 18)
+  2. `_try_vop` (variation of parameters, Phase 20)
+  3. `_collect_second_order_coeffs` / `solve_second_order_const_coeff`
+  4. `_try_euler_cauchy` (Phase 19)
+  5. **`_try_var_coeff_named_ode`** ← new (Phase 21)
+  6. `_try_bernoulli`
+  7. `_collect_linear_first_order` / `solve_linear_first_order`
+  8. `_try_separable`
+  9. `_try_homogeneous_type`
+  10. `_try_exact`
+
+- Module docstring updated: "nine" → "thirteen" ODE classes; Phase 21 entries
+  (Legendre, Bessel, Hermite, Chebyshev) added to the class enumeration and
+  the literate reading guide (entries 26–38 added).
+- `pyproject.toml` description updated to include named variable-coefficient
+  ODEs.
+- `symbolic-ir` dependency bumped to `>=0.14.0` (required for `LEGENDRE_P`,
+  `LEGENDRE_Q`, `BESSEL_J`, `BESSEL_Y`, `HERMITE_H`, `HERMITE_H2`,
+  `CHEBYSHEV_T`, `CHEBYSHEV_U` head symbols).
+
+### Tests
+
+- **95 new tests** in `tests/test_phase21.py` across eight new classes:
+  - `TestSplitOutFactor` — 11 tests: identity, direct left/right, nested,
+    Neg wrappers, unrelated terms, different-target None.
+  - `TestCollectVar2Coeffs` — 6 tests: Legendre n=2, Bessel ν=1, Hermite n=3
+    coefficient checks; no-y'' None; free-constant None; missing-Q defaults-0.
+  - `TestLegendreNFromLambda` — 10 tests: n=0..4 round-trips; non-triangular
+    λ=5, λ=7; negative λ; slightly-off float; float precision near n=3.
+  - `TestNuFromRMinusXSq` — 8 tests: ν=0,1,2,3,1/2,3/2; non-x²-minus-const
+    input; negative ν².
+  - `TestTryLegendreOde` — 9 tests: n=0..3 recognised; λ=5 rejected; wrong-Q
+    rejected; Bessel/Hermite/const-coeff fall through.
+  - `TestTryBesselOde` — 10 tests: ν=0,1,2,1/2,3/2 recognised; C1/C2
+    present; Legendre/Hermite/const-coeff fall through; R=x²+1 rejects.
+  - `TestTryHermiteOde` — 10 tests: n=0..3 recognised; non-integer R; negative
+    R; Legendre/Bessel fall through; P≠1 rejects.
+  - `TestTryChebyshevOde` — 9 tests: n=0..3 recognised; non-square R; not
+    confused with Legendre; Bessel/Hermite fall through.
+  - `TestVarCoeffNamedOdeDispatcher` — 7 tests: dispatches all four families;
+    Chebyshev-before-Legendre priority verified; unrelated and 1st-order None.
+  - `TestPhase21EndToEnd` — 9 tests: solve_ode and VM-level dispatch for each
+    family; rational ν parameter; Equal(y,...) structure; C1/C2 present.
+  - `TestPhase21Regressions` — 6 tests: const-coeff real/complex roots;
+    no cross-contamination with named ODEs; Euler-Cauchy; first-order linear;
+    unrecognised variable-coeff stays unevaluated.
+- Combined coverage: **86.86%** (332 tests total).
+
+---
+
 ## [0.5.0] — 2026-05-08
 
 ### Added

--- a/code/packages/python/cas-ode/pyproject.toml
+++ b/code/packages/python/cas-ode/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-ode"
-version = "0.5.0"
-description = "Symbolic ODE solver for the MACSYMA CAS system — separable, first-order linear, Bernoulli, exact, homogeneous-type, second-order constant-coefficient, Euler-Cauchy equidimensional, and variation-of-parameters ODEs."
+version = "0.6.0"
+description = "Symbolic ODE solver for the MACSYMA CAS system — separable, first-order linear, Bernoulli, exact, homogeneous-type, second-order constant-coefficient, Euler-Cauchy, variation-of-parameters, and named variable-coefficient ODEs (Legendre, Bessel, Hermite, Chebyshev)."
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["cas", "ode", "differential-equations", "symbolic", "education"]
 dependencies = [
-    "coding-adventures-symbolic-ir>=0.7.4",
+    "coding-adventures-symbolic-ir>=0.14.0",
     "coding-adventures-symbolic-vm>=0.32.5",
 ]
 classifiers = [

--- a/code/packages/python/cas-ode/src/cas_ode/ode.py
+++ b/code/packages/python/cas-ode/src/cas_ode/ode.py
@@ -1,8 +1,8 @@
 """Symbolic ODE solver — the heart of cas-ode.
 
-This module provides pure-Python functions that recognise and solve nine
-classes of ordinary differential equations whose solutions can always be
-written in closed form:
+This module provides pure-Python functions that recognise and solve thirteen
+classes of ordinary differential equations whose solutions can be written in
+closed form or in terms of named special functions:
 
 1. **First-order linear**: ``dy/dx + P(x)·y = Q(x)``
 2. **Separable**: ``dy/dx = f(x)·g(y)`` (including the degenerate cases
@@ -31,6 +31,21 @@ written in closed form:
    discriminant case (distinct real, repeated, complex roots); the VM then
    integrates them.  Falls back gracefully (returns ``None``) when the
    integrals are not computable.
+
+10. **Legendre ODE** (Phase 21): ``(1−x²)·y'' − 2x·y' + n(n+1)·y = 0`` →
+    ``%c1·LegendreP(n,x) + %c2·LegendreQ(n,x)``  (n non-negative integer).
+11. **Bessel ODE** (Phase 21): ``x²·y'' + x·y' + (x²−ν²)·y = 0`` →
+    ``%c1·BesselJ(ν,x) + %c2·BesselY(ν,x)``  (ν rational, denominator ≤ 20).
+12. **Hermite ODE** (Phase 21): ``y'' − 2x·y' + 2n·y = 0`` →
+    ``%c1·HermiteH(n,x) + %c2·HermiteH2(n,x)``  (n non-negative integer).
+13. **Chebyshev ODE** (Phase 21): ``(1−x²)·y'' − x·y' + n²·y = 0`` →
+    ``%c1·ChebyshevT(n,x) + %c2·ChebyshevU(n,x)``  (n non-negative integer).
+
+The named-ODE solvers (10–13) use *numerical pattern matching* — the variable
+coefficients ``P(x)``, ``Q(x)``, ``R(x)`` are evaluated at a few test points
+and compared to the expected functions.  This is correct when the coefficients
+are analytic near the test points, but it means the solver may fail for
+expressions that are structurally unusual.
 
 Every public function takes IR nodes as input and returns IR nodes as
 output.  No floats are used for exact computation; rational arithmetic
@@ -83,7 +98,19 @@ Read the functions in this order:
     root case (distinct real, repeated, complex)
 24. :func:`_try_vop` — Phase 20 entry point; integrates and assembles the
     general solution ``y = y_h + y_p``
-25. :func:`solve_ode` — the top-level dispatcher
+25. :func:`_split_out_factor`      — extract K from K·target in a Mul tree (Phase 21)
+26. :func:`_collect_var2_coeffs`   — extract (P, Q, R) from variable-coeff 2nd-order ODE
+27. :func:`_eval_ir_at_x`          — numerically evaluate x-only IR at a point
+28. :func:`_coeff_matches_func`    — check if IR node ≈ expected_func(x) at test points
+29. :func:`_extract_const_val`     — get float value if IR node is x-independent
+30. :func:`_legendre_n_from_lambda`— find non-neg integer n with n(n+1) = λ
+31. :func:`_nu_from_r_minus_xsq`   — extract ν from R(x) − x² = −ν² (Bessel)
+32. :func:`_try_legendre_ode`      — Phase 21: Legendre ODE → LegendreP/Q
+33. :func:`_try_bessel_ode`        — Phase 21: Bessel ODE → BesselJ/Y
+34. :func:`_try_hermite_ode`       — Phase 21: Hermite ODE → HermiteH/H2
+35. :func:`_try_chebyshev_ode`     — Phase 21: Chebyshev ODE → ChebyshevT/U
+36. :func:`_try_var_coeff_named_ode` — dispatcher for named-ODE families
+37. :func:`solve_ode` — the top-level dispatcher
 """
 
 from __future__ import annotations
@@ -94,11 +121,19 @@ from typing import TYPE_CHECKING
 
 from symbolic_ir import (
     ADD,
+    BESSEL_J,
+    BESSEL_Y,
+    CHEBYSHEV_T,
+    CHEBYSHEV_U,
     COS,
     DIV,
     EQUAL,
     EXP,
+    HERMITE_H,
+    HERMITE_H2,
     INTEGRATE,
+    LEGENDRE_P,
+    LEGENDRE_Q,
     LOG,
     MUL,
     NEG,
@@ -864,6 +899,535 @@ def _try_euler_cauchy(
         return None
     a, b, c = coeffs
     return solve_euler_cauchy(a, b, c, y, x)
+
+
+# ---------------------------------------------------------------------------
+# Section 3b — Phase 21: Variable-coefficient 2nd-order named ODE recognition
+# ---------------------------------------------------------------------------
+#
+# This section implements pattern recognition for classic named families of
+# variable-coefficient second-order ODEs.  Each family has the form:
+#
+#     P(x)·y'' + Q(x)·y' + R(x)·y = 0
+#
+# where P, Q, R are polynomials in x.  When we recognise such an ODE as
+# belonging to a named family, we return the solution in terms of the
+# canonical named special functions for that family.
+#
+# Reading guide
+# -------------
+# 27. :func:`_split_out_factor`      — extract K from K·target in a Mul tree
+# 28. :func:`_collect_var2_coeffs`   — extract (P, Q, R) from variable-coeff 2nd-order ODE
+# 29. :func:`_eval_ir_at_x`          — numerically evaluate x-only IR at a point
+# 30. :func:`_coeff_matches_func`    — check if IR node ≈ expected_func(x) at test points
+# 31. :func:`_extract_const_val`     — get float value if IR node is x-independent
+# 32. :func:`_legendre_n_from_lambda`— find non-neg integer n with n(n+1) = λ
+# 33. :func:`_nu_from_r_minus_xsq`   — extract ν from R(x) - x² = -ν² (Bessel)
+# 34. :func:`_try_legendre_ode`      — recognise Legendre ODE → LegendreP/Q
+# 35. :func:`_try_bessel_ode`        — recognise Bessel ODE → BesselJ/Y
+# 36. :func:`_try_hermite_ode`       — recognise Hermite ODE → HermiteH/H2
+# 37. :func:`_try_chebyshev_ode`     — recognise Chebyshev ODE → ChebyshevT/U
+# 38. :func:`_try_var_coeff_named_ode` — dispatcher for all named-ODE families
+
+
+def _split_out_factor(term: IRNode, target: IRNode) -> IRNode | None:
+    """Return the coefficient K such that ``term = K * target``, or ``None``.
+
+    Handles nested ``Mul`` trees, ``Neg`` wrappers, and the degenerate
+    case ``term == target`` (coefficient = 1).
+
+    Examples::
+
+        _split_out_factor(Mul(Sub(1, Pow(x,2)), y''), y'')
+            → Sub(1, Pow(x,2))           # (1-x²)·y'' → coeff = (1-x²)
+
+        _split_out_factor(Mul(x, y'), y')
+            → x                          # x·y' → coeff = x
+
+        _split_out_factor(Neg(Mul(2, Mul(x, y'))), y')
+            → Neg(Mul(2, x))             # -2x·y' → coeff = -2x
+
+        _split_out_factor(y'', y')
+            → None                       # y'' ≠ y'
+    """
+    if term == target:
+        return _ONE
+    if not isinstance(term, IRApply):
+        return None
+    if term.head == NEG:
+        # Neg(inner) = -inner — try inner and negate the coefficient
+        inner_k = _split_out_factor(term.args[0], target)
+        if inner_k is not None:
+            return _neg(inner_k)
+        return None
+    if term.head == MUL:
+        a, b = term.args
+        # Directly: b is the target
+        if b == target:
+            return a
+        # Directly: a is the target
+        if a == target:
+            return b
+        # Recursively try the right sub-tree as coefficient × (something × target)
+        coeff_b = _split_out_factor(b, target)
+        if coeff_b is not None:
+            # term = a · (coeff_b · target) = (a · coeff_b) · target
+            return _mul(a, coeff_b)
+        # Recursively try the left sub-tree
+        coeff_a = _split_out_factor(a, target)
+        if coeff_a is not None:
+            # term = (coeff_a · target) · b = (coeff_a · b) · target
+            return _mul(coeff_a, b)
+    return None
+
+
+def _collect_var2_coeffs(
+    expr: IRNode,
+    y: IRSymbol,
+    x: IRSymbol,
+) -> tuple[IRNode, IRNode, IRNode] | None:
+    """Extract ``(P, Q, R)`` from ``P(x)·y'' + Q(x)·y' + R(x)·y = 0``.
+
+    Unlike :func:`_collect_second_order_coeffs`, the coefficients here may
+    be arbitrary IR expressions in ``x`` (polynomials, products, etc.).  They
+    must *not* contain ``y``, ``y'``, or ``y''``.
+
+    Returns ``(P, Q, R)`` IR nodes, or ``None`` if any term of ``expr`` does
+    not fit the pattern.  Note that the leading coefficient ``P`` must be
+    present (at least one term with ``y''``); ``Q`` and ``R`` default to ``0``
+    if their terms are absent.
+
+    Algorithm
+    ---------
+    1. Flatten ``expr`` into a sum of terms with :func:`_flatten_add`.
+    2. For each term, attempt to extract the coefficient of ``y''``, then
+       ``y'``, then ``y`` via :func:`_split_out_factor`.
+    3. Reject if a term contains none of ``y'', y', y`` (e.g. a free x-only
+       constant that the ODE solver cannot account for).
+    4. Aggregate each coefficient list and return their sum.
+    """
+    y_prime = IRApply(D, (y, x))
+    y_double = IRApply(D, (y_prime, x))
+
+    terms = _flatten_add(expr)
+
+    p_parts: list[IRNode] = []
+    q_parts: list[IRNode] = []
+    r_parts: list[IRNode] = []
+
+    for term in terms:
+        # Highest priority: term involves y'' (second derivative)
+        coeff_ypp = _split_out_factor(term, y_double)
+        if coeff_ypp is not None:
+            p_parts.append(coeff_ypp)
+            continue
+        # Next: term involves y' (first derivative)
+        coeff_yp = _split_out_factor(term, y_prime)
+        if coeff_yp is not None:
+            q_parts.append(coeff_yp)
+            continue
+        # Last: term involves y itself
+        coeff_y = _split_out_factor(term, y)
+        if coeff_y is not None:
+            r_parts.append(coeff_y)
+            continue
+        # Term contains no y-dependent factor — this ODE is not purely 2nd-order
+        return None
+
+    if not p_parts:
+        # No y'' term found — not a 2nd-order ODE in standard form
+        return None
+
+    def _sum_parts(parts: list[IRNode]) -> IRNode:
+        result = parts[0]
+        for p in parts[1:]:
+            result = _add(result, p)
+        return result
+
+    P_node = _sum_parts(p_parts)
+    Q_node = _sum_parts(q_parts) if q_parts else _ZERO
+    R_node = _sum_parts(r_parts) if r_parts else _ZERO
+    return (P_node, Q_node, R_node)
+
+
+# Canonical test x-values for coefficient matching.  These are chosen to
+# avoid singularities (|x| ≠ 1 for Legendre, x ≠ 0 for Bessel, etc.) while
+# probing a representative range.
+_VAR2_TEST_X: tuple[float, ...] = (0.3, 0.6, -0.25, 0.85)
+_VAR2_DUMMY_Y = IRSymbol("__var2_dummy_y__")
+
+
+def _eval_ir_at_x(node: IRNode, x: IRSymbol, xv: float) -> float | None:
+    """Numerically evaluate ``node`` at ``x = xv``, returning ``None`` on error.
+
+    Uses :func:`_eval_at_xy` with a dummy y-symbol so that x-only
+    expressions (polynomial coefficients) evaluate cleanly.
+    """
+    try:
+        return _eval_at_xy(node, x, _VAR2_DUMMY_Y, xv, 0.0)
+    except (ValueError, ZeroDivisionError, OverflowError, TypeError):
+        return None
+
+
+def _coeff_matches_func(
+    node: IRNode,
+    x: IRSymbol,
+    expected: object,  # Callable[[float], float]
+    tol: float = 1e-9,
+) -> bool:
+    """Return ``True`` iff ``node`` numerically agrees with ``expected(xv)``
+    at all of the canonical test points :data:`_VAR2_TEST_X`.
+
+    Falls through to ``False`` if numerical evaluation fails or any test
+    point differs by more than ``tol``.
+    """
+    for xv in _VAR2_TEST_X:
+        actual = _eval_ir_at_x(node, x, xv)
+        if actual is None:
+            return False
+        try:
+            want = expected(xv)  # type: ignore[operator]
+        except (ZeroDivisionError, ValueError):
+            return False
+        if abs(actual - want) > tol:
+            return False
+    return True
+
+
+def _extract_const_val(node: IRNode, x: IRSymbol) -> float | None:
+    """Return the float value of ``node`` if it is constant w.r.t. ``x``.
+
+    Returns ``None`` if ``node`` contains ``x`` or if numerical evaluation
+    fails for any reason.
+    """
+    if not _is_const_wrt(node, x):
+        return None
+    val = _eval_ir_at_x(node, x, 0.0)
+    return val
+
+
+def _legendre_n_from_lambda(lam: float) -> int | None:
+    """Return the non-negative integer ``n`` such that ``n(n+1) == lam``.
+
+    Uses the quadratic formula: ``n = (−1 + √(1 + 4λ)) / 2``.
+    Returns ``None`` if no such integer exists.
+
+    Examples::
+
+        _legendre_n_from_lambda(0)   → 0   (n=0: 0·1=0)
+        _legendre_n_from_lambda(2)   → 1   (n=1: 1·2=2)
+        _legendre_n_from_lambda(6)   → 2   (n=2: 2·3=6)
+        _legendre_n_from_lambda(12)  → 3   (n=3: 3·4=12)
+        _legendre_n_from_lambda(5)   → None
+    """
+    disc = 1.0 + 4.0 * lam
+    if disc < -1e-12:
+        return None
+    sqrt_disc = math.sqrt(max(disc, 0.0))
+    n_float = (-1.0 + sqrt_disc) / 2.0
+    n = round(n_float)
+    if n < 0:
+        return None
+    if abs(n_float - n) > 1e-7:
+        return None
+    # Verify exactly: n(n+1) should equal lam
+    if abs(n * (n + 1) - lam) > 1e-7:
+        return None
+    return n
+
+
+def _nu_from_r_minus_xsq(
+    R_node: IRNode,
+    x: IRSymbol,
+) -> tuple[int, int] | None:
+    """Extract ν as a rational ``(p, q)`` from ``R(x) = x² − ν²``.
+
+    Strategy: ``R(x) − x²`` must be constant (= −ν²).  Evaluate at a
+    non-zero test point to get ``−ν²``, then determine the positive rational
+    ν = p/q (with q ≤ 20) by trial.
+
+    Returns ``(p, q)`` such that ``ν = p/q`` in lowest terms, or ``None``
+    if ν is not a recognisable rational.
+
+    Examples::
+
+        # R(x) = x² − 4  →  ν = 2, returns (2, 1)
+        # R(x) = x² − 1/4 →  ν = 1/2, returns (1, 2)
+        # R(x) = x² − 9/4 →  ν = 3/2, returns (3, 2)
+    """
+    # R_minus_xsq_at(xv) should return -ν²  (independent of xv)
+    r_at_1 = _eval_ir_at_x(R_node, x, 1.0)
+    r_at_2 = _eval_ir_at_x(R_node, x, 2.0)
+    if r_at_1 is None or r_at_2 is None:
+        return None
+    # R(1) = 1 - ν²,  R(2) = 4 - ν²
+    # Consistency check: R(2) - R(1) should equal 3
+    if abs((r_at_2 - r_at_1) - 3.0) > 1e-8:
+        return None
+    # ν² = 1 - R(1)
+    nu_sq = 1.0 - r_at_1
+    if nu_sq < -1e-12:
+        return None
+    nu_sq = max(nu_sq, 0.0)
+    # Find rational ν = p/q with small denominator
+    from math import gcd as _gcd
+    for q in range(1, 21):
+        # (p/q)² = nu_sq  →  p² = nu_sq * q²
+        p_sq = nu_sq * q * q
+        p = round(math.sqrt(p_sq))
+        if abs(p * p - p_sq) < 1e-6 and p >= 0:
+            g = _gcd(p, q)
+            return (p // g, q // g)
+    return None
+
+
+def _build_named_solution(
+    sym1: IRSymbol,
+    sym2: IRSymbol,
+    param_ir: IRNode,
+    y: IRSymbol,
+    x: IRSymbol,
+) -> IRNode:
+    """Build ``Equal(y, %c1·sym1(param, x) + %c2·sym2(param, x))``."""
+    sol1 = _mul(C1, IRApply(sym1, (param_ir, x)))
+    sol2 = _mul(C2, IRApply(sym2, (param_ir, x)))
+    return IRApply(EQUAL, (y, _add(sol1, sol2)))
+
+
+def _try_legendre_ode(
+    expr: IRNode,
+    y: IRSymbol,
+    x: IRSymbol,
+) -> IRNode | None:
+    """Recognise and solve the Legendre ODE.
+
+    Standard form (all terms on the left, equal to zero):
+
+        ``(1 − x²)·y'' − 2x·y' + n(n+1)·y = 0``
+
+    Pattern checks (all numerical):
+
+    1. The y''-coefficient ``P(x)`` must equal ``1 − x²`` at four test
+       points: ``P(xv) ≈ 1 − xv²``.
+    2. The y'-coefficient ``Q(x)`` must equal ``−2x``:
+       ``Q(xv) ≈ −2·xv``.
+    3. The y-coefficient ``R`` must be constant and equal to ``n(n+1)``
+       for some non-negative integer ``n``.
+
+    On success, returns::
+
+        Equal(y, %c1·LegendreP(n, x) + %c2·LegendreQ(n, x))
+
+    The Legendre polynomial ``LegendreP(n, x)`` is the standard P_n(x)
+    (Rodrigues formula); ``LegendreQ(n, x)`` is the second solution Q_n(x)
+    (logarithmically singular at x = ±1).
+    """
+    coeffs = _collect_var2_coeffs(expr, y, x)
+    if coeffs is None:
+        return None
+    P_node, Q_node, R_node = coeffs
+
+    # Check P ≈ 1 - x²
+    if not _coeff_matches_func(P_node, x, lambda xv: 1.0 - xv * xv):
+        return None
+    # Check Q ≈ -2x
+    if not _coeff_matches_func(Q_node, x, lambda xv: -2.0 * xv):
+        return None
+    # R must be constant = n(n+1)
+    lam = _extract_const_val(R_node, x)
+    if lam is None:
+        return None
+    n = _legendre_n_from_lambda(lam)
+    if n is None:
+        return None
+
+    n_ir = IRInteger(n)
+    return _build_named_solution(LEGENDRE_P, LEGENDRE_Q, n_ir, y, x)
+
+
+def _try_bessel_ode(
+    expr: IRNode,
+    y: IRSymbol,
+    x: IRSymbol,
+) -> IRNode | None:
+    """Recognise and solve the Bessel ODE.
+
+    Standard form (all terms on the left, equal to zero):
+
+        ``x²·y'' + x·y' + (x² − ν²)·y = 0``
+
+    Pattern checks (numerical):
+
+    1. P(x) ≈ x²  at test points.
+    2. Q(x) ≈ x   at test points.
+    3. R(x) − x² is constant and equals −ν² for some non-negative rational ν.
+       Equivalently, R(x₁) − R(x₂) = x₁² − x₂² at any two points.
+
+    The order parameter ν is extracted as a rational p/q (denominator ≤ 20).
+
+    On success, returns::
+
+        Equal(y, %c1·BesselJ(ν, x) + %c2·BesselY(ν, x))
+
+    ``BesselJ(ν, x)`` is the Bessel function of the first kind; ``BesselY``
+    is the Bessel function (Neumann function) of the second kind.  For
+    integer n, J_n and Y_n are linearly independent.  For half-integer
+    orders (ν = n + 1/2), they reduce to spherical Bessel functions.
+    """
+    coeffs = _collect_var2_coeffs(expr, y, x)
+    if coeffs is None:
+        return None
+    P_node, Q_node, R_node = coeffs
+
+    # Check P ≈ x²
+    if not _coeff_matches_func(P_node, x, lambda xv: xv * xv):
+        return None
+    # Check Q ≈ x
+    if not _coeff_matches_func(Q_node, x, lambda xv: xv):
+        return None
+    # Extract ν from R(x) = x² - ν²
+    nu_pq = _nu_from_r_minus_xsq(R_node, x)
+    if nu_pq is None:
+        return None
+    p, q = nu_pq
+    nu_ir: IRNode = IRInteger(p) if q == 1 else IRRational(p, q)
+    return _build_named_solution(BESSEL_J, BESSEL_Y, nu_ir, y, x)
+
+
+def _try_hermite_ode(
+    expr: IRNode,
+    y: IRSymbol,
+    x: IRSymbol,
+) -> IRNode | None:
+    """Recognise and solve the Hermite ODE.
+
+    Standard form (all terms on the left, equal to zero):
+
+        ``y'' − 2x·y' + 2n·y = 0``
+
+    Pattern checks (numerical):
+
+    1. P(x) is constant = 1.
+    2. Q(x) ≈ −2x  at test points.
+    3. R is constant and equals 2n for some non-negative integer n.
+
+    On success, returns::
+
+        Equal(y, %c1·HermiteH(n, x) + %c2·HermiteH2(n, x))
+
+    ``HermiteH(n, x)`` is the physicist's Hermite polynomial H_n(x)
+    for non-negative integer n.  These arise in quantum harmonic oscillator
+    eigenfunctions.  ``HermiteH2(n, x)`` is the second linearly independent
+    solution (a parabolic cylinder function); it diverges as |x| → ∞.
+    """
+    coeffs = _collect_var2_coeffs(expr, y, x)
+    if coeffs is None:
+        return None
+    P_node, Q_node, R_node = coeffs
+
+    # Check P ≡ 1 (leading coefficient must be constant = 1)
+    p_val = _extract_const_val(P_node, x)
+    if p_val is None or abs(p_val - 1.0) > 1e-9:
+        return None
+    # Check Q ≈ -2x
+    if not _coeff_matches_func(Q_node, x, lambda xv: -2.0 * xv):
+        return None
+    # R must be constant = 2n, n non-negative integer
+    r_val = _extract_const_val(R_node, x)
+    if r_val is None:
+        return None
+    if r_val < -1e-12:
+        return None  # 2n must be non-negative
+    n_float = r_val / 2.0
+    n = round(n_float)
+    if n < 0 or abs(n_float - n) > 1e-9:
+        return None  # n must be a non-negative integer
+    n_ir = IRInteger(n)
+    return _build_named_solution(HERMITE_H, HERMITE_H2, n_ir, y, x)
+
+
+def _try_chebyshev_ode(
+    expr: IRNode,
+    y: IRSymbol,
+    x: IRSymbol,
+) -> IRNode | None:
+    """Recognise and solve the Chebyshev ODE.
+
+    Standard form (all terms on the left, equal to zero):
+
+        ``(1 − x²)·y'' − x·y' + n²·y = 0``
+
+    Pattern checks (numerical):
+
+    1. P(x) ≈ 1 − x²  at test points.
+    2. Q(x) ≈ −x      at test points.
+    3. R is constant and equals n² for some non-negative integer n.
+
+    On success, returns::
+
+        Equal(y, %c1·ChebyshevT(n, x) + %c2·ChebyshevU(n, x))
+
+    ``ChebyshevT(n, x)`` is the Chebyshev polynomial of the first kind T_n(x);
+    ``ChebyshevU(n, x)`` is the second kind U_n(x).  The T_n polynomials are
+    orthogonal on [−1, 1] with weight 1/√(1−x²) and satisfy
+    T_n(cos θ) = cos(n·θ).
+    """
+    coeffs = _collect_var2_coeffs(expr, y, x)
+    if coeffs is None:
+        return None
+    P_node, Q_node, R_node = coeffs
+
+    # Check P ≈ 1 - x²
+    if not _coeff_matches_func(P_node, x, lambda xv: 1.0 - xv * xv):
+        return None
+    # Check Q ≈ -x
+    if not _coeff_matches_func(Q_node, x, lambda xv: -xv):
+        return None
+    # R must be constant = n²
+    r_val = _extract_const_val(R_node, x)
+    if r_val is None or r_val < -1e-12:
+        return None
+    n_float = math.sqrt(max(r_val, 0.0))
+    n = round(n_float)
+    if n < 0 or abs(n_float - n) > 1e-7 or abs(n * n - r_val) > 1e-7:
+        return None  # n must be a non-negative integer with n² = r_val
+    n_ir = IRInteger(n)
+    return _build_named_solution(CHEBYSHEV_T, CHEBYSHEV_U, n_ir, y, x)
+
+
+def _try_var_coeff_named_ode(
+    expr: IRNode,
+    y: IRSymbol,
+    x: IRSymbol,
+) -> IRNode | None:
+    """Phase 21 dispatcher — try all named variable-coefficient ODE families.
+
+    Attempts to match ``expr = 0`` against each of the four recognised
+    named-ODE families in priority order:
+
+    1. **Chebyshev** — checked before Legendre because both have
+       ``P ≈ 1 − x²`` but Chebyshev has ``Q ≈ −x`` while Legendre
+       has ``Q ≈ −2x``.
+    2. **Legendre** — ``(1−x²)y'' − 2xy' + n(n+1)y = 0``.
+    3. **Bessel** — ``x²y'' + xy' + (x²−ν²)y = 0``.
+    4. **Hermite** — ``y'' − 2xy' + 2ny = 0``.
+
+    Returns ``Equal(y, solution)`` for the first match, ``None`` if none
+    of the families match.
+    """
+    result = _try_chebyshev_ode(expr, y, x)
+    if result is not None:
+        return result
+    result = _try_legendre_ode(expr, y, x)
+    if result is not None:
+        return result
+    result = _try_bessel_ode(expr, y, x)
+    if result is not None:
+        return result
+    result = _try_hermite_ode(expr, y, x)
+    if result is not None:
+        return result
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -2881,6 +3445,16 @@ def solve_ode(
     euler = _try_euler_cauchy(expr, y, x)
     if euler is not None:
         return euler
+
+    # ---- Phase 21: Named variable-coefficient 2nd-order ODEs ---------------
+    # Recognise Legendre, Bessel, Hermite, and Chebyshev ODEs.  These are
+    # tried *after* Euler-Cauchy because their coefficient patterns are more
+    # general (polynomial coefficients) and would not match constant-coeff
+    # or Euler-Cauchy forms anyway.  Runs before Bernoulli because it handles
+    # purely second-order equations.
+    named = _try_var_coeff_named_ode(expr, y, x)
+    if named is not None:
+        return named
 
     # ---- Phase 18: Bernoulli ------------------------------------------------
     bern = _try_bernoulli(expr, y, x, vm)

--- a/code/packages/python/cas-ode/tests/test_phase21.py
+++ b/code/packages/python/cas-ode/tests/test_phase21.py
@@ -1,0 +1,1100 @@
+"""Phase 21 tests — Named variable-coefficient 2nd-order ODE recognition.
+
+New solver family added in cas-ode 0.6.0
+-----------------------------------------
+- **Legendre**   ``(1−x²)y'' − 2x·y' + n(n+1)y = 0``  → LegendreP/Q
+- **Bessel**     ``x²y'' + x·y' + (x²−ν²)y = 0``       → BesselJ/Y
+- **Hermite**    ``y'' − 2x·y' + 2n·y = 0``             → HermiteH/H2
+- **Chebyshev**  ``(1−x²)y'' − x·y' + n²·y = 0``        → ChebyshevT/U
+
+Testing strategy
+----------------
+1. Unit-test each helper in isolation: ``_split_out_factor``,
+   ``_collect_var2_coeffs``, ``_legendre_n_from_lambda``,
+   ``_nu_from_r_minus_xsq``, ``_coeff_matches_func``,
+   ``_extract_const_val``.
+2. Test each recogniser function (``_try_legendre_ode`` etc.) with
+   valid inputs for several parameter values, invalid inputs that
+   look similar (e.g. wrong Q-coefficient), and completely unrelated
+   ODEs that must fall through.
+3. Test the dispatcher ``_try_var_coeff_named_ode``.
+4. End-to-end pipeline tests through ``solve_ode`` / ``eval_ode``
+   (ODE2 VM dispatch).
+5. Regression: const-coeff and Euler-Cauchy ODEs must still work
+   after Phase 21 is inserted above them in the dispatcher.
+
+Shape of solution nodes
+-----------------------
+Each recogniser returns::
+
+    Equal(y, Add(Mul(%c1, Sym(n, x)), Mul(%c2, Sym2(n, x))))
+
+where ``Sym`` and ``Sym2`` are the pair of named solution symbols
+(e.g. LEGENDRE_P / LEGENDRE_Q).  Tests verify:
+
+- The returned value is an ``IRApply`` with head ``EQUAL``.
+- The LHS of Equal is the dependent variable ``y``.
+- The solution contains the expected head symbol names.
+- The integration constants ``%c1`` and ``%c2`` are present.
+- The ODE parameter (n or ν) has the correct numeric value.
+"""
+
+from __future__ import annotations
+
+import math
+
+from symbolic_ir import (
+    ADD,
+    EQUAL,
+    MUL,
+    NEG,
+    POW,
+    SUB,
+    IRApply,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+from symbolic_ir.nodes import (
+    BESSEL_J,
+    BESSEL_Y,
+    CHEBYSHEV_T,
+    CHEBYSHEV_U,
+    C1,
+    C2,
+    D,
+    HERMITE_H,
+    HERMITE_H2,
+    LEGENDRE_P,
+    LEGENDRE_Q,
+    ODE2,
+)
+from symbolic_vm import VM, SymbolicBackend
+
+from cas_ode import build_ode_handler_table, solve_ode
+from cas_ode.ode import (
+    _build_named_solution,
+    _coeff_matches_func,
+    _collect_var2_coeffs,
+    _eval_ir_at_x,
+    _extract_const_val,
+    _legendre_n_from_lambda,
+    _nu_from_r_minus_xsq,
+    _split_out_factor,
+    _try_bessel_ode,
+    _try_chebyshev_ode,
+    _try_hermite_ode,
+    _try_legendre_ode,
+    _try_var_coeff_named_ode,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures and tiny IR builders
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+Y = IRSymbol("y")
+Y_PRIME = IRApply(D, (Y, X))
+Y_DOUBLE = IRApply(D, (Y_PRIME, X))
+
+
+def _I(n: int) -> IRInteger:
+    return IRInteger(n)
+
+
+def _R(p: int, q: int) -> IRRational:
+    return IRRational(p, q)
+
+
+def _mul(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(MUL, (a, b))
+
+
+def _add(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(ADD, (a, b))
+
+
+def _sub(a: IRNode, b: IRNode) -> IRNode:
+    return IRApply(SUB, (a, b))
+
+
+def _neg(node: IRNode) -> IRNode:
+    return IRApply(NEG, (node,))
+
+
+def _pow(base: IRNode, exp: IRNode) -> IRNode:
+    return IRApply(POW, (base, exp))
+
+
+def _x_sq() -> IRNode:
+    """Build x² as Pow(x, 2)."""
+    return _pow(X, _I(2))
+
+
+def _one_minus_x_sq() -> IRNode:
+    """Build (1 − x²) as Sub(1, Pow(x, 2))."""
+    return _sub(_I(1), _x_sq())
+
+
+# ---------------------------------------------------------------------------
+# ODE expression builders — canonical zero-form for each family
+# ---------------------------------------------------------------------------
+# Each function returns the expression `E` such that `E = 0` is the ODE.
+# The solve_ode / _try_* functions expect this zero form.
+
+def _legendre_expr(n: int) -> IRNode:
+    """(1−x²)y'' − 2x·y' + n(n+1)·y = 0  in zero form."""
+    lam = n * (n + 1)
+    # (1-x²)·y''
+    p_term = _mul(_one_minus_x_sq(), Y_DOUBLE)
+    # -2x·y'  =  Neg(Mul(Mul(2, x), y'))
+    q_term = _neg(_mul(_mul(_I(2), X), Y_PRIME))
+    # n(n+1)·y  — use integer node
+    r_term = _mul(_I(lam), Y)
+    return _add(_add(p_term, q_term), r_term)
+
+
+def _bessel_expr(nu_p: int, nu_q: int = 1) -> IRNode:
+    """x²y'' + x·y' + (x²−ν²)·y = 0  in zero form.  ν = nu_p / nu_q."""
+    # x²·y''
+    p_term = _mul(_x_sq(), Y_DOUBLE)
+    # x·y'
+    q_term = _mul(X, Y_PRIME)
+    # (x² − ν²)·y
+    if nu_q == 1:
+        nu_sq: IRNode = _I(nu_p * nu_p)
+    else:
+        # ν² = (nu_p/nu_q)²
+        nu_sq = _R(nu_p * nu_p, nu_q * nu_q)
+    r_coeff = _sub(_x_sq(), nu_sq)   # x² - ν²
+    r_term = _mul(r_coeff, Y)
+    return _add(_add(p_term, q_term), r_term)
+
+
+def _hermite_expr(n: int) -> IRNode:
+    """y'' − 2x·y' + 2n·y = 0  in zero form."""
+    # y''  (coefficient = 1)
+    p_term = Y_DOUBLE
+    # −2x·y'
+    q_term = _neg(_mul(_mul(_I(2), X), Y_PRIME))
+    # 2n·y
+    r_term = _mul(_I(2 * n), Y)
+    return _add(_add(p_term, q_term), r_term)
+
+
+def _chebyshev_expr(n: int) -> IRNode:
+    """(1−x²)y'' − x·y' + n²·y = 0  in zero form."""
+    # (1−x²)·y''
+    p_term = _mul(_one_minus_x_sq(), Y_DOUBLE)
+    # −x·y'
+    q_term = _neg(_mul(X, Y_PRIME))
+    # n²·y
+    r_term = _mul(_I(n * n), Y)
+    return _add(_add(p_term, q_term), r_term)
+
+
+# ---------------------------------------------------------------------------
+# VM / dispatcher helpers
+# ---------------------------------------------------------------------------
+
+def make_vm() -> VM:
+    """Return a SymbolicBackend VM with the ODE2 handler wired in."""
+    backend = SymbolicBackend()
+    backend._handlers.update(build_ode_handler_table())  # type: ignore[attr-defined]
+    return VM(backend)
+
+
+def eval_ode(expr: IRNode, y: IRSymbol = Y, x: IRSymbol = X) -> IRNode:
+    """Evaluate ODE2(expr, y, x) through the full VM pipeline."""
+    vm = make_vm()
+    return vm.eval(IRApply(ODE2, (expr, y, x)))
+
+
+def _is_equal_node(result: IRNode) -> tuple[IRNode, IRNode]:
+    """Assert result is Equal(lhs, rhs) and return (lhs, rhs)."""
+    assert isinstance(result, IRApply) and result.head == EQUAL, (
+        f"Expected Equal(...), got: {result!r}"
+    )
+    return result.args[0], result.args[1]
+
+
+def _was_evaluated(result: IRNode) -> None:
+    """Assert the result is NOT an unevaluated ODE2 node."""
+    assert not (isinstance(result, IRApply) and result.head == ODE2), (
+        f"Expected solved ODE, got unevaluated: {result!r}"
+    )
+
+
+def _is_unevaluated(result: IRNode) -> None:
+    """Assert the result IS an unevaluated ODE2 node."""
+    assert isinstance(result, IRApply) and result.head == ODE2, (
+        f"Expected unevaluated ODE2, got: {result!r}"
+    )
+
+
+def _has_symbol_name(node: IRNode, name: str) -> bool:
+    """Return True if any IRSymbol in the tree has the given name."""
+    if isinstance(node, IRSymbol):
+        return node.name == name
+    if isinstance(node, IRApply):
+        if node.head.name == name:
+            return True
+        return any(_has_symbol_name(c, name) for c in node.args)
+    return False
+
+
+def _collect_apply_heads(node: IRNode, acc: list[str]) -> None:
+    """Collect all head names of IRApply nodes into acc."""
+    if isinstance(node, IRApply):
+        acc.append(node.head.name)
+        for c in node.args:
+            _collect_apply_heads(c, acc)
+
+
+# ---------------------------------------------------------------------------
+# TestSplitOutFactor
+# ---------------------------------------------------------------------------
+
+
+class TestSplitOutFactor:
+    """Unit tests for :func:`_split_out_factor`.
+
+    The function must return K such that ``term = K * target``, or ``None``
+    if the target is not a factor of the term.
+    """
+
+    def test_term_equals_target_returns_one(self) -> None:
+        """term == target  →  K = 1 (the integer)."""
+        k = _split_out_factor(Y_DOUBLE, Y_DOUBLE)
+        assert k == IRInteger(1)
+
+    def test_direct_mul_right_is_target(self) -> None:
+        """Mul(2, y'')  →  K = 2."""
+        term = _mul(_I(2), Y_DOUBLE)
+        k = _split_out_factor(term, Y_DOUBLE)
+        assert k == _I(2)
+
+    def test_direct_mul_left_is_target(self) -> None:
+        """Mul(y'', x)  →  K = x."""
+        term = _mul(Y_DOUBLE, X)
+        k = _split_out_factor(term, Y_DOUBLE)
+        assert k == X
+
+    def test_nested_mul_right(self) -> None:
+        """Mul(Mul(2, x), y')  →  K = Mul(2, x)."""
+        coeff = _mul(_I(2), X)
+        term = _mul(coeff, Y_PRIME)
+        k = _split_out_factor(term, Y_PRIME)
+        assert k == coeff
+
+    def test_nested_mul_left(self) -> None:
+        """Mul(y', Mul(3, x))  →  K = Mul(3, x)."""
+        coeff = _mul(_I(3), X)
+        term = _mul(Y_PRIME, coeff)
+        k = _split_out_factor(term, Y_PRIME)
+        assert k == coeff
+
+    def test_neg_wraps_target(self) -> None:
+        """Neg(y'')  →  K = Neg(1) = Neg(IRInteger(1))."""
+        term = _neg(Y_DOUBLE)
+        k = _split_out_factor(term, Y_DOUBLE)
+        assert k is not None
+        # K should be Neg(1)
+        assert isinstance(k, IRApply) and k.head == NEG
+
+    def test_neg_mul(self) -> None:
+        """Neg(Mul(2, y'))  →  K = Neg(2)."""
+        term = _neg(_mul(_I(2), Y_PRIME))
+        k = _split_out_factor(term, Y_PRIME)
+        assert k is not None
+        assert isinstance(k, IRApply) and k.head == NEG
+
+    def test_unrelated_term_returns_none(self) -> None:
+        """x²  (no y factor)  →  None."""
+        k = _split_out_factor(_x_sq(), Y)
+        assert k is None
+
+    def test_different_yprime_vs_ydouble(self) -> None:
+        """Trying to extract y' from Mul(2, y'') returns None."""
+        term = _mul(_I(2), Y_DOUBLE)
+        k = _split_out_factor(term, Y_PRIME)
+        assert k is None
+
+    def test_mul_of_three_nested(self) -> None:
+        """Mul(a, Mul(b, y))  →  K = Mul(a, b)."""
+        a, b = _I(3), _I(5)
+        inner = _mul(b, Y)
+        term = _mul(a, inner)
+        k = _split_out_factor(term, Y)
+        # K should be Mul(3, 5) — the combined outer coefficient
+        assert k is not None
+
+    def test_integer_node_no_match(self) -> None:
+        """A bare IRInteger is never a K·target."""
+        k = _split_out_factor(_I(7), Y_DOUBLE)
+        assert k is None
+
+
+# ---------------------------------------------------------------------------
+# TestCollectVar2Coeffs
+# ---------------------------------------------------------------------------
+
+
+class TestCollectVar2Coeffs:
+    """Unit tests for :func:`_collect_var2_coeffs`.
+
+    Verifies that (P, Q, R) triples are extracted correctly from valid
+    variable-coefficient 2nd-order ODE expressions.
+    """
+
+    def test_legendre_n2_coefficients(self) -> None:
+        """Legendre n=2: P=(1-x²), Q=-2x, R=6."""
+        expr = _legendre_expr(2)
+        result = _collect_var2_coeffs(expr, Y, X)
+        assert result is not None
+        P, Q, R = result
+        # P ≈ 1-x² at test points
+        for xv in (0.3, 0.6, -0.25, 0.85):
+            p_val = _eval_ir_at_x(P, X, xv)
+            assert p_val is not None
+            assert abs(p_val - (1 - xv**2)) < 1e-9, f"P({xv}) off"
+
+    def test_bessel_n1_coefficients(self) -> None:
+        """Bessel ν=1: P=x², Q=x, R=(x²-1)."""
+        expr = _bessel_expr(1)
+        result = _collect_var2_coeffs(expr, Y, X)
+        assert result is not None
+        P, Q, R = result
+        for xv in (0.3, 0.6, 0.85):
+            p_val = _eval_ir_at_x(P, X, xv)
+            q_val = _eval_ir_at_x(Q, X, xv)
+            r_val = _eval_ir_at_x(R, X, xv)
+            assert p_val is not None and abs(p_val - xv**2) < 1e-9
+            assert q_val is not None and abs(q_val - xv) < 1e-9
+            assert r_val is not None and abs(r_val - (xv**2 - 1)) < 1e-9
+
+    def test_hermite_n3_coefficients(self) -> None:
+        """Hermite n=3: P=1, Q=-2x, R=6."""
+        expr = _hermite_expr(3)
+        result = _collect_var2_coeffs(expr, Y, X)
+        assert result is not None
+        P, Q, R = result
+        for xv in (0.3, 0.6):
+            p_val = _eval_ir_at_x(P, X, xv)
+            q_val = _eval_ir_at_x(Q, X, xv)
+            r_val = _eval_ir_at_x(R, X, xv)
+            assert p_val is not None and abs(p_val - 1.0) < 1e-9
+            assert q_val is not None and abs(q_val - (-2 * xv)) < 1e-9
+            assert r_val is not None and abs(r_val - 6.0) < 1e-9
+
+    def test_no_ydouble_term_returns_none(self) -> None:
+        """First-order ODE has no y'' — returns None."""
+        # y' + y = 0  (no y'' term)
+        expr = _add(Y_PRIME, Y)
+        assert _collect_var2_coeffs(expr, Y, X) is None
+
+    def test_free_constant_term_returns_none(self) -> None:
+        """y'' + y + 1 = 0 has a free x-only term (1) — returns None."""
+        expr = _add(_add(Y_DOUBLE, Y), _I(1))
+        assert _collect_var2_coeffs(expr, Y, X) is None
+
+    def test_missing_q_term_defaults_to_zero(self) -> None:
+        """y'' + n²y = 0 has no y' term — Q defaults to 0."""
+        n = 2
+        expr = _add(Y_DOUBLE, _mul(_I(n * n), Y))
+        result = _collect_var2_coeffs(expr, Y, X)
+        assert result is not None
+        P, Q, R = result
+        for xv in _VAR2_TEST_X:
+            q_val = _eval_ir_at_x(Q, X, xv)
+            assert q_val is not None and abs(q_val) < 1e-12
+
+
+_VAR2_TEST_X: tuple[float, ...] = (0.3, 0.6, -0.25, 0.85)
+
+
+# ---------------------------------------------------------------------------
+# TestLegendreNFromLambda
+# ---------------------------------------------------------------------------
+
+
+class TestLegendreNFromLambda:
+    """Unit tests for :func:`_legendre_n_from_lambda`."""
+
+    def test_n0(self) -> None:
+        """λ=0 → n=0  (0·1=0)."""
+        assert _legendre_n_from_lambda(0.0) == 0
+
+    def test_n1(self) -> None:
+        """λ=2 → n=1  (1·2=2)."""
+        assert _legendre_n_from_lambda(2.0) == 1
+
+    def test_n2(self) -> None:
+        """λ=6 → n=2  (2·3=6)."""
+        assert _legendre_n_from_lambda(6.0) == 2
+
+    def test_n3(self) -> None:
+        """λ=12 → n=3  (3·4=12)."""
+        assert _legendre_n_from_lambda(12.0) == 3
+
+    def test_n4(self) -> None:
+        """λ=20 → n=4  (4·5=20)."""
+        assert _legendre_n_from_lambda(20.0) == 4
+
+    def test_non_triangular_lambda_returns_none(self) -> None:
+        """λ=5 is not n(n+1) for any integer n → None."""
+        assert _legendre_n_from_lambda(5.0) is None
+
+    def test_lambda_7_returns_none(self) -> None:
+        """λ=7 → None."""
+        assert _legendre_n_from_lambda(7.0) is None
+
+    def test_negative_lambda_returns_none(self) -> None:
+        """λ=-3 → None (negative discriminant)."""
+        assert _legendre_n_from_lambda(-3.0) is None
+
+    def test_lambda_slightly_off_returns_none(self) -> None:
+        """λ=6.01 is not close enough to 6 → None."""
+        assert _legendre_n_from_lambda(6.01) is None
+
+    def test_float_precision_near_n3(self) -> None:
+        """λ=12.0000001 should still resolve to n=3 (within tolerance)."""
+        # The tolerance is 1e-7, so a tiny float error is forgiven
+        result = _legendre_n_from_lambda(12.0 + 1e-8)
+        assert result == 3
+
+
+# ---------------------------------------------------------------------------
+# TestNuFromRMinusXSq
+# ---------------------------------------------------------------------------
+
+
+class TestNuFromRMinusXSq:
+    """Unit tests for :func:`_nu_from_r_minus_xsq`."""
+
+    def _make_r(self, nu_p: int, nu_q: int = 1) -> IRNode:
+        """Build IR for R(x) = x² − ν² where ν = nu_p/nu_q."""
+        if nu_q == 1:
+            nu_sq_ir: IRNode = _I(nu_p * nu_p)
+        else:
+            nu_sq_ir = _R(nu_p * nu_p, nu_q * nu_q)
+        return _sub(_x_sq(), nu_sq_ir)
+
+    def test_nu_0(self) -> None:
+        """R = x² → ν = 0, returns (0, 1)."""
+        R = _x_sq()
+        result = _nu_from_r_minus_xsq(R, X)
+        assert result is not None
+        p, q = result
+        assert p == 0
+
+    def test_nu_1(self) -> None:
+        """R = x²−1 → ν = 1, returns (1, 1)."""
+        R = self._make_r(1)
+        result = _nu_from_r_minus_xsq(R, X)
+        assert result == (1, 1)
+
+    def test_nu_2(self) -> None:
+        """R = x²−4 → ν = 2, returns (2, 1)."""
+        R = self._make_r(2)
+        result = _nu_from_r_minus_xsq(R, X)
+        assert result == (2, 1)
+
+    def test_nu_3(self) -> None:
+        """R = x²−9 → ν = 3, returns (3, 1)."""
+        R = self._make_r(3)
+        result = _nu_from_r_minus_xsq(R, X)
+        assert result == (3, 1)
+
+    def test_nu_half(self) -> None:
+        """R = x²−1/4 → ν = 1/2, returns (1, 2)."""
+        R = self._make_r(1, 2)
+        result = _nu_from_r_minus_xsq(R, X)
+        assert result == (1, 2)
+
+    def test_nu_three_halves(self) -> None:
+        """R = x²−9/4 → ν = 3/2, returns (3, 2)."""
+        R = self._make_r(3, 2)
+        result = _nu_from_r_minus_xsq(R, X)
+        assert result == (3, 2)
+
+    def test_non_xsq_minus_const_returns_none(self) -> None:
+        """R = x (linear, not x²−c) → None."""
+        R = X
+        result = _nu_from_r_minus_xsq(R, X)
+        assert result is None
+
+    def test_neg_nu_sq_returns_none(self) -> None:
+        """R = x²+1 → ν² = −1 < 0 → None."""
+        R = _add(_x_sq(), _I(1))
+        result = _nu_from_r_minus_xsq(R, X)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestTryLegendreOde
+# ---------------------------------------------------------------------------
+
+
+class TestTryLegendreOde:
+    """Tests for :func:`_try_legendre_ode`.
+
+    The Legendre ODE is ``(1−x²)y'' − 2x·y' + n(n+1)·y = 0``.
+    The recogniser verifies coefficients numerically and extracts ``n``.
+    """
+
+    def _check_legendre_solution(self, result: IRNode, expected_n: int) -> None:
+        """Assert result is Equal(y, %c1·LegendreP(n,x) + %c2·LegendreQ(n,x))."""
+        assert result is not None, "Expected solution, got None"
+        lhs, rhs = _is_equal_node(result)
+        assert lhs == Y
+        # Must contain LegendreP and LegendreQ
+        assert _has_symbol_name(rhs, "LegendreP"), f"LegendreP missing in {rhs!r}"
+        assert _has_symbol_name(rhs, "LegendreQ"), f"LegendreQ missing in {rhs!r}"
+        # Must contain %c1 and %c2
+        assert _has_symbol_name(rhs, "%c1"), f"%c1 missing in {rhs!r}"
+        assert _has_symbol_name(rhs, "%c2"), f"%c2 missing in {rhs!r}"
+        # Verify the n parameter
+        assert _has_symbol_name(rhs, str(expected_n)) or _param_in_apply(
+            rhs, expected_n
+        ), f"Expected n={expected_n} in {rhs!r}"
+
+    def _check_legendre_result(self, result: IRNode, expected_n: int) -> None:
+        """Assert result has the correct LegendreP/Q structure."""
+        self._check_legendre_solution(result, expected_n)
+
+    def test_legendre_n0(self) -> None:
+        """n=0: (1−x²)y'' − 2xy' + 0·y = 0  →  LegendreP/Q with n=0."""
+        result = _try_legendre_ode(_legendre_expr(0), Y, X)
+        assert result is not None
+        lhs, rhs = _is_equal_node(result)
+        assert lhs == Y
+        assert _has_symbol_name(rhs, "LegendreP")
+        assert _has_symbol_name(rhs, "LegendreQ")
+
+    def test_legendre_n1(self) -> None:
+        """n=1: λ=2, Q=-2x, should be recognised."""
+        result = _try_legendre_ode(_legendre_expr(1), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "LegendreP")
+
+    def test_legendre_n2(self) -> None:
+        """n=2: λ=6, standard form, should be recognised."""
+        result = _try_legendre_ode(_legendre_expr(2), Y, X)
+        assert result is not None
+        lhs, rhs = _is_equal_node(result)
+        assert lhs == Y
+        assert _has_symbol_name(rhs, "LegendreP")
+        assert _has_symbol_name(rhs, "LegendreQ")
+
+    def test_legendre_n3(self) -> None:
+        """n=3: λ=12, should be recognised."""
+        result = _try_legendre_ode(_legendre_expr(3), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "LegendreP")
+
+    def test_legendre_bad_lambda_5_returns_none(self) -> None:
+        """(1−x²)y'' − 2xy' + 5y = 0: λ=5 is not n(n+1) → None."""
+        # Build with λ=5
+        p_term = _mul(_one_minus_x_sq(), Y_DOUBLE)
+        q_term = _neg(_mul(_mul(_I(2), X), Y_PRIME))
+        r_term = _mul(_I(5), Y)
+        expr = _add(_add(p_term, q_term), r_term)
+        result = _try_legendre_ode(expr, Y, X)
+        assert result is None
+
+    def test_legendre_wrong_q_coeff_returns_none(self) -> None:
+        """(1−x²)y'' − x·y' + 6y = 0: Q≈−x, not −2x  (this is Chebyshev n=√6 — non-integer, also None)."""
+        # Q = -x instead of -2x  →  not Legendre
+        p_term = _mul(_one_minus_x_sq(), Y_DOUBLE)
+        q_term = _neg(_mul(X, Y_PRIME))
+        r_term = _mul(_I(6), Y)
+        expr = _add(_add(p_term, q_term), r_term)
+        result = _try_legendre_ode(expr, Y, X)
+        assert result is None
+
+    def test_legendre_bessel_not_recognised(self) -> None:
+        """Bessel ODE is not Legendre."""
+        result = _try_legendre_ode(_bessel_expr(1), Y, X)
+        assert result is None
+
+    def test_legendre_hermite_not_recognised(self) -> None:
+        """Hermite ODE is not Legendre."""
+        result = _try_legendre_ode(_hermite_expr(2), Y, X)
+        assert result is None
+
+    def test_legendre_const_coeff_not_recognised(self) -> None:
+        """y'' + y = 0 (const-coeff) is not Legendre."""
+        expr = _add(Y_DOUBLE, Y)
+        result = _try_legendre_ode(expr, Y, X)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestTryBesselOde
+# ---------------------------------------------------------------------------
+
+
+class TestTryBesselOde:
+    """Tests for :func:`_try_bessel_ode`.
+
+    Bessel ODE: ``x²y'' + x·y' + (x²−ν²)·y = 0``.
+    """
+
+    def test_bessel_nu0(self) -> None:
+        """ν=0: R = x², should be recognised."""
+        result = _try_bessel_ode(_bessel_expr(0), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "BesselJ")
+        assert _has_symbol_name(result, "BesselY")
+
+    def test_bessel_nu1(self) -> None:
+        """ν=1: R = x²−1, should be recognised."""
+        result = _try_bessel_ode(_bessel_expr(1), Y, X)
+        assert result is not None
+        lhs, rhs = _is_equal_node(result)
+        assert lhs == Y
+        assert _has_symbol_name(rhs, "BesselJ")
+        assert _has_symbol_name(rhs, "BesselY")
+
+    def test_bessel_nu2(self) -> None:
+        """ν=2: R = x²−4, should be recognised."""
+        result = _try_bessel_ode(_bessel_expr(2), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "BesselJ")
+
+    def test_bessel_nu_half(self) -> None:
+        """ν=1/2: R = x²−1/4, should be recognised as rational order."""
+        result = _try_bessel_ode(_bessel_expr(1, 2), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "BesselJ")
+        # Parameter should be IRRational(1,2)
+        assert _has_rational_param(result, 1, 2)
+
+    def test_bessel_nu_three_halves(self) -> None:
+        """ν=3/2: R = x²−9/4, should be recognised."""
+        result = _try_bessel_ode(_bessel_expr(3, 2), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "BesselJ")
+
+    def test_bessel_contains_c1_c2(self) -> None:
+        """Bessel solution contains %c1 and %c2."""
+        result = _try_bessel_ode(_bessel_expr(1), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "%c1")
+        assert _has_symbol_name(result, "%c2")
+
+    def test_bessel_legendre_not_recognised(self) -> None:
+        """Legendre ODE is not Bessel."""
+        result = _try_bessel_ode(_legendre_expr(2), Y, X)
+        assert result is None
+
+    def test_bessel_hermite_not_recognised(self) -> None:
+        """Hermite ODE is not Bessel."""
+        result = _try_bessel_ode(_hermite_expr(2), Y, X)
+        assert result is None
+
+    def test_bessel_const_coeff_not_recognised(self) -> None:
+        """y'' + y = 0 (const-coeff) is not Bessel."""
+        expr = _add(Y_DOUBLE, Y)
+        result = _try_bessel_ode(expr, Y, X)
+        assert result is None
+
+    def test_bessel_r_is_xsq_plus_const_not_xsq_minus_nu_sq(self) -> None:
+        """x²y'' + xy' + (x²+1)y = 0: ν² = −1 < 0 → None."""
+        r_coeff = _add(_x_sq(), _I(1))
+        expr = _add(
+            _add(_mul(_x_sq(), Y_DOUBLE), _mul(X, Y_PRIME)),
+            _mul(r_coeff, Y),
+        )
+        result = _try_bessel_ode(expr, Y, X)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestTryHermiteOde
+# ---------------------------------------------------------------------------
+
+
+class TestTryHermiteOde:
+    """Tests for :func:`_try_hermite_ode`.
+
+    Hermite ODE: ``y'' − 2x·y' + 2n·y = 0``.
+    """
+
+    def test_hermite_n0(self) -> None:
+        """n=0: y'' − 2xy' = 0, should be recognised."""
+        result = _try_hermite_ode(_hermite_expr(0), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "HermiteH")
+        assert _has_symbol_name(result, "HermiteH2")
+
+    def test_hermite_n1(self) -> None:
+        """n=1: y'' − 2xy' + 2y = 0, should be recognised."""
+        result = _try_hermite_ode(_hermite_expr(1), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "HermiteH")
+
+    def test_hermite_n2(self) -> None:
+        """n=2: y'' − 2xy' + 4y = 0, should be recognised."""
+        result = _try_hermite_ode(_hermite_expr(2), Y, X)
+        assert result is not None
+        lhs, rhs = _is_equal_node(result)
+        assert lhs == Y
+
+    def test_hermite_n3(self) -> None:
+        """n=3: y'' − 2xy' + 6y = 0, should be recognised."""
+        result = _try_hermite_ode(_hermite_expr(3), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "HermiteH")
+
+    def test_hermite_contains_c1_c2(self) -> None:
+        """Hermite solution contains %c1 and %c2."""
+        result = _try_hermite_ode(_hermite_expr(2), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "%c1")
+        assert _has_symbol_name(result, "%c2")
+
+    def test_hermite_non_integer_r_val_returns_none(self) -> None:
+        """y'' − 2xy' + 3y = 0: 2n=3 → n=1.5 (non-integer) → None."""
+        # R = 3 (odd, not even integer means n=1.5)
+        p_term = Y_DOUBLE
+        q_term = _neg(_mul(_mul(_I(2), X), Y_PRIME))
+        r_term = _mul(_I(3), Y)
+        expr = _add(_add(p_term, q_term), r_term)
+        result = _try_hermite_ode(expr, Y, X)
+        assert result is None
+
+    def test_hermite_negative_r_returns_none(self) -> None:
+        """y'' − 2xy' − 2y = 0: R=-2 < 0 → None."""
+        p_term = Y_DOUBLE
+        q_term = _neg(_mul(_mul(_I(2), X), Y_PRIME))
+        r_term = _neg(_mul(_I(2), Y))
+        expr = _add(_add(p_term, q_term), r_term)
+        result = _try_hermite_ode(expr, Y, X)
+        assert result is None
+
+    def test_hermite_legendre_not_recognised(self) -> None:
+        """Legendre ODE is not Hermite."""
+        result = _try_hermite_ode(_legendre_expr(2), Y, X)
+        assert result is None
+
+    def test_hermite_bessel_not_recognised(self) -> None:
+        """Bessel ODE is not Hermite."""
+        result = _try_hermite_ode(_bessel_expr(1), Y, X)
+        assert result is None
+
+    def test_hermite_non_unit_p_returns_none(self) -> None:
+        """2y'' − 2xy' + 4y = 0: P=2 ≠ 1 → not standard Hermite form → None."""
+        p_term = _mul(_I(2), Y_DOUBLE)
+        q_term = _neg(_mul(_mul(_I(2), X), Y_PRIME))
+        r_term = _mul(_I(4), Y)
+        expr = _add(_add(p_term, q_term), r_term)
+        result = _try_hermite_ode(expr, Y, X)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestTryChebyshevOde
+# ---------------------------------------------------------------------------
+
+
+class TestTryChebyshevOde:
+    """Tests for :func:`_try_chebyshev_ode`.
+
+    Chebyshev ODE: ``(1−x²)y'' − x·y' + n²·y = 0``.
+    """
+
+    def test_chebyshev_n0(self) -> None:
+        """n=0: (1−x²)y'' − xy' + 0·y = 0, should be recognised."""
+        result = _try_chebyshev_ode(_chebyshev_expr(0), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "ChebyshevT")
+        assert _has_symbol_name(result, "ChebyshevU")
+
+    def test_chebyshev_n1(self) -> None:
+        """n=1: (1−x²)y'' − xy' + y = 0, should be recognised."""
+        result = _try_chebyshev_ode(_chebyshev_expr(1), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "ChebyshevT")
+
+    def test_chebyshev_n2(self) -> None:
+        """n=2: (1−x²)y'' − xy' + 4y = 0, should be recognised."""
+        result = _try_chebyshev_ode(_chebyshev_expr(2), Y, X)
+        assert result is not None
+        lhs, rhs = _is_equal_node(result)
+        assert lhs == Y
+        assert _has_symbol_name(rhs, "ChebyshevT")
+        assert _has_symbol_name(rhs, "ChebyshevU")
+
+    def test_chebyshev_n3(self) -> None:
+        """n=3: (1−x²)y'' − xy' + 9y = 0, should be recognised."""
+        result = _try_chebyshev_ode(_chebyshev_expr(3), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "ChebyshevT")
+
+    def test_chebyshev_contains_c1_c2(self) -> None:
+        """Chebyshev solution contains %c1 and %c2."""
+        result = _try_chebyshev_ode(_chebyshev_expr(2), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "%c1")
+        assert _has_symbol_name(result, "%c2")
+
+    def test_chebyshev_non_perfect_square_r_returns_none(self) -> None:
+        """(1−x²)y'' − xy' + 2y = 0: n²=2 → n=√2 (non-integer) → None."""
+        p_term = _mul(_one_minus_x_sq(), Y_DOUBLE)
+        q_term = _neg(_mul(X, Y_PRIME))
+        r_term = _mul(_I(2), Y)
+        expr = _add(_add(p_term, q_term), r_term)
+        result = _try_chebyshev_ode(expr, Y, X)
+        assert result is None
+
+    def test_chebyshev_not_confused_with_legendre_n2(self) -> None:
+        """Legendre n=2 has Q≈−2x; Chebyshev recogniser checks Q≈−x → should not match."""
+        # _try_chebyshev_ode on the Legendre n=2 expression must return None
+        # because Q = -2x ≠ -x
+        result = _try_chebyshev_ode(_legendre_expr(2), Y, X)
+        assert result is None
+
+    def test_chebyshev_bessel_not_recognised(self) -> None:
+        """Bessel ODE is not Chebyshev."""
+        result = _try_chebyshev_ode(_bessel_expr(1), Y, X)
+        assert result is None
+
+    def test_chebyshev_hermite_not_recognised(self) -> None:
+        """Hermite ODE is not Chebyshev."""
+        result = _try_chebyshev_ode(_hermite_expr(2), Y, X)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestVarCoeffNamedOdeDispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestVarCoeffNamedOdeDispatcher:
+    """Tests for :func:`_try_var_coeff_named_ode` — the Phase 21 dispatcher."""
+
+    def test_dispatches_legendre(self) -> None:
+        """Dispatcher recognises Legendre n=2."""
+        result = _try_var_coeff_named_ode(_legendre_expr(2), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "LegendreP")
+
+    def test_dispatches_bessel(self) -> None:
+        """Dispatcher recognises Bessel ν=1."""
+        result = _try_var_coeff_named_ode(_bessel_expr(1), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "BesselJ")
+
+    def test_dispatches_hermite(self) -> None:
+        """Dispatcher recognises Hermite n=3."""
+        result = _try_var_coeff_named_ode(_hermite_expr(3), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "HermiteH")
+
+    def test_dispatches_chebyshev(self) -> None:
+        """Dispatcher recognises Chebyshev n=2."""
+        result = _try_var_coeff_named_ode(_chebyshev_expr(2), Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "ChebyshevT")
+
+    def test_chebyshev_before_legendre_in_priority(self) -> None:
+        """Chebyshev is tried before Legendre; the correct family wins.
+
+        Chebyshev n=2: Q≈−x.  If tried second it would incorrectly match
+        Legendre's P≈1−x² check first and get stuck on Q≈−2x.  By trying
+        Chebyshev first we guarantee the correct family is identified.
+        """
+        cheb_expr = _chebyshev_expr(2)   # Q = -x (Chebyshev)
+        result = _try_var_coeff_named_ode(cheb_expr, Y, X)
+        assert result is not None
+        assert _has_symbol_name(result, "ChebyshevT")
+        assert not _has_symbol_name(result, "LegendreP")
+
+    def test_unrelated_ode_returns_none(self) -> None:
+        """y'' + y = 0 (const-coeff) returns None from dispatcher."""
+        expr = _add(Y_DOUBLE, Y)
+        result = _try_var_coeff_named_ode(expr, Y, X)
+        assert result is None
+
+    def test_first_order_returns_none(self) -> None:
+        """y' + y = 0 returns None (not 2nd-order)."""
+        expr = _add(Y_PRIME, Y)
+        result = _try_var_coeff_named_ode(expr, Y, X)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestPhase21EndToEnd — through solve_ode and the VM
+# ---------------------------------------------------------------------------
+
+
+class TestPhase21EndToEnd:
+    """End-to-end tests running through solve_ode and the ODE2 VM handler.
+
+    These verify the full pipeline: MACSYMA IR → dispatcher → recogniser →
+    named solution node.
+    """
+
+    def test_legendre_n2_via_solve_ode(self) -> None:
+        """solve_ode recognises Legendre n=2 directly (passed a live VM)."""
+        vm = make_vm()
+        result = solve_ode(_legendre_expr(2), Y, X, vm)
+        assert result is not None
+        assert _has_symbol_name(result, "LegendreP")
+        assert _has_symbol_name(result, "LegendreQ")
+
+    def test_legendre_n3_via_vm(self) -> None:
+        """ODE2(legendre_n3, y, x) through the VM."""
+        result = eval_ode(_legendre_expr(3))
+        _was_evaluated(result)
+        assert _has_symbol_name(result, "LegendreP")
+
+    def test_bessel_nu1_via_solve_ode(self) -> None:
+        """solve_ode recognises Bessel ν=1 (passed a live VM)."""
+        vm = make_vm()
+        result = solve_ode(_bessel_expr(1), Y, X, vm)
+        assert result is not None
+        assert _has_symbol_name(result, "BesselJ")
+        assert _has_symbol_name(result, "BesselY")
+
+    def test_bessel_nu1_via_vm(self) -> None:
+        """ODE2(bessel_nu1, y, x) through the VM."""
+        result = eval_ode(_bessel_expr(1))
+        _was_evaluated(result)
+        assert _has_symbol_name(result, "BesselJ")
+
+    def test_bessel_nu_half_via_vm(self) -> None:
+        """ODE2(bessel_nu=1/2, y, x) through the VM — rational parameter."""
+        result = eval_ode(_bessel_expr(1, 2))
+        _was_evaluated(result)
+        assert _has_symbol_name(result, "BesselJ")
+        # ν=1/2 should appear as IRRational(1,2) in the solution
+        assert _has_rational_param(result, 1, 2)
+
+    def test_hermite_n3_via_vm(self) -> None:
+        """ODE2(hermite_n3, y, x) through the VM."""
+        result = eval_ode(_hermite_expr(3))
+        _was_evaluated(result)
+        assert _has_symbol_name(result, "HermiteH")
+        assert _has_symbol_name(result, "HermiteH2")
+
+    def test_chebyshev_n2_via_vm(self) -> None:
+        """ODE2(chebyshev_n2, y, x) through the VM."""
+        result = eval_ode(_chebyshev_expr(2))
+        _was_evaluated(result)
+        assert _has_symbol_name(result, "ChebyshevT")
+        assert _has_symbol_name(result, "ChebyshevU")
+
+    def test_solution_structure_is_equal_y(self) -> None:
+        """All named-ODE solutions are Equal(y, ...) with y as LHS."""
+        for expr in [
+            _legendre_expr(2),
+            _bessel_expr(1),
+            _hermite_expr(2),
+            _chebyshev_expr(2),
+        ]:
+            result = eval_ode(expr)
+            lhs, _ = _is_equal_node(result)
+            assert lhs == Y, f"LHS of Equal should be y, got {lhs!r}"
+
+    def test_solution_contains_c1_c2(self) -> None:
+        """All named-ODE solutions contain integration constants %c1 and %c2."""
+        for expr in [
+            _legendre_expr(2),
+            _bessel_expr(1),
+            _hermite_expr(2),
+            _chebyshev_expr(2),
+        ]:
+            result = eval_ode(expr)
+            assert _has_symbol_name(result, "%c1"), f"Missing %c1 in {result!r}"
+            assert _has_symbol_name(result, "%c2"), f"Missing %c2 in {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# TestPhase21Regressions — previous ODE types must still work
+# ---------------------------------------------------------------------------
+
+
+class TestPhase21Regressions:
+    """Regression tests — Phase 21 must not break earlier solver types.
+
+    The named-ODE dispatcher fires in the solve_ode chain after Euler-Cauchy.
+    These tests confirm that const-coeff, Euler-Cauchy, and the first-order
+    solvers still produce correct results.
+    """
+
+    def test_const_coeff_homogeneous_still_works(self) -> None:
+        """y'' − 3y' + 2y = 0 still returns explicit Equal(y, ...) solution."""
+        expr = _add(
+            _add(Y_DOUBLE, _neg(_mul(_I(3), Y_PRIME))),
+            _mul(_I(2), Y),
+        )
+        result = eval_ode(expr)
+        _was_evaluated(result)
+        assert isinstance(result, IRApply) and result.head.name == "Equal"
+
+    def test_const_coeff_complex_roots_still_works(self) -> None:
+        """y'' + y = 0 still gives cos-based solution."""
+        expr = _add(Y_DOUBLE, Y)
+        result = eval_ode(expr)
+        _was_evaluated(result)
+        assert _has_symbol_name(result, "Cos") or _has_symbol_name(result, "Sin")
+
+    def test_const_coeff_not_confused_with_named_ode(self) -> None:
+        """y'' + 4y = 0 is const-coeff, not a named family (no variable P,Q,R)."""
+        expr = _add(Y_DOUBLE, _mul(_I(4), Y))
+        result = eval_ode(expr)
+        _was_evaluated(result)
+        # Should NOT match any named ODE family
+        assert not _has_symbol_name(result, "HermiteH")
+        assert not _has_symbol_name(result, "LegendreP")
+        assert not _has_symbol_name(result, "BesselJ")
+        assert not _has_symbol_name(result, "ChebyshevT")
+
+    def test_euler_cauchy_distinct_real_roots_still_works(self) -> None:
+        """x²y'' − 2y = 0 (Euler-Cauchy, r=2,r=-1) still works."""
+        expr = _add(_mul(_x_sq(), Y_DOUBLE), _neg(_mul(_I(2), Y)))
+        result = eval_ode(expr)
+        _was_evaluated(result)
+        # Euler-Cauchy gives Pow(x, r) terms
+        assert _has_symbol_name(result, "Pow") or _has_symbol_name(result, "Equal")
+
+    def test_first_order_linear_still_works(self) -> None:
+        """y' + 2y = 0 still returns Equal(y, ...)."""
+        expr = _add(Y_PRIME, _mul(_I(2), Y))
+        result = eval_ode(expr)
+        _was_evaluated(result)
+
+    def test_unrecognised_variable_coeff_stays_unevaluated(self) -> None:
+        """x·y'' + y = 0 — variable-coeff but not a named family → unevaluated."""
+        expr = _add(_mul(X, Y_DOUBLE), Y)
+        result = eval_ode(expr)
+        _is_unevaluated(result)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers for assertion predicates
+# ---------------------------------------------------------------------------
+
+
+def _param_in_apply(node: IRNode, expected: int) -> bool:
+    """Return True if an IRApply argument list contains IRInteger(expected)."""
+    if isinstance(node, IRApply):
+        for arg in node.args:
+            if isinstance(arg, IRInteger) and arg.value == expected:
+                return True
+            if _param_in_apply(arg, expected):
+                return True
+    return False
+
+
+def _has_rational_param(node: IRNode, p: int, q: int) -> bool:
+    """Return True if the tree contains IRRational(p, q) as an argument."""
+    if isinstance(node, IRRational):
+        return node.numer == p and node.denom == q
+    if isinstance(node, IRApply):
+        return any(_has_rational_param(c, p, q) for c in node.args)
+    return False

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 — 2026-05-16
 
 - Parse capacitor `IC=<voltage>` initial-voltage parameters.
 - Parse inductor `IC=<current>` initial-current parameters.

--- a/code/packages/python/spice-netlist-parser/pyproject.toml
+++ b/code/packages/python/spice-netlist-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-netlist-parser"
-version = "0.1.6"
+version = "0.2.0"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-ir/CHANGELOG.md
+++ b/code/packages/python/symbolic-ir/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.14.0 — 2026-05-16
+
+**Add 8 named-ODE solution function head symbols — Phase 27.**
+
+New `IRSymbol` singletons in `nodes.py`, exported from `__init__.py`:
+
+Legendre ODE solutions (`(1-x²)y'' - 2xy' + n(n+1)y = 0`):
+- `LEGENDRE_P = IRSymbol("LegendreP")` — Legendre polynomial of the first kind P_n(x)
+- `LEGENDRE_Q = IRSymbol("LegendreQ")` — Legendre function of the second kind Q_n(x)
+
+Bessel ODE solutions (`x²y'' + xy' + (x²-ν²)y = 0`):
+- `BESSEL_J = IRSymbol("BesselJ")` — Bessel function of the first kind J_ν(x)
+- `BESSEL_Y = IRSymbol("BesselY")` — Bessel function of the second kind Y_ν(x) (Neumann)
+
+Hermite ODE solutions (`y'' - 2xy' + 2ny = 0`):
+- `HERMITE_H = IRSymbol("HermiteH")` — Hermite polynomial H_n(x) for integer n ≥ 0
+- `HERMITE_H2 = IRSymbol("HermiteH2")` — second independent solution (parabolic cylinder function)
+
+Chebyshev ODE solutions (`(1-x²)y'' - xy' + n²y = 0`):
+- `CHEBYSHEV_T = IRSymbol("ChebyshevT")` — Chebyshev polynomial of the first kind T_n(x)
+- `CHEBYSHEV_U = IRSymbol("ChebyshevU")` — Chebyshev polynomial of the second kind U_n(x)
+
+---
+
 ## 0.13.0 — 2026-05-05
 
 **Add 2 transcendental-solving head symbols — Phase 26.**

--- a/code/packages/python/symbolic-ir/pyproject.toml
+++ b/code/packages/python/symbolic-ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-ir"
-version = "0.13.0"
+version = "0.14.0"
 description = "Universal symbolic expression IR — the shared tree representation that every CAS frontend compiles to and every CAS backend consumes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-ir/src/symbolic_ir/__init__.py
+++ b/code/packages/python/symbolic-ir/src/symbolic_ir/__init__.py
@@ -121,6 +121,14 @@ from symbolic_ir.nodes import (
     UNIT_STEP,
     WHILE,
     D,
+    BESSEL_J,
+    BESSEL_Y,
+    CHEBYSHEV_T,
+    CHEBYSHEV_U,
+    HERMITE_H,
+    HERMITE_H2,
+    LEGENDRE_P,
+    LEGENDRE_Q,
     IRApply,
     IRFloat,
     IRInteger,
@@ -241,4 +249,13 @@ __all__ = [
     # Transcendental solving (Phase 26)
     "FREE_INTEGER",
     "LAMBERT_W",
+    # Named ODE solution functions (Phase 27)
+    "LEGENDRE_P",
+    "LEGENDRE_Q",
+    "BESSEL_J",
+    "BESSEL_Y",
+    "HERMITE_H",
+    "HERMITE_H2",
+    "CHEBYSHEV_T",
+    "CHEBYSHEV_U",
 ]

--- a/code/packages/python/symbolic-ir/src/symbolic_ir/nodes.py
+++ b/code/packages/python/symbolic-ir/src/symbolic_ir/nodes.py
@@ -492,3 +492,66 @@ PRODUCT = IRSymbol("Product")
 # Numeric evaluation: Newton iteration on  w_{n+1} = w_n − (w_n·e^w_n − c)/(e^w_n·(w_n+1))
 FREE_INTEGER = IRSymbol("FreeInteger")
 LAMBERT_W = IRSymbol("LambertW")
+
+# ---------------------------------------------------------------------------
+# Phase 27 — Named ODE solution functions
+# ---------------------------------------------------------------------------
+#
+# These symbols name the standard special-function solutions that arise from
+# classic variable-coefficient second-order ODEs.  They are *symbolic* —
+# the CAS produces them as unevaluated function calls when it recognises a
+# named ODE family.  Numeric evaluation handlers are a separate concern.
+#
+# LegendreP(n, x) / LegendreQ(n, x)
+# ----------------------------------
+#   First and second solutions of the Legendre ODE:
+#     (1 − x²)·y'' − 2x·y' + n(n+1)·y = 0
+#   LegendreP(n, x) is the Legendre polynomial of degree n (first kind).
+#   LegendreQ(n, x) is the Legendre function of the second kind.
+#   The general solution is  y = %c1·LegendreP(n, x) + %c2·LegendreQ(n, x).
+#
+#   MACSYMA surface name: legendre_p(n, x) / legendre_q(n, x)
+#
+LEGENDRE_P = IRSymbol("LegendreP")
+LEGENDRE_Q = IRSymbol("LegendreQ")
+
+# BesselJ(ν, x) / BesselY(ν, x)
+# --------------------------------
+#   First and second solutions of the Bessel ODE:
+#     x²·y'' + x·y' + (x² − ν²)·y = 0
+#   BesselJ(ν, x) is the Bessel function of the first kind of order ν.
+#   BesselY(ν, x) is the Bessel function of the second kind (Neumann function).
+#   The general solution is  y = %c1·BesselJ(ν, x) + %c2·BesselY(ν, x).
+#
+#   MACSYMA surface names: bessel_j(ν, x) / bessel_y(ν, x)
+#
+BESSEL_J = IRSymbol("BesselJ")
+BESSEL_Y = IRSymbol("BesselY")
+
+# HermiteH(n, x) / HermiteH2(n, x)
+# -----------------------------------
+#   Solutions of the Hermite ODE:
+#     y'' − 2x·y' + 2n·y = 0
+#   HermiteH(n, x) is the Hermite polynomial Hₙ(x) for non-negative integer n.
+#   HermiteH2(n, x) denotes the second independent solution (parabolic cylinder
+#   function), used when n is not a non-negative integer.
+#   For integer n ≥ 0 the general solution is:
+#     y = %c1·HermiteH(n, x) + %c2·HermiteH2(n, x)
+#
+#   MACSYMA surface name: hermite(n, x)
+#
+HERMITE_H = IRSymbol("HermiteH")
+HERMITE_H2 = IRSymbol("HermiteH2")
+
+# ChebyshevT(n, x) / ChebyshevU(n, x)
+# --------------------------------------
+#   First and second solutions of the Chebyshev ODE:
+#     (1 − x²)·y'' − x·y' + n²·y = 0
+#   ChebyshevT(n, x) is the Chebyshev polynomial of the first kind Tₙ(x).
+#   ChebyshevU(n, x) is the Chebyshev polynomial of the second kind Uₙ(x).
+#   The general solution is  y = %c1·ChebyshevT(n, x) + %c2·ChebyshevU(n, x).
+#
+#   MACSYMA surface names: chebyshev_t(n, x) / chebyshev_u(n, x)
+#
+CHEBYSHEV_T = IRSymbol("ChebyshevT")
+CHEBYSHEV_U = IRSymbol("ChebyshevU")


### PR DESCRIPTION
## Summary

- **symbolic-ir 0.14.0** — 8 new head symbols for named ODE solution functions (LegendreP/Q, BesselJ/Y, HermiteH/H2, ChebyshevT/U). Required by cas-ode Phase 21.
- **cas-ode 0.6.0** — Phase 21: numerical pattern recognition for 4 classical variable-coefficient ODE families. Chebyshev, Legendre, Bessel, and Hermite ODEs now return named special-function solutions instead of falling through unevaluated. 95 new tests; 332 total; 86.86% coverage.
- **spice-netlist-parser 0.2.0** — version bump from 0.1.6: all Unreleased features (IC params, AC sources, .tf/.sens/.mc/.noise cards) were already implemented; just needed a version number.

## Details

### symbolic-ir 0.14.0 (Phase 27)
New `IRSymbol` singletons for all 8 named ODE solution functions, with full docstrings and exports.

### cas-ode 0.6.0 (Phase 21)
Pattern matching strategy: coefficients P(x), Q(x), R(x) of the ODE are evaluated numerically at test points `(0.3, 0.6, -0.25, 0.85)` and compared to the expected analytic forms. This is robust to any IR tree structure the MACSYMA compiler might generate.

Dispatcher order (Chebyshev before Legendre because both have P≈1−x²; their Q differs):
1. Chebyshev: `(1−x²)y'' − xy' + n²y = 0` → `ChebyshevT(n,x)/ChebyshevU(n,x)`
2. Legendre: `(1−x²)y'' − 2xy' + n(n+1)y = 0` → `LegendreP(n,x)/LegendreQ(n,x)`
3. Bessel: `x²y'' + xy' + (x²−ν²)y = 0` → `BesselJ(ν,x)/BesselY(ν,x)` (rational ν supported)
4. Hermite: `y'' − 2xy' + 2ny = 0` → `HermiteH(n,x)/HermiteH2(n,x)`

All 4 insert after Euler-Cauchy in the `solve_ode` dispatcher so constant-coefficient ODEs are handled first.

### spice-netlist-parser 0.2.0
No code changes. All features were implemented in 0.1.6+ but the CHANGELOG had them in Unreleased. Cut the proper release.

## Test plan
- [x] `cd code/packages/python/symbolic-ir && python -m pytest` (coverage maintained)
- [x] `cd code/packages/python/cas-ode && python -m pytest` — 332 tests pass, 86.86% coverage
- [x] `cd code/packages/python/spice-netlist-parser && python -m pytest` — existing tests unchanged
- [x] Security review passed — pure CAS math code, no external attack surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)