### PR TITLE
feat(symbolic-vm): Phase 27 trig-of-log integration — symbolic-vm 0.57.0

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.57.0 — 2026-05-16
+
+**Phase 27 integration — trig-of-log: `∫ sin(log x) dx`, `∫ cos(log x) dx`,
+and `∫ Q(x)·sin/cos(log x) dx`.**
+
+The substitution u = log(x) converts `∫ x^k · trig(log x) dx` into the
+standard exp×trig form `∫ e^((k+1)u) · trig(u) du` (Phase 4c), yielding:
+
+    ∫ sin(log x) dx = x/2 · (sin(log x) − cos(log x))
+    ∫ cos(log x) dx = x/2 · (sin(log x) + cos(log x))
+
+    ∫ x^k sin(log x) dx = x^(k+1) · ((k+1)·sin(log x) − cos(log x)) / ((k+1)²+1)
+    ∫ x^k cos(log x) dx = x^(k+1) · ((k+1)·cos(log x) + sin(log x)) / ((k+1)²+1)
+
+### Added
+
+- **`_trig_log_integral(trig_head, k, x)`** — closed-form kernel for
+  `∫ x^k · sin/cos(log x) dx` for integer k ≥ 0.  The denominator
+  `(k+1)²+1` is always a positive integer; no division by zero possible.
+
+- **`_try_trig_log_product(transcendental, poly_candidate, x)`** — matches
+  when `transcendental` is `Sin(Log(x))` or `Cos(Log(x))` (bare `x` only;
+  shifted log arguments deferred) and `poly_candidate` is a polynomial of x.
+  Sums `_trig_log_integral` over each monomial.
+
+- **Phase 27 pure-form hook** — recognises `Sin(Log(x))` / `Cos(Log(x))`
+  in the single-function branch of `_integrate`, triggering
+  `_trig_log_integral(head, 0, x)` before the Phase 3 linear-argument scan.
+
+- **Phase 27 MUL hook** — inserted in the MUL product handler directly
+  after Phase 26, trying both orderings of the two factors.
+
+- **13 new tests** in `tests/test_phase27_trig_log.py`:
+  - Pure sin(log(x)) and cos(log(x)): closed-form check + numerical (≤1e-5).
+  - x·sin/cos(log(x)): closed-form check + numerical.
+  - x²·sin/cos(log(x)): numerical (≤1e-4).
+  - (x²+2x+1)·sin(log(x)): structural closed-form check.
+  - Regression: `∫ sin(x) dx = −cos(x)` and `∫ cos(x) dx = sin(x)` still correct.
+
 ## 0.56.0 — 2026-05-16
 
 **Phase 26 integration — log-power IBP reduction: `∫ log(ax+b)^n dx` and

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.56.0"
+version = "0.57.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -1,4 +1,4 @@
-"""Symbolic integration — the ``Integrate`` handler (Phases 1–24).
+"""Symbolic integration — the ``Integrate`` handler (Phases 1–27).
 
 The handler tries two routes, in order:
 
@@ -916,6 +916,12 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
         result = _try_log_power_product(a, b, x) or _try_log_power_product(b, a, x)
         if result is not None:
             return result
+        # Phase 27: polynomial × sin(log(x)) or cos(log(x)) — closed form via
+        # the substitution u = log(x) which converts the integral to the
+        # standard exp×trig form ∫ e^((k+1)u) · trig(u) du.
+        result = _try_trig_log_product(a, b, x) or _try_trig_log_product(b, a, x)
+        if result is not None:
+            return result
         # Phase 14a: exp(linear) × sinh/cosh(linear) — double-IBP closed form.
         result = _try_exp_hyp(a, b, x) or _try_exp_hyp(b, a, x)
         if result is not None:
@@ -1066,6 +1072,20 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
                     IRApply(POW, (x, IRRational(3, 2))),
                 ),
             )
+
+    # --- Phase 27: trig(log(x)) — single-factor case (k = 0) -----------------
+    # ∫ sin(log(x)) dx = x/2 · (sin(log(x)) − cos(log(x)))
+    # ∫ cos(log(x)) dx = x/2 · (sin(log(x)) + cos(log(x)))
+    # Derived from u = log(x): ∫ sin(u)·eᵘ du = eᵘ(sin(u)−cos(u))/2.
+    if len(f.args) == 1 and head in {SIN, COS}:
+        _inner = f.args[0]
+        if (
+            isinstance(_inner, IRApply)
+            and _inner.head == LOG
+            and len(_inner.args) == 1
+            and _inner.args[0] == x
+        ):
+            return _trig_log_integral(head, 0, x)
 
     # --- Phase 3a/3b/3c + Phase 5a + Phase 9 bonus: elementary fn of linear arg ---
     # Generalises the Phase 1 rules above to any a·x + b argument.
@@ -1496,6 +1516,142 @@ def _try_log_power_product(
 
     if not pieces:
         return x  # zero polynomial — shouldn't normally be reached
+
+    result: IRNode = pieces[0]
+    for piece in pieces[1:]:
+        result = IRApply(ADD, (result, piece))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Phase 27 — trig(log(x)) integration
+# ---------------------------------------------------------------------------
+#
+# **Mathematical foundation.**  For k ≥ 0, the substitution u = log(x)
+# (so x = eᵘ, dx = eᵘ du) converts:
+#
+#     ∫ xᵏ · sin(log(x)) dx  =  ∫ eᵏᵘ · sin(u) · eᵘ du
+#                              =  ∫ e^((k+1)u) · sin(u) du
+#
+# The standard exp×trig formula (Phase 4c) gives:
+#     ∫ e^(αu) sin(u) du = e^(αu) (α sin(u) − cos(u)) / (α² + 1)
+#
+# Setting α = k+1 and back-substituting u = log(x):
+#     ∫ xᵏ sin(log(x)) dx = x^(k+1) · ((k+1) sin(log(x)) − cos(log(x))) / ((k+1)² + 1)
+#
+# Analogously for cosine:
+#     ∫ xᵏ cos(log(x)) dx = x^(k+1) · ((k+1) cos(log(x)) + sin(log(x))) / ((k+1)² + 1)
+#
+# **Verification (k = 0).**
+#   d/dx [ x/2 · (sin(log x) − cos(log x)) ]
+#     = 1/2 (sin(log x) − cos(log x)) + x/2 · (cos(log x)/x + sin(log x)/x)
+#     = 1/2 sin(log x) − 1/2 cos(log x) + 1/2 cos(log x) + 1/2 sin(log x)
+#     = sin(log x)  ✓
+
+
+def _trig_log_integral(trig_head: IRSymbol, k: int, x: IRSymbol) -> IRNode:
+    """Phase 27: closed form of ``∫ x^k · trig(log(x)) dx``.
+
+    Parameters
+    ----------
+    trig_head : IRSymbol
+        Must be ``SIN`` or ``COS``.
+    k : int
+        Non-negative integer power of *x*.
+    x : IRSymbol
+        Integration variable.
+
+    Returns
+    -------
+    IRNode
+        The antiderivative:
+
+        * **sin case**: ``x^(k+1) · ((k+1)·sin(log x) − cos(log x)) / ((k+1)²+1)``
+        * **cos case**: ``x^(k+1) · ((k+1)·cos(log x) + sin(log x)) / ((k+1)²+1)``
+    """
+    kp1 = k + 1                    # k + 1 appears repeatedly
+    denom = kp1 * kp1 + 1          # (k+1)^2 + 1  — always a positive integer
+
+    log_x = IRApply(LOG, (x,))
+    sin_log_x = IRApply(SIN, (log_x,))
+    cos_log_x = IRApply(COS, (log_x,))
+
+    # x^(k+1): x itself for k=0, otherwise POW node.
+    x_pow: IRNode = x if kp1 == 1 else IRApply(POW, (x, IRInteger(kp1)))
+    kp1_ir: IRNode = IRInteger(kp1)
+    denom_ir: IRNode = IRInteger(denom)
+
+    if trig_head == SIN:
+        # Numerator: (k+1)·sin(log x) − cos(log x)
+        numerator = IRApply(SUB, (IRApply(MUL, (kp1_ir, sin_log_x)), cos_log_x))
+    else:
+        # Numerator: (k+1)·cos(log x) + sin(log x)
+        numerator = IRApply(ADD, (IRApply(MUL, (kp1_ir, cos_log_x)), sin_log_x))
+
+    # x^(k+1) · numerator / denom
+    return IRApply(DIV, (IRApply(MUL, (x_pow, numerator)), denom_ir))
+
+
+def _try_trig_log_product(
+    transcendental: IRNode, poly_candidate: IRNode, x: IRSymbol
+) -> IRNode | None:
+    """Phase 27: ``∫ Q(x) · trig(log(x)) dx`` — term-by-term IBP via substitution.
+
+    Matches when ``transcendental`` is ``Sin(Log(x))`` or ``Cos(Log(x))``
+    (with bare ``x``, not a shifted argument) and ``poly_candidate`` is a
+    polynomial of *x*.
+
+    Each monomial ``cᵢ · xⁱ`` in *Q* contributes
+    ``cᵢ · _trig_log_integral(trig_head, i, x)`` to the result.
+
+    Only ``log(x)`` (not ``log(ax+b)``) is supported here; the general
+    shifted case requires a substitution that changes the integration
+    variable and is left as future work.
+    """
+    if not isinstance(transcendental, IRApply):
+        return None
+    trig_head = transcendental.head
+    if trig_head not in {SIN, COS}:
+        return None
+    if len(transcendental.args) != 1:
+        return None
+    trig_arg = transcendental.args[0]
+    # Require the argument of sin/cos to be exactly Log(x).
+    if not (
+        isinstance(trig_arg, IRApply)
+        and trig_arg.head == LOG
+        and len(trig_arg.args) == 1
+        and trig_arg.args[0] == x
+    ):
+        return None
+
+    # poly_candidate must be a proper polynomial (denominator = 1).
+    r = to_rational(poly_candidate, x)
+    if r is None:
+        return None
+    num, den = r
+    from polynomial import normalize as _norm
+    if len(_norm(den)) > 1:
+        return None  # rational function, not polynomial
+    poly = tuple(Fraction(c) for c in _norm(num))
+    if not poly:
+        return None
+
+    # Sum up the antiderivative for each monomial cᵢ · xⁱ.
+    pieces: list[IRNode] = []
+    for i, coef in enumerate(poly):
+        if coef == Fraction(0):
+            continue
+        term = _trig_log_integral(trig_head, i, x)
+        if coef == Fraction(1):
+            pieces.append(term)
+        elif coef == Fraction(-1):
+            pieces.append(IRApply(NEG, (term,)))
+        else:
+            pieces.append(IRApply(MUL, (_frac_ir(coef), term)))
+
+    if not pieces:
+        return ZERO  # zero polynomial — edge case
 
     result: IRNode = pieces[0]
     for piece in pieces[1:]:

--- a/code/packages/python/symbolic-vm/tests/test_phase27_trig_log.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase27_trig_log.py
@@ -1,0 +1,371 @@
+"""Tests for Phase 27: sin(log(x)) and cos(log(x)) integration.
+
+Phase 27 adds two new patterns to the ``Integrate`` handler:
+
+1. **Pure trig-of-log** — ``∫ sin(log(x)) dx`` and ``∫ cos(log(x)) dx``.
+   Uses the substitution u = log(x) which converts the integral to the
+   standard exp×trig form, giving:
+
+       ∫ sin(log x) dx = x/2 · (sin(log x) − cos(log x))
+       ∫ cos(log x) dx = x/2 · (sin(log x) + cos(log x))
+
+2. **Polynomial × trig(log(x))** — ``∫ Q(x) · sin(log(x)) dx`` and
+   ``∫ Q(x) · cos(log(x)) dx``.
+   Applies the term-by-term formula:
+
+       ∫ xᵏ sin(log x) dx = x^(k+1) · ((k+1) sin(log x) − cos(log x)) / ((k+1)² + 1)
+       ∫ xᵏ cos(log x) dx = x^(k+1) · ((k+1) cos(log x) + sin(log x)) / ((k+1)² + 1)
+
+Both patterns recurse down to k = 0 from the polynomial degree, all handled
+by the same ``_trig_log_integral`` kernel.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    COS,
+    INTEGRATE,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SUB,
+    DIV,
+    IRApply,
+    IRInteger,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, SymbolicBackend
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+
+
+@pytest.fixture
+def vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+def _integrate(f: IRApply) -> IRApply:
+    return IRApply(INTEGRATE, (f, X))
+
+
+def _contains_head(node: object, head: IRSymbol) -> bool:
+    """Recursively check whether any sub-node has the given head."""
+    if isinstance(node, IRApply):
+        if node.head == head:
+            return True
+        return any(_contains_head(a, head) for a in node.args)
+    return False
+
+
+def _eval_ir(node: object, x_val: float) -> float:
+    """Numerically evaluate a simple IR tree by substitution."""
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRSymbol):
+        if node == X:
+            return x_val
+        raise ValueError(f"unknown symbol {node}")
+    assert isinstance(node, IRApply)
+    h = node.head
+    if h == ADD:
+        return sum(_eval_ir(a, x_val) for a in node.args)
+    if h == SUB:
+        a, b = node.args
+        return _eval_ir(a, x_val) - _eval_ir(b, x_val)
+    if h == MUL:
+        result = 1.0
+        for a in node.args:
+            result *= _eval_ir(a, x_val)
+        return result
+    if h == NEG:
+        return -_eval_ir(node.args[0], x_val)
+    if h == POW:
+        base, exp = node.args
+        return _eval_ir(base, x_val) ** _eval_ir(exp, x_val)
+    if h == DIV:
+        a, b = node.args
+        return _eval_ir(a, x_val) / _eval_ir(b, x_val)
+    if h == LOG:
+        return math.log(_eval_ir(node.args[0], x_val))
+    if h == SIN:
+        return math.sin(_eval_ir(node.args[0], x_val))
+    if h == COS:
+        return math.cos(_eval_ir(node.args[0], x_val))
+    raise ValueError(f"unsupported head {h}")
+
+
+def _numerical_definite(integrand_fn: object, a: float, b: float, n: int = 10_000) -> float:
+    """Simple trapezoidal rule for ground-truth comparison."""
+    assert callable(integrand_fn)
+    h = (b - a) / n
+    total = 0.5 * (integrand_fn(a) + integrand_fn(b))
+    for i in range(1, n):
+        total += integrand_fn(a + i * h)
+    return total * h
+
+
+def _sin_log_x(x: float) -> float:
+    return math.sin(math.log(x))
+
+
+def _cos_log_x(x: float) -> float:
+    return math.cos(math.log(x))
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — ∫ sin(log(x)) dx returns a closed form
+# ---------------------------------------------------------------------------
+
+
+def test_sin_log_x_is_closed(vm: VM) -> None:
+    """``∫ sin(log(x)) dx`` must return a closed form without ``Integrate``."""
+    integrand = IRApply(SIN, (IRApply(LOG, (X,)),))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    # Result must involve both SIN and COS of log(x).
+    assert _contains_head(out, SIN), f"expected SIN in result, got: {out}"
+    assert _contains_head(out, COS), f"expected COS in result, got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — ∫ sin(log(x)) dx numerical correctness
+# ---------------------------------------------------------------------------
+
+
+def test_sin_log_x_numeric(vm: VM) -> None:
+    """``∫₁^3 sin(log(x)) dx``: antiderivative difference matches trapezoidal.
+
+    Closed form: F(x) = x/2 · (sin(log x) − cos(log x)).
+    """
+    integrand = IRApply(SIN, (IRApply(LOG, (X,)),))
+    out = vm.eval(_integrate(integrand))
+    f3 = _eval_ir(out, 3.0)
+    f1 = _eval_ir(out, 1.0)
+    antideriv_diff = f3 - f1
+
+    numerical = _numerical_definite(_sin_log_x, 1.0, 3.0)
+    assert abs(antideriv_diff - numerical) < 1e-5, (
+        f"antiderivative diff {antideriv_diff:.8f} != numerical {numerical:.8f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — ∫ cos(log(x)) dx returns a closed form
+# ---------------------------------------------------------------------------
+
+
+def test_cos_log_x_is_closed(vm: VM) -> None:
+    """``∫ cos(log(x)) dx`` must return a closed form without ``Integrate``."""
+    integrand = IRApply(COS, (IRApply(LOG, (X,)),))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    assert _contains_head(out, SIN), f"expected SIN in result, got: {out}"
+    assert _contains_head(out, COS), f"expected COS in result, got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — ∫ cos(log(x)) dx numerical correctness
+# ---------------------------------------------------------------------------
+
+
+def test_cos_log_x_numeric(vm: VM) -> None:
+    """``∫₁^3 cos(log(x)) dx``: antiderivative difference matches trapezoidal.
+
+    Closed form: F(x) = x/2 · (sin(log x) + cos(log x)).
+    """
+    integrand = IRApply(COS, (IRApply(LOG, (X,)),))
+    out = vm.eval(_integrate(integrand))
+    f3 = _eval_ir(out, 3.0)
+    f1 = _eval_ir(out, 1.0)
+    antideriv_diff = f3 - f1
+
+    numerical = _numerical_definite(_cos_log_x, 1.0, 3.0)
+    assert abs(antideriv_diff - numerical) < 1e-5, (
+        f"antiderivative diff {antideriv_diff:.8f} != numerical {numerical:.8f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — ∫ x·sin(log(x)) dx is closed
+# ---------------------------------------------------------------------------
+
+
+def test_x_sin_log_x_is_closed(vm: VM) -> None:
+    """``∫ x·sin(log(x)) dx`` must return a closed form."""
+    integrand = IRApply(MUL, (X, IRApply(SIN, (IRApply(LOG, (X,)),))))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    assert _contains_head(out, SIN), f"expected SIN in result, got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — ∫ x·sin(log(x)) dx numerical correctness
+# ---------------------------------------------------------------------------
+
+
+def test_x_sin_log_x_numeric(vm: VM) -> None:
+    """``∫₁^2 x·sin(log(x)) dx``.
+
+    Closed form: x²/5 · (2 sin(log x) − cos(log x)).
+    """
+    integrand = IRApply(MUL, (X, IRApply(SIN, (IRApply(LOG, (X,)),))))
+    out = vm.eval(_integrate(integrand))
+    f2 = _eval_ir(out, 2.0)
+    f1 = _eval_ir(out, 1.0)
+    antideriv_diff = f2 - f1
+
+    numerical = _numerical_definite(lambda xv: xv * _sin_log_x(xv), 1.0, 2.0)
+    assert abs(antideriv_diff - numerical) < 1e-5, (
+        f"antiderivative diff {antideriv_diff:.8f} != numerical {numerical:.8f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — ∫ x·cos(log(x)) dx is closed
+# ---------------------------------------------------------------------------
+
+
+def test_x_cos_log_x_is_closed(vm: VM) -> None:
+    """``∫ x·cos(log(x)) dx`` must return a closed form."""
+    integrand = IRApply(MUL, (X, IRApply(COS, (IRApply(LOG, (X,)),))))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    assert _contains_head(out, COS), f"expected COS in result, got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — ∫ x·cos(log(x)) dx numerical correctness
+# ---------------------------------------------------------------------------
+
+
+def test_x_cos_log_x_numeric(vm: VM) -> None:
+    """``∫₁^2 x·cos(log(x)) dx``.
+
+    Closed form: x²/5 · (2 cos(log x) + sin(log x)).
+    """
+    integrand = IRApply(MUL, (X, IRApply(COS, (IRApply(LOG, (X,)),))))
+    out = vm.eval(_integrate(integrand))
+    f2 = _eval_ir(out, 2.0)
+    f1 = _eval_ir(out, 1.0)
+    antideriv_diff = f2 - f1
+
+    numerical = _numerical_definite(lambda xv: xv * _cos_log_x(xv), 1.0, 2.0)
+    assert abs(antideriv_diff - numerical) < 1e-5, (
+        f"antiderivative diff {antideriv_diff:.8f} != numerical {numerical:.8f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — ∫ x²·sin(log(x)) dx numerical correctness
+# ---------------------------------------------------------------------------
+
+
+def test_x_sq_sin_log_x_numeric(vm: VM) -> None:
+    """``∫₁^2 x²·sin(log(x)) dx``.
+
+    Closed form: x³/10 · (3 sin(log x) − cos(log x)).
+    """
+    x_sq = IRApply(POW, (X, IRInteger(2)))
+    integrand = IRApply(MUL, (x_sq, IRApply(SIN, (IRApply(LOG, (X,)),))))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    f2 = _eval_ir(out, 2.0)
+    f1 = _eval_ir(out, 1.0)
+    antideriv_diff = f2 - f1
+
+    numerical = _numerical_definite(lambda xv: xv**2 * _sin_log_x(xv), 1.0, 2.0)
+    assert abs(antideriv_diff - numerical) < 1e-4, (
+        f"antiderivative diff {antideriv_diff:.8f} != numerical {numerical:.8f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — ∫ x²·cos(log(x)) dx numerical correctness
+# ---------------------------------------------------------------------------
+
+
+def test_x_sq_cos_log_x_numeric(vm: VM) -> None:
+    """``∫₁^2 x²·cos(log(x)) dx``.
+
+    Closed form: x³/10 · (3 cos(log x) + sin(log x)).
+    """
+    x_sq = IRApply(POW, (X, IRInteger(2)))
+    integrand = IRApply(MUL, (x_sq, IRApply(COS, (IRApply(LOG, (X,)),))))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    f2 = _eval_ir(out, 2.0)
+    f1 = _eval_ir(out, 1.0)
+    antideriv_diff = f2 - f1
+
+    numerical = _numerical_definite(lambda xv: xv**2 * _cos_log_x(xv), 1.0, 2.0)
+    assert abs(antideriv_diff - numerical) < 1e-4, (
+        f"antiderivative diff {antideriv_diff:.8f} != numerical {numerical:.8f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — polynomial × sin(log(x)) is closed
+# ---------------------------------------------------------------------------
+
+
+def test_poly_sin_log_x_is_closed(vm: VM) -> None:
+    """``∫ (x^2 + 2·x + 1)·sin(log(x)) dx`` must return a closed form."""
+    # (x^2 + 2x + 1) = (x+1)^2
+    x_sq = IRApply(POW, (X, IRInteger(2)))
+    two_x = IRApply(MUL, (IRInteger(2), X))
+    from symbolic_ir import ADD as _ADD
+    poly = IRApply(_ADD, (IRApply(_ADD, (x_sq, two_x)), IRInteger(1)))
+    integrand = IRApply(MUL, (poly, IRApply(SIN, (IRApply(LOG, (X,)),))))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    assert _contains_head(out, SIN), f"expected SIN in result, got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Test 12 — regression: ∫ sin(x) dx still works (no Phase 27 interference)
+# ---------------------------------------------------------------------------
+
+
+def test_regression_sin_x(vm: VM) -> None:
+    """``∫ sin(x) dx = −cos(x)`` still correct after Phase 27 is added."""
+    integrand = IRApply(SIN, (X,))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    # Numerical check: ∫₀^(π/2) sin(x) dx = 1
+    f_pi2 = _eval_ir(out, math.pi / 2)
+    f_0 = _eval_ir(out, 0.0)
+    assert abs((f_pi2 - f_0) - 1.0) < 1e-9, (
+        f"expected 1.0, got {f_pi2 - f_0}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 13 — regression: ∫ cos(x) dx still works
+# ---------------------------------------------------------------------------
+
+
+def test_regression_cos_x(vm: VM) -> None:
+    """``∫ cos(x) dx = sin(x)`` still correct after Phase 27 is added."""
+    integrand = IRApply(COS, (X,))
+    out = vm.eval(_integrate(integrand))
+    assert not _contains_head(out, INTEGRATE), f"expected closed form, got: {out}"
+    # Numerical: ∫₀^(π/2) cos(x) dx = 1
+    f_pi2 = _eval_ir(out, math.pi / 2)
+    f_0 = _eval_ir(out, 0.0)
+    assert abs((f_pi2 - f_0) - 1.0) < 1e-9, (
+        f"expected 1.0, got {f_pi2 - f_0}"
+    )


### PR DESCRIPTION
## Summary

- **Phase 27** adds closed-form integration of `sin(log(x))`, `cos(log(x))`, and `Q(x)·sin/cos(log(x))` to the Python `symbolic-vm` integration engine
- Technique: substitution `u = log(x)` converts `∫ xᵏ·trig(log x) dx` into the standard exp×trig form `∫ e^((k+1)u)·trig(u) du` (already handled by Phase 4c), yielding exact closed forms
- Bumps `symbolic-vm` from **0.56.0 → 0.57.0**

**Closed forms added:**
```
∫ sin(log x) dx = x/2 · (sin(log x) − cos(log x))
∫ cos(log x) dx = x/2 · (sin(log x) + cos(log x))
∫ xᵏ sin(log x) dx = xᵏ⁺¹ · ((k+1)·sin(log x) − cos(log x)) / ((k+1)²+1)
∫ xᵏ cos(log x) dx = xᵏ⁺¹ · ((k+1)·cos(log x) + sin(log x)) / ((k+1)²+1)
```

**New code:**
- `_trig_log_integral(trig_head, k, x)` — closed-form kernel, works for any integer k ≥ 0
- `_try_trig_log_product(transcendental, poly, x)` — MUL dispatcher for `Q(x)·trig(log x)`
- Phase 27 pure-form hook before Phase 3 (catches bare `sin(log x)` and `cos(log x)`)
- Phase 27 MUL hook after Phase 26 in the product handler

## Test plan

- [ ] 13 new tests in `tests/test_phase27_trig_log.py`
  - Structural: closed form contains no `Integrate` head, contains `SIN` and `COS`
  - Numerical: antiderivative difference vs. trapezoidal quadrature ≤ 1e-5
  - Cases: pure sin/cos, x·sin/cos, x²·sin/cos, poly·sin, regression for sin(x)/cos(x)
- [ ] Full CI build passes (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)