### PR TITLE
feat(LANG65): TW05-K extended self-compile — parser.tw + emit.tw → 102

### DIFF
--- a/code/packages/rust/twig-module-driver/CHANGELOG.md
+++ b/code/packages/rust/twig-module-driver/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog — twig-module-driver
 
+## [0.10.0] — 2026-05-17
+
+### Added (LANG65 — TW05-K extended self-compilation via parser.tw + emit.tw)
+
+Extended `self-compile-all` in `code/twig/compiler/main.tw` from four files
+(TW05-J, 38 total) to six files (TW05-K, 102 total) by adding `parser.tw`
+(29 functions) and `emit.tw` (35 functions).
+
+New `run_in_xlarge_stack` helper (3 GiB thread stack) for tests that lex files
+larger than 8593 chars.  `emit.tw` at 22 697 chars requires ~1.33 GiB debug-
+mode stack (22 697 frames × 60 KiB/frame); 3 GiB gives ≥ 2× headroom.
+
+New `#[cfg(test)] mod tw05k_tests` with 5 integration tests:
+
+| Test | What it verifies |
+|------|-----------------|
+| `self_compile_all_returns_102` | `self-compile-all` on all 6 files → 102 functions |
+| `self_compile_parser_from_disk` | Real `parser.tw` (19 708 chars) via `host/read_file` → 29 functions |
+| `self_compile_emit_from_disk` | Real `emit.tw` (22 697 chars) via `host/read_file` → 35 functions |
+| `self_compile_tw05j_modules_regression` | Original 4 TW05-J files still → 38 (independent of self-compile-all) |
+| `existing_main_still_returns_2_after_tw05k` | TW05-I regression: `(main)` still → 2 |
+
+### Changed
+
+`tw05j_tests::self_compile_all_returns_38` renamed to
+`self_compile_all_returns_102` and updated to expect 102 (TW05-K total).
+Stack upgraded from `run_in_large_stack` (768 MiB) to `run_in_xlarge_stack`
+(3 GiB) since the extended `self-compile-all` now lexes `emit.tw`.
+
+#### Updated function count table
+
+| File | Size | Functions |
+|------|------|-----------|
+| `span.tw` | 2 426 | 2 |
+| `diagnostic.tw` | 2 446 | 3 |
+| `iir-builder.tw` | 6 278 | 8 |
+| `lexer.tw` | 8 593 | 25 |
+| `parser.tw` | 19 708 | 29 ← TW05-K |
+| `emit.tw` | 22 697 | 35 ← TW05-K |
+| **Total** | | **102** |
+
 ## [0.9.0] — 2026-05-17
 
 ### Added (LANG64 — TW05-J multi-module self-compilation via host/read_file)

--- a/code/packages/rust/twig-module-driver/Cargo.toml
+++ b/code/packages/rust/twig-module-driver/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name        = "twig-module-driver"
-version     = "0.9.0"
+version     = "0.10.0"
 edition     = "2021"
-description = "LANG56-LANG64 — multi-file module resolver for Twig.  Resolves (import …) declarations recursively, compiles and links all modules into a single IIRModule ready for twig-vm.  LANG57 adds TW05-D data-model tests; LANG58 adds TW05-E lexer+parser tests; LANG59 adds TW05-F IIR emitter tests; LANG60 adds TW05-G lambda+DefExpr tests; LANG61 adds TW05-H program emitter tests; LANG62 adds TW05-I first self-compilation check; LANG63 adds cst-parser to all test copy lists; LANG64 adds TW05-J multi-module self-compilation via host/read_file."
+description = "LANG56-LANG65 — multi-file module resolver for Twig.  Resolves (import …) declarations recursively, compiles and links all modules into a single IIRModule ready for twig-vm.  LANG57 adds TW05-D data-model tests; LANG58 adds TW05-E lexer+parser tests; LANG59 adds TW05-F IIR emitter tests; LANG60 adds TW05-G lambda+DefExpr tests; LANG61 adds TW05-H program emitter tests; LANG62 adds TW05-I first self-compilation check; LANG63 adds cst-parser to all test copy lists; LANG64 adds TW05-J multi-module self-compilation via host/read_file; LANG65 adds TW05-K extended self-compilation (parser.tw + emit.tw → 102 total functions)."
 
 [dependencies]
 twig-parser       = { path = "../twig-parser" }

--- a/code/packages/rust/twig-module-driver/src/lib.rs
+++ b/code/packages/rust/twig-module-driver/src/lib.rs
@@ -657,6 +657,35 @@ fn run_in_large_stack(root: std::path::PathBuf, dir: std::path::PathBuf, tag: &'
         .expect("thread panicked")
 }
 
+// `run_in_xlarge_stack` — 3 GiB thread stack for TW05-K and later tests that
+// lex files larger than 8593 chars (the LANG64 ceiling).
+//
+// ## Stack budget (LANG65 / TW05-K)
+//
+// The largest TW05-K file is `emit.tw` at 22 697 chars, requiring up to
+// 22 697 nested Rust `dispatch` frames.  At 60 KiB per frame (debug-mode
+// upper bound) that is ~1.33 GiB.
+//
+// 3 GiB gives ≥ 2× headroom.  OS pages are allocated lazily, so the
+// physical RSS peaks at the actual maximum stack depth, not the full 3 GiB.
+// GitHub Actions ubuntu-latest runners have ≥ 7 GiB RAM; 3 GiB virtual
+// reservation is safe.
+
+#[cfg(test)]
+fn run_in_xlarge_stack(root: std::path::PathBuf, dir: std::path::PathBuf, tag: &'static str)
+    -> twig_vm::LispyValue
+{
+    std::thread::Builder::new()
+        .stack_size(3 * 1024 * 1024 * 1024) // 3 GiB — see budget note above
+        .spawn(move || {
+            twig_vm::run_module_tree(&root, &[dir.as_path()])
+                .unwrap_or_else(|e| panic!("{tag}: {e}"))
+        })
+        .expect("thread spawn failed")
+        .join()
+        .expect("thread panicked")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2478,14 +2507,19 @@ mod tw05j_tests {
             .replace('\n', "\\n")
     }
 
-    // ── Test 1: self-compile-all returns 38 ──────────────────────────────────
+    // ── Test 1: self-compile-all returns 102 (TW05-K extended) ──────────────
+    //
+    // TW05-K extended self-compile-all from 4 files (38) to 6 files (102).
+    // This test uses run_in_xlarge_stack (3 GiB) because emit.tw (22 697 chars)
+    // is the largest file and requires ~1.33 GiB stack in debug builds.
+    // (Previously this test used run_in_large_stack and expected 38 before TW05-K.)
 
     #[test]
-    fn self_compile_all_returns_38() {
+    fn self_compile_all_returns_102() {
         // Compile all modules, write a main-test.tw that calls (self-compile-all),
-        // and verify the total function count is 38 (2+3+8+25).
+        // and verify the total function count is 102 (2+3+8+25+29+35).
         let src = compiler_src_dir();
-        let dir = make_tempdir("all38");
+        let dir = make_tempdir("all102");
         copy_all_tw_modules(&src, &dir);
 
         let src_str = twig_escape_path(&src);
@@ -2499,9 +2533,9 @@ mod tw05j_tests {
         let root = dir.join("compiler").join("main-test.tw");
         fs::write(&root, &main_test_src).unwrap();
 
-        let v = crate::run_in_large_stack(root, dir.clone(), "self_compile_all_returns_38");
-        assert_eq!(v.to_string(), "38",
-            "expected 38 functions (2+3+8+25); got {v}");
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_102");
+        assert_eq!(v.to_string(), "102",
+            "expected 102 functions (2+3+8+25+29+35); got {v}");
     }
 
     // ── Test 2: span.tw from disk → 2 functions ──────────────────────────────
@@ -2626,6 +2660,215 @@ mod tw05j_tests {
         let root = dir.join("compiler").join("main.tw");
 
         let v = crate::run_in_large_stack(root, dir.clone(), "existing_main_still_returns_2");
+        assert_eq!(v.to_string(), "2",
+            "TW05-I regression: expected (main) = 2; got {v}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tw05k_tests — TW05-K: extended self-compilation (parser.tw + emit.tw)
+// ---------------------------------------------------------------------------
+//
+// TW05-K extends `self-compile-all` from four files (TW05-J, 38 total) to six
+// files by adding `parser.tw` (29 functions) and `emit.tw` (35 functions).
+// The new total is 2 + 3 + 8 + 25 + 29 + 35 = 102.
+//
+// ## Stack requirement
+//
+// The largest new file is `emit.tw` at 22 697 chars.  At 60 KiB/frame (debug
+// upper bound) that is ~1.33 GiB.  All tests below use `run_in_xlarge_stack`
+// (3 GiB) for adequate headroom.
+//
+// ## Instruction budget
+//
+// Total source chars across 6 files: 62 148.  Lex: ~1.86 M instructions.
+// Parse + emit overhead: ~0.5 M.  Total: ~2.4 M < MAX_INSTRUCTIONS_PER_RUN
+// (8 M).  No VM constant change required.
+
+#[cfg(test)]
+mod tw05k_tests {
+    use std::fs;
+    use std::path::Path;
+
+    fn compiler_src_dir() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent().unwrap()  // rust/
+            .parent().unwrap()  // packages/
+            .parent().unwrap()  // code/
+            .join("twig/compiler")
+            .canonicalize()
+            .expect("code/twig/compiler/ must exist")
+    }
+
+    fn make_tempdir(tag: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "twig_tw05k_{tag}_{}_{}", std::process::id(), nonce
+        ));
+        std::fs::create_dir(&dir).unwrap_or_else(|e| {
+            panic!("make_tempdir: could not create {}: {e}", dir.display())
+        });
+        dir
+    }
+
+    fn twig_escape_path(p: &std::path::Path) -> String {
+        p.to_str().unwrap()
+            .replace('\\', "\\\\")
+            .replace('"',  "\\\"")
+            .replace('\n', "\\n")
+    }
+
+    fn copy_tw(twig_src: &Path, dest_dir: &Path, name: &str) {
+        let src  = twig_src.join(format!("{name}.tw"));
+        let dest = dest_dir.join("compiler");
+        fs::create_dir_all(&dest).unwrap();
+        fs::copy(&src, dest.join(format!("{name}.tw")))
+            .unwrap_or_else(|e| panic!("copy {name}.tw: {e}"));
+    }
+
+    fn copy_all_tw_modules(twig_src: &Path, dest_dir: &Path) {
+        for name in &["span","token","diagnostic","ast","iir-types",
+                      "iir-builder","lexer","cst-parser","parser","emit","main"] {
+            copy_tw(twig_src, dest_dir, name);
+        }
+    }
+
+    // ── Test 1: self-compile-all returns 102 ─────────────────────────────────
+
+    #[test]
+    fn self_compile_all_returns_102() {
+        // Full pipeline across 6 files → 2+3+8+25+29+35 = 102.
+        // Uses run_in_xlarge_stack (3 GiB) because emit.tw is 22 697 chars.
+        let src = compiler_src_dir();
+        let dir = make_tempdir("all102");
+        copy_all_tw_modules(&src, &dir);
+
+        let src_str = twig_escape_path(&src);
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/main)) \
+             (define (main) (self-compile-all \"{src_str}\"))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_102");
+        assert_eq!(v.to_string(), "102",
+            "expected 102 functions (2+3+8+25+29+35); got {v}");
+    }
+
+    // ── Test 2: parser.tw from disk → 29 functions ───────────────────────────
+
+    #[test]
+    fn self_compile_parser_from_disk() {
+        // parser.tw is 19 708 chars and defines 29 functions.
+        // Peak lex-loop depth: up to 19 708 frames (well within MAX_DISPATCH_DEPTH=65536).
+        let src = compiler_src_dir();
+        let dir = make_tempdir("parser_disk");
+        copy_all_tw_modules(&src, &dir);
+
+        let path_str = twig_escape_path(&src.join("parser.tw"));
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/lexer compiler/parser compiler/emit)) \
+             (define (main) \
+               (length (emit-program (parse-program (lex-source \
+                 (host/read_file \"{path_str}\"))))))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_parser_from_disk");
+        assert_eq!(v.to_string(), "29",
+            "expected 29 functions from parser.tw; got {v}");
+    }
+
+    // ── Test 3: emit.tw from disk → 35 functions ─────────────────────────────
+
+    #[test]
+    fn self_compile_emit_from_disk() {
+        // emit.tw is 22 697 chars — the largest TW05-K file.
+        // Peak lex-loop depth: up to 22 697 frames.
+        // Debug-mode worst case: 22 697 × 60 KiB ≈ 1.33 GiB → run_in_xlarge_stack.
+        let src = compiler_src_dir();
+        let dir = make_tempdir("emit_disk");
+        copy_all_tw_modules(&src, &dir);
+
+        let path_str = twig_escape_path(&src.join("emit.tw"));
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/lexer compiler/parser compiler/emit)) \
+             (define (main) \
+               (length (emit-program (parse-program (lex-source \
+                 (host/read_file \"{path_str}\"))))))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_emit_from_disk");
+        assert_eq!(v.to_string(), "35",
+            "expected 35 functions from emit.tw; got {v}");
+    }
+
+    // ── Test 4: TW05-J regression — original 4 files still produce 38 ────────
+
+    #[test]
+    fn self_compile_tw05j_modules_regression() {
+        // Verify that the four original TW05-J modules still produce the same
+        // counts after the self-compile-all extension.  This test invokes the
+        // pipeline directly (not via self-compile-all) so it is independent of
+        // the main.tw update.
+        let src = compiler_src_dir();
+        let dir = make_tempdir("tw05j_regression");
+        copy_all_tw_modules(&src, &dir);
+
+        // Build a main-test.tw that compiles the four TW05-J files individually
+        // and sums them.
+        let span_path    = twig_escape_path(&src.join("span.tw"));
+        let diag_path    = twig_escape_path(&src.join("diagnostic.tw"));
+        let builder_path = twig_escape_path(&src.join("iir-builder.tw"));
+        let lexer_path   = twig_escape_path(&src.join("lexer.tw"));
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/lexer compiler/parser compiler/emit)) \
+             (define (main) \
+               (+ (length (emit-program (parse-program (lex-source (host/read_file \"{span_path}\"))))) \
+                  (+ (length (emit-program (parse-program (lex-source (host/read_file \"{diag_path}\"))))) \
+                     (+ (length (emit-program (parse-program (lex-source (host/read_file \"{builder_path}\"))))) \
+                        (length (emit-program (parse-program (lex-source (host/read_file \"{lexer_path}\")))))))))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_tw05j_modules_regression");
+        assert_eq!(v.to_string(), "38",
+            "TW05-J regression: expected 38 (2+3+8+25) from original 4 modules; got {v}");
+    }
+
+    // ── Test 5: TW05-I regression — (main) still returns 2 after TW05-K ─────
+
+    #[test]
+    fn existing_main_still_returns_2_after_tw05k() {
+        // The original (main) entry point (TW05-I smoke test, stripped span.tw)
+        // must still return 2 unchanged after the TW05-K extension.
+        let src = compiler_src_dir();
+        let dir = make_tempdir("tw05k_regression_main");
+        copy_all_tw_modules(&src, &dir);
+        let root = dir.join("compiler").join("main.tw");
+
+        let v = crate::run_in_large_stack(root, dir.clone(), "existing_main_still_returns_2_after_tw05k");
         assert_eq!(v.to_string(), "2",
             "TW05-I regression: expected (main) = 2; got {v}");
     }

--- a/code/specs/LANG65-tw05k-extended-self-compilation.md
+++ b/code/specs/LANG65-tw05k-extended-self-compilation.md
@@ -1,0 +1,122 @@
+# LANG65 — TW05-K: Extended Self-Compilation (parser.tw + emit.tw)
+
+## Overview
+
+TW05-K extends the `self-compile-all` pipeline introduced in TW05-J (LANG64) to
+cover the two largest and most semantically rich compiler modules: `parser.tw`
+and `emit.tw`.
+
+After this milestone `self-compile-all` compiles **six** real `.tw` files from
+disk and returns **102** total emitted function definitions.
+
+## Context
+
+TW05-J (LANG64) proved the self-hosted `lex → parse → emit-program` pipeline on
+four data-structure modules (span, diagnostic, iir-builder, lexer) and returned
+38 total functions.  The pipeline was not yet exercised on the compiler's own
+*compilation* modules — the files that contain non-trivial control flow, deep
+recursion, and complex pattern-dispatch logic.
+
+TW05-K adds those two modules:
+
+| Module | Size (chars) | New functions | Depth required |
+|--------|-------------|--------------|----------------|
+| `parser.tw`  | 19 708 | 29 | ≤ 19 708 |
+| `emit.tw`    | 22 697 | 35 | ≤ 22 697 |
+
+Both files are well within the `MAX_DISPATCH_DEPTH = 65536` ceiling set in
+LANG64.  In debug builds, `lex-loop` frames are ~60 KiB each; lexing `emit.tw`
+(the larger of the two) requires up to ~22 697 frames × 60 KiB ≈ 1.3 GiB of
+native stack.  Integration tests therefore use a `run_in_xlarge_stack` helper
+(3 GiB) introduced in this milestone.
+
+## Updated function counts
+
+| File | Size | Functions | Names (first/last) |
+|------|------|----------|--------------------|
+| `span.tw`        | 2 426 |  2 | `make-span`, `dummy-span` |
+| `diagnostic.tw`  | 2 446 |  3 | `make-error`, `make-warning`, `make-info` |
+| `iir-builder.tw` | 6 278 |  8 | `iirbuilder-with-instrs` … `finalise-builder` |
+| `lexer.tw`       | 8 593 | 25 | `lex-digit?` … `lex-source` |
+| `parser.tw`      | 19 708 | 29 | `parse-expr` … `parse-program` |
+| `emit.tw`        | 22 697 | 35 | `emit-const` … `emit-program` |
+| **Total** | | **102** | |
+
+## Changes
+
+### `code/twig/compiler/main.tw`
+
+`self-compile-all` extended to read `parser.tw` and `emit.tw` and sum their
+function counts alongside the existing four files.  Return value changes from
+38 → **102**.
+
+Updated export comment explains TW05-K scope and new total.
+
+### `code/packages/rust/twig-module-driver/src/lib.rs`
+
+#### `run_in_xlarge_stack` helper (new)
+
+3 GiB thread stack for files up to ~35 000 chars in debug builds.
+Mirrors `run_in_large_stack` (768 MiB) but sized for the larger TW05-K files.
+
+Budget rationale:
+- Empirical debug-mode frame size: 30–60 KiB.
+- Largest TW05-K file: `emit.tw` at 22 697 chars.
+- Worst case: 22 697 × 60 KiB = ~1.33 GiB.
+- 3 GiB gives ≥ 2× headroom; physical pages are allocated lazily by the OS.
+
+#### tw05j regression update
+
+`self_compile_all_returns_38` renamed to `self_compile_all_returns_102` and
+updated to expect 102.  Stack upgraded to `run_in_xlarge_stack` since the new
+`self-compile-all` lexes `emit.tw` (22 697 chars).
+
+#### `mod tw05k_tests` (new)
+
+5 integration tests:
+
+| Test | File | Expected |
+|------|------|---------|
+| `self_compile_all_returns_102` | all 6 files | 102 |
+| `self_compile_parser_from_disk` | `parser.tw` | 29 |
+| `self_compile_emit_from_disk` | `emit.tw` | 35 |
+| `self_compile_all_tw05j_modules_regression` | original 4 files only | 38 |
+| `existing_main_still_returns_2_after_tw05k` | `(main)` | 2 |
+
+The regression test re-invokes the individual `lex → parse → emit-program`
+pipeline on the four original TW05-J files to confirm they still produce correct
+counts after the stack and depth changes.
+
+### `code/packages/rust/twig-module-driver/Cargo.toml`
+
+Version: 0.9.0 → 0.10.0
+
+### `code/packages/rust/twig-module-driver/CHANGELOG.md`
+
+Prepend `## [0.10.0]` entry.
+
+## Instruction budget
+
+`self-compile-all` compiles six files sequentially.  Budget estimate:
+- `lex-loop` executes ≈ 30 IIR instructions per source character.
+- Total chars: 2 426 + 2 446 + 6 278 + 8 593 + 19 708 + 22 697 = 62 148.
+- Lex instructions: 62 148 × 30 ≈ 1.86 M.
+- Parse + emit overhead ≈ 0.5 M.
+- Total: ≈ 2.4 M instructions.
+- `MAX_INSTRUCTIONS_PER_RUN = 2²³ = 8 M` — 3.3× headroom.  No change needed.
+
+## Acceptance criteria
+
+- `(self-compile-all dir)` returns 102.
+- `cargo test -p twig-module-driver --lib -- tw05k` — all 5 tests pass.
+- `cargo test -p twig-module-driver --lib -- tw05j` — updated test passes (expects 102).
+- `cargo build --workspace` — clean build.
+
+## Roadmap: what remains after LANG65
+
+| Milestone | Scope | Remaining modules |
+|-----------|-------|-------------------|
+| LANG66 (TW05-L) | Add cst-parser.tw (69 fns, 29 122 chars) to self-compile-all | 1 |
+| LANG67 (TW05-M) | All 11 modules including token/ast/iir-types (0-fn union modules) | main.tw |
+| TW05-G | Fixed-point: stage1 IIR = stage2 IIR for all modules | — |
+| TW05-H | Strict mode: all modules `(typed strict)` | — |

--- a/code/twig/compiler/main.tw
+++ b/code/twig/compiler/main.tw
@@ -1,4 +1,5 @@
-; # main.tw — Root Module + Smoke-Test Entry Point (LANG62 / TW05-I + LANG64 / TW05-J)
+; # main.tw — Root Module + Smoke-Test Entry Point
+;             (LANG62/TW05-I + LANG64/TW05-J + LANG65/TW05-K)
 ;
 ; This is the root module of the self-hosted compiler.  It imports all nine
 ; sub-modules (six data-model modules from TW05-D, lexer and parser from
@@ -7,10 +8,12 @@
 ;   `(main)` — TW05-I: exercises the full pipeline on a stripped in-memory
 ;              version of span.tw (returns 2, unchanged from TW05-H).
 ;
-;   `(self-compile-all dir)` — TW05-J: reads four real `.tw` files from
+;   `(self-compile-all dir)` — TW05-K: reads SIX real `.tw` files from
 ;              disk via `host/read_file`, compiles each through the full
 ;              lex → parse → emit-program pipeline, and returns the sum
-;              of emitted function counts (2 + 3 + 8 + 25 = 38).
+;              of emitted function counts (2 + 3 + 8 + 25 + 29 + 35 = 102).
+;              Extended in TW05-K (LANG65) from the original four-file
+;              TW05-J (LANG64) set (which returned 38).
 ;
 ; ## TW05-I pipeline (LANG62)
 ;
@@ -38,22 +41,33 @@
 ;
 ; The `(main)` return value of `2` is unchanged from TW05-H.
 ;
-; ## TW05-J multi-module self-compilation (LANG64)
+; ## TW05-J multi-module self-compilation (LANG64) — original 4-file set
 ;
-; TW05-J widens the self-compilation test to read actual `.tw` files from
-; disk via `host/read_file`.  `self-compile-all` compiles four modules:
+; TW05-J introduced `self-compile-all` reading four data-structure modules:
 ;
 ;   span.tw          → 2 functions  (make-span, dummy-span)
 ;   diagnostic.tw    → 3 functions  (make-error, make-warning, make-info)
 ;   iir-builder.tw   → 8 functions  (new-builder, alloc-slot, …)
 ;   lexer.tw         → 25 functions (lex-digit?, …, lex-source)
 ;                     ────────────
-;                     38 total
+;                     38 subtotal
 ;
 ; `MAX_DISPATCH_DEPTH` was bumped from 4096 to 65536 in twig-vm 0.17.0
-; (LANG64) to allow lexing files larger than 4096 chars.  The largest file
-; in the set (lexer.tw at 8593 chars) requires up to 8593 recursive frames
-; during the lex phase.
+; (LANG64) to allow lexing files up to 65536 chars.
+;
+; ## TW05-K extended self-compilation (LANG65) — 6-file set
+;
+; TW05-K adds the two main compilation modules to `self-compile-all`:
+;
+;   parser.tw        → 29 functions (parse-expr, …, parse-program)
+;   emit.tw          → 35 functions (emit-const, …, emit-program)
+;                     ────────────
+;                     64 new + 38 original = 102 total
+;
+; `parser.tw` is 19 708 chars; `emit.tw` is 22 697 chars.  Both are well
+; within the 65 536 frame ceiling.  Integration tests use a 3 GiB stack
+; thread (`run_in_xlarge_stack`) to accommodate the ~1.3 GiB worst-case
+; debug-mode stack depth for emit.tw (22 697 × 60 KiB ≈ 1.33 GiB).
 ;
 ; ## VM call-depth note
 ;
@@ -139,21 +153,26 @@
 
 ; ── self-compile-all ──────────────────────────────────────────────────────────
 ;
-; TW05-J milestone: read four compiler source files from `dir` via
-; `host/read_file`, compile each through the self-hosted lex → parse →
-; emit-program pipeline, and return the sum of emitted function counts.
+; TW05-K milestone (extended from TW05-J): read six compiler source files from
+; `dir` via `host/read_file`, compile each through the self-hosted
+; lex → parse → emit-program pipeline, and return the sum of emitted function
+; counts.
 ;
-; `dir` must be the absolute path to the directory containing the
-; compiler `.tw` files (no trailing slash).
+; `dir` must be the absolute path to the directory containing the compiler
+; `.tw` files (no trailing slash).
 ;
-; ## Files compiled and expected counts
+; ## Files compiled and expected counts (TW05-K / LANG65)
 ;
-;   span.tw          2  defines (make-span, dummy-span)
-;   diagnostic.tw    3  defines (make-error, make-warning, make-info)
-;   iir-builder.tw   8  defines (new-builder, alloc-slot, …)
-;   lexer.tw        25  defines (lex-digit?, lex-whitespace?, …, lex-source)
-;                  ───
-;                   38  total
+;   span.tw           2  defines  (make-span, dummy-span)
+;   diagnostic.tw     3  defines  (make-error, make-warning, make-info)
+;   iir-builder.tw    8  defines  (new-builder, alloc-slot, …)
+;   lexer.tw         25  defines  (lex-digit?, …, lex-source)
+;   parser.tw        29  defines  (parse-expr, …, parse-program)        ← TW05-K
+;   emit.tw          35  defines  (emit-const, …, emit-program)         ← TW05-K
+;                   ───
+;                   102  total
+;
+; TW05-J (LANG64) compiled only the first four modules (38 total).
 ;
 ; ## Why host/read_file is safe here
 ;
@@ -162,21 +181,34 @@
 ; processes the full file content including comments (comments are consumed
 ; by `lex-skip-comment` and do not produce tokens).
 ;
-; ## MAX_DISPATCH_DEPTH requirement
+; ## MAX_DISPATCH_DEPTH and stack requirement
 ;
 ; `lex-loop` recurses once per source character.  The largest file compiled
-; here (lexer.tw at 8593 chars) therefore requires up to 8593 dispatch frames.
-; `MAX_DISPATCH_DEPTH` was bumped to 65536 in twig-vm 0.17.0 (LANG64) to
-; accommodate this.
+; here is `emit.tw` at 22 697 chars, requiring up to 22 697 dispatch frames.
+; `MAX_DISPATCH_DEPTH = 65536` (set in LANG64) provides ample headroom.
+;
+; In debug builds, frame sizes are ~60 KiB → 22 697 × 60 KiB ≈ 1.33 GiB.
+; Integration tests therefore use `run_in_xlarge_stack` (3 GiB thread).
+;
+; ## Instruction budget
+;
+; Total source chars: 2 426 + 2 446 + 6 278 + 8 593 + 19 708 + 22 697 = 62 148.
+; Lex: ~30 instrs/char × 62 148 ≈ 1.86 M.  Parse + emit ≈ 0.5 M.
+; Total ≈ 2.4 M << MAX_INSTRUCTIONS_PER_RUN = 8 M.
 
 (define (self-compile-all dir)
   ; Read each source file from disk and compile through the pipeline.
   ; `host/read_file` returns the full file content including comments;
   ; `lex-source` handles them transparently.
+  ;
+  ; Files are compiled sequentially; peak stack depth = max single file depth
+  ; (emit.tw at 22 697 chars), not the sum of all files.
   (let* ((span-src    (host/read_file (string-append dir "/span.tw")))
          (diag-src    (host/read_file (string-append dir "/diagnostic.tw")))
          (builder-src (host/read_file (string-append dir "/iir-builder.tw")))
          (lexer-src   (host/read_file (string-append dir "/lexer.tw")))
+         (parser-src  (host/read_file (string-append dir "/parser.tw")))
+         (emit-src    (host/read_file (string-append dir "/emit.tw")))
 
          ; Compile each module: lex → parse → emit-program.
          ; emit-program returns a list of (fn-name . instrs) pairs —
@@ -185,10 +217,14 @@
          (span-fns    (emit-program (parse-program (lex-source span-src))))
          (diag-fns    (emit-program (parse-program (lex-source diag-src))))
          (builder-fns (emit-program (parse-program (lex-source builder-src))))
-         (lexer-fns   (emit-program (parse-program (lex-source lexer-src)))))
+         (lexer-fns   (emit-program (parse-program (lex-source lexer-src))))
+         (parser-fns  (emit-program (parse-program (lex-source parser-src))))
+         (emit-fns    (emit-program (parse-program (lex-source emit-src)))))
 
-    ; Sum the function counts: 2 + 3 + 8 + 25 = 38.
+    ; Sum the function counts: 2 + 3 + 8 + 25 + 29 + 35 = 102.
     (+ (length span-fns)
        (+ (length diag-fns)
           (+ (length builder-fns)
-             (length lexer-fns))))))
+             (+ (length lexer-fns)
+                (+ (length parser-fns)
+                   (length emit-fns))))))))


### PR DESCRIPTION
## Summary

- **`self-compile-all`** extended from 4 files (TW05-J, 38 fns) to 6 files: adds `parser.tw` (29 fns, 19 708 chars) and `emit.tw` (35 fns, 22 697 chars) → **102 total**
- **`run_in_xlarge_stack`** helper added (3 GiB thread stack) for files larger than 8593 chars; debug-mode worst case for emit.tw: 22 697 × 60 KiB ≈ 1.33 GiB
- **5 new integration tests** in `tw05k_tests`: per-file counts (29, 35), full pipeline (102), TW05-J regression (38 unchanged), TW05-I regression (main=2)
- No twig-vm changes needed — `MAX_DISPATCH_DEPTH=65536` and `MAX_INSTRUCTIONS_PER_RUN=8M` provide sufficient headroom

## Function count table

| File | Chars | Functions |
|------|-------|-----------|
| span.tw | 2 426 | 2 |
| diagnostic.tw | 2 446 | 3 |
| iir-builder.tw | 6 278 | 8 |
| lexer.tw | 8 593 | 25 |
| parser.tw | 19 708 | **29** ← new |
| emit.tw | 22 697 | **35** ← new |
| **Total** | | **102** |

## Security review

- 1 round, passed immediately — all path embeddings use `twig_escape_path` (established in LANG64), `make_tempdir` uses atomic `create_dir`

## Test plan

- [ ] `cargo test -p twig-module-driver --lib -- tw05k` — 5 new tests pass
- [ ] `cargo test -p twig-module-driver --lib -- tw05j` — 7 tests still pass (updated to expect 102)
- [ ] `cargo test -p twig-module-driver --lib -- tw05i` — 6 regression tests still pass
- [ ] `cargo build --workspace` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)