### PR TITLE
feat(forme-pipeline-config): JSON Schema validation of stage configs (FM03 §2.4 #3)

### DIFF
--- a/code/packages/typescript/forme-pipeline-config/CHANGELOG.md
+++ b/code/packages/typescript/forme-pipeline-config/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog — @coding-adventures/forme-pipeline-config
 
+## 0.2.0 — 2026-05-16
+
+### Added — JSON Schema validation of stage configs (FM03 §2.4 #3)
+
+When a stage declares a non-null `configSchema`, `validateConfig`
+now validates the supplied `config` against that schema and surfaces
+violations as `CONFIG_SCHEMA_VIOLATION` errors with field-level
+paths. Previously the v0.1.0 validator only enforced the *presence*
+half of the rule (`CONFIG_REQUIRED`) and deferred shape validation
+to "the orchestrator" — but the orchestrator was deferring back
+here, so in practice no validation happened. This closes that hole.
+
+### Public API
+
+- `validateAgainstSchema(value, schema)` → `SchemaValidationResult`
+  exported. A pure, no-dependency draft-07 subset validator usable
+  outside `validateConfig` (e.g. for live editing in the dev server).
+- `SchemaViolation`, `SchemaValidationResult` types exported.
+- `CONFIG_ERROR_CODES.CONFIG_SCHEMA_VIOLATION` added.
+
+### JSON Schema subset
+
+Supported keywords (a draft-07 subset focused on stage configs):
+`type`, `enum`, `const`, `required`, `properties`,
+`additionalProperties: false`, `items`, `minLength`/`maxLength`,
+`minItems`/`maxItems`, `minimum`/`maximum`, `pattern`, `oneOf`/
+`anyOf`/`allOf`. Unknown keywords are silently ignored
+(draft-07 forward-compat). `$ref`, `format`, `if`/`then`/`else`,
+`propertyNames`, `not` are deliberately NOT supported — out of
+scope for stage configs.
+
+### Security
+
+`deepEqual` (used by `enum`/`const`) skips `__proto__` /
+`constructor` / `prototype` keys, defence-in-depth against
+prototype-pollution attempts via crafted schemas.
+
+### Tests
+
+32 new tests in `tests/json-schema.test.ts` covering every
+supported keyword and rejection mode. 5 new integration tests in
+`tests/validate.test.ts` confirming the schema check fires
+through `validateConfig` and surfaces with field-level paths.
+
+Total: 105 tests pass (up from 68).
+
 ## 0.1.0 — 2026-05-15
 
 Initial release. First package of the FM03 orchestrator stack — the

--- a/code/packages/typescript/forme-pipeline-config/package-lock.json
+++ b/code/packages/typescript/forme-pipeline-config/package-lock.json
@@ -21,6 +21,7 @@
       }
     },
     "../forme-capability": {
+      "name": "@coding-adventures/forme-capability",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -30,6 +31,7 @@
       }
     },
     "../forme-errors": {
+      "name": "@coding-adventures/forme-errors",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -42,6 +44,7 @@
       }
     },
     "../forme-stage": {
+      "name": "@coding-adventures/forme-stage",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -56,6 +59,7 @@
       }
     },
     "../forme-types": {
+      "name": "@coding-adventures/forme-types",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/code/packages/typescript/forme-pipeline-config/package.json
+++ b/code/packages/typescript/forme-pipeline-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coding-adventures/forme-pipeline-config",
-  "version": "0.1.0",
-  "description": "Forme orchestrator: PipelineConfig types, validator, and TS-form config loader (FM03 §2).",
+  "version": "0.2.0",
+  "description": "Forme orchestrator: PipelineConfig types, validator (now with JSON Schema validation of stage configs), and TS-form config loader (FM03 §2).",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/code/packages/typescript/forme-pipeline-config/src/errors.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/errors.ts
@@ -78,6 +78,13 @@ export const CONFIG_ERROR_CODES = Object.freeze({
   /** A stage demands a config but none was provided. */
   CONFIG_REQUIRED:           "CONFIG_REQUIRED",
   /**
+   * The provided config violates the stage's declared `configSchema`.
+   * Field-level details (which property, what constraint) are in
+   * the entry's `message`.  See `json-schema.ts` for the subset
+   * of draft-07 keywords supported.
+   */
+  CONFIG_SCHEMA_VIOLATION:   "CONFIG_SCHEMA_VIOLATION",
+  /**
    * Multiple terminal stages (no consumer) exist without a matching
    * `OutputSpec` for each (FM03 §3.3 step 5).
    */

--- a/code/packages/typescript/forme-pipeline-config/src/index.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/index.ts
@@ -42,5 +42,8 @@ export type { ConfigErrorEntry, ConfigErrorCode } from "./errors.js";
 export { validateConfig } from "./validate.js";
 export type { ResolvedPipelineConfig } from "./validate.js";
 
+export { validateAgainstSchema } from "./json-schema.js";
+export type { SchemaViolation, SchemaValidationResult } from "./json-schema.js";
+
 export { loadTsConfig } from "./load.js";
 export type { LoadTsConfigOptions } from "./load.js";

--- a/code/packages/typescript/forme-pipeline-config/src/json-schema.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/json-schema.ts
@@ -1,0 +1,384 @@
+/**
+ * json-schema.ts — a tiny JSON Schema (draft-07 subset) validator
+ * focused on the shape of stage configuration objects.
+ *
+ * The point: when a stage declares
+ *
+ *     configSchema: {
+ *       type: "object",
+ *       required: ["glob"],
+ *       properties: { glob: { type: "string" }, root: { type: "string" } },
+ *     }
+ *
+ * and the user's pipeline supplies `config: { gloob: "**\/*.md" }`
+ * (typo), the validator catches this at `buildPipeline()` time with
+ * a precise message rather than letting the misconfig blow up
+ * inside the stage's `run()` later (or worse, accept it as
+ * `glob: undefined` and silently misbehave).
+ *
+ * ═══ Subset supported ════════════════════════════════════════════
+ *
+ * Keywords we accept (everything else is silently ignored, per
+ * draft-07 forward-compatibility):
+ *
+ *   - `type` — one of: "string", "number", "integer", "boolean",
+ *     "array", "object", "null".  May also be an array of those
+ *     for union types.
+ *   - `enum` — array of allowed values; checked via deep equality.
+ *   - `const` — single allowed value; checked via deep equality.
+ *   - `required` — array of property names; applies on type=object.
+ *   - `properties` — map of property name → sub-schema; applies on
+ *     type=object.  Properties not declared but present are allowed
+ *     by default (matches draft-07; flip via `additionalProperties:
+ *     false`).
+ *   - `additionalProperties` — boolean.  When false on an object,
+ *     properties not in `properties` are rejected.
+ *   - `items` — sub-schema for array elements.
+ *   - `minLength` / `maxLength` — string length bounds.
+ *   - `minItems` / `maxItems` — array length bounds.
+ *   - `minimum` / `maximum` — numeric inclusive bounds.
+ *   - `pattern` — regex string that must match (string types only).
+ *   - `oneOf` / `anyOf` / `allOf` — composition keywords; each takes
+ *     an array of sub-schemas.
+ *
+ * What we DON'T support (clearly out of scope for stage configs):
+ *
+ *   - `$ref` / `$id` / `$schema` — no schema resolution; stages
+ *     ship their own schemas inline.
+ *   - `format` (`"email"`, `"date-time"`, etc.) — would require a
+ *     format registry.  Stages can use `pattern` instead.
+ *   - `if` / `then` / `else` — branching is rarely needed for
+ *     configs; bigger expressivity at the cost of subtle bugs.
+ *   - `propertyNames`, `dependencies`, `not` — uncommon; out of
+ *     scope.
+ *   - `multipleOf`, `exclusiveMinimum/Maximum`, `uniqueItems` —
+ *     uncommon for stage configs.
+ *
+ * Unknown keywords are silently ignored.  This matches draft-07's
+ * forward-compat policy: a schema that declares a future keyword
+ * still validates the documented half.
+ *
+ * @module json-schema
+ */
+
+import type { JsonValue } from "@coding-adventures/forme-types";
+import type { JsonSchema } from "@coding-adventures/forme-stage";
+
+/** Per-finding violation entry. */
+export interface SchemaViolation {
+  /** JSON-pointer-ish path INTO the validated value. */
+  readonly path: string;
+  /** Human-readable explanation. */
+  readonly message: string;
+}
+
+/** Result of running the validator. */
+export interface SchemaValidationResult {
+  readonly ok: boolean;
+  readonly violations: readonly SchemaViolation[];
+}
+
+/**
+ * Validate a value against a JSON Schema (draft-07 subset).
+ *
+ * Never throws on malformed schema input — instead, treats malformed
+ * keywords as "no constraint" and skips them.  This is intentional:
+ * an upstream typo in a stage's schema shouldn't crash the validator;
+ * the result just reports fewer violations than it would have.
+ *
+ * Returns `{ ok: true, violations: [] }` on success.
+ *
+ * Returns `{ ok: false, violations: [...] }` listing every constraint
+ * the value violated.  All violations are surfaced in one pass.
+ */
+export function validateAgainstSchema(
+  value: JsonValue | undefined,
+  schema: JsonSchema,
+): SchemaValidationResult {
+  const violations: SchemaViolation[] = [];
+  walk(value, asObject(schema), "", violations);
+  return { ok: violations.length === 0, violations };
+}
+
+// ─── Recursive walker ───────────────────────────────────────────────
+
+function walk(
+  value: JsonValue | undefined,
+  schema: Record<string, JsonValue> | null,
+  path: string,
+  out: SchemaViolation[],
+): void {
+  if (schema === null) return;
+
+  // Composition keywords short-circuit individual constraint checks.
+  if (Array.isArray(schema["allOf"])) {
+    for (const sub of schema["allOf"] as readonly JsonValue[]) {
+      walk(value, asObject(sub), path, out);
+    }
+  }
+  if (Array.isArray(schema["anyOf"])) {
+    const subs = schema["anyOf"] as readonly JsonValue[];
+    let anyOk = false;
+    for (const sub of subs) {
+      const r = validateAgainstSchema(value, sub as JsonSchema);
+      if (r.ok) { anyOk = true; break; }
+    }
+    if (!anyOk && subs.length > 0) {
+      out.push({ path: path || "$",
+        message: `value matches none of the ${subs.length} schemas in anyOf` });
+    }
+  }
+  if (Array.isArray(schema["oneOf"])) {
+    const subs = schema["oneOf"] as readonly JsonValue[];
+    let matchCount = 0;
+    for (const sub of subs) {
+      const r = validateAgainstSchema(value, sub as JsonSchema);
+      if (r.ok) matchCount++;
+    }
+    if (matchCount !== 1 && subs.length > 0) {
+      out.push({ path: path || "$",
+        message: `value matches ${matchCount} schemas in oneOf (expected exactly 1)` });
+    }
+  }
+
+  // Type check first — if the actual type doesn't match the declared
+  // type, downstream constraint checks are meaningless.
+  if (!checkType(value, schema, path, out)) return;
+
+  if (Array.isArray(schema["enum"])) {
+    checkEnum(value, schema["enum"] as readonly JsonValue[], path, out);
+  }
+  if (schema["const"] !== undefined) {
+    if (!deepEqual(value as JsonValue, schema["const"] as JsonValue)) {
+      out.push({ path: path || "$",
+        message: `value does not equal const ${JSON.stringify(schema["const"])}` });
+    }
+  }
+
+  // Per-type constraints.
+  switch (typeof value) {
+    case "string":
+      checkString(value, schema, path, out);
+      break;
+    case "number":
+      checkNumber(value, schema, path, out);
+      break;
+  }
+  if (Array.isArray(value)) {
+    checkArray(value, schema, path, out);
+  } else if (value !== null && typeof value === "object") {
+    checkObject(value as Record<string, JsonValue>, schema, path, out);
+  }
+}
+
+// ─── Type ───────────────────────────────────────────────────────────
+
+function checkType(
+  value: JsonValue | undefined,
+  schema: Record<string, JsonValue>,
+  path: string,
+  out: SchemaViolation[],
+): boolean {
+  const t = schema["type"];
+  if (t === undefined) return true;
+  const allowed = typeof t === "string" ? [t] : Array.isArray(t) ? t.map(String) : [];
+  if (allowed.length === 0) return true;
+  const actual = jsonTypeOf(value);
+  // "integer" requires actual === "number" AND the value is an integer.
+  if (allowed.includes("integer") && actual === "number"
+      && Number.isInteger(value as number)) {
+    return true;
+  }
+  if (allowed.includes(actual)) return true;
+  out.push({ path: path || "$",
+    message: `expected type ${allowed.join(" | ")}, got ${actual}` });
+  return false;
+}
+
+function jsonTypeOf(value: JsonValue | undefined): string {
+  if (value === undefined) return "undefined";
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "object") return "object";
+  return typeof value;  // "string" | "number" | "boolean"
+}
+
+// ─── Enum ───────────────────────────────────────────────────────────
+
+function checkEnum(
+  value: JsonValue | undefined,
+  allowed: readonly JsonValue[],
+  path: string,
+  out: SchemaViolation[],
+): void {
+  if (value === undefined) return;
+  for (const candidate of allowed) {
+    if (deepEqual(value, candidate)) return;
+  }
+  out.push({ path: path || "$",
+    message: `value ${JSON.stringify(value)} is not one of the allowed enum members` });
+}
+
+// ─── String ─────────────────────────────────────────────────────────
+
+function checkString(
+  value: string,
+  schema: Record<string, JsonValue>,
+  path: string,
+  out: SchemaViolation[],
+): void {
+  const minLen = schema["minLength"];
+  if (typeof minLen === "number" && value.length < minLen) {
+    out.push({ path: path || "$",
+      message: `string length ${value.length} is less than minLength ${minLen}` });
+  }
+  const maxLen = schema["maxLength"];
+  if (typeof maxLen === "number" && value.length > maxLen) {
+    out.push({ path: path || "$",
+      message: `string length ${value.length} exceeds maxLength ${maxLen}` });
+  }
+  const pat = schema["pattern"];
+  if (typeof pat === "string") {
+    let re: RegExp | null = null;
+    try { re = new RegExp(pat); } catch { /* malformed; skip */ }
+    if (re && !re.test(value)) {
+      out.push({ path: path || "$",
+        message: `string does not match pattern ${JSON.stringify(pat)}` });
+    }
+  }
+}
+
+// ─── Number ─────────────────────────────────────────────────────────
+
+function checkNumber(
+  value: number,
+  schema: Record<string, JsonValue>,
+  path: string,
+  out: SchemaViolation[],
+): void {
+  const min = schema["minimum"];
+  if (typeof min === "number" && value < min) {
+    out.push({ path: path || "$",
+      message: `value ${value} is less than minimum ${min}` });
+  }
+  const max = schema["maximum"];
+  if (typeof max === "number" && value > max) {
+    out.push({ path: path || "$",
+      message: `value ${value} exceeds maximum ${max}` });
+  }
+}
+
+// ─── Array ──────────────────────────────────────────────────────────
+
+function checkArray(
+  value: readonly JsonValue[],
+  schema: Record<string, JsonValue>,
+  path: string,
+  out: SchemaViolation[],
+): void {
+  const minItems = schema["minItems"];
+  if (typeof minItems === "number" && value.length < minItems) {
+    out.push({ path: path || "$",
+      message: `array has ${value.length} items, fewer than minItems ${minItems}` });
+  }
+  const maxItems = schema["maxItems"];
+  if (typeof maxItems === "number" && value.length > maxItems) {
+    out.push({ path: path || "$",
+      message: `array has ${value.length} items, more than maxItems ${maxItems}` });
+  }
+  const items = schema["items"];
+  if (items !== undefined && items !== null) {
+    const itemSchema = asObject(items as JsonSchema);
+    if (itemSchema) {
+      for (let i = 0; i < value.length; i++) {
+        walk(value[i]!, itemSchema, `${path}[${i}]`, out);
+      }
+    }
+  }
+}
+
+// ─── Object ─────────────────────────────────────────────────────────
+
+function checkObject(
+  value: Record<string, JsonValue>,
+  schema: Record<string, JsonValue>,
+  path: string,
+  out: SchemaViolation[],
+): void {
+  const required = schema["required"];
+  if (Array.isArray(required)) {
+    for (const key of required) {
+      if (typeof key === "string" && !(key in value)) {
+        out.push({ path: path ? `${path}.${key}` : key,
+          message: "required property is missing" });
+      }
+    }
+  }
+
+  const propsRaw = schema["properties"];
+  const properties = (propsRaw !== null && typeof propsRaw === "object" && !Array.isArray(propsRaw))
+    ? propsRaw as Record<string, JsonValue>
+    : null;
+
+  // Validate every declared property against its sub-schema.
+  if (properties) {
+    for (const [key, subSchema] of Object.entries(properties)) {
+      if (key in value) {
+        const sub = asObject(subSchema as JsonSchema);
+        if (sub) walk(value[key]!, sub, path ? `${path}.${key}` : key, out);
+      }
+    }
+  }
+
+  // Catch unknown properties when additionalProperties === false.
+  if (schema["additionalProperties"] === false && properties) {
+    for (const key of Object.keys(value)) {
+      if (!(key in properties)) {
+        out.push({ path: path ? `${path}.${key}` : key,
+          message: "additional property is not allowed (additionalProperties: false)" });
+      }
+    }
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function asObject(s: JsonSchema | undefined): Record<string, JsonValue> | null {
+  if (s === null || s === undefined) return null;
+  if (typeof s !== "object") return null;
+  if (Array.isArray(s)) return null;
+  return s as Record<string, JsonValue>;
+}
+
+/**
+ * Structural equality for JsonValue, with prototype-pollution
+ * defensiveness: we use a denylist on object keys so neither side
+ * can accidentally read `__proto__` and have prototype-chain
+ * inheritance leak into the comparison.
+ */
+function deepEqual(a: JsonValue, b: JsonValue): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i]!, b[i]!)) return false;
+    }
+    return true;
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, JsonValue>;
+    const bo = b as Record<string, JsonValue>;
+    const akeys = Object.keys(ao);
+    const bkeys = Object.keys(bo);
+    if (akeys.length !== bkeys.length) return false;
+    for (const k of akeys) {
+      // Defence: ignore prototype keys outright (matches FM02 §3 defence pattern).
+      if (k === "__proto__" || k === "constructor" || k === "prototype") continue;
+      if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
+      if (!deepEqual(ao[k]!, bo[k]!)) return false;
+    }
+    return true;
+  }
+  return false;
+}

--- a/code/packages/typescript/forme-pipeline-config/src/json-schema.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/json-schema.ts
@@ -79,12 +79,39 @@ export interface SchemaValidationResult {
 }
 
 /**
+ * Maximum recursion depth for `walk` and `deepEqual`.  Prevents
+ * stack-overflow DoS via deeply-nested schemas / values.
+ *
+ * 256 levels is well beyond any sane schema; pipelines that
+ * legitimately need deeper nesting can split into composed
+ * sub-schemas using `$ref` (not supported in v0) or restructure.
+ *
+ * On exceedance we push a synthetic violation and stop — preserving
+ * the validator's "never throws" contract.
+ */
+export const MAX_WALK_DEPTH = 256;
+
+/**
+ * Maximum length of a `pattern` regex string before we refuse to
+ * compile it.  Defence against catastrophic-backtracking and large-
+ * pattern DoS in the dev-server live-editing scenario where schemas
+ * may flow in from less-trusted sources (e.g. a user typing schema
+ * into the editor).  1 KiB is generous for any real schema.
+ */
+export const MAX_PATTERN_LENGTH = 1024;
+
+/**
  * Validate a value against a JSON Schema (draft-07 subset).
  *
  * Never throws on malformed schema input — instead, treats malformed
  * keywords as "no constraint" and skips them.  This is intentional:
  * an upstream typo in a stage's schema shouldn't crash the validator;
  * the result just reports fewer violations than it would have.
+ *
+ * Never throws on adversarial input either: depth-bounded
+ * (`MAX_WALK_DEPTH`), pattern-size-bounded (`MAX_PATTERN_LENGTH`),
+ * and uses own-property checks throughout to prevent prototype-
+ * chain bypass.
  *
  * Returns `{ ok: true, violations: [] }` on success.
  *
@@ -96,7 +123,7 @@ export function validateAgainstSchema(
   schema: JsonSchema,
 ): SchemaValidationResult {
   const violations: SchemaViolation[] = [];
-  walk(value, asObject(schema), "", violations);
+  walk(value, asObject(schema), "", violations, 0);
   return { ok: violations.length === 0, violations };
 }
 
@@ -107,21 +134,30 @@ function walk(
   schema: Record<string, JsonValue> | null,
   path: string,
   out: SchemaViolation[],
+  depth: number,
 ): void {
   if (schema === null) return;
+  if (depth > MAX_WALK_DEPTH) {
+    out.push({
+      path: path || "$",
+      message: `validation aborted at depth ${MAX_WALK_DEPTH} (schema or value nesting too deep)`,
+    });
+    return;
+  }
 
   // Composition keywords short-circuit individual constraint checks.
   if (Array.isArray(schema["allOf"])) {
     for (const sub of schema["allOf"] as readonly JsonValue[]) {
-      walk(value, asObject(sub), path, out);
+      walk(value, asObject(sub), path, out, depth + 1);
     }
   }
   if (Array.isArray(schema["anyOf"])) {
     const subs = schema["anyOf"] as readonly JsonValue[];
     let anyOk = false;
     for (const sub of subs) {
-      const r = validateAgainstSchema(value, sub as JsonSchema);
-      if (r.ok) { anyOk = true; break; }
+      const inner: SchemaViolation[] = [];
+      walk(value, asObject(sub as JsonSchema), path, inner, depth + 1);
+      if (inner.length === 0) { anyOk = true; break; }
     }
     if (!anyOk && subs.length > 0) {
       out.push({ path: path || "$",
@@ -132,8 +168,9 @@ function walk(
     const subs = schema["oneOf"] as readonly JsonValue[];
     let matchCount = 0;
     for (const sub of subs) {
-      const r = validateAgainstSchema(value, sub as JsonSchema);
-      if (r.ok) matchCount++;
+      const inner: SchemaViolation[] = [];
+      walk(value, asObject(sub as JsonSchema), path, inner, depth + 1);
+      if (inner.length === 0) matchCount++;
     }
     if (matchCount !== 1 && subs.length > 0) {
       out.push({ path: path || "$",
@@ -149,7 +186,7 @@ function walk(
     checkEnum(value, schema["enum"] as readonly JsonValue[], path, out);
   }
   if (schema["const"] !== undefined) {
-    if (!deepEqual(value as JsonValue, schema["const"] as JsonValue)) {
+    if (!deepEqual(value as JsonValue, schema["const"] as JsonValue, 0)) {
       out.push({ path: path || "$",
         message: `value does not equal const ${JSON.stringify(schema["const"])}` });
     }
@@ -165,9 +202,9 @@ function walk(
       break;
   }
   if (Array.isArray(value)) {
-    checkArray(value, schema, path, out);
+    checkArray(value, schema, path, out, depth);
   } else if (value !== null && typeof value === "object") {
-    checkObject(value as Record<string, JsonValue>, schema, path, out);
+    checkObject(value as Record<string, JsonValue>, schema, path, out, depth);
   }
 }
 
@@ -213,7 +250,7 @@ function checkEnum(
 ): void {
   if (value === undefined) return;
   for (const candidate of allowed) {
-    if (deepEqual(value, candidate)) return;
+    if (deepEqual(value, candidate, 0)) return;
   }
   out.push({ path: path || "$",
     message: `value ${JSON.stringify(value)} is not one of the allowed enum members` });
@@ -239,11 +276,21 @@ function checkString(
   }
   const pat = schema["pattern"];
   if (typeof pat === "string") {
-    let re: RegExp | null = null;
-    try { re = new RegExp(pat); } catch { /* malformed; skip */ }
-    if (re && !re.test(value)) {
+    // Refuse to compile patterns longer than MAX_PATTERN_LENGTH —
+    // protects against catastrophic-backtracking DoS in dev-server
+    // live-edit scenarios where schemas flow from less-trusted
+    // sources.  Stage authors writing their own configSchemas
+    // shouldn't ever bump this limit in practice.
+    if (pat.length > MAX_PATTERN_LENGTH) {
       out.push({ path: path || "$",
-        message: `string does not match pattern ${JSON.stringify(pat)}` });
+        message: `pattern length ${pat.length} exceeds the validator's ${MAX_PATTERN_LENGTH}-char cap` });
+    } else {
+      let re: RegExp | null = null;
+      try { re = new RegExp(pat); } catch { /* malformed; skip */ }
+      if (re && !re.test(value)) {
+        out.push({ path: path || "$",
+          message: `string does not match pattern ${JSON.stringify(pat)}` });
+      }
     }
   }
 }
@@ -275,6 +322,7 @@ function checkArray(
   schema: Record<string, JsonValue>,
   path: string,
   out: SchemaViolation[],
+  depth: number,
 ): void {
   const minItems = schema["minItems"];
   if (typeof minItems === "number" && value.length < minItems) {
@@ -291,7 +339,7 @@ function checkArray(
     const itemSchema = asObject(items as JsonSchema);
     if (itemSchema) {
       for (let i = 0; i < value.length; i++) {
-        walk(value[i]!, itemSchema, `${path}[${i}]`, out);
+        walk(value[i]!, itemSchema, `${path}[${i}]`, out, depth + 1);
       }
     }
   }
@@ -299,16 +347,37 @@ function checkArray(
 
 // ─── Object ─────────────────────────────────────────────────────────
 
+/**
+ * Own-property membership test.  Used everywhere we'd otherwise
+ * write `key in obj` — `in` walks the prototype chain, which
+ * means a schema with `required: ["toString"]` would pass
+ * vacuously against any object (since `Object.prototype.toString`
+ * exists for everything), and a `properties: {}` with
+ * `additionalProperties: false` would silently accept
+ * `{ toString: "x" }` (because `"toString" in {}` is true).
+ *
+ * Caught in the FM02 §3 security review and the matching review of
+ * this validator.  Defence-in-depth — combined with the
+ * `__proto__`/`constructor`/`prototype` exclusion in `deepEqual`,
+ * this gives the validator end-to-end prototype-pollution
+ * resistance even when validating against attacker-supplied
+ * schemas (the dev-server live-edit scenario).
+ */
+function hasOwn(obj: Record<string, JsonValue>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
 function checkObject(
   value: Record<string, JsonValue>,
   schema: Record<string, JsonValue>,
   path: string,
   out: SchemaViolation[],
+  depth: number,
 ): void {
   const required = schema["required"];
   if (Array.isArray(required)) {
     for (const key of required) {
-      if (typeof key === "string" && !(key in value)) {
+      if (typeof key === "string" && !hasOwn(value, key)) {
         out.push({ path: path ? `${path}.${key}` : key,
           message: "required property is missing" });
       }
@@ -323,9 +392,9 @@ function checkObject(
   // Validate every declared property against its sub-schema.
   if (properties) {
     for (const [key, subSchema] of Object.entries(properties)) {
-      if (key in value) {
+      if (hasOwn(value, key)) {
         const sub = asObject(subSchema as JsonSchema);
-        if (sub) walk(value[key]!, sub, path ? `${path}.${key}` : key, out);
+        if (sub) walk(value[key]!, sub, path ? `${path}.${key}` : key, out, depth + 1);
       }
     }
   }
@@ -333,7 +402,7 @@ function checkObject(
   // Catch unknown properties when additionalProperties === false.
   if (schema["additionalProperties"] === false && properties) {
     for (const key of Object.keys(value)) {
-      if (!(key in properties)) {
+      if (!hasOwn(properties, key)) {
         out.push({ path: path ? `${path}.${key}` : key,
           message: "additional property is not allowed (additionalProperties: false)" });
       }
@@ -351,18 +420,21 @@ function asObject(s: JsonSchema | undefined): Record<string, JsonValue> | null {
 }
 
 /**
- * Structural equality for JsonValue, with prototype-pollution
- * defensiveness: we use a denylist on object keys so neither side
- * can accidentally read `__proto__` and have prototype-chain
- * inheritance leak into the comparison.
+ * Structural equality for JsonValue.  Defences:
+ *   - Skips `__proto__`/`constructor`/`prototype` keys outright.
+ *   - Uses `hasOwnProperty.call` for the cross-side membership
+ *     test so prototype-chain inheritance doesn't leak in.
+ *   - Bounded recursion (`MAX_WALK_DEPTH`) — returns `false` on
+ *     overflow rather than throwing.
  */
-function deepEqual(a: JsonValue, b: JsonValue): boolean {
+function deepEqual(a: JsonValue, b: JsonValue, depth: number): boolean {
+  if (depth > MAX_WALK_DEPTH) return false;
   if (a === b) return true;
   if (a === null || b === null) return false;
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
-      if (!deepEqual(a[i]!, b[i]!)) return false;
+      if (!deepEqual(a[i]!, b[i]!, depth + 1)) return false;
     }
     return true;
   }
@@ -373,10 +445,9 @@ function deepEqual(a: JsonValue, b: JsonValue): boolean {
     const bkeys = Object.keys(bo);
     if (akeys.length !== bkeys.length) return false;
     for (const k of akeys) {
-      // Defence: ignore prototype keys outright (matches FM02 §3 defence pattern).
       if (k === "__proto__" || k === "constructor" || k === "prototype") continue;
       if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
-      if (!deepEqual(ao[k]!, bo[k]!)) return false;
+      if (!deepEqual(ao[k]!, bo[k]!, depth + 1)) return false;
     }
     return true;
   }

--- a/code/packages/typescript/forme-pipeline-config/src/validate.ts
+++ b/code/packages/typescript/forme-pipeline-config/src/validate.ts
@@ -28,9 +28,11 @@
  */
 
 import { KERNEL_API_VERSION } from "@coding-adventures/forme-types";
+import type { JsonValue } from "@coding-adventures/forme-types";
 import { isStageRef } from "./types.js";
 import { CONFIG_ERROR_CODES, ConfigError } from "./errors.js";
 import type { ConfigErrorEntry } from "./errors.js";
+import { validateAgainstSchema } from "./json-schema.js";
 import type {
   PipelineConfig,
   PipelineSettings,
@@ -196,15 +198,33 @@ function validateStageInstance(
       }
     }
   }
-  // Config presence rule (FM03 §2.4 #3 — full JSON-Schema validation
-  // is the orchestrator's job; we only enforce the presence half here).
-  if (stage.configSchema !== null && spec.config === undefined) {
-    errors.push({
-      path: `${path}.config`,
-      code: CONFIG_ERROR_CODES.CONFIG_REQUIRED,
-      message:
-        `Stage ${JSON.stringify(stage.name)} declares a configSchema but no config was supplied.`,
-    });
+  // Config presence rule (FM03 §2.4 #3) + JSON-Schema validation.
+  // We surface BOTH halves at config-validate time:
+  //   - presence: stage declares a schema → config must be present;
+  //   - shape:    config supplied → must match the schema.
+  // Schema validation is intentionally tolerant of unknown keywords
+  // (draft-07 forward-compat); see `json-schema.ts` for the subset.
+  if (stage.configSchema !== null) {
+    if (spec.config === undefined) {
+      errors.push({
+        path: `${path}.config`,
+        code: CONFIG_ERROR_CODES.CONFIG_REQUIRED,
+        message:
+          `Stage ${JSON.stringify(stage.name)} declares a configSchema but no config was supplied.`,
+      });
+    } else {
+      const result = validateAgainstSchema(spec.config as JsonValue, stage.configSchema);
+      if (!result.ok) {
+        for (const v of result.violations) {
+          errors.push({
+            path: v.path === "$" ? `${path}.config` : `${path}.config.${v.path}`,
+            code: CONFIG_ERROR_CODES.CONFIG_SCHEMA_VIOLATION,
+            message:
+              `Stage ${JSON.stringify(stage.name)} config violates schema: ${v.message}`,
+          });
+        }
+      }
+    }
   }
 }
 

--- a/code/packages/typescript/forme-pipeline-config/tests/json-schema.test.ts
+++ b/code/packages/typescript/forme-pipeline-config/tests/json-schema.test.ts
@@ -231,6 +231,91 @@ describe("validateAgainstSchema — malformed schema tolerance", () => {
   });
 });
 
+describe("validateAgainstSchema — security: prototype-chain bypass", () => {
+  it("required: ['toString'] does NOT vacuously pass on {} (own-property check)", () => {
+    // Before the hasOwn fix: `"toString" in {}` returned true via
+    // Object.prototype.toString, so the validator would accept this.
+    // After the fix: `toString` is an inherited property, not own;
+    // required check correctly fails.
+    const r = validateAgainstSchema({}, {
+      type: "object",
+      required: ["toString"],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.message).toMatch(/required.*missing/);
+  });
+
+  it("additionalProperties:false does NOT accept inherited Object.prototype keys", () => {
+    // Before the fix: validating { toString: "x" } against a schema
+    // with properties:{} and additionalProperties:false PASSED because
+    // `"toString" in {}` (the empty properties map) returned true via
+    // the prototype chain.  After: it correctly rejects.
+    const r = validateAgainstSchema({ toString: "x" }, {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.path).toBe("toString");
+    expect(r.violations[0]!.message).toMatch(/additional property/);
+  });
+
+  it("required check uses own-property: 'hasOwnProperty' as required key isn't free-passed", () => {
+    expect(validateAgainstSchema({}, {
+      type: "object", required: ["hasOwnProperty"],
+    }).ok).toBe(false);
+  });
+});
+
+describe("validateAgainstSchema — security: depth bound", () => {
+  it("deeply-nested allOf does not crash with RangeError", () => {
+    // Build a chain of allOfs ~1000 deep.  Before the depth guard,
+    // this overflowed V8's stack with a RangeError.  After: the
+    // validator pushes a "depth exceeded" violation and returns
+    // cleanly.
+    let schema: Record<string, unknown> = { type: "string" };
+    for (let i = 0; i < 1000; i++) {
+      schema = { allOf: [schema] };
+    }
+    let result: ReturnType<typeof validateAgainstSchema>;
+    expect(() => { result = validateAgainstSchema("hi", schema as never); })
+      .not.toThrow();
+    // The result either passes (if the depth guard bottoms out
+    // before any type mismatch) or surfaces a "too deep" violation.
+    // Either way, we did NOT throw — that's the contract.
+    expect(result!.violations.every((v) => /too deep|aborted/.test(v.message) || v.message.length > 0))
+      .toBe(true);
+  });
+
+  it("deeply-nested array value does not crash", () => {
+    let arr: unknown = "leaf";
+    for (let i = 0; i < 1000; i++) arr = [arr];
+    expect(() => validateAgainstSchema(arr as never, {
+      type: "array", items: { type: ["array", "string"] },
+    })).not.toThrow();
+  });
+});
+
+describe("validateAgainstSchema — security: pattern length cap", () => {
+  it("refuses to compile patterns longer than 1024 characters", () => {
+    const longPattern = "a".repeat(2000);
+    const r = validateAgainstSchema("xxx", {
+      type: "string",
+      pattern: longPattern,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.message).toMatch(/pattern length.*cap/);
+  });
+
+  it("accepts patterns up to 1024 characters", () => {
+    const okPattern = "[a-z]" + "+".repeat(50);  // tiny, well under cap
+    expect(validateAgainstSchema("abc", {
+      type: "string",
+      pattern: okPattern,
+    }).ok).toBe(true);
+  });
+});
+
 describe("validateAgainstSchema — real stage configs", () => {
   it("validates forme-source-fs's schema", () => {
     const fsSchema = {

--- a/code/packages/typescript/forme-pipeline-config/tests/json-schema.test.ts
+++ b/code/packages/typescript/forme-pipeline-config/tests/json-schema.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema } from "../src/index.js";
+
+describe("validateAgainstSchema — type", () => {
+  it("accepts a matching primitive type", () => {
+    expect(validateAgainstSchema("hi",    { type: "string"  }).ok).toBe(true);
+    expect(validateAgainstSchema(42,      { type: "number"  }).ok).toBe(true);
+    expect(validateAgainstSchema(true,    { type: "boolean" }).ok).toBe(true);
+    expect(validateAgainstSchema(null,    { type: "null"    }).ok).toBe(true);
+    expect(validateAgainstSchema([1, 2],  { type: "array"   }).ok).toBe(true);
+    expect(validateAgainstSchema({},      { type: "object"  }).ok).toBe(true);
+  });
+
+  it("rejects a mismatched primitive type", () => {
+    const r = validateAgainstSchema(42, { type: "string" });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.message).toMatch(/expected type string, got number/);
+  });
+
+  it("integer type rejects floats", () => {
+    expect(validateAgainstSchema(42,  { type: "integer" }).ok).toBe(true);
+    expect(validateAgainstSchema(1.5, { type: "integer" }).ok).toBe(false);
+  });
+
+  it("array of types accepts any of the listed", () => {
+    expect(validateAgainstSchema("hi", { type: ["string", "number"] }).ok).toBe(true);
+    expect(validateAgainstSchema(42,   { type: ["string", "number"] }).ok).toBe(true);
+    expect(validateAgainstSchema(true, { type: ["string", "number"] }).ok).toBe(false);
+  });
+
+  it("missing type means no type constraint", () => {
+    expect(validateAgainstSchema("hi", { enum: ["hi"] }).ok).toBe(true);
+  });
+});
+
+describe("validateAgainstSchema — enum / const", () => {
+  it("enum accepts members", () => {
+    const s = { enum: ["a", "b", "c"] };
+    expect(validateAgainstSchema("a", s).ok).toBe(true);
+    expect(validateAgainstSchema("d", s).ok).toBe(false);
+  });
+
+  it("enum uses deep equality", () => {
+    const s = { enum: [{ a: 1 }, { a: 2 }] };
+    expect(validateAgainstSchema({ a: 1 }, s).ok).toBe(true);
+    expect(validateAgainstSchema({ a: 3 }, s).ok).toBe(false);
+  });
+
+  it("const requires exact value", () => {
+    expect(validateAgainstSchema("hi", { const: "hi" }).ok).toBe(true);
+    expect(validateAgainstSchema("ho", { const: "hi" }).ok).toBe(false);
+  });
+});
+
+describe("validateAgainstSchema — string", () => {
+  it("minLength / maxLength", () => {
+    expect(validateAgainstSchema("ab",  { type: "string", minLength: 3 }).ok).toBe(false);
+    expect(validateAgainstSchema("abc", { type: "string", minLength: 3 }).ok).toBe(true);
+    expect(validateAgainstSchema("abcd",{ type: "string", maxLength: 3 }).ok).toBe(false);
+  });
+
+  it("pattern", () => {
+    expect(validateAgainstSchema("123", { type: "string", pattern: "^[0-9]+$" }).ok).toBe(true);
+    expect(validateAgainstSchema("abc", { type: "string", pattern: "^[0-9]+$" }).ok).toBe(false);
+  });
+
+  it("malformed pattern is silently ignored", () => {
+    // Not a regex syntax error in JS, but illustrative — `[` is invalid.
+    expect(() => validateAgainstSchema("abc", { type: "string", pattern: "[" }))
+      .not.toThrow();
+  });
+});
+
+describe("validateAgainstSchema — number", () => {
+  it("minimum / maximum", () => {
+    expect(validateAgainstSchema(5, { type: "number", minimum: 10 }).ok).toBe(false);
+    expect(validateAgainstSchema(15, { type: "number", maximum: 10 }).ok).toBe(false);
+    expect(validateAgainstSchema(7,  { type: "number", minimum: 1, maximum: 10 }).ok).toBe(true);
+  });
+});
+
+describe("validateAgainstSchema — array", () => {
+  it("items schema applies to every element", () => {
+    const s = { type: "array", items: { type: "string" } };
+    expect(validateAgainstSchema(["a", "b"], s).ok).toBe(true);
+    const r = validateAgainstSchema(["a", 42], s);
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.path).toBe("[1]");
+  });
+
+  it("minItems / maxItems", () => {
+    expect(validateAgainstSchema([1, 2, 3],    { type: "array", minItems: 4 }).ok).toBe(false);
+    expect(validateAgainstSchema([1, 2, 3, 4], { type: "array", minItems: 4 }).ok).toBe(true);
+    expect(validateAgainstSchema([1, 2, 3, 4], { type: "array", maxItems: 3 }).ok).toBe(false);
+  });
+});
+
+describe("validateAgainstSchema — object", () => {
+  const s = {
+    type: "object",
+    required: ["a"],
+    properties: {
+      a: { type: "string" },
+      b: { type: "number" },
+    },
+  };
+
+  it("required: present → ok", () => {
+    expect(validateAgainstSchema({ a: "hi" }, s).ok).toBe(true);
+  });
+
+  it("required: missing → violation with right path", () => {
+    const r = validateAgainstSchema({}, s);
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.path).toBe("a");
+    expect(r.violations[0]!.message).toMatch(/required.*missing/);
+  });
+
+  it("property type mismatch surfaces nested path", () => {
+    const r = validateAgainstSchema({ a: 42 }, s);
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.path).toBe("a");
+    expect(r.violations[0]!.message).toMatch(/expected type string/);
+  });
+
+  it("nested object", () => {
+    const ns = {
+      type: "object",
+      properties: { outer: { type: "object", required: ["inner"], properties: { inner: { type: "string" } } } },
+    };
+    const r = validateAgainstSchema({ outer: { wrong: "x" } }, ns);
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.path).toBe("outer.inner");
+  });
+
+  it("additionalProperties: false rejects unknown keys", () => {
+    const strict = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: false,
+    };
+    const r = validateAgainstSchema({ a: "hi", b: "extra" }, strict);
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]!.path).toBe("b");
+    expect(r.violations[0]!.message).toMatch(/additional property/);
+  });
+
+  it("additionalProperties default (true): unknown keys allowed", () => {
+    const lax = { type: "object", properties: { a: { type: "string" } } };
+    expect(validateAgainstSchema({ a: "hi", b: 1 }, lax).ok).toBe(true);
+  });
+
+  it("aggregates multiple violations", () => {
+    const r = validateAgainstSchema({ a: 42, b: "wrong-type" }, s);
+    expect(r.ok).toBe(false);
+    expect(r.violations).toHaveLength(2);
+  });
+});
+
+describe("validateAgainstSchema — composition", () => {
+  it("allOf requires all branches to succeed", () => {
+    const s = {
+      allOf: [
+        { type: "string" },
+        { minLength: 3 },
+      ],
+    };
+    expect(validateAgainstSchema("hello", s).ok).toBe(true);
+    expect(validateAgainstSchema("hi",    s).ok).toBe(false);
+    expect(validateAgainstSchema(123,     s).ok).toBe(false);
+  });
+
+  it("anyOf accepts when any branch succeeds", () => {
+    const s = { anyOf: [{ type: "string" }, { type: "number" }] };
+    expect(validateAgainstSchema("hi", s).ok).toBe(true);
+    expect(validateAgainstSchema(42,   s).ok).toBe(true);
+    expect(validateAgainstSchema(true, s).ok).toBe(false);
+  });
+
+  it("oneOf rejects when zero or multiple branches succeed", () => {
+    const s = { oneOf: [{ type: "string", maxLength: 3 }, { type: "string", minLength: 2 }] };
+    // "ab" matches both: maxLength:3 and minLength:2 → oneOf fails
+    expect(validateAgainstSchema("ab", s).ok).toBe(false);
+    // 42 matches neither → oneOf fails
+    expect(validateAgainstSchema(42, s).ok).toBe(false);
+    // "abcde" matches only minLength:2 → oneOf succeeds
+    expect(validateAgainstSchema("abcde", s).ok).toBe(true);
+  });
+});
+
+describe("validateAgainstSchema — unknown keywords", () => {
+  it("silently ignores unrecognised keywords (draft-07 forward-compat)", () => {
+    const s = { type: "string", futureKeyword: "doesn't matter" };
+    expect(validateAgainstSchema("hi", s).ok).toBe(true);
+  });
+});
+
+describe("validateAgainstSchema — security: prototype pollution defence", () => {
+  it("deepEqual ignores __proto__ / constructor / prototype keys", () => {
+    const s = { const: { a: 1 } };
+    // A value containing a __proto__ key should still match if a/values match.
+    // (The check skips __proto__/constructor/prototype on both sides.)
+    expect(validateAgainstSchema({ a: 1 }, s).ok).toBe(true);
+  });
+
+  it("does not mutate Object.prototype during validation", () => {
+    const before = Object.keys(Object.prototype).length;
+    validateAgainstSchema({ a: "hi" }, {
+      type: "object",
+      required: ["a"],
+      properties: { a: { type: "string" } },
+    });
+    const after = Object.keys(Object.prototype).length;
+    expect(after).toBe(before);
+  });
+});
+
+describe("validateAgainstSchema — malformed schema tolerance", () => {
+  it("schema = null → treats as no constraint", () => {
+    // Casting `null` because validateAgainstSchema's signature accepts
+    // JsonSchema (which is JsonValue).  null is valid JsonValue.
+    expect(validateAgainstSchema(42, null as never).ok).toBe(true);
+  });
+
+  it("schema = number → treats as no constraint", () => {
+    expect(validateAgainstSchema(42, 99 as never).ok).toBe(true);
+  });
+
+  it("type field with non-string value silently ignored", () => {
+    expect(validateAgainstSchema(42, { type: 99 } as never).ok).toBe(true);
+  });
+});
+
+describe("validateAgainstSchema — real stage configs", () => {
+  it("validates forme-source-fs's schema", () => {
+    const fsSchema = {
+      type: "object",
+      required: ["glob"],
+      properties: { glob: { type: "string" }, root: { type: "string" } },
+    };
+    expect(validateAgainstSchema({ glob: "**/*.md" }, fsSchema).ok).toBe(true);
+    expect(validateAgainstSchema({ glob: "**/*.md", root: "/abs" }, fsSchema).ok).toBe(true);
+    expect(validateAgainstSchema({ root: "/abs" }, fsSchema).ok).toBe(false);  // missing glob
+    expect(validateAgainstSchema({ glob: 42 }, fsSchema).ok).toBe(false);
+  });
+
+  it("validates forme-emit-fs's schema", () => {
+    const emitSchema = {
+      type: "object",
+      required: ["outDir"],
+      properties: { outDir: { type: "string" } },
+    };
+    expect(validateAgainstSchema({ outDir: "./dist" }, emitSchema).ok).toBe(true);
+    expect(validateAgainstSchema({}, emitSchema).ok).toBe(false);
+  });
+});

--- a/code/packages/typescript/forme-pipeline-config/tests/validate.test.ts
+++ b/code/packages/typescript/forme-pipeline-config/tests/validate.test.ts
@@ -434,6 +434,76 @@ describe("validateConfig — outputs & multiple terminals", () => {
 
 // ─── Multi-error aggregation ──────────────────────────────────────────────
 
+describe("validateConfig — JSON Schema validation of stage configs", () => {
+  function schemaStage() {
+    return makeStage("schema-stage", Kinds.Void, Kinds.DeployArtifact, {
+      configSchema: {
+        type: "object",
+        required: ["glob"],
+        properties: {
+          glob: { type: "string" },
+          root: { type: "string" },
+        },
+      },
+    });
+  }
+
+  it("accepts a config that satisfies the schema", () => {
+    expect(() => validateConfig(config([{
+      stage: schemaStage(),
+      config: { glob: "**/*.md", root: "/abs" },
+    }]))).not.toThrow();
+  });
+
+  it("rejects a config missing a required property", () => {
+    try {
+      validateConfig(config([{
+        stage: schemaStage(),
+        config: { root: "/abs" },
+      }]));
+      expect.fail("should have thrown");
+    } catch (e) {
+      const err = e as ConfigError;
+      const v = err.errors.filter(x => x.code === CONFIG_ERROR_CODES.CONFIG_SCHEMA_VIOLATION);
+      expect(v.length).toBeGreaterThan(0);
+      expect(v[0]!.path).toMatch(/stages\[0\]\.config/);
+      expect(v[0]!.message).toMatch(/required.*missing/);
+    }
+  });
+
+  it("rejects a config with wrong-typed property", () => {
+    try {
+      validateConfig(config([{
+        stage: schemaStage(),
+        config: { glob: 42 },
+      }]));
+      expect.fail("should have thrown");
+    } catch (e) {
+      const err = e as ConfigError;
+      const v = err.errors.filter(x => x.code === CONFIG_ERROR_CODES.CONFIG_SCHEMA_VIOLATION);
+      expect(v.length).toBeGreaterThan(0);
+      expect(v[0]!.message).toMatch(/expected type string/);
+    }
+  });
+
+  it("still surfaces CONFIG_REQUIRED when configSchema is non-null but no config", () => {
+    try {
+      validateConfig(config([{ stage: schemaStage() }]));
+      expect.fail("should have thrown");
+    } catch (e) {
+      const err = e as ConfigError;
+      expect(err.errors.some(x => x.code === CONFIG_ERROR_CODES.CONFIG_REQUIRED)).toBe(true);
+    }
+  });
+
+  it("doesn't validate against schema when configSchema is null", () => {
+    expect(() => validateConfig(config([{
+      stage: makeStage("no-schema", Kinds.Void, Kinds.DeployArtifact, { configSchema: null }),
+      config: { anything: "goes" },
+    }]))).not.toThrow();
+  });
+});
+
 describe("validateConfig — collects all errors in one pass", () => {
   it("multiple distinct violations all surface together", () => {
     try {


### PR DESCRIPTION
## Summary

Closes the v0.1.0 deferred TODO: "JSON-Schema validation of stage configs is deferred to the orchestrator." Implementation now lives in ``validateConfig``, where it runs at ``buildPipeline()`` time — catching misconfigs BEFORE any stage's ``run()`` is invoked.

Version bumped to **0.2.0** (new public API surface; minor semver).

## What this PR adds

- New module ``src/json-schema.ts``: a hand-rolled, dependency-free JSON Schema draft-07 subset validator (~300 lines).
- Supported keywords: ``type`` (incl. ``integer`` + arrays), ``enum``, ``const``, ``required``, ``properties``, ``additionalProperties: false``, ``items``, ``minItems/maxItems``, ``minLength/maxLength``, ``minimum/maximum``, ``pattern``, ``oneOf/anyOf/allOf``.
- Unsupported (silently ignored for draft-07 forward-compat): ``$ref``, ``$id``, ``format``, ``if/then/else``, ``propertyNames``, ``not``, ``multipleOf``, ``uniqueItems``.
- New public exports: ``validateAgainstSchema``, ``SchemaViolation``, ``SchemaValidationResult``, ``CONFIG_ERROR_CODES.CONFIG_SCHEMA_VIOLATION``.
- Wired into ``validateConfig`` — schema violations surface as ``CONFIG_SCHEMA_VIOLATION`` entries with field-level paths.

## Security posture

The security sub-agent caught **1 MEDIUM + 2 LOW**; all fixed in commit 2:
- **MEDIUM**: ``key in obj`` walks the prototype chain — bypass via ``required: ["toString"]``. Fixed with ``hasOwn()`` helper using ``hasOwnProperty.call``.
- **LOW**: Stack overflow via deep recursion. Fixed with ``MAX_WALK_DEPTH = 256`` and depth threading.
- **LOW**: Unbounded RegExp pattern compile. Fixed with ``MAX_PATTERN_LENGTH = 1024`` cap.

All three findings have regression tests pinning the fixed behaviour.

## Test plan

- [x] 112 tests pass (39 in json-schema.test.ts + 47 in validate.test.ts + 26 elsewhere)
- [x] Schema validation surfaces through validateConfig with the right error code and field paths
- [x] No regressions in existing 68 tests
- [x] Prototype-chain bypass tests cover toString/hasOwnProperty as adversarial inputs
- [x] Deep-recursion tests confirm validator never throws RangeError on adversarial schemas
- [x] Pattern length cap rejects oversize patterns cleanly
- [x] Security review (sub-agent) — 3 findings caught BEFORE PR opened, all fixed
- [ ] CI green

## Commits

1. ``feat(forme-pipeline-config): JSON Schema validation of stage configs (FM03 §2.4 #3)``
2. ``fix(security): JSON Schema validator — own-property checks, depth bound, pattern length cap``

🤖 Generated with [Claude Code](https://claude.com/claude-code)