### PR TITLE
spice: add behavioral source elements

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Behavioral B sources** — `BSource` adds DC behavioral current and voltage
+  sources with arithmetic expressions over constants and node-voltage
+  references `V(node)` / `V(node1,node2)`.
+
 - **Inductor initial current** — `Inductor` now accepts an `initial_current`
   value that seeds transient analysis companion models.
 

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -2,6 +2,7 @@
 
 from spice_engine.elements import (
     AcSource,
+    BSource,
     BJT,
     CCCS,
     CCVS,
@@ -54,6 +55,7 @@ __all__ = [
     "AcPoint",
     "AcResult",
     "AcSource",
+    "BSource",
     "BJT",
     "CCCS",
     "CCVS",

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -330,6 +330,26 @@ class CurrentSource:
 
 
 @dataclass(frozen=True, slots=True)
+class BSource:
+    """Behavioral source (SPICE ``B`` element).
+
+    Exactly one expression must be supplied. ``current_expr`` models a current
+    flowing from ``n_plus`` to ``n_minus``. ``voltage_expr`` models the voltage
+    constraint ``V(n_plus, n_minus)`` and introduces a branch unknown, like an
+    ideal voltage source.
+
+    Expressions support numeric constants, ``+``, ``-``, ``*``, ``/``,
+    parentheses, and node-voltage references ``V(node)`` or ``V(node1,node2)``.
+    """
+
+    name: str
+    n_plus: str
+    n_minus: str
+    voltage_expr: str | None = None
+    current_expr: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class Diode:
     """Simple diode using Shockley equation."""
 
@@ -657,6 +677,7 @@ Element = (
     | Inductor
     | VoltageSource
     | CurrentSource
+    | BSource
     | Diode
     | Mosfet
     | BJT

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -47,14 +47,17 @@ For transient: two integration methods are supported:
 
 from __future__ import annotations
 
+import ast
 import cmath
 import math
 import random
+import re
 import statistics
 from dataclasses import dataclass, field
 
 from spice_engine.elements import (
     AcSource,
+    BSource,
     BJT,
     CCCS,
     CCVS,
@@ -303,6 +306,12 @@ def _element_nodes(el: Element) -> list[str]:
     """All nodes touched by an element."""
     if isinstance(el, (Resistor, Capacitor, Inductor, VoltageSource, CurrentSource)):
         return [el.n_plus, el.n_minus]
+    if isinstance(el, BSource):
+        nodes = [el.n_plus, el.n_minus]
+        expr = el.voltage_expr if el.voltage_expr is not None else el.current_expr
+        if expr is not None:
+            nodes.extend(_bsource_expr_nodes(expr))
+        return nodes
     if isinstance(el, Diode):
         return [el.anode, el.cathode]
     if isinstance(el, Mosfet):
@@ -325,7 +334,7 @@ def _voltage_sources(circuit: Circuit) -> list[VoltageSource]:
 
 def _branch_sources(
     circuit: Circuit,
-) -> list[VoltageSource | VCVS | CCVS]:
+) -> list[VoltageSource | VCVS | CCVS | BSource]:
     """Elements that require a branch unknown (current variable) in MNA.
 
     All three element types introduce a KVL constraint row and a corresponding
@@ -351,10 +360,13 @@ def _branch_sources(
     vcvs_list: list[VoltageSource | VCVS | CCVS] = [
         el for el in circuit.elements if isinstance(el, VCVS)
     ]
-    ccvs_list: list[VoltageSource | VCVS | CCVS] = [
+    ccvs_list: list[VoltageSource | VCVS | CCVS | BSource] = [
         el for el in circuit.elements if isinstance(el, CCVS)
     ]
-    return vsrcs + vcvs_list + ccvs_list
+    bsources: list[VoltageSource | VCVS | CCVS | BSource] = [
+        el for el in circuit.elements if isinstance(el, BSource) and el.voltage_expr is not None
+    ]
+    return vsrcs + vcvs_list + ccvs_list + bsources
 
 
 def _is_ground(name: str) -> bool:
@@ -698,7 +710,7 @@ def _stamp_dc(
     b: list[float],
     x: list[float],
     node_to_idx: dict[str, int],
-    branch_srcs: list[VoltageSource | VCVS | CCVS],
+    branch_srcs: list[VoltageSource | VCVS | CCVS | BSource],
 ) -> None:
     """Stamp one element's MNA contribution at the current operating point."""
     n_nodes = len(node_to_idx)
@@ -712,6 +724,8 @@ def _stamp_dc(
             b[node_to_idx[el.n_plus]] -= el.current
         if not _is_ground(el.n_minus):
             b[node_to_idx[el.n_minus]] += el.current
+    elif isinstance(el, BSource):
+        _stamp_bsource(G, b, x, node_to_idx, branch_srcs, el)
     elif isinstance(el, Diode):
         _stamp_diode(G, b, x, node_to_idx, el)
     elif isinstance(el, Mosfet):
@@ -786,15 +800,155 @@ def _stamp_vsrc(
     b[branch_idx] = el.voltage
 
 
+def _bsource_expr_nodes(expr: str) -> list[str]:
+    nodes: list[str] = []
+    for match in re.finditer(r"V\s*\(([^)]*)\)", expr):
+        args = [arg.strip() for arg in match.group(1).split(",")]
+        if len(args) not in (1, 2):
+            raise ValueError("V() expects one or two node arguments")
+        for node_name in args:
+            if node_name and not _is_ground(node_name):
+                nodes.append(node_name)
+    return nodes
+
+
+def _normalize_bsource_expr(expr: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        args = [arg.strip() for arg in match.group(1).split(",")]
+        if len(args) not in (1, 2):
+            raise ValueError("V() expects one or two node arguments")
+        return "V(" + ", ".join(repr(arg) for arg in args) + ")"
+
+    return re.sub(r"V\s*\(([^)]*)\)", replace, expr)
+
+
+def _ast_call_name(node: ast.Call) -> str | None:
+    return node.func.id if isinstance(node.func, ast.Name) else None
+
+
+def _ast_node_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Constant) and isinstance(node.value, (str, int)):
+        return str(node.value)
+    raise ValueError("V() node references must be bare node names or 0")
+
+
+def _bsource_voltage(name: str, node_to_idx: dict[str, int], x: list[float]) -> float:
+    return 0.0 if _is_ground(name) else x[node_to_idx[name]]
+
+
+def _eval_bsource_expr(expr: str, node_to_idx: dict[str, int], x: list[float]) -> float:
+    normalized_expr = _normalize_bsource_expr(expr)
+    tree = ast.parse(normalized_expr, mode="eval")
+
+    def eval_node(node: ast.AST) -> float:
+        if isinstance(node, ast.Expression):
+            return eval_node(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return float(node.value)
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+            value = eval_node(node.operand)
+            return value if isinstance(node.op, ast.UAdd) else -value
+        if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub, ast.Mult, ast.Div)):
+            left = eval_node(node.left)
+            right = eval_node(node.right)
+            if isinstance(node.op, ast.Add):
+                return left + right
+            if isinstance(node.op, ast.Sub):
+                return left - right
+            if isinstance(node.op, ast.Mult):
+                return left * right
+            return left / right
+        if isinstance(node, ast.Call) and _ast_call_name(node) == "V":
+            if len(node.args) == 1:
+                return _bsource_voltage(_ast_node_name(node.args[0]), node_to_idx, x)
+            if len(node.args) == 2:
+                return (
+                    _bsource_voltage(_ast_node_name(node.args[0]), node_to_idx, x)
+                    - _bsource_voltage(_ast_node_name(node.args[1]), node_to_idx, x)
+                )
+        raise ValueError(f"unsupported behavioral source expression in '{expr}'")
+
+    value = eval_node(tree)
+    if not math.isfinite(value):
+        raise ValueError(f"behavioral source expression produced non-finite value: {expr}")
+    return value
+
+
+def _bsource_linearization(
+    expr: str,
+    node_to_idx: dict[str, int],
+    x: list[float],
+) -> tuple[float, dict[str, float], float]:
+    value = _eval_bsource_expr(expr, node_to_idx, x)
+    derivatives: dict[str, float] = {}
+    for node, idx in node_to_idx.items():
+        h = max(1e-6, abs(x[idx]) * 1e-6)
+        xp = list(x)
+        xm = list(x)
+        xp[idx] += h
+        xm[idx] -= h
+        derivatives[node] = (
+            _eval_bsource_expr(expr, node_to_idx, xp)
+            - _eval_bsource_expr(expr, node_to_idx, xm)
+        ) / (2.0 * h)
+    offset = value - sum(derivatives[node] * x[idx] for node, idx in node_to_idx.items())
+    return value, derivatives, offset
+
+
+def _stamp_bsource(
+    G: list[list[float]],
+    b: list[float],
+    x: list[float],
+    node_to_idx: dict[str, int],
+    branch_srcs: list[VoltageSource | VCVS | CCVS | BSource],
+    el: BSource,
+) -> None:
+    has_voltage = el.voltage_expr is not None
+    has_current = el.current_expr is not None
+    if has_voltage == has_current:
+        raise ValueError(f"BSource '{el.name}' must define exactly one voltage_expr or current_expr.")
+
+    if el.current_expr is not None:
+        _, derivatives, offset = _bsource_linearization(el.current_expr, node_to_idx, x)
+        if not _is_ground(el.n_plus):
+            row = node_to_idx[el.n_plus]
+            for node, derivative in derivatives.items():
+                G[row][node_to_idx[node]] += derivative
+            b[row] -= offset
+        if not _is_ground(el.n_minus):
+            row = node_to_idx[el.n_minus]
+            for node, derivative in derivatives.items():
+                G[row][node_to_idx[node]] -= derivative
+            b[row] += offset
+        return
+
+    assert el.voltage_expr is not None
+    _, derivatives, offset = _bsource_linearization(el.voltage_expr, node_to_idx, x)
+    branch_idx = len(node_to_idx) + branch_srcs.index(el)
+    if not _is_ground(el.n_plus):
+        p = node_to_idx[el.n_plus]
+        G[p][branch_idx] += 1.0
+        G[branch_idx][p] += 1.0
+    if not _is_ground(el.n_minus):
+        q = node_to_idx[el.n_minus]
+        G[q][branch_idx] -= 1.0
+        G[branch_idx][q] -= 1.0
+    for node, derivative in derivatives.items():
+        G[branch_idx][node_to_idx[node]] -= derivative
+    b[branch_idx] += offset
+
+
 # ---------------------------------------------------------------------------
 # Controlled-source MNA stamps
 # ---------------------------------------------------------------------------
 
 
 def _find_branch_source(
-    branch_srcs: list[VoltageSource | VCVS | CCVS],
+    branch_srcs: list[VoltageSource | VCVS | CCVS | BSource],
     name: str,
-) -> VoltageSource | VCVS | CCVS | None:
+) -> VoltageSource | VCVS | CCVS | BSource | None:
     """Return the branch-source element with the given name, or None."""
     for el in branch_srcs:
         if el.name == name:

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -78,6 +78,7 @@ from math import exp, isclose
 import pytest
 
 from spice_engine import (
+    BSource,
     BJT,
     CCCS,
     CCVS,
@@ -196,6 +197,27 @@ def test_current_source_into_resistor():
     c.add(Resistor("R1", "n1", "0", 1000.0))
     r = dc_op(c)
     assert isclose(r.node_voltages["n1"], 1.0, abs_tol=1e-6)
+
+
+def test_behavioral_current_source_tracks_node_voltage():
+    c = Circuit()
+    c.add(VoltageSource("Vin", "in", "0", voltage=2.0))
+    c.add(BSource("B1", "0", "out", current_expr="0.002 * V(in)"))
+    c.add(Resistor("Rload", "out", "0", 1000.0))
+    r = dc_op(c)
+    assert r.converged
+    assert isclose(r.node_voltages["out"], 4.0, abs_tol=1e-6)
+
+
+def test_behavioral_voltage_source_tracks_differential_voltage():
+    c = Circuit()
+    c.add(VoltageSource("Vin", "in", "0", voltage=3.0))
+    c.add(BSource("B1", "out", "0", voltage_expr="2.0 * V(in, 0) + 1.0"))
+    c.add(Resistor("Rload", "out", "0", 1000.0))
+    r = dc_op(c)
+    assert r.converged
+    assert isclose(r.node_voltages["out"], 7.0, abs_tol=1e-6)
+    assert "I(B1)" in r.branch_currents
 
 
 def test_branch_current_in_voltage_source():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add behavioral B sources for DC current and voltage expressions over
+  constants and `V(node)` / `V(node1,node2)` node-voltage references.
 - Add DC operating-point convergence metadata and configurable Newton controls,
   with nonlinear Gmin/source stepping fallback aids for difficult bias points.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -340,6 +340,7 @@ pub enum Element {
     Inductor(Inductor),
     VoltageSource(VoltageSource),
     CurrentSource(CurrentSource),
+    BSource(BSource),
     Diode(Diode),
     Bjt(Bjt),
     Mosfet(Mosfet),
@@ -567,6 +568,47 @@ impl CurrentSource {
             current,
             ac: None,
             waveform: Some(waveform),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BSource {
+    pub name: String,
+    pub positive: String,
+    pub negative: String,
+    pub voltage_expr: Option<String>,
+    pub current_expr: Option<String>,
+}
+
+impl BSource {
+    pub fn current(
+        name: impl Into<String>,
+        positive: impl Into<String>,
+        negative: impl Into<String>,
+        current_expr: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            positive: positive.into(),
+            negative: negative.into(),
+            voltage_expr: None,
+            current_expr: Some(current_expr.into()),
+        }
+    }
+
+    pub fn voltage(
+        name: impl Into<String>,
+        positive: impl Into<String>,
+        negative: impl Into<String>,
+        voltage_expr: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            positive: positive.into(),
+            negative: negative.into(),
+            voltage_expr: Some(voltage_expr.into()),
+            current_expr: None,
         }
     }
 }
@@ -1889,7 +1931,7 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
             "transresistance_ohms".to_string(),
             source.transresistance_ohms,
         )),
-        Element::Capacitor(_) | Element::Inductor(_) => None,
+        Element::BSource(_) | Element::Capacitor(_) | Element::Inductor(_) => None,
     }
 }
 
@@ -1909,7 +1951,7 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::Vcvs(source) => source.gain += delta,
         Element::Cccs(source) => source.gain += delta,
         Element::Ccvs(source) => source.transresistance_ohms += delta,
-        Element::Capacitor(_) | Element::Inductor(_) => {}
+        Element::BSource(_) | Element::Capacitor(_) | Element::Inductor(_) => {}
     }
 }
 
@@ -2032,7 +2074,7 @@ fn randomized_element(
                 randomized_value(varied.transresistance_ohms, tolerance, distribution, rng);
             Element::Ccvs(varied)
         }
-        Element::Capacitor(_) | Element::Inductor(_) => element.clone(),
+        Element::BSource(_) | Element::Capacitor(_) | Element::Inductor(_) => element.clone(),
     }
 }
 
@@ -2173,7 +2215,7 @@ fn solve_linear_circuit_with_options(
     let has_nonlinear = circuit.elements().iter().any(|element| {
         matches!(
             element,
-            Element::Diode(_) | Element::Bjt(_) | Element::Mosfet(_)
+            Element::Diode(_) | Element::Bjt(_) | Element::Mosfet(_) | Element::BSource(_)
         )
     });
     let return_singular_as_unconverged = options.return_singular_as_unconverged && has_nonlinear;
@@ -2330,6 +2372,15 @@ fn solve_linear_circuit_at_operating_point(
             Element::CurrentSource(source) => {
                 stamp_current_source(source, node_indices, source_time, &mut rhs)?
             }
+            Element::BSource(source) => stamp_bsource(
+                source,
+                node_indices,
+                voltage_sources,
+                node_count,
+                &mut matrix,
+                &mut rhs,
+                operating_point,
+            )?,
             Element::Diode(diode) => {
                 stamp_diode(diode, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
@@ -2453,6 +2504,7 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             Element::CurrentSource(source) => {
                 stamp_ac_current_source(source, &node_indices, uses_explicit_ac_sources, &mut rhs)?
             }
+            Element::BSource(_) => {}
             Element::Resistor(_)
             | Element::Capacitor(_)
             | Element::Inductor(_)
@@ -2512,6 +2564,14 @@ fn build_ac_matrix(
             Element::CurrentSource(source) => {
                 validate_ac_current_source(source)?;
             }
+            Element::BSource(source) => stamp_ac_bsource(
+                source,
+                node_indices,
+                voltage_sources,
+                node_count,
+                &mut matrix,
+                operating_point,
+            )?,
             Element::Diode(diode) => {
                 validate_diode(diode)?;
                 let anode = node_index(node_indices, &diode.anode);
@@ -2603,6 +2663,14 @@ fn build_small_signal_matrix(
                     });
                 }
             }
+            Element::BSource(source) => stamp_bsource_small_signal(
+                source,
+                node_indices,
+                voltage_sources,
+                node_count,
+                &mut matrix,
+                operating_point,
+            )?,
             Element::Diode(diode) => {
                 validate_diode(diode)?;
                 let anode = node_index(node_indices, &diode.anode);
@@ -2703,6 +2771,18 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &source.positive);
                 insert_node(&mut names, &source.negative);
             }
+            Element::BSource(source) => {
+                insert_node(&mut names, &source.positive);
+                insert_node(&mut names, &source.negative);
+                let expr = source
+                    .voltage_expr
+                    .as_deref()
+                    .or(source.current_expr.as_deref())
+                    .unwrap_or("");
+                for node in bsource_expr_nodes(expr) {
+                    insert_node(&mut names, &node);
+                }
+            }
             Element::Diode(diode) => {
                 insert_node(&mut names, &diode.anode);
                 insert_node(&mut names, &diode.cathode);
@@ -2763,6 +2843,9 @@ fn collect_voltage_sources(
             Element::Ccvs(source) => {
                 insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
             }
+            Element::BSource(source) if source.voltage_expr.is_some() => {
+                insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
+            }
             Element::Inductor(inductor) => {
                 if sources.contains_key(&inductor.name) {
                     return Err(SpiceError::InvalidElement {
@@ -2796,6 +2879,9 @@ fn collect_ac_voltage_sources(circuit: &Circuit) -> Result<BTreeMap<String, usiz
             Element::Ccvs(source) => {
                 insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
             }
+            Element::BSource(source) if source.voltage_expr.is_some() => {
+                insert_branch_name(&mut sources, &source.name, "duplicate voltage source name")?;
+            }
             _ => {}
         }
     }
@@ -2813,6 +2899,9 @@ fn find_input_source<'a>(
             }
             Element::CurrentSource(source) if source.name == input_source => {
                 return Ok(InputSource::Current(source));
+            }
+            Element::BSource(source) if source.name == input_source => {
+                return Err(input_source_type_error(input_source, "B-source"));
             }
             Element::Resistor(resistor) if resistor.name == input_source => {
                 return Err(input_source_type_error(input_source, "resistor"));
@@ -3740,6 +3829,424 @@ fn source_current_at(source: &CurrentSource, source_time: Option<f64>) -> Result
     } else {
         Ok(source.current)
     }
+}
+
+struct BSourceExprParser<'a, F: Fn(&str) -> f64> {
+    input: &'a str,
+    position: usize,
+    resolver: F,
+}
+
+impl<'a, F: Fn(&str) -> f64> BSourceExprParser<'a, F> {
+    fn new(input: &'a str, resolver: F) -> Self {
+        Self {
+            input,
+            position: 0,
+            resolver,
+        }
+    }
+
+    fn parse(mut self) -> Result<f64, String> {
+        let value = self.parse_expression()?;
+        self.skip_whitespace();
+        if self.position != self.input.len() {
+            return Err("unexpected expression input".to_string());
+        }
+        Ok(value)
+    }
+
+    fn parse_expression(&mut self) -> Result<f64, String> {
+        let mut value = self.parse_term()?;
+        loop {
+            self.skip_whitespace();
+            if self.consume("+") {
+                value += self.parse_term()?;
+            } else if self.consume("-") {
+                value -= self.parse_term()?;
+            } else {
+                return Ok(value);
+            }
+        }
+    }
+
+    fn parse_term(&mut self) -> Result<f64, String> {
+        let mut value = self.parse_factor()?;
+        loop {
+            self.skip_whitespace();
+            if self.consume("*") {
+                value *= self.parse_factor()?;
+            } else if self.consume("/") {
+                value /= self.parse_factor()?;
+            } else {
+                return Ok(value);
+            }
+        }
+    }
+
+    fn parse_factor(&mut self) -> Result<f64, String> {
+        self.skip_whitespace();
+        if self.consume("+") {
+            return self.parse_factor();
+        }
+        if self.consume("-") {
+            return Ok(-self.parse_factor()?);
+        }
+        if self.consume("(") {
+            let value = self.parse_expression()?;
+            self.expect(")")?;
+            return Ok(value);
+        }
+        if self.peek("V") {
+            self.position += 1;
+            self.expect("(")?;
+            let first = self.parse_node_name()?;
+            self.skip_whitespace();
+            if self.consume(",") {
+                let second = self.parse_node_name()?;
+                self.expect(")")?;
+                return Ok((self.resolver)(&first) - (self.resolver)(&second));
+            }
+            self.expect(")")?;
+            return Ok((self.resolver)(&first));
+        }
+        self.parse_number()
+    }
+
+    fn parse_number(&mut self) -> Result<f64, String> {
+        self.skip_whitespace();
+        let start = self.position;
+        while self
+            .input
+            .as_bytes()
+            .get(self.position)
+            .is_some_and(u8::is_ascii_digit)
+        {
+            self.position += 1;
+        }
+        if self.peek(".") {
+            self.position += 1;
+            while self
+                .input
+                .as_bytes()
+                .get(self.position)
+                .is_some_and(u8::is_ascii_digit)
+            {
+                self.position += 1;
+            }
+        }
+        if self.peek("e") || self.peek("E") {
+            self.position += 1;
+            if self.peek("+") || self.peek("-") {
+                self.position += 1;
+            }
+            while self
+                .input
+                .as_bytes()
+                .get(self.position)
+                .is_some_and(u8::is_ascii_digit)
+            {
+                self.position += 1;
+            }
+        }
+        if self.position == start {
+            return Err("expected number".to_string());
+        }
+        let value = self.input[start..self.position]
+            .parse::<f64>()
+            .map_err(|_| "invalid number".to_string())?;
+        if !value.is_finite() {
+            return Err("number must be finite".to_string());
+        }
+        Ok(value)
+    }
+
+    fn parse_node_name(&mut self) -> Result<String, String> {
+        self.skip_whitespace();
+        let start = self.position;
+        while let Some(ch) = self.input[self.position..].chars().next() {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | '$' | ':' | '-') {
+                self.position += ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+        if self.position == start {
+            return Err("expected node name".to_string());
+        }
+        self.skip_whitespace();
+        Ok(self.input[start..self.position].to_string())
+    }
+
+    fn consume(&mut self, token: &str) -> bool {
+        self.skip_whitespace();
+        if self.input[self.position..].starts_with(token) {
+            self.position += token.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn expect(&mut self, token: &str) -> Result<(), String> {
+        if self.consume(token) {
+            Ok(())
+        } else {
+            Err(format!("expected {token}"))
+        }
+    }
+
+    fn peek(&self, token: &str) -> bool {
+        self.input[self.position..].starts_with(token)
+    }
+
+    fn skip_whitespace(&mut self) {
+        while let Some(ch) = self.input[self.position..].chars().next() {
+            if ch.is_whitespace() {
+                self.position += ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+fn bsource_expr_nodes(expr: &str) -> Vec<String> {
+    let mut nodes = Vec::new();
+    let mut rest = expr;
+    while let Some(start) = rest.find("V(") {
+        rest = &rest[start + 2..];
+        let Some(end) = rest.find(')') else {
+            break;
+        };
+        for node in rest[..end].split(',') {
+            let trimmed = node.trim();
+            if !trimmed.is_empty() && !is_ground(trimmed) {
+                nodes.push(trimmed.to_string());
+            }
+        }
+        rest = &rest[end + 1..];
+    }
+    nodes
+}
+
+fn eval_bsource_expr(
+    expr: &str,
+    node_indices: &HashMap<String, usize>,
+    operating_point: &[f64],
+) -> Result<f64, String> {
+    let value = BSourceExprParser::new(expr, |node: &str| {
+        node_index(node_indices, node).map_or(0.0, |index| operating_point[index])
+    })
+    .parse()?;
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err("expression produced a non-finite value".to_string())
+    }
+}
+
+fn bsource_linearization(
+    expr: &str,
+    node_indices: &HashMap<String, usize>,
+    operating_point: &[f64],
+) -> Result<(BTreeMap<String, f64>, f64), String> {
+    let value = eval_bsource_expr(expr, node_indices, operating_point)?;
+    let mut derivatives = BTreeMap::new();
+    for (node, index) in node_indices {
+        let h = (operating_point[*index].abs() * 1.0e-6).max(1.0e-6);
+        let mut plus = operating_point.to_vec();
+        let mut minus = operating_point.to_vec();
+        plus[*index] += h;
+        minus[*index] -= h;
+        let derivative = (eval_bsource_expr(expr, node_indices, &plus)?
+            - eval_bsource_expr(expr, node_indices, &minus)?)
+            / (2.0 * h);
+        derivatives.insert(node.clone(), derivative);
+    }
+    let linear_part = derivatives
+        .iter()
+        .map(|(node, derivative)| derivative * operating_point[node_indices[node]])
+        .sum::<f64>();
+    Ok((derivatives, value - linear_part))
+}
+
+fn validate_bsource(source: &BSource) -> Result<(), SpiceError> {
+    if source.voltage_expr.is_some() == source.current_expr.is_some() {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "B-source must define exactly one voltage_expr or current_expr".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn stamp_bsource(
+    source: &BSource,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    node_count: usize,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_bsource(source)?;
+    if let Some(expr) = &source.current_expr {
+        let (derivatives, offset) = bsource_linearization(expr, node_indices, operating_point)
+            .map_err(|reason| SpiceError::InvalidElement {
+                name: source.name.clone(),
+                reason,
+            })?;
+        let positive = node_index(node_indices, &source.positive);
+        let negative = node_index(node_indices, &source.negative);
+        if let Some(row) = positive {
+            for (node, derivative) in &derivatives {
+                matrix[row][node_indices[node]] += derivative;
+            }
+            rhs[row] -= offset;
+        }
+        if let Some(row) = negative {
+            for (node, derivative) in &derivatives {
+                matrix[row][node_indices[node]] -= derivative;
+            }
+            rhs[row] += offset;
+        }
+        return Ok(());
+    }
+    let Some(expr) = &source.voltage_expr else {
+        return Ok(());
+    };
+    let Some(source_index) = voltage_sources.get(&source.name) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "voltage B-source was not indexed".to_string(),
+        });
+    };
+    let branch = node_count + source_index;
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    stamp_branch_matrix(matrix, branch, positive, negative);
+    let (derivatives, offset) = bsource_linearization(expr, node_indices, operating_point)
+        .map_err(|reason| SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason,
+        })?;
+    for (node, derivative) in derivatives {
+        matrix[branch][node_indices[&node]] -= derivative;
+    }
+    rhs[branch] += offset;
+    Ok(())
+}
+
+fn stamp_bsource_small_signal(
+    source: &BSource,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    node_count: usize,
+    matrix: &mut [Vec<f64>],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_bsource(source)?;
+    if let Some(expr) = &source.current_expr {
+        let (derivatives, _) =
+            bsource_linearization(expr, node_indices, operating_point).map_err(|reason| {
+                SpiceError::InvalidElement {
+                    name: source.name.clone(),
+                    reason,
+                }
+            })?;
+        let positive = node_index(node_indices, &source.positive);
+        let negative = node_index(node_indices, &source.negative);
+        for (node, derivative) in derivatives {
+            let control = Some(node_indices[&node]);
+            stamp_transconductance(matrix, positive, negative, control, None, derivative);
+        }
+        return Ok(());
+    }
+
+    let Some(expr) = &source.voltage_expr else {
+        return Ok(());
+    };
+    let Some(source_index) = voltage_sources.get(&source.name) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "voltage B-source was not indexed".to_string(),
+        });
+    };
+    let branch = node_count + source_index;
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    stamp_branch_matrix(matrix, branch, positive, negative);
+    let (derivatives, offset) = bsource_linearization(expr, node_indices, operating_point)
+        .map_err(|reason| SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason,
+        })?;
+    for (node, derivative) in derivatives {
+        matrix[branch][node_indices[&node]] -= derivative;
+    }
+    // DC callers add this offset to the RHS after this helper returns.
+    let _ = offset;
+    Ok(())
+}
+
+fn stamp_ac_bsource(
+    source: &BSource,
+    node_indices: &HashMap<String, usize>,
+    voltage_sources: &BTreeMap<String, usize>,
+    node_count: usize,
+    matrix: &mut [Vec<Complex>],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_bsource(source)?;
+    if let Some(expr) = &source.current_expr {
+        let (derivatives, _) =
+            bsource_linearization(expr, node_indices, operating_point).map_err(|reason| {
+                SpiceError::InvalidElement {
+                    name: source.name.clone(),
+                    reason,
+                }
+            })?;
+        let positive = node_index(node_indices, &source.positive);
+        let negative = node_index(node_indices, &source.negative);
+        for (node, derivative) in derivatives {
+            let control = Some(node_indices[&node]);
+            stamp_complex_transconductance(
+                matrix,
+                positive,
+                negative,
+                control,
+                None,
+                Complex::new(derivative, 0.0),
+            );
+        }
+        return Ok(());
+    }
+
+    let Some(expr) = &source.voltage_expr else {
+        return Ok(());
+    };
+    let Some(source_index) = voltage_sources.get(&source.name) else {
+        return Err(SpiceError::InvalidElement {
+            name: source.name.clone(),
+            reason: "voltage B-source was not indexed".to_string(),
+        });
+    };
+    let branch = node_count + source_index;
+    let positive = node_index(node_indices, &source.positive);
+    let negative = node_index(node_indices, &source.negative);
+    stamp_complex_branch_matrix(matrix, branch, positive, negative);
+    let (derivatives, _) =
+        bsource_linearization(expr, node_indices, operating_point).map_err(|reason| {
+            SpiceError::InvalidElement {
+                name: source.name.clone(),
+                reason,
+            }
+        })?;
+    for (node, derivative) in derivatives {
+        matrix[branch][node_indices[&node]] =
+            matrix[branch][node_indices[&node]] - Complex::new(derivative, 0.0);
+    }
+    Ok(())
 }
 
 fn stamp_vccs(

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,7 +1,7 @@
 use spice_engine::{
-    dc_op, dc_op_with_options, dc_sweep, Bjt, BjtPolarity, Cccs, Ccvs, Circuit, CurrentSource,
-    DcOpOptions, Diode, Element, Inductor, Mosfet, MosfetLevel1Params, MosfetType, Resistor,
-    SinWaveform, SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
+    dc_op, dc_op_with_options, dc_sweep, BSource, Bjt, BjtPolarity, Cccs, Ccvs, Circuit,
+    CurrentSource, DcOpOptions, Diode, Element, Inductor, Mosfet, MosfetLevel1Params, MosfetType,
+    Resistor, SinWaveform, SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -42,6 +42,51 @@ fn dc_current_source_into_resistor_uses_positive_to_negative_orientation() {
     let result = dc_op(&circuit).unwrap();
 
     assert_close(result.voltage("n1").unwrap(), 1.0);
+}
+
+#[test]
+fn dc_behavioral_current_source_tracks_node_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 2.0,
+    )));
+    circuit.add(Element::BSource(BSource::current(
+        "B1",
+        "0",
+        "out",
+        "0.002 * V(in)",
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert!(result.converged);
+    assert_close(result.voltage("out").unwrap(), 4.0);
+}
+
+#[test]
+fn dc_behavioral_voltage_source_tracks_differential_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 3.0,
+    )));
+    circuit.add(Element::BSource(BSource::voltage(
+        "B1",
+        "out",
+        "0",
+        "2.0 * V(in, 0) + 1.0",
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert!(result.converged);
+    assert_close(result.voltage("out").unwrap(), 7.0);
+    assert_close(result.branch_current("B1").unwrap(), -7.0e-3);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add behavioral B sources for DC current and voltage expressions over
+  constants and `V(node)` / `V(node1,node2)` node-voltage references.
 - Add independent-source AC phasors with separate DC bias for AC analysis.
   Voltage and current sources can now carry an explicit AC magnitude and
   phase; once any explicit AC source is present, other independent sources are

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -3353,14 +3353,38 @@ class BSourceExpressionParser {
 
 function bSourceExprNodes(expression: string): string[] {
   const nodes: string[] = [];
-  const pattern = /V\s*\(([^)]*)\)/g;
-  for (const match of expression.matchAll(pattern)) {
-    for (const node of match[1].split(",")) {
+  let index = 0;
+  while (index < expression.length) {
+    if (expression[index] !== "V") {
+      index += 1;
+      continue;
+    }
+
+    let cursor = index + 1;
+    while (/\s/.test(expression[cursor] ?? "")) {
+      cursor += 1;
+    }
+    if (expression[cursor] !== "(") {
+      index += 1;
+      continue;
+    }
+
+    const argsStart = cursor + 1;
+    let argsEnd = argsStart;
+    while (argsEnd < expression.length && expression[argsEnd] !== ")") {
+      argsEnd += 1;
+    }
+    if (argsEnd >= expression.length) {
+      break;
+    }
+
+    for (const node of expression.slice(argsStart, argsEnd).split(",")) {
       const trimmed = node.trim();
       if (trimmed !== "" && !isGround(trimmed)) {
         nodes.push(trimmed);
       }
     }
+    index = argsEnd + 1;
   }
   return nodes;
 }

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8,6 +8,7 @@ export type Element =
   | Inductor
   | VoltageSource
   | CurrentSource
+  | BSource
   | Diode
   | Bjt
   | Mosfet
@@ -279,6 +280,15 @@ export interface CurrentSource {
   readonly current: number;
   readonly ac?: AcSource;
   readonly waveform?: Waveform;
+}
+
+export interface BSource {
+  readonly kind: "b-source";
+  readonly name: string;
+  readonly positive: string;
+  readonly negative: string;
+  readonly voltageExpr?: string;
+  readonly currentExpr?: string;
 }
 
 export interface Diode {
@@ -654,6 +664,24 @@ export function currentSourceWithWaveform(
     current,
     waveform,
   };
+}
+
+export function bSourceCurrent(
+  name: string,
+  positive: string,
+  negative: string,
+  currentExpr: string,
+): BSource {
+  return { kind: "b-source", name, positive, negative, currentExpr };
+}
+
+export function bSourceVoltage(
+  name: string,
+  positive: string,
+  negative: string,
+  voltageExpr: string,
+): BSource {
+  return { kind: "b-source", name, positive, negative, voltageExpr };
 }
 
 export function diode(
@@ -1555,6 +1583,8 @@ function randomizedElement(
           rng,
         ),
       };
+    case "b-source":
+      return element;
     case "capacitor":
     case "inductor":
       return element;
@@ -1689,7 +1719,13 @@ function solveLinearCircuitWithOptions(
 
   const hasNonlinearElement = circuit
     .elements()
-    .some((element) => element.kind === "diode" || element.kind === "bjt" || element.kind === "mosfet");
+    .some(
+      (element) =>
+        element.kind === "diode" ||
+        element.kind === "bjt" ||
+        element.kind === "mosfet" ||
+        element.kind === "b-source",
+    );
   const returnSingularAsUnconverged =
     (options.returnSingularAsUnconverged ?? false) && hasNonlinearElement;
   let operatingPoint =
@@ -1937,6 +1973,17 @@ function solveLinearCircuitAtOperatingPoint(
         break;
       case "current-source":
         stampCurrentSource(element, nodeIndices, rhs, sourceTime);
+        break;
+      case "b-source":
+        stampBSource(
+          element,
+          nodeIndices,
+          voltageSources,
+          nodeCount,
+          matrix,
+          rhs,
+          operatingPoint,
+        );
         break;
       case "diode":
         stampDiode(element, nodeIndices, matrix, rhs, operatingPoint);
@@ -2429,6 +2476,15 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.positive);
         insertNode(names, element.negative);
         break;
+      case "b-source":
+        insertNode(names, element.positive);
+        insertNode(names, element.negative);
+        for (const node of bSourceExprNodes(
+          element.voltageExpr ?? element.currentExpr ?? "",
+        )) {
+          insertNode(names, node);
+        }
+        break;
       case "diode":
         insertNode(names, element.anode);
         insertNode(names, element.cathode);
@@ -2483,7 +2539,8 @@ function collectVoltageSources(
     if (
       element.kind === "voltage-source" ||
       element.kind === "vcvs" ||
-      element.kind === "ccvs"
+      element.kind === "ccvs" ||
+      (element.kind === "b-source" && element.voltageExpr !== undefined)
     ) {
       insertBranchName(sources, element.name, "duplicate voltage source name");
     } else if (element.kind === "inductor") {
@@ -2504,7 +2561,8 @@ function collectAcVoltageSources(circuit: Circuit): Map<string, number> {
     if (
       element.kind === "voltage-source" ||
       element.kind === "vcvs" ||
-      element.kind === "ccvs"
+      element.kind === "ccvs" ||
+      (element.kind === "b-source" && element.voltageExpr !== undefined)
     ) {
       insertBranchName(sources, element.name, "duplicate voltage source name");
     }
@@ -2538,7 +2596,8 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
         element.kind === "vccs" ||
         element.kind === "vcvs" ||
         element.kind === "cccs" ||
-        element.kind === "ccvs") &&
+        element.kind === "ccvs" ||
+        element.kind === "b-source") &&
       element.name === inputSource
     ) {
       throw invalidElement(
@@ -3144,6 +3203,211 @@ function voltageAt(
   return isGround(node) ? 0.0 : nodeVoltages.get(node) ?? 0.0;
 }
 
+class BSourceExpressionParser {
+  private position = 0;
+
+  constructor(
+    private readonly expression: string,
+    private readonly resolver: (node: string) => number,
+  ) {}
+
+  parse(): number {
+    const value = this.parseExpression();
+    this.skipWhitespace();
+    if (this.position !== this.expression.length) {
+      throw new Error("unexpected expression input");
+    }
+    return value;
+  }
+
+  private parseExpression(): number {
+    let value = this.parseTerm();
+    while (true) {
+      this.skipWhitespace();
+      if (this.consume("+")) {
+        value += this.parseTerm();
+      } else if (this.consume("-")) {
+        value -= this.parseTerm();
+      } else {
+        return value;
+      }
+    }
+  }
+
+  private parseTerm(): number {
+    let value = this.parseFactor();
+    while (true) {
+      this.skipWhitespace();
+      if (this.consume("*")) {
+        value *= this.parseFactor();
+      } else if (this.consume("/")) {
+        value /= this.parseFactor();
+      } else {
+        return value;
+      }
+    }
+  }
+
+  private parseFactor(): number {
+    this.skipWhitespace();
+    if (this.consume("+")) {
+      return this.parseFactor();
+    }
+    if (this.consume("-")) {
+      return -this.parseFactor();
+    }
+    if (this.consume("(")) {
+      const value = this.parseExpression();
+      this.expect(")");
+      return value;
+    }
+    if (this.peekIdentifier("V")) {
+      this.position += 1;
+      this.expect("(");
+      const first = this.parseNodeName();
+      this.skipWhitespace();
+      if (this.consume(",")) {
+        const second = this.parseNodeName();
+        this.expect(")");
+        return this.resolver(first) - this.resolver(second);
+      }
+      this.expect(")");
+      return this.resolver(first);
+    }
+    return this.parseNumber();
+  }
+
+  private parseNumber(): number {
+    this.skipWhitespace();
+    const start = this.position;
+    if (this.expression[this.position] === ".") {
+      this.position += 1;
+    }
+    while (/[0-9]/.test(this.expression[this.position] ?? "")) {
+      this.position += 1;
+    }
+    if (this.expression[this.position] === ".") {
+      this.position += 1;
+      while (/[0-9]/.test(this.expression[this.position] ?? "")) {
+        this.position += 1;
+      }
+    }
+    if (/[eE]/.test(this.expression[this.position] ?? "")) {
+      this.position += 1;
+      if (/[+-]/.test(this.expression[this.position] ?? "")) {
+        this.position += 1;
+      }
+      while (/[0-9]/.test(this.expression[this.position] ?? "")) {
+        this.position += 1;
+      }
+    }
+    if (this.position === start) {
+      throw new Error("expected number");
+    }
+    const value = Number(this.expression.slice(start, this.position));
+    if (!Number.isFinite(value)) {
+      throw new Error("number must be finite");
+    }
+    return value;
+  }
+
+  private parseNodeName(): string {
+    this.skipWhitespace();
+    const start = this.position;
+    while (/[A-Za-z0-9_.$:-]/.test(this.expression[this.position] ?? "")) {
+      this.position += 1;
+    }
+    if (this.position === start) {
+      throw new Error("expected node name");
+    }
+    this.skipWhitespace();
+    return this.expression.slice(start, this.position);
+  }
+
+  private consume(token: string): boolean {
+    this.skipWhitespace();
+    if (this.expression.startsWith(token, this.position)) {
+      this.position += token.length;
+      return true;
+    }
+    return false;
+  }
+
+  private expect(token: string): void {
+    if (!this.consume(token)) {
+      throw new Error(`expected ${token}`);
+    }
+  }
+
+  private peekIdentifier(name: string): boolean {
+    this.skipWhitespace();
+    return this.expression.startsWith(name, this.position);
+  }
+
+  private skipWhitespace(): void {
+    while (/\s/.test(this.expression[this.position] ?? "")) {
+      this.position += 1;
+    }
+  }
+}
+
+function bSourceExprNodes(expression: string): string[] {
+  const nodes: string[] = [];
+  const pattern = /V\s*\(([^)]*)\)/g;
+  for (const match of expression.matchAll(pattern)) {
+    for (const node of match[1].split(",")) {
+      const trimmed = node.trim();
+      if (trimmed !== "" && !isGround(trimmed)) {
+        nodes.push(trimmed);
+      }
+    }
+  }
+  return nodes;
+}
+
+function evalBSourceExpression(
+  expression: string,
+  nodeIndices: ReadonlyMap<string, number>,
+  operatingPoint: readonly number[],
+): number {
+  const parser = new BSourceExpressionParser(expression, (node) => {
+    const index = nodeIndex(nodeIndices, node);
+    return index === undefined ? 0.0 : operatingPoint[index];
+  });
+  const value = parser.parse();
+  if (!Number.isFinite(value)) {
+    throw new Error("expression produced a non-finite value");
+  }
+  return value;
+}
+
+function bSourceLinearization(
+  expression: string,
+  nodeIndices: ReadonlyMap<string, number>,
+  operatingPoint: readonly number[],
+): { derivatives: Map<string, number>; offset: number } {
+  const value = evalBSourceExpression(expression, nodeIndices, operatingPoint);
+  const derivatives = new Map<string, number>();
+  for (const [node, index] of nodeIndices) {
+    const h = Math.max(1.0e-6, Math.abs(operatingPoint[index]) * 1.0e-6);
+    const plus = [...operatingPoint];
+    const minus = [...operatingPoint];
+    plus[index] += h;
+    minus[index] -= h;
+    derivatives.set(
+      node,
+      (evalBSourceExpression(expression, nodeIndices, plus) -
+        evalBSourceExpression(expression, nodeIndices, minus)) /
+        (2.0 * h),
+    );
+  }
+  let linearPart = 0.0;
+  for (const [node, derivative] of derivatives) {
+    linearPart += derivative * operatingPoint[nodeIndices.get(node)!];
+  }
+  return { derivatives, offset: value - linearPart };
+}
+
 function stampVoltageSource(
   element: VoltageSource,
   nodeIndices: ReadonlyMap<string, number>,
@@ -3205,6 +3469,74 @@ function stampCurrentSource(
   }
   if (negative !== undefined) {
     rhs[negative] += current;
+  }
+}
+
+function stampBSource(
+  element: BSource,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+  nodeCount: number,
+  matrix: number[][],
+  rhs: number[],
+  operatingPoint: readonly number[],
+): void {
+  const hasVoltage = element.voltageExpr !== undefined;
+  const hasCurrent = element.currentExpr !== undefined;
+  if (hasVoltage === hasCurrent) {
+    throw invalidElement(
+      element.name,
+      "B-source must define exactly one voltageExpr or currentExpr",
+    );
+  }
+
+  const positive = nodeIndex(nodeIndices, element.positive);
+  const negative = nodeIndex(nodeIndices, element.negative);
+  try {
+    if (element.currentExpr !== undefined) {
+      const { derivatives, offset } = bSourceLinearization(
+        element.currentExpr,
+        nodeIndices,
+        operatingPoint,
+      );
+      if (positive !== undefined) {
+        for (const [node, derivative] of derivatives) {
+          matrix[positive][nodeIndices.get(node)!] += derivative;
+        }
+        rhs[positive] -= offset;
+      }
+      if (negative !== undefined) {
+        for (const [node, derivative] of derivatives) {
+          matrix[negative][nodeIndices.get(node)!] -= derivative;
+        }
+        rhs[negative] += offset;
+      }
+      return;
+    }
+
+    const sourceIndex = voltageSources.get(element.name);
+    if (sourceIndex === undefined || element.voltageExpr === undefined) {
+      throw invalidElement(element.name, "voltage B-source was not indexed");
+    }
+    const branch = nodeCount + sourceIndex;
+    const { derivatives, offset } = bSourceLinearization(
+      element.voltageExpr,
+      nodeIndices,
+      operatingPoint,
+    );
+    stampBranchMatrix(matrix, branch, positive, negative);
+    for (const [node, derivative] of derivatives) {
+      matrix[branch][nodeIndices.get(node)!] -= derivative;
+    }
+    rhs[branch] += offset;
+  } catch (error) {
+    if (error instanceof SpiceError) {
+      throw error;
+    }
+    throw invalidElement(
+      element.name,
+      error instanceof Error ? error.message : "invalid behavioral expression",
+    );
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -3,6 +3,8 @@ import {
   Circuit,
   SinWaveform,
   SpiceError,
+  bSourceCurrent,
+  bSourceVoltage,
   bjt,
   cccs,
   ccvs,
@@ -48,6 +50,31 @@ describe("dcOp", () => {
     const result = dcOp(circuit);
 
     expectClose(result.voltage("n1"), 1.0);
+  });
+
+  it("stamps behavioral current sources from node-voltage expressions", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 2.0));
+    circuit.add(bSourceCurrent("B1", "0", "out", "0.002 * V(in)"));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expect(result.converged).toBe(true);
+    expectClose(result.voltage("out"), 4.0);
+  });
+
+  it("stamps behavioral voltage sources from differential expressions", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 3.0));
+    circuit.add(bSourceVoltage("B1", "out", "0", "2.0 * V(in, 0) + 1.0"));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expect(result.converged).toBe(true);
+    expectClose(result.voltage("out"), 7.0);
+    expectClose(result.branchCurrent("B1"), -7.0e-3);
   });
 
   it("reports voltage source branch current", () => {

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -98,7 +98,9 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-_Nothing currently in flight._
+- Behavioral modeling (B-element) across Python, TypeScript, and Rust SPICE
+  engines: DC behavioral current/voltage sources with arithmetic expressions
+  over constants and `V(node)` / `V(node1,node2)` references.
 
 ---
 
@@ -115,7 +117,6 @@ All Group 1 items have shipped. See "What is on main" above.
 | Feature | Why it matters | Design notes |
 |---|---|---|
 | **Sub-circuit support (`.subckt` / X-element)** | Essential for hierarchical design — reusing a cell (e.g. an inverter) multiple times with different parameter values. | Add an `XInstance` element class. At circuit build time, expand each X-element by cloning its `.subckt` definition with renamed nodes (prefix with instance name). Parameters propagate via a dict of `{param: value}` substitutions. |
-| **Behavioral modeling (B-element)** | Enables arbitrary nonlinear voltage/current sources defined by algebraic expressions — useful for behavioral models and controlled oscillators. | `BSource` element with `voltage_expr: str` or `current_expr: str`. At stamp time, parse and evaluate the expression numerically; linearise around the operating point for Newton. |
 | **Sparse matrix solver** | Dense LU is O(n³). At ~100 nodes it becomes the bottleneck. SPICE netlists for a small IC cell can have 300+ nodes. | Replace `numpy.linalg.solve` with `scipy.sparse.linalg.splu` (already a dependency). MNA matrices are naturally sparse (each element touches only 2–4 nodes). Keep dense path as fallback for small circuits (< 30 nodes). |
 
 #### Group 3 — Lower priority / longer horizon


### PR DESCRIPTION
## Summary
- add Python, TypeScript, and Rust `BSource` behavioral source elements
- support DC current and voltage expressions over constants plus `V(node)` / `V(node1,node2)` references
- linearize expressions around the operating point for Newton stamping and add comparable DC tests
- update SPICE pending-work status and package changelogs

## Validation
- `sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`
