### PR TITLE
feat(symbolic-vm): Phase 26+27 TypeScript+Rust ports — symbolic-vm 0.4.0

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.4.0] — 2026-05-16
+
+### Added — Phase 26: log-power integration via IBP reduction
+
+- `is_log_of_x(node, x)` — guard helper: returns `true` when `node` is
+  `Log(x)` for bare integration variable `x`.
+- `to_polynomial_coeffs(expr, x)` — extracts polynomial coefficients from an
+  IR expression; returns `Vec<(degree, coeff_node)>` or `None`.
+  Handles constants, `x`, `x^k`, `c·f`, `f·c`, ADD, SUB, NEG.
+- `poly_log_power_term(k, n, x)` — closed form of `∫ x^k · log(x)^n dx` for
+  k ≥ 0, n ≥ 1, via the IBP reduction formula:
+  `G_{k,m}(x) = x^(k+1)/(k+1) · log(x)^m  −  m/(k+1) · G_{k,m-1}(x)`.
+- `try_log_power_product(transcendental, poly, x)` — handles
+  `∫ Q(x) · log(x)^n dx` for integer n ≥ 2 by term-by-term application
+  of `poly_log_power_term`.
+- Standalone `∫ log(x)^n dx` (n ≥ 2) via new `(POW, [base, exp])` match arm.
+
+### Added — Phase 27: trig-of-log integration via u = log(x) substitution
+
+- `trig_log_integral(trig_head, k, x)` — closed form of `∫ x^k · trig(log(x)) dx`:
+  - `∫ xᵏ sin(log x) dx = x^(k+1)·((k+1)sin(log x)−cos(log x))/((k+1)²+1)`
+  - `∫ xᵏ cos(log x) dx = x^(k+1)·((k+1)cos(log x)+sin(log x))/((k+1)²+1)`
+- `try_trig_log_product(transcendental, poly, x)` — handles
+  `∫ Q(x)·sin(log(x)) dx` and `∫ Q(x)·cos(log(x)) dx`.
+- Standalone `∫ sin(log(x)) dx` and `∫ cos(log(x)) dx` via new
+  `(SIN|COS, [inner]) if is_log_of_x(inner, x)` match arms.
+
 ## [0.3.0] — 2026-05-14
 
 ### Added

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1116,6 +1116,22 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
                 apply_node(POW, vec![inner.clone(), IRNode::Rational(3, 2)]),
             ],
         ),
+        // Phase 26: ∫ log(x)^n dx for integer n ≥ 2 (standalone, no poly factor).
+        (POW, [base, exponent]) if is_log_of_x(base, x) => {
+            match to_numeric(exponent) {
+                Some(Numeric::Int(n)) if n >= 2 => poly_log_power_term(0, n as usize, x),
+                _ => apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]),
+            }
+        }
+        // Phase 27: ∫ sin(log(x)) dx and ∫ cos(log(x)) dx (k=0 direct forms).
+        (SIN, [inner]) if is_log_of_x(inner, x) => trig_log_integral(SIN, 0, x),
+        (COS, [inner]) if is_log_of_x(inner, x) => trig_log_integral(COS, 0, x),
+        // Phase 26+27: Q(x) · log(x)^n or Q(x) · trig(log(x)) — both factors depend on x.
+        (MUL, [a, b]) => try_log_power_product(a, b, x)
+            .or_else(|| try_log_power_product(b, a, x))
+            .or_else(|| try_trig_log_product(a, b, x))
+            .or_else(|| try_trig_log_product(b, a, x))
+            .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
         _ => apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]),
     }
 }
@@ -1370,6 +1386,328 @@ fn complete_elliptic_third_kind(
     }
     elliptic_third_kind_params(f, x)
         .map(|(n, k)| apply_node("EllipticPi", vec![n, k]))
+}
+
+// ---------------------------------------------------------------------------
+// Phase 26 — log-power integration via IBP reduction
+// ---------------------------------------------------------------------------
+
+/// Returns ``true`` when ``node`` is ``Log(x)`` — i.e., the log of the bare
+/// integration variable.  Used as a guard in the integrate match arms.
+fn is_log_of_x(node: &IRNode, x: &str) -> bool {
+    if let IRNode::Apply(a) = node {
+        a.head == IRNode::Symbol(LOG.to_string())
+            && a.args.len() == 1
+            && a.args[0] == IRNode::Symbol(x.to_string())
+    } else {
+        false
+    }
+}
+
+/// Extract polynomial coefficients from an IR expression in variable ``x``.
+///
+/// Returns ``Some(Vec<(degree, coefficient)>)`` sorted by ascending degree,
+/// or ``None`` if ``expr`` is not a polynomial in ``x`` over the rationals.
+///
+/// Handles:
+/// - constants free of x (degree 0)
+/// - x itself (degree 1, coefficient 1)
+/// - x^k for non-negative integer k
+/// - c · f or f · c where c is free of x — scalar-multiply inner poly
+/// - ADD and SUB of two polynomials — merge coefficient lists
+/// - NEG of a polynomial — negate all coefficients
+fn to_polynomial_coeffs(expr: &IRNode, x: &str) -> Option<Vec<(usize, IRNode)>> {
+    if !depends_on(expr, x) {
+        return Some(vec![(0, expr.clone())]);
+    }
+    if expr == &IRNode::Symbol(x.to_string()) {
+        return Some(vec![(1, IRNode::Integer(1))]);
+    }
+    let IRNode::Apply(apply) = expr else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    match (head.as_str(), apply.args.as_slice()) {
+        (POW, [base, exponent]) if base == &IRNode::Symbol(x.to_string()) => {
+            if let Some(Numeric::Int(k)) = to_numeric(exponent) {
+                if k >= 0 {
+                    return Some(vec![(k as usize, IRNode::Integer(1))]);
+                }
+            }
+            None
+        }
+        (MUL, [a, b]) if !depends_on(a, x) => {
+            let mut poly = to_polynomial_coeffs(b, x)?;
+            for (_, coef) in &mut poly {
+                if to_numeric(a).is_some_and(Numeric::is_one) {
+                    // no-op: coef stays the same
+                } else {
+                    *coef = apply_node(MUL, vec![a.clone(), coef.clone()]);
+                }
+            }
+            Some(poly)
+        }
+        (MUL, [a, b]) if !depends_on(b, x) => {
+            let mut poly = to_polynomial_coeffs(a, x)?;
+            for (_, coef) in &mut poly {
+                if to_numeric(b).is_some_and(Numeric::is_one) {
+                    // no-op
+                } else {
+                    *coef = apply_node(MUL, vec![b.clone(), coef.clone()]);
+                }
+            }
+            Some(poly)
+        }
+        (ADD, [a, b]) => {
+            let mut poly_a = to_polynomial_coeffs(a, x)?;
+            let poly_b = to_polynomial_coeffs(b, x)?;
+            for (kb, vb) in poly_b {
+                if let Some(entry) = poly_a.iter_mut().find(|(ka, _)| *ka == kb) {
+                    entry.1 = apply_node(ADD, vec![entry.1.clone(), vb]);
+                } else {
+                    poly_a.push((kb, vb));
+                }
+            }
+            poly_a.sort_by_key(|(k, _)| *k);
+            Some(poly_a)
+        }
+        (SUB, [a, b]) => {
+            let mut poly_a = to_polynomial_coeffs(a, x)?;
+            let poly_b = to_polynomial_coeffs(b, x)?;
+            for (kb, vb) in poly_b {
+                if let Some(entry) = poly_a.iter_mut().find(|(ka, _)| *ka == kb) {
+                    entry.1 = apply_node(SUB, vec![entry.1.clone(), vb]);
+                } else {
+                    poly_a.push((kb, apply_node(NEG, vec![vb])));
+                }
+            }
+            poly_a.sort_by_key(|(k, _)| *k);
+            Some(poly_a)
+        }
+        (NEG, [inner]) => {
+            let poly = to_polynomial_coeffs(inner, x)?;
+            Some(
+                poly.into_iter()
+                    .map(|(k, v)| (k, apply_node(NEG, vec![v])))
+                    .collect(),
+            )
+        }
+        _ => None,
+    }
+}
+
+/// Phase 26: closed form of ``∫ x^k · log(x)^n dx``.
+///
+/// Uses the IBP reduction formula (u = log(x)^n, dv = x^k dx):
+///
+///   G_{k,0}(x) = x^(k+1)/(k+1)
+///   G_{k,m}(x) = x^(k+1)/(k+1) · log(x)^m  −  m/(k+1) · G_{k,m-1}(x)
+///
+/// For k = 0, the base case simplifies to ``G_{0,0}(x) = x``.
+fn poly_log_power_term(k: usize, n: usize, x: &str) -> IRNode {
+    let kp1 = k + 1;
+    let x_sym = IRNode::Symbol(x.to_string());
+    let kp1_frac = make_rat(1, kp1 as i64);
+    let log_node = apply_node(LOG, vec![x_sym.clone()]);
+
+    // Base: G_{k,0}
+    let mut acc: IRNode = if kp1 == 1 {
+        x_sym.clone()
+    } else {
+        apply_node(
+            MUL,
+            vec![
+                from_numeric(kp1_frac),
+                apply_node(POW, vec![x_sym.clone(), IRNode::Integer(kp1 as i64)]),
+            ],
+        )
+    };
+
+    for m in 1..=n {
+        let log_pow: IRNode = if m == 1 {
+            log_node.clone()
+        } else {
+            apply_node(POW, vec![log_node.clone(), IRNode::Integer(m as i64)])
+        };
+        let first: IRNode = if kp1 == 1 {
+            apply_node(MUL, vec![x_sym.clone(), log_pow])
+        } else {
+            apply_node(
+                MUL,
+                vec![
+                    from_numeric(kp1_frac),
+                    apply_node(
+                        MUL,
+                        vec![
+                            apply_node(POW, vec![x_sym.clone(), IRNode::Integer(kp1 as i64)]),
+                            log_pow,
+                        ],
+                    ),
+                ],
+            )
+        };
+        let n_coef = from_numeric(make_rat(m as i64, kp1 as i64));
+        acc = apply_node(SUB, vec![first, apply_node(MUL, vec![n_coef, acc])]);
+    }
+    acc
+}
+
+/// Phase 26: ``∫ Q(x) · log(x)^n dx`` for integer n ≥ 2 via term-by-term IBP.
+///
+/// ``transcendental`` must be ``Pow(Log(x), n)`` with integer n ≥ 2.
+/// ``poly_candidate`` must be a polynomial in x.
+fn try_log_power_product(
+    transcendental: &IRNode,
+    poly_candidate: &IRNode,
+    x: &str,
+) -> Option<IRNode> {
+    let IRNode::Apply(apply) = transcendental else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    if head.as_str() != POW || apply.args.len() != 2 {
+        return None;
+    }
+    let log_node = &apply.args[0];
+    let exp_node = &apply.args[1];
+    if !is_log_of_x(log_node, x) {
+        return None;
+    }
+    let n = match to_numeric(exp_node)? {
+        Numeric::Int(n) if n >= 2 => n as usize,
+        _ => return None,
+    };
+
+    let poly = to_polynomial_coeffs(poly_candidate, x)?;
+    if poly.is_empty() {
+        return None;
+    }
+
+    let pieces: Vec<IRNode> = poly
+        .into_iter()
+        .filter_map(|(k, coef)| {
+            if to_numeric(&coef).is_some_and(Numeric::is_zero) {
+                return None;
+            }
+            let term = poly_log_power_term(k, n, x);
+            if to_numeric(&coef).is_some_and(Numeric::is_one) {
+                Some(term)
+            } else {
+                Some(apply_node(MUL, vec![coef, term]))
+            }
+        })
+        .collect();
+
+    if pieces.is_empty() {
+        return Some(IRNode::Integer(0));
+    }
+    Some(
+        pieces
+            .into_iter()
+            .reduce(|acc, p| apply_node(ADD, vec![acc, p]))
+            .unwrap(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Phase 27 — trig(log(x)) integration via u = log(x) substitution
+// ---------------------------------------------------------------------------
+//
+// The substitution u = log(x) converts:
+//   ∫ xᵏ sin(log x) dx = ∫ e^((k+1)u) sin(u) du
+//                       = x^(k+1) · ((k+1)sin(log x) − cos(log x)) / ((k+1)² + 1)
+//
+//   ∫ xᵏ cos(log x) dx = x^(k+1) · ((k+1)cos(log x) + sin(log x)) / ((k+1)² + 1)
+
+/// Phase 27: closed form of ``∫ x^k · trig(log(x)) dx``.
+///
+/// ``trig_head`` is ``SIN`` or ``COS``; ``k`` is the integer power of x.
+fn trig_log_integral(trig_head: &str, k: usize, x: &str) -> IRNode {
+    let kp1 = k + 1;
+    let denom = (kp1 * kp1 + 1) as i64;
+    let log_x = apply_node(LOG, vec![IRNode::Symbol(x.to_string())]);
+    let sin_log_x = apply_node(SIN, vec![log_x.clone()]);
+    let cos_log_x = apply_node(COS, vec![log_x.clone()]);
+    let x_pow: IRNode = if kp1 == 1 {
+        IRNode::Symbol(x.to_string())
+    } else {
+        apply_node(
+            POW,
+            vec![IRNode::Symbol(x.to_string()), IRNode::Integer(kp1 as i64)],
+        )
+    };
+    let kp1_ir = IRNode::Integer(kp1 as i64);
+    let denom_ir = IRNode::Integer(denom);
+    let numerator: IRNode = if trig_head == SIN {
+        apply_node(
+            SUB,
+            vec![apply_node(MUL, vec![kp1_ir, sin_log_x]), cos_log_x],
+        )
+    } else {
+        apply_node(
+            ADD,
+            vec![apply_node(MUL, vec![kp1_ir, cos_log_x]), sin_log_x],
+        )
+    };
+    apply_node(DIV, vec![apply_node(MUL, vec![x_pow, numerator]), denom_ir])
+}
+
+/// Phase 27: ``∫ Q(x) · sin(log(x)) dx`` or ``∫ Q(x) · cos(log(x)) dx``.
+///
+/// ``transcendental`` must be ``Sin(Log(x))`` or ``Cos(Log(x))``.
+/// ``poly_candidate`` must be a polynomial in x.
+fn try_trig_log_product(
+    transcendental: &IRNode,
+    poly_candidate: &IRNode,
+    x: &str,
+) -> Option<IRNode> {
+    let IRNode::Apply(apply) = transcendental else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    let trig_head = head.as_str();
+    if trig_head != SIN && trig_head != COS {
+        return None;
+    }
+    if apply.args.len() != 1 || !is_log_of_x(&apply.args[0], x) {
+        return None;
+    }
+
+    let poly = to_polynomial_coeffs(poly_candidate, x)?;
+    if poly.is_empty() {
+        return None;
+    }
+
+    let pieces: Vec<IRNode> = poly
+        .into_iter()
+        .filter_map(|(k, coef)| {
+            if to_numeric(&coef).is_some_and(Numeric::is_zero) {
+                return None;
+            }
+            let term = trig_log_integral(trig_head, k, x);
+            if to_numeric(&coef).is_some_and(Numeric::is_one) {
+                Some(term)
+            } else {
+                Some(apply_node(MUL, vec![coef, term]))
+            }
+        })
+        .collect();
+
+    if pieces.is_empty() {
+        return Some(IRNode::Integer(0));
+    }
+    Some(
+        pieces
+            .into_iter()
+            .reduce(|acc, p| apply_node(ADD, vec![acc, p]))
+            .unwrap(),
+    )
 }
 
 fn integrate_power_of_x(exponent: &IRNode, x: &str) -> IRNode {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -1373,6 +1373,160 @@ fn integrate_unknown_dependent_form_stays_unevaluated() {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 26 — log-power integration via IBP reduction
+// ---------------------------------------------------------------------------
+
+/// Numerically evaluate a simple IR tree by substituting ``x = xval``.
+fn eval_at(node: &symbolic_ir::IRNode, xval: f64) -> f64 {
+    match node {
+        symbolic_ir::IRNode::Integer(n) => *n as f64,
+        symbolic_ir::IRNode::Rational(n, d) => *n as f64 / *d as f64,
+        symbolic_ir::IRNode::Float(f) => *f,
+        symbolic_ir::IRNode::Symbol(s) if s == "x" => xval,
+        symbolic_ir::IRNode::Apply(a) => {
+            let h = match &a.head {
+                symbolic_ir::IRNode::Symbol(s) => s.as_str(),
+                _ => panic!("eval_at: non-symbol head"),
+            };
+            let args = &a.args;
+            match (h, args.as_slice()) {
+                ("Add", [l, r]) => eval_at(l, xval) + eval_at(r, xval),
+                ("Sub", [l, r]) => eval_at(l, xval) - eval_at(r, xval),
+                ("Mul", [l, r]) => eval_at(l, xval) * eval_at(r, xval),
+                ("Div", [l, r]) => eval_at(l, xval) / eval_at(r, xval),
+                ("Neg", [v]) => -eval_at(v, xval),
+                ("Pow", [b, e]) => eval_at(b, xval).powf(eval_at(e, xval)),
+                ("Log", [v]) => eval_at(v, xval).ln(),
+                ("Sin", [v]) => eval_at(v, xval).sin(),
+                ("Cos", [v]) => eval_at(v, xval).cos(),
+                _ => panic!("eval_at: unsupported head {h}"),
+            }
+        }
+        _ => panic!("eval_at: unsupported node"),
+    }
+}
+
+fn trapezoid(f: impl Fn(f64) -> f64, a: f64, b: f64, n: usize) -> f64 {
+    let h = (b - a) / n as f64;
+    let mut total = 0.5 * (f(a) + f(b));
+    for i in 1..n {
+        total += f(a + i as f64 * h);
+    }
+    total * h
+}
+
+fn contains_head(node: &symbolic_ir::IRNode, name: &str) -> bool {
+    match node {
+        symbolic_ir::IRNode::Apply(a) => {
+            if let symbolic_ir::IRNode::Symbol(h) = &a.head {
+                if h == name {
+                    return true;
+                }
+            }
+            a.args.iter().any(|arg| contains_head(arg, name))
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn phase26_log_power_2_is_closed() {
+    // ∫ log(x)^2 dx must return a closed form containing Log.
+    let result = integrate(apply(sym(POW), vec![apply(sym(LOG), vec![sym("x")]), int(2)]));
+    let original = apply(
+        sym(INTEGRATE),
+        vec![
+            apply(sym(POW), vec![apply(sym(LOG), vec![sym("x")]), int(2)]),
+            sym("x"),
+        ],
+    );
+    assert_ne!(result, original, "expected closed form, got unevaluated Integrate");
+    assert!(contains_head(&result, "Log"), "expected Log in result");
+}
+
+#[test]
+fn phase26_x_log2_x_numeric() {
+    // ∫₁^2 x · log(x)^2 dx  vs trapezoidal ground truth.
+    let integrand = apply(
+        sym(MUL),
+        vec![
+            sym("x"),
+            apply(sym(POW), vec![apply(sym(LOG), vec![sym("x")]), int(2)]),
+        ],
+    );
+    let antideriv = integrate(integrand);
+    let diff = eval_at(&antideriv, 2.0) - eval_at(&antideriv, 1.0);
+    let numerical = trapezoid(|t| t * t.ln().powi(2), 1.0, 2.0, 10_000);
+    assert!((diff - numerical).abs() < 1e-5, "diff={diff:.8}, numerical={numerical:.8}");
+}
+
+// ---------------------------------------------------------------------------
+// Phase 27 — trig-of-log integration via u = log(x) substitution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase27_sin_log_x_is_closed() {
+    // ∫ sin(log(x)) dx must return a closed form with SIN and COS.
+    let integrand = apply(sym(SIN), vec![apply(sym(LOG), vec![sym("x")])]);
+    let result = integrate(integrand.clone());
+    let original = apply(sym(INTEGRATE), vec![integrand, sym("x")]);
+    assert_ne!(result, original, "expected closed form");
+    assert!(contains_head(&result, "Sin"), "expected Sin in result");
+    assert!(contains_head(&result, "Cos"), "expected Cos in result");
+}
+
+#[test]
+fn phase27_sin_log_x_numeric() {
+    // ∫₁^3 sin(log(x)) dx  vs trapezoidal.
+    let integrand = apply(sym(SIN), vec![apply(sym(LOG), vec![sym("x")])]);
+    let antideriv = integrate(integrand);
+    let diff = eval_at(&antideriv, 3.0) - eval_at(&antideriv, 1.0);
+    let numerical = trapezoid(|t| t.ln().sin(), 1.0, 3.0, 10_000);
+    assert!((diff - numerical).abs() < 1e-5, "diff={diff:.8}, numerical={numerical:.8}");
+}
+
+#[test]
+fn phase27_cos_log_x_numeric() {
+    // ∫₁^3 cos(log(x)) dx  vs trapezoidal.
+    let integrand = apply(sym(COS), vec![apply(sym(LOG), vec![sym("x")])]);
+    let antideriv = integrate(integrand);
+    let diff = eval_at(&antideriv, 3.0) - eval_at(&antideriv, 1.0);
+    let numerical = trapezoid(|t| t.ln().cos(), 1.0, 3.0, 10_000);
+    assert!((diff - numerical).abs() < 1e-5, "diff={diff:.8}, numerical={numerical:.8}");
+}
+
+#[test]
+fn phase27_x_sin_log_x_numeric() {
+    // ∫₁^2 x · sin(log(x)) dx  vs trapezoidal.
+    let integrand = apply(
+        sym(MUL),
+        vec![sym("x"), apply(sym(SIN), vec![apply(sym(LOG), vec![sym("x")])])],
+    );
+    let antideriv = integrate(integrand);
+    let diff = eval_at(&antideriv, 2.0) - eval_at(&antideriv, 1.0);
+    let numerical = trapezoid(|t| t * t.ln().sin(), 1.0, 2.0, 10_000);
+    assert!((diff - numerical).abs() < 1e-5, "diff={diff:.8}, numerical={numerical:.8}");
+}
+
+#[test]
+fn phase27_regression_sin_x_unchanged() {
+    // ∫ sin(x) dx = -cos(x) — must not be broken by Phase 27.
+    assert_eq!(
+        integrate(apply(sym(SIN), vec![sym("x")])),
+        apply(sym(NEG), vec![apply(sym(COS), vec![sym("x")])])
+    );
+}
+
+#[test]
+fn phase27_regression_cos_x_unchanged() {
+    // ∫ cos(x) dx = sin(x).
+    assert_eq!(
+        integrate(apply(sym(COS), vec![sym("x")])),
+        apply(sym(SIN), vec![sym("x")])
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Logic
 // ---------------------------------------------------------------------------
 

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.4.0] — 2026-05-16
+
+### Added — Phase 26: log-power integration via IBP reduction
+
+- `polyLogPowerTerm(k, n, x)` — closed form of `∫ xᵏ · log(x)^n dx` for
+  integer k ≥ 0, n ≥ 1, using the IBP reduction formula:
+  `G_{k,m}(x) = x^(k+1)/(k+1) · log(x)^m − m/(k+1) · G_{k,m-1}(x)`.
+- `tryLogPowerProduct(transcendental, poly, x)` — handles `∫ Q(x) · log(x)^n dx`
+  for integer n ≥ 2 by decomposing Q(x) into monomials and applying
+  `polyLogPowerTerm` term-by-term.
+- `toPolynomialCoeffs(expr, x)` — utility that extracts a `Map<degree, coeff>`
+  polynomial coefficient map from an IR expression; handles constants, `x`,
+  `x^k`, `c·f`, `f·c`, ADD, SUB, NEG.
+- Integration of standalone `log(x)^n` (n ≥ 2) via `polyLogPowerTerm(0, n, x)`.
+
+### Added — Phase 27: trig-of-log integration via u = log(x) substitution
+
+- `trigLogIntegral(trigHead, k, x)` — closed form of `∫ xᵏ · trig(log(x)) dx`
+  via the identity `∫ e^((k+1)u) trig(u) du` (with u = log x):
+  - `∫ xᵏ sin(log x) dx = x^(k+1)·((k+1)sin(log x)−cos(log x))/((k+1)²+1)`
+  - `∫ xᵏ cos(log x) dx = x^(k+1)·((k+1)cos(log x)+sin(log x))/((k+1)²+1)`
+- `tryTrigLogProduct(transcendental, poly, x)` — handles `∫ Q(x)·sin(log(x)) dx`
+  and `∫ Q(x)·cos(log(x)) dx` by decomposing Q(x) and applying `trigLogIntegral`
+  term-by-term.
+- Integration of standalone `sin(log(x))` and `cos(log(x))` (k = 0 case):
+  - `∫ sin(log x) dx = x/2·(sin(log x)−cos(log x))`
+  - `∫ cos(log x) dx = x/2·(sin(log x)+cos(log x))`
+
 ## [0.3.1] — 2026-05-14
 
 **Bug fix: elliptic modulus extraction now handles pre-evaluated numeric `k²`.**

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1107,6 +1107,14 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
       const ia = integrateIndefinite(a, x);
       return ia === undefined ? undefined : app(MUL, [b, ia]);
     }
+    // Phase 26: Q(x) · log(x)^n for integer n ≥ 2
+    const lp26 =
+      tryLogPowerProduct(a, b, x) ?? tryLogPowerProduct(b, a, x);
+    if (lp26 !== undefined) return lp26;
+    // Phase 27: Q(x) · sin(log(x)) or Q(x) · cos(log(x))
+    const tl27 =
+      tryTrigLogProduct(a, b, x) ?? tryTrigLogProduct(b, a, x);
+    if (tl27 !== undefined) return tl27;
     return undefined;
   }
   if (equals(f.head, DIV)) {
@@ -1129,6 +1137,18 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
     if (!dependsOn(base, x) && equals(exponent, x)) {
       return app(DIV, [f, app(LOG, [base])]);
     }
+    // Phase 26: ∫ log(x)^n dx for integer n ≥ 2 (standalone, no poly factor).
+    if (
+      base.kind === "apply" &&
+      equals(base.head, LOG) &&
+      base.args.length === 1 &&
+      equals(base.args[0], x)
+    ) {
+      const n26 = exactRational(exponent);
+      if (n26 !== undefined && n26.denom === 1n && n26.numer >= 2n) {
+        return polyLogPowerTerm(0, Number(n26.numer), x);
+      }
+    }
     return undefined;
   }
 
@@ -1141,6 +1161,18 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
     if (equals(f.head, SQRT)) {
       return app(MUL, [rational(2, 3), app(POW, [x, rational(3, 2)])]);
     }
+  }
+
+  // Phase 27: ∫ sin(log(x)) dx and ∫ cos(log(x)) dx (k=0 single-factor form).
+  if (
+    inner !== undefined &&
+    inner.kind === "apply" &&
+    equals(inner.head, LOG) &&
+    inner.args.length === 1 &&
+    equals(inner.args[0], x)
+  ) {
+    if (equals(f.head, SIN)) return trigLogIntegral(SIN, 0, x);
+    if (equals(f.head, COS)) return trigLogIntegral(COS, 0, x);
   }
 
   return undefined;
@@ -1357,6 +1389,274 @@ function completeEllipticThirdKind(f: IRNode, x: IRNode, lower: IRNode, upper: I
   if (!isZero(lower) || !isPiOverTwo(upper)) return undefined;
   const params = ellipticThirdKindParams(f, x);
   return params === undefined ? undefined : app(sym("EllipticPi"), [params.n, params.k]);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 26 — log-power integration via IBP reduction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the polynomial coefficient map for ``expr`` as a polynomial in ``x``.
+ *
+ * Returns a ``Map<degree, coefficient>`` where coefficients are unevaluated
+ * ``IRNode`` constant expressions, or ``undefined`` if ``expr`` is not a
+ * polynomial in ``x``.  Handles:
+ *
+ * - constants free of x (degree 0)
+ * - x itself (degree 1)
+ * - x^k for non-negative integer k
+ * - c·f and f·c where c is free of x — scalar-multiply the inner poly
+ * - ADD and SUB of two polynomials — merge coefficient maps
+ * - NEG of a polynomial — negate all coefficients
+ */
+function toPolynomialCoeffs(
+  expr: IRNode,
+  x: IRNode,
+): Map<number, IRNode> | undefined {
+  if (!dependsOn(expr, x)) {
+    return new Map([[0, expr]]);
+  }
+  if (equals(expr, x)) {
+    return new Map([[1, int(1)]]);
+  }
+  if (expr.kind !== "apply") return undefined;
+
+  if (equals(expr.head, POW)) {
+    const [base, exponent] = binaryArgs(expr);
+    if (equals(base, x)) {
+      const n = exactRational(exponent);
+      if (n !== undefined && n.denom === 1n && n.numer >= 0n) {
+        return new Map([[Number(n.numer), int(1)]]);
+      }
+    }
+    return undefined;
+  }
+
+  if (equals(expr.head, MUL)) {
+    const [a, b] = binaryArgs(expr);
+    if (!dependsOn(a, x)) {
+      const polyB = toPolynomialCoeffs(b, x);
+      if (polyB === undefined) return undefined;
+      const result = new Map<number, IRNode>();
+      for (const [k, v] of polyB) {
+        result.set(k, isOne(a) ? v : app(MUL, [a, v]));
+      }
+      return result;
+    }
+    if (!dependsOn(b, x)) {
+      const polyA = toPolynomialCoeffs(a, x);
+      if (polyA === undefined) return undefined;
+      const result = new Map<number, IRNode>();
+      for (const [k, v] of polyA) {
+        result.set(k, isOne(b) ? v : app(MUL, [b, v]));
+      }
+      return result;
+    }
+    return undefined;
+  }
+
+  if (equals(expr.head, ADD)) {
+    const [a, b] = binaryArgs(expr);
+    const polyA = toPolynomialCoeffs(a, x);
+    const polyB = toPolynomialCoeffs(b, x);
+    if (polyA === undefined || polyB === undefined) return undefined;
+    const result = new Map<number, IRNode>(polyA);
+    for (const [k, v] of polyB) {
+      const existing = result.get(k);
+      result.set(k, existing !== undefined ? app(ADD, [existing, v]) : v);
+    }
+    return result;
+  }
+
+  if (equals(expr.head, SUB)) {
+    const [a, b] = binaryArgs(expr);
+    const polyA = toPolynomialCoeffs(a, x);
+    const polyB = toPolynomialCoeffs(b, x);
+    if (polyA === undefined || polyB === undefined) return undefined;
+    const result = new Map<number, IRNode>(polyA);
+    for (const [k, v] of polyB) {
+      const existing = result.get(k);
+      result.set(k, existing !== undefined ? app(SUB, [existing, v]) : app(NEG, [v]));
+    }
+    return result;
+  }
+
+  if (equals(expr.head, NEG)) {
+    const [inner] = unaryArgs(expr);
+    const polyInner = toPolynomialCoeffs(inner, x);
+    if (polyInner === undefined) return undefined;
+    const result = new Map<number, IRNode>();
+    for (const [k, v] of polyInner) {
+      result.set(k, app(NEG, [v]));
+    }
+    return result;
+  }
+
+  return undefined;
+}
+
+/**
+ * Phase 26: closed form of ``∫ x^k · log(x)^n dx`` for any k ≥ 0, n ≥ 1.
+ *
+ * Reduction formula (IBP with u = log(x)^n, dv = x^k dx):
+ *
+ *     ∫ x^k · log(x)^n dx  =  x^(k+1)/(k+1) · log(x)^n
+ *                              − n/(k+1) · ∫ x^k · log(x)^(n-1) dx
+ *
+ * Iterating from the base case G_{k,0}(x) = x^(k+1)/(k+1):
+ *
+ *     G_{k,0}(x) = x^(k+1)/(k+1)
+ *     G_{k,m}(x) = x^(k+1)/(k+1) · log(x)^m  −  m/(k+1) · G_{k,m-1}(x)
+ *
+ * For k = 0, G_{0,0}(x) = x and the first factor simplifies accordingly.
+ */
+function polyLogPowerTerm(k: number, n: number, x: IRNode): IRNode {
+  const kp1 = k + 1;
+  const kp1Frac: Numeric = makeRat(1n, BigInt(kp1));
+
+  // Base: G_{k,0} = x (when k=0) or x^(k+1)/(k+1) (otherwise).
+  let acc: IRNode =
+    kp1 === 1
+      ? x
+      : app(MUL, [fromNumeric(kp1Frac), app(POW, [x, int(kp1)])]);
+
+  const logNode = app(LOG, [x]);
+  for (let m = 1; m <= n; m++) {
+    const logPow: IRNode = m === 1 ? logNode : app(POW, [logNode, int(m)]);
+    // first = x^(k+1)/(k+1) · log(x)^m
+    const first: IRNode =
+      kp1 === 1
+        ? app(MUL, [x, logPow])
+        : app(MUL, [
+            fromNumeric(kp1Frac),
+            app(MUL, [app(POW, [x, int(kp1)]), logPow]),
+          ]);
+    const nCoef = fromNumeric(makeRat(BigInt(m), BigInt(kp1))); // m/(k+1)
+    acc = app(SUB, [first, app(MUL, [nCoef, acc])]);
+  }
+  return acc;
+}
+
+/**
+ * Phase 26: ``∫ Q(x) · log(x)^n dx`` via term-by-term IBP, for integer n ≥ 2.
+ *
+ * ``transcendental`` must be ``Pow(Log(x), n)`` with integer n ≥ 2.
+ * (n = 1 is covered by the existing Phase 3 log-product handler.)
+ * ``polyCandidate`` must be a polynomial in x over Q.
+ *
+ * Applies linearity: Σᵢ cᵢ · ∫ xⁱ · log(x)^n dx, each term via
+ * ``polyLogPowerTerm``.
+ */
+function tryLogPowerProduct(
+  transcendental: IRNode,
+  polyCandidate: IRNode,
+  x: IRNode,
+): IRNode | undefined {
+  if (transcendental.kind !== "apply") return undefined;
+  if (!equals(transcendental.head, POW) || transcendental.args.length !== 2)
+    return undefined;
+  const [logNode, expNode] = binaryArgs(transcendental);
+  if (logNode.kind !== "apply" || !equals(logNode.head, LOG)) return undefined;
+  if (logNode.args.length !== 1 || !equals(logNode.args[0], x)) return undefined;
+  const expVal = exactRational(expNode);
+  if (expVal === undefined || expVal.denom !== 1n || expVal.numer < 2n)
+    return undefined;
+  const n = Number(expVal.numer);
+
+  const poly = toPolynomialCoeffs(polyCandidate, x);
+  if (poly === undefined || poly.size === 0) return undefined;
+
+  const pieces: IRNode[] = [];
+  for (const [k, coef] of poly) {
+    if (isZero(coef)) continue;
+    const term = polyLogPowerTerm(k, n, x);
+    pieces.push(isOne(coef) ? term : app(MUL, [coef, term]));
+  }
+  if (pieces.length === 0) return int(0);
+  return pieces.reduce((acc, p) => app(ADD, [acc, p]));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 27 — trig(log(x)) integration via u = log(x) substitution
+// ---------------------------------------------------------------------------
+//
+// The substitution u = log(x) (so x = eᵘ, dx = eᵘ du) converts:
+//
+//   ∫ xᵏ sin(log x) dx = ∫ e^((k+1)u) sin(u) du
+//
+// The standard exp×trig formula gives:
+//   ∫ e^(αu) sin(u) du = e^(αu) (α sin(u) − cos(u)) / (α² + 1)
+//
+// Setting α = k+1 and back-substituting u = log(x):
+//
+//   ∫ xᵏ sin(log x) dx = x^(k+1) · ((k+1)sin(log x) − cos(log x)) / ((k+1)² + 1)
+//   ∫ xᵏ cos(log x) dx = x^(k+1) · ((k+1)cos(log x) + sin(log x)) / ((k+1)² + 1)
+//
+// The k=0 forms are:
+//   ∫ sin(log x) dx = x/2 · (sin(log x) − cos(log x))
+//   ∫ cos(log x) dx = x/2 · (sin(log x) + cos(log x))
+
+/**
+ * Phase 27: closed form of ``∫ x^k · trig(log(x)) dx``.
+ *
+ * ``trigHead`` is the symbol node for ``SIN`` or ``COS``; ``k`` is the
+ * integer power of x (k=0 means the integrand is just trig(log(x))).
+ *
+ *   ∫ xᵏ sin(log x) dx = x^(k+1) · ((k+1)·sin(log x) − cos(log x)) / ((k+1)² + 1)
+ *   ∫ xᵏ cos(log x) dx = x^(k+1) · ((k+1)·cos(log x) + sin(log x)) / ((k+1)² + 1)
+ */
+function trigLogIntegral(trigHead: IRNode, k: number, x: IRNode): IRNode {
+  const kp1 = k + 1;
+  const denom = kp1 * kp1 + 1;
+  const logX = app(LOG, [x]);
+  const sinLogX = app(SIN, [logX]);
+  const cosLogX = app(COS, [logX]);
+  const xPow: IRNode = kp1 === 1 ? x : app(POW, [x, int(kp1)]);
+  const kp1Ir = int(kp1);
+  const denomIr = int(denom);
+  const numerator: IRNode = equals(trigHead, SIN)
+    ? app(SUB, [app(MUL, [kp1Ir, sinLogX]), cosLogX])
+    : app(ADD, [app(MUL, [kp1Ir, cosLogX]), sinLogX]);
+  return app(DIV, [app(MUL, [xPow, numerator]), denomIr]);
+}
+
+/**
+ * Phase 27: ``∫ Q(x) · sin(log(x)) dx`` or ``∫ Q(x) · cos(log(x)) dx``.
+ *
+ * ``transcendental`` must be ``Sin(Log(x))`` or ``Cos(Log(x))``.
+ * ``polyCandidate`` must be a polynomial in x.
+ * Applies linearity: Σᵢ cᵢ · ∫ xⁱ · trig(log(x)) dx via ``trigLogIntegral``.
+ */
+function tryTrigLogProduct(
+  transcendental: IRNode,
+  polyCandidate: IRNode,
+  x: IRNode,
+): IRNode | undefined {
+  if (transcendental.kind !== "apply") return undefined;
+  if (!equals(transcendental.head, SIN) && !equals(transcendental.head, COS))
+    return undefined;
+  if (transcendental.args.length !== 1) return undefined;
+  const trigArg = transcendental.args[0];
+  if (
+    trigArg.kind !== "apply" ||
+    !equals(trigArg.head, LOG) ||
+    trigArg.args.length !== 1 ||
+    !equals(trigArg.args[0], x)
+  )
+    return undefined;
+
+  const poly = toPolynomialCoeffs(polyCandidate, x);
+  if (poly === undefined || poly.size === 0) return undefined;
+
+  const trigHead = transcendental.head;
+  const pieces: IRNode[] = [];
+  for (const [k, coef] of poly) {
+    if (isZero(coef)) continue;
+    const term = trigLogIntegral(trigHead, k, x);
+    pieces.push(isOne(coef) ? term : app(MUL, [coef, term]));
+  }
+  if (pieces.length === 0) return int(0);
+  return pieces.reduce((acc, p) => app(ADD, [acc, p]));
 }
 
 function differentiate(): Handler {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -721,4 +721,217 @@ describe("symbolic-vm", () => {
     expect(vm.eval(expr)).toEqual(expr);
     expect(() => vm.eval(app(INTEGRATE, [sym("x")]))).toThrow(ArityError);
   });
+
+  // Recursively check whether any sub-node has the given head symbol name.
+  function containsHeadName(node: ReturnType<typeof sym>, name: string): boolean {
+    const n = node as unknown as { kind: string; name?: string; head?: unknown; args?: unknown[] };
+    if (n.kind === "apply") {
+      const h = n.head as { name?: string } | null;
+      if (h?.name === name) return true;
+      return (n.args ?? []).some((a) => containsHeadName(a as ReturnType<typeof sym>, name));
+    }
+    return false;
+  }
+
+  // Phase 26 — log-power IBP reduction
+  // ∫ log(x)^2 dx = x·log²x − 2x·log x + 2x
+  it("Phase 26: ∫ log(x)^2 dx returns a closed form", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(POW, [app(LOG, [x]), int(2)]);
+    const result = vm.eval(app(INTEGRATE, [integrand, x]));
+    // Must not contain INTEGRATE as its head
+    expect(result).not.toMatchObject({ head: INTEGRATE });
+    // Must contain LOG (antiderivative involves log(x))
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Log")).toBe(true);
+  });
+
+  it("Phase 26: ∫ x·log(x)^2 dx numerical correctness", () => {
+    // Closed form: x²/4·log²x − x²/4·log x + x²/8
+    // ∫₁^2 x·log(x)^2 dx
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(MUL, [x, app(POW, [app(LOG, [x]), int(2)])]);
+    const result = vm.eval(app(INTEGRATE, [integrand, x]));
+
+    function evalIR(node: ReturnType<typeof sym>, xVal: number): number {
+      const n = node as unknown as { kind: string; value?: number | bigint; numer?: bigint; denom?: bigint; head?: unknown; args?: unknown[] };
+      if (n.kind === "integer") return Number(n.value);
+      if (n.kind === "rational") return Number(n.numer!) / Number(n.denom!);
+      if (n.kind === "float") return n.value as number;
+      if (n.kind === "symbol") return xVal;
+      const h = (n.head as { name?: string })?.name ?? "";
+      const args = n.args as typeof node[];
+      if (h === "Add") return evalIR(args[0], xVal) + evalIR(args[1], xVal);
+      if (h === "Sub") return evalIR(args[0], xVal) - evalIR(args[1], xVal);
+      if (h === "Mul") return evalIR(args[0], xVal) * evalIR(args[1], xVal);
+      if (h === "Div") return evalIR(args[0], xVal) / evalIR(args[1], xVal);
+      if (h === "Neg") return -evalIR(args[0], xVal);
+      if (h === "Pow") return Math.pow(evalIR(args[0], xVal), evalIR(args[1], xVal));
+      if (h === "Log") return Math.log(evalIR(args[0], xVal));
+      if (h === "Sin") return Math.sin(evalIR(args[0], xVal));
+      if (h === "Cos") return Math.cos(evalIR(args[0], xVal));
+      throw new Error(`unsupported head: ${h}`);
+    }
+
+    function trapezoid(fn: (t: number) => number, a: number, b: number, n = 10000): number {
+      const h = (b - a) / n;
+      let total = 0.5 * (fn(a) + fn(b));
+      for (let i = 1; i < n; i++) total += fn(a + i * h);
+      return total * h;
+    }
+
+    const antiderivDiff = evalIR(result as unknown as ReturnType<typeof sym>, 2) -
+                          evalIR(result as unknown as ReturnType<typeof sym>, 1);
+    const numerical = trapezoid(t => t * Math.log(t) ** 2, 1, 2);
+    expect(Math.abs(antiderivDiff - numerical)).toBeLessThan(1e-5);
+  });
+
+  // Phase 27 — trig-of-log integration
+  it("Phase 27: ∫ sin(log(x)) dx returns a closed form with SIN and COS", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(SIN, [app(LOG, [x])]);
+    const result = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(result).not.toMatchObject({ head: INTEGRATE });
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Sin")).toBe(true);
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Cos")).toBe(true);
+  });
+
+  it("Phase 27: ∫ sin(log(x)) dx numerical correctness", () => {
+    // ∫₁^3 sin(log x) dx
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(SIN, [app(LOG, [x])]);
+    const result = vm.eval(app(INTEGRATE, [integrand, x]));
+
+    function evalIR(node: ReturnType<typeof sym>, xVal: number): number {
+      const n = node as unknown as { kind: string; value?: number | bigint; numer?: bigint; denom?: bigint; head?: unknown; args?: unknown[] };
+      if (n.kind === "integer") return Number(n.value);
+      if (n.kind === "rational") return Number(n.numer!) / Number(n.denom!);
+      if (n.kind === "float") return n.value as number;
+      if (n.kind === "symbol") return xVal;
+      const h = (n.head as { name?: string })?.name ?? "";
+      const args = n.args as typeof node[];
+      if (h === "Add") return evalIR(args[0], xVal) + evalIR(args[1], xVal);
+      if (h === "Sub") return evalIR(args[0], xVal) - evalIR(args[1], xVal);
+      if (h === "Mul") return evalIR(args[0], xVal) * evalIR(args[1], xVal);
+      if (h === "Div") return evalIR(args[0], xVal) / evalIR(args[1], xVal);
+      if (h === "Neg") return -evalIR(args[0], xVal);
+      if (h === "Pow") return Math.pow(evalIR(args[0], xVal), evalIR(args[1], xVal));
+      if (h === "Log") return Math.log(evalIR(args[0], xVal));
+      if (h === "Sin") return Math.sin(evalIR(args[0], xVal));
+      if (h === "Cos") return Math.cos(evalIR(args[0], xVal));
+      throw new Error(`unsupported head: ${h}`);
+    }
+
+    function trapezoid(fn: (t: number) => number, a: number, b: number, n = 10000): number {
+      const h = (b - a) / n;
+      let total = 0.5 * (fn(a) + fn(b));
+      for (let i = 1; i < n; i++) total += fn(a + i * h);
+      return total * h;
+    }
+
+    const antiderivDiff = evalIR(result as unknown as ReturnType<typeof sym>, 3) -
+                          evalIR(result as unknown as ReturnType<typeof sym>, 1);
+    const numerical = trapezoid(t => Math.sin(Math.log(t)), 1, 3);
+    expect(Math.abs(antiderivDiff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 27: ∫ cos(log(x)) dx numerical correctness", () => {
+    // ∫₁^3 cos(log x) dx
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(COS, [app(LOG, [x])]);
+    const result = vm.eval(app(INTEGRATE, [integrand, x]));
+
+    function evalIR(node: ReturnType<typeof sym>, xVal: number): number {
+      const n = node as unknown as { kind: string; value?: number | bigint; numer?: bigint; denom?: bigint; head?: unknown; args?: unknown[] };
+      if (n.kind === "integer") return Number(n.value);
+      if (n.kind === "rational") return Number(n.numer!) / Number(n.denom!);
+      if (n.kind === "float") return n.value as number;
+      if (n.kind === "symbol") return xVal;
+      const h = (n.head as { name?: string })?.name ?? "";
+      const args = n.args as typeof node[];
+      if (h === "Add") return evalIR(args[0], xVal) + evalIR(args[1], xVal);
+      if (h === "Sub") return evalIR(args[0], xVal) - evalIR(args[1], xVal);
+      if (h === "Mul") return evalIR(args[0], xVal) * evalIR(args[1], xVal);
+      if (h === "Div") return evalIR(args[0], xVal) / evalIR(args[1], xVal);
+      if (h === "Neg") return -evalIR(args[0], xVal);
+      if (h === "Pow") return Math.pow(evalIR(args[0], xVal), evalIR(args[1], xVal));
+      if (h === "Log") return Math.log(evalIR(args[0], xVal));
+      if (h === "Sin") return Math.sin(evalIR(args[0], xVal));
+      if (h === "Cos") return Math.cos(evalIR(args[0], xVal));
+      throw new Error(`unsupported head: ${h}`);
+    }
+
+    function trapezoid(fn: (t: number) => number, a: number, b: number, n = 10000): number {
+      const h = (b - a) / n;
+      let total = 0.5 * (fn(a) + fn(b));
+      for (let i = 1; i < n; i++) total += fn(a + i * h);
+      return total * h;
+    }
+
+    const antiderivDiff = evalIR(result as unknown as ReturnType<typeof sym>, 3) -
+                          evalIR(result as unknown as ReturnType<typeof sym>, 1);
+    const numerical = trapezoid(t => Math.cos(Math.log(t)), 1, 3);
+    expect(Math.abs(antiderivDiff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 27: ∫ x·sin(log(x)) dx numerical correctness", () => {
+    // ∫₁^2 x·sin(log x) dx
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(MUL, [x, app(SIN, [app(LOG, [x])])]);
+    const result = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(result).not.toMatchObject({ head: INTEGRATE });
+
+    function evalIR(node: ReturnType<typeof sym>, xVal: number): number {
+      const n = node as unknown as { kind: string; value?: number | bigint; numer?: bigint; denom?: bigint; head?: unknown; args?: unknown[] };
+      if (n.kind === "integer") return Number(n.value);
+      if (n.kind === "rational") return Number(n.numer!) / Number(n.denom!);
+      if (n.kind === "float") return n.value as number;
+      if (n.kind === "symbol") return xVal;
+      const h = (n.head as { name?: string })?.name ?? "";
+      const args = n.args as typeof node[];
+      if (h === "Add") return evalIR(args[0], xVal) + evalIR(args[1], xVal);
+      if (h === "Sub") return evalIR(args[0], xVal) - evalIR(args[1], xVal);
+      if (h === "Mul") return evalIR(args[0], xVal) * evalIR(args[1], xVal);
+      if (h === "Div") return evalIR(args[0], xVal) / evalIR(args[1], xVal);
+      if (h === "Neg") return -evalIR(args[0], xVal);
+      if (h === "Pow") return Math.pow(evalIR(args[0], xVal), evalIR(args[1], xVal));
+      if (h === "Log") return Math.log(evalIR(args[0], xVal));
+      if (h === "Sin") return Math.sin(evalIR(args[0], xVal));
+      if (h === "Cos") return Math.cos(evalIR(args[0], xVal));
+      throw new Error(`unsupported head: ${h}`);
+    }
+
+    function trapezoid(fn: (t: number) => number, a: number, b: number, n = 10000): number {
+      const h = (b - a) / n;
+      let total = 0.5 * (fn(a) + fn(b));
+      for (let i = 1; i < n; i++) total += fn(a + i * h);
+      return total * h;
+    }
+
+    const antiderivDiff = evalIR(result as unknown as ReturnType<typeof sym>, 2) -
+                          evalIR(result as unknown as ReturnType<typeof sym>, 1);
+    const numerical = trapezoid(t => t * Math.sin(Math.log(t)), 1, 2);
+    expect(Math.abs(antiderivDiff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 27: regression — ∫ sin(x) dx still works", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const result = vm.eval(app(INTEGRATE, [app(SIN, [x]), x]));
+    // Should be -cos(x)
+    expect(result).toEqual(app(NEG, [app(COS, [x])]));
+  });
+
+  it("Phase 27: regression — ∫ cos(x) dx still works", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const result = vm.eval(app(INTEGRATE, [app(COS, [x]), x]));
+    // Should be sin(x)
+    expect(result).toEqual(app(SIN, [x]));
+  });
 });

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -181,6 +181,13 @@ CHANGELOG section. PR #3171 cut proper 0.2.0 releases and created the missing
 |---|---|---|
 | `rust/symbolic-vm` | 0.3.0 | EllipticE (complete + incomplete), EllipticPi (complete) pattern recognition |
 
+#### Phase 26 + Phase 27: log-power IBP and trig-of-log — TypeScript + Rust ports
+
+| Package | Version | Notes |
+|---|---|---|
+| `typescript/symbolic-vm` | 0.4.0 | Phase 26 `∫ Q(x)·log(x)^n dx` + Phase 27 `∫ xᵏ·trig(log(x)) dx` via u=log(x) substitution |
+| `rust/symbolic-vm` | 0.4.0 | Same as TypeScript 0.4.0 |
+
 #### Phase 21 — named variable-coefficient ODE recognition (all three languages)
 
 Python `cas-ode` 0.6.0 (PR #3360 ✅ merged), TypeScript `cas-ode` 0.2.0 and
@@ -326,8 +333,8 @@ The Risch integration suite is ~90% complete. Known remaining gaps:
 | Elliptic integrals — first-kind foothold | `∫ 1/√(1-k²sin²θ) dθ` | ✅ #3141: returns `EllipticF(θ,k)`; definite 0…π/2 returns `EllipticK(k)` |
 | Elliptic integrals — second kind | `∫ √(1-k²sin²θ) dθ`, `∫₀^(π/2) √(1-k²sin²θ) dθ` | ✅ Python PR #3173, TypeScript PR #3179, Rust PR #3178 — all three languages at 0.3.0/0.54.0 |
 | Elliptic integrals — third kind | `∫₀^(π/2) 1/((1+n·sin²θ)·√(1-k²sin²θ)) dθ` | ✅ Python PR #3173, TypeScript PR #3179, Rust PR #3178 — all three languages at 0.3.0/0.54.0 |
-| `∫ log(ax+b)^n dx`, `∫ Q(x)·log(x)^n dx` (Phase 26 log-power IBP) | IBP reduction `F_n = (ax+b)/a·log(ax+b)^n − n·F_{n-1}` and term-by-term poly×log^n | ✅ Python PR #3372 `symbolic-vm` 0.56.0 |
-| `∫ sin(log(x)) dx`, `∫ cos(log(x)) dx`, `∫ xᵏ·sin/cos(log(x)) dx` (Phase 27 trig-of-log) | u=log(x) substitution converts to exp×trig form; closed form `x^(k+1)·((k+1)trig(log x)∓cotrig(log x))/((k+1)²+1)` | ✅ Python PR #3373 `symbolic-vm` 0.57.0 |
+| `∫ log(ax+b)^n dx`, `∫ Q(x)·log(x)^n dx` (Phase 26 log-power IBP) | IBP reduction `F_n = (ax+b)/a·log(ax+b)^n − n·F_{n-1}` and term-by-term poly×log^n | ✅ Python PR #3372 `symbolic-vm` 0.56.0; TS + Rust `symbolic-vm` 0.4.0 (same PR as Phase 27) |
+| `∫ sin(log(x)) dx`, `∫ cos(log(x)) dx`, `∫ xᵏ·sin/cos(log(x)) dx` (Phase 27 trig-of-log) | u=log(x) substitution converts to exp×trig form; closed form `x^(k+1)·((k+1)trig(log x)∓cotrig(log x))/((k+1)²+1)` | ✅ Python PR #3373 `symbolic-vm` 0.57.0; TS + Rust `symbolic-vm` 0.4.0 |
 | `∫ f(x)·g(x)` where neither integrates alone | General IBP fallback missing; only specific matched patterns work | Open |
 
 #### Completed REPL and session features

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -10,7 +10,9 @@
 > `rust/macsyma-runtime` 0.3.0 (EllipticE/Pi pipeline tests),
 > Phase 21 named variable-coefficient ODEs Python (PR #3360 ✅ merged),
 > Phase 21 TypeScript + Rust ports (PR #3369 ✅ merged),
-> version housekeeping chore (PR #3354 ✅ merged).
+> version housekeeping chore (PR #3354 ✅ merged),
+> Phase 26 log-power IBP Python (PR #3372 ✅ merged),
+> Phase 27 trig-of-log integration Python `symbolic-vm` 0.57.0 (PR #3373 ✅ merged).
 
 This document is the canonical reference for resuming work on either project.
 It records exactly what is on `main`, what is in flight, and what has not been
@@ -139,7 +141,7 @@ Every item below is wired end-to-end: surface syntax → compile → VM → corr
 | Package | Version | What it provides |
 |---|---|---|
 | `symbolic-ir` | latest | `IRSymbol`, `IRInteger`, `IRRational`, `IRFloat`, `IRString`, `IRApply` node types |
-| `symbolic-vm` | 0.56.0 | Pluggable VM, `SymbolicBackend`, arithmetic, Risch integration (phases 1–14+, Phase 25 EllipticF/K/E/Pi, Phase 26 log-power IBP), numeric folding, 100+ handlers |
+| `symbolic-vm` | 0.57.0 | Pluggable VM, `SymbolicBackend`, arithmetic, Risch integration (phases 1–14+, Phase 25 EllipticF/K/E/Pi, Phase 26 log-power IBP, Phase 27 trig-of-log), numeric folding, 100+ handlers |
 | `macsyma-lexer` | 0.1.0 | Grammar-driven tokenizer |
 | `macsyma-parser` | 0.1.0 | Grammar-driven parser |
 | `macsyma-compiler` | 0.9.0 | AST → IR; 60+ MACSYMA identifier mappings in name table |
@@ -234,10 +236,10 @@ Eight new head symbols added to `symbolic-ir` in all three languages:
 
 #### VM-level operations (live in `symbolic-vm`, not separate packages)
 
-**Integration** (Risch phases 1–14+): polynomials, rational functions, trig,
+**Integration** (Risch phases 1–27): polynomials, rational functions, trig,
 exp, log, IBP, partial fractions, inverse-trig, hyperbolic powers,
 exp×hyperbolic, sinh/cosh mixed powers, Rothstein-Trager for rational
-functions.
+functions, EllipticF/K/E/Pi, log-power IBP, trig-of-log.
 
 **Calculus:** `diff` (all elementary functions).
 
@@ -325,6 +327,7 @@ The Risch integration suite is ~90% complete. Known remaining gaps:
 | Elliptic integrals — second kind | `∫ √(1-k²sin²θ) dθ`, `∫₀^(π/2) √(1-k²sin²θ) dθ` | ✅ Python PR #3173, TypeScript PR #3179, Rust PR #3178 — all three languages at 0.3.0/0.54.0 |
 | Elliptic integrals — third kind | `∫₀^(π/2) 1/((1+n·sin²θ)·√(1-k²sin²θ)) dθ` | ✅ Python PR #3173, TypeScript PR #3179, Rust PR #3178 — all three languages at 0.3.0/0.54.0 |
 | `∫ log(ax+b)^n dx`, `∫ Q(x)·log(x)^n dx` (Phase 26 log-power IBP) | IBP reduction `F_n = (ax+b)/a·log(ax+b)^n − n·F_{n-1}` and term-by-term poly×log^n | ✅ Python PR #3372 `symbolic-vm` 0.56.0 |
+| `∫ sin(log(x)) dx`, `∫ cos(log(x)) dx`, `∫ xᵏ·sin/cos(log(x)) dx` (Phase 27 trig-of-log) | u=log(x) substitution converts to exp×trig form; closed form `x^(k+1)·((k+1)trig(log x)∓cotrig(log x))/((k+1)²+1)` | ✅ Python PR #3373 `symbolic-vm` 0.57.0 |
 | `∫ f(x)·g(x)` where neither integrates alone | General IBP fallback missing; only specific matched patterns work | Open |
 
 #### Completed REPL and session features


### PR DESCRIPTION
## Summary

- **Spec update**: Records Phase 26 (log-power IBP, PR #3372) and Phase 27 (trig-of-log, PR #3373) as merged in Python; marks TS + Rust ports as complete at 0.4.0
- **TypeScript symbolic-vm 0.4.0**: Ports Phase 26 (`∫ Q(x)·log(x)^n dx` via IBP) and Phase 27 (`∫ xᵏ·sin/cos(log(x)) dx` via u=log(x) substitution) with 8 new tests (55 total, all passing)
- **Rust symbolic-vm 0.4.0**: Same Phase 26+27 port in Rust with 8 new tests (95 total, all passing); adds `is_log_of_x`, `to_polynomial_coeffs`, `poly_log_power_term`, `try_log_power_product`, `trig_log_integral`, `try_trig_log_product`

## Key formulas implemented

- `∫ xᵏ·log(x)^n dx` via IBP reduction: `G_{k,m} = x^(k+1)/(k+1)·log^m − m/(k+1)·G_{k,m-1}`
- `∫ xᵏ·sin(log x) dx = x^(k+1)·((k+1)sin(log x)−cos(log x))/((k+1)²+1)`
- `∫ xᵏ·cos(log x) dx = x^(k+1)·((k+1)cos(log x)+sin(log x))/((k+1)²+1)`

## Test plan

- [ ] TypeScript: `npm test` in `packages/typescript/symbolic-vm` — 55 tests pass
- [ ] Rust: `cargo test` in `packages/rust/symbolic-vm` — 95 tests pass
- [ ] Regression: `∫ sin(x) dx = -cos(x)` and `∫ cos(x) dx = sin(x)` verified unbroken
- [ ] Numerical: trapezoidal quadrature confirms closed forms are correct antiderivatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)