### PR TITLE
feat(board-vm): add UNO R4 CAN metadata

### DIFF
--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -67,6 +67,16 @@ pub struct UartBusInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CanBusInfo {
+    pub bus: u8,
+    pub name: &'static str,
+    pub tx_pin: u8,
+    pub rx_pin: u8,
+    pub controller: &'static str,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DigitalPinInfo {
     pub pin: u8,
     pub label: &'static str,
@@ -121,6 +131,7 @@ pub struct BoardTargetInfo {
     pub i2c_buses: &'static [I2cBusInfo],
     pub spi_buses: &'static [SpiBusInfo],
     pub uart_buses: &'static [UartBusInfo],
+    pub can_buses: &'static [CanBusInfo],
     pub wireless: &'static [WirelessInterfaceInfo],
     pub capabilities: &'static [&'static str],
 }
@@ -294,6 +305,8 @@ pub const UNO_R4_MINIMA_UART_BUSES: [UartBusInfo; 1] =
     map_uno_r4_uart_buses(board_vm_uno_r4::UNO_R4_MINIMA_UART_BUSES);
 pub const UNO_R4_WIFI_UART_BUSES: [UartBusInfo; 3] =
     map_uno_r4_uart_buses(board_vm_uno_r4::UNO_R4_WIFI_UART_BUSES);
+pub const UNO_R4_CAN_BUSES: [CanBusInfo; 1] =
+    map_uno_r4_can_buses(board_vm_uno_r4::UNO_R4_CAN_BUSES);
 
 pub const ESP32_DIGITAL_PINS: [DigitalPinInfo; 30] =
     map_esp32_digital_pins(board_vm_esp32::ESP32_DEVKIT_V1_DIGITAL_PINS);
@@ -416,6 +429,33 @@ const fn map_uno_r4_uart_buses<const N: usize>(
     buses
 }
 
+const fn map_uno_r4_can_buses<const N: usize>(
+    source: [board_vm_uno_r4::CanBusDescriptor; N],
+) -> [CanBusInfo; N] {
+    let mut buses = [CanBusInfo {
+        bus: 0,
+        name: "",
+        tx_pin: 0,
+        rx_pin: 0,
+        controller: "",
+        notes: "",
+    }; N];
+    let mut index = 0;
+    while index < N {
+        let bus = source[index];
+        buses[index] = CanBusInfo {
+            bus: bus.bus,
+            name: bus.name,
+            tx_pin: bus.tx_pin,
+            rx_pin: bus.rx_pin,
+            controller: bus.controller,
+            notes: bus.notes,
+        };
+        index += 1;
+    }
+    buses
+}
+
 const fn map_esp32_digital_pins<const N: usize>(
     source: [board_vm_esp32::DigitalPinDescriptor; N],
 ) -> [DigitalPinInfo; N] {
@@ -496,6 +536,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         i2c_buses: &UNO_R4_MINIMA_I2C_BUSES,
         spi_buses: &UNO_R4_SPI_BUSES,
         uart_buses: &UNO_R4_MINIMA_UART_BUSES,
+        can_buses: &UNO_R4_CAN_BUSES,
         wireless: &[],
         capabilities: &UNO_R4_MINIMA_CAPABILITIES,
     },
@@ -522,6 +563,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         i2c_buses: &UNO_R4_WIFI_I2C_BUSES,
         spi_buses: &UNO_R4_SPI_BUSES,
         uart_buses: &UNO_R4_WIFI_UART_BUSES,
+        can_buses: &UNO_R4_CAN_BUSES,
         wireless: &UNO_R4_WIFI_WIRELESS,
         capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
@@ -545,6 +587,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         i2c_buses: &[],
         spi_buses: &[],
         uart_buses: &[],
+        can_buses: &[],
         wireless: &ESP32_WIRELESS,
         capabilities: &ESP32_CAPABILITIES,
     },
@@ -571,6 +614,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         i2c_buses: &[],
         spi_buses: &[],
         uart_buses: &[],
+        can_buses: &[],
         wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
@@ -597,6 +641,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         i2c_buses: &[],
         spi_buses: &[],
         uart_buses: &[],
+        can_buses: &[],
         wireless: &PICO_W_WIRELESS,
         capabilities: &PICO_W_CAPABILITIES,
     },
@@ -714,6 +759,30 @@ mod tests {
         assert!(find_target("esp32-devkit-v1")
             .unwrap()
             .uart_buses
+            .is_empty());
+    }
+
+    #[test]
+    fn registry_exposes_can_bus_metadata() {
+        let minima = find_target("arduino-uno-r4-minima").unwrap();
+        assert_eq!(minima.can_buses.len(), 1);
+        assert_eq!(minima.can_buses[0].name, "CAN0");
+        assert_eq!(minima.can_buses[0].tx_pin, 10);
+        assert_eq!(minima.can_buses[0].rx_pin, 13);
+        assert_eq!(minima.can_buses[0].controller, "RA4M1 CAN0");
+
+        let wifi = find_target("arduino-uno-r4-wifi").unwrap();
+        assert_eq!(wifi.can_buses, minima.can_buses);
+        assert!(wifi.can_buses[0].notes.contains("SPI"));
+
+        assert!(find_target("esp32-devkit-v1").unwrap().can_buses.is_empty());
+        assert!(find_target("raspberry-pi-pico")
+            .unwrap()
+            .can_buses
+            .is_empty());
+        assert!(find_target("raspberry-pi-pico-w")
+            .unwrap()
+            .can_buses
             .is_empty());
     }
 

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -67,6 +67,7 @@ pub struct TargetDescriptor {
     pub i2c_buses: &'static [I2cBusDescriptor],
     pub spi_buses: &'static [SpiBusDescriptor],
     pub uart_buses: &'static [UartBusDescriptor],
+    pub can_buses: &'static [CanBusDescriptor],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -109,6 +110,16 @@ pub struct UartBusDescriptor {
     pub rx_pin: u8,
     pub arduino_uart: u8,
     pub internal: bool,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CanBusDescriptor {
+    pub bus: u8,
+    pub name: &'static str,
+    pub tx_pin: u8,
+    pub rx_pin: u8,
+    pub controller: &'static str,
     pub notes: &'static str,
 }
 
@@ -377,6 +388,17 @@ pub const UNO_R4_WIFI_UART_BUSES: [UartBusDescriptor; 3] = [
     UNO_R4_WIFI_MODULE_UART_BUS,
 ];
 
+pub const UNO_R4_CAN_BUS: CanBusDescriptor = CanBusDescriptor {
+    bus: 0,
+    name: "CAN0",
+    tx_pin: 10,
+    rx_pin: 13,
+    controller: "RA4M1 CAN0",
+    notes: "CAN0 on D10/TX and D13/RX; conflicts with header SPI CS/SCK and onboard LED",
+};
+
+pub const UNO_R4_CAN_BUSES: [CanBusDescriptor; 1] = [UNO_R4_CAN_BUS];
+
 pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     board_id: "arduino-uno-r4-minima",
     display_name: "Arduino Uno R4 Minima",
@@ -404,6 +426,7 @@ pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     i2c_buses: &UNO_R4_MINIMA_I2C_BUSES,
     spi_buses: &UNO_R4_SPI_BUSES,
     uart_buses: &UNO_R4_MINIMA_UART_BUSES,
+    can_buses: &UNO_R4_CAN_BUSES,
 };
 
 pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
@@ -434,6 +457,7 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
     i2c_buses: &UNO_R4_WIFI_I2C_BUSES,
     spi_buses: &UNO_R4_SPI_BUSES,
     uart_buses: &UNO_R4_WIFI_UART_BUSES,
+    can_buses: &UNO_R4_CAN_BUSES,
 };
 
 pub trait UnoR4Backend {
@@ -1255,6 +1279,20 @@ mod tests {
         assert_eq!(UNO_R4_WIFI.uart_buses[2].tx_pin, 24);
         assert_eq!(UNO_R4_WIFI.uart_buses[2].rx_pin, 25);
         assert!(UNO_R4_WIFI.uart_buses[2].internal);
+    }
+
+    #[test]
+    fn knows_uno_r4_can_buses() {
+        assert_eq!(UNO_R4_MINIMA.can_buses, &[UNO_R4_CAN_BUS]);
+        assert_eq!(UNO_R4_WIFI.can_buses, &[UNO_R4_CAN_BUS]);
+
+        let can = UNO_R4_WIFI.can_buses[0];
+        assert_eq!(can.name, "CAN0");
+        assert_eq!(can.tx_pin, 10);
+        assert_eq!(can.rx_pin, 13);
+        assert_eq!(can.controller, "RA4M1 CAN0");
+        assert!(can.notes.contains("SPI"));
+        assert!(can.notes.contains("onboard LED"));
     }
 
     #[test]

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -32,7 +32,7 @@ Source snapshot:
 | I2C master | `Wire` on A4/A5, `Wire1` on Qwiic D27/D26 | bus metadata, handle open, single-byte write/read, byte-buffer write/read, and write-read transfer implemented | `i2c.open`, `i2c.write_u8`, `i2c.read_u8`, `i2c.write`, `i2c.read`, `i2c.transfer` |
 | SPI master | COPI D11, CIPO D12, SCK D13, conventional CS D10 | bus metadata, handle open, bounded write-then-read transfer, and transfer-backed read/write SDK commands implemented | `spi.open`, `spi.transfer`; SDK `spi.write`/`spi.read` lower to transfer |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | descriptor metadata, handle open, and single-byte write/read implemented | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
-| CAN | CAN0 TX D10, RX D13 | pending | `can.open`, `can.write`, `can.read` |
+| CAN | CAN0 TX D10, RX D13 | descriptor metadata implemented; bytecode capability pending | `can.open`, `can.write`, `can.read` |
 | RTC | one RTC instance in the core | pending | `rtc.now`, `rtc.set`, alarms/events later |
 | EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | pending | `program.store` and possibly `kv.store` |
 | Watchdog | Renesas WDT library | pending | `watchdog.configure`, `watchdog.kick` |
@@ -80,9 +80,11 @@ reject conflicting handles.
    capabilities in separate tranches with conformance tests. UART now has
    descriptor metadata for Minima `Serial1` and WiFi `Serial1`/`Serial2`/
    `Serial3`, while `uart.open`, `uart.write`, and `uart.read` establish the
-   first UART handle and byte I/O tranche. The next independent tranche can move
-   on to CAN, RTC, watchdog, EEPROM/store, or WiFi/network metadata and
-   capability slices.
+   first UART handle and byte I/O tranche. CAN now has descriptor metadata for
+   UNO R4 `CAN0` on D10/TX and D13/RX while `can.open`, `can.write`, and
+   `can.read` remain the next CAN capability tranche. The next independent
+   tranche can move on to CAN byte I/O, RTC, watchdog, EEPROM/store, or
+   WiFi/network metadata and capability slices.
 
 Every tranche should include the same layers: spec entry, IR capability id,
 runtime HAL method, UNO R4 target descriptor, firmware backend, host builder,


### PR DESCRIPTION
## Summary
- add UNO R4 CAN0 descriptor metadata for D10/TX and D13/RX
- expose CAN bus metadata through the board target registry while keeping can.open/write/read pending
- update BVM07 to mark CAN descriptor metadata as implemented and bytecode capability as next

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-can-rtc-storage-metadata cargo fmt -p board-vm-uno-r4 -p board-vm-targets
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-can-rtc-storage-metadata cargo test -p board-vm-uno-r4 -p board-vm-targets
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check