### PR TITLE
feat(dsp-wavelets): DSP06 Phase 3b (partial) — Db6 and Db8

### DIFF
--- a/code/packages/rust/dsp-wavelets/CHANGELOG.md
+++ b/code/packages/rust/dsp-wavelets/CHANGELOG.md
@@ -1,5 +1,74 @@
 # Changelog — dsp-wavelets
 
+## 0.3.0 — 2026-05-17
+
+### Added — DSP06 Phase 3b (partial — Db6 and Db8)
+
+Two more Daubechies wavelets land:
+
+- **Db6** (12 taps, 6 vanishing moments) — the canonical
+  "longer-than-toy" orthogonal wavelet.  6 vanishing moments
+  perfectly suppress polynomial signals up to degree 5 (on
+  non-Periodic boundaries — see Phase 4 for Symmetric).
+- **Db8** (16 taps, 8 vanishing moments) — the standard
+  high-order Daubechies, common in audio compression and
+  scientific signal denoising.
+
+Both pass the orthogonal-wavelet invariants (`Σ h = √2` within
+`5e-4`, `Σ h² = 1` within `5e-4`) and round-trip through
+`idwt_1d(dwt_1d(x))` within `1e-3` under Periodic boundary on
+128-sample sinusoid test signals.
+
+#### Source of coefficients
+
+Imported from PyWavelets'
+`_extensions/c/wavelets_coeffs.template.h` table via WebFetch,
+cross-checked against the Wikipedia "Orthogonal Daubechies
+coefficients" table (after rescaling from the "normalized to
+sum 2" convention Wikipedia uses to the "normalized to sum √2"
+convention pywt / this crate use).
+
+#### Why Sym6, Sym8, Coif2, Coif3 are still deferred
+
+The same WebFetch returned data for these wavelets but the values
+did NOT pass the strict orthogonal-wavelet invariants at f32
+precision:
+
+- **Sym6** — `Σ h = 1.658` (should be `√2 ≈ 1.414`), 17% off.
+  Source data was likely from a different normalisation
+  convention or has a copy-paste error.
+- **Sym8** — `Σ h = 1.416` vs `1.4142`, error `2e-3` above the
+  `5e-4` tolerance.  Close but not close enough — likely
+  truncation in the source rather than a wrong filter.
+- **Coif2** — source returned 6 values instead of 12 (the
+  scaling-function half; the wavelet-function half was missing).
+- **Coif3** — source returned 9 values instead of 18 (same
+  truncation pattern).
+
+Phase 3a's strict invariant tests catch all four cases.  Rather
+than relax the tolerance (which would hide the issue), the
+deferred variants stay behind `WaveletError::InvalidParam` until
+a clean source ships — likely a build.rs that calls Python
+PyWavelets directly to dump verified values into a vendored CSV.
+
+#### Public API change
+
+None.  Identical surface to 0.2.0.  Only the `analysis_lowpass`
+dispatch in `src/filters.rs` adds two new arms.
+
+#### New tests — 2
+
+- `db6_round_trip_periodic` — 128-sample sinusoid, 2 levels,
+  Periodic, central region within `1e-3`.
+- `db8_round_trip_periodic` — same setup, Db8.
+
+Plus the existing `Σ h = √2`, `Σ h² = 1`, and `Σ g = 0`
+invariant loops in `src/filters.rs` were extended to include
+the new variants.
+
+All 28 unit tests + 1 doctest pass (26 from Phases 1+2+3a +
+2 new Db6/Db8 round-trips).
+
 ## 0.2.0 — 2026-05-17
 
 ### Added — DSP06 Phase 3a (Daubechies / Symlets / Coiflets — verified subset)

--- a/code/packages/rust/dsp-wavelets/Cargo.toml
+++ b/code/packages/rust/dsp-wavelets/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dsp-wavelets"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "DSP06 Phases 1-3a: scalar reference Haar + Daubechies (Db2/Db4) + Symlets (Sym4) + Coiflets (Coif1) discrete wavelet transforms (DWT) + inverse, via a generic Mallat pyramid filter bank that works for any orthogonal wavelet. The wavelet sibling of dsp-fft / dsp-stft — adaptive multi-resolution time-frequency analysis. Phase 3a verified-coefficient subset only; Phase 3b extends to Db6/Db8/Sym6/Sym8/Coif2/Coif3 from PyWavelets-imported tables. 2-D DWT pending Phase 4, CWT pending Phase 5, matrix-IR lowering pending Phase 6."
+description = "DSP06 Phases 1-3b (partial): scalar reference Haar + Daubechies (Db2/Db4/Db6/Db8) + Symlets (Sym4) + Coiflets (Coif1) discrete wavelet transforms (DWT) + inverse, via a generic Mallat pyramid filter bank that works for any orthogonal wavelet. The wavelet sibling of dsp-fft / dsp-stft — adaptive multi-resolution time-frequency analysis. Phase 3b adds Db6 and Db8 (12-tap and 16-tap Daubechies) from verified PyWavelets-table values; Sym6/Sym8/Coif2/Coif3 still deferred pending a clean upstream source. 2-D DWT pending Phase 4, CWT pending Phase 5, matrix-IR lowering pending Phase 6."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/dsp-wavelets/README.md
+++ b/code/packages/rust/dsp-wavelets/README.md
@@ -1,10 +1,11 @@
 # dsp-wavelets
 
 Scalar reference wavelet transforms for the DSP layer.  As of
-**0.2.0 (DSP06 Phase 3a)** the crate ships **Haar + Daubechies
-(Db2, Db4) + Symlets (Sym4) + Coiflets (Coif1)** — all four
-orthogonal wavelet families wired through a generic Mallat
-pyramid filter bank that works for any orthogonal wavelet:
+**0.3.0 (DSP06 Phase 3b partial)** the crate ships **Haar +
+Daubechies (Db2, Db4, Db6, Db8) + Symlets (Sym4) + Coiflets
+(Coif1)** — the four orthogonal wavelet families wired through
+a generic Mallat pyramid filter bank that works for any
+orthogonal wavelet:
 
 - **`dwt_1d`** — forward 1-D DWT via Mallat pyramid.
 - **`idwt_1d`** — inverse 1-D DWT (synthesis filter bank).
@@ -131,8 +132,8 @@ pub enum WaveletError {
 | ------ | ---------------------------------------------------- | ------ |
 | 0      | Spec (`code/specs/DSP06-wavelets.md`)                | landed |
 | 1+2    | Crate skeleton + scalar Haar DWT / IDWT             | landed (0.1.0) |
-| **3a** | **Db2, Db4, Sym4, Coif1 (verified-coefficient subset)** | **this PR (0.2.0)** |
-| 3b     | Db6, Db8, Sym6, Sym8, Coif2, Coif3 (PyWavelets-imported) | pending |
+| 3a     | Db2, Db4, Sym4, Coif1 (verified-coefficient subset) | landed (0.2.0) |
+| **3b** | **Db6, Db8 (PyWavelets-imported); Sym6/Sym8/Coif2/Coif3 still deferred** | **this PR (0.3.0)** |
 | 4      | 2-D DWT + JPEG 2000 biorthogonal wavelets           | pending |
 | 5      | CWT (Morlet, MexicanHat) via FFT                     | pending |
 | 6      | Matrix-IR-lowered `dwt_1d` / `dwt_2d`                | pending |

--- a/code/packages/rust/dsp-wavelets/src/filters.rs
+++ b/code/packages/rust/dsp-wavelets/src/filters.rs
@@ -66,46 +66,46 @@ const DB4_DEC_LO: &[f32] = &[
      0.230_377_813_308_855_23,
 ];
 
-/// Daubechies Db6 — 12-tap, 6 vanishing moments.  **Phase 3b
-/// placeholder**: approximate values pulled from memory; needs to
-/// be replaced with verified PyWavelets-table values before
-/// being routed through `analysis_lowpass`.
-#[allow(dead_code)]
+/// Daubechies Db6 — 12-tap, 6 vanishing moments.  Coefficients
+/// from PyWavelets `_extensions/c/wavelets_coeffs.template.h`
+/// (cross-checked against the Wikipedia "Orthogonal Daubechies
+/// coefficients" table, after rescaling from the
+/// "normalized-to-sum-2" convention to the "normalized-to-sum-√2"
+/// convention pywt uses).
 const DB6_DEC_LO: &[f32] = &[
-    -0.000_720_549_445_366_4,
-     0.001_823_208_870_703_7,
-     0.005_611_434_819_394_8,
-    -0.023_680_171_946_334_2,
-    -0.005_946_355_481_851_2,
-     0.077_571_493_840_065_1,
-    -0.032_244_869_584_638_1,
-    -0.242_294_887_066_382_2,
-     0.138_428_145_901_320_3,
-     0.724_308_528_437_773_5,
-     0.603_829_269_797_473_2,
-     0.160_102_397_974_125_4,
+     0.111_540_743_350_109_4,
+     0.494_623_890_398_453_1,
+     0.751_133_908_021_095_3,
+     0.315_250_351_709_197_6,
+    -0.226_264_693_965_440_0,
+    -0.129_766_867_567_262_0,
+     0.097_501_605_587_323_0,
+     0.027_522_865_530_305_7,
+    -0.031_582_039_317_486_0,
+     0.000_553_842_201_161_5,
+     0.004_777_257_510_945_5,
+    -0.001_077_301_085_308_5,
 ];
 
-/// Daubechies Db8 — 16-tap, 8 vanishing moments.  **Phase 3b
-/// placeholder** — see DB6_DEC_LO doc comment.
-#[allow(dead_code)]
+/// Daubechies Db8 — 16-tap, 8 vanishing moments.  PyWavelets
+/// convention (sum = √2 normalisation).
 const DB8_DEC_LO: &[f32] = &[
-    -0.000_011_747_678_412_476_953,
-     0.000_067_544_940_645_203_61,
-    -0.000_039_174_037_337_694_67,
-    -0.001_174_767_841_247_695_3,
-     0.002_487_675_859_038_148_5,
-     0.006_063_581_955_902_4,
-    -0.020_968_398_563_900_0,
-    -0.014_834_270_637_596_0,
-     0.090_756_191_204_521_8,
-     0.057_127_080_088_201_7,
-    -0.236_504_252_898_249_0,
-    -0.124_672_881_993_553_1,
-     0.530_270_064_374_064_1,
-     0.687_173_443_815_357_1,
-     0.408_320_829_059_802_5,
-     0.085_388_898_396_585_1,
+     0.054_415_842_243_104_0,
+     0.312_871_590_914_300_0,
+     0.675_630_736_297_289_8,
+     0.585_354_683_654_206_7,
+    -0.015_829_105_256_349_3,
+    -0.284_015_542_961_546_9,
+     0.000_472_484_573_913_3,
+     0.128_747_426_620_478_5,
+    -0.017_369_301_001_807_5,
+    -0.044_088_253_930_794_8,
+     0.013_981_027_917_398_3,
+     0.008_746_094_047_405_8,
+    -0.004_870_352_993_451_6,
+    -0.000_391_740_373_376_9,
+     0.000_675_449_406_450_6,
+    -0.000_117_476_784_124_8,
 ];
 
 // ─────────────────────── Symlets ───────────────────────
@@ -132,44 +132,49 @@ const SYM4_DEC_LO: &[f32] = &[
      0.032_223_100_604_042_6,
 ];
 
-/// Symlet Sym6 — 12-tap, 6 vanishing moments.  **Phase 3b
-/// placeholder** — see DB6_DEC_LO doc comment.
+/// Symlet Sym6 — 12-tap, 6 vanishing moments.  **Still deferred**
+/// — upstream WebFetch returned values that fail the Σ h = √2
+/// invariant by ~17% (1.658 vs 1.414).  Will land once a clean
+/// source is in hand.
 #[allow(dead_code)]
 const SYM6_DEC_LO: &[f32] = &[
-     0.015_404_109_327_027_4,
-     0.003_490_712_084_188_8,
-    -0.117_990_111_148_191_5,
-    -0.048_311_742_585_633_0,
-     0.491_055_941_926_747_5,
-     0.787_641_141_028_794_2,
-     0.337_929_421_727_622_2,
-    -0.072_637_522_786_465_4,
-    -0.021_060_292_512_300_3,
-     0.044_724_901_770_665_5,
-     0.001_767_711_864_201_0,
-    -0.007_800_708_325_034_2,
+    -0.022_646_469_396_543_98,
+     0.101_254_389_354_605_9,
+     0.117_905_132_559_498_9,
+     0.434_983_283_404_562_7,
+     0.732_715_675_427_783_3,
+     0.377_983_734_210_946_0,
+    -0.101_747_316_003_476_8,
+    -0.022_688_727_500_668_8,
+     0.032_823_194_889_490_5,
+     0.010_428_510_487_684_3,
+    -0.002_273_169_124_038_2,
+    -0.001_010_325_897_689_4,
 ];
 
-/// Symlet Sym8 — 16-tap, 8 vanishing moments.  **Phase 3b
-/// placeholder** — see DB6_DEC_LO doc comment.
+/// Symlet Sym8 — 16-tap, 8 vanishing moments.  **Still deferred**
+/// — upstream WebFetch returned values that fail the Σ h = √2
+/// invariant by ~2e-3 (above the 5e-4 tolerance).  Phase 3a's
+/// invariant check is strict by design; rather than relax it for
+/// one wavelet, defer until a clean source ships.
 #[allow(dead_code)]
 const SYM8_DEC_LO: &[f32] = &[
-    -0.003_382_415_951_015_7,
-    -0.000_542_132_331_791_4,
-     0.031_695_087_811_493_6,
-     0.007_607_487_324_917_4,
-    -0.143_294_238_350_809_8,
-    -0.061_273_359_067_904_0,
-     0.481_359_651_258_372_4,
-     0.777_185_751_700_524_3,
-     0.364_441_894_835_331_1,
-    -0.051_945_838_107_881_8,
-    -0.027_219_029_917_103_5,
-     0.049_137_179_673_607_8,
-     0.003_808_752_013_890_6,
-    -0.014_952_258_337_062_2,
-    -0.000_302_920_514_721_8,
-     0.001_889_950_332_768_8,
+    -0.001_582_910_525_634_9,
+     0.012_874_742_662_047_8,
+     0.030_841_381_835_560_8,
+     0.243_684_986_140_822_7,
+     0.604_823_123_690_111_1,
+     0.657_288_078_051_300_5,
+     0.133_197_385_825_007_6,
+    -0.293_273_783_279_174_9,
+    -0.096_840_783_222_976_5,
+     0.148_540_749_338_106_4,
+     0.030_725_681_479_333_4,
+    -0.067_632_829_061_330_0,
+     0.000_250_947_114_831_5,
+     0.022_361_662_123_679_1,
+    -0.004_723_204_757_751_4,
+    -0.004_281_503_682_463_4,
 ];
 
 // ─────────────────────── Coiflets ───────────────────────
@@ -269,6 +274,8 @@ pub(crate) fn analysis_lowpass(wavelet: WaveletType) -> &'static [f32] {
     match wavelet {
         WaveletType::Daubechies(2) => DB2_DEC_LO,
         WaveletType::Daubechies(4) => DB4_DEC_LO,
+        WaveletType::Daubechies(6) => DB6_DEC_LO,
+        WaveletType::Daubechies(8) => DB8_DEC_LO,
         WaveletType::Symlets(4) => SYM4_DEC_LO,
         WaveletType::Coiflets(1) => COIF1_DEC_LO,
         _ => EMPTY,
@@ -313,10 +320,14 @@ mod tests {
     #[test]
     fn lowpass_filters_sum_to_sqrt_2() {
         let sqrt2 = std::f32::consts::SQRT_2;
-        // Phase 3a verified subset — see analysis_lowpass dispatch.
+        // Phase 3b extends the verified set to include the longer
+        // Daubechies and Symlets filters; Coif2/Coif3 remain deferred
+        // (truncated upstream data — see analysis_lowpass dispatch).
         for w in [
             WaveletType::Daubechies(2),
             WaveletType::Daubechies(4),
+            WaveletType::Daubechies(6),
+            WaveletType::Daubechies(8),
             WaveletType::Symlets(4),
             WaveletType::Coiflets(1),
         ] {
@@ -335,10 +346,14 @@ mod tests {
     /// Σ h[i]² = 1 for every orthogonal filter (energy normalisation).
     #[test]
     fn lowpass_filters_have_unit_energy() {
-        // Phase 3a verified subset — see analysis_lowpass dispatch.
+        // Phase 3b extends the verified set to include the longer
+        // Daubechies and Symlets filters; Coif2/Coif3 remain deferred
+        // (truncated upstream data — see analysis_lowpass dispatch).
         for w in [
             WaveletType::Daubechies(2),
             WaveletType::Daubechies(4),
+            WaveletType::Daubechies(6),
+            WaveletType::Daubechies(8),
             WaveletType::Symlets(4),
             WaveletType::Coiflets(1),
         ] {
@@ -361,6 +376,8 @@ mod tests {
         for w in [
             WaveletType::Daubechies(2),
             WaveletType::Daubechies(4),
+            WaveletType::Daubechies(6),
+            WaveletType::Daubechies(8),
             WaveletType::Symlets(4),
             WaveletType::Coiflets(1),
         ] {
@@ -395,11 +412,12 @@ mod tests {
             WaveletType::Coiflets(0),
             WaveletType::Coiflets(4),
             WaveletType::Coiflets(99),
-            // Phase 3b-deferred (placeholder coefficients exist
-            // but the dispatch deliberately returns EMPTY until
-            // verified values are imported):
-            WaveletType::Daubechies(6),
-            WaveletType::Daubechies(8),
+            // Sym6 / Sym8 / Coif2 / Coif3 still deferred — upstream
+            // WebFetch data was either incorrect (Sym6 fails the
+            // Σ h = √2 invariant by ~17%, Sym8 by ~2e-3 above the
+            // 5e-4 tolerance) or truncated (Coif2 returned 6 values
+            // instead of 12; Coif3 returned 9 instead of 18).  Will
+            // land in a follow-up PR with a cleaner source.
             WaveletType::Symlets(6),
             WaveletType::Symlets(8),
             WaveletType::Coiflets(2),

--- a/code/packages/rust/dsp-wavelets/src/lib.rs
+++ b/code/packages/rust/dsp-wavelets/src/lib.rs
@@ -986,10 +986,12 @@ mod tests {
         // N values for any family) must still return InvalidParam.
         for w in [
             WaveletType::Daubechies(3),   // odd N — never supported
-            WaveletType::Daubechies(6),   // Phase 3b deferred
             WaveletType::Daubechies(99),
-            WaveletType::Symlets(6),      // Phase 3b deferred
-            WaveletType::Coiflets(2),     // Phase 3b deferred
+            WaveletType::Symlets(6),      // still deferred (bad upstream data)
+            WaveletType::Symlets(8),      // still deferred (slight upstream truncation)
+            WaveletType::Symlets(99),
+            WaveletType::Coiflets(2),     // Coif2/3 still deferred
+            WaveletType::Coiflets(99),
             WaveletType::Biorthogonal { vm_decomp: 5, vm_recon: 3 },
             WaveletType::Morlet,
             WaveletType::MexicanHat,
@@ -1377,6 +1379,32 @@ mod tests {
         let signal: Vec<f32> = (0..64).map(|i| ((i as f32) * 0.09).cos()).collect();
         round_trip_check(&signal, WaveletType::Coiflets(1), 2, WaveletBoundary::Periodic, 1e-3);
     }
+
+    // ── Phase 3b: longer Daubechies (Db6, Db8) round-trips ─────
+
+    #[test]
+    fn db6_round_trip_periodic() {
+        // Db6 has 12 taps — needs a longer signal to have a sensible
+        // central region after the edge-effect skip.
+        let signal: Vec<f32> = (0..128).map(|i| ((i as f32) * 0.04).sin()).collect();
+        round_trip_check(&signal, WaveletType::Daubechies(6), 2, WaveletBoundary::Periodic, 1e-3);
+    }
+
+    #[test]
+    fn db8_round_trip_periodic() {
+        // Db8 has 16 taps — same reasoning as Db6.
+        let signal: Vec<f32> = (0..128).map(|i| ((i as f32) * 0.03).cos()).collect();
+        round_trip_check(&signal, WaveletType::Daubechies(8), 2, WaveletBoundary::Periodic, 1e-3);
+    }
+
+    // Note: a "Db6 suppresses quadratics" test along the lines of
+    // Phase 3a's `db2_dwt_of_constant_signal_has_small_detail` does
+    // NOT work under Periodic boundary — wrapping a quadratic
+    // creates a giant step at i=N that contaminates every detail
+    // band.  The vanishing-moments property holds for signals that
+    // are *truly* polynomial across the boundary (which Periodic
+    // never is for non-constant polynomials).  Phase 4's Symmetric/
+    // Reflect boundary will let us write that test correctly.
 
     // Note: Symmetric boundary round-trips with non-Haar wavelets
     // do not satisfy orthogonality exactly even in the central


### PR DESCRIPTION
## Summary

Two more Daubechies wavelets land:

- **Db6** (12 taps, 6 vanishing moments) — the canonical "longer-than-toy" orthogonal wavelet
- **Db8** (16 taps, 8 vanishing moments) — standard high-order Daubechies for audio compression and scientific denoising

Both pass the orthogonal-wavelet invariants (`Σ h = √2` within `5e-4`, `Σ h² = 1` within `5e-4`) and round-trip through `idwt_1d(dwt_1d(x))` within `1e-3` under Periodic boundary on 128-sample test signals.

## Source of coefficients

Imported from PyWavelets' `_extensions/c/wavelets_coeffs.template.h` table via WebFetch, cross-checked against the Wikipedia "Orthogonal Daubechies coefficients" table (after rescaling from the "sum = 2" Wikipedia convention to the "sum = √2" pywt convention).

## Why "Partial"

The same WebFetch returned data for Sym6, Sym8, Coif2, Coif3 — but the values failed the strict orthogonal-wavelet invariants at f32 precision:

| Wavelet | Issue                                         |
|---------|-----------------------------------------------|
| Sym6    | `Σ h = 1.658` (17% off — wrong convention)    |
| Sym8    | `Σ h = 1.416 vs 1.4142`, error `2e-3 > 5e-4`  |
| Coif2   | Source returned 6 values instead of 12        |
| Coif3   | Source returned 9 values instead of 18        |

Phase 3a's strict invariant tests catch all four. Rather than relax the tolerance (which would hide the issue), the deferred variants stay behind `WaveletError::InvalidParam` until a clean source ships — likely a `build.rs` that calls Python pywt directly to dump verified values into a vendored CSV.

## Test plan

- [x] `cargo test -p dsp-wavelets` — 28 unit tests + 1 doctest pass (26 from Phases 1+2+3a + 2 new Db6/Db8 round-trips)
- [x] Invariant loops (`Σ h = √2`, `Σ h² = 1`, `Σ g = 0`) extended to include Db6 and Db8
- [x] `db6_round_trip_periodic` and `db8_round_trip_periodic` — 128-sample sinusoid, 2 levels, central region within `1e-3`
- [x] `rejects_unsupported_wavelet` updated: Db6/Db8 now supported, Sym8 joins deferred list
- [x] Security review: PASSED — trivial data + dispatch change

## Public API change

None. Identical surface to 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)