### PR TITLE
spice: add sparse real solver path

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Sparse real solver path** — large DC / real small-signal matrices now route
+  through a sparse-row Gaussian elimination path while small systems keep the
+  dense solver.
+
 - **Programmatic subcircuits** — `SubcircuitDefinition` plus `XInstance`
   let callers define reusable cells and expand each instance into namespaced
   primitive elements before simulation.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -1434,8 +1434,16 @@ def _stamp_bjt(
 # Linear solver
 # ---------------------------------------------------------------------------
 
+_SPARSE_SOLVER_THRESHOLD = 30
+
 
 def _solve(A: list[list[float]], b: list[float]) -> list[float]:
+    if len(A) >= _SPARSE_SOLVER_THRESHOLD:
+        return _solve_sparse(A, b)
+    return _solve_dense(A, b)
+
+
+def _solve_dense(A: list[list[float]], b: list[float]) -> list[float]:
     """Gaussian elimination with partial pivoting. Returns x s.t. A x = b."""
     n = len(A)
     if n == 0:
@@ -1466,6 +1474,68 @@ def _solve(A: list[list[float]], b: list[float]) -> list[float]:
         for c in range(i + 1, n):
             s -= aug[i][c] * x[c]
         x[i] = s / aug[i][i]
+    return x
+
+
+def _solve_sparse(A: list[list[float]], b: list[float]) -> list[float]:
+    """Sparse-row Gaussian elimination with partial pivoting.
+
+    The MNA matrix is assembled densely today, but each device stamp touches
+    only a few columns. Converting rows to dictionaries keeps the large-circuit
+    solve path from doing work on structural zeros.
+    """
+
+    n = len(A)
+    if n == 0:
+        return []
+    rows = [
+        {col: value for col, value in enumerate(row) if value != 0.0}
+        for row in A
+    ]
+    rhs = list(b)
+
+    for pivot_col in range(n):
+        pivot_row = max(
+            range(pivot_col, n),
+            key=lambda row: abs(rows[row].get(pivot_col, 0.0)),
+        )
+        pivot_abs = abs(rows[pivot_row].get(pivot_col, 0.0))
+        if pivot_abs < 1e-15:
+            raise ZeroDivisionError(f"singular matrix at row {pivot_col}")
+
+        rows[pivot_col], rows[pivot_row] = rows[pivot_row], rows[pivot_col]
+        rhs[pivot_col], rhs[pivot_row] = rhs[pivot_row], rhs[pivot_col]
+
+        pivot_value = rows[pivot_col][pivot_col]
+        pivot_entries = [
+            (col, value)
+            for col, value in rows[pivot_col].items()
+            if col > pivot_col
+        ]
+        for row_index in range(pivot_col + 1, n):
+            value = rows[row_index].get(pivot_col, 0.0)
+            if value == 0.0:
+                continue
+            factor = value / pivot_value
+            rows[row_index].pop(pivot_col, None)
+            for col, pivot_entry in pivot_entries:
+                next_value = rows[row_index].get(col, 0.0) - factor * pivot_entry
+                if abs(next_value) < 1e-15:
+                    rows[row_index].pop(col, None)
+                else:
+                    rows[row_index][col] = next_value
+            rhs[row_index] -= factor * rhs[pivot_col]
+
+    x = [0.0] * n
+    for row_index in range(n - 1, -1, -1):
+        diag = rows[row_index].get(row_index, 0.0)
+        if abs(diag) < 1e-15:
+            raise ZeroDivisionError(f"singular matrix at row {row_index}")
+        total = rhs[row_index]
+        for col, value in rows[row_index].items():
+            if col > row_index:
+                total -= value * x[col]
+        x[row_index] = total / diag
     return x
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -192,6 +192,19 @@ def test_two_resistors_in_series():
     assert isclose(r.node_voltages["b"], 8.0, abs_tol=1e-6)
 
 
+def test_large_resistor_ladder_uses_sparse_real_solver_path():
+    c = Circuit()
+    c.add(VoltageSource("V1", "n0", "0", voltage=10.0))
+    for index in range(34):
+        c.add(Resistor(f"R{index}", f"n{index}", f"n{index + 1}", 1000.0))
+    c.add(Resistor("R34", "n34", "0", 1000.0))
+
+    r = dc_op(c)
+
+    assert r.converged
+    assert isclose(r.node_voltages["n34"], 10.0 / 35.0, abs_tol=1e-9)
+
+
 def test_current_source_into_resistor():
     """I = 1mA into R = 1k -> V = 1V."""
     c = Circuit()

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a sparse-row real linear solver path for large DC / real small-signal
+  matrices while keeping the dense solver for small systems.
 - Add programmatic subcircuits with `SubcircuitDefinition` and `XInstance`
   expansion into namespaced primitive elements before simulation.
 - Add behavioral B sources for DC current and voltage expressions over

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 const PIVOT_EPSILON: f64 = 1.0e-12;
+const SPARSE_SOLVER_THRESHOLD: usize = 30;
 const TWO_PI: f64 = std::f64::consts::PI * 2.0;
 const BOLTZMANN: f64 = 1.380_649e-23;
 
@@ -5130,7 +5131,14 @@ fn stamp_complex_transconductance(
     }
 }
 
-fn solve_linear_system(
+fn solve_linear_system(matrix: Vec<Vec<f64>>, rhs: Vec<f64>) -> Result<Vec<f64>, SpiceError> {
+    if rhs.len() >= SPARSE_SOLVER_THRESHOLD {
+        return solve_sparse_linear_system(matrix, rhs);
+    }
+    solve_dense_linear_system(matrix, rhs)
+}
+
+fn solve_dense_linear_system(
     mut matrix: Vec<Vec<f64>>,
     mut rhs: Vec<f64>,
 ) -> Result<Vec<f64>, SpiceError> {
@@ -5173,6 +5181,90 @@ fn solve_linear_system(
             .sum();
         solution[row] = (rhs[row] - tail_sum) / matrix[row][row];
     }
+    Ok(solution)
+}
+
+fn solve_sparse_linear_system(
+    matrix: Vec<Vec<f64>>,
+    rhs: Vec<f64>,
+) -> Result<Vec<f64>, SpiceError> {
+    let n = rhs.len();
+    let mut rows: Vec<HashMap<usize, f64>> = matrix
+        .into_iter()
+        .map(|row| {
+            row.into_iter()
+                .enumerate()
+                .filter_map(|(col, value)| (value != 0.0).then_some((col, value)))
+                .collect()
+        })
+        .collect();
+    let mut rhs = rhs;
+
+    for pivot_col in 0..n {
+        let pivot_row = (pivot_col..n)
+            .max_by(|&a, &b| {
+                rows[a]
+                    .get(&pivot_col)
+                    .copied()
+                    .unwrap_or(0.0)
+                    .abs()
+                    .partial_cmp(&rows[b].get(&pivot_col).copied().unwrap_or(0.0).abs())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .ok_or(SpiceError::SingularMatrix)?;
+
+        if rows[pivot_row]
+            .get(&pivot_col)
+            .copied()
+            .unwrap_or(0.0)
+            .abs()
+            < PIVOT_EPSILON
+        {
+            return Err(SpiceError::SingularMatrix);
+        }
+
+        rows.swap(pivot_col, pivot_row);
+        rhs.swap(pivot_col, pivot_row);
+
+        let pivot = rows[pivot_col][&pivot_col];
+        let pivot_entries: Vec<(usize, f64)> = rows[pivot_col]
+            .iter()
+            .filter_map(|(&col, &value)| (col > pivot_col).then_some((col, value)))
+            .collect();
+        for row in (pivot_col + 1)..n {
+            let value = rows[row].get(&pivot_col).copied().unwrap_or(0.0);
+            if value == 0.0 {
+                continue;
+            }
+            let factor = value / pivot;
+            rows[row].remove(&pivot_col);
+            for (col, pivot_value) in &pivot_entries {
+                let next_value = rows[row].get(col).copied().unwrap_or(0.0) - factor * pivot_value;
+                if next_value.abs() < PIVOT_EPSILON {
+                    rows[row].remove(col);
+                } else {
+                    rows[row].insert(*col, next_value);
+                }
+            }
+            rhs[row] -= factor * rhs[pivot_col];
+        }
+    }
+
+    let mut solution = vec![0.0; n];
+    for row in (0..n).rev() {
+        let diagonal = rows[row].get(&row).copied().unwrap_or(0.0);
+        if diagonal.abs() < PIVOT_EPSILON {
+            return Err(SpiceError::SingularMatrix);
+        }
+        let mut value = rhs[row];
+        for (&col, &entry) in &rows[row] {
+            if col > row {
+                value -= entry * solution[col];
+            }
+        }
+        solution[row] = value / diagonal;
+    }
+
     Ok(solution)
 }
 

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -33,6 +33,28 @@ fn dc_voltage_divider_solves_midpoint_voltage() {
 }
 
 #[test]
+fn dc_large_resistor_ladder_uses_sparse_real_solver_path() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "n0", "0", 10.0,
+    )));
+    for index in 0..34 {
+        circuit.add(Element::Resistor(Resistor::new(
+            format!("R{index}"),
+            format!("n{index}"),
+            format!("n{}", index + 1),
+            1_000.0,
+        )));
+    }
+    circuit.add(Element::Resistor(Resistor::new("R34", "n34", "0", 1_000.0)));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert!(result.converged);
+    assert_close(result.voltage("n34").unwrap(), 10.0 / 35.0);
+}
+
+#[test]
 fn dc_subcircuit_instance_expands_resistor_divider() {
     let mut circuit = Circuit::new();
     circuit

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a sparse-row real linear solver path for large DC / real small-signal
+  matrices while keeping the dense solver for small systems.
 - Add programmatic subcircuits with `SubcircuitDefinition` and `XInstance`
   expansion into namespaced primitive elements before simulation.
 - Add behavioral B sources for DC current and voltage expressions over

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1,4 +1,5 @@
 const PIVOT_EPSILON = 1.0e-12;
+const SPARSE_SOLVER_THRESHOLD = 30;
 const TWO_PI = Math.PI * 2.0;
 const BOLTZMANN = 1.380_649e-23;
 
@@ -4424,6 +4425,13 @@ function stampAcMosfetSmallSignal(
 }
 
 function solveLinearSystem(matrix: number[][], rhs: number[]): number[] {
+  if (rhs.length >= SPARSE_SOLVER_THRESHOLD) {
+    return solveSparseLinearSystem(matrix, rhs);
+  }
+  return solveDenseLinearSystem(matrix, rhs);
+}
+
+function solveDenseLinearSystem(matrix: number[][], rhs: number[]): number[] {
   const n = rhs.length;
   for (let pivotCol = 0; pivotCol < n; pivotCol++) {
     let pivotRow = pivotCol;
@@ -4470,6 +4478,80 @@ function solveLinearSystem(matrix: number[][], rhs: number[]): number[] {
       tailSum += matrix[row][col] * solution[col];
     }
     solution[row] = (rhs[row] - tailSum) / matrix[row][row];
+  }
+  return solution;
+}
+
+function solveSparseLinearSystem(matrix: number[][], rhs: number[]): number[] {
+  const n = rhs.length;
+  const rows = matrix.map((row) => {
+    const entries = new Map<number, number>();
+    row.forEach((value, col) => {
+      if (value !== 0.0) {
+        entries.set(col, value);
+      }
+    });
+    return entries;
+  });
+  const sparseRhs = [...rhs];
+
+  for (let pivotCol = 0; pivotCol < n; pivotCol++) {
+    let pivotRow = pivotCol;
+    let pivotAbs = Math.abs(rows[pivotCol].get(pivotCol) ?? 0.0);
+    for (let row = pivotCol + 1; row < n; row++) {
+      const candidateAbs = Math.abs(rows[row].get(pivotCol) ?? 0.0);
+      if (candidateAbs > pivotAbs) {
+        pivotAbs = candidateAbs;
+        pivotRow = row;
+      }
+    }
+
+    if (pivotAbs < PIVOT_EPSILON) {
+      throw new SpiceError("circuit matrix is singular", "SINGULAR_MATRIX");
+    }
+
+    [rows[pivotCol], rows[pivotRow]] = [rows[pivotRow], rows[pivotCol]];
+    [sparseRhs[pivotCol], sparseRhs[pivotRow]] = [
+      sparseRhs[pivotRow],
+      sparseRhs[pivotCol],
+    ];
+
+    const pivot = rows[pivotCol].get(pivotCol)!;
+    const pivotEntries = [...rows[pivotCol].entries()].filter(
+      ([col]) => col > pivotCol,
+    );
+    for (let row = pivotCol + 1; row < n; row++) {
+      const value = rows[row].get(pivotCol) ?? 0.0;
+      if (value === 0.0) {
+        continue;
+      }
+      const factor = value / pivot;
+      rows[row].delete(pivotCol);
+      for (const [col, pivotValue] of pivotEntries) {
+        const nextValue = (rows[row].get(col) ?? 0.0) - factor * pivotValue;
+        if (Math.abs(nextValue) < PIVOT_EPSILON) {
+          rows[row].delete(col);
+        } else {
+          rows[row].set(col, nextValue);
+        }
+      }
+      sparseRhs[row] -= factor * sparseRhs[pivotCol];
+    }
+  }
+
+  const solution = Array.from({ length: n }, () => 0.0);
+  for (let row = n - 1; row >= 0; row--) {
+    const diagonal = rows[row].get(row) ?? 0.0;
+    if (Math.abs(diagonal) < PIVOT_EPSILON) {
+      throw new SpiceError("circuit matrix is singular", "SINGULAR_MATRIX");
+    }
+    let value = sparseRhs[row];
+    for (const [col, entry] of rows[row].entries()) {
+      if (col > row) {
+        value -= entry * solution[col];
+      }
+    }
+    solution[row] = value / diagonal;
   }
   return solution;
 }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -44,6 +44,20 @@ describe("dcOp", () => {
     expect(result.iterations).toBe(1);
   });
 
+  it("solves a large resistor ladder through the sparse real solver path", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "n0", "0", 10.0));
+    for (let index = 0; index < 34; index++) {
+      circuit.add(resistor(`R${index}`, `n${index}`, `n${index + 1}`, 1_000.0));
+    }
+    circuit.add(resistor("R34", "n34", "0", 1_000.0));
+
+    const result = dcOp(circuit);
+
+    expect(result.converged).toBe(true);
+    expectClose(result.voltage("n34"), 10.0 / 35.0);
+  });
+
   it("expands subcircuit instances into namespaced primitive elements", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -99,9 +99,9 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- Sub-circuit support across Python, TypeScript, and Rust SPICE engines:
-  programmatic `SubcircuitDefinition` / `XInstance` expansion into namespaced
-  primitive elements before simulation.
+- Sparse real solver path across Python, TypeScript, and Rust SPICE engines:
+  large DC / real small-signal matrices route through sparse-row Gaussian
+  elimination while small systems keep the dense solver.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add sparse-row real linear solver paths in Python, TypeScript, and Rust SPICE engines for larger DC / real small-signal matrices.
- Keep the existing dense Gaussian solver for small systems.
- Add large resistor-ladder DC tests that cross the sparse threshold in each language and update SPICE/MACSYMA status notes.

## Validation
- sh BUILD (code/packages/python/spice-engine)
- sh BUILD (code/packages/typescript/spice-engine)
- cargo test -p spice-engine (code/packages/rust)
- git diff --check