### PR TITLE
feat(forme-source-fs): identity sidecar persistence (read side)

### DIFF
--- a/code/packages/typescript/forme-source-fs/CHANGELOG.md
+++ b/code/packages/typescript/forme-source-fs/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog — @coding-adventures/forme-source-fs
 
+## 0.2.0 — 2026-05-16
+
+### Added — identity persistence (read side)
+
+Resolves the TODO from v0.1.0's CHANGELOG: "LogicalId is freshly
+generated on every read (TODO: persist + read from id.json adjacent
+to the source file when the identity-tracking story lands)."
+
+When a hidden sidecar file `<dirname>/.<basename>.id.json` exists
+next to a source file, source-fs now reads the persisted
+`LogicalId` from it instead of generating a fresh one.  Sidecar
+shape:
+
+```json
+{
+  "logicalId": "01952c0d-7e63-7000-8000-...",
+  "createdAt": "2026-05-16T00:00:00Z",   // optional
+  "note": "optional human-readable note"   // optional
+}
+```
+
+Only `logicalId` is required.  Unknown fields are ignored (draft-07-
+style forward-compat).  Malformed JSON, missing/wrong-typed
+`logicalId`, or wrong-version UUID values log a `warn` and fall
+back to a fresh LogicalId — never fail the pipeline.
+
+A new config field `persistIdentities: boolean` controls behaviour;
+default `true`.  Set to `false` to opt out (matches v0.1.0
+generate-every-read semantics; useful for ephemeral test fixtures
+where stable identities don't matter).
+
+The write side — automatically creating sidecars on first read —
+is intentionally NOT in this release.  A separate stage (or CLI
+command) will own that responsibility so source-fs can keep its
+`storage:read`-only capability declaration; adding `filesystem:write`
+to a read-shaped source would change the capability profile and
+trigger user-facing install prompts.
+
+### Fixed
+
+- `walker.test.ts` was using POSIX `/` separators in assertions
+  that ran against `path.join` output containing native
+  separators.  Passed on Linux/macOS CI; would have failed on
+  Windows CI as soon as a forme-source-fs change triggered a
+  Windows-side BUILD (pre-existing bug from 0.1.0).  Now
+  normalised to forward slashes in the assertion.
+
+### Tests
+
+13 new tests in `tests/identity-sidecar.test.ts` covering:
+- Valid sidecar → persisted id used.
+- Same id across runs when sidecar present.
+- Different ids across runs when sidecar absent.
+- Per-file sidecar resolution (no cross-file leakage).
+- Malformed-JSON sidecar → warn + fallback.
+- Wrong-shape sidecar (string / number / missing field) → fallback.
+- UUIDv4 in sidecar → rejected, fallback.
+- Forward-compat: unknown sidecar fields ignored.
+- `persistIdentities: false` opts out.
+- Sidecar files are not themselves emitted as content sources.
+- Empty sidecar file → fresh id.
+
+Total: 37 tests pass (up from 23).
+
 ## 0.1.0 — 2026-05-15
 
 Initial release.  First actual pipeline stage in the Forme effort —

--- a/code/packages/typescript/forme-source-fs/package-lock.json
+++ b/code/packages/typescript/forme-source-fs/package-lock.json
@@ -20,6 +20,7 @@
       }
     },
     "../forme-identity": {
+      "name": "@coding-adventures/forme-identity",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -33,6 +34,7 @@
       }
     },
     "../forme-stage": {
+      "name": "@coding-adventures/forme-stage",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -47,6 +49,7 @@
       }
     },
     "../forme-types": {
+      "name": "@coding-adventures/forme-types",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/code/packages/typescript/forme-source-fs/package.json
+++ b/code/packages/typescript/forme-source-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/forme-source-fs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Forme source stage: walks a filesystem directory and emits a Stream<ContentSource> per matching file (FM00 §5.1).",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/forme-source-fs/src/index.ts
+++ b/code/packages/typescript/forme-source-fs/src/index.ts
@@ -29,17 +29,20 @@
  */
 
 import { readFile } from "node:fs/promises";
-import { relative } from "node:path";
+import { basename, dirname, join, relative } from "node:path";
 import {
   Kinds,
   streamOf,
   type ContentSource,
+  type LogicalId,
 } from "@coding-adventures/forme-types";
 import { defineStage } from "@coding-adventures/forme-stage";
 import {
   computeRevisionId,
   generateLogicalId,
+  isLogicalIdShape,
 } from "@coding-adventures/forme-identity";
+import type { Logger } from "@coding-adventures/forme-stage";
 import { parseGlob, walkFiles } from "./walker.js";
 
 export interface SourceFsConfig {
@@ -47,6 +50,101 @@ export interface SourceFsConfig {
   readonly glob: string;
   /** Directory to search; defaults to process.cwd(). */
   readonly root?: string;
+  /**
+   * When true (default), read existing `<dirname>/.<basename>.id.json`
+   * sidecar files to derive each source's stable `LogicalId`.  When
+   * the sidecar is missing, malformed, or contains a non-UUIDv7
+   * value, a fresh LogicalId is generated instead (current v0
+   * behaviour preserved as the fallback).
+   *
+   * The sidecar contains JSON of shape:
+   *
+   *     { "logicalId": "<uuid-v7>", "createdAt": "<iso?>", "note": "<?>" }
+   *
+   * Only `logicalId` is required.  Future revisions may extend the
+   * shape (parent ids, semantic tags); the reader ignores unknown
+   * keys.
+   *
+   * Setting this to `false` always generates a fresh id (the v0.1.0
+   * behaviour).  Useful for ephemeral builds where stable identities
+   * matter less than predictable test fixtures.
+   */
+  readonly persistIdentities?: boolean;
+}
+
+/**
+ * Filename of the identity sidecar.  Hidden (leading dot) so file
+ * managers and shells don't render it as a "real" content file, and
+ * named after the source basename so multiple sources in the same
+ * directory don't collide:
+ *
+ *     posts/
+ *       hello.md           ← source
+ *       .hello.md.id.json  ← sidecar
+ *       intro.md           ← source
+ *       .intro.md.id.json  ← sidecar
+ *
+ * The full extension (`.id.json`) keeps the file recognisable as
+ * structured metadata when authors stumble across it in `ls -la`.
+ */
+function identitySidecarPath(absSourcePath: string): string {
+  return join(dirname(absSourcePath), "." + basename(absSourcePath) + ".id.json");
+}
+
+/**
+ * Read the identity sidecar adjacent to `absSourcePath`.  Returns the
+ * persisted `LogicalId` on success, `null` when the sidecar is missing
+ * or its contents fail validation.
+ *
+ * Validation failures (malformed JSON, non-string logicalId, wrong
+ * UUIDv7 shape) are logged at `warn` so users notice broken sidecars
+ * without the pipeline failing.  A missing sidecar is the common
+ * case and is NOT logged.
+ */
+async function readPersistedIdentity(
+  absSourcePath: string,
+  logger: Logger,
+): Promise<LogicalId | null> {
+  const sidecarPath = identitySidecarPath(absSourcePath);
+  let text: string;
+  try {
+    text = (await readFile(sidecarPath, "utf-8")).trim();
+  } catch (err) {
+    // ENOENT = no sidecar; that's the common case, silent.
+    // Anything else is unusual; log at debug for visibility.
+    if ((err as { code?: string }).code !== "ENOENT") {
+      logger.debug("forme-source-fs: identity sidecar read failed", {
+        sidecarPath,
+        error: String(err),
+      });
+    }
+    return null;
+  }
+  if (text.length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    logger.warn("forme-source-fs: identity sidecar contains invalid JSON; generating fresh id", {
+      sidecarPath,
+    });
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    logger.warn("forme-source-fs: identity sidecar is not a JSON object; generating fresh id", {
+      sidecarPath,
+    });
+    return null;
+  }
+  const raw = (parsed as { logicalId?: unknown }).logicalId;
+  if (typeof raw !== "string" || !isLogicalIdShape(raw)) {
+    logger.warn("forme-source-fs: identity sidecar has missing/malformed logicalId; generating fresh id", {
+      sidecarPath,
+      raw: typeof raw === "string" ? raw : typeof raw,
+    });
+    return null;
+  }
+  return raw as LogicalId;
 }
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -85,7 +183,11 @@ const sourceFs = defineStage({
     }
     const root = config.root ?? process.cwd();
     const { ext } = parseGlob(config.glob);
-    const stats = { matched: 0 };
+    // Persistence defaults to TRUE.  Tests can opt out by setting
+    // `persistIdentities: false` in the config to get the legacy
+    // generate-fresh-every-time behaviour.
+    const persistIdentities = config.persistIdentities !== false;
+    const stats = { matched: 0, sidecarsLoaded: 0 };
 
     for await (const absPath of walkFiles(root, ext)) {
       ctx.cancellation.throwIfCancelled();
@@ -93,11 +195,27 @@ const sourceFs = defineStage({
       const fileBytes = await readFile(absPath);
       const fileStat = await getFileStat(absPath);
       const bytes = new Uint8Array(fileBytes);
+      // Resolve LogicalId.  Persistence is opt-out — when the
+      // sidecar is present and valid we get stable identities
+      // across runs; otherwise we fall through to a fresh UUID
+      // (the v0.1.0 behaviour, preserved as the fallback).
+      let identity: LogicalId;
+      if (persistIdentities) {
+        const persisted = await readPersistedIdentity(absPath, ctx.logger);
+        if (persisted !== null) {
+          identity = persisted;
+          stats.sidecarsLoaded++;
+        } else {
+          identity = generateLogicalId();
+        }
+      } else {
+        identity = generateLogicalId();
+      }
       const source: ContentSource = {
         path: relPath,
         bytes,
         mimeType: mimeFor(ext),
-        identity: generateLogicalId(),
+        identity,
         // Hash the bytes via canonical-json wrapping so RevisionId
         // semantics are uniform across kinds.  (Hashing raw bytes
         // would require a second `bytesToHex` API to compose into the
@@ -112,7 +230,11 @@ const sourceFs = defineStage({
       yield source as never;
     }
 
-    ctx.logger.debug("forme-source-fs scan complete", { root, ext, matched: stats.matched });
+    ctx.logger.debug("forme-source-fs scan complete", {
+      root, ext,
+      matched: stats.matched,
+      sidecarsLoaded: stats.sidecarsLoaded,
+    });
   },
 });
 

--- a/code/packages/typescript/forme-source-fs/tests/identity-sidecar.test.ts
+++ b/code/packages/typescript/forme-source-fs/tests/identity-sidecar.test.ts
@@ -1,0 +1,190 @@
+/**
+ * identity-sidecar.test.ts — exercise the read-side identity
+ * persistence (FM01 §7.2 sidecar reading) added in v0.2.0.
+ *
+ * Strategy: stage a tempdir with various sidecar configurations
+ * (present / missing / malformed / wrong-shape / wrong-uuid-version)
+ * and verify the stage produces the expected LogicalId in each case.
+ */
+
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createCancellationTokenSource,
+  inMemoryCache,
+  inMemoryEventBus,
+  noOpTelemetryEmitter,
+  silentLogger,
+  systemClock,
+  deniedEnvApi,
+  deniedFilesystemApi,
+  deniedNetworkApi,
+  deniedShellApi,
+  deniedStorageApi,
+  type StageContext,
+} from "@coding-adventures/forme-stage";
+import sourceFs from "../src/index.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "forme-source-fs-id-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function makeCtx(): StageContext {
+  return {
+    logger: silentLogger(),
+    cancellation: createCancellationTokenSource().token,
+    time: systemClock(),
+    cache: inMemoryCache(),
+    telemetry: noOpTelemetryEmitter(),
+    storage: deniedStorageApi(),
+    network: deniedNetworkApi(),
+    env: deniedEnvApi(),
+    filesystem: deniedFilesystemApi(),
+    shell: deniedShellApi(),
+    events: inMemoryEventBus(),
+  };
+}
+
+async function runAndCollect(
+  config: { glob: string; root: string; persistIdentities?: boolean },
+): Promise<Array<{ path: string; identity: string }>> {
+  const ctx = makeCtx();
+  const out: Array<{ path: string; identity: string }> = [];
+  const iter = sourceFs.run(undefined as never, config, ctx) as AsyncIterable<{ path: string; identity: string }>;
+  for await (const v of iter) out.push(v);
+  return out;
+}
+
+/** A valid UUIDv7 (version nibble `7`, variant nibble in `[89ab]`). */
+const STABLE_ID_1 = "01952c0d-7e63-7000-8000-000000000001";
+const STABLE_ID_2 = "01952c0d-7e63-7000-8000-000000000002";
+
+describe("sourceFs — identity sidecar (read side)", () => {
+  it("reads a valid sidecar and uses the persisted LogicalId", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(
+      join(root, ".hello.md.id.json"),
+      JSON.stringify({ logicalId: STABLE_ID_1 }),
+    );
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.identity).toBe(STABLE_ID_1);
+  });
+
+  it("produces the same identity across two runs when sidecar is present", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(
+      join(root, ".hello.md.id.json"),
+      JSON.stringify({ logicalId: STABLE_ID_1 }),
+    );
+    const a = await runAndCollect({ glob: "**/*.md", root });
+    const b = await runAndCollect({ glob: "**/*.md", root });
+    expect(a[0]!.identity).toBe(b[0]!.identity);
+  });
+
+  it("produces DIFFERENT identities across two runs when sidecar is missing", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    const a = await runAndCollect({ glob: "**/*.md", root });
+    const b = await runAndCollect({ glob: "**/*.md", root });
+    expect(a[0]!.identity).not.toBe(b[0]!.identity);
+  });
+
+  it("multiple files with distinct sidecars get their own identities", async () => {
+    await writeFile(join(root, "a.md"), "A");
+    await writeFile(join(root, "b.md"), "B");
+    await writeFile(join(root, ".a.md.id.json"), JSON.stringify({ logicalId: STABLE_ID_1 }));
+    await writeFile(join(root, ".b.md.id.json"), JSON.stringify({ logicalId: STABLE_ID_2 }));
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    const byPath = new Map(out.map((s) => [s.path, s.identity]));
+    expect(byPath.get("a.md")).toBe(STABLE_ID_1);
+    expect(byPath.get("b.md")).toBe(STABLE_ID_2);
+  });
+
+  it("falls back to fresh id when sidecar contains malformed JSON", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(join(root, ".hello.md.id.json"), "not-json{");
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out).toHaveLength(1);
+    // Some fresh UUIDv7.
+    expect(out[0]!.identity).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(out[0]!.identity).not.toBe(STABLE_ID_1);
+  });
+
+  it("falls back to fresh id when sidecar is not an object", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(join(root, ".hello.md.id.json"), JSON.stringify("just-a-string"));
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out[0]!.identity).not.toBe("just-a-string");
+  });
+
+  it("falls back when logicalId field is missing", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(join(root, ".hello.md.id.json"), JSON.stringify({ note: "no id" }));
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out[0]!.identity).not.toBe("");
+    expect(out[0]!.identity).toMatch(/^[0-9a-f]{8}-/);
+  });
+
+  it("falls back when logicalId is wrong shape (v4 instead of v7)", async () => {
+    // UUIDv4 has version nibble 4; we require 7.
+    const v4 = "01952c0d-7e63-4000-8000-000000000001";
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(join(root, ".hello.md.id.json"), JSON.stringify({ logicalId: v4 }));
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out[0]!.identity).not.toBe(v4);
+  });
+
+  it("falls back when logicalId is a number, not a string", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(join(root, ".hello.md.id.json"), JSON.stringify({ logicalId: 42 }));
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out[0]!.identity).toMatch(/^[0-9a-f]{8}-/);
+  });
+
+  it("ignores unknown sidecar fields (forward-compat)", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(
+      join(root, ".hello.md.id.json"),
+      JSON.stringify({
+        logicalId: STABLE_ID_1,
+        createdAt: "2026-05-16T00:00:00Z",
+        note: "human-readable",
+        someFutureField: { nested: true },
+      }),
+    );
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out[0]!.identity).toBe(STABLE_ID_1);
+  });
+
+  it("persistIdentities=false → always generates fresh, ignoring sidecar", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(join(root, ".hello.md.id.json"), JSON.stringify({ logicalId: STABLE_ID_1 }));
+    const out = await runAndCollect({ glob: "**/*.md", root, persistIdentities: false });
+    expect(out[0]!.identity).not.toBe(STABLE_ID_1);
+  });
+
+  it("sidecar files themselves are NOT emitted as content sources", async () => {
+    // Sidecars start with a dot — the walker should skip them as
+    // hidden files.  Verify this stays true.
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(join(root, ".hello.md.id.json"), JSON.stringify({ logicalId: STABLE_ID_1 }));
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.path).toBe("hello.md");
+  });
+
+  it("empty sidecar file → fresh id (treated as missing)", async () => {
+    await writeFile(join(root, "hello.md"), "body");
+    await writeFile(join(root, ".hello.md.id.json"), "");
+    const out = await runAndCollect({ glob: "**/*.md", root });
+    expect(out[0]!.identity).toMatch(/^[0-9a-f]{8}-/);
+  });
+});

--- a/code/packages/typescript/forme-source-fs/tests/walker.test.ts
+++ b/code/packages/typescript/forme-source-fs/tests/walker.test.ts
@@ -68,9 +68,12 @@ describe("walkFiles", () => {
     await writeFile(join(root, "posts", "2026", "deep.md"), "x");
     const files = await collect(walkFiles(root, ".md"));
     expect(files.length).toBe(3);
-    expect(files.some(f => f.endsWith("/top.md"))).toBe(true);
-    expect(files.some(f => f.endsWith("/hello.md"))).toBe(true);
-    expect(files.some(f => f.endsWith("/deep.md"))).toBe(true);
+    // walkFiles uses `path.join` which returns native separators
+    // (`\` on Windows).  Normalise to POSIX for stable assertions.
+    const posix = files.map(f => f.split(/[/\\]/).join("/"));
+    expect(posix.some(f => f.endsWith("/top.md"))).toBe(true);
+    expect(posix.some(f => f.endsWith("/hello.md"))).toBe(true);
+    expect(posix.some(f => f.endsWith("/deep.md"))).toBe(true);
   });
 
   it("filters by extension", async () => {


### PR DESCRIPTION
## Summary

Resolves the documented TODO from v0.1.0's CHANGELOG: stable ``LogicalId``s across runs via hidden sidecar files (``<dir>/.<basename>.id.json``).

Version bumped to **0.2.0** (new public API field ``persistIdentities``).

## What this PR adds

- **Identity sidecar reading**: when a source file ``posts/hello.md`` has a sidecar ``posts/.hello.md.id.json`` containing ``{ "logicalId": "<uuid-v7>" }``, source-fs uses that id. Fallback: generate fresh.
- **``persistIdentities: boolean`` config field** (default ``true``). Set ``false`` to opt out for ephemeral builds.
- **Forward-compat sidecar shape**: ``createdAt``, ``note``, and any future fields are silently ignored.
- **Defensive fallback** on every malformed-sidecar case (bad JSON, missing field, wrong type, UUIDv4 instead of v7) — logs ``warn`` and generates fresh; never fails the pipeline.

## What's NOT in this PR

- **Write side** (auto-create sidecars on first read). Deferred because adding ``filesystem:write`` to source-fs would change its capability profile and trigger install prompts. A separate stage or CLI command (``forme identity init``) will own that. The CHANGELOG documents this explicitly.

## Also fixed

Pre-existing Windows-only bug in ``walker.test.ts`` — assertions used POSIX ``/`` against ``path.join`` output which returns ``\`` on Windows. The original PR #3304 merged because no Windows-touching change to forme-source-fs had triggered the package's BUILD on Windows CI since then. This PR will, so the test is normalised to forward slashes in the same commit. No production behaviour change.

## Test plan

- [x] 37 tests pass (up from 23): 13 new in ``identity-sidecar.test.ts`` + 13 stage + 11 walker
- [x] Sidecar persistence: same id across two runs ✓
- [x] No sidecar: different ids across two runs ✓
- [x] Per-file resolution (no cross-file leakage) ✓
- [x] Malformed-JSON sidecar → warn + fallback ✓
- [x] Wrong-shape sidecar (string / number / missing field) → fallback ✓
- [x] UUIDv4 in sidecar → rejected, fallback ✓
- [x] Forward-compat: unknown sidecar fields ignored ✓
- [x] ``persistIdentities: false`` opts out ✓
- [x] Sidecar files are not themselves emitted as content sources ✓
- [x] Security review (sub-agent): no findings — path traversal safe, no prototype pollution, no privilege escalation via symlinks
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)