### PR TITLE
feat(forme-style-theme): FM04 §7 / §13.3 theme registry + composition

### DIFF
--- a/code/packages/typescript/forme-style-theme/BUILD
+++ b/code/packages/typescript/forme-style-theme/BUILD
@@ -1,0 +1,4 @@
+cd ../document-ast && npm install --silent
+cd ../forme-types && npm install --silent
+cd ../forme-style-ir && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-style-theme/CHANGELOG.md
+++ b/code/packages/typescript/forme-style-theme/CHANGELOG.md
@@ -1,0 +1,114 @@
+# Changelog — @coding-adventures/forme-style-theme
+
+## 0.1.0 — 2026-05-17
+
+Initial release.  Third package of the FM04 Style IR family —
+theme composition + in-memory registry + bulk `TokenRef` resolution.
+
+### Added
+
+- `composeWithTheme(base, theme): StyleDocument` — apply a
+  `Theme`'s sparse token overrides + appended rules to a base
+  `StyleDocument` per FM04 §7.2.  Per-named-entry merge within
+  every bucket (recurses into the five `typography` sub-buckets);
+  theme rules are appended (FM04 §4.9 specificity = source order);
+  inputs are not mutated.
+- `createThemeRegistry(): ThemeRegistry` — in-memory registry per
+  FM04 §13.3.  `register(theme)` (replace-on-duplicate for dev-mode
+  hot reload), `lookup(name)`, `list()` (sorted, frozen).
+- `resolveTokenRefs(doc, refs): Map<string, ResolvedValue | null>`
+  per FM04 §3.5 — bulk-resolve `TokenRef`s against a document's
+  tokens for analyser pre-passes (AOT CSS slicer, LaTeX preamble
+  extractor, theme coverage reporters).  Chain depth capped at 8
+  hops; cycles return `null`.
+- `ResolvedValue` type = `Color | Length | Shadow | FontStack |
+  number` — the recognised leaf value types a `TokenRef` may
+  resolve to.
+
+### Spec adherence
+
+Implements FM04 §7.2 (theme composition), §13.3 (theme registry),
+§3.5 (`TokenRef` resolution).  No exports beyond those three concerns
+— keeps the surface focused.
+
+### Behavioural notes
+
+- **`composeWithTheme` returns a *new* `StyleDocument`.**  When
+  `theme.tokens` is absent the resulting `tokens` is reference-equal
+  to the base's (zero-copy fast path); same for `rules` when
+  `theme.rules` is absent.
+- **`typography` is a two-level bucket** — `families`, `scale`,
+  `weights`, `leading`, `tracking`.  Each is independently
+  per-name-overridable.  TypeScript's `Partial<TokenSet>` is
+  one-level partial, so partial typography overrides may need a
+  cast at the call site; runtime handling is correct.
+- **Theme rules trail base rules in the merged document.**  Per
+  FM04 §4.9 source-order = specificity, so theme rules naturally
+  win on equal-specificity ties without any explicit "cascade"
+  machinery in this package.
+- **`createThemeRegistry()` yields independent instances.**  No
+  global state; per-tenant / per-project registries are a one-line
+  ergonomic.
+- **`list()` is sorted lexicographically AND frozen.**  Sorted so
+  output is byte-stable across runs (FM04 §12 reproducibility);
+  frozen so accidental in-place sorts by callers don't race future
+  calls.
+- **`resolveTokenRefs` collapses duplicate input paths.**  Two refs
+  with the same `path` produce one map entry (idempotent — the
+  resolution is pure, so the value is identical).
+
+### Spec divergences
+
+None.
+
+### v0 simplifications (documented)
+
+- **In-memory registry only.**  Persistent backing (filesystem,
+  database) is deferred until FM06 (AOT compiler) needs it.
+- **One-theme-at-a-time composition.**  Multi-theme stacks compose
+  by chaining: `composeWithTheme(composeWithTheme(base, t1), t2)`.
+
+### Security posture
+
+Pre-push security focus areas (per the task brief):
+
+- **Deep-merge prototype-pollution defence.**  Token names
+  `__proto__`, `constructor`, `prototype` refused unconditionally
+  across `mergeRecord` / `mergeTypography` / `mergeTokens`.  Merged
+  records backed by `Object.create(null)` so even a successful
+  bypass of the deny-list leaves `Object.prototype` untouched.
+  Two tests pin the behaviour (forbidden `__proto__` and
+  `constructor` keys are dropped; pollution doesn't reach
+  `Object.prototype`).
+- **Registry mutation safety.**  Backed by `Map<string, Theme>`
+  (own-key semantics by construction).  The three forbidden names
+  are additionally refused with a thrown error — they'd only ever
+  appear through a programming mistake.  Two tests pin the
+  rejection paths.
+- **`TokenRef.path` walks** mirror the
+  `forme-style-to-css/token-resolver` defence: deny-list +
+  `hasOwnProperty.call` (own-only).  Three tests pin
+  `__proto__` / `constructor` / `prototype` in path segments.
+
+Validator-trust posture: the `forme-style-ir` validator already
+restricts token names to a dotted-identifier grammar that doesn't
+admit the forbidden keys.  Defending here too means a stage that
+hands us a hand-rolled `Theme` (bypassing the validator) can't
+poison `Object.prototype` through us.
+
+### Tests
+
+51 tests across 3 files:
+
+- `compose.test.ts` (18 tests — token override, rule append,
+  immutability, passthrough fields, token extensions merge,
+  reproducibility, prototype-pollution defence covering
+  `__proto__` / `constructor` / `prototype`)
+- `registry.test.ts` (13 tests — CRUD, replace-on-duplicate, input
+  validation, isolation, bounded self-referential lookup)
+- `resolve.test.ts` (20 tests — concrete leaves, chains, failure
+  modes including cycle and NaN, bulk semantics, prototype-traversal
+  defence)
+
+Coverage: **100% line / 96.51% branch** — above the FM04 §14.4
+≥95% line target.

--- a/code/packages/typescript/forme-style-theme/README.md
+++ b/code/packages/typescript/forme-style-theme/README.md
@@ -1,0 +1,168 @@
+# @coding-adventures/forme-style-theme
+
+Theme registry + composition for Forme **Style IR**.  Three small
+exports, each a focused FM04 concern:
+
+| Export                 | Spec ref       | Concern                                                                |
+|------------------------|----------------|------------------------------------------------------------------------|
+| `composeWithTheme`     | FM04 §7.2      | Apply a `Theme`'s sparse token overrides + appended rules to a base `StyleDocument`.   |
+| `createThemeRegistry`  | FM04 §13.3     | In-memory `{ register, lookup, list }` keyed by theme name.            |
+| `resolveTokenRefs`     | FM04 §3.5      | Bulk-resolve `TokenRef`s against a document's tokens (analyser pre-pass). |
+
+This is the **third** package of the FM04 family; the IR substrate
+lives in [`forme-style-ir`](../forme-style-ir) and the reference CSS
+translator in [`forme-style-to-css`](../forme-style-to-css).
+
+## Why a separate package?
+
+The FM04 spec deliberately splits the *IR* (types + validator),
+*translators* (one per output format), and the *composition layer*
+into separate packages so each can evolve independently — themes are
+useful even when only the LaTeX translator is loaded, and the LaTeX
+translator can ship without a theme registry if a backend doesn't
+need one.
+
+## Quick start
+
+```ts
+import {
+  composeWithTheme, createThemeRegistry, resolveTokenRefs,
+} from "@coding-adventures/forme-style-theme";
+import {
+  emptyStyleDocument, styleRuleId, sel,
+  type Theme,
+} from "@coding-adventures/forme-style-ir";
+
+const base = {
+  ...emptyStyleDocument(),
+  tokens: {
+    ...emptyStyleDocument().tokens,
+    colors: {
+      text: { kind: "rgb", r: 31, g: 35, b: 40 },
+      link: { kind: "rgb", r: 9,  g: 105, b: 218 },
+    },
+  },
+  rules: [
+    {
+      id: styleRuleId("body"),
+      selector: sel.type("paragraph"),
+      properties: [
+        { kind: "color", value: { kind: "token-ref", path: "colors.text" } },
+      ],
+    },
+  ],
+};
+
+// 1. A theme registry — hot-reload friendly (replace-on-duplicate).
+const themes = createThemeRegistry();
+themes.register({
+  name: "dark",
+  tokens: { colors: { text: { kind: "rgb", r: 240, g: 240, b: 240 } } },
+} as const satisfies Theme);
+
+// 2. Composition — merge the theme onto the base document.
+const dark = themes.lookup("dark");
+if (dark) {
+  const composed = composeWithTheme(base, dark);
+  // composed.tokens.colors.text === { rgb 240/240/240 } (overridden)
+  // composed.tokens.colors.link === { rgb 9/105/218 }   (preserved)
+}
+
+// 3. Bulk-resolve refs (analyser pre-pass — e.g. AOT CSS slicer).
+const resolved = resolveTokenRefs(base, [
+  { kind: "token-ref", path: "colors.text" },
+  { kind: "token-ref", path: "colors.nonexistent" },
+]);
+// resolved.get("colors.text")        → { kind: "rgb", r: 31, g: 35, b: 40 }
+// resolved.get("colors.nonexistent") → null
+```
+
+## Composition semantics (FM04 §7.2)
+
+1. **Token override is per-named-entry within each bucket.**  A theme
+   that contributes one color does not wipe other base colors;
+   entries the theme doesn't mention stay at their base value.  This
+   applies recursively into `typography`'s five sub-buckets
+   (`families`, `scale`, `weights`, `leading`, `tracking`).
+2. **Token values are atomic — no value-level merge.**  Overriding
+   `colors.text` swaps the *whole* color value; you can't half-merge
+   an `rgb` with an `hsl`.
+3. **Rules are appended.**  Theme rules trail the base's, so they
+   naturally win on equal-specificity ties per FM04 §4.9 (source
+   order = specificity).
+4. **`contexts`, `theme`, and `extensions` are preserved verbatim
+   from `base`.**  Themes don't redeclare contexts or pivot the
+   document's identity.
+5. **Inputs are not mutated.**  `composeWithTheme` always returns a
+   new `StyleDocument`.
+
+## Registry semantics (FM04 §13.3)
+
+- **Replace-on-duplicate** — registering the same name overwrites.
+  The use case is dev-mode hot-reload; production stages register
+  each theme once.
+- **`list()` returns names sorted lexicographically** so downstream
+  callers (config dumps, error messages, AOT manifests) are
+  byte-stable across runs.
+- **`lookup()` is read-only** — returns the registered `Theme` by
+  reference (no defensive copy; `Theme` is `readonly` throughout the
+  IR).
+- **Each `createThemeRegistry()` call yields an independent
+  instance** — no shared global state.
+
+## Bulk resolution (FM04 §3.5)
+
+`resolveTokenRefs(doc, refs)` returns a `Map<string, ResolvedValue |
+null>` keyed by `ref.path`.  Null means unresolvable (path missing,
+cycle, type mismatch, non-leaf landing).  Token-chain depth is
+capped at 8 hops — covers any sensible design system and converts
+cycles into `null` rather than a stack overflow.
+
+Resolution is independent of any translator backend — the same map
+feeds the CSS slicer (FM06), the LaTeX preamble extractor, theme
+coverage reporters, and so on.
+
+## Security posture
+
+Two attack surfaces, both addressed:
+
+1. **Deep-merge prototype-pollution.**  Token names like
+   `__proto__`, `constructor`, and `prototype` are refused at every
+   level of the bucket walk.  Merged records are backed by
+   `Object.create(null)` so even if an attacker found a way past
+   the deny-list, `Object.prototype` would still be untouched.
+2. **Registry name pollution.**  The registry stores `Theme` values
+   in a `Map<string, Theme>` (own-key semantics by construction)
+   and additionally refuses the three forbidden names defensively.
+
+`TokenRef.path` walks also refuse the forbidden segments and require
+`hasOwnProperty`, defending against a hand-rolled `TokenRef` that
+bypasses the validator's grammar.
+
+## Spec divergences
+
+None known.  Implements FM04 §7.2 / §13.3 / §3.5 verbatim.
+
+## v0 simplifications
+
+- **No persistent registry** — in-memory only.  Persistent backing
+  (filesystem, database) lands when FM06 (AOT compiler) actually
+  needs it.
+- **No multi-theme composition** — `composeWithTheme(base, theme)`
+  composes one theme at a time.  For multi-theme stacks, chain
+  calls: `composeWithTheme(composeWithTheme(base, theme1), theme2)`.
+
+## Tests
+
+51 tests across 3 files:
+
+- `compose.test.ts` (18 tests — token override, rule append,
+  immutability, passthrough fields, extensions, reproducibility,
+  prototype-pollution defence)
+- `registry.test.ts` (13 tests — CRUD, replace-on-duplicate, input
+  validation, isolation, bounded self-referential lookup)
+- `resolve.test.ts` (20 tests — concrete leaves, chains, failure
+  modes, bulk semantics, prototype traversal defence)
+
+Coverage: **100% line / 96.51% branch** — above the FM04 §14.4
+≥95% line target.

--- a/code/packages/typescript/forme-style-theme/package-lock.json
+++ b/code/packages/typescript/forme-style-theme/package-lock.json
@@ -1,11 +1,24 @@
 {
-  "name": "@coding-adventures/forme-style-ir",
+  "name": "@coding-adventures/forme-style-theme",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@coding-adventures/forme-style-ir",
+      "name": "@coding-adventures/forme-style-theme",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-style-ir": {
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -18,7 +31,6 @@
       }
     },
     "../forme-types": {
-      "name": "@coding-adventures/forme-types",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -97,6 +109,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/forme-style-ir": {
+      "resolved": "../forme-style-ir",
+      "link": true
     },
     "node_modules/@coding-adventures/forme-types": {
       "resolved": "../forme-types",

--- a/code/packages/typescript/forme-style-theme/package.json
+++ b/code/packages/typescript/forme-style-theme/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/forme-style-theme",
+  "version": "0.1.0",
+  "description": "Theme registry + composition for Forme Style IR — composeWithTheme (base + theme → merged StyleDocument), createThemeRegistry (in-memory name → Theme lookup), resolveTokenRefs (bulk TokenRef resolution) (FM04 §7 / §13.3).",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+    "@coding-adventures/forme-types": "file:../forme-types"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-style-theme/required_capabilities.json
+++ b/code/packages/typescript/forme-style-theme/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-style-theme",
+  "capabilities": [],
+  "justification": "Pure transform + in-memory registry: StyleDocument + Theme → StyleDocument, plus an in-memory Map keyed by theme name.  No I/O, no network, no env, no shell.  Same posture as forme-style-ir and forme-style-to-css."
+}

--- a/code/packages/typescript/forme-style-theme/src/compose.ts
+++ b/code/packages/typescript/forme-style-theme/src/compose.ts
@@ -1,0 +1,149 @@
+/**
+ * compose.ts — `composeWithTheme(base, theme)` per FM04 §7.2.
+ *
+ * A `Theme` is a sparse overlay on a `StyleDocument`: a partial
+ * `TokenSet` (per-named-token overrides) plus an optional appended
+ * `rules` list.  Composition is mechanical:
+ *
+ *   1. Start with `base`.
+ *   2. **Deep-merge** `theme.tokens` over `base.tokens` — per-named
+ *      override; missing entries stay at their base value.  The merge
+ *      stops at *named* tokens; we don't recursively deep-merge the
+ *      *value* (you can't merge half of an rgb color with half of an
+ *      hsl one — overriding a token swaps the whole value).
+ *   3. **Append** `theme.rules` to `base.rules` in order.  Per FM04
+ *      §4.9, later-in-source wins on equal-specificity ties — so
+ *      theme rules naturally override base rules with overlapping
+ *      selectors without any special "cascade" machinery here.
+ *   4. `kind`, `contexts`, `theme`, and `extensions` are preserved
+ *      from `base` (themes don't redeclare contexts or pivot the
+ *      whole document's identity).
+ *
+ * ## Why a custom deep-merge instead of `{ ...a, ...b }`?
+ *
+ * `TokenSet` has *two* levels of named-record nesting (top-level
+ * buckets + per-bucket entries, plus a third level inside
+ * `typography`).  A single spread only merges the top level — it
+ * would overwrite an entire `colors` bucket if the theme contributed
+ * any colors at all, wiping out base colors not mentioned in the
+ * theme.  Bucket-aware merge is the correct semantics per §7.2.
+ *
+ * ## Security note — prototype-pollution defence
+ *
+ * The merge walks user-supplied keys.  We refuse `__proto__`,
+ * `constructor`, and `prototype` unconditionally, and only copy
+ * **own** properties.  In practice the `forme-style-ir` validator
+ * already restricts token-name keys via the token-grammar
+ * (dotted-identifier), but a stage that hands us a hand-rolled
+ * `Theme` (bypassing the validator) can't poison the base
+ * `Object.prototype` through us.
+ *
+ * @module compose
+ */
+
+import type {
+  ReadonlyRecord,
+} from "@coding-adventures/forme-types";
+import type {
+  StyleDocument, StyleRule, Theme,
+  TokenSet, TypographyTokens,
+} from "@coding-adventures/forme-style-ir";
+
+/** Keys we refuse to follow during deep-merge (proto-pollution shields). */
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Compose a theme onto a base `StyleDocument`, returning a new merged
+ * `StyleDocument`.  Inputs are not mutated.
+ *
+ * Token override is **per-named-entry** within each bucket; rules
+ * are **appended** so the theme's rules trail the base's (later wins
+ * per FM04 §4.9 specificity).
+ */
+export function composeWithTheme(
+  base: StyleDocument,
+  theme: Theme,
+): StyleDocument {
+  const tokens = mergeTokens(base.tokens, theme.tokens);
+  const rules: readonly StyleRule[] = theme.rules
+    ? [...base.rules, ...theme.rules]
+    : base.rules;
+
+  // Preserve extensions verbatim — themes don't merge into them in v0.
+  // (Plugin-contributed extension data is opaque; a plugin that wants
+  // theme-aware extension data exposes its own composition helper.)
+  return {
+    kind: "StyleDocument",
+    tokens,
+    rules,
+    contexts: base.contexts,
+    theme: base.theme,
+    ...(base.extensions !== undefined ? { extensions: base.extensions } : {}),
+  };
+}
+
+// ─── TokenSet merge ──────────────────────────────────────────────────────
+
+function mergeTokens(
+  base: TokenSet,
+  overlay: Partial<TokenSet> | undefined,
+): TokenSet {
+  if (overlay === undefined) return base;
+
+  // Each bucket is a flat ReadonlyRecord<string, V> — except
+  // `typography`, which is itself a record of records.  Handle that
+  // one specially; the rest share a generic per-entry override.
+  return {
+    colors:     mergeRecord(base.colors,    overlay.colors),
+    typography: mergeTypography(base.typography, overlay.typography),
+    space:      mergeRecord(base.space,     overlay.space),
+    radii:      mergeRecord(base.radii,     overlay.radii),
+    shadows:    mergeRecord(base.shadows,   overlay.shadows),
+    ...(base.extensions !== undefined || overlay.extensions !== undefined
+      ? { extensions: mergeRecord(base.extensions ?? {}, overlay.extensions) }
+      : {}),
+  };
+}
+
+function mergeTypography(
+  base: TypographyTokens,
+  overlay: Partial<TypographyTokens> | undefined,
+): TypographyTokens {
+  if (overlay === undefined) return base;
+  return {
+    families: mergeRecord(base.families, overlay.families),
+    scale:    mergeRecord(base.scale,    overlay.scale),
+    weights:  mergeRecord(base.weights,  overlay.weights),
+    leading:  mergeRecord(base.leading,  overlay.leading),
+    tracking: mergeRecord(base.tracking, overlay.tracking),
+  };
+}
+
+/**
+ * Per-named-entry override: copy own keys from `base`, then
+ * overwrite with own keys from `overlay`.  Forbidden keys
+ * (`__proto__`, `constructor`, `prototype`) are silently dropped —
+ * the validator's grammar should have caught them already, but
+ * belt-and-braces.
+ */
+function mergeRecord<V>(
+  base: ReadonlyRecord<string, V>,
+  overlay: ReadonlyRecord<string, V> | undefined,
+): ReadonlyRecord<string, V> {
+  if (overlay === undefined) return base;
+  const out: Record<string, V> = Object.create(null);
+  copyOwn(base, out);
+  copyOwn(overlay, out);
+  return out;
+}
+
+function copyOwn<V>(
+  src: ReadonlyRecord<string, V>,
+  dst: Record<string, V>,
+): void {
+  for (const key of Object.keys(src)) {
+    if (FORBIDDEN_KEYS.has(key)) continue;
+    if (!Object.prototype.hasOwnProperty.call(src, key)) continue;
+    dst[key] = src[key]!;
+  }
+}

--- a/code/packages/typescript/forme-style-theme/src/index.ts
+++ b/code/packages/typescript/forme-style-theme/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @coding-adventures/forme-style-theme
+ *
+ * Theme registry + composition for Forme Style IR (FM04 §7, §13.3).
+ *
+ * Three exports, three concerns:
+ *
+ *   composeWithTheme(base, theme) → StyleDocument
+ *     Apply a `Theme`'s sparse token overrides + appended rules to a
+ *     base `StyleDocument`, returning a new merged document.  Per
+ *     FM04 §7.2.
+ *
+ *   createThemeRegistry() → ThemeRegistry
+ *     In-memory map { register, lookup, list } keyed by theme name.
+ *     Dev-mode hot-reload friendly (re-register replaces).  Per
+ *     FM04 §13.3.
+ *
+ *   resolveTokenRefs(doc, refs) → Map<string, ResolvedValue | null>
+ *     Bulk `TokenRef` resolution against a document's tokens.  For
+ *     analyser pre-passes (AOT CSS slicer, theme coverage report,
+ *     etc.).  Per FM04 §3.5.
+ *
+ * This package has **no I/O** and **no shell** — pure
+ * data-in / data-out plus an in-memory map.
+ *
+ * @module index
+ */
+
+export { composeWithTheme } from "./compose.js";
+export { createThemeRegistry } from "./registry.js";
+export type { ThemeRegistry } from "./registry.js";
+export { resolveTokenRefs } from "./resolve.js";
+export type { ResolvedValue } from "./resolve.js";

--- a/code/packages/typescript/forme-style-theme/src/registry.ts
+++ b/code/packages/typescript/forme-style-theme/src/registry.ts
@@ -1,0 +1,108 @@
+/**
+ * registry.ts — `createThemeRegistry()` per FM04 §13.3.
+ *
+ * The theme registry is the lookup table the orchestrator consults
+ * when a `StyleDocument` declares `theme: "<name>"`.  In v0 it's an
+ * in-memory map; later (FM01 §3) a persistent registry may back it.
+ *
+ * ## API shape
+ *
+ *   const reg = createThemeRegistry();
+ *   reg.register(brandTheme);          // keyed by brandTheme.name
+ *   reg.register(highContrastTheme);
+ *   reg.lookup("brand");               // → Theme | undefined
+ *   reg.list();                        // → readonly ["brand", "high-contrast"]   (sorted)
+ *
+ * ## Semantics
+ *
+ * - **Replace-on-duplicate** — re-registering the same name overwrites.
+ *   The use case is hot-reload during development: the dev server
+ *   re-runs the theme producer on file change and the new value
+ *   should win.  Production producers register once.
+ * - **`list()` returns names in sorted order** — deterministic so
+ *   downstream callers (config dumps, error messages, AOT manifests)
+ *   are byte-stable across runs.
+ * - **`lookup()` is read-only** — returns the registered `Theme` by
+ *   reference (no defensive copy).  `Theme` is `readonly` throughout
+ *   the IR, so structural mutation by callers is a type error.
+ *
+ * ## Security note — registry mutation safety
+ *
+ * The registry stores `Theme` values keyed by user-supplied names.
+ * Two ways a malicious or buggy caller could try to misuse the map:
+ *
+ * 1. **Prototype-pollution names** — `"__proto__"` / `"constructor"` /
+ *    `"prototype"` would, in a naive `{}`-backed map, poison
+ *    `Object.prototype`.  We use a `Map<string, Theme>` rather than a
+ *    plain object, so own-vs-inherited key semantics are not a
+ *    concern; the `Map` API is closed over a discrete entry set.
+ *    We additionally refuse these three names explicitly, throwing —
+ *    they'd only ever appear by mistake.
+ *
+ * 2. **Reference aliasing** — the registry stores the `Theme` by
+ *    reference.  Themes are `readonly` in the IR; TypeScript's
+ *    `readonly` doesn't prevent runtime mutation, but it does flag
+ *    accidents at compile time.  We choose not to deep-clone on
+ *    register/lookup — the cost would be O(theme-size) per call and
+ *    most callers never mutate.  The `readonly` discipline is the
+ *    contract.
+ *
+ * @module registry
+ */
+
+import type { Theme } from "@coding-adventures/forme-style-ir";
+
+/** Keys we refuse to register under — prototype-pollution shields. */
+const FORBIDDEN_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
+/** The public interface for the in-memory theme registry. */
+export interface ThemeRegistry {
+  /**
+   * Insert (or replace) a theme.  Keyed by `theme.name`.  Throws if
+   * `name` is empty or one of the prototype-pollution shield names
+   * (which should never appear in real input but are refused
+   * defensively).
+   */
+  register(theme: Theme): void;
+  /** Lookup by name.  Returns `undefined` for unknown names. */
+  lookup(name: string): Theme | undefined;
+  /** All registered names, sorted lexicographically (deterministic). */
+  list(): readonly string[];
+}
+
+/**
+ * Construct a fresh, empty theme registry.  Each call yields an
+ * independent registry — useful for tests and for orchestrators that
+ * want isolated theme scopes (per-tenant, per-project, …).
+ */
+export function createThemeRegistry(): ThemeRegistry {
+  // Backing `Map` rather than `{}` so we don't have to worry about
+  // prototype-pollution semantics in the *storage*; we still refuse
+  // the three forbidden names defensively to keep the registry's
+  // observable surface clean.
+  const themes = new Map<string, Theme>();
+
+  return {
+    register(theme: Theme): void {
+      if (typeof theme.name !== "string" || theme.name.length === 0) {
+        throw new Error("ThemeRegistry.register: theme.name must be a non-empty string");
+      }
+      if (FORBIDDEN_NAMES.has(theme.name)) {
+        throw new Error(
+          `ThemeRegistry.register: refusing forbidden name "${theme.name}"`,
+        );
+      }
+      themes.set(theme.name, theme);
+    },
+    lookup(name: string): Theme | undefined {
+      // `Map.get` is own-key lookup by construction — no inherited-
+      // property concerns.
+      return themes.get(name);
+    },
+    list(): readonly string[] {
+      // Sort for byte-stable iteration.  Object.freeze stops accidental
+      // in-place sorts by the caller from racing with future calls.
+      return Object.freeze([...themes.keys()].sort());
+    },
+  };
+}

--- a/code/packages/typescript/forme-style-theme/src/resolve.ts
+++ b/code/packages/typescript/forme-style-theme/src/resolve.ts
@@ -1,0 +1,142 @@
+/**
+ * resolve.ts — `resolveTokenRefs(doc, refs)` per FM04 §13.3.
+ *
+ * Bulk `TokenRef` resolution.  Used by analyser pre-passes (the AOT
+ * compiler's CSS-slice planner, the LaTeX preamble extractor, theme
+ * coverage reporters, …) that want to know "if I resolve *these*
+ * refs against *this* document's tokens, what do I get?" without
+ * stepping through a full translator.
+ *
+ * Returns a `Map<string, ResolvedValue | null>` keyed by `ref.path`.
+ * `null` means the ref couldn't be resolved — path not found, cycle,
+ * type mismatch, or a non-leaf landing point.  The translator-side
+ * mappers warn-and-skip on null per FM04 §9.6; analyser callers
+ * decide their own policy.
+ *
+ * ## Resolution semantics
+ *
+ * - Walk the dotted path through `doc.tokens`.
+ * - If the landing value is itself a `TokenRef`, recurse — token
+ *   chains are valid (a "link" color pointing at a "text" color).
+ * - Cap chains at `MAX_RESOLVE_DEPTH = 8` (covers any sensible
+ *   design system; the cap converts a cycle into `null` rather
+ *   than letting the stack overflow).
+ * - Return one of the recognised leaf shapes (`Color`, `Length`,
+ *   `Shadow`, `FontStack`, `number`) — anything else (object that
+ *   doesn't match a known shape, undefined, etc.) yields `null`.
+ *
+ * ## Security note — prototype traversal
+ *
+ * Identical defence to `forme-style-to-css`'s token resolver: deny
+ * `__proto__` / `constructor` / `prototype` AND require
+ * `hasOwnProperty`.  Independently coded here so this package
+ * doesn't transitively depend on a translator backend.
+ *
+ * @module resolve
+ */
+
+import {
+  isTokenRef,
+  type Color, type FontStack, type Length, type Shadow,
+  type StyleDocument, type TokenRef, type TokenSet,
+} from "@coding-adventures/forme-style-ir";
+
+/** Cap on token-chain hops.  See module docstring. */
+const MAX_RESOLVE_DEPTH = 8;
+
+/**
+ * The concrete leaf-value types a `TokenRef` may resolve to.  Note
+ * that `number` covers font weights and leading multipliers — the
+ * two scalar tokens in `TypographyTokens`.
+ */
+export type ResolvedValue = Color | Length | Shadow | FontStack | number;
+
+/**
+ * Bulk-resolve a list of `TokenRef`s against a `StyleDocument`'s
+ * tokens.  Returns a map keyed by `ref.path`; duplicate paths in the
+ * input collapse to one entry (last-write-wins, but since the
+ * resolution is pure, the value is identical anyway).
+ */
+export function resolveTokenRefs(
+  doc: StyleDocument,
+  refs: readonly TokenRef[],
+): Map<string, ResolvedValue | null> {
+  const out = new Map<string, ResolvedValue | null>();
+  for (const ref of refs) {
+    out.set(ref.path, resolveOne(ref, doc.tokens));
+  }
+  return out;
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────
+
+function resolveOne(
+  ref: TokenRef,
+  tokens: TokenSet,
+  depth = 0,
+): ResolvedValue | null {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const v = walkPath(ref.path, tokens as unknown as Record<string, unknown>);
+  if (v === undefined) return null;
+  if (isTokenRef(v)) return resolveOne(v as TokenRef, tokens, depth + 1);
+  return narrow(v);
+}
+
+/**
+ * Walk a dotted path through an object tree.  Returns undefined if
+ * any segment is missing, non-object, or hits a prototype-pollution
+ * shield.  See module docstring for the security rationale.
+ */
+function walkPath(path: string, root: Record<string, unknown>): unknown {
+  const parts = path.split(".");
+  let cursor: unknown = root;
+  for (const part of parts) {
+    if (typeof cursor !== "object" || cursor === null) return undefined;
+    if (part === "__proto__" || part === "constructor" || part === "prototype") return undefined;
+    const obj = cursor as Record<string, unknown>;
+    if (!Object.prototype.hasOwnProperty.call(obj, part)) return undefined;
+    cursor = obj[part];
+    if (cursor === undefined) return undefined;
+  }
+  return cursor;
+}
+
+/**
+ * Narrow a resolved value to one of the recognised leaf shapes.
+ * Returns null for anything we don't recognise (intermediate object
+ * nodes, undefined, NaN, …).
+ */
+function narrow(v: unknown): ResolvedValue | null {
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (isFontStack(v)) return v;
+  if (isLength(v)) return v;
+  if (isColor(v)) return v;
+  if (isShadow(v)) return v;
+  return null;
+}
+
+function isColor(v: unknown): v is Color {
+  if (typeof v !== "object" || v === null) return false;
+  const k = (v as { kind?: unknown }).kind;
+  return k === "rgb" || k === "hsl" || k === "oklch" || k === "named";
+}
+
+function isLength(v: unknown): v is Length {
+  if (typeof v !== "object" || v === null) return false;
+  const u = (v as { unit?: unknown }).unit;
+  return typeof u === "string" && typeof (v as { value?: unknown }).value === "number";
+}
+
+function isShadow(v: unknown): v is Shadow {
+  if (typeof v !== "object" || v === null) return false;
+  const s = v as Record<string, unknown>;
+  return (
+    isLength(s.offsetX) && isLength(s.offsetY)
+    && isLength(s.blur) && isLength(s.spread)
+    && s.color !== undefined
+  );
+}
+
+function isFontStack(v: unknown): v is FontStack {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}

--- a/code/packages/typescript/forme-style-theme/tests/compose.test.ts
+++ b/code/packages/typescript/forme-style-theme/tests/compose.test.ts
@@ -1,0 +1,332 @@
+/**
+ * compose.test.ts — `composeWithTheme` semantics.
+ *
+ * The big-ticket invariants:
+ *
+ * - Base tokens NOT mentioned by the theme stay at their base value.
+ * - Theme tokens override per-named-entry.
+ * - Bucket-level merge: a theme adding one color doesn't wipe other
+ *   base colors.
+ * - Typography is bucket-nested; same rules apply to families /
+ *   scale / weights / leading / tracking individually.
+ * - Theme rules are APPENDED to base rules in order (FM04 §4.9
+ *   specificity = source order).
+ * - Inputs are not mutated.
+ * - Empty theme (no overrides, no rules) is a no-op shape-wise.
+ * - Reproducibility: same inputs → byte-identical canonical output.
+ * - Prototype-pollution defence (deny-list keys silently dropped).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  canonicalStyleDocument,
+  emptyStyleDocument, styleRuleId, sel,
+  type StyleDocument, type Theme, type StyleRule,
+} from "@coding-adventures/forme-style-ir";
+import { composeWithTheme } from "../src/index.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────
+
+function baseDoc(): StyleDocument {
+  return {
+    kind: "StyleDocument",
+    tokens: {
+      colors: {
+        text: { kind: "rgb", r: 31, g: 35, b: 40 },
+        link: { kind: "rgb", r: 9,  g: 105, b: 218 },
+      },
+      typography: {
+        families: { body: ["Inter", "sans-serif"] },
+        scale:    { md: { unit: "rem", value: 1 } },
+        weights:  { regular: 400 },
+        leading:  { normal: 1.5 },
+        tracking: { normal: { unit: "em", value: 0 } },
+      },
+      space:   { md: { unit: "rem", value: 1 } },
+      radii:   { sm: { unit: "px", value: 4 } },
+      shadows: {},
+    },
+    rules: [
+      {
+        id: styleRuleId("body"),
+        selector: sel.type("paragraph"),
+        properties: [
+          { kind: "color", value: { kind: "token-ref", path: "colors.text" } },
+        ],
+      },
+    ],
+    contexts: [],
+    theme: null,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe("composeWithTheme — token override", () => {
+  it("preserves base tokens not overridden by the theme", () => {
+    const base = baseDoc();
+    const theme: Theme = {
+      name: "dark",
+      tokens: {
+        colors: {
+          // Override `text` only.  `link` should survive.
+          text: { kind: "rgb", r: 240, g: 240, b: 240 },
+        },
+      },
+    };
+    const out = composeWithTheme(base, theme);
+    expect(out.tokens.colors.text).toEqual({ kind: "rgb", r: 240, g: 240, b: 240 });
+    expect(out.tokens.colors.link).toEqual({ kind: "rgb", r: 9, g: 105, b: 218 });
+  });
+
+  it("overrides per-named-entry within a typography sub-bucket", () => {
+    const base = baseDoc();
+    // Theme.tokens is Partial<TokenSet> at the bucket level — but the
+    // typography sub-buckets themselves should also be partial-overridable
+    // at runtime per FM04 §7.2.  We cast the typography sub-record
+    // because the static type is conservatively "full TypographyTokens"
+    // (TypeScript's Partial<> doesn't recurse into nested types).
+    const theme = {
+      name: "compact",
+      tokens: {
+        typography: {
+          // Override scale.md only.  Other typography sub-buckets and
+          // other scale entries should be untouched.
+          scale: { md: { unit: "rem", value: 0.875 } },
+        },
+      },
+    } as unknown as Theme;
+    const out = composeWithTheme(base, theme);
+    expect(out.tokens.typography.scale.md).toEqual({ unit: "rem", value: 0.875 });
+    expect(out.tokens.typography.families.body).toEqual(["Inter", "sans-serif"]);
+    expect(out.tokens.typography.weights.regular).toBe(400);
+  });
+
+  it("a theme adding one color doesn't drop other base colors", () => {
+    const base = baseDoc();
+    const theme: Theme = {
+      name: "extra",
+      tokens: {
+        colors: {
+          accent: { kind: "named", name: "tomato" },
+        },
+      },
+    };
+    const out = composeWithTheme(base, theme);
+    expect(Object.keys(out.tokens.colors).sort()).toEqual(["accent", "link", "text"]);
+  });
+
+  it("a missing theme.tokens leaves base.tokens untouched (reference-equal bucket OK)", () => {
+    const base = baseDoc();
+    const theme: Theme = { name: "rules-only" };
+    const out = composeWithTheme(base, theme);
+    expect(out.tokens).toBe(base.tokens);
+  });
+});
+
+describe("composeWithTheme — rules append", () => {
+  it("appends theme.rules after base.rules in order", () => {
+    const base = baseDoc();
+    const extra: StyleRule = {
+      id: styleRuleId("heading"),
+      selector: sel.type("heading"),
+      properties: [
+        { kind: "font-weight", value: { kind: "token-ref", path: "typography.weights.bold" } },
+      ],
+    };
+    const theme: Theme = { name: "headings", rules: [extra] };
+    const out = composeWithTheme(base, theme);
+    expect(out.rules.length).toBe(2);
+    expect(out.rules[0]!.id).toBe("body");
+    expect(out.rules[1]!.id).toBe("heading");
+  });
+
+  it("no theme.rules ⇒ rules array is preserved by reference", () => {
+    const base = baseDoc();
+    const theme: Theme = { name: "tokens-only", tokens: { colors: {} } };
+    const out = composeWithTheme(base, theme);
+    expect(out.rules).toBe(base.rules);
+  });
+
+  it("multiple theme rules retain their relative order", () => {
+    const base = baseDoc();
+    const r1: StyleRule = {
+      id: styleRuleId("r1"), selector: sel.type("h1"), properties: [],
+    };
+    const r2: StyleRule = {
+      id: styleRuleId("r2"), selector: sel.type("h2"), properties: [],
+    };
+    const r3: StyleRule = {
+      id: styleRuleId("r3"), selector: sel.type("h3"), properties: [],
+    };
+    const out = composeWithTheme(base, { name: "h", rules: [r1, r2, r3] });
+    expect(out.rules.map((r) => r.id)).toEqual(["body", "r1", "r2", "r3"]);
+  });
+});
+
+describe("composeWithTheme — immutability", () => {
+  it("does not mutate the base document", () => {
+    const base = baseDoc();
+    const snapshot = canonicalStyleDocument(base);
+    composeWithTheme(base, {
+      name: "x",
+      tokens: { colors: { text: { kind: "named", name: "white" } } },
+      rules: [{
+        id: styleRuleId("r"), selector: sel.type("paragraph"), properties: [],
+      }],
+    });
+    expect(canonicalStyleDocument(base)).toBe(snapshot);
+  });
+
+  it("does not mutate the theme", () => {
+    const base = baseDoc();
+    const theme: Theme = {
+      name: "x",
+      tokens: { colors: { text: { kind: "named", name: "white" } } },
+    };
+    const before = JSON.stringify(theme);
+    composeWithTheme(base, theme);
+    expect(JSON.stringify(theme)).toBe(before);
+  });
+});
+
+describe("composeWithTheme — passthrough fields", () => {
+  it("preserves contexts, theme, and extensions from base", () => {
+    const base = baseDoc();
+    const richBase: StyleDocument = {
+      ...base,
+      contexts: ["context:print"],
+      theme: "brand",
+      extensions: { "ext:plugin:meta": { version: 1 } },
+    };
+    const out = composeWithTheme(richBase, { name: "x" });
+    expect(out.contexts).toEqual(["context:print"]);
+    expect(out.theme).toBe("brand");
+    expect(out.extensions).toEqual({ "ext:plugin:meta": { version: 1 } });
+  });
+
+  it("preserves base extensions even when overlay has its own", () => {
+    const base = baseDoc();
+    const richBase: StyleDocument = {
+      ...base,
+      extensions: { "ext:a:meta": { v: 1 } },
+    };
+    const out = composeWithTheme(richBase, { name: "x" });
+    expect(out.extensions).toEqual({ "ext:a:meta": { v: 1 } });
+  });
+
+  it("kind discriminant is preserved", () => {
+    const out = composeWithTheme(emptyStyleDocument(), { name: "noop" });
+    expect(out.kind).toBe("StyleDocument");
+  });
+});
+
+describe("composeWithTheme — token extensions bucket", () => {
+  it("uses overlay-only extensions when base has none", () => {
+    // Covers the `base.extensions ?? {}` branch in mergeTokens.
+    const base = baseDoc();
+    const theme: Theme = {
+      name: "x",
+      tokens: { extensions: { "ext:b:meta": { v: 2 } } },
+    };
+    const out = composeWithTheme(base, theme);
+    expect(out.tokens.extensions).toEqual({ "ext:b:meta": { v: 2 } });
+  });
+
+  it("merges extensions per-named-entry when present in either side", () => {
+    const base = baseDoc();
+    const richBase: StyleDocument = {
+      ...base,
+      tokens: {
+        ...base.tokens,
+        extensions: { "ext:a:meta": { v: 1 } },
+      },
+    };
+    const theme: Theme = {
+      name: "x",
+      tokens: {
+        extensions: { "ext:b:meta": { v: 2 } },
+      },
+    };
+    const out = composeWithTheme(richBase, theme);
+    expect(out.tokens.extensions).toEqual({
+      "ext:a:meta": { v: 1 },
+      "ext:b:meta": { v: 2 },
+    });
+  });
+});
+
+describe("composeWithTheme — reproducibility (FM04 §12)", () => {
+  it("same inputs produce byte-identical canonical output", () => {
+    const base = baseDoc();
+    const theme: Theme = {
+      name: "dark",
+      tokens: { colors: { text: { kind: "named", name: "white" } } },
+      rules: [{
+        id: styleRuleId("dark-only"),
+        selector: sel.type("paragraph"),
+        properties: [
+          { kind: "background", value: { kind: "named", name: "black" } },
+        ],
+      }],
+    };
+    const a = canonicalStyleDocument(composeWithTheme(base, theme));
+    const b = canonicalStyleDocument(composeWithTheme(base, theme));
+    expect(a).toBe(b);
+  });
+});
+
+describe("composeWithTheme — security (prototype-pollution defence)", () => {
+  it("silently drops a forbidden __proto__ key in theme overrides", () => {
+    const base = baseDoc();
+    // Build a theme that bypasses the type system (a malicious or
+    // buggy stage that didn't go through the validator).
+    const pollutedOverlay: Record<string, unknown> = {};
+    pollutedOverlay["__proto__"] = { polluted: true };
+    pollutedOverlay["accent"] = { kind: "named", name: "tomato" };
+    const theme = {
+      name: "polluted",
+      tokens: { colors: pollutedOverlay as unknown as Record<string, never> },
+    } as unknown as Theme;
+
+    const out = composeWithTheme(base, theme);
+    // The legitimate key landed.
+    expect(out.tokens.colors).toHaveProperty("accent");
+    // The pollution did NOT land in the merged record.
+    expect(Object.prototype.hasOwnProperty.call(out.tokens.colors, "__proto__")).toBe(false);
+    // And critically, `Object.prototype` was not poisoned.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("silently drops a forbidden prototype key", () => {
+    const base = baseDoc();
+    const overlay: Record<string, unknown> = {
+      prototype: { evil: true },
+      good: { unit: "px", value: 12 },
+    };
+    const theme = {
+      name: "x",
+      tokens: { radii: overlay as unknown as Record<string, never> },
+    } as unknown as Theme;
+    const out = composeWithTheme(base, theme);
+    expect(out.tokens.radii).toHaveProperty("good");
+    expect(out.tokens.radii).toHaveProperty("sm");           // base preserved
+    expect(Object.prototype.hasOwnProperty.call(out.tokens.radii, "prototype")).toBe(false);
+  });
+
+  it("silently drops a forbidden constructor key", () => {
+    const base = baseDoc();
+    const overlay: Record<string, unknown> = { constructor: { evil: true }, ok: { unit: "px", value: 8 } };
+    const theme = {
+      name: "x",
+      tokens: { space: overlay as unknown as Record<string, never> },
+    } as unknown as Theme;
+    const out = composeWithTheme(base, theme);
+    expect(out.tokens.space).toHaveProperty("ok");
+    // We back the merged record with `Object.create(null)` AND refuse
+    // the "constructor" key.  So the overlay's `constructor: {evil:true}`
+    // does NOT land, and there's no inherited `constructor` either —
+    // the property is genuinely absent.
+    expect((out.tokens.space as Record<string, unknown>).constructor).toBeUndefined();
+  });
+});

--- a/code/packages/typescript/forme-style-theme/tests/registry.test.ts
+++ b/code/packages/typescript/forme-style-theme/tests/registry.test.ts
@@ -1,0 +1,126 @@
+/**
+ * registry.test.ts — `createThemeRegistry` semantics.
+ *
+ * Invariants:
+ * - register / lookup / list round-trip
+ * - lookup of unknown name returns undefined
+ * - list() is sorted lexicographically (deterministic)
+ * - register replaces on duplicate name (hot-reload friendly)
+ * - register refuses empty name and prototype-pollution names
+ * - each createThemeRegistry() call yields an independent instance
+ *   (no shared state)
+ * - cyclic "theme references itself" via base.theme name is
+ *   the orchestrator's concern, not the registry's — but the
+ *   registry must not loop on its own lookup chain (it doesn't,
+ *   because lookup never recurses)
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Theme } from "@coding-adventures/forme-style-ir";
+import { createThemeRegistry } from "../src/index.js";
+
+function t(name: string): Theme {
+  return { name };
+}
+
+describe("createThemeRegistry — basic CRUD", () => {
+  it("register + lookup round-trips a theme", () => {
+    const reg = createThemeRegistry();
+    const dark = t("dark");
+    reg.register(dark);
+    expect(reg.lookup("dark")).toBe(dark);
+  });
+
+  it("lookup of an unknown name returns undefined", () => {
+    const reg = createThemeRegistry();
+    expect(reg.lookup("nonexistent")).toBeUndefined();
+  });
+
+  it("list() returns sorted names", () => {
+    const reg = createThemeRegistry();
+    reg.register(t("zebra"));
+    reg.register(t("alpha"));
+    reg.register(t("mango"));
+    expect(reg.list()).toEqual(["alpha", "mango", "zebra"]);
+  });
+
+  it("list() on an empty registry returns []", () => {
+    const reg = createThemeRegistry();
+    expect(reg.list()).toEqual([]);
+  });
+
+  it("list() result is frozen", () => {
+    const reg = createThemeRegistry();
+    reg.register(t("a"));
+    const names = reg.list();
+    expect(Object.isFrozen(names)).toBe(true);
+  });
+});
+
+describe("createThemeRegistry — replace-on-duplicate", () => {
+  it("re-registering the same name overwrites the previous theme", () => {
+    const reg = createThemeRegistry();
+    const v1: Theme = { name: "brand", rules: [] };
+    const v2: Theme = { name: "brand", tokens: { colors: {} } };
+    reg.register(v1);
+    reg.register(v2);
+    expect(reg.lookup("brand")).toBe(v2);
+    // List still contains a single entry — no duplication.
+    expect(reg.list()).toEqual(["brand"]);
+  });
+});
+
+describe("createThemeRegistry — input validation", () => {
+  it("rejects an empty theme name", () => {
+    const reg = createThemeRegistry();
+    expect(() => reg.register({ name: "" })).toThrow(/non-empty string/);
+  });
+
+  it("rejects a non-string theme name", () => {
+    const reg = createThemeRegistry();
+    expect(() => reg.register({ name: 42 as unknown as string })).toThrow(/non-empty string/);
+  });
+
+  it("refuses the forbidden name __proto__", () => {
+    const reg = createThemeRegistry();
+    expect(() => reg.register({ name: "__proto__" })).toThrow(/forbidden name/);
+  });
+
+  it("refuses the forbidden name constructor", () => {
+    const reg = createThemeRegistry();
+    expect(() => reg.register({ name: "constructor" })).toThrow(/forbidden name/);
+  });
+
+  it("refuses the forbidden name prototype", () => {
+    const reg = createThemeRegistry();
+    expect(() => reg.register({ name: "prototype" })).toThrow(/forbidden name/);
+  });
+});
+
+describe("createThemeRegistry — isolation", () => {
+  it("two registries are independent (no shared state)", () => {
+    const a = createThemeRegistry();
+    const b = createThemeRegistry();
+    a.register(t("only-in-a"));
+    b.register(t("only-in-b"));
+    expect(a.lookup("only-in-b")).toBeUndefined();
+    expect(b.lookup("only-in-a")).toBeUndefined();
+  });
+});
+
+describe("createThemeRegistry — self-referential lookup is bounded", () => {
+  it("a theme registered under its own name doesn't loop on lookup", () => {
+    // The registry isn't reentrant — lookup is a single Map.get.
+    // This test just pins that property: even if a malicious caller
+    // shoves a theme whose `name` matches the lookup key (the normal
+    // case) and whose body references the same name (irrelevant to
+    // the registry — it doesn't follow references), lookup returns
+    // in constant time without recursion.
+    const reg = createThemeRegistry();
+    const selfRef = { name: "self", refersTo: "self" } as unknown as Theme;
+    reg.register(selfRef);
+    // Two lookups in a row to "tempt" any latent recursion.
+    expect(reg.lookup("self")).toBe(selfRef);
+    expect(reg.lookup("self")).toBe(selfRef);
+  });
+});

--- a/code/packages/typescript/forme-style-theme/tests/resolve.test.ts
+++ b/code/packages/typescript/forme-style-theme/tests/resolve.test.ts
@@ -1,0 +1,209 @@
+/**
+ * resolve.test.ts — `resolveTokenRefs` semantics.
+ *
+ * Invariants:
+ * - Concrete leaves (Color, Length, Shadow, FontStack, number) resolve
+ *   to their value.
+ * - Token chains follow refs to their concrete leaf.
+ * - Cycles return null (depth-capped).
+ * - Unresolvable paths (missing segment) return null.
+ * - Non-leaf landings (path stops at an intermediate object) return null.
+ * - Prototype-pollution paths are refused.
+ * - Bulk: duplicate paths in input collapse to one map entry.
+ * - Empty input → empty map.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  styleRuleId, sel,
+  type StyleDocument, type TokenRef,
+} from "@coding-adventures/forme-style-ir";
+import { resolveTokenRefs } from "../src/index.js";
+
+function doc(): StyleDocument {
+  return {
+    kind: "StyleDocument",
+    tokens: {
+      colors: {
+        text: { kind: "rgb", r: 31, g: 35, b: 40 },
+        // Chain: link → text → concrete rgb.
+        link: { kind: "token-ref", path: "colors.text" },
+        // Cycle: a ↔ b.
+        a: { kind: "token-ref", path: "colors.b" },
+        b: { kind: "token-ref", path: "colors.a" },
+      },
+      typography: {
+        families: { body: ["Inter", "sans-serif"] },
+        scale:    { md: { unit: "rem", value: 1 } },
+        weights:  { regular: 400 },
+        leading:  { normal: 1.5 },
+        tracking: { normal: { unit: "em", value: 0 } },
+      },
+      space:   { md: { unit: "rem", value: 1 } },
+      radii:   { sm: { unit: "px", value: 4 } },
+      shadows: {
+        soft: {
+          offsetX: { unit: "px", value: 0 },
+          offsetY: { unit: "px", value: 2 },
+          blur:    { unit: "px", value: 4 },
+          spread:  { unit: "px", value: 0 },
+          color:   { kind: "rgb", r: 0, g: 0, b: 0, a: 0.1 },
+        },
+      },
+    },
+    rules: [{
+      id: styleRuleId("noop"), selector: sel.type("paragraph"), properties: [],
+    }],
+    contexts: [],
+    theme: null,
+  };
+}
+
+function ref(path: string): TokenRef {
+  return { kind: "token-ref", path };
+}
+
+describe("resolveTokenRefs — concrete leaves", () => {
+  it("resolves a Color", () => {
+    const out = resolveTokenRefs(doc(), [ref("colors.text")]);
+    expect(out.get("colors.text")).toEqual({ kind: "rgb", r: 31, g: 35, b: 40 });
+  });
+
+  it("resolves a Length", () => {
+    const out = resolveTokenRefs(doc(), [ref("space.md")]);
+    expect(out.get("space.md")).toEqual({ unit: "rem", value: 1 });
+  });
+
+  it("resolves a Shadow", () => {
+    const out = resolveTokenRefs(doc(), [ref("shadows.soft")]);
+    const v = out.get("shadows.soft");
+    expect(v).toBeDefined();
+    expect((v as { offsetY?: unknown }).offsetY).toEqual({ unit: "px", value: 2 });
+  });
+
+  it("resolves a FontStack", () => {
+    const out = resolveTokenRefs(doc(), [ref("typography.families.body")]);
+    expect(out.get("typography.families.body")).toEqual(["Inter", "sans-serif"]);
+  });
+
+  it("resolves a number (font weight)", () => {
+    const out = resolveTokenRefs(doc(), [ref("typography.weights.regular")]);
+    expect(out.get("typography.weights.regular")).toBe(400);
+  });
+
+  it("resolves a number (leading)", () => {
+    const out = resolveTokenRefs(doc(), [ref("typography.leading.normal")]);
+    expect(out.get("typography.leading.normal")).toBe(1.5);
+  });
+});
+
+describe("resolveTokenRefs — chains", () => {
+  it("follows a one-hop ref chain", () => {
+    const out = resolveTokenRefs(doc(), [ref("colors.link")]);
+    // link → text → rgb(31,35,40)
+    expect(out.get("colors.link")).toEqual({ kind: "rgb", r: 31, g: 35, b: 40 });
+  });
+});
+
+describe("resolveTokenRefs — failures", () => {
+  it("missing path → null", () => {
+    const out = resolveTokenRefs(doc(), [ref("colors.nonexistent")]);
+    expect(out.get("colors.nonexistent")).toBeNull();
+  });
+
+  it("missing top-level bucket → null", () => {
+    const out = resolveTokenRefs(doc(), [ref("nope.also-nope")]);
+    expect(out.get("nope.also-nope")).toBeNull();
+  });
+
+  it("descending past a primitive in the middle of a path → null", () => {
+    // Path attempts to descend "into" a number — e.g. `colors.text.r.x`
+    // takes the `r` channel (a number) and tries to step further.
+    // walkPath should bail when cursor becomes non-object.
+    const out = resolveTokenRefs(doc(), [ref("typography.weights.regular.foo")]);
+    expect(out.get("typography.weights.regular.foo")).toBeNull();
+  });
+
+  it("descending past an explicit-undefined own property → null", () => {
+    // A token bucket that has an own property with `undefined` value.
+    // walkPath's "value === undefined" guard kicks in.
+    const d = doc();
+    const dWithUndef: StyleDocument = {
+      ...d,
+      tokens: {
+        ...d.tokens,
+        space: { ...d.tokens.space, ghost: undefined as unknown as never },
+      },
+    };
+    const out = resolveTokenRefs(dWithUndef, [ref("space.ghost")]);
+    expect(out.get("space.ghost")).toBeNull();
+  });
+
+  it("non-leaf landing (path stops at an intermediate object) → null", () => {
+    // `colors` itself is an object — it's not a recognised leaf value.
+    const out = resolveTokenRefs(doc(), [ref("colors")]);
+    expect(out.get("colors")).toBeNull();
+  });
+
+  it("cycle → null (depth-capped)", () => {
+    const out = resolveTokenRefs(doc(), [ref("colors.a")]);
+    expect(out.get("colors.a")).toBeNull();
+  });
+
+  it("NaN as a numeric leaf → null (defensive)", () => {
+    const d: StyleDocument = doc();
+    const dWithNaN: StyleDocument = {
+      ...d,
+      tokens: {
+        ...d.tokens,
+        typography: {
+          ...d.tokens.typography,
+          weights: { broken: NaN },
+        },
+      },
+    };
+    const out = resolveTokenRefs(dWithNaN, [ref("typography.weights.broken")]);
+    expect(out.get("typography.weights.broken")).toBeNull();
+  });
+});
+
+describe("resolveTokenRefs — bulk semantics", () => {
+  it("empty input → empty map", () => {
+    expect(resolveTokenRefs(doc(), []).size).toBe(0);
+  });
+
+  it("duplicate paths collapse to one entry (idempotent — same result)", () => {
+    const out = resolveTokenRefs(doc(), [ref("space.md"), ref("space.md")]);
+    expect(out.size).toBe(1);
+    expect(out.get("space.md")).toEqual({ unit: "rem", value: 1 });
+  });
+
+  it("mixed resolvable + unresolvable input — every input has an entry", () => {
+    const out = resolveTokenRefs(doc(), [
+      ref("colors.text"),
+      ref("colors.nonexistent"),
+      ref("space.md"),
+    ]);
+    expect(out.size).toBe(3);
+    expect(out.get("colors.text")).not.toBeNull();
+    expect(out.get("colors.nonexistent")).toBeNull();
+    expect(out.get("space.md")).not.toBeNull();
+  });
+});
+
+describe("resolveTokenRefs — security (prototype traversal)", () => {
+  it("refuses __proto__ in a path segment", () => {
+    const out = resolveTokenRefs(doc(), [ref("__proto__.toString")]);
+    expect(out.get("__proto__.toString")).toBeNull();
+  });
+
+  it("refuses constructor in a path segment", () => {
+    const out = resolveTokenRefs(doc(), [ref("colors.constructor.name")]);
+    expect(out.get("colors.constructor.name")).toBeNull();
+  });
+
+  it("refuses prototype in a path segment", () => {
+    const out = resolveTokenRefs(doc(), [ref("colors.prototype")]);
+    expect(out.get("colors.prototype")).toBeNull();
+  });
+});

--- a/code/packages/typescript/forme-style-theme/tsconfig.json
+++ b/code/packages/typescript/forme-style-theme/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-style-theme/vitest.config.ts
+++ b/code/packages/typescript/forme-style-theme/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});

--- a/code/packages/typescript/forme-types/package-lock.json
+++ b/code/packages/typescript/forme-types/package-lock.json
@@ -18,6 +18,7 @@
       }
     },
     "../document-ast": {
+      "name": "@coding-adventures/document-ast",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
## Summary

Third package of the FM04 Style IR family — **theme composition + in-memory registry + bulk `TokenRef` resolution**.  Sits next to [`forme-style-ir`](../forme-style-ir) (substrate) and [`forme-style-to-css`](../forme-style-to-css) (reference translator).

Three focused exports:

- **`composeWithTheme(base, theme): StyleDocument`** — bucket-aware per-named-entry merge of a sparse `Theme` (token overrides + appended rules) onto a base `StyleDocument`.  Per FM04 §7.2.  Recurses into typography's five sub-buckets; theme rules trail base rules so they win on equal-specificity ties (FM04 §4.9); inputs not mutated.
- **`createThemeRegistry(): ThemeRegistry`** — in-memory `Map<name, Theme>` with `register` / `lookup` / `list`.  Per FM04 §13.3.  Replace-on-duplicate for dev-mode hot reload; `list()` sorted + frozen for byte-stable reproducibility.
- **`resolveTokenRefs(doc, refs): Map<path, ResolvedValue | null>`** — bulk-walk dotted `TokenRef.path`s into the token tree, returning resolved leaf values for analyser pre-passes (AOT CSS slicer, LaTeX preamble extractor, theme coverage reporters).  Per FM04 §3.5.  Chain-depth capped at 8 hops; cycles return `null`.

## Security posture

Pre-push focused security review = **PASS**.  Three concerns explicitly verified:

1. **Deep-merge prototype-pollution.**  Forbidden token names (`__proto__`, `constructor`, `prototype`) refused at every call into `copyOwn`; merged records backed by `Object.create(null)` so even a deny-list bypass cannot reach `Object.prototype`.  Three tests pin the rejection paths.
2. **Registry mutation safety.**  `Map<string, Theme>` backing means own-key semantics by construction; the three forbidden names are also refused on `register` with a thrown error.
3. **`TokenRef` path traversal.**  `walkPath` mirrors `forme-style-to-css/walkPath`'s defence — deny-list segments + `Object.prototype.hasOwnProperty.call`.  Three tests pin `__proto__` / `constructor` / `prototype` in path segments.

## Capabilities

`[]` — pure transform + in-memory `Map`.  No I/O, no shell, no network.

## Tests

**51 tests across 3 files**, **100% line / 96.51% branch** coverage (above the FM04 §14.4 ≥95% line target):

- `compose.test.ts` (18) — token override per bucket, rule append in order, immutability of inputs, passthrough of `contexts` / `theme` / `extensions`, reproducibility via `canonicalStyleDocument`, prototype-pollution defence for all three forbidden keys.
- `registry.test.ts` (13) — CRUD round-trip, sorted-and-frozen `list()`, replace-on-duplicate, empty/non-string/forbidden-name rejection, isolation between registries, bounded self-referential lookup.
- `resolve.test.ts` (20) — concrete leaves (Color, Length, Shadow, FontStack, number), one-hop ref chains, all failure modes (missing path, cycle, NaN, non-leaf landing, primitive mid-path, undefined-own), bulk semantics (empty / duplicate / mixed), prototype-traversal defence.

## Spec adherence

Implements FM04 §7.2 (theme composition) / §13.3 (theme registry) / §3.5 (`TokenRef` resolution).  No spec divergences.

## v0 simplifications (documented in CHANGELOG)

- In-memory registry only; persistent backing deferred until FM06 (AOT compiler) needs it.
- One-theme-at-a-time composition; multi-theme stacks compose by chaining `composeWithTheme(composeWithTheme(base, t1), t2)`.

## Test plan

- [x] `vitest run --coverage` — 51 / 51 pass, 100% line / 96.51% branch
- [x] `tsc --noEmit` — clean
- [x] Security review — PASS (forbidden-key tests pin every defence)
- [ ] CI: lint, build, security scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)