### PR TITLE
spice: add programmatic subcircuits

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Programmatic subcircuits** — `SubcircuitDefinition` plus `XInstance`
+  let callers define reusable cells and expand each instance into namespaced
+  primitive elements before simulation.
+
 ## [0.13.0] — 2026-05-16
 
 ### Added

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -19,8 +19,10 @@ from spice_engine.elements import (
     PwlWaveform,
     Resistor,
     SinWaveform,
+    SubcircuitDefinition,
     VoltageSource,
     Waveform,
+    XInstance,
 )
 from spice_engine.engine import (
     AcPoint,
@@ -81,6 +83,7 @@ __all__ = [
     "SensEntry",
     "SensResult",
     "SinWaveform",
+    "SubcircuitDefinition",
     "TfResult",
     "TransientPoint",
     "TransientResult",
@@ -88,6 +91,7 @@ __all__ = [
     "VCVS",
     "VoltageSource",
     "Waveform",
+    "XInstance",
     "__version__",
     "ac_sweep",
     "dc_op",

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -350,6 +350,30 @@ class BSource:
 
 
 @dataclass(frozen=True, slots=True)
+class SubcircuitDefinition:
+    """Reusable hierarchical circuit cell.
+
+    ``pins`` names the external nodes used by ``elements``. Internal nodes are
+    renamed when an instance is expanded so multiple instances do not collide.
+    """
+
+    name: str
+    pins: tuple[str, ...]
+    elements: tuple[object, ...]
+    parameters: dict[str, float] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class XInstance:
+    """Subcircuit instance (SPICE ``X`` element)."""
+
+    name: str
+    nodes: tuple[str, ...]
+    subckt: str
+    parameters: dict[str, float] | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class Diode:
     """Simple diode using Shockley equation."""
 
@@ -678,6 +702,7 @@ Element = (
     | VoltageSource
     | CurrentSource
     | BSource
+    | XInstance
     | Diode
     | Mosfet
     | BJT

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -70,16 +70,145 @@ from spice_engine.elements import (
     Inductor,
     Mosfet,
     Resistor,
+    SubcircuitDefinition,
     VoltageSource,
+    XInstance,
 )
 
 
 @dataclass
 class Circuit:
     elements: list[Element] = field(default_factory=list)
+    subcircuits: dict[str, SubcircuitDefinition] = field(default_factory=dict)
 
-    def add(self, element: Element) -> None:
+    def __post_init__(self) -> None:
+        initial_elements = self.elements
+        self.elements = []
+        for element in initial_elements:
+            self.add(element)
+
+    def add(self, element: Element | XInstance) -> None:
+        if isinstance(element, XInstance):
+            self.instantiate(element)
+            return
         self.elements.append(element)
+
+    def define_subcircuit(self, definition: SubcircuitDefinition) -> None:
+        key = definition.name.lower()
+        if key in self.subcircuits:
+            raise ValueError(f"duplicate subcircuit definition {definition.name!r}")
+        self.subcircuits[key] = definition
+
+    def instantiate(self, instance: XInstance) -> None:
+        self.elements.extend(_expand_xinstance(instance, self.subcircuits, ()))
+
+
+def _expand_xinstance(
+    instance: XInstance,
+    subcircuits: dict[str, SubcircuitDefinition],
+    stack: tuple[str, ...],
+) -> list[Element]:
+    definition = subcircuits.get(instance.subckt.lower())
+    if definition is None:
+        raise ValueError(f"unknown subcircuit {instance.subckt!r}")
+    definition_key = definition.name.lower()
+    if definition_key in stack:
+        cycle = " -> ".join((*stack, definition_key))
+        raise ValueError(f"recursive subcircuit expansion is not supported: {cycle}")
+    if len(instance.nodes) != len(definition.pins):
+        raise ValueError(
+            f"subcircuit {definition.name!r} expects {len(definition.pins)} pins, "
+            f"got {len(instance.nodes)}"
+        )
+
+    node_map = {pin: node for pin, node in zip(definition.pins, instance.nodes, strict=True)}
+    node_map.update(
+        {pin.lower(): node for pin, node in zip(definition.pins, instance.nodes, strict=True)}
+    )
+    expanded: list[Element] = []
+    next_stack = (*stack, definition_key)
+    for element in definition.elements:
+        if isinstance(element, XInstance):
+            nested_nodes = tuple(_map_subckt_node(node, instance.name, node_map) for node in element.nodes)
+            expanded.extend(
+                _expand_xinstance(
+                    XInstance(f"{instance.name}.{element.name}", nested_nodes, element.subckt, element.parameters),
+                    subcircuits,
+                    next_stack,
+                )
+            )
+        else:
+            expanded.append(_clone_subckt_element(element, instance.name, node_map))
+    return expanded
+
+
+def _map_subckt_node(node: str, instance_name: str, node_map: dict[str, str]) -> str:
+    if node.lower() in {"0", "gnd"}:
+        return node
+    if node in node_map:
+        return node_map[node]
+    if node.lower() in node_map:
+        return node_map[node.lower()]
+    return f"{instance_name}.{node}"
+
+
+def _map_subckt_source_ref(source_name: str, instance_name: str) -> str:
+    if "." in source_name:
+        return source_name
+    return f"{instance_name}.{source_name}"
+
+
+def _map_bsource_expr_nodes(expr: str | None, instance_name: str, node_map: dict[str, str]) -> str | None:
+    if expr is None:
+        return None
+    result: list[str] = []
+    index = 0
+    while index < len(expr):
+        if expr[index] == "V" and index + 1 < len(expr) and expr[index + 1] == "(":
+            close = expr.find(")", index + 2)
+            if close != -1:
+                args = expr[index + 2 : close].split(",")
+                if 1 <= len(args) <= 2:
+                    mapped_args = [
+                        _map_subckt_node(arg.strip(), instance_name, node_map) for arg in args
+                    ]
+                    result.append(f"V({','.join(mapped_args)})")
+                    index = close + 1
+                    continue
+        result.append(expr[index])
+        index += 1
+    return "".join(result)
+
+
+def _clone_subckt_element(element: object, instance_name: str, node_map: dict[str, str]) -> Element:
+    name = f"{instance_name}.{getattr(element, 'name')}"
+    if isinstance(element, Resistor):
+        return Resistor(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), element.resistance)
+    if isinstance(element, Capacitor):
+        return Capacitor(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), element.capacitance, element.initial_voltage)
+    if isinstance(element, Inductor):
+        return Inductor(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), element.inductance, element.initial_current)
+    if isinstance(element, VoltageSource):
+        return VoltageSource(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), element.voltage, element.waveform, element.ac)
+    if isinstance(element, CurrentSource):
+        return CurrentSource(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), element.current, element.waveform, element.ac)
+    if isinstance(element, BSource):
+        return BSource(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_bsource_expr_nodes(element.voltage_expr, instance_name, node_map), _map_bsource_expr_nodes(element.current_expr, instance_name, node_map))
+    if isinstance(element, Diode):
+        return Diode(name, _map_subckt_node(element.anode, instance_name, node_map), _map_subckt_node(element.cathode, instance_name, node_map), element.Is, element.Vt)
+    if isinstance(element, Mosfet):
+        return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
+    if isinstance(element, BJT):
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt)
+    if isinstance(element, VCVS):
+        return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
+    if isinstance(element, VCCS):
+        return VCCS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gm)
+    if isinstance(element, CCCS):
+        return CCCS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_source_ref(element.ctrl_source, instance_name), element.beta)
+    if isinstance(element, CCVS):
+        return CCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_source_ref(element.ctrl_source, instance_name), element.transresistance)
+    raise TypeError(f"unsupported subcircuit element {type(element).__name__}")
 
 
 @dataclass

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -106,8 +106,10 @@ from spice_engine import (
     SensEntry,
     SensResult,
     SinWaveform,
+    SubcircuitDefinition,
     TfResult,
     VoltageSource,
+    XInstance,
     ac_sweep,
     dc_op,
     dc_sweep,
@@ -218,6 +220,30 @@ def test_behavioral_voltage_source_tracks_differential_voltage():
     assert r.converged
     assert isclose(r.node_voltages["out"], 7.0, abs_tol=1e-6)
     assert "I(B1)" in r.branch_currents
+
+
+def test_subcircuit_instance_expands_resistor_divider_at_build_time():
+    cell = SubcircuitDefinition(
+        "atten2",
+        ("in", "out"),
+        (
+            Resistor("Rtop", "in", "out", 1000.0),
+            Resistor("Rbot", "out", "0", 1000.0),
+        ),
+    )
+    c = Circuit()
+    c.define_subcircuit(cell)
+    c.add(VoltageSource("V1", "vin", "0", voltage=10.0))
+    c.add(XInstance("X1", ("vin", "vout"), "atten2"))
+
+    r = dc_op(c)
+
+    assert r.converged
+    assert isclose(r.node_voltages["vout"], 5.0, abs_tol=1e-9)
+    assert [element.name for element in c.elements if isinstance(element, Resistor)] == [
+        "X1.Rtop",
+        "X1.Rbot",
+    ]
 
 
 def test_branch_current_in_voltage_source():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add programmatic subcircuits with `SubcircuitDefinition` and `XInstance`
+  expansion into namespaced primitive elements before simulation.
 - Add behavioral B sources for DC current and voltage expressions over
   constants and `V(node)` / `V(node1,node2)` node-voltage references.
 - Add DC operating-point convergence metadata and configurable Newton controls,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -8,12 +8,14 @@ const BOLTZMANN: f64 = 1.380_649e-23;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Circuit {
     elements: Vec<Element>,
+    subcircuits: HashMap<String, SubcircuitDefinition>,
 }
 
 impl Circuit {
     pub fn new() -> Self {
         Self {
             elements: Vec::new(),
+            subcircuits: HashMap::new(),
         }
     }
 
@@ -24,11 +26,311 @@ impl Circuit {
     pub fn elements(&self) -> &[Element] {
         &self.elements
     }
+
+    pub fn define_subcircuit(&mut self, definition: SubcircuitDefinition) -> Result<(), String> {
+        let key = definition.name.to_ascii_lowercase();
+        if self.subcircuits.contains_key(&key) {
+            return Err(format!(
+                "duplicate subcircuit definition {:?}",
+                definition.name
+            ));
+        }
+        self.subcircuits.insert(key, definition);
+        Ok(())
+    }
+
+    pub fn instantiate(&mut self, instance: XInstance) -> Result<(), String> {
+        let elements = expand_xinstance(&instance, &self.subcircuits, &[])?;
+        self.elements.extend(elements);
+        Ok(())
+    }
 }
 
 impl Default for Circuit {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubcircuitDefinition {
+    pub name: String,
+    pub pins: Vec<String>,
+    pub elements: Vec<SubcircuitElement>,
+    pub parameters: HashMap<String, f64>,
+}
+
+impl SubcircuitDefinition {
+    pub fn new(
+        name: impl Into<String>,
+        pins: impl Into<Vec<String>>,
+        elements: impl Into<Vec<SubcircuitElement>>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            pins: pins.into(),
+            elements: elements.into(),
+            parameters: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SubcircuitElement {
+    Element(Element),
+    XInstance(XInstance),
+}
+
+impl From<Element> for SubcircuitElement {
+    fn from(element: Element) -> Self {
+        Self::Element(element)
+    }
+}
+
+impl From<XInstance> for SubcircuitElement {
+    fn from(instance: XInstance) -> Self {
+        Self::XInstance(instance)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct XInstance {
+    pub name: String,
+    pub nodes: Vec<String>,
+    pub subckt: String,
+    pub parameters: HashMap<String, f64>,
+}
+
+impl XInstance {
+    pub fn new(
+        name: impl Into<String>,
+        nodes: impl Into<Vec<String>>,
+        subckt: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            nodes: nodes.into(),
+            subckt: subckt.into(),
+            parameters: HashMap::new(),
+        }
+    }
+}
+
+fn expand_xinstance(
+    instance: &XInstance,
+    subcircuits: &HashMap<String, SubcircuitDefinition>,
+    stack: &[String],
+) -> Result<Vec<Element>, String> {
+    let definition = subcircuits
+        .get(&instance.subckt.to_ascii_lowercase())
+        .ok_or_else(|| format!("unknown subcircuit {:?}", instance.subckt))?;
+    let definition_key = definition.name.to_ascii_lowercase();
+    if stack.contains(&definition_key) {
+        let mut cycle = stack.to_vec();
+        cycle.push(definition_key);
+        return Err(format!(
+            "recursive subcircuit expansion is not supported: {}",
+            cycle.join(" -> ")
+        ));
+    }
+    if instance.nodes.len() != definition.pins.len() {
+        return Err(format!(
+            "subcircuit {:?} expects {} pins, got {}",
+            definition.name,
+            definition.pins.len(),
+            instance.nodes.len()
+        ));
+    }
+
+    let mut node_map = HashMap::new();
+    for (pin, node) in definition.pins.iter().zip(instance.nodes.iter()) {
+        node_map.insert(pin.clone(), node.clone());
+        node_map.insert(pin.to_ascii_lowercase(), node.clone());
+    }
+    let mut expanded = Vec::new();
+    let mut next_stack = stack.to_vec();
+    next_stack.push(definition.name.to_ascii_lowercase());
+    for element in &definition.elements {
+        match element {
+            SubcircuitElement::Element(element) => {
+                expanded.push(clone_subckt_element(element, &instance.name, &node_map));
+            }
+            SubcircuitElement::XInstance(nested) => {
+                let mut nested_instance = nested.clone();
+                nested_instance.name = format!("{}.{}", instance.name, nested.name);
+                nested_instance.nodes = nested
+                    .nodes
+                    .iter()
+                    .map(|node| map_subckt_node(node, &instance.name, &node_map))
+                    .collect();
+                expanded.extend(expand_xinstance(
+                    &nested_instance,
+                    subcircuits,
+                    &next_stack,
+                )?);
+            }
+        }
+    }
+    Ok(expanded)
+}
+
+fn map_subckt_node(node: &str, instance_name: &str, node_map: &HashMap<String, String>) -> String {
+    if node.eq_ignore_ascii_case("0") || node.eq_ignore_ascii_case("gnd") {
+        return node.to_string();
+    }
+    node_map
+        .get(node)
+        .or_else(|| node_map.get(&node.to_ascii_lowercase()))
+        .cloned()
+        .unwrap_or_else(|| format!("{instance_name}.{node}"))
+}
+
+fn map_subckt_source_ref(source_name: &str, instance_name: &str) -> String {
+    if source_name.contains('.') {
+        source_name.to_string()
+    } else {
+        format!("{instance_name}.{source_name}")
+    }
+}
+
+fn map_bsource_expr_nodes(
+    expr: &Option<String>,
+    instance_name: &str,
+    node_map: &HashMap<String, String>,
+) -> Option<String> {
+    let expr = expr.as_ref()?;
+    let mut result = String::new();
+    let mut index = 0;
+    while index < expr.len() {
+        let rest = &expr[index..];
+        if rest.starts_with("V(") {
+            if let Some(close_offset) = rest.find(')') {
+                let args: Vec<String> = rest[2..close_offset]
+                    .split(',')
+                    .map(|arg| map_subckt_node(arg.trim(), instance_name, node_map))
+                    .collect();
+                if (1..=2).contains(&args.len()) {
+                    result.push_str(&format!("V({})", args.join(",")));
+                    index += close_offset + 1;
+                    continue;
+                }
+            }
+        }
+        if let Some(ch) = rest.chars().next() {
+            result.push(ch);
+            index += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    Some(result)
+}
+
+fn clone_subckt_element(
+    element: &Element,
+    instance_name: &str,
+    node_map: &HashMap<String, String>,
+) -> Element {
+    match element {
+        Element::Resistor(element) => Element::Resistor(Resistor::new(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.n1, instance_name, node_map),
+            map_subckt_node(&element.n2, instance_name, node_map),
+            element.resistance_ohms,
+        )),
+        Element::Capacitor(element) => Element::Capacitor(Capacitor::with_initial_voltage(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.n1, instance_name, node_map),
+            map_subckt_node(&element.n2, instance_name, node_map),
+            element.capacitance_farads,
+            element.initial_voltage,
+        )),
+        Element::Inductor(element) => Element::Inductor(Inductor::with_initial_current(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.n1, instance_name, node_map),
+            map_subckt_node(&element.n2, instance_name, node_map),
+            element.inductance_henrys,
+            element.initial_current,
+        )),
+        Element::VoltageSource(element) => Element::VoltageSource(VoltageSource {
+            name: format!("{instance_name}.{}", element.name),
+            positive: map_subckt_node(&element.positive, instance_name, node_map),
+            negative: map_subckt_node(&element.negative, instance_name, node_map),
+            voltage: element.voltage,
+            ac: element.ac,
+            waveform: element.waveform.clone(),
+        }),
+        Element::CurrentSource(element) => Element::CurrentSource(CurrentSource {
+            name: format!("{instance_name}.{}", element.name),
+            positive: map_subckt_node(&element.positive, instance_name, node_map),
+            negative: map_subckt_node(&element.negative, instance_name, node_map),
+            current: element.current,
+            ac: element.ac,
+            waveform: element.waveform.clone(),
+        }),
+        Element::BSource(element) => Element::BSource(BSource {
+            name: format!("{instance_name}.{}", element.name),
+            positive: map_subckt_node(&element.positive, instance_name, node_map),
+            negative: map_subckt_node(&element.negative, instance_name, node_map),
+            voltage_expr: map_bsource_expr_nodes(&element.voltage_expr, instance_name, node_map),
+            current_expr: map_bsource_expr_nodes(&element.current_expr, instance_name, node_map),
+        }),
+        Element::Diode(element) => Element::Diode(Diode::with_model(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.anode, instance_name, node_map),
+            map_subckt_node(&element.cathode, instance_name, node_map),
+            element.saturation_current,
+            element.thermal_voltage,
+        )),
+        Element::Bjt(element) => Element::Bjt(Bjt::with_model(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.collector, instance_name, node_map),
+            map_subckt_node(&element.base, instance_name, node_map),
+            map_subckt_node(&element.emitter, instance_name, node_map),
+            element.polarity,
+            element.saturation_current,
+            element.forward_beta,
+            element.thermal_voltage,
+        )),
+        Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.drain, instance_name, node_map),
+            map_subckt_node(&element.gate, instance_name, node_map),
+            map_subckt_node(&element.source, instance_name, node_map),
+            map_subckt_node(&element.body, instance_name, node_map),
+            element.mosfet_type,
+            element.params,
+        )),
+        Element::Vccs(element) => Element::Vccs(Vccs::new(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.positive, instance_name, node_map),
+            map_subckt_node(&element.negative, instance_name, node_map),
+            map_subckt_node(&element.control_positive, instance_name, node_map),
+            map_subckt_node(&element.control_negative, instance_name, node_map),
+            element.transconductance_siemens,
+        )),
+        Element::Vcvs(element) => Element::Vcvs(Vcvs::new(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.positive, instance_name, node_map),
+            map_subckt_node(&element.negative, instance_name, node_map),
+            map_subckt_node(&element.control_positive, instance_name, node_map),
+            map_subckt_node(&element.control_negative, instance_name, node_map),
+            element.gain,
+        )),
+        Element::Cccs(element) => Element::Cccs(Cccs::new(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.positive, instance_name, node_map),
+            map_subckt_node(&element.negative, instance_name, node_map),
+            map_subckt_source_ref(&element.control_source, instance_name),
+            element.gain,
+        )),
+        Element::Ccvs(element) => Element::Ccvs(Ccvs::new(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_node(&element.positive, instance_name, node_map),
+            map_subckt_node(&element.negative, instance_name, node_map),
+            map_subckt_source_ref(&element.control_source, instance_name),
+            element.transresistance_ohms,
+        )),
     }
 }
 

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,7 +1,8 @@
 use spice_engine::{
     dc_op, dc_op_with_options, dc_sweep, BSource, Bjt, BjtPolarity, Cccs, Ccvs, Circuit,
     CurrentSource, DcOpOptions, Diode, Element, Inductor, Mosfet, MosfetLevel1Params, MosfetType,
-    Resistor, SinWaveform, SpiceError, Vccs, Vcvs, VoltageSource, Waveform,
+    Resistor, SinWaveform, SpiceError, SubcircuitDefinition, SubcircuitElement, Vccs, Vcvs,
+    VoltageSource, Waveform, XInstance,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -29,6 +30,48 @@ fn dc_voltage_divider_solves_midpoint_voltage() {
     assert_close(result.voltage("0").unwrap(), 0.0);
     assert!(result.converged);
     assert_eq!(result.iterations, 1);
+}
+
+#[test]
+fn dc_subcircuit_instance_expands_resistor_divider() {
+    let mut circuit = Circuit::new();
+    circuit
+        .define_subcircuit(SubcircuitDefinition::new(
+            "atten2",
+            vec!["in".to_string(), "out".to_string()],
+            vec![
+                SubcircuitElement::from(Element::Resistor(Resistor::new(
+                    "Rtop", "in", "out", 1_000.0,
+                ))),
+                SubcircuitElement::from(Element::Resistor(Resistor::new(
+                    "Rbot", "out", "0", 1_000.0,
+                ))),
+            ],
+        ))
+        .unwrap();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vin", "0", 10.0,
+    )));
+    circuit
+        .instantiate(XInstance::new(
+            "X1",
+            vec!["vin".to_string(), "vout".to_string()],
+            "atten2",
+        ))
+        .unwrap();
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert_close(result.voltage("vout").unwrap(), 5.0);
+    let names: Vec<&str> = circuit
+        .elements()
+        .iter()
+        .filter_map(|element| match element {
+            Element::Resistor(resistor) => Some(resistor.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(names, vec!["X1.Rtop", "X1.Rbot"]);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add programmatic subcircuits with `SubcircuitDefinition` and `XInstance`
+  expansion into namespaced primitive elements before simulation.
 - Add behavioral B sources for DC current and voltage expressions over
   constants and `V(node)` / `V(node1,node2)` node-voltage references.
 - Add independent-source AC phasors with separate DC bias for AC analysis.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -291,6 +291,23 @@ export interface BSource {
   readonly currentExpr?: string;
 }
 
+export type SubcircuitElement = Element | XInstance;
+
+export interface SubcircuitDefinition {
+  readonly name: string;
+  readonly pins: readonly string[];
+  readonly elements: readonly SubcircuitElement[];
+  readonly parameters?: Readonly<Record<string, number>>;
+}
+
+export interface XInstance {
+  readonly kind: "x-instance";
+  readonly name: string;
+  readonly nodes: readonly string[];
+  readonly subckt: string;
+  readonly parameters?: Readonly<Record<string, number>>;
+}
+
 export interface Diode {
   readonly kind: "diode";
   readonly name: string;
@@ -503,13 +520,173 @@ export class SpiceError extends Error {
 
 export class Circuit {
   private readonly _elements: Element[] = [];
+  private readonly _subcircuits = new Map<string, SubcircuitDefinition>();
 
-  add(element: Element): void {
+  add(element: Element | XInstance): void {
+    if (element.kind === "x-instance") {
+      this.instantiate(element);
+      return;
+    }
     this._elements.push(element);
   }
 
   elements(): readonly Element[] {
     return this._elements;
+  }
+
+  defineSubcircuit(definition: SubcircuitDefinition): void {
+    const key = definition.name.toLowerCase();
+    if (this._subcircuits.has(key)) {
+      throw new SpiceError(
+        `duplicate subcircuit definition ${JSON.stringify(definition.name)}`,
+        "INVALID_ELEMENT",
+        definition.name,
+      );
+    }
+    this._subcircuits.set(key, definition);
+  }
+
+  instantiate(instance: XInstance): void {
+    this._elements.push(...expandXInstance(instance, this._subcircuits, []));
+  }
+}
+
+function expandXInstance(
+  instance: XInstance,
+  subcircuits: ReadonlyMap<string, SubcircuitDefinition>,
+  stack: readonly string[],
+): Element[] {
+  const definition = subcircuits.get(instance.subckt.toLowerCase());
+  if (definition === undefined) {
+    throw new SpiceError(
+      `unknown subcircuit ${JSON.stringify(instance.subckt)}`,
+      "INVALID_ELEMENT",
+      instance.name,
+    );
+  }
+  const definitionKey = definition.name.toLowerCase();
+  if (stack.includes(definitionKey)) {
+    throw new SpiceError(
+      `recursive subcircuit expansion is not supported: ${[...stack, definitionKey].join(" -> ")}`,
+      "INVALID_ELEMENT",
+      instance.name,
+    );
+  }
+  if (instance.nodes.length !== definition.pins.length) {
+    throw new SpiceError(
+      `subcircuit ${JSON.stringify(definition.name)} expects ${definition.pins.length} pins, got ${instance.nodes.length}`,
+      "INVALID_ELEMENT",
+      instance.name,
+    );
+  }
+
+  const nodeMap = new Map<string, string>();
+  for (let index = 0; index < definition.pins.length; index++) {
+    nodeMap.set(definition.pins[index], instance.nodes[index]);
+    nodeMap.set(definition.pins[index].toLowerCase(), instance.nodes[index]);
+  }
+  const expanded: Element[] = [];
+  const nextStack = [...stack, definitionKey];
+  for (const element of definition.elements) {
+    if (element.kind === "x-instance") {
+      expanded.push(
+        ...expandXInstance(
+          {
+            ...element,
+            name: `${instance.name}.${element.name}`,
+            nodes: element.nodes.map((node) =>
+              mapSubcktNode(node, instance.name, nodeMap),
+            ),
+          },
+          subcircuits,
+          nextStack,
+        ),
+      );
+    } else {
+      expanded.push(cloneSubcktElement(element, instance.name, nodeMap));
+    }
+  }
+  return expanded;
+}
+
+function mapSubcktNode(
+  node: string,
+  instanceName: string,
+  nodeMap: ReadonlyMap<string, string>,
+): string {
+  if (node.toLowerCase() === "0" || node.toLowerCase() === "gnd") {
+    return node;
+  }
+  return nodeMap.get(node) ?? nodeMap.get(node.toLowerCase()) ?? `${instanceName}.${node}`;
+}
+
+function mapSubcktSourceRef(sourceName: string, instanceName: string): string {
+  return sourceName.includes(".") ? sourceName : `${instanceName}.${sourceName}`;
+}
+
+function mapBSourceExprNodes(
+  expr: string | undefined,
+  instanceName: string,
+  nodeMap: ReadonlyMap<string, string>,
+): string | undefined {
+  if (expr === undefined) {
+    return undefined;
+  }
+  let result = "";
+  let index = 0;
+  while (index < expr.length) {
+    if (expr[index] === "V" && expr[index + 1] === "(") {
+      const close = expr.indexOf(")", index + 2);
+      if (close !== -1) {
+        const args = expr.slice(index + 2, close).split(",");
+        if (args.length >= 1 && args.length <= 2) {
+          result += `V(${args
+            .map((arg) => mapSubcktNode(arg.trim(), instanceName, nodeMap))
+            .join(",")})`;
+          index = close + 1;
+          continue;
+        }
+      }
+    }
+    result += expr[index];
+    index++;
+  }
+  return result;
+}
+
+function cloneSubcktElement(
+  element: Element,
+  instanceName: string,
+  nodeMap: ReadonlyMap<string, string>,
+): Element {
+  const name = `${instanceName}.${element.name}`;
+  switch (element.kind) {
+    case "resistor":
+      return resistor(name, mapSubcktNode(element.n1, instanceName, nodeMap), mapSubcktNode(element.n2, instanceName, nodeMap), element.resistanceOhms);
+    case "capacitor":
+      return capacitorWithInitialVoltage(name, mapSubcktNode(element.n1, instanceName, nodeMap), mapSubcktNode(element.n2, instanceName, nodeMap), element.capacitanceFarads, element.initialVoltage);
+    case "inductor":
+      return inductorWithInitialCurrent(name, mapSubcktNode(element.n1, instanceName, nodeMap), mapSubcktNode(element.n2, instanceName, nodeMap), element.inductanceHenrys, element.initialCurrent);
+    case "voltage-source":
+      return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap) };
+    case "current-source":
+      return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap) };
+    case "b-source":
+      return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap), voltageExpr: mapBSourceExprNodes(element.voltageExpr, instanceName, nodeMap), currentExpr: mapBSourceExprNodes(element.currentExpr, instanceName, nodeMap) };
+    case "diode":
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage);
+    case "bjt":
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage);
+    case "mosfet":
+      return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
+    case "vccs":
+      return vccs(name, mapSubcktNode(element.positive, instanceName, nodeMap), mapSubcktNode(element.negative, instanceName, nodeMap), mapSubcktNode(element.controlPositive, instanceName, nodeMap), mapSubcktNode(element.controlNegative, instanceName, nodeMap), element.transconductanceSiemens);
+    case "vcvs":
+      return vcvs(name, mapSubcktNode(element.positive, instanceName, nodeMap), mapSubcktNode(element.negative, instanceName, nodeMap), mapSubcktNode(element.controlPositive, instanceName, nodeMap), mapSubcktNode(element.controlNegative, instanceName, nodeMap), element.gain);
+    case "cccs":
+      return cccs(name, mapSubcktNode(element.positive, instanceName, nodeMap), mapSubcktNode(element.negative, instanceName, nodeMap), mapSubcktSourceRef(element.controlSource, instanceName), element.gain);
+    case "ccvs":
+      return ccvs(name, mapSubcktNode(element.positive, instanceName, nodeMap), mapSubcktNode(element.negative, instanceName, nodeMap), mapSubcktSourceRef(element.controlSource, instanceName), element.transresistanceOhms);
   }
 }
 
@@ -682,6 +859,24 @@ export function bSourceVoltage(
   voltageExpr: string,
 ): BSource {
   return { kind: "b-source", name, positive, negative, voltageExpr };
+}
+
+export function subcircuitDefinition(
+  name: string,
+  pins: readonly string[],
+  elements: readonly SubcircuitElement[],
+  parameters?: Readonly<Record<string, number>>,
+): SubcircuitDefinition {
+  return { name, pins, elements, parameters };
+}
+
+export function xInstance(
+  name: string,
+  nodes: readonly string[],
+  subckt: string,
+  parameters?: Readonly<Record<string, number>>,
+): XInstance {
+  return { kind: "x-instance", name, nodes, subckt, parameters };
 }
 
 export function diode(

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -15,10 +15,12 @@ import {
   inductor,
   mosfet,
   resistor,
+  subcircuitDefinition,
   vccs,
   vcvs,
   voltageSource,
   voltageSourceWithWaveform,
+  xInstance,
 } from "../src/index.js";
 
 function expectClose(actual: number | undefined, expected: number): void {
@@ -40,6 +42,28 @@ describe("dcOp", () => {
     expectClose(result.voltage("0"), 0.0);
     expect(result.converged).toBe(true);
     expect(result.iterations).toBe(1);
+  });
+
+  it("expands subcircuit instances into namespaced primitive elements", () => {
+    const circuit = new Circuit();
+    circuit.defineSubcircuit(
+      subcircuitDefinition("atten2", ["in", "out"], [
+        resistor("Rtop", "in", "out", 1_000.0),
+        resistor("Rbot", "out", "0", 1_000.0),
+      ]),
+    );
+    circuit.add(voltageSource("V1", "vin", "0", 10.0));
+    circuit.add(xInstance("X1", ["vin", "vout"], "atten2"));
+
+    const result = dcOp(circuit);
+
+    expectClose(result.voltage("vout"), 5.0);
+    expect(
+      circuit
+        .elements()
+        .filter((element) => element.kind === "resistor")
+        .map((element) => element.name),
+    ).toEqual(["X1.Rtop", "X1.Rbot"]);
   });
 
   it("uses positive-to-negative orientation for current sources", () => {

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -72,6 +72,7 @@ files.
 | v0.11.0 | — | Time-varying source waveforms: `PwlWaveform`, `SinWaveform`, `PulseWaveform`, `ExpWaveform`; waveform evaluation at each transient timestep |
 | v0.12.0 | — | DC convergence aids: Gmin stepping + source stepping fallback chain; `_dc_newton` / `_x_from_result` helpers |
 | v0.13.0 | — | Inductor `initial_current` for transient seeding; explicit AC source phasors (`AcSource`) on `VoltageSource`/`CurrentSource` |
+| v0.14.0 | #3384 ✅ | Behavioral B sources across Python, TypeScript, and Rust: DC behavioral current/voltage expressions over constants and `V(node)` / `V(node1,node2)` references. |
 | v0.2.0 | #2339 | Trapezoidal + Backward Euler integration, LTE-based adaptive timestep |
 | v0.3.0 | #2342 | `BJT` element (Ebers-Moll, NPN/PNP) |
 | v0.4.0 | #2344 | AC small-signal frequency sweep (`.AC`) |
@@ -82,7 +83,7 @@ files.
 | v0.9.0 | #2370 | Noise analysis (`.NOISE`) — Johnson-Nyquist + shot noise, adjoint method |
 
 **Elements on main:** `Resistor`, `Capacitor`, `Inductor`, `VoltageSource`,
-`CurrentSource`, `Diode`, `Mosfet`, `BJT`
+`CurrentSource`, `BSource`, `Diode`, `Mosfet`, `BJT`
 
 **Analyses on main:** `dc_op`, `transient`, `ac_sweep`, `tf`, `dc_sweep`,
 `sens_dc`, `mc_dc`, `noise_ac`
@@ -98,9 +99,9 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- Behavioral modeling (B-element) across Python, TypeScript, and Rust SPICE
-  engines: DC behavioral current/voltage sources with arithmetic expressions
-  over constants and `V(node)` / `V(node1,node2)` references.
+- Sub-circuit support across Python, TypeScript, and Rust SPICE engines:
+  programmatic `SubcircuitDefinition` / `XInstance` expansion into namespaced
+  primitive elements before simulation.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add programmatic SubcircuitDefinition and XInstance support in Python, TypeScript, and Rust SPICE engines.
- Expand subcircuit instances into namespaced primitive elements before simulation.
- Add matching DC validation tests and update SPICE/MACSYMA status notes.

## Validation
- sh BUILD (code/packages/python/spice-engine)
- sh BUILD (code/packages/typescript/spice-engine)
- cargo test -p spice-engine (code/packages/rust)
- git diff --check