### PR TITLE
fix(blog-site): drop double coding-adventures/ prefix (URLs were 404ing)

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -3,13 +3,17 @@
 # ================================================================
 #
 # Builds the Forme pipeline (5 stages, FM00 §5 demo) and deploys the
-# generated dist/coding-adventures/blog/ tree to the gh-pages branch
-# under coding-adventures/blog/, preserving other content on Pages.
+# generated dist/blog/ tree to the gh-pages branch under blog/,
+# preserving other content on Pages.
 #
 # Pages is configured to serve from the gh-pages branch (legacy mode).
-# The peaceiris action pushes built assets into coding-adventures/blog/
-# on that branch, so the site is available at:
-#   https://adhithyan15.github.io/coding-adventures/blog/<slug>.html
+# Project-page repos like this one are served at
+# https://<user>.github.io/<repo>/, so the `coding-adventures/` segment
+# of the live URL comes from the *repo name* (project-page prefix), not
+# from the publish destination.  Files at gh-pages/blog/foo.html land at
+#   https://adhithyan15.github.io/coding-adventures/blog/foo.html
+# — getting the prefix from a directory on gh-pages too would
+# double-prefix and produce 404s.
 #
 # Pipeline shape (see code/sites/blog/forme.config.ts):
 #   forme-source-fs          Stream<ContentSource>
@@ -124,14 +128,14 @@ jobs:
 
       - name: Verify expected output exists
         run: |
-          test -d code/sites/blog/dist/coding-adventures/blog
-          ls code/sites/blog/dist/coding-adventures/blog
-          test -n "$(ls code/sites/blog/dist/coding-adventures/blog/*.html 2>/dev/null)"
+          test -d code/sites/blog/dist/blog
+          ls code/sites/blog/dist/blog
+          test -n "$(ls code/sites/blog/dist/blog/*.html 2>/dev/null)"
 
-      - name: Deploy to GitHub Pages (coding-adventures/blog/ subdirectory)
+      - name: Deploy to GitHub Pages (blog/ on gh-pages, served at <user>.github.io/<repo>/blog/)
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: code/sites/blog/dist/coding-adventures/blog
-          destination_dir: coding-adventures/blog
+          publish_dir: code/sites/blog/dist/blog
+          destination_dir: blog
           keep_files: true

--- a/code/sites/blog/BUILD
+++ b/code/sites/blog/BUILD
@@ -17,4 +17,4 @@ cd ../../packages/typescript/forme-parse-markdown && npm install --silent
 cd ../../packages/typescript/forme-collect-chronological && npm install --silent
 cd ../../packages/typescript/forme-render-static && npm install --silent
 cd ../../packages/typescript/forme-emit-fs && npm install --silent
-npm install --silent && npx tsx build.ts && test -d dist/coding-adventures/blog && ls dist/coding-adventures/blog
+npm install --silent && npx tsx build.ts && test -d dist/blog && ls dist/blog

--- a/code/sites/blog/README.md
+++ b/code/sites/blog/README.md
@@ -2,9 +2,20 @@
 
 The end-to-end demo of the [Forme](../../specs/fm00-vision.md) universal
 authoring pipeline. Markdown lives in `data/`; HTML lands in
-`dist/coding-adventures/blog/` and is deployed to
+`dist/blog/` and is deployed to
 [adhithyan15.github.io/coding-adventures/blog/](https://adhithyan15.github.io/coding-adventures/blog/)
 by `.github/workflows/deploy-blog.yml`.
+
+### Why the route says `/blog/...` but the URL says `/coding-adventures/blog/...`
+
+This repo is a GitHub Pages **project** page. Project pages are served
+from `https://<user>.github.io/<repo>/`, so the `coding-adventures/`
+segment of the live URL comes from the repo name (project-page prefix),
+not from anything in the build. The route template
+(`/blog/{slug}.html`) and the publish destination (`gh-pages:blog/`)
+both stay clean of that prefix; Pages composes it at the edge. If the
+repo ever gets a custom domain or moves to a user/org page, the route
+template and the destination don't need to change.
 
 ## Pipeline
 
@@ -29,7 +40,7 @@ npm install
 npx tsx build.ts        # or: npm run build
 ```
 
-That runs the full pipeline and writes `dist/coding-adventures/blog/*.html`.
+That runs the full pipeline and writes `dist/blog/*.html`.
 Each file is a self-contained HTML5 document with a classless theme
 inlined in `<style>` — no JS, no external CSS.
 
@@ -49,7 +60,7 @@ site driver runs straight from source.
 - `build.ts` — ~50-line driver: load config → `createOrchestrator`
   → `buildPipeline` → `runOnce` → assert success.
 - `BUILD` — chain-installs the file:dependency graph then runs the
-  pipeline. Verifies `dist/coding-adventures/blog/` is produced.
+  pipeline. Verifies `dist/blog/` is produced.
 - `dist/` — build output (git-ignored).
 
 ## Adding a post
@@ -67,7 +78,7 @@ site driver runs straight from source.
    …body in GFM…
    ```
 2. Re-run `npm run build`.
-3. Open `dist/coding-adventures/blog/<slug>.html`.
+3. Open `dist/blog/<slug>.html`.
 
 The slug is derived from the filename (strip `.md`, lowercase,
 replace whitespace/`_` with `-`). To override, set `slug:` in

--- a/code/sites/blog/forme.config.ts
+++ b/code/sites/blog/forme.config.ts
@@ -19,6 +19,17 @@
  * single-terminal heuristic stays happy — it'll come back in once
  * an index-page renderer can consume the Collection.  See the
  * forme-render-static README for the v0.2 roadmap.
+ *
+ * Note on the route template: `/blog/{slug}.html` does NOT include the
+ * `/coding-adventures/` repo-name prefix that the live URL has.  That
+ * prefix is a GitHub-Pages-project-page deployment detail — every
+ * project page lives under https://<user>.github.io/<repo>/ — not a
+ * routing concern.  Baking it into the route would make the build
+ * non-portable (rename the repo, switch to a user/org page, point a
+ * custom domain at it → all the routes would need rewriting).  The
+ * deploy workflow publishes dist/blog/ to gh-pages:blog/, and Pages
+ * exposes it as <user>.github.io/<repo>/blog/<slug>.html — composition
+ * lives at the deploy boundary, not in the content.
  */
 
 import sourceFs       from "@coding-adventures/forme-source-fs";
@@ -51,7 +62,7 @@ const config: PipelineConfig = {
       stage: renderStatic,
       config: {
         siteTitle: "Coding Adventures",
-        routeTemplate: "/coding-adventures/blog/{slug}.html",
+        routeTemplate: "/blog/{slug}.html",
       },
     },
     {

--- a/code/sites/blog/package-lock.json
+++ b/code/sites/blog/package-lock.json
@@ -55,7 +55,7 @@
     },
     "../../packages/typescript/forme-orchestrator": {
       "name": "@coding-adventures/forme-orchestrator",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/forme-cache": "file:../forme-cache",
@@ -91,7 +91,7 @@
     },
     "../../packages/typescript/forme-pipeline-config": {
       "name": "@coding-adventures/forme-pipeline-config",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/forme-capability": "file:../forme-capability",
@@ -124,7 +124,7 @@
     },
     "../../packages/typescript/forme-source-fs": {
       "name": "@coding-adventures/forme-source-fs",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/forme-identity": "file:../forme-identity",


### PR DESCRIPTION
## Summary

**The deployed blog was 404ing because the live URL had `coding-adventures/` doubled.** GitHub Pages project pages are served from `https://<user>.github.io/<repo>/`, so the `coding-adventures/` segment of the URL comes from the *repo name* — it's a deployment detail, not a routing concern. The original setup baked it into the route template AND the publish destination, producing this composition:

```
adhithyan15.github.io/coding-adventures/  +  coding-adventures/blog/foo.html
└─ project-page prefix (from repo name)    └─ destination_dir on gh-pages
= adhithyan15.github.io/coding-adventures/coding-adventures/blog/foo.html  ← 200 (wrong!)
```

The URLs we documented (`/coding-adventures/blog/foo.html` — single prefix) 404'd.

### Confirmed by curl

```
https://adhithyan15.github.io/coding-adventures/coding-adventures/blog/2026-05-15-hello-forme.html → 200
https://adhithyan15.github.io/coding-adventures/blog/2026-05-15-hello-forme.html                  → 404
```

### Three coordinated changes

1. **`code/sites/blog/forme.config.ts`**: `routeTemplate` is now `/blog/{slug}.html`. The route is the URL path relative to the site root; the project-page prefix is the deployment boundary's job, not the content's. Documented in a new header comment.

2. **`.github/workflows/deploy-blog.yml`**: `publish_dir: code/sites/blog/dist/blog`, `destination_dir: blog`. Files now land at `gh-pages:blog/foo.html` and Pages exposes them at `<user>.github.io/<repo>/blog/foo.html`. Header comment explains why the prefix is implicit.

3. **README + BUILD**: stale `dist/coding-adventures/blog/` paths updated to `dist/blog/`; added a "Why the route says `/blog/...` but the URL says `/coding-adventures/blog/...`" explainer.

### Local re-verification

```
$ npx tsx build.ts
…
{"message":"Build complete","outcome":"success","elapsedMs":36,"buildId":"blake2b:...","stages":4}
$ find dist -type f
dist/blog/2026-05-08-capability-typed-stages.html
dist/blog/2026-05-12-why-forme.html
dist/blog/2026-05-15-hello-forme.html
```

### Known follow-ups (NOT in this PR)

- **Header `<a href="/">` is also project-page-aware-wrong.** It goes to `<user>.github.io/` rather than `<user>.github.io/<repo>/`. Needs a `siteHome` / `basePath` config knob on `forme-render-static` — separate stage-package PR.
- **Orphan `coding-adventures/blog/` on gh-pages**. Five workflow runs published to the wrong path before this fix. The directory needs a one-off deletion from `gh-pages` after this merges (the action's `keep_files: true` won't remove it because it's outside the new `destination_dir`).

## Test plan

- [x] Local build emits `dist/blog/*.html` (3 files, all with rendered body content)
- [x] curl confirms the diagnosis: `coding-adventures/coding-adventures/blog/...` returns 200, `coding-adventures/blog/...` returns 404
- [ ] CI green
- [ ] After merge: deploy workflow runs, then visit `https://adhithyan15.github.io/coding-adventures/blog/2026-05-15-hello-forme.html` → expect 200
- [ ] Manual: delete orphan `coding-adventures/blog/` directory from gh-pages branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)