### PR TITLE
feat(phase21): port named variable-coefficient ODE recognition to TypeScript and Rust

### DIFF
--- a/code/packages/rust/cas-ode/CHANGELOG.md
+++ b/code/packages/rust/cas-ode/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — cas-ode (Rust)
 
+## [0.2.0] — 2026-05-16
+
+### Added
+
+- **Phase 21 — Variable-coefficient named ODE recognition** (`try_var_coeff_named_ode`):
+  - `collect_var2_coeffs` — extracts (P, Q, R) from `P(x)·y'' + Q(x)·y' + R(x)·y = 0`
+    where the coefficients are arbitrary IR expressions in x (not just rationals).
+  - `split_out_factor` — extracts coefficient K from `K·target` in Mul/Neg IR trees.
+  - `eval_ir_at_xy` / `eval_ir_at_x` — recursive numeric IR evaluator at concrete f64 values.
+  - `coeff_matches_func` — checks if an IR node ≈ expected analytic function at 4 test points.
+  - `extract_const_val` — returns f64 value of constant (w.r.t. x) IR node.
+  - `legendre_n_from_lambda` — finds non-negative integer n with n(n+1) = λ.
+  - `nu_from_r_minus_xsq` — extracts rational ν from R(x) = x² − ν² (denominator ≤ 20).
+  - `build_named_solution` — builds `Equal(y, %c1·F(n,x) + %c2·G(n,x))`.
+  - `try_legendre_ode` — recognises `(1−x²)y'' − 2xy' + n(n+1)y = 0` → `LegendreP/Q(n,x)`.
+  - `try_bessel_ode` — recognises `x²y'' + xy' + (x²−ν²)y = 0` → `BesselJ/Y(ν,x)`.
+  - `try_hermite_ode` — recognises `y'' − 2xy' + 2ny = 0` → `HermiteH/H2(n,x)`.
+  - `try_chebyshev_ode` — recognises `(1−x²)y'' − xy' + n²y = 0` → `ChebyshevT/U(n,x)`.
+  - Dispatch order: Chebyshev → Legendre → Bessel → Hermite; inserted in `solve_ode` after
+    `collect_euler_cauchy_coeffs`.
+- Updated `symbolic-ir` dependency to `0.2.0` to access the Phase 27 named-ODE head constants.
+
 ## [0.1.0] — 2026-05-08
 
 **Initial release — full Phase 18–20 symbolic ODE2 solver over symbolic IR.**

--- a/code/packages/rust/cas-ode/Cargo.toml
+++ b/code/packages/rust/cas-ode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-ode"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Symbolic ODE2 solver over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-ode/src/lib.rs
+++ b/code/packages/rust/cas-ode/src/lib.rs
@@ -10,7 +10,8 @@ use std::collections::BTreeMap;
 use std::ops::{Add as AddOp, Div as DivOp, Mul as MulOp, Neg as NegOp, Sub as SubOp};
 
 use symbolic_ir::{
-    apply, int, rat, sym, IRNode, ADD, COS, D, DIV, EQUAL, EXP, INTEGRATE, LOG, MUL, NEG, POW, SIN,
+    apply, int, rat, sym, IRNode, ADD, BESSEL_J, BESSEL_Y, CHEBYSHEV_T, CHEBYSHEV_U, COS, D, DIV,
+    EQUAL, EXP, HERMITE_H, HERMITE_H2, INTEGRATE, LEGENDRE_P, LEGENDRE_Q, LOG, MUL, NEG, POW, SIN,
     SUB,
 };
 
@@ -1311,6 +1312,384 @@ fn vop_integrand_pair(
     }
 }
 
+// ============================================================================
+// Phase 21 — Variable-coefficient named ODE recognition
+//
+// Recognises four classical second-order ODEs with variable polynomial
+// coefficients by *numerical pattern matching*: the IR coefficient expressions
+// P(x), Q(x), R(x) are evaluated at four canonical test points and compared
+// against the expected analytic functions.
+//
+// Reading order:
+//   eval_ir_at_xy       — recursive numeric evaluator for IR trees
+//   eval_ir_at_x        — wrapper: evaluate x-only expressions
+//   coeff_matches_func  — check IR node ≈ expected function at test points
+//   extract_const_val   — extract float if node is constant w.r.t. x
+//   split_out_factor    — extract coefficient K from K·target in Mul/Neg tree
+//   collect_var2_coeffs — extract (P, Q, R) from variable-coeff 2nd-order ODE
+//   legendre_n_from_lambda — find n with n(n+1) = λ
+//   nu_from_r_minus_xsq   — extract ν from R(x) = x² − ν² (Bessel)
+//   build_named_solution   — build Equal(y, c1·F(n,x) + c2·G(n,x))
+//   try_legendre_ode, try_bessel_ode, try_hermite_ode, try_chebyshev_ode
+//   try_var_coeff_named_ode — Phase 21 dispatcher (called from solve_ode)
+// ============================================================================
+
+/// Canonical test x-values for coefficient matching.
+/// Chosen to avoid singularities (|x| ≠ 1 for Legendre, x ≠ 0 for Bessel)
+/// while probing a representative range.
+const VAR2_TEST_X: [f64; 4] = [0.3, 0.6, -0.25, 0.85];
+
+/// Recursively evaluate an IR node at concrete floating-point values of x and y.
+///
+/// Supports Integer, Rational, Float, and basic arithmetic/elementary-function
+/// heads (Add, Sub, Mul, Div, Neg, Pow, Exp, Log, Sin, Cos).
+/// Returns `None` for unrecognised symbols or unsupported heads.
+fn eval_ir_at_xy(
+    node: &IRNode,
+    x_sym: &IRNode,
+    y_sym: &IRNode,
+    x_val: f64,
+    y_val: f64,
+) -> Option<f64> {
+    // Check symbol identity first (before the match so it works for any variant)
+    if node == x_sym {
+        return Some(x_val);
+    }
+    if node == y_sym {
+        return Some(y_val);
+    }
+    match node {
+        IRNode::Integer(n) => Some(*n as f64),
+        IRNode::Rational(n, d) => Some(*n as f64 / *d as f64),
+        IRNode::Float(v) => Some(*v),
+        IRNode::Symbol(_) => None, // unknown symbol
+        IRNode::Apply(app) => {
+            if app.head == sym(ADD) {
+                app.args
+                    .iter()
+                    .try_fold(0.0_f64, |acc, a| {
+                        Some(acc + eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val)?)
+                    })
+            } else if let Some((a, b)) = binary_args(node, SUB) {
+                Some(
+                    eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val)?
+                        - eval_ir_at_xy(b, x_sym, y_sym, x_val, y_val)?,
+                )
+            } else if app.head == sym(MUL) {
+                app.args
+                    .iter()
+                    .try_fold(1.0_f64, |acc, a| {
+                        Some(acc * eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val)?)
+                    })
+            } else if let Some((a, b)) = binary_args(node, DIV) {
+                let dv = eval_ir_at_xy(b, x_sym, y_sym, x_val, y_val)?;
+                if dv == 0.0 {
+                    return None;
+                }
+                Some(eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val)? / dv)
+            } else if let Some(inner) = unary_arg(node, NEG) {
+                eval_ir_at_xy(inner, x_sym, y_sym, x_val, y_val).map(|v| -v)
+            } else if let Some((a, b)) = binary_args(node, POW) {
+                Some(
+                    eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val)?
+                        .powf(eval_ir_at_xy(b, x_sym, y_sym, x_val, y_val)?),
+                )
+            } else if let Some(a) = unary_arg(node, EXP) {
+                eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val).map(|v| v.exp())
+            } else if let Some(a) = unary_arg(node, LOG) {
+                eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val).map(|v| v.abs().ln())
+            } else if let Some(a) = unary_arg(node, SIN) {
+                eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val).map(|v| v.sin())
+            } else if let Some(a) = unary_arg(node, COS) {
+                eval_ir_at_xy(a, x_sym, y_sym, x_val, y_val).map(|v| v.cos())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Evaluate an x-only IR expression at `xv`.
+/// Returns `None` if evaluation fails (unknown symbol, unsupported head, etc.).
+fn eval_ir_at_x(node: &IRNode, x_sym: &IRNode, xv: f64) -> Option<f64> {
+    let dummy_y = sym("__var2_dummy_y__");
+    eval_ir_at_xy(node, x_sym, &dummy_y, xv, 0.0)
+}
+
+/// Return true iff `node` numerically agrees with `expected(xv)` at every
+/// canonical test point (tolerance `tol`).  Returns false on eval failures.
+fn coeff_matches_func(
+    node: &IRNode,
+    x: &IRNode,
+    expected: impl Fn(f64) -> f64,
+    tol: f64,
+) -> bool {
+    for &xv in &VAR2_TEST_X {
+        let actual = match eval_ir_at_x(node, x, xv) {
+            Some(v) => v,
+            None => return false,
+        };
+        if (actual - expected(xv)).abs() > tol {
+            return false;
+        }
+    }
+    true
+}
+
+/// Return the float value of `node` if it is constant w.r.t. `x`.
+/// Returns `None` if `node` contains `x` or if evaluation fails.
+fn extract_const_val(node: &IRNode, x: &IRNode) -> Option<f64> {
+    if !is_const_wrt(node, x) {
+        return None;
+    }
+    eval_ir_at_x(node, x, 0.0)
+}
+
+/// Return the coefficient K such that `term = K * target`, or `None`.
+///
+/// Handles nested Mul trees, Neg wrappers, and the degenerate case
+/// `term == target` (coefficient = 1).  Rust Mul is always binary.
+///
+/// Examples:
+///   split_out_factor(Mul(Sub(1,Pow(x,2)), ypp), ypp) → Sub(1,Pow(x,2))
+///   split_out_factor(Neg(Mul(2x, yp)), yp)           → Neg(Mul(2, x))
+fn split_out_factor(term: &IRNode, target: &IRNode) -> Option<IRNode> {
+    if term == target {
+        return Some(one());
+    }
+    // Neg wrapper: negate the coefficient
+    if let Some(inner) = unary_arg(term, NEG) {
+        return split_out_factor(inner, target).map(neg);
+    }
+    // Binary Mul: check direct match and recursive match
+    if let Some((a, b)) = binary_args(term, MUL) {
+        if b == target {
+            return Some(a.clone());
+        }
+        if a == target {
+            return Some(b.clone());
+        }
+        // Recursive descent into right sub-tree
+        if let Some(coeff_b) = split_out_factor(b, target) {
+            return Some(mul(a.clone(), coeff_b));
+        }
+        // Recursive descent into left sub-tree
+        if let Some(coeff_a) = split_out_factor(a, target) {
+            return Some(mul(coeff_a, b.clone()));
+        }
+    }
+    None
+}
+
+/// Extract (P, Q, R) from a variable-coefficient 2nd-order ODE:
+///   P(x)·y'' + Q(x)·y' + R(x)·y = 0
+///
+/// Unlike `collect_second_order_coeffs`, P/Q/R may be arbitrary IR
+/// expressions in x.  Returns `None` if any term does not fit the pattern
+/// or if no y'' term is present.
+fn collect_var2_coeffs(
+    expr: &IRNode,
+    y: &IRNode,
+    x: &IRNode,
+) -> Option<(IRNode, IRNode, IRNode)> {
+    let yp = y_prime(y, x);
+    let yd = y_double(y, x);
+    let mut p_parts: Vec<IRNode> = Vec::new();
+    let mut q_parts: Vec<IRNode> = Vec::new();
+    let mut r_parts: Vec<IRNode> = Vec::new();
+
+    for term in flatten_add(expr) {
+        if let Some(cp) = split_out_factor(&term, &yd) {
+            p_parts.push(cp);
+        } else if let Some(cq) = split_out_factor(&term, &yp) {
+            q_parts.push(cq);
+        } else if let Some(cr) = split_out_factor(&term, y) {
+            r_parts.push(cr);
+        } else {
+            return None; // unrecognised term
+        }
+    }
+
+    if p_parts.is_empty() {
+        return None; // no y'' term found
+    }
+
+    let sum_parts = |parts: Vec<IRNode>| -> IRNode {
+        parts.into_iter().fold(zero(), add)
+    };
+
+    let p = sum_parts(p_parts);
+    let q = if q_parts.is_empty() { zero() } else { sum_parts(q_parts) };
+    let r = if r_parts.is_empty() { zero() } else { sum_parts(r_parts) };
+    Some((p, q, r))
+}
+
+/// Return the non-negative integer n such that n(n+1) = λ, or `None`.
+///
+/// Uses the quadratic formula: n = (−1 + √(1+4λ)) / 2.
+fn legendre_n_from_lambda(lam: f64) -> Option<i64> {
+    let disc = 1.0 + 4.0 * lam;
+    if disc < -1e-12 {
+        return None;
+    }
+    let sqrt_disc = disc.max(0.0).sqrt();
+    let n_float = (-1.0 + sqrt_disc) / 2.0;
+    let n = n_float.round() as i64;
+    if n < 0 {
+        return None;
+    }
+    if (n_float - n as f64).abs() > 1e-7 {
+        return None;
+    }
+    if ((n * (n + 1)) as f64 - lam).abs() > 1e-7 {
+        return None;
+    }
+    Some(n)
+}
+
+/// Extract ν as a rational (p, q) from R(x) = x² − ν².
+///
+/// Evaluates R at 1 and 2 to verify the quadratic shape (R(2)−R(1)=3),
+/// then determines ν = p/q (denominator ≤ 20) by trial.
+/// Returns (p, q) in lowest terms, or `None`.
+fn nu_from_r_minus_xsq(r_node: &IRNode, x: &IRNode) -> Option<(i64, i64)> {
+    let r1 = eval_ir_at_x(r_node, x, 1.0)?;
+    let r2 = eval_ir_at_x(r_node, x, 2.0)?;
+    // Consistency: R(2) − R(1) should equal 4 − 1 = 3
+    if ((r2 - r1) - 3.0).abs() > 1e-8 {
+        return None;
+    }
+    // ν² = 1 − R(1)
+    let nu_sq_raw = 1.0 - r1;
+    if nu_sq_raw < -1e-12 {
+        return None;
+    }
+    let nu_sq = nu_sq_raw.max(0.0);
+    for q in 1i64..=20 {
+        let p_sq = nu_sq * (q * q) as f64;
+        let p = p_sq.sqrt().round() as i64;
+        if p >= 0 && ((p * p) as f64 - p_sq).abs() < 1e-6 {
+            let g = gcd(p.unsigned_abs(), q.unsigned_abs()) as i64;
+            return Some((p / g, q / g));
+        }
+    }
+    None
+}
+
+/// Build `Equal(y, %c1·head1(param, x) + %c2·head2(param, x))`.
+fn build_named_solution(
+    head1: &str,
+    head2: &str,
+    param_ir: IRNode,
+    y: &IRNode,
+    x: &IRNode,
+) -> IRNode {
+    let sol1 = mul(c1(), apply(sym(head1), vec![param_ir.clone(), x.clone()]));
+    let sol2 = mul(c2(), apply(sym(head2), vec![param_ir, x.clone()]));
+    equal(y.clone(), add(sol1, sol2))
+}
+
+// ---------------------------------------------------------------------------
+// The four named-ODE recognisers
+// ---------------------------------------------------------------------------
+
+/// Recognise the Legendre ODE: (1−x²)·y'' − 2x·y' + n(n+1)·y = 0.
+///
+/// Checks: P≈1−x², Q≈−2x, R constant = n(n+1) for non-negative integer n.
+/// Returns: Equal(y, %c1·LegendreP(n,x) + %c2·LegendreQ(n,x))
+fn try_legendre_ode(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNode> {
+    let (p, q, r) = collect_var2_coeffs(expr, y, x)?;
+    if !coeff_matches_func(&p, x, |xv| 1.0 - xv * xv, 1e-9) {
+        return None;
+    }
+    if !coeff_matches_func(&q, x, |xv| -2.0 * xv, 1e-9) {
+        return None;
+    }
+    let lam = extract_const_val(&r, x)?;
+    let n = legendre_n_from_lambda(lam)?;
+    Some(build_named_solution(LEGENDRE_P, LEGENDRE_Q, int(n), y, x))
+}
+
+/// Recognise the Bessel ODE: x²·y'' + x·y' + (x²−ν²)·y = 0.
+///
+/// Checks: P≈x², Q≈x, R(x) = x² − ν² for rational ν (denominator ≤ 20).
+/// Returns: Equal(y, %c1·BesselJ(ν,x) + %c2·BesselY(ν,x))
+fn try_bessel_ode(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNode> {
+    let (p, q, r) = collect_var2_coeffs(expr, y, x)?;
+    if !coeff_matches_func(&p, x, |xv| xv * xv, 1e-9) {
+        return None;
+    }
+    if !coeff_matches_func(&q, x, |xv| xv, 1e-9) {
+        return None;
+    }
+    let (np, nq) = nu_from_r_minus_xsq(&r, x)?;
+    let nu_ir = if nq == 1 { int(np) } else { rat(np, nq) };
+    Some(build_named_solution(BESSEL_J, BESSEL_Y, nu_ir, y, x))
+}
+
+/// Recognise the Hermite ODE: y'' − 2x·y' + 2n·y = 0.
+///
+/// Checks: P≡1, Q≈−2x, R constant = 2n for non-negative integer n.
+/// Returns: Equal(y, %c1·HermiteH(n,x) + %c2·HermiteH2(n,x))
+fn try_hermite_ode(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNode> {
+    let (p, q, r) = collect_var2_coeffs(expr, y, x)?;
+    let p_val = extract_const_val(&p, x)?;
+    if (p_val - 1.0).abs() > 1e-9 {
+        return None;
+    }
+    if !coeff_matches_func(&q, x, |xv| -2.0 * xv, 1e-9) {
+        return None;
+    }
+    let r_val = extract_const_val(&r, x)?;
+    if r_val < -1e-12 {
+        return None;
+    }
+    let n_float = r_val / 2.0;
+    let n = n_float.round() as i64;
+    if n < 0 || (n_float - n as f64).abs() > 1e-9 {
+        return None;
+    }
+    Some(build_named_solution(HERMITE_H, HERMITE_H2, int(n), y, x))
+}
+
+/// Recognise the Chebyshev ODE: (1−x²)·y'' − x·y' + n²·y = 0.
+///
+/// Checks: P≈1−x², Q≈−x, R constant = n² for non-negative integer n.
+/// Checked before Legendre (both have P≈1−x²; Chebyshev has Q≈−x not −2x).
+/// Returns: Equal(y, %c1·ChebyshevT(n,x) + %c2·ChebyshevU(n,x))
+fn try_chebyshev_ode(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNode> {
+    let (p, q, r) = collect_var2_coeffs(expr, y, x)?;
+    if !coeff_matches_func(&p, x, |xv| 1.0 - xv * xv, 1e-9) {
+        return None;
+    }
+    if !coeff_matches_func(&q, x, |xv| -xv, 1e-9) {
+        return None;
+    }
+    let r_val = extract_const_val(&r, x)?;
+    if r_val < -1e-12 {
+        return None;
+    }
+    let n_float = r_val.max(0.0).sqrt();
+    let n = n_float.round() as i64;
+    if n < 0 || (n_float - n as f64).abs() > 1e-7 || ((n * n) as f64 - r_val).abs() > 1e-7 {
+        return None;
+    }
+    Some(build_named_solution(CHEBYSHEV_T, CHEBYSHEV_U, int(n), y, x))
+}
+
+/// Phase 21 dispatcher — try all four named variable-coefficient ODE families.
+///
+/// Priority order: Chebyshev → Legendre → Bessel → Hermite.
+/// (Chebyshev before Legendre because both have P≈1−x²; Q distinguishes them.)
+/// Called from `solve_ode` after `collect_euler_cauchy_coeffs`.
+fn try_var_coeff_named_ode(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNode> {
+    try_chebyshev_ode(expr, y, x)
+        .or_else(|| try_legendre_ode(expr, y, x))
+        .or_else(|| try_bessel_ode(expr, y, x))
+        .or_else(|| try_hermite_ode(expr, y, x))
+}
+
 fn try_vop(expr: &IRNode, y: &IRNode, x: &IRNode) -> Option<IRNode> {
     let (a, b, ccoef, f) = collect_second_order_nonhom(expr, y, x)?;
     let (u1p, u2p, y1, y2) = vop_integrand_pair(a, b, ccoef, f, x)?;
@@ -1339,6 +1718,9 @@ pub fn solve_ode(expr: IRNode, y: IRNode, x: IRNode) -> Option<IRNode> {
     }
     if let Some((a, b, ccoef)) = collect_euler_cauchy_coeffs(&expr, &y, &x) {
         return Some(solve_euler_cauchy_frac(a, b, ccoef, &y, &x));
+    }
+    if let Some(result) = try_var_coeff_named_ode(&expr, &y, &x) {
+        return Some(result);
     }
     if let Some(result) = try_bernoulli(&expr, &y, &x) {
         return Some(result);
@@ -1590,5 +1972,185 @@ mod tests {
 
         let unsupported = apply(sym(ODE2), vec![apply(sym("Mystery"), vec![x()]), y(), x()]);
         assert_eq!(ode2_handler(&unsupported), unsupported);
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 21 — Variable-coefficient named ODE helpers and recognisers
+    // -----------------------------------------------------------------------
+
+    /// Build the Legendre ODE zero-form for order n:
+    ///   (1 − x²)·y'' − 2x·y' + n(n+1)·y = 0
+    fn legendre_expr(n: i64) -> IRNode {
+        let lam = n * (n + 1);
+        let x_sq = pow(x(), int(2));
+        let one_minus_x_sq = sub(one(), x_sq);
+        add(
+            mul(one_minus_x_sq, yd()),
+            add(neg(mul(int(2), mul(x(), yp()))), mul(int(lam), y())),
+        )
+    }
+
+    /// Build the Bessel ODE zero-form for order ν = nu_n/nu_d:
+    ///   x²·y'' + x·y' + (x² − ν²)·y = 0
+    fn bessel_expr(nu_n: i64, nu_d: i64) -> IRNode {
+        let x_sq = pow(x(), int(2));
+        let nu_sq_ir = if nu_d == 1 {
+            int(nu_n * nu_n)
+        } else {
+            rat(nu_n * nu_n, nu_d * nu_d)
+        };
+        add(
+            mul(x_sq.clone(), yd()),
+            add(mul(x(), yp()), mul(sub(x_sq, nu_sq_ir), y())),
+        )
+    }
+
+    /// Build the Hermite ODE zero-form for order n:
+    ///   y'' − 2x·y' + 2n·y = 0
+    fn hermite_expr(n: i64) -> IRNode {
+        add(yd(), add(neg(mul(int(2), mul(x(), yp()))), mul(int(2 * n), y())))
+    }
+
+    /// Build the Chebyshev ODE zero-form for order n:
+    ///   (1 − x²)·y'' − x·y' + n²·y = 0
+    fn chebyshev_expr(n: i64) -> IRNode {
+        let x_sq = pow(x(), int(2));
+        let one_minus_x_sq = sub(one(), x_sq);
+        add(
+            mul(one_minus_x_sq, yd()),
+            add(neg(mul(x(), yp())), mul(int(n * n), y())),
+        )
+    }
+
+    /// Extract the RHS of `Equal(y, rhs)` from a solve_ode result.
+    fn rhs_of_equal(node: &IRNode) -> IRNode {
+        let IRNode::Apply(app) = node else {
+            panic!("expected Apply");
+        };
+        assert_eq!(app.head, sym(EQUAL));
+        app.args[1].clone()
+    }
+
+    #[test]
+    fn phase21_legendre_n2_returns_legendrep_q_solution() {
+        let result = solve_ode(legendre_expr(2), y(), x()).unwrap();
+        let rhs = rhs_of_equal(&result);
+        // Equal(y, Add(Mul(%c1, LegendreP(2, x)), Mul(%c2, LegendreQ(2, x))))
+        let expected = add(
+            mul(c1(), apply(sym(LEGENDRE_P), vec![int(2), x()])),
+            mul(c2(), apply(sym(LEGENDRE_Q), vec![int(2), x()])),
+        );
+        assert_eq!(rhs, expected);
+    }
+
+    #[test]
+    fn phase21_legendre_n3_encodes_order_3() {
+        let result = solve_ode(legendre_expr(3), y(), x()).unwrap();
+        let s = format!("{result}");
+        assert!(s.contains("LegendreP"), "expected LegendreP in {s}");
+        assert!(s.contains("LegendreQ"), "expected LegendreQ in {s}");
+        assert!(s.contains("3"), "expected order 3 in {s}");
+        assert!(s.contains("%c1") && s.contains("%c2"));
+    }
+
+    #[test]
+    fn phase21_bessel_nu1_integer_order() {
+        // x²y'' + xy' + (x²−1)y = 0  →  ν = 1
+        let result = solve_ode(bessel_expr(1, 1), y(), x()).unwrap();
+        let rhs = rhs_of_equal(&result);
+        let expected = add(
+            mul(c1(), apply(sym(BESSEL_J), vec![int(1), x()])),
+            mul(c2(), apply(sym(BESSEL_Y), vec![int(1), x()])),
+        );
+        assert_eq!(rhs, expected);
+    }
+
+    #[test]
+    fn phase21_bessel_nu2_integer_order() {
+        // x²y'' + xy' + (x²−4)y = 0  →  ν = 2
+        let result = solve_ode(bessel_expr(2, 1), y(), x()).unwrap();
+        let s = format!("{result}");
+        assert!(s.contains("BesselJ"), "expected BesselJ in {s}");
+        assert!(s.contains("BesselY"), "expected BesselY in {s}");
+        assert!(s.contains("2"));
+    }
+
+    #[test]
+    fn phase21_bessel_nu_half_integer() {
+        // x²y'' + xy' + (x²−1/4)y = 0  →  ν = 1/2
+        let result = solve_ode(bessel_expr(1, 2), y(), x()).unwrap();
+        let s = format!("{result}");
+        assert!(s.contains("BesselJ"), "expected BesselJ in {s}");
+        assert!(s.contains("BesselY"), "expected BesselY in {s}");
+    }
+
+    #[test]
+    fn phase21_hermite_n3_returns_hermiteh_h2_solution() {
+        let result = solve_ode(hermite_expr(3), y(), x()).unwrap();
+        let rhs = rhs_of_equal(&result);
+        let expected = add(
+            mul(c1(), apply(sym(HERMITE_H), vec![int(3), x()])),
+            mul(c2(), apply(sym(HERMITE_H2), vec![int(3), x()])),
+        );
+        assert_eq!(rhs, expected);
+    }
+
+    #[test]
+    fn phase21_hermite_n0_trivial() {
+        // y'' + 0·y' + 0·y = 0 (hermite n=0 has 2n=0)
+        let result = solve_ode(hermite_expr(0), y(), x()).unwrap();
+        let s = format!("{result}");
+        assert!(s.contains("HermiteH"), "expected HermiteH in {s}");
+    }
+
+    #[test]
+    fn phase21_chebyshev_n2_returns_chebyshevt_u_solution() {
+        let result = solve_ode(chebyshev_expr(2), y(), x()).unwrap();
+        let rhs = rhs_of_equal(&result);
+        let expected = add(
+            mul(c1(), apply(sym(CHEBYSHEV_T), vec![int(2), x()])),
+            mul(c2(), apply(sym(CHEBYSHEV_U), vec![int(2), x()])),
+        );
+        assert_eq!(rhs, expected);
+    }
+
+    #[test]
+    fn phase21_chebyshev_n3_encodes_order_3() {
+        let result = solve_ode(chebyshev_expr(3), y(), x()).unwrap();
+        let s = format!("{result}");
+        assert!(s.contains("ChebyshevT"), "expected ChebyshevT in {s}");
+        assert!(s.contains("ChebyshevU"), "expected ChebyshevU in {s}");
+        assert!(s.contains("3"));
+    }
+
+    #[test]
+    fn phase21_chebyshev_distinguished_from_legendre() {
+        // Chebyshev and Legendre both have P ≈ 1−x²; Q distinguishes them.
+        let legendre_result = solve_ode(legendre_expr(2), y(), x()).unwrap();
+        let chebyshev_result = solve_ode(chebyshev_expr(2), y(), x()).unwrap();
+        let ls = format!("{legendre_result}");
+        let cs = format!("{chebyshev_result}");
+        assert!(
+            ls.contains("LegendreP") && !ls.contains("ChebyshevT"),
+            "Legendre result should contain LegendreP not ChebyshevT: {ls}"
+        );
+        assert!(
+            cs.contains("ChebyshevT") && !cs.contains("LegendreP"),
+            "Chebyshev result should contain ChebyshevT not LegendreP: {cs}"
+        );
+    }
+
+    #[test]
+    fn phase21_regression_euler_cauchy_still_works() {
+        // x²y'' − 2y = 0 should be caught by tryEulerCauchy BEFORE Phase 21
+        let expr = sub(mul(pow(x(), int(2)), yd()), mul(int(2), y()));
+        let result = solve_ode(expr, y(), x()).unwrap();
+        let s = format!("{result}");
+        // Euler-Cauchy: r²-r-2=0 → r=2,-1 → %c1·x² + %c2·x^(-1)
+        assert!(s.contains("Pow"), "expected Pow in Euler-Cauchy solution: {s}");
+        assert!(
+            !s.contains("LegendreP") && !s.contains("BesselJ"),
+            "Euler-Cauchy result must not contain named-ODE heads: {s}"
+        );
     }
 }

--- a/code/packages/rust/symbolic-ir/CHANGELOG.md
+++ b/code/packages/rust/symbolic-ir/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog — symbolic-ir (Rust)
 
-## Unreleased
+## [0.2.0] — 2026-05-16
 
 ### Added
 
 - First-class reciprocal hyperbolic head constants: `COTH`, `SECH`, and `CSCH`.
+- Eight Phase 27 named ODE solution function head constants: `LEGENDRE_P`,
+  `LEGENDRE_Q`, `BESSEL_J`, `BESSEL_Y`, `HERMITE_H`, `HERMITE_H2`,
+  `CHEBYSHEV_T`, and `CHEBYSHEV_U`, covering the four classical
+  variable-coefficient ODE families (Legendre, Bessel, Hermite, Chebyshev).
 
 ## [0.1.0] — 2026-04-27
 

--- a/code/packages/rust/symbolic-ir/Cargo.toml
+++ b/code/packages/rust/symbolic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Universal symbolic expression IR — the shared tree representation for CAS frontends and backends"
 license = "MIT"

--- a/code/packages/rust/symbolic-ir/src/lib.rs
+++ b/code/packages/rust/symbolic-ir/src/lib.rs
@@ -382,6 +382,20 @@ pub const ASSIGN: &str = "Assign";
 pub const DEFINE: &str = "Define";
 pub const RULE: &str = "Rule";
 
+// Named ODE solution function heads (Phase 27)
+// Legendre ODE: (1-x²)y'' - 2xy' + n(n+1)y = 0
+pub const LEGENDRE_P: &str = "LegendreP";   // Legendre polynomial of the first kind P_n(x)
+pub const LEGENDRE_Q: &str = "LegendreQ";   // Legendre function of the second kind Q_n(x)
+// Bessel ODE: x²y'' + xy' + (x²-ν²)y = 0
+pub const BESSEL_J: &str = "BesselJ";       // Bessel function of the first kind J_ν(x)
+pub const BESSEL_Y: &str = "BesselY";       // Bessel function of the second kind Y_ν(x)
+// Hermite ODE: y'' - 2xy' + 2ny = 0
+pub const HERMITE_H: &str = "HermiteH";     // Hermite polynomial H_n(x)
+pub const HERMITE_H2: &str = "HermiteH2";   // Second independent solution (parabolic cylinder)
+// Chebyshev ODE: (1-x²)y'' - xy' + n²y = 0
+pub const CHEBYSHEV_T: &str = "ChebyshevT"; // Chebyshev polynomial of the first kind T_n(x)
+pub const CHEBYSHEV_U: &str = "ChebyshevU"; // Chebyshev polynomial of the second kind U_n(x)
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/cas-ode/CHANGELOG.md
+++ b/code/packages/typescript/cas-ode/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.2.0 — 2026-05-16
+
+### Added
+
+- **Phase 21 — Variable-coefficient named ODE recognition** (`tryVarCoeffNamedOde`):
+  - `collectVar2Coeffs` — extracts (P, Q, R) from `P(x)·y'' + Q(x)·y' + R(x)·y = 0`
+    where coefficients are arbitrary IR expressions in x, not just rationals.
+  - `splitOutFactor` — extracts coefficient K from `K·target` in Mul/Neg IR trees.
+  - `evalAtXy` / `evalIrAtX` — recursive numeric IR evaluator at concrete float values.
+  - `coeffMatchesFunc` — checks if an IR node ≈ expected analytic function at 4 test points.
+  - `extractConstVal` — returns float value of constant (w.r.t. x) IR node.
+  - `legendreNFromLambda` — finds non-negative integer n with n(n+1) = λ.
+  - `nuFromRMinusXSq` — extracts rational ν from R(x) = x² − ν² (denominator ≤ 20).
+  - `buildNamedSolution` — builds `Equal(y, %c1·F(n,x) + %c2·G(n,x))`.
+  - `tryLegendreOde` — recognises `(1−x²)y'' − 2xy' + n(n+1)y = 0` → `LegendreP/Q(n,x)`.
+  - `tryBesselOde` — recognises `x²y'' + xy' + (x²−ν²)y = 0` → `BesselJ/Y(ν,x)`.
+  - `tryHermiteOde` — recognises `y'' − 2xy' + 2ny = 0` → `HermiteH/H2(n,x)`.
+  - `tryChebyshevOde` — recognises `(1−x²)y'' − xy' + n²y = 0` → `ChebyshevT/U(n,x)`.
+  - Dispatch order: Chebyshev → Legendre → Bessel → Hermite; inserted in `solveOde` after `tryEulerCauchy`.
+- Bumped `@coding-adventures/symbolic-ir` peer to `^0.2.0` (requires new Phase 27 head symbols).
+
 ## 0.1.0
 
 - Added the pure TypeScript symbolic ODE solver over `@coding-adventures/symbolic-ir`.

--- a/code/packages/typescript/cas-ode/package-lock.json
+++ b/code/packages/typescript/cas-ode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-ode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-ode",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
@@ -20,7 +20,7 @@
     },
     "../symbolic-ir": {
       "name": "@coding-adventures/symbolic-ir",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",

--- a/code/packages/typescript/cas-ode/package.json
+++ b/code/packages/typescript/cas-ode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-ode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pure TypeScript symbolic ODE solver over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-ode/src/index.ts
+++ b/code/packages/typescript/cas-ode/src/index.ts
@@ -1,11 +1,19 @@
 import {
   ADD,
+  BESSEL_J,
+  BESSEL_Y,
+  CHEBYSHEV_T,
+  CHEBYSHEV_U,
   COS,
   D,
   DIV,
   EQUAL,
   EXP,
+  HERMITE_H,
+  HERMITE_H2,
   INTEGRATE,
+  LEGENDRE_P,
+  LEGENDRE_Q,
   LOG,
   MUL,
   NEG,
@@ -148,6 +156,9 @@ export function solveOde(equation: IRNode, y: IRNode, x: IRNode, options: SolveO
 
   const euler = tryEulerCauchy(expr, y, x);
   if (euler !== null) return euler;
+
+  const named = tryVarCoeffNamedOde(expr, y, x);
+  if (named !== null) return named;
 
   const bernoulli = tryBernoulli(expr, y, x, ops);
   if (bernoulli !== null) return bernoulli;
@@ -1123,4 +1134,384 @@ function gcd(a: bigint, b: bigint): bigint {
 
 function abs(value: bigint): bigint {
   return value < 0n ? -value : value;
+}
+
+// ============================================================================
+// Phase 21 — Variable-coefficient named ODE recognition
+//
+// Recognises four classical second-order ODEs with variable polynomial
+// coefficients by *numerical pattern matching*: the IR coefficient expressions
+// P(x), Q(x), R(x) are evaluated at four canonical test points and compared
+// against the expected analytic functions.  This is exact for polynomial
+// coefficients (all that the ODE families use) and is robust enough for the
+// handful of cases we care about.
+//
+// Reading order:
+//   evalAtXy          — recursive numeric evaluator for IR trees
+//   evalIrAtX         — thin wrapper: evaluate x-only expressions
+//   coeffMatchesFunc  — check IR node ≈ expected function at test points
+//   extractConstVal   — extract float if node is constant w.r.t. x
+//   splitOutFactor    — extract coefficient K from K·target in Mul/Neg tree
+//   collectVar2Coeffs — extract (P, Q, R) from variable-coeff 2nd-order ODE
+//   legendreNFromLambda — find n with n(n+1) = λ
+//   nuFromRMinusXSq   — extract ν from R(x) = x² − ν² (Bessel)
+//   buildNamedSolution — build Equal(y, %c1·F(n,x) + %c2·G(n,x))
+//   tryLegendreOde, tryBesselOde, tryHermiteOde, tryChebyshevOde
+//   tryVarCoeffNamedOde — Phase 21 dispatcher (called from solveOde)
+// ============================================================================
+
+// Four test x-values chosen to avoid singularities (|x| ≠ 1 for Legendre,
+// x ≠ 0 for Bessel) while probing a representative range.
+const VAR2_TEST_X = [0.3, 0.6, -0.25, 0.85] as const;
+
+// Dummy y-symbol used when evaluating x-only coefficient expressions.
+const DUMMY_Y_SYM = sym("__var2_dummy_y__");
+
+/**
+ * Recursively evaluate an IR node at concrete floating-point values of x and y.
+ *
+ * Supports Integer, Rational, Float, and the basic arithmetic/elementary
+ * function heads (Add, Sub, Mul, Div, Neg, Pow, Exp, Log, Sin, Cos).
+ * Throws a RangeError for unrecognised symbols or unsupported heads so that
+ * the caller can catch and return null.
+ */
+function evalAtXy(node: IRNode, xSym: IRNode, ySym: IRNode, xVal: number, yVal: number): number {
+  if (node.kind === "integer") return Number(node.value);
+  if (node.kind === "rational") return Number(node.numer) / Number(node.denom);
+  if (node.kind === "float") return node.value;
+  if (node.kind === "symbol") {
+    if (xSym.kind === "symbol" && node.name === xSym.name) return xVal;
+    if (ySym.kind === "symbol" && node.name === ySym.name) return yVal;
+    throw new RangeError(`Unknown symbol: ${node.name}`);
+  }
+  if (node.kind !== "apply") throw new RangeError("Unsupported node");
+  const name = headName(node.head);
+  const ev = (n: IRNode): number => evalAtXy(n, xSym, ySym, xVal, yVal);
+  // n-ary Add and Mul (TypeScript IR uses multi-arg forms after simplification)
+  if (name === ADD.name) return node.args.reduce((acc, arg) => acc + ev(arg), 0);
+  if (name === MUL.name) return node.args.reduce((acc, arg) => acc * ev(arg), 1);
+  if (name === SUB.name && node.args.length === 2) return ev(node.args[0]) - ev(node.args[1]);
+  if (name === DIV.name && node.args.length === 2) {
+    const dv = ev(node.args[1]);
+    if (dv === 0) throw new RangeError("Division by zero");
+    return ev(node.args[0]) / dv;
+  }
+  if (name === NEG.name && node.args.length === 1) return -ev(node.args[0]);
+  if (name === POW.name && node.args.length === 2) return ev(node.args[0]) ** ev(node.args[1]);
+  if (name === EXP.name && node.args.length === 1) return Math.exp(ev(node.args[0]));
+  if (name === LOG.name && node.args.length === 1) return Math.log(Math.abs(ev(node.args[0])));
+  if (name === SIN.name && node.args.length === 1) return Math.sin(ev(node.args[0]));
+  if (name === COS.name && node.args.length === 1) return Math.cos(ev(node.args[0]));
+  throw new RangeError(`Unsupported head: ${name}`);
+}
+
+/**
+ * Evaluate an x-only IR expression at xv.  Returns null on any error
+ * (unknown symbol, division by zero, unsupported head).
+ */
+function evalIrAtX(node: IRNode, x: IRNode, xv: number): number | null {
+  try {
+    return evalAtXy(node, x, DUMMY_Y_SYM, xv, 0);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return true iff `node` numerically agrees with `expected(xv)` at every
+ * canonical test point.  Falls through to false on evaluation failures.
+ */
+function coeffMatchesFunc(
+  node: IRNode,
+  x: IRNode,
+  expected: (xv: number) => number,
+  tol = 1e-9,
+): boolean {
+  for (const xv of VAR2_TEST_X) {
+    const actual = evalIrAtX(node, x, xv);
+    if (actual === null) return false;
+    let want: number;
+    try {
+      want = expected(xv);
+    } catch {
+      return false;
+    }
+    if (Math.abs(actual - want) > tol) return false;
+  }
+  return true;
+}
+
+/**
+ * Return the float value of `node` if it is constant w.r.t. `x`.
+ * Returns null if `node` contains `x` or if evaluation fails.
+ */
+function extractConstVal(node: IRNode, x: IRNode): number | null {
+  if (!isConstWrt(node, x)) return null;
+  return evalIrAtX(node, x, 0);
+}
+
+/**
+ * Return the coefficient K such that term = K * target, or null.
+ *
+ * Handles nested Mul trees, Neg wrappers, and the degenerate case
+ * term === target (coefficient = 1).  Works on both binary and n-ary Mul.
+ *
+ * Examples:
+ *   splitOutFactor(Mul(Sub(1,Pow(x,2)), ypp), ypp)  → Sub(1,Pow(x,2))
+ *   splitOutFactor(Neg(Mul(2, Mul(x, yp))), yp)     → Neg(Mul(2, x))
+ *   splitOutFactor(ypp, yp)                          → null  (ypp ≠ yp)
+ */
+function splitOutFactor(term: IRNode, target: IRNode): IRNode | null {
+  if (equals(term, target)) return ONE;
+  if (term.kind !== "apply") return null;
+  const name = headName(term.head);
+  // Neg wrapper: negate the coefficient
+  if (name === NEG.name && term.args.length === 1) {
+    const inner = splitOutFactor(term.args[0], target);
+    return inner !== null ? neg(inner) : null;
+  }
+  if (name === MUL.name) {
+    const args = term.args;
+    // Direct match: one of the factors IS the target
+    for (let i = 0; i < args.length; i++) {
+      if (equals(args[i], target)) {
+        const rest = args.filter((_, j) => j !== i) as IRNode[];
+        if (rest.length === 0) return ONE;
+        if (rest.length === 1) return rest[0];
+        return app(MUL, rest);
+      }
+    }
+    // For binary Mul, recurse into sub-trees to handle nested Mul chains
+    if (args.length === 2) {
+      const coeffB = splitOutFactor(args[1], target);
+      if (coeffB !== null) return mul(args[0], coeffB);
+      const coeffA = splitOutFactor(args[0], target);
+      if (coeffA !== null) return mul(coeffA, args[1]);
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract (P, Q, R) from a variable-coefficient 2nd-order ODE:
+ *   P(x)·y'' + Q(x)·y' + R(x)·y = 0
+ *
+ * Unlike collectSecondOrderCoeffs, P/Q/R may be arbitrary IR expressions
+ * in x (not just rationals).  Returns null if any term does not fit the
+ * pattern or if no y'' term is present.
+ */
+function collectVar2Coeffs(
+  expr: IRNode,
+  y: IRNode,
+  x: IRNode,
+): { p: IRNode; q: IRNode; r: IRNode } | null {
+  const yPrime = deriv(y, x);
+  const yDouble = deriv(yPrime, x);
+  const pParts: IRNode[] = [];
+  const qParts: IRNode[] = [];
+  const rParts: IRNode[] = [];
+
+  for (const term of flattenAdd(expr)) {
+    const cp = splitOutFactor(term, yDouble);
+    if (cp !== null) { pParts.push(cp); continue; }
+    const cq = splitOutFactor(term, yPrime);
+    if (cq !== null) { qParts.push(cq); continue; }
+    const cr = splitOutFactor(term, y);
+    if (cr !== null) { rParts.push(cr); continue; }
+    return null;  // unrecognised term
+  }
+
+  if (pParts.length === 0) return null;  // no y'' term found
+  return {
+    p: pParts.length === 1 ? pParts[0] : sum(pParts),
+    q: qParts.length === 0 ? ZERO : qParts.length === 1 ? qParts[0] : sum(qParts),
+    r: rParts.length === 0 ? ZERO : rParts.length === 1 ? rParts[0] : sum(rParts),
+  };
+}
+
+/**
+ * Return the non-negative integer n such that n(n+1) = λ, or null.
+ *
+ * Uses the quadratic formula: n = (−1 + √(1+4λ)) / 2.
+ *
+ * Examples:
+ *   legendreNFromLambda(0)   → 0   (0·1 = 0)
+ *   legendreNFromLambda(6)   → 2   (2·3 = 6)
+ *   legendreNFromLambda(5)   → null
+ */
+function legendreNFromLambda(lam: number): number | null {
+  const disc = 1 + 4 * lam;
+  if (disc < -1e-12) return null;
+  const sqrtDisc = Math.sqrt(Math.max(disc, 0));
+  const nFloat = (-1 + sqrtDisc) / 2;
+  const n = Math.round(nFloat);
+  if (n < 0) return null;
+  if (Math.abs(nFloat - n) > 1e-7) return null;
+  if (Math.abs(n * (n + 1) - lam) > 1e-7) return null;
+  return n;
+}
+
+/**
+ * Extract ν as a rational [p, q] from R(x) = x² − ν².
+ *
+ * Strategy: R(x) − x² must be constant (= −ν²).  Evaluate R at two points to
+ * verify the quadratic shape, then determine ν = p/q (denominator ≤ 20) by
+ * trial.  Returns [p, q] in lowest terms, or null.
+ *
+ * Examples:
+ *   R(x) = x² − 4     → ν = 2,   returns [2, 1]
+ *   R(x) = x² − 1/4   → ν = 1/2, returns [1, 2]
+ *   R(x) = x² − 9/4   → ν = 3/2, returns [3, 2]
+ */
+function nuFromRMinusXSq(rNode: IRNode, x: IRNode): [number, number] | null {
+  const r1 = evalIrAtX(rNode, x, 1.0);
+  const r2 = evalIrAtX(rNode, x, 2.0);
+  if (r1 === null || r2 === null) return null;
+  // R(2) − R(1) should equal 4 − 1 = 3 for R(x) = x² + const
+  if (Math.abs((r2 - r1) - 3) > 1e-8) return null;
+  // ν² = x² − R(x) evaluated at x=1: ν² = 1 − R(1)
+  const nuSq = 1 - r1;
+  if (nuSq < -1e-12) return null;
+  const nuSqPos = Math.max(nuSq, 0);
+  // Trial-search for rational ν = p/q with denominator ≤ 20
+  for (let q = 1; q <= 20; q++) {
+    const pSq = nuSqPos * q * q;
+    const p = Math.round(Math.sqrt(pSq));
+    if (p >= 0 && Math.abs(p * p - pSq) < 1e-6) {
+      const g = Number(gcd(BigInt(p), BigInt(q)));
+      return [p / g, q / g];
+    }
+  }
+  return null;
+}
+
+/**
+ * Build Equal(y, %c1·head1(param, x) + %c2·head2(param, x)).
+ *
+ * Used by all four named-ODE solvers to assemble the general solution.
+ */
+function buildNamedSolution(h1: IRNode, h2: IRNode, paramIr: IRNode, y: IRNode, x: IRNode): IRNode {
+  const sol1 = mul(C1, app(h1, [paramIr, x]));
+  const sol2 = mul(C2, app(h2, [paramIr, x]));
+  return app(EQUAL, [y, add(sol1, sol2)]);
+}
+
+// ---------------------------------------------------------------------------
+// The four named-ODE recognisers
+// ---------------------------------------------------------------------------
+
+/**
+ * Recognise the Legendre ODE: (1−x²)·y'' − 2x·y' + n(n+1)·y = 0.
+ *
+ * Checks:
+ *   1. P(x) ≈ 1 − x²  at four test points.
+ *   2. Q(x) ≈ −2x     at four test points.
+ *   3. R is constant = n(n+1) for some non-negative integer n.
+ *
+ * Returns: Equal(y, %c1·LegendreP(n,x) + %c2·LegendreQ(n,x))
+ */
+function tryLegendreOde(expr: IRNode, y: IRNode, x: IRNode): IRNode | null {
+  const coeffs = collectVar2Coeffs(expr, y, x);
+  if (coeffs === null) return null;
+  const { p, q, r } = coeffs;
+  if (!coeffMatchesFunc(p, x, (xv) => 1 - xv * xv)) return null;
+  if (!coeffMatchesFunc(q, x, (xv) => -2 * xv)) return null;
+  const lam = extractConstVal(r, x);
+  if (lam === null) return null;
+  const n = legendreNFromLambda(lam);
+  if (n === null) return null;
+  return buildNamedSolution(LEGENDRE_P, LEGENDRE_Q, int(n), y, x);
+}
+
+/**
+ * Recognise the Bessel ODE: x²·y'' + x·y' + (x²−ν²)·y = 0.
+ *
+ * Checks:
+ *   1. P(x) ≈ x²   at four test points.
+ *   2. Q(x) ≈ x    at four test points.
+ *   3. R(x) = x² − ν² for some non-negative rational ν (denominator ≤ 20).
+ *
+ * Returns: Equal(y, %c1·BesselJ(ν,x) + %c2·BesselY(ν,x))
+ */
+function tryBesselOde(expr: IRNode, y: IRNode, x: IRNode): IRNode | null {
+  const coeffs = collectVar2Coeffs(expr, y, x);
+  if (coeffs === null) return null;
+  const { p, q, r } = coeffs;
+  if (!coeffMatchesFunc(p, x, (xv) => xv * xv)) return null;
+  if (!coeffMatchesFunc(q, x, (xv) => xv)) return null;
+  const nuPq = nuFromRMinusXSq(r, x);
+  if (nuPq === null) return null;
+  const [np, nq] = nuPq;
+  const nuIr: IRNode = nq === 1 ? int(np) : rational(np, nq);
+  return buildNamedSolution(BESSEL_J, BESSEL_Y, nuIr, y, x);
+}
+
+/**
+ * Recognise the Hermite ODE: y'' − 2x·y' + 2n·y = 0.
+ *
+ * Checks:
+ *   1. P ≡ 1 (constant).
+ *   2. Q(x) ≈ −2x   at four test points.
+ *   3. R is constant = 2n for some non-negative integer n.
+ *
+ * Returns: Equal(y, %c1·HermiteH(n,x) + %c2·HermiteH2(n,x))
+ */
+function tryHermiteOde(expr: IRNode, y: IRNode, x: IRNode): IRNode | null {
+  const coeffs = collectVar2Coeffs(expr, y, x);
+  if (coeffs === null) return null;
+  const { p, q, r } = coeffs;
+  const pVal = extractConstVal(p, x);
+  if (pVal === null || Math.abs(pVal - 1) > 1e-9) return null;
+  if (!coeffMatchesFunc(q, x, (xv) => -2 * xv)) return null;
+  const rVal = extractConstVal(r, x);
+  if (rVal === null || rVal < -1e-12) return null;
+  const nFloat = rVal / 2;
+  const n = Math.round(nFloat);
+  if (n < 0 || Math.abs(nFloat - n) > 1e-9) return null;
+  return buildNamedSolution(HERMITE_H, HERMITE_H2, int(n), y, x);
+}
+
+/**
+ * Recognise the Chebyshev ODE: (1−x²)·y'' − x·y' + n²·y = 0.
+ *
+ * Checks:
+ *   1. P(x) ≈ 1 − x²  at four test points.
+ *   2. Q(x) ≈ −x       at four test points.
+ *   3. R is constant = n² for some non-negative integer n.
+ *
+ * Checked before Legendre because both have P ≈ 1−x²; Chebyshev is
+ * distinguished by Q ≈ −x while Legendre has Q ≈ −2x.
+ *
+ * Returns: Equal(y, %c1·ChebyshevT(n,x) + %c2·ChebyshevU(n,x))
+ */
+function tryChebyshevOde(expr: IRNode, y: IRNode, x: IRNode): IRNode | null {
+  const coeffs = collectVar2Coeffs(expr, y, x);
+  if (coeffs === null) return null;
+  const { p, q, r } = coeffs;
+  if (!coeffMatchesFunc(p, x, (xv) => 1 - xv * xv)) return null;
+  if (!coeffMatchesFunc(q, x, (xv) => -xv)) return null;
+  const rVal = extractConstVal(r, x);
+  if (rVal === null || rVal < -1e-12) return null;
+  const nFloat = Math.sqrt(Math.max(rVal, 0));
+  const n = Math.round(nFloat);
+  if (n < 0 || Math.abs(nFloat - n) > 1e-7 || Math.abs(n * n - rVal) > 1e-7) return null;
+  return buildNamedSolution(CHEBYSHEV_T, CHEBYSHEV_U, int(n), y, x);
+}
+
+/**
+ * Phase 21 dispatcher — try all four named variable-coefficient ODE families.
+ *
+ * Priority order:
+ *   1. Chebyshev — before Legendre (both have P ≈ 1−x²; Q distinguishes them)
+ *   2. Legendre  — (1−x²)y'' − 2xy' + n(n+1)y = 0
+ *   3. Bessel    — x²y'' + xy' + (x²−ν²)y = 0
+ *   4. Hermite   — y'' − 2xy' + 2ny = 0
+ *
+ * Called from solveOde after tryEulerCauchy.
+ */
+function tryVarCoeffNamedOde(expr: IRNode, y: IRNode, x: IRNode): IRNode | null {
+  return tryChebyshevOde(expr, y, x)
+    ?? tryLegendreOde(expr, y, x)
+    ?? tryBesselOde(expr, y, x)
+    ?? tryHermiteOde(expr, y, x);
 }

--- a/code/packages/typescript/cas-ode/tests/cas-ode.test.ts
+++ b/code/packages/typescript/cas-ode/tests/cas-ode.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
   ADD,
+  BESSEL_J,
+  BESSEL_Y,
+  CHEBYSHEV_T,
+  CHEBYSHEV_U,
   COS,
   D,
   DIV,
   EQUAL,
   EXP,
+  HERMITE_H,
+  HERMITE_H2,
   INTEGRATE,
+  LEGENDRE_P,
+  LEGENDRE_Q,
   LOG,
   MUL,
   POW,
@@ -16,6 +24,7 @@ import {
   equals,
   headName,
   int,
+  rational,
   sym,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
@@ -184,5 +193,196 @@ describe("second-order ODEs", () => {
     expect(display(rhs)).toContain("%c1");
     expect(display(rhs)).toContain("%c2");
     expect(hasHead(rhs, POW.name)).toBe(true);
+  });
+});
+
+// ============================================================================
+// Phase 21 — Variable-coefficient named ODE recognition
+// ============================================================================
+
+/**
+ * Build the Legendre ODE expression (zero form) for order n:
+ *   (1 − x²)·y'' − 2x·y' + n(n+1)·y = 0
+ */
+function legendreOdeExpr(n: number): IRNode {
+  const xSq = app(POW, [x, int(2)]);
+  const oneMinusXSq = app(SUB, [int(1), xSq]);
+  const lambda = n * (n + 1);
+  return app(ADD, [
+    app(MUL, [oneMinusXSq, ypp]),
+    app(ADD, [
+      app(MUL, [int(-2), app(MUL, [x, yp])]),
+      app(MUL, [int(lambda), y]),
+    ]),
+  ]);
+}
+
+/**
+ * Build the Bessel ODE expression (zero form) for order ν given as an IR node:
+ *   x²·y'' + x·y' + (x² − ν²)·y = 0
+ */
+function besselOdeExpr(nuIr: IRNode, nuSqIr: IRNode): IRNode {
+  const xSq = app(POW, [x, int(2)]);
+  return app(ADD, [
+    app(MUL, [xSq, ypp]),
+    app(ADD, [
+      app(MUL, [x, yp]),
+      app(MUL, [app(SUB, [xSq, nuSqIr]), y]),
+    ]),
+  ]);
+}
+
+/**
+ * Build the Hermite ODE expression (zero form) for order n:
+ *   y'' − 2x·y' + 2n·y = 0
+ */
+function hermiteOdeExpr(n: number): IRNode {
+  return app(ADD, [
+    ypp,
+    app(ADD, [
+      app(MUL, [int(-2), app(MUL, [x, yp])]),
+      app(MUL, [int(2 * n), y]),
+    ]),
+  ]);
+}
+
+/**
+ * Build the Chebyshev ODE expression (zero form) for order n:
+ *   (1 − x²)·y'' − x·y' + n²·y = 0
+ */
+function chebyshevOdeExpr(n: number): IRNode {
+  const xSq = app(POW, [x, int(2)]);
+  const oneMinusXSq = app(SUB, [int(1), xSq]);
+  return app(ADD, [
+    app(MUL, [oneMinusXSq, ypp]),
+    app(ADD, [
+      app(MUL, [int(-1), app(MUL, [x, yp])]),
+      app(MUL, [int(n * n), y]),
+    ]),
+  ]);
+}
+
+describe("Phase 21 — named variable-coefficient ODEs", () => {
+  it("recognises Legendre ODE n=2 and returns LegendreP/Q solution", () => {
+    const result = solveOde(legendreOdeExpr(2), y, x);
+    expect(result).not.toBeNull();
+    const rhs = rhsOfEqual(result!);
+    // Solution: %c1·LegendreP(2,x) + %c2·LegendreQ(2,x)
+    const expected = app(ADD, [
+      app(MUL, [C1, app(LEGENDRE_P, [int(2), x])]),
+      app(MUL, [C2, app(LEGENDRE_Q, [int(2), x])]),
+    ]);
+    expectEqual(rhs, expected);
+  });
+
+  it("recognises Legendre ODE n=3 and encodes n=3 in the solution", () => {
+    const result = solveOde(legendreOdeExpr(3), y, x);
+    expect(result).not.toBeNull();
+    expect(display(result!)).toContain("LegendreP");
+    expect(display(result!)).toContain("LegendreQ");
+    // The integer 3 must appear as the order parameter
+    expect(display(result!)).toContain('"3"');
+  });
+
+  it("recognises Bessel ODE ν=1 (integer order) and returns BesselJ/Y solution", () => {
+    // x²y'' + xy' + (x²−1)y = 0
+    const result = solveOde(besselOdeExpr(int(1), int(1)), y, x);
+    expect(result).not.toBeNull();
+    const rhs = rhsOfEqual(result!);
+    const expected = app(ADD, [
+      app(MUL, [C1, app(BESSEL_J, [int(1), x])]),
+      app(MUL, [C2, app(BESSEL_Y, [int(1), x])]),
+    ]);
+    expectEqual(rhs, expected);
+  });
+
+  it("recognises Bessel ODE ν=2 (integer order)", () => {
+    // x²y'' + xy' + (x²−4)y = 0
+    const result = solveOde(besselOdeExpr(int(2), int(4)), y, x);
+    expect(result).not.toBeNull();
+    expect(display(result!)).toContain("BesselJ");
+    expect(display(result!)).toContain("BesselY");
+    expect(display(result!)).toContain('"2"');
+  });
+
+  it("recognises Bessel ODE ν=1/2 (half-integer order)", () => {
+    // x²y'' + xy' + (x²−1/4)y = 0  →  ν = 1/2
+    const result = solveOde(besselOdeExpr(rational(1, 2), rational(1, 4)), y, x);
+    expect(result).not.toBeNull();
+    expect(display(result!)).toContain("BesselJ");
+    expect(display(result!)).toContain("BesselY");
+  });
+
+  it("recognises Hermite ODE n=3 and returns HermiteH/H2 solution", () => {
+    const result = solveOde(hermiteOdeExpr(3), y, x);
+    expect(result).not.toBeNull();
+    const rhs = rhsOfEqual(result!);
+    const expected = app(ADD, [
+      app(MUL, [C1, app(HERMITE_H, [int(3), x])]),
+      app(MUL, [C2, app(HERMITE_H2, [int(3), x])]),
+    ]);
+    expectEqual(rhs, expected);
+  });
+
+  it("recognises Hermite ODE n=0 (trivial: y'' = 0)", () => {
+    // y'' + 0·y' + 0·y = 0 should match Hermite with n=0
+    const result = solveOde(hermiteOdeExpr(0), y, x);
+    expect(result).not.toBeNull();
+    expect(display(result!)).toContain("HermiteH");
+  });
+
+  it("recognises Chebyshev ODE n=2 and returns ChebyshevT/U solution", () => {
+    const result = solveOde(chebyshevOdeExpr(2), y, x);
+    expect(result).not.toBeNull();
+    const rhs = rhsOfEqual(result!);
+    const expected = app(ADD, [
+      app(MUL, [C1, app(CHEBYSHEV_T, [int(2), x])]),
+      app(MUL, [C2, app(CHEBYSHEV_U, [int(2), x])]),
+    ]);
+    expectEqual(rhs, expected);
+  });
+
+  it("recognises Chebyshev ODE n=3", () => {
+    const result = solveOde(chebyshevOdeExpr(3), y, x);
+    expect(result).not.toBeNull();
+    expect(display(result!)).toContain("ChebyshevT");
+    expect(display(result!)).toContain("ChebyshevU");
+    expect(display(result!)).toContain('"3"');
+  });
+
+  it("distinguishes Chebyshev (Q≈-x) from Legendre (Q≈-2x)", () => {
+    const legendreResult = solveOde(legendreOdeExpr(2), y, x);
+    const chebyshevResult = solveOde(chebyshevOdeExpr(2), y, x);
+    // Legendre should NOT produce Chebyshev output and vice versa
+    expect(display(legendreResult!)).toContain("LegendreP");
+    expect(display(legendreResult!)).not.toContain("ChebyshevT");
+    expect(display(chebyshevResult!)).toContain("ChebyshevT");
+    expect(display(chebyshevResult!)).not.toContain("LegendreP");
+  });
+
+  it("does not misidentify generic 2nd-order ODEs as named families", () => {
+    // y'' + x³·y' + y = 0 — P=1 constant, Q=x³ not ±x or ±2x, R=1
+    // (would match Hermite P check since P=1, but Q check fails since x³ ≠ -2x)
+    const xCubed = app(POW, [x, int(3)]);
+    const expr = app(ADD, [ypp, app(ADD, [app(MUL, [xCubed, yp]), y])]);
+    const result = solveOde(expr, y, x);
+    if (result !== null) {
+      // If any solver catches it, it must not be a named-ODE family result
+      expect(display(result)).not.toContain("LegendreP");
+      expect(display(result)).not.toContain("BesselJ");
+      expect(display(result)).not.toContain("HermiteH");
+      expect(display(result)).not.toContain("ChebyshevT");
+    }
+  });
+
+  it("regression: Euler-Cauchy still works after Phase 21 dispatch", () => {
+    // x²y'' − 2y = 0 should still be caught by tryEulerCauchy BEFORE tryVarCoeffNamedOde
+    const equation = app(SUB, [app(MUL, [app(POW, [x, int(2)]), ypp]), app(MUL, [int(2), y])]);
+    const result = solveOde(equation, y, x);
+    expect(result).not.toBeNull();
+    // Euler-Cauchy with roots r² + (0-1)r - 2 = 0: r²-r-2=0 → (r-2)(r+1)=0 → r=2,-1
+    expect(display(result!)).toContain("Pow");
+    expect(display(result!)).not.toContain("LegendreP");
+    expect(display(result!)).not.toContain("BesselJ");
   });
 });

--- a/code/packages/typescript/symbolic-ir/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-ir/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## Unreleased
+## [0.2.0] - 2026-05-16
 
 ### Added
 
 - Added first-class reciprocal hyperbolic head symbols `COTH`, `SECH`, and
   `CSCH` for `Coth`, `Sech`, and `Csch`.
+- Added eight Phase 27 named ODE solution function head symbols: `LEGENDRE_P`,
+  `LEGENDRE_Q`, `BESSEL_J`, `BESSEL_Y`, `HERMITE_H`, `HERMITE_H2`,
+  `CHEBYSHEV_T`, and `CHEBYSHEV_U`, covering the four classical
+  variable-coefficient ODE families (Legendre, Bessel, Hermite, Chebyshev).
 
 ## [0.1.0] - 2026-05-08
 

--- a/code/packages/typescript/symbolic-ir/package-lock.json
+++ b/code/packages/typescript/symbolic-ir/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/symbolic-ir",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/symbolic-ir",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",

--- a/code/packages/typescript/symbolic-ir/package.json
+++ b/code/packages/typescript/symbolic-ir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-ir",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pure TypeScript symbolic expression IR for CAS frontends and backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-ir/src/index.ts
+++ b/code/packages/typescript/symbolic-ir/src/index.ts
@@ -266,3 +266,17 @@ export const ASSUME = sym("Assume");
 export const FORGET = sym("Forget");
 export const IS = sym("Is");
 export const SIGN = sym("Sign");
+
+// Named ODE solution function heads (Phase 27)
+// Legendre ODE: (1-x²)y'' - 2xy' + n(n+1)y = 0
+export const LEGENDRE_P = sym("LegendreP");  // Legendre polynomial of the first kind P_n(x)
+export const LEGENDRE_Q = sym("LegendreQ");  // Legendre function of the second kind Q_n(x)
+// Bessel ODE: x²y'' + xy' + (x²-ν²)y = 0
+export const BESSEL_J = sym("BesselJ");      // Bessel function of the first kind J_ν(x)
+export const BESSEL_Y = sym("BesselY");      // Bessel function of the second kind Y_ν(x)
+// Hermite ODE: y'' - 2xy' + 2ny = 0
+export const HERMITE_H = sym("HermiteH");    // Hermite polynomial H_n(x)
+export const HERMITE_H2 = sym("HermiteH2");  // Second independent solution (parabolic cylinder)
+// Chebyshev ODE: (1-x²)y'' - xy' + n²y = 0
+export const CHEBYSHEV_T = sym("ChebyshevT"); // Chebyshev polynomial of the first kind T_n(x)
+export const CHEBYSHEV_U = sym("ChebyshevU"); // Chebyshev polynomial of the second kind U_n(x)


### PR DESCRIPTION
## Summary

- **TypeScript symbolic-ir 0.2.0**: Add 8 Phase 27 named-ODE head symbols (`LEGENDRE_P`, `LEGENDRE_Q`, `BESSEL_J`, `BESSEL_Y`, `HERMITE_H`, `HERMITE_H2`, `CHEBYSHEV_T`, `CHEBYSHEV_U`); release the Unreleased COTH/SECH/CSCH symbols
- **Rust symbolic-ir 0.2.0**: Same 8 Phase 27 constants as `pub const &str`; release COTH/SECH/CSCH  
- **TypeScript cas-ode 0.2.0**: Full Phase 21 port — numerical IR evaluator (`evalAtXy`/`evalIrAtX`), coefficient pattern matchers, `collectVar2Coeffs`, four named-ODE recognisers (Legendre/Bessel/Hermite/Chebyshev), dispatcher `tryVarCoeffNamedOde`; 28 tests
- **Rust cas-ode 0.2.0**: Same Phase 21 port in Rust — `eval_ir_at_xy`, `coeff_matches_func`, `collect_var2_coeffs`, four recognisers, dispatcher `try_var_coeff_named_ode`; 30 tests

Both ports use the same numerical pattern matching approach as Python cas-ode 0.6.0: P(x), Q(x), R(x) are evaluated at four canonical test points (0.3, 0.6, -0.25, 0.85) and compared against expected analytic functions to tolerance 1e-9. Dispatch order is Chebyshev → Legendre → Bessel → Hermite, inserted after Euler-Cauchy so constant-coefficient forms are caught earlier.

## Test plan

- [x] `cargo test` in `rust/symbolic-ir` — 8 doc-tests pass
- [x] `cargo test` in `rust/cas-ode` — 30 tests pass (19 original + 11 Phase 21)
- [x] `npm test` in `typescript/symbolic-ir` — 7 tests pass
- [x] `npm test` in `typescript/cas-ode` — 28 tests pass (16 original + 12 Phase 21)
- [x] Security review passed (pure CAS math, no I/O, no user input surface)
- [x] Chebyshev/Legendre disambiguation verified (Q≈-x vs Q≈-2x)
- [x] Euler-Cauchy regression verified (caught before Phase 21 dispatcher)
- [x] Bessel half-integer order ν=1/2 verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)