### PR TITLE
[codex] Align HTML lexer fixtures with html5lib audit

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -5833,7 +5833,6 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-comment)",
-  "append_comment(-)",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -5940,7 +5939,6 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-comment)",
-  "append_comment(-)",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -5982,7 +5980,6 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-comment)",
-  "append_comment(-)",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -7630,31 +7627,26 @@ to = "end_tag_attributes"
 from = "end_tag_name"
 matcher = { literal = " " }
 to = "before_end_tag_close"
-actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
 
 [[transitions]]
 from = "end_tag_name"
 matcher = { literal = "\n" }
 to = "before_end_tag_close"
-actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
 
 [[transitions]]
 from = "end_tag_name"
 matcher = { literal = "\t" }
 to = "before_end_tag_close"
-actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
 
 [[transitions]]
 from = "end_tag_name"
 matcher = { literal = "\r" }
 to = "before_end_tag_close"
-actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
 
 [[transitions]]
 from = "end_tag_name"
 matcher = { literal = "\u000C" }
 to = "before_end_tag_close"
-actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
 
 [[transitions]]
 from = "end_tag_name"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -12191,7 +12191,6 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-comment)".to_string(),
-                "append_comment(-)".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -12433,7 +12432,6 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-comment)".to_string(),
-                "append_comment(-)".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -12518,7 +12516,6 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-comment)".to_string(),
-                "append_comment(-)".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -15859,9 +15856,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
-            actions: vec![
-                "parse_error(unexpected-whitespace-after-end-tag-name)".to_string(),
-            ],
+            actions: Vec::new(),
             consume: true,
         },
         TransitionDefinition {
@@ -15874,9 +15869,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
-            actions: vec![
-                "parse_error(unexpected-whitespace-after-end-tag-name)".to_string(),
-            ],
+            actions: Vec::new(),
             consume: true,
         },
         TransitionDefinition {
@@ -15889,9 +15882,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
-            actions: vec![
-                "parse_error(unexpected-whitespace-after-end-tag-name)".to_string(),
-            ],
+            actions: Vec::new(),
             consume: true,
         },
         TransitionDefinition {
@@ -15904,9 +15895,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
-            actions: vec![
-                "parse_error(unexpected-whitespace-after-end-tag-name)".to_string(),
-            ],
+            actions: Vec::new(),
             consume: true,
         },
         TransitionDefinition {
@@ -15919,9 +15908,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
-            actions: vec![
-                "parse_error(unexpected-whitespace-after-end-tag-name)".to_string(),
-            ],
+            actions: Vec::new(),
             consume: true,
         },
         TransitionDefinition {

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -55,6 +55,22 @@ binary while production code continues to link only static Rust source.
 - `normalize_html5lib_fixtures.py`: importer that lowers supported raw
   html5lib-style tokenizer cases into Venture's portable fixture schema
 
+## Conformance Audit
+
+The parser package owns a shared html5lib source-coverage audit that checks the
+tree-construction fixture, this raw tokenizer mirror, and the generated
+normalized tokenizer corpus together:
+
+```bash
+HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
+  python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
+```
+
+The command exits nonzero if any upstream tokenizer case is missing from
+`upstream-html5lib-smoke.test`, if any upstream tree-construction case is
+missing from the parser fixture, or if `html5lib-smoke.json` still records
+skipped runtime gaps.
+
 ## WPT Path
 
 The next layer normalizes WHATWG/WPT or html5lib-style tokenizer coverage into

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -1650,7 +1650,6 @@
         "EOF"
       ],
       "diagnostics": [
-        "unexpected-whitespace-after-end-tag-name",
         "end-tag-with-attributes",
         "eof-in-end-tag-name-state"
       ]

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -2019,7 +2019,6 @@
         "EOF"
       ],
       "diagnostics": [
-        "unexpected-whitespace-after-end-tag-name",
         "end-tag-with-attributes",
         "eof-in-end-tag-name-state"
       ]
@@ -3045,7 +3044,6 @@
         "EOF"
       ],
       "diagnostics": [
-        "unexpected-whitespace-after-end-tag-name",
         "end-tag-with-attributes"
       ]
     },
@@ -4862,7 +4860,7 @@
       "description": "<!-- -",
       "input": "<!-- -",
       "tokens": [
-        "Comment(data= -)",
+        "Comment(data= )",
         "EOF"
       ],
       "diagnostics": [
@@ -5583,7 +5581,7 @@
       "description": "<!---",
       "input": "<!---",
       "tokens": [
-        "Comment(data=-)",
+        "Comment(data=)",
         "EOF"
       ],
       "diagnostics": [
@@ -5813,7 +5811,7 @@
       "description": "<!---- -",
       "input": "<!---- -",
       "tokens": [
-        "Comment(data=-- -)",
+        "Comment(data=-- )",
         "EOF"
       ],
       "diagnostics": [
@@ -5951,7 +5949,7 @@
       "description": "<!----!a-",
       "input": "<!----!a-",
       "tokens": [
-        "Comment(data=--!a-)",
+        "Comment(data=--!a)",
         "EOF"
       ],
       "diagnostics": [
@@ -5985,7 +5983,7 @@
       "description": "<!----!-",
       "input": "<!----!-",
       "tokens": [
-        "Comment(data=--!-)",
+        "Comment(data=--!)",
         "EOF"
       ],
       "diagnostics": [
@@ -23233,7 +23231,6 @@
         "EOF"
       ],
       "diagnostics": [
-        "unexpected-whitespace-after-end-tag-name",
         "end-tag-with-attributes"
       ]
     },
@@ -23246,7 +23243,6 @@
         "EOF"
       ],
       "diagnostics": [
-        "unexpected-whitespace-after-end-tag-name",
         "end-tag-with-attributes"
       ]
     },

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -578,12 +578,6 @@ def normalize_diagnostic_set(diagnostics: list[str], test: dict[str, Any]) -> li
             for diagnostic in diagnostics
             if diagnostic != "unexpected-null-character"
         ]
-    if (
-        "end-tag-with-attributes" in diagnostics
-        and "unexpected-whitespace-after-end-tag-name" not in diagnostics
-        and re.search(r"</[A-Za-z0-9]+[\t\n\f\r ]", test["input"])
-    ):
-        diagnostics.insert(0, "unexpected-whitespace-after-end-tag-name")
     if "end-tag-with-attributes" in diagnostics:
         diagnostics = [diagnostic for diagnostic in diagnostics if diagnostic != "duplicate-attribute"]
     last_start_tag = test.get("lastStartTag")
@@ -606,14 +600,6 @@ def normalize_comment_data(data: str, test: dict[str, Any]) -> str:
     if test["input"].lower().startswith("<!doc") and data.startswith("doc"):
         data = "DOC" + data[3:]
     has_eof_in_comment = any(error["code"] == "eof-in-comment" for error in test.get("errors", []))
-    if (
-        has_eof_in_comment
-        and test["input"].endswith("-")
-        and not test["input"].endswith("<!--")
-        and (not test["input"].endswith("--") or test["input"] == "<!---")
-        and not data.endswith("-")
-    ):
-        data += "-"
     if has_eof_in_comment and test["input"].endswith("--!") and data == "":
         data = "--!"
     return data

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -4479,11 +4479,6 @@
       "output": [],
       "errors": [
         {
-          "code": "unexpected-whitespace-after-end-tag-name",
-          "line": 1,
-          "col": 10
-        },
-        {
           "code": "end-tag-with-attributes",
           "line": 1,
           "col": 11
@@ -5919,14 +5914,9 @@
       ],
       "errors": [
         {
-          "code": "unexpected-whitespace-after-end-tag-name",
-          "line": 1,
-          "col": 7
-        },
-        {
           "code": "end-tag-with-attributes",
           "line": 1,
-          "col": 12
+          "col": 13
         }
       ]
     },
@@ -8663,7 +8653,7 @@
       "output": [
         [
           "Comment",
-          " -"
+          " "
         ]
       ],
       "errors": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -756,10 +756,7 @@ fn default_html_lexer_recovers_truncated_doctype_keyword_as_bogus_comment() {
 
     assert_eq!(
         lexer.drain_tokens(),
-        vec![
-            Token::Comment("DOC".to_string()),
-            Token::Eof,
-        ]
+        vec![Token::Comment("DOC".to_string()), Token::Eof,]
     );
     assert!(lexer
         .diagnostics()
@@ -776,10 +773,7 @@ fn default_html_lexer_recovers_invalid_doctype_keyword_as_bogus_comment() {
 
     assert_eq!(
         lexer.drain_tokens(),
-        vec![
-            Token::Comment("DOX".to_string()),
-            Token::Eof,
-        ]
+        vec![Token::Comment("DOX".to_string()), Token::Eof,]
     );
     assert!(lexer
         .diagnostics()
@@ -1642,7 +1636,7 @@ fn default_html_lexer_recovers_end_tag_with_whitespace_then_trailing_solidus() {
             Token::Eof,
         ]
     );
-    assert!(lexer
+    assert!(!lexer
         .diagnostics()
         .iter()
         .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"));
@@ -1674,7 +1668,7 @@ fn default_html_lexer_recovers_end_tag_with_form_feed_then_trailing_solidus() {
             Token::Eof,
         ]
     );
-    assert!(lexer
+    assert!(!lexer
         .diagnostics()
         .iter()
         .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"));
@@ -1706,7 +1700,7 @@ fn default_html_lexer_recovers_end_tag_with_attributes() {
             Token::Eof,
         ]
     );
-    assert!(lexer
+    assert!(!lexer
         .diagnostics()
         .iter()
         .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"));
@@ -1933,6 +1927,10 @@ fn default_html_lexer_does_not_include_comment_end_dashes_at_eof() {
     let tokens = lex_html("<!--x--").unwrap();
 
     assert_eq!(tokens, vec![Token::Comment("x".to_string()), Token::Eof]);
+
+    let tokens = lex_html("<!-- -").unwrap();
+
+    assert_eq!(tokens, vec![Token::Comment(" ".to_string()), Token::Eof]);
 }
 
 #[test]

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -7,7 +7,7 @@ DOM tree from `dom-core`. DOM is the primary browser-facing output because it
 preserves element names, attributes, comments, doctypes, and text exactly enough
 for later CSS, layout, scripting, and Paint VM work.
 
-This first slice intentionally starts small:
+The current parser surface includes:
 
 - text, comments, doctypes, start tags, end tags, attributes
 - a stack of open elements
@@ -59,9 +59,26 @@ This first slice intentionally starts small:
 - body-fragment parsing that returns DOM nodes without the implied
   `html/head/body` shell while preserving lexer/parser diagnostics
 
-Future batches can layer the full WHATWG HTML tree-construction insertion modes
-onto the same DOM target. A separate adapter can project DOM into
-`document-ast` for existing native document rendering.
+The checked-in html5lib tree-construction smoke corpus now covers every case in
+the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources
+by source signature. A separate adapter can project DOM into `document-ast` for
+existing native document rendering.
+
+## Conformance Audit
+
+The tree-construction fixture lives in
+`tests/fixtures/html5lib-tree-construction-smoke.dat`, and the shared
+html5lib tokenizer corpus lives under `../html-lexer/tests/fixtures`. To verify
+that the checked-in fixtures still cover an upstream html5lib-tests checkout:
+
+```bash
+HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
+  python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
+```
+
+The audit fails if an upstream tree-construction case is missing, if an
+upstream tokenizer case is missing from the raw mirrored tokenizer corpus, or
+if the normalized tokenizer corpus records skipped cases.
 
 ## Usage
 

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -1,9 +1,23 @@
 # html-parser fixtures
 
-`html5lib-tree-construction-smoke.dat` is a small checked-in subset of
-`html5lib/html5lib-tests/tree-construction/tests1.dat`.
+`html5lib-tree-construction-smoke.dat` is the checked-in Venture smoke corpus
+mirrored from the currently audited
+`html5lib/html5lib-tests/tree-construction/*.dat` sources.
 
 The format is the upstream tree-construction test format documented in
 `html5lib/html5lib-tests/tree-construction/README.md`. Keeping the fixture in
 that format lets this crate grow toward WHATWG tree-construction compliance
 without inventing a Rust-only test schema.
+
+`audit_html5lib_coverage.py` compares this fixture and the sibling lexer
+html5lib fixtures against an upstream html5lib-tests checkout by source
+signature:
+
+```bash
+HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
+  python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
+```
+
+The command exits nonzero if any upstream tree-construction or tokenizer source
+case is missing, or if the normalized tokenizer fixture still has skipped
+runtime gaps.

--- a/code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
+++ b/code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+
+"""Audit Venture's checked-in HTML fixtures against upstream html5lib tests.
+
+The script is intentionally dependency-free so it can run from a fresh checkout
+with only Python 3 installed. Point it at an html5lib-tests checkout:
+
+    HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests python3 \
+      code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
+
+It compares source fixture signatures rather than test descriptions so local
+fixture names can stay stable while still proving upstream coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+TOKENIZER_SIGNATURE_KEYS = (
+    "input",
+    "output",
+    "initialStates",
+    "lastStartTag",
+    "doubleEscaped",
+    "errors",
+)
+
+
+@dataclass(frozen=True)
+class TreeCase:
+    source: str
+    signature: str
+
+
+@dataclass(frozen=True)
+class TokenizerCase:
+    source: str
+    signature: str
+
+
+def main() -> int:
+    args = parse_args()
+    project_rust_root = Path(__file__).resolve().parents[3]
+    upstream_root = resolve_upstream_root(args.upstream_root)
+
+    local_tree_path = (
+        project_rust_root
+        / "html-parser"
+        / "tests"
+        / "fixtures"
+        / "html5lib-tree-construction-smoke.dat"
+    )
+    local_tokenizer_raw_path = (
+        project_rust_root
+        / "html-lexer"
+        / "tests"
+        / "fixtures"
+        / "upstream-html5lib-smoke.test"
+    )
+    local_tokenizer_normalized_path = (
+        project_rust_root
+        / "html-lexer"
+        / "tests"
+        / "fixtures"
+        / "html5lib-smoke.json"
+    )
+
+    upstream_tree = load_tree_cases(upstream_root / "tree-construction")
+    local_tree = parse_tree_construction_dat(local_tree_path)
+    missing_tree = missing_cases(upstream_tree, local_tree)
+
+    upstream_tokenizer = load_tokenizer_cases(upstream_root / "tokenizer")
+    local_tokenizer = load_tokenizer_cases(local_tokenizer_raw_path)
+    missing_tokenizer = missing_cases(upstream_tokenizer, local_tokenizer)
+
+    normalized = json.loads(local_tokenizer_normalized_path.read_text())
+    normalized_cases = normalized.get("cases", [])
+    normalized_skipped = normalized.get("skipped", [])
+
+    report = {
+        "tree_construction": {
+            "upstream_cases": len(upstream_tree),
+            "local_cases": len(local_tree),
+            "missing": len(missing_tree),
+            "missing_sources": [case.source for case in missing_tree[: args.max_missing]],
+        },
+        "tokenizer": {
+            "upstream_cases": len(upstream_tokenizer),
+            "local_raw_cases": len(local_tokenizer),
+            "missing": len(missing_tokenizer),
+            "missing_sources": [
+                case.source for case in missing_tokenizer[: args.max_missing]
+            ],
+            "normalized_cases": len(normalized_cases),
+            "normalized_skipped": len(normalized_skipped),
+        },
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_report(report, upstream_root)
+
+    if missing_tree or missing_tokenizer or normalized_skipped:
+        return 1
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit checked-in Venture HTML fixtures against html5lib tests."
+    )
+    parser.add_argument(
+        "upstream_root",
+        nargs="?",
+        default=os.environ.get("HTML5LIB_TESTS_ROOT"),
+        help=(
+            "Path to html5lib-tests, or a checkout containing that directory. "
+            "Defaults to HTML5LIB_TESTS_ROOT."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print a machine-readable JSON report.",
+    )
+    parser.add_argument(
+        "--max-missing",
+        type=int,
+        default=20,
+        help="Maximum missing case sources to include in the report.",
+    )
+    return parser.parse_args()
+
+
+def resolve_upstream_root(raw_root: str | None) -> Path:
+    if not raw_root:
+        raise SystemExit(
+            "Provide html5lib-tests via an argument or HTML5LIB_TESTS_ROOT."
+        )
+
+    root = Path(raw_root).expanduser().resolve()
+    candidates = [root, root / "html5lib-tests"]
+    for candidate in candidates:
+        if (candidate / "tree-construction").is_dir() and (
+            candidate / "tokenizer"
+        ).is_dir():
+            return candidate
+
+    raise SystemExit(f"{root} does not look like an html5lib-tests checkout")
+
+
+def load_tree_cases(path: Path) -> list[TreeCase]:
+    if path.is_file():
+        return parse_tree_construction_dat(path)
+
+    cases: list[TreeCase] = []
+    for fixture_path in sorted(path.glob("*.dat")):
+        cases.extend(parse_tree_construction_dat(fixture_path))
+    return cases
+
+
+def parse_tree_construction_dat(path: Path) -> list[TreeCase]:
+    cases: list[TreeCase] = []
+    lines = path.read_text().splitlines()
+    index = 0
+    source_hint: str | None = None
+    case_number = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if not line:
+            index += 1
+            continue
+        if line.startswith("#source "):
+            source_hint = line.removeprefix("#source ").strip()
+            index += 1
+            continue
+        if line != "#data":
+            index += 1
+            continue
+
+        case_number += 1
+        index += 1
+        data_lines: list[str] = []
+        while index < len(lines) and lines[index] != "#errors":
+            data_lines.append(lines[index])
+            index += 1
+
+        if index >= len(lines):
+            raise ValueError(f"{path}: case {case_number} is missing #errors")
+        index += 1
+
+        fragment_context: str | None = None
+        script_mode: str | None = None
+        while index < len(lines):
+            marker = lines[index]
+            if marker == "#document":
+                index += 1
+                break
+            if marker == "#document-fragment":
+                index += 1
+                if index >= len(lines):
+                    raise ValueError(
+                        f"{path}: case {case_number} is missing fragment context"
+                    )
+                fragment_context = lines[index]
+                index += 1
+                continue
+            if marker == "#script-off":
+                script_mode = "off"
+                index += 1
+                continue
+            if marker == "#script-on":
+                script_mode = "on"
+                index += 1
+                continue
+            index += 1
+        else:
+            raise ValueError(f"{path}: case {case_number} is missing #document")
+
+        document_lines: list[str] = []
+        while index < len(lines):
+            if lines[index] == "#data" or lines[index].startswith("#source "):
+                break
+            document_lines.append(lines[index])
+            index += 1
+        while document_lines and document_lines[-1] == "":
+            document_lines.pop()
+
+        source = source_hint or f"{path.name}:{case_number}"
+        cases.append(
+            TreeCase(
+                source=source,
+                signature=stable_signature(
+                    {
+                        "data": "\n".join(data_lines),
+                        "document": document_lines,
+                        "fragment_context": fragment_context,
+                        "script_mode": script_mode,
+                    }
+                ),
+            )
+        )
+        source_hint = None
+
+    return cases
+
+
+def load_tokenizer_cases(path: Path) -> list[TokenizerCase]:
+    if path.is_file():
+        return parse_tokenizer_file(path)
+
+    cases: list[TokenizerCase] = []
+    for fixture_path in sorted(path.glob("*.test")):
+        cases.extend(parse_tokenizer_file(fixture_path))
+    return cases
+
+
+def parse_tokenizer_file(path: Path) -> list[TokenizerCase]:
+    raw = json.loads(path.read_text())
+    cases: list[TokenizerCase] = []
+    for index, test in enumerate(raw.get("tests", []), start=1):
+        signature = {
+            key: test[key] for key in TOKENIZER_SIGNATURE_KEYS if key in test
+        }
+        description = test.get("description", f"case {index}")
+        cases.append(
+            TokenizerCase(
+                source=f"{path.name}:{index} {description}",
+                signature=stable_signature(signature),
+            )
+        )
+    return cases
+
+
+def missing_cases(
+    upstream: Iterable[TreeCase] | Iterable[TokenizerCase],
+    local: Iterable[TreeCase] | Iterable[TokenizerCase],
+) -> list[TreeCase] | list[TokenizerCase]:
+    local_signatures = {case.signature for case in local}
+    return [case for case in upstream if case.signature not in local_signatures]
+
+
+def stable_signature(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def print_report(report: dict[str, Any], upstream_root: Path) -> None:
+    tree = report["tree_construction"]
+    tokenizer = report["tokenizer"]
+
+    print("html5lib coverage audit")
+    print(f"upstream: {upstream_root}")
+    print("")
+    print("tree-construction:")
+    print(f"  upstream cases: {tree['upstream_cases']}")
+    print(f"  local cases:    {tree['local_cases']}")
+    print(f"  missing:        {tree['missing']}")
+    print_missing(tree["missing_sources"])
+    print("")
+    print("tokenizer:")
+    print(f"  upstream cases:     {tokenizer['upstream_cases']}")
+    print(f"  local raw cases:    {tokenizer['local_raw_cases']}")
+    print(f"  missing:            {tokenizer['missing']}")
+    print(f"  normalized cases:   {tokenizer['normalized_cases']}")
+    print(f"  normalized skipped: {tokenizer['normalized_skipped']}")
+    print_missing(tokenizer["missing_sources"])
+
+
+def print_missing(sources: list[str]) -> None:
+    if not sources:
+        return
+    print("  first missing sources:")
+    for source in sources:
+        print(f"    - {source}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a repo-native html5lib coverage audit for tree-construction and tokenizer fixtures
- align ordinary end-tag whitespace and comment EOF recovery with current upstream html5lib tokenizer signatures
- remove stale normalization shims and refresh the mirrored/normalized html5lib fixture expectations

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit

Audit result: tree-construction missing=0, tokenizer missing=0, normalized skipped=0.