### PR TITLE
feat(dsp-stft): DSP05 Phase 3+4 — istft + spectrogram helpers

### DIFF
--- a/code/packages/rust/dsp-stft/CHANGELOG.md
+++ b/code/packages/rust/dsp-stft/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog — dsp-stft
 
+## 0.2.0 — 2026-05-16
+
+### Added — DSP05 Phase 3 + 4 (ISTFT + spectrogram helpers)
+
+Closes the analysis/synthesis loop and adds the magnitude /
+log helpers that downstream audio code actually wants.
+
+#### Public API
+
+```rust
+pub fn istft(spectrogram, n_fft, hop_length, window, output_length)
+    -> Result<Vec<f32>, StftError>;
+
+pub fn spectrogram(signal, n_fft, hop_length, window)
+    -> Result<Vec<f32>, StftError>;
+
+pub fn log_spectrogram(signal, n_fft, hop_length, window)
+    -> Result<Vec<f32>, StftError>;
+```
+
+All re-exported at the crate root.
+
+#### Algorithm — `istft` (overlap-add)
+
+For each frame `m`, irfft the spectrum to length-`n_fft` time
+domain, multiply by the synthesis window, add into the output
+buffer at position `m · hop_length`.  Also accumulate the
+sum-of-squared-windows at each position.  Divide the output
+by that running norm (skipping samples where the norm is
+near-zero).
+
+Under COLA-satisfying window/hop choices (Hann at
+`hop = n_fft / 2` is canonical), `istft(stft(x))` recovers
+`x` within `1e-3` relative tolerance in the central region
+(edges are subject to the usual transient boundary effects).
+
+#### `spectrogram` / `log_spectrogram`
+
+- `spectrogram(signal, ...)` — returns `|STFT|²` flattened
+  `[num_frames, n_fft/2 + 1]`.  Half the size of the complex
+  spectrogram (one magnitude lane instead of two `[re, im]`
+  lanes).  Non-negative by construction.
+- `log_spectrogram(signal, ...)` — `log(|STFT|² + ε)` with
+  `ε = 1e-10`.  Always finite (no `-∞` at silent bins).  The
+  canonical input feature for plotting and ML pipelines.
+
+#### New unit tests — 14
+
+`inverse` module (8):
+- 5 error paths: empty spectrogram, n_fft=0, hop=0,
+  output_length=0, misaligned spectrogram length.
+- COLA round-trip recovers a signal within 1e-3 (Hann/hop=n_fft/2).
+- Output length matches request.
+- Constant signal round-trips to the same constant in central region.
+
+`spectrogram` module (6):
+- spectrogram non-negative.
+- length matches `num_frames × bins`.
+- zero signal → all-zero spectrogram.
+- log_spectrogram finite everywhere.
+- log_spectrogram of zero signal ≈ log(ε) ≈ -23.0259.
+- log_spectrogram length matches spectrogram length.
+
+All 25 unit tests + 1 doctest pass (11 stft + 8 inverse + 6 spectrogram).
+
+### What this phase does NOT include
+
+- Phase 5: mel filterbank + mel_spectrogram + MFCC.
+- Phase 6: matrix-ir-lowered stft.
+- Centred-padding mode.
+- Streaming / real-time API.
+
 ## 0.1.0 — 2026-05-16
 
 ### Added — DSP05 Phase 1 + 2 (crate skeleton + scalar STFT forward)

--- a/code/packages/rust/dsp-stft/Cargo.toml
+++ b/code/packages/rust/dsp-stft/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dsp-stft"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "DSP05 Phase 1+2: scalar reference Short-Time Fourier Transform (STFT) for the DSP layer. Sliding-window FFT for time-frequency analysis. Output is row-major [num_frames, n_fft/2+1, 2] interleaved complex. Strict-mode framing (no centred padding) in V1. Reuses dsp-fft for the per-frame FFT and dsp-filters::WindowType for the analysis window."
+description = "DSP05 Phases 1-4: scalar reference STFT (forward), ISTFT (overlap-add reconstruction, COLA-aware), magnitude spectrogram, and log spectrogram for the DSP layer. Sliding-window FFT for time-frequency analysis with optional reconstruction. Strict-mode framing in V1; mel/MFCC helpers (Phase 5) and matrix-ir lowered STFT (Phase 6) still pending."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/dsp-stft/README.md
+++ b/code/packages/rust/dsp-stft/README.md
@@ -1,7 +1,13 @@
 # dsp-stft
 
-**DSP05 Phase 1+2** — scalar reference Short-Time Fourier
-Transform (STFT) for the DSP layer.
+Scalar reference Short-Time Fourier Transform (STFT) for the
+DSP layer.  As of **0.2.0 (DSP05 Phase 3+4)** the crate ships
+the full analysis/synthesis loop plus magnitude/log helpers:
+
+- **`stft`** — forward (sliding-window FFT).
+- **`istft`** — inverse via overlap-add reconstruction (COLA).
+- **`spectrogram`** — `|STFT|²` (magnitude squared).
+- **`log_spectrogram`** — `log(|STFT|² + ε)`.
 
 The STFT is the workhorse primitive for time-frequency
 analysis of audio, speech, and music.  Plain DFT collapses a

--- a/code/packages/rust/dsp-stft/src/inverse.rs
+++ b/code/packages/rust/dsp-stft/src/inverse.rs
@@ -1,0 +1,269 @@
+//! # Inverse STFT (overlap-add reconstruction)
+//!
+//! **DSP05 Phase 3.**  Reconstructs a time-domain signal from
+//! its STFT spectrogram via the standard overlap-add (OLA)
+//! formula:
+//!
+//! ```text
+//!     x_hat[n] = ( Σ_m  IFFT(STFT[:, m])[n - m·hop] · w[n - m·hop] )
+//!               / ( Σ_m  w[n - m·hop]² )
+//! ```
+//!
+//! Under COLA-satisfying choices (e.g. Hann window at
+//! `hop = n_fft / 2`), `istft(stft(x))` recovers `x` exactly
+//! up to FP noise.
+
+use dsp_fft::{irfft_scalar, FftError};
+use std::f32::consts::PI;
+
+use crate::{StftError, WindowType};
+
+/// Inverse short-time Fourier transform via overlap-add.
+///
+/// `spectrogram` is the flattened
+/// `[num_frames, n_fft/2 + 1, 2]` row-major buffer that
+/// [`crate::stft`] produces.  `output_length` is the desired
+/// length of the reconstructed signal — typically the original
+/// signal length passed to `stft`.
+///
+/// The same `n_fft`, `hop_length`, and `window` must be passed
+/// that were used on the forward `stft`.
+///
+/// Output length equals `output_length`.  For COLA-satisfying
+/// `(window, hop_length)` combos, `istft(stft(x))` recovers `x`
+/// within `1e-4` relative tolerance.
+pub fn istft(
+    spectrogram: &[f32],
+    n_fft: u32,
+    hop_length: u32,
+    window: WindowType,
+    output_length: u32,
+) -> Result<Vec<f32>, StftError> {
+    if spectrogram.is_empty() {
+        return Err(StftError::InvalidSpectrogram(
+            "spectrogram is empty".into(),
+        ));
+    }
+    if n_fft == 0 {
+        return Err(StftError::InvalidParam("n_fft must be > 0".into()));
+    }
+    if hop_length == 0 {
+        return Err(StftError::InvalidParam("hop_length must be > 0".into()));
+    }
+    if output_length == 0 {
+        return Err(StftError::InvalidParam(
+            "output_length must be > 0".into(),
+        ));
+    }
+
+    let nf = n_fft as usize;
+    let hop = hop_length as usize;
+    let out_len = output_length as usize;
+    let bins = nf / 2 + 1;
+    let frame_floats = bins * 2;
+
+    if spectrogram.len() % frame_floats != 0 {
+        return Err(StftError::InvalidSpectrogram(format!(
+            "spectrogram length {} is not a multiple of bins×2 = {}",
+            spectrogram.len(),
+            frame_floats
+        )));
+    }
+    let num_frames = spectrogram.len() / frame_floats;
+
+    let win = build_window(window, nf);
+
+    // ── Output buffer and normalisation buffer.
+    //
+    //   out[n]  = Σ_m  irfft(frame m)[n - m·hop] · w[n - m·hop]
+    //   norm[n] = Σ_m  w[n - m·hop]²
+    let mut out = vec![0.0f32; out_len];
+    let mut norm = vec![0.0f32; out_len];
+
+    for m in 0..num_frames {
+        let frame_start_global = m * hop;
+        let frame_slice =
+            &spectrogram[m * frame_floats..(m + 1) * frame_floats];
+        // irfft returns a real Vec<f32> of length n_fft.
+        let frame = irfft_scalar(frame_slice, n_fft).map_err(fft_err)?;
+        debug_assert_eq!(frame.len(), nf);
+
+        // Window the frame, then overlap-add into the output.
+        for k in 0..nf {
+            let n = frame_start_global + k;
+            if n >= out_len {
+                break;
+            }
+            let w = win[k];
+            out[n] += frame[k] * w;
+            norm[n] += w * w;
+        }
+    }
+
+    // ── Normalise.  Avoid div-by-zero where the window
+    //   coverage is near zero (at very edge samples for some
+    //   window/hop combos) — leave those samples as 0.
+    for n in 0..out_len {
+        if norm[n] > 1e-10 {
+            out[n] /= norm[n];
+        }
+    }
+    Ok(out)
+}
+
+/// Build the same analysis/synthesis window the forward STFT
+/// uses.  Duplicated here rather than imported from `lib.rs`
+/// to keep modules independent — both copies follow the same
+/// formulas (`scipy.signal.get_window` with `sym=True`).
+fn build_window(window: WindowType, n_fft: usize) -> Vec<f32> {
+    let m = (n_fft - 1) as f32;
+    (0..n_fft)
+        .map(|n| {
+            let nn = n as f32;
+            match window {
+                WindowType::Rectangular => 1.0,
+                WindowType::Hamming => 0.54 - 0.46 * (2.0 * PI * nn / m).cos(),
+                WindowType::Hann => 0.5 * (1.0 - (2.0 * PI * nn / m).cos()),
+                WindowType::Blackman => {
+                    0.42 - 0.5 * (2.0 * PI * nn / m).cos()
+                        + 0.08 * (4.0 * PI * nn / m).cos()
+                }
+            }
+        })
+        .collect()
+}
+
+fn fft_err(e: FftError) -> StftError {
+    StftError::Fft(format!("{:?}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stft;
+
+    fn approx_eq(a: f32, b: f32, tol: f32) -> bool {
+        let scale = a.abs().max(b.abs()).max(1.0);
+        (a - b).abs() <= scale * tol
+    }
+
+    fn assert_close(a: &[f32], b: &[f32], tol: f32) {
+        assert_eq!(a.len(), b.len(), "length mismatch");
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!(
+                approx_eq(*x, *y, tol),
+                "mismatch at {}: {} vs {} (tol {})",
+                i,
+                x,
+                y,
+                tol
+            );
+        }
+    }
+
+    // ── error paths ────────────────────────────────────────────
+
+    #[test]
+    fn istft_rejects_empty_spectrogram() {
+        let err = istft(&[], 64, 32, WindowType::Hann, 128).unwrap_err();
+        assert!(matches!(err, StftError::InvalidSpectrogram(_)));
+    }
+
+    #[test]
+    fn istft_rejects_zero_n_fft() {
+        let err =
+            istft(&[0.0; 16], 0, 32, WindowType::Hann, 128).unwrap_err();
+        assert!(matches!(err, StftError::InvalidParam(_)));
+    }
+
+    #[test]
+    fn istft_rejects_zero_hop() {
+        let err =
+            istft(&[0.0; 16], 64, 0, WindowType::Hann, 128).unwrap_err();
+        assert!(matches!(err, StftError::InvalidParam(_)));
+    }
+
+    #[test]
+    fn istft_rejects_zero_output_length() {
+        let err = istft(&[0.0; 16], 64, 32, WindowType::Hann, 0).unwrap_err();
+        assert!(matches!(err, StftError::InvalidParam(_)));
+    }
+
+    #[test]
+    fn istft_rejects_misaligned_spectrogram() {
+        // n_fft=64 → bins=33 → 66 floats per frame. Length 100
+        // is not a multiple of 66.
+        let err =
+            istft(&[0.0; 100], 64, 32, WindowType::Hann, 128).unwrap_err();
+        assert!(matches!(err, StftError::InvalidSpectrogram(_)));
+    }
+
+    // ── round-trip (COLA) ──────────────────────────────────────
+
+    #[test]
+    fn istft_recovers_signal_with_hann_hop_half() {
+        // Hann window at hop = n_fft / 2 satisfies COLA exactly,
+        // so the istft(stft(x)) round-trip should recover the
+        // signal within FP tolerance.  We compare the central
+        // portion of the recovered signal (skip the edges where
+        // boundary effects matter).
+        let n_fft = 256u32;
+        let hop = 128u32;
+        let signal: Vec<f32> = (0..2048)
+            .map(|i| ((i as f32) * 0.05).sin() + 0.3 * ((i as f32) * 0.02).cos())
+            .collect();
+        let spec = stft(&signal, n_fft, hop, WindowType::Hann).unwrap();
+        let recovered = istft(
+            &spec,
+            n_fft,
+            hop,
+            WindowType::Hann,
+            signal.len() as u32,
+        )
+        .unwrap();
+        // Central portion: skip the first and last n_fft/2
+        // samples (boundary transients where overlap-add
+        // hasn't fully built up).
+        let pad = (n_fft / 2) as usize;
+        assert_close(
+            &recovered[pad..(signal.len() - pad)],
+            &signal[pad..(signal.len() - pad)],
+            1e-3,
+        );
+    }
+
+    #[test]
+    fn istft_output_length_matches_request() {
+        // The output length is whatever the caller asks for,
+        // regardless of how many frames the spectrogram has.
+        let n_fft = 128u32;
+        let hop = 64u32;
+        let signal = vec![0.5f32; 512];
+        let spec = stft(&signal, n_fft, hop, WindowType::Hann).unwrap();
+        let recovered =
+            istft(&spec, n_fft, hop, WindowType::Hann, 512).unwrap();
+        assert_eq!(recovered.len(), 512);
+    }
+
+    #[test]
+    fn istft_constant_signal_round_trip_under_hann() {
+        // Constant signal with COLA-satisfying Hann/hop=n_fft/2:
+        // each sample in the central region should match the
+        // original constant.
+        let n_fft = 128u32;
+        let hop = 64u32;
+        let signal = vec![1.5f32; 1024];
+        let spec = stft(&signal, n_fft, hop, WindowType::Hann).unwrap();
+        let recovered =
+            istft(&spec, n_fft, hop, WindowType::Hann, 1024).unwrap();
+        let pad = (n_fft / 2) as usize;
+        for n in pad..(1024 - pad) {
+            assert!(
+                approx_eq(recovered[n], 1.5, 1e-3),
+                "n={}: got {}, expected 1.5",
+                n,
+                recovered[n]
+            );
+        }
+    }
+}

--- a/code/packages/rust/dsp-stft/src/lib.rs
+++ b/code/packages/rust/dsp-stft/src/lib.rs
@@ -38,6 +38,11 @@
 
 #![warn(rust_2018_idioms)]
 
+pub mod inverse;
+pub mod spectrogram;
+pub use inverse::istft;
+pub use spectrogram::{log_spectrogram, spectrogram};
+
 use dsp_fft::{rfft_scalar, FftError};
 pub use dsp_filters::WindowType;
 use std::f32::consts::PI;

--- a/code/packages/rust/dsp-stft/src/spectrogram.rs
+++ b/code/packages/rust/dsp-stft/src/spectrogram.rs
@@ -1,0 +1,146 @@
+//! # Magnitude and log spectrograms (DSP05 Phase 4)
+//!
+//! Convenience helpers that compute the STFT and then collapse
+//! the complex spectrum into a real-valued magnitude or
+//! log-magnitude image — the form used for plotting, machine
+//! learning input features, and most audio analysis pipelines.
+
+use crate::{stft, StftError, WindowType};
+
+/// Power spectrogram — `|STFT|²` at each time-frequency bin.
+///
+/// Returns a flattened row-major `[num_frames, n_fft/2 + 1]`
+/// `Vec<f32>` of non-negative real values.  Length is
+/// `num_frames · (n_fft/2 + 1)` (i.e. half the size of the
+/// complex spectrogram from `stft`, since we collapse the two
+/// interleaved `[re, im]` lanes into one magnitude lane).
+///
+/// Useful for energy visualisation, voice activity detection,
+/// audio fingerprinting, etc.
+pub fn spectrogram(
+    signal: &[f32],
+    n_fft: u32,
+    hop_length: u32,
+    window: WindowType,
+) -> Result<Vec<f32>, StftError> {
+    let complex_spec = stft(signal, n_fft, hop_length, window)?;
+    let nf = n_fft as usize;
+    let bins = nf / 2 + 1;
+    let frame_floats = bins * 2;
+    debug_assert!(complex_spec.len() % frame_floats == 0);
+    let num_frames = complex_spec.len() / frame_floats;
+    let mut out = Vec::with_capacity(num_frames * bins);
+    for m in 0..num_frames {
+        let frame =
+            &complex_spec[m * frame_floats..(m + 1) * frame_floats];
+        for k in 0..bins {
+            let re = frame[2 * k];
+            let im = frame[2 * k + 1];
+            out.push(re * re + im * im);
+        }
+    }
+    debug_assert_eq!(out.len(), num_frames * bins);
+    Ok(out)
+}
+
+/// Log-power spectrogram — `log(|STFT|² + ε)`.
+///
+/// Uses `ε = 1e-10` to keep the logarithm finite at silent
+/// bins (`|STFT|² == 0` would otherwise produce `-∞`).  Output
+/// shape and length match [`spectrogram`].
+///
+/// Used as the input feature for MFCCs (after the mel
+/// filterbank in Phase 5), for spectrograms in plotting / ML
+/// pipelines (where the log compression makes quiet structure
+/// visible), and for perceptual loss functions in audio
+/// neural networks.
+pub fn log_spectrogram(
+    signal: &[f32],
+    n_fft: u32,
+    hop_length: u32,
+    window: WindowType,
+) -> Result<Vec<f32>, StftError> {
+    const EPS: f32 = 1e-10;
+    let mut power = spectrogram(signal, n_fft, hop_length, window)?;
+    for v in &mut power {
+        *v = (*v + EPS).ln();
+    }
+    Ok(power)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── spectrogram ────────────────────────────────────────────
+
+    #[test]
+    fn spectrogram_is_non_negative() {
+        // |STFT|² ≥ 0 by construction.
+        let signal: Vec<f32> =
+            (0..1024).map(|i| ((i as f32) * 0.1).sin()).collect();
+        let spec =
+            spectrogram(&signal, 256, 128, WindowType::Hann).unwrap();
+        for &v in &spec {
+            assert!(v >= 0.0, "negative bin: {}", v);
+        }
+    }
+
+    #[test]
+    fn spectrogram_length_matches_num_frames_times_bins() {
+        let n: usize = 1024;
+        let n_fft = 256u32;
+        let hop = 128u32;
+        let signal = vec![0.0f32; n];
+        let spec =
+            spectrogram(&signal, n_fft, hop, WindowType::Hann).unwrap();
+        let expected_frames = 1 + (n - n_fft as usize) / hop as usize;
+        let bins = (n_fft as usize) / 2 + 1;
+        assert_eq!(spec.len(), expected_frames * bins);
+    }
+
+    #[test]
+    fn spectrogram_of_zero_signal_is_all_zero() {
+        let signal = vec![0.0f32; 1024];
+        let spec =
+            spectrogram(&signal, 256, 128, WindowType::Hann).unwrap();
+        for &v in &spec {
+            assert_eq!(v, 0.0);
+        }
+    }
+
+    // ── log spectrogram ────────────────────────────────────────
+
+    #[test]
+    fn log_spectrogram_is_finite() {
+        // log(power + ε) is always finite (ε > 0 prevents -∞).
+        let signal: Vec<f32> =
+            (0..1024).map(|i| ((i as f32) * 0.07).cos()).collect();
+        let log_spec =
+            log_spectrogram(&signal, 256, 128, WindowType::Hann).unwrap();
+        for &v in &log_spec {
+            assert!(v.is_finite(), "non-finite value: {}", v);
+        }
+    }
+
+    #[test]
+    fn log_spectrogram_of_zero_signal_is_near_log_eps() {
+        // log(0 + 1e-10) ≈ -23.0259 — finite, just very small.
+        let signal = vec![0.0f32; 1024];
+        let log_spec =
+            log_spectrogram(&signal, 256, 128, WindowType::Hann).unwrap();
+        let expected = (1e-10f32).ln(); // ≈ -23.0259
+        for &v in &log_spec {
+            assert!((v - expected).abs() < 1e-4, "got {}", v);
+        }
+    }
+
+    #[test]
+    fn log_spectrogram_length_matches_spectrogram() {
+        let signal: Vec<f32> = (0..1024).map(|i| (i as f32) * 0.01).collect();
+        let spec = spectrogram(&signal, 256, 128, WindowType::Hann).unwrap();
+        let log_spec =
+            log_spectrogram(&signal, 256, 128, WindowType::Hann).unwrap();
+        assert_eq!(spec.len(), log_spec.len());
+    }
+}


### PR DESCRIPTION
## Summary

- **`istft`** — overlap-add reconstruction with COLA-aware sum-of-squared-windows normalization. Under COLA-satisfying window/hop choices (Hann at `hop = n_fft/2` is canonical), `istft(stft(x))` recovers `x` within `1e-3` relative tolerance in the central region.
- **`spectrogram`** — `|STFT|²`, flattened `[num_frames, n_fft/2 + 1]`. Half the size of the complex spectrogram (one magnitude lane instead of two `[re, im]` lanes). Non-negative by construction.
- **`log_spectrogram`** — `log(|STFT|² + ε)` with `ε = 1e-10`. Always finite, no `-∞` at silent bins. Canonical input feature for plotting and ML pipelines.

Bumped `dsp-stft` to `0.2.0`.

## Algorithm — `istft`

For each frame `m`: irfft the spectrum to length-`n_fft` time-domain, multiply by the synthesis window, add into the output buffer at position `m · hop_length`. Also accumulate the sum-of-squared-windows at each position. Divide the output by that running norm (skipping samples where the norm is near-zero).

## Test plan

- [x] `cargo test -p dsp-stft` — 25 unit tests + 1 doctest pass (11 stft + 8 inverse + 6 spectrogram)
- [x] COLA round-trip recovers Hann/hop=n_fft/2 signal within 1e-3 in central region
- [x] Constant signal round-trips to the same constant
- [x] All error paths: empty spectrogram, n_fft=0, hop=0, output_length=0, misaligned spectrogram length
- [x] spectrogram non-negative; zero signal → all-zero spectrogram
- [x] log_spectrogram finite everywhere; zero signal → ≈ log(ε) ≈ -23.0259
- [x] Security review: pure-Rust math, no FFI/unsafe, only LOW/INFO defense-in-depth findings

## What this PR does NOT include

- Phase 5: `mel_filterbank` + `mel_spectrogram` + `mfcc`
- Phase 6: matrix-ir-lowered `stft`
- Centred-padding mode
- Streaming / real-time API

🤖 Generated with [Claude Code](https://claude.com/claude-code)