### PR TITLE
feat(forme-style-to-latex): FM04 §9.3 LaTeX backend translator

### DIFF
--- a/code/packages/typescript/forme-style-to-latex/BUILD
+++ b/code/packages/typescript/forme-style-to-latex/BUILD
@@ -1,0 +1,4 @@
+cd ../document-ast && npm install --silent
+cd ../forme-types && npm install --silent
+cd ../forme-style-ir && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-style-to-latex/CHANGELOG.md
+++ b/code/packages/typescript/forme-style-to-latex/CHANGELOG.md
@@ -1,0 +1,139 @@
+# Changelog — @coding-adventures/forme-style-to-latex
+
+## 0.1.0 — 2026-05-17
+
+Initial release.  Fourth package of the FM04 Style IR family —
+the second concrete backend translator (after `forme-style-to-css`),
+validating the multi-backend story FM04 §9.1 promises.
+
+### Added
+
+- `translateToLatex(doc, options): TranslateResult<string>` — public
+  entry point per FM04 §9.3.  Emits a LaTeX preamble fragment
+  (`\definecolor` / `\setlength` / `\newcommand` / `\if<flag>`).
+- `TranslateOptions`: `activeContexts`, `usedRuleIds?`, `scope?`.
+  Same shape as the CSS translator's options, redeclared locally per
+  FM04 §9.1 (each translator owns its own `TranslateOptions` /
+  `TranslateResult` rather than importing a shared package — avoids
+  a circular dependency for a single-method contract).
+- `TranslateResult<string>`: `output`, `emittedRules`, `warnings`.
+- Property mappers (`property-mappers.ts`) — exhaustive `switch`
+  over every kernel-known `StyleProperty.kind` (29 kinds).  Native
+  LaTeX for color / font / leading / page-break / spacing;
+  warn-and-skip for decoration without a preamble form
+  (`background`, `border`, `border-radius`, `shadow`, `opacity`,
+  `padding`, `display`, `vertical-align`, `tracking`).
+- Selector mapper (`selector-mapper.ts`) — simple kinds become
+  stable `\formeNode<Type>` / `\formeHeading<Word>` / `\formeKind`
+  / `\formeTag` / `\formeId` / `\formeRole` macros.  Composition
+  kinds (`and`, `or`, `not`, `nth`, `child-of`, `descendant-of`,
+  `adjacent`) warn-and-skip — no preamble equivalent.
+- Context mapper (`context-mapper.ts`) — seven kernel contexts map
+  to `\if<flag>` conditionals; ext:* returns null.  Exports the
+  `CONTEXT_FLAG_DECLARATIONS` constant (frozen) that the translator
+  emits at the top of the preamble.
+- Token resolver (`token-resolver.ts`) — same FM04 §3.5 walker as
+  `forme-style-to-css`, intentionally duplicated.  Cycles cap at 8
+  hops; prototype-pollution defence (deny-list + `hasOwnProperty`).
+- Value mappers (`value-mappers.ts`) — `Color` → xcolor `{RGB}{r,g,b}`
+  (HSL converts inline; OKLCH warn-skips for v0; named colors via a
+  small safe map); `Length` → LaTeX dimension (px→pt at 0.75×, rem→em,
+  pass-through for pt/mm/in/ex/em, skip for %/vh/vw/ch); `FontStack`
+  → first family escaped (LaTeX has no fallback chain).
+- Escape helpers (`escape.ts`) — `escapeLatexText` (all ten LaTeX
+  specials + control-char strip; uses placeholder substitution for
+  multi-character escapes so synthetic braces don't get
+  double-escaped); `latexIdent` (encodes non-letter chars as `Z<hex>Z`
+  so command names stay valid).
+
+### Spec adherence
+
+Implements FM04 §9.3 reference LaTeX translator end-to-end.  All
+three mapping tables (properties, selectors, contexts) covered with
+documented warn-and-skip for the cases LaTeX can't natively express.
+
+### Behavioural notes
+
+- **Preamble header is fixed.**  Every output begins with
+  `% forme-style-to-latex generated preamble` followed by the seven
+  `\newif\if<flag>` declarations.  Document authors `\printtrue`
+  etc. to switch contexts at compile time.
+- **Unconditional rules emit BEFORE `\if<flag>` blocks.**  Same
+  cascade-friendly ordering as the CSS translator.
+- **Rules sharing a context group under one `\if...\fi` block**
+  in source order — minimises `\fi` noise and matches readable
+  hand-authored LaTeX.
+- **Empty rule blocks suppressed.**  A rule where every property
+  warn-skipped (or the selector itself was unmappable) does not
+  emit; its id is not in `emittedRules`.
+- **`important` becomes a `% !important` comment trailer.**  LaTeX
+  has no specificity to override, so we preserve traceability
+  rather than the semantics.
+- **Scope is concatenated before the macro name.**  e.g. `scope =
+  "\\page"` + macro `\formeNodeParagraph` → `\page\formeNodeParagraph`.
+  Caller-trusted — same posture as the CSS translator's `scope`.
+
+### Spec divergences (documented)
+
+- **`forme-style-to-latex` does NOT define `StyleTranslator<Out>`
+  abstract interface.**  Same rationale as `forme-style-to-css`:
+  per FM04 §9.1 the interface lives next to each translator.
+  `TranslateOptions` / `TranslateResult` redeclared here.
+
+### v0 simplifications (documented)
+
+- **OKLCH warn-skips.**  Round-trip through CIE / sRGB gamut
+  mapping is out of scope.
+- **`align` is LTR-only** — `start`/`end` → `\raggedright`/`\raggedleft`.
+  A future i18n layer (`ext:i18n:*`) re-emits contextually for RTL.
+- **`tracking` warns** — needs `microtype`.
+- **`text-decoration: line-through` warns** — needs `ulem`.
+
+### Security posture
+
+Pre-push focused security review areas:
+
+- **LaTeX injection.**  Every interpolated string routes through
+  `escapeLatexText` (text-mode) or `latexIdent` (command-name).
+  All ten LaTeX specials (`\ % $ & _ # { } ^ ~`) covered.  The
+  backslash and accent escapes use placeholder substitution so
+  their synthetic `{` / `}` don't get double-escaped on the brace
+  pass — a subtle bug we pinned with a composite test
+  (`escapes all ten in one string in the right order`).
+- **Prototype-pollution in `walkPath`.**  Mirrors
+  `forme-style-to-css`'s defence: deny-listed segments + own-key
+  `hasOwnProperty` check.  Three tests pin the rejections; one
+  test pins inherited-key non-traversal.
+- **Control-character stripping.**  ASCII control chars (0x00–0x1F,
+  0x7F) stripped from every escape helper.  Tests pin behaviour
+  for both text and identifier paths, plus end-to-end through
+  rule-id comments.
+- **Numeric heading levels routed through `latexIdent`.**  Defence
+  in depth: a hand-rolled IR with `node-type-level: -1` or
+  `node-type-level: 1.5` would otherwise produce broken
+  `\formeHeadingD-D1` / `\formeHeadingD1D.D5` macros (raw `-` / `.`
+  are invalid in LaTeX command names — not injection, but
+  cosmetically broken).  Now encoded as `Z<hex>Z` runs.  Two tests
+  pin the behaviour.
+
+### Tests
+
+155 tests across 7 files:
+
+- `escape.test.ts` (18 — every LaTeX-special, control-char strip,
+  identifier sanitisation, all-ten-in-one composite)
+- `value-mappers.test.ts` (25 — color models, length units,
+  font-stack escaping, fallback comments)
+- `selector-mapper.test.ts` (20 — simple kinds, identifier
+  sanitisation, composition warn-skips, defensive numeric
+  encoding for negative / fractional / out-of-range heading levels)
+- `context-mapper.test.ts` (5 — kernel contexts + flag declarations)
+- `token-resolver.test.ts` (14 — happy path, prototype-pollution
+  defence, typed wrappers, cycle cap, NaN rejection)
+- `property-mappers.test.ts` (52 — every kernel kind, exhaustive
+  meta-check over `PROPERTY_KINDS`, defensive fallthroughs)
+- `translate.test.ts` (16 — end-to-end happy path, filtering, scope,
+  important, reproducibility, LaTeX-injection defence)
+
+Coverage: **100% line / 96.15% branch** — above the FM04 §14.4
+≥95% line target.

--- a/code/packages/typescript/forme-style-to-latex/README.md
+++ b/code/packages/typescript/forme-style-to-latex/README.md
@@ -1,0 +1,196 @@
+# @coding-adventures/forme-style-to-latex
+
+The **second FM04 backend translator**. Takes a `StyleDocument` from
+[`@coding-adventures/forme-style-ir`](../forme-style-ir) and emits a
+LaTeX preamble fragment (`\definecolor` / `\setlength` /
+`\newcommand` macros / `\if<flag>` conditionals).
+
+Implements [FM04 §9.3](../../specs/FM04-forme-style-ir.md). Sister of
+[`forme-style-to-css`](../forme-style-to-css) (the §9.2 CSS
+backend) — they share the IR, the validator-trust posture, and the
+warn-and-skip robustness contract, but differ in everything they emit.
+
+## Quick start
+
+```ts
+import { translateToLatex } from "@coding-adventures/forme-style-to-latex";
+import {
+  emptyStyleDocument, styleRuleId, sel,
+} from "@coding-adventures/forme-style-ir";
+
+const doc = {
+  ...emptyStyleDocument(),
+  tokens: {
+    ...emptyStyleDocument().tokens,
+    colors: { text: { kind: "rgb", r: 31, g: 35, b: 40 } },
+  },
+  rules: [
+    {
+      id: styleRuleId("body"),
+      selector: sel.type("paragraph"),
+      properties: [
+        { kind: "color",   value: { kind: "token-ref", path: "colors.text" } },
+        { kind: "leading", value: 1.5 },
+      ],
+    },
+  ],
+};
+
+const { output, emittedRules, warnings } = translateToLatex(doc, {
+  activeContexts: ["print"],
+});
+
+console.log(output);
+// → "% forme-style-to-latex generated preamble
+//    % --- context flags ---
+//    \newif\ifprint \newif\ifscreen ...
+//    % --- rules ---
+//    % rule "body" — node type: paragraph
+//    \newcommand{\formeNodeParagraph}{%
+//      \color{RGB}{31,35,40}%
+//      \linespread{1.5}\selectfont%
+//    }"
+```
+
+## Translation strategy (FM04 §9.3)
+
+**Selectors → named macros.**  LaTeX has no document tree to walk
+against in the preamble, so each rule becomes a stable command the
+document body invokes:
+
+| Selector kind   | Macro form              | Example                  |
+|-----------------|-------------------------|--------------------------|
+| `node-type`     | `\formeNode<Type>`      | `\formeNodeParagraph`    |
+| `node-type-level` | `\formeHeading<Word>` | `\formeHeadingOne`       |
+| `custom-kind`   | `\formeKind<Slug>`      | `\formeKindCallout`      |
+| `tag`           | `\formeTag<Slug>`       | `\formeTagWarning`       |
+| `id`            | `\formeId<Slug>`        | `\formeIdMain`           |
+| `role`          | `\formeRole<Slug>`      | `\formeRoleNote`         |
+
+Composition selectors (`and`, `or`, `not`, `nth`, `child-of`,
+`descendant-of`, `adjacent`) require runtime document-tree walking
+LaTeX has no equivalent for — they **warn and skip** per FM04 §9.6.
+
+**Properties → LaTeX commands** where there's a natural form:
+
+| Style IR kind     | LaTeX command(s)                       |
+|-------------------|----------------------------------------|
+| `color`           | `\color{RGB}{r,g,b}` (xcolor)          |
+| `font-family`     | `\setmainfont{...}` (fontspec)         |
+| `font-size`       | `\fontsize{...}{...}\selectfont`       |
+| `font-weight`     | `\fontseries{m|b|bx}\selectfont`       |
+| `font-style`      | `\fontshape{n|it|sl}\selectfont`       |
+| `leading`         | `\linespread{n}\selectfont`            |
+| `space-before/after` | `\setlength{\parskip}{...}`         |
+| `indent`          | `\setlength{\parindent}{...}`          |
+| `max-width`       | `\setlength{\linewidth}{...}`          |
+| `align`           | `\raggedright` / `\raggedleft` / `\centering` / justify-glue |
+| `column-break`    | `\columnbreak` / `\nobreak`            |
+| `page-break`      | `\pagebreak` / `\nopagebreak`          |
+| `widow-orphan`    | `\widowpenalty=N\clubpenalty=N`        |
+| `visible`         | `\let\formeVisible=\relax|\hphantom`   |
+
+Decorative properties without a preamble equivalent
+(`background`, `border`, `border-radius`, `shadow`, `opacity`,
+`padding`, `display`, `vertical-align`, `tracking`) **warn and skip**.
+They typically require TikZ / tcolorbox at the *call site* rather
+than as preamble configuration.
+
+**Contexts → `\if<flag>` conditionals**:
+
+| Context           | Conditional        |
+|-------------------|--------------------|
+| `print`           | `\ifprint`         |
+| `screen`          | `\ifscreen`        |
+| `dark`            | `\ifdark`          |
+| `narrow`          | `\ifnarrow`        |
+| `wide`            | `\ifwide`          |
+| `reduced-motion`  | `\ifreducedmotion` |
+| `high-contrast`   | `\ifhighcontrast`  |
+
+The translator emits the `\newif\if<flag>` declarations at the top of
+the preamble so document authors can toggle them at compile time
+(e.g. `\printtrue` to activate the `print` context).
+
+## Unit conversions (documented assumptions)
+
+| IR unit | LaTeX form        | Conversion                       |
+|---------|-------------------|----------------------------------|
+| `pt`    | `Npt`             | passthrough                      |
+| `mm`, `in`, `ex`, `em` | `N<unit>` | passthrough               |
+| `px`    | `Npt`             | 1px = 0.75pt (CSS standard)      |
+| `rem`   | `Nem`             | rem ≈ em (LaTeX has no "root em"; document author tunes the root font size) |
+| `%`, `vh`, `vw`, `ch` | (skip)  | no page-geometry context in preamble |
+
+## Color models
+
+`xcolor`'s `RGB` model is the lingua franca; HSL is converted inline
+(lossless within sRGB).  OKLCH warn-skips for v0 — round-tripping
+through CIE conversion is out of scope.  Named colors fall back to a
+small built-in safe map (matches `\usepackage{xcolor}` with no
+options); unknown names warn-skip.
+
+## LaTeX special-character escaping
+
+All user-controlled strings (selector targets, color names, font
+names, rule ids) route through `escape.ts` first.  The ten LaTeX
+specials (`\ % $ & _ # { } ^ ~`) become their canonical escape
+forms; ASCII control characters (0x00–0x1F, 0x7F) are stripped.
+
+The backslash and accent escapes use placeholder substitution so
+their synthetic `{` / `}` don't get double-escaped on the brace pass.
+
+## Security posture
+
+Three concerns explicitly verified before push:
+
+1. **LaTeX injection via insufficient escaping.**  Every interpolated
+   string routes through `escapeLatexText` (text-mode) or `latexIdent`
+   (command-name).  Tests pin escape coverage for all ten specials
+   and round-trip through every public-facing string path.
+2. **Prototype-pollution in `walkPath`.**  Mirrors
+   `forme-style-to-css`'s defence — deny-listed segments + own-key
+   `hasOwnProperty` check.  Three tests pin the rejections.
+3. **Control-character handling.**  Stripped from every escape
+   helper before further processing.  Tests pin behaviour for both
+   text and identifier paths.
+
+`scope` is **caller-trusted** (concatenated verbatim) — same posture
+as `forme-style-to-css`'s `scope`.  Documented in the JSDoc.
+
+## Spec divergences
+
+None known.  Implements FM04 §9.3 LaTeX target end-to-end.
+
+## v0 simplifications
+
+- **OKLCH colors warn-skip** — round-trip through CIE / sRGB
+  gamut mapping is out of scope; add when a real document needs it.
+- **LTR-only `align`** — `start` → `\raggedright`, `end` →
+  `\raggedleft`.  A future i18n layer (`ext:i18n:*`) re-emits
+  contextually for RTL.
+- **`tracking` warns** — needs `microtype`'s `\letterspacing`;
+  emit manually until we want microtype as a documented dependency.
+- **`text-decoration: line-through` warns** — needs `ulem`'s
+  `\sout{}`.
+
+## Tests
+
+155 tests across 7 files:
+
+- `escape.test.ts` (18 — every LaTeX-special, control-char strip,
+  identifier sanitisation, all-ten-in-one composite)
+- `value-mappers.test.ts` (25 — color models, length units,
+  font-stack escaping, fallback comments)
+- `selector-mapper.test.ts` (20 — simple kinds, identifier
+  sanitisation, composition warn-skips, defensive numeric encoding)
+- `context-mapper.test.ts` (5 — kernel contexts + flag declarations)
+- `token-resolver.test.ts` (14 — happy path, prototype-pollution
+  defence, typed wrappers, cycle cap, NaN rejection)
+- `property-mappers.test.ts` (52 — every kernel kind, exhaustive
+  meta-check, defensive fallthroughs)
+- `translate.test.ts` (16 — happy path, filtering, scope, important,
+  reproducibility, LaTeX-injection defence)
+
+Coverage: **100% line / 96.15% branch** — above FM04 §14.4
+≥95% line target.

--- a/code/packages/typescript/forme-style-to-latex/package-lock.json
+++ b/code/packages/typescript/forme-style-to-latex/package-lock.json
@@ -1,0 +1,2337 @@
+{
+  "name": "@coding-adventures/forme-style-to-latex",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-style-to-latex",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-style-ir": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-types": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-style-ir": {
+      "resolved": "../forme-style-ir",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-types": {
+      "resolved": "../forme-types",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-style-to-latex/package.json
+++ b/code/packages/typescript/forme-style-to-latex/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/forme-style-to-latex",
+  "version": "0.1.0",
+  "description": "Style IR → LaTeX preamble translator: takes a forme-style-ir StyleDocument and emits a LaTeX preamble fragment (\\definecolor / \\setlength / \\newcommand) per FM04 §9.3.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+    "@coding-adventures/forme-types": "file:../forme-types"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-style-to-latex/required_capabilities.json
+++ b/code/packages/typescript/forme-style-to-latex/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-style-to-latex",
+  "capabilities": [],
+  "justification": "Pure transform: StyleDocument → LaTeX preamble string.  No I/O, no network, no env, no shell.  Same posture as forme-style-ir and forme-style-to-css."
+}

--- a/code/packages/typescript/forme-style-to-latex/src/context-mapper.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/context-mapper.ts
@@ -1,0 +1,66 @@
+/**
+ * context-mapper.ts — context name → LaTeX conditional macro (FM04 §9.3).
+ *
+ * LaTeX has no built-in equivalent of CSS `@media` queries — context
+ * switches must be driven by user-controlled flags (the document's
+ * preamble sets `\printtrue` / `\printfalse`, the translator emits
+ * `\ifprint ... \fi`).
+ *
+ * We map each kernel-blessed context to a conventional flag name:
+ *
+ *   print          → \ifprint        ... \fi
+ *   screen         → \ifscreen       ... \fi
+ *   dark           → \ifdark         ... \fi
+ *   narrow         → \ifnarrow       ... \fi
+ *   wide           → \ifwide         ... \fi
+ *   reduced-motion → \ifreducedmotion ... \fi
+ *   high-contrast  → \ifhighcontrast ... \fi
+ *
+ * The caller (translator) emits a preamble header that defines these
+ * flags as `\newif` once at the top of the output, so the rule
+ * bodies can use them without further setup.
+ *
+ * `ext:*` contexts have no built-in mapping and return null — the
+ * translator emits a warning and skips the rule.
+ *
+ * @module context-mapper
+ */
+
+/** Result: the conditional command prefix, e.g. `\ifprint`. */
+export type LatexConditional = string;
+
+/**
+ * Map a context name to a LaTeX `\if<name>` conditional.  Returns
+ * null for unknown / `ext:*` contexts — the translator emits a
+ * warning at the call site.
+ */
+export function contextToLatex(name: string): LatexConditional | null {
+  switch (name) {
+    case "print":          return "\\ifprint";
+    case "screen":         return "\\ifscreen";
+    case "dark":           return "\\ifdark";
+    case "narrow":         return "\\ifnarrow";
+    case "wide":           return "\\ifwide";
+    case "reduced-motion": return "\\ifreducedmotion";
+    case "high-contrast":  return "\\ifhighcontrast";
+    default:               return null;
+  }
+}
+
+/**
+ * The list of `\newif` declarations the translator emits at the top
+ * of the preamble so every conditional name above is defined,
+ * regardless of whether the document actually uses every context.
+ *
+ * Each `\newif\if<name>` simultaneously defines `\<name>true` and
+ * `\<name>false` so the document author can switch contexts on/off.
+ */
+export const CONTEXT_FLAG_DECLARATIONS: readonly string[] = Object.freeze([
+  "\\newif\\ifprint",
+  "\\newif\\ifscreen",
+  "\\newif\\ifdark",
+  "\\newif\\ifnarrow",
+  "\\newif\\ifwide",
+  "\\newif\\ifreducedmotion",
+  "\\newif\\ifhighcontrast",
+]);

--- a/code/packages/typescript/forme-style-to-latex/src/escape.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/escape.ts
@@ -1,0 +1,118 @@
+/**
+ * escape.ts — LaTeX special-character escaping.
+ *
+ * LaTeX has ten characters that trigger non-literal behaviour in text
+ * mode (and a few more in math mode, but we never emit math mode
+ * from here):
+ *
+ *   \  command introducer
+ *   %  comment-to-end-of-line
+ *   $  toggle math mode
+ *   &  alignment tab
+ *   _  subscript (math) / fragile (text)
+ *   #  macro parameter
+ *   {  group open
+ *   }  group close
+ *   ^  superscript (math) / accent (text)
+ *   ~  non-breaking space
+ *
+ * Any of these landing unescaped in our output can:
+ *
+ *   - silently swallow output up to the next newline (`%`),
+ *   - drop the LaTeX compiler into math mode (`$`),
+ *   - terminate a group early or open one (`{` / `}`),
+ *   - invoke an unintended command (`\foo` where `foo` is anything),
+ *   - or trigger a compile error that points at our generated file
+ *     rather than the offending source.
+ *
+ * We escape every special character in any string we interpolate
+ * into the output — color names, font names, selector targets,
+ * id strings, role strings.  Real-world input is clean ASCII; the
+ * escaper is defence in depth for hand-rolled IRs that bypass the
+ * forme-style-ir validator's identifier grammar.
+ *
+ * ASCII control characters (0x00–0x1F and 0x7F) are stripped
+ * outright — they can't appear in a legitimate selector / identifier
+ * and they confuse LaTeX's lexer.
+ *
+ * @module escape
+ */
+
+/**
+ * Escape LaTeX special characters in a free-form string destined for
+ * text-mode output (e.g. inside a `\textbf{...}` body or a comment).
+ *
+ * **Order matters.**  Naively escaping `\` first would produce
+ * `\textbackslash{}` — but the `{` / `}` inside that escape would
+ * then get re-escaped on subsequent passes, yielding the broken
+ * `\textbackslash\{\}`.  The fix: substitute a unique
+ * never-appears-in-input placeholder for each multi-character escape
+ * during the pass, then swap the placeholders back at the end.
+ *
+ * The placeholder strings (`\x00BS`, `\x00CARET`, `\x00TILDE`) start
+ * with NUL bytes that `stripControl` has already removed from the
+ * input — so they cannot collide with anything the user supplied.
+ */
+const BACKSLASH_PLACEHOLDER = "\x00BS\x00";
+const CARET_PLACEHOLDER     = "\x00CARET\x00";
+const TILDE_PLACEHOLDER     = "\x00TILDE\x00";
+
+export function escapeLatexText(s: string): string {
+  return stripControl(s)
+    // First pass — replace multi-character escape targets with
+    // placeholders so their literal `{` / `}` don't get
+    // double-escaped on the brace pass below.
+    .replace(/\\/g, BACKSLASH_PLACEHOLDER)
+    .replace(/\^/g, CARET_PLACEHOLDER)
+    .replace(/~/g, TILDE_PLACEHOLDER)
+    // Single-char escapes — safe to do in any order at this point.
+    .replace(/%/g, "\\%")
+    .replace(/\$/g, "\\$")
+    .replace(/&/g, "\\&")
+    .replace(/_/g, "\\_")
+    .replace(/#/g, "\\#")
+    .replace(/\{/g, "\\{")
+    .replace(/\}/g, "\\}")
+    // Swap placeholders back to their LaTeX-correct escapes.
+    .replace(new RegExp(BACKSLASH_PLACEHOLDER, "g"), "\\textbackslash{}")
+    .replace(new RegExp(CARET_PLACEHOLDER, "g"), "\\textasciicircum{}")
+    .replace(new RegExp(TILDE_PLACEHOLDER, "g"), "\\textasciitilde{}");
+}
+
+/**
+ * Sanitise a string for use as a LaTeX identifier (e.g. a color
+ * name fed to `\definecolor{<name>}{...}{...}`).  LaTeX command
+ * names are restricted to letters only (no digits, no punctuation,
+ * no Unicode) so we map any non-letter to `Z<hex>Z` — a reversible
+ * encoding that's still a valid letter run.
+ *
+ * The output is **always** a non-empty string of ASCII letters.  An
+ * empty input is rejected as `Zempty` (defensive; the validator
+ * doesn't admit empty token names).
+ */
+export function latexIdent(s: string): string {
+  const sanitised = stripControl(s);
+  if (sanitised.length === 0) return "Zempty";
+  let out = "";
+  for (const ch of sanitised) {
+    if (/[A-Za-z]/.test(ch)) {
+      out += ch;
+    } else {
+      const code = ch.codePointAt(0)!;
+      out += `Z${code.toString(16)}Z`;
+    }
+  }
+  // Refuse to emit an empty identifier (theoretical — sanitised
+  // is non-empty and every char becomes at least one character).
+  return out.length === 0 ? "Zempty" : out;
+}
+
+/**
+ * Strip ASCII control characters (0x00–0x1F and 0x7F).  These are
+ * never legitimate in a selector / identifier / token name and they
+ * confuse LaTeX's lexer.
+ */
+function stripControl(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\x00-\x1F\x7F]/g, "");
+}

--- a/code/packages/typescript/forme-style-to-latex/src/escape.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/escape.ts
@@ -42,41 +42,36 @@
  * Escape LaTeX special characters in a free-form string destined for
  * text-mode output (e.g. inside a `\textbf{...}` body or a comment).
  *
- * **Order matters.**  Naively escaping `\` first would produce
- * `\textbackslash{}` — but the `{` / `}` inside that escape would
- * then get re-escaped on subsequent passes, yielding the broken
- * `\textbackslash\{\}`.  The fix: substitute a unique
- * never-appears-in-input placeholder for each multi-character escape
- * during the pass, then swap the placeholders back at the end.
- *
- * The placeholder strings (`\x00BS`, `\x00CARET`, `\x00TILDE`) start
- * with NUL bytes that `stripControl` has already removed from the
- * input — so they cannot collide with anything the user supplied.
+ * Implementation note: **one single-pass replacement** — not a chain.
+ * A chained-`.replace` approach (escape `\` first, then `%`, then
+ * `&`, …) produces wrong output because the synthetic
+ * `\textbackslash{}` introduced for `\` contains `{` and `}`, which
+ * the later brace-escape passes then re-escape into
+ * `\textbackslash\{\}`.  A single pass over the original string
+ * with a per-character mapping table sidesteps this entirely — and
+ * is the form CodeQL's "incomplete string escaping" rule accepts
+ * without complaint.
  */
-const BACKSLASH_PLACEHOLDER = "\x00BS\x00";
-const CARET_PLACEHOLDER     = "\x00CARET\x00";
-const TILDE_PLACEHOLDER     = "\x00TILDE\x00";
+const LATEX_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "\\": "\\textbackslash{}",
+  "%":  "\\%",
+  "$":  "\\$",
+  "&":  "\\&",
+  "_":  "\\_",
+  "#":  "\\#",
+  "{":  "\\{",
+  "}":  "\\}",
+  "^":  "\\textasciicircum{}",
+  "~":  "\\textasciitilde{}",
+});
+
+// Class of LaTeX-special characters.  Order inside `[]` doesn't
+// matter for matching; the `]` before the character class form
+// (`[\\%$&_#{}^~]`) is just a single pass.
+const LATEX_SPECIAL_RE = /[\\%$&_#{}^~]/g;
 
 export function escapeLatexText(s: string): string {
-  return stripControl(s)
-    // First pass — replace multi-character escape targets with
-    // placeholders so their literal `{` / `}` don't get
-    // double-escaped on the brace pass below.
-    .replace(/\\/g, BACKSLASH_PLACEHOLDER)
-    .replace(/\^/g, CARET_PLACEHOLDER)
-    .replace(/~/g, TILDE_PLACEHOLDER)
-    // Single-char escapes — safe to do in any order at this point.
-    .replace(/%/g, "\\%")
-    .replace(/\$/g, "\\$")
-    .replace(/&/g, "\\&")
-    .replace(/_/g, "\\_")
-    .replace(/#/g, "\\#")
-    .replace(/\{/g, "\\{")
-    .replace(/\}/g, "\\}")
-    // Swap placeholders back to their LaTeX-correct escapes.
-    .replace(new RegExp(BACKSLASH_PLACEHOLDER, "g"), "\\textbackslash{}")
-    .replace(new RegExp(CARET_PLACEHOLDER, "g"), "\\textasciicircum{}")
-    .replace(new RegExp(TILDE_PLACEHOLDER, "g"), "\\textasciitilde{}");
+  return stripControl(s).replace(LATEX_SPECIAL_RE, (ch) => LATEX_ESCAPE_MAP[ch]!);
 }
 
 /**

--- a/code/packages/typescript/forme-style-to-latex/src/index.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * @coding-adventures/forme-style-to-latex
+ *
+ * Second FM04 backend translator: Style IR → LaTeX preamble.
+ *
+ * ```ts
+ * import { translateToLatex } from "@coding-adventures/forme-style-to-latex";
+ * import { emptyStyleDocument, styleRuleId, sel } from "@coding-adventures/forme-style-ir";
+ *
+ * const doc = emptyStyleDocument();
+ * // … populate doc.tokens and doc.rules …
+ *
+ * const { output, emittedRules, warnings } = translateToLatex(doc, {
+ *   activeContexts: ["print"],
+ * });
+ * console.log(output);
+ * // → "% forme-style-to-latex generated preamble\n\\newif\\ifprint ..."
+ * ```
+ *
+ * Translation strategy (see FM04 §9.3):
+ *
+ * - **Selectors** become named macros (`\formeNodeParagraph`, etc).
+ *   Composition selectors (and/or/not/nth/child-of/...) have no
+ *   preamble equivalent — they warn-and-skip per FM04 §9.6.
+ * - **Properties** map to native LaTeX commands where possible
+ *   (`\color`, `\fontsize`, `\linespread`, `\setlength`, page-break
+ *   penalties).  Properties with no preamble equivalent (shadow,
+ *   opacity, max-width, padding, border, …) warn-and-skip.
+ * - **Contexts** become `\if<flag>` conditional blocks; the translator
+ *   emits the `\newif\if<flag>` declarations at the top so document
+ *   authors can toggle.
+ *
+ * Same FM04 §9.6 robustness as the CSS translator: pure
+ * (deterministic), never throws on shape, warn-skips on unknown
+ * kinds / unresolved refs / non-expressible values.
+ *
+ * @module index
+ */
+
+export { translateToLatex } from "./translate.js";
+export type { TranslateOptions, TranslateResult } from "./translate.js";
+
+// Mappers re-exported so plugins can compose them when building
+// extension-property translators of their own.
+export { colorToLatex, lengthToLatex, fontStackToLatex, fontStackFallbacksComment } from "./value-mappers.js";
+export { selectorToLatex } from "./selector-mapper.js";
+export type { SelectorEmit } from "./selector-mapper.js";
+export { contextToLatex, CONTEXT_FLAG_DECLARATIONS } from "./context-mapper.js";
+export type { LatexConditional } from "./context-mapper.js";
+export { propertyToLatex } from "./property-mappers.js";
+export type { PropertyEmit } from "./property-mappers.js";
+export {
+  resolveRef,
+  resolveColor, resolveLength, resolveShadow, resolveFontStack, resolveNumber,
+} from "./token-resolver.js";
+export { escapeLatexText, latexIdent } from "./escape.js";

--- a/code/packages/typescript/forme-style-to-latex/src/property-mappers.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/property-mappers.ts
@@ -1,0 +1,261 @@
+/**
+ * property-mappers.ts — one LaTeX style-command per Style IR property.
+ *
+ * The translator's `emitRule` calls `propertyToLatex` for each
+ * property in a rule; the returned `commands` get concatenated
+ * inside the rule's `\newcommand{\formeRule...}{...}` body.
+ *
+ * Mapping philosophy:
+ *
+ *   - **Map what LaTeX expresses naturally.**  Color, font size,
+ *     leading, weight, page-break — these have clean LaTeX forms.
+ *   - **Warn-and-skip what it doesn't.**  Shadow, opacity, layout
+ *     primitives (max-width, min-height, padding, border-radius),
+ *     display semantics — LaTeX either has no equivalent at all
+ *     (drop-shadow, opacity) or requires runtime context the
+ *     preamble can't provide (max-width depends on column geometry).
+ *   - **Document any conversion fudges** (px→pt, rem→em) inline.
+ *
+ * Every emit goes through the escape helpers — no caller-controlled
+ * data lands in output unescaped.
+ *
+ * The `important` flag on `StyleProperty` has no LaTeX equivalent
+ * (LaTeX has no specificity to override).  We honour it as a comment
+ * trailer for traceability.
+ *
+ * @module property-mappers
+ */
+
+import type {
+  StyleProperty,
+  Color, Length, FontStack, TokenSet,
+} from "@coding-adventures/forme-style-ir";
+import { colorToLatex, lengthToLatex, fontStackToLatex } from "./value-mappers.js";
+import {
+  resolveColor, resolveLength, resolveFontStack, resolveNumber,
+} from "./token-resolver.js";
+
+/**
+ * One emit per property: either a LaTeX-command fragment or a
+ * skip-with-warning.
+ */
+export type PropertyEmit =
+  | { ok: true; commands: string }
+  | { ok: false; warning: string };
+
+/**
+ * Map a `StyleProperty` to LaTeX style commands.  Each successful
+ * emit returns a string of `\command{arg}` calls (no leading/trailing
+ * whitespace — caller joins).  Failures return a warning string.
+ */
+export function propertyToLatex(
+  prop: StyleProperty,
+  tokens: TokenSet,
+): PropertyEmit {
+  switch (prop.kind) {
+    // ─── Color / fill ────────────────────────────────────────────────────
+    case "color": {
+      const c = resolveColor(prop.value, tokens);
+      if (!c) return warn(`color: unresolved`);
+      const spec = colorToLatex(c);
+      if (!spec) return warn(`color: model not expressible in xcolor`);
+      // \color[<model>]{<spec>} is the inline form (no \definecolor needed).
+      return ok(`\\color${spec}`);
+    }
+    case "background":
+    case "border-color":
+    case "outline-color":
+      // No native LaTeX preamble equivalent.  Backgrounds/borders
+      // require boxing machinery (\colorbox / \fbox) that's per-use,
+      // not per-style.  Caller (document body) layers these as needed.
+      return warn(`${prop.kind}: no LaTeX preamble equivalent (use \\colorbox / \\fbox at the call site)`);
+
+    // ─── Typography ──────────────────────────────────────────────────────
+    case "font-family": {
+      const fs = resolveFontStack(prop.value, tokens);
+      if (!fs) return warn(`font-family: unresolved`);
+      const name = fontStackToLatex(fs);
+      if (!name) return warn(`font-family: empty stack`);
+      // `fontspec` is the modern XeLaTeX/LuaLaTeX way.  Caller is
+      // responsible for `\usepackage{fontspec}` in their preamble.
+      return ok(`\\setmainfont{${name}}`);
+    }
+    case "font-size": {
+      const l = resolveLength(prop.value, tokens);
+      if (!l) return warn(`font-size: unresolved`);
+      const dim = lengthToLatex(l);
+      if (!dim) return warn(`font-size: unit ${JSON.stringify(l.unit)} has no LaTeX dimension`);
+      // \fontsize{<size>}{<leading>}\selectfont — we don't know
+      // leading here, so use 1.2× size as a sensible default.  If
+      // the rule also sets `leading`, it'll override via \linespread.
+      const lead = leadingDefault(l);
+      return ok(`\\fontsize{${dim}}{${lead}}\\selectfont`);
+    }
+    case "font-weight": {
+      const n = resolveNumber(prop.value, tokens);
+      if (n === null) return warn(`font-weight: unresolved`);
+      // CSS weights → LaTeX \fontseries codes (NFSS).
+      // 100–500 → m (medium), 600+ → b (bold), 800+ → bx (bold extended).
+      const series = n >= 800 ? "bx" : n >= 600 ? "b" : "m";
+      return ok(`\\fontseries{${series}}\\selectfont`);
+    }
+    case "font-style":
+      // italic/oblique/normal → \fontshape (NFSS).
+      // CSS values: "normal" | "italic" | "oblique".
+      switch (prop.value) {
+        case "italic":  return ok(`\\fontshape{it}\\selectfont`);
+        case "oblique": return ok(`\\fontshape{sl}\\selectfont`);
+        case "normal":  return ok(`\\fontshape{n}\\selectfont`);
+      }
+      return warn(`font-style: unknown value ${JSON.stringify((prop as { value: unknown }).value)}`);
+    case "text-transform":
+      // LaTeX has \MakeUppercase / \MakeLowercase but only as inline
+      // wrappers, not declarative.  Emit a per-style toggle macro.
+      switch (prop.value) {
+        case "uppercase":  return ok(`\\let\\formeXform=\\MakeUppercase`);
+        case "lowercase":  return ok(`\\let\\formeXform=\\MakeLowercase`);
+        case "capitalize": return warn(`text-transform: "capitalize" has no LaTeX equivalent (would require per-word logic)`);
+        case "none":       return ok(`\\let\\formeXform=\\relax`);
+      }
+      return warn(`text-transform: unknown value ${JSON.stringify((prop as { value: unknown }).value)}`);
+    case "leading": {
+      const n = resolveNumber(prop.value, tokens);
+      if (n === null) return warn(`leading: unresolved`);
+      // \linespread takes a multiplier (1.0 = single, 1.5 = 1.5× …).
+      return ok(`\\linespread{${num(n)}}\\selectfont`);
+    }
+    case "tracking":
+      // letter-spacing has no native LaTeX equivalent — `microtype`
+      // provides `\letterspacing` but it's a heavy dependency we
+      // don't want to require.  Warn.
+      return warn(`tracking: requires the \`microtype\` package; install it and emit \\letterspacing manually`);
+    case "text-decoration":
+      switch (prop.value.line) {
+        case "underline":    return ok(`\\let\\formeDecor=\\underline`);
+        case "none":         return ok(`\\let\\formeDecor=\\relax`);
+        case "line-through": return warn(`text-decoration: "line-through" requires the \`ulem\` package; emit \\sout{} manually`);
+        case "overline":     return warn(`text-decoration: "overline" has no built-in LaTeX equivalent`);
+      }
+      return warn(`text-decoration: unknown line ${JSON.stringify((prop.value as { line: unknown }).line)}`);
+
+    // ─── Layout / spacing ────────────────────────────────────────────────
+    case "space-before":
+      return lengthCommand("\\parskip", prop.value, tokens, "space-before");
+    case "space-after":
+      return lengthCommand("\\parskip", prop.value, tokens, "space-after");
+    case "indent":
+      return lengthCommand("\\parindent", prop.value, tokens, "indent");
+    case "padding":
+      // No analogue at the preamble level; \fboxsep is the closest
+      // but it's tied to box machinery.  Skip.
+      return warn(`padding: no preamble-level LaTeX equivalent (set \\fboxsep at the call site)`);
+    case "max-width":
+      return lengthCommand("\\linewidth", prop.value, tokens, "max-width");
+    case "min-height":
+      return warn(`min-height: no LaTeX equivalent (height is content-driven)`);
+    case "align":
+      // `start` / `end` are bidi-aware in the IR — we treat them as
+      // left / right for LTR.  A future i18n layer can re-emit
+      // contextually; v0 is LTR-only per FM04 §15.4.
+      switch (prop.value) {
+        case "start":   return ok(`\\raggedright`);
+        case "end":     return ok(`\\raggedleft`);
+        case "center":  return ok(`\\centering`);
+        case "justify": return ok(`\\leftskip=0pt\\rightskip=0pt plus 1fil minus 1fil`);
+      }
+      return warn(`align: unknown value ${JSON.stringify((prop as { value: unknown }).value)}`);
+    case "vertical-align":
+      return warn(`vertical-align: no preamble-level LaTeX equivalent`);
+
+    // ─── Decoration ──────────────────────────────────────────────────────
+    case "border":
+    case "border-radius":
+    case "shadow":
+    case "opacity":
+      return warn(`${prop.kind}: no LaTeX preamble equivalent (decorative properties require TikZ or tcolorbox at the call site)`);
+
+    // ─── Page break (print) ──────────────────────────────────────────────
+    case "column-break":
+      switch (prop.value) {
+        case "before": return ok(`\\columnbreak`);
+        case "after":  return ok(`\\columnbreak`);   // post-content; user places \columnbreak manually
+        case "avoid":  return ok(`\\nobreak`);
+      }
+      return warn(`column-break: unknown value ${JSON.stringify((prop as { value: unknown }).value)}`);
+    case "page-break":
+      switch (prop.value) {
+        case "before": return ok(`\\pagebreak`);
+        case "after":  return ok(`\\pagebreak`);
+        case "avoid":  return ok(`\\nopagebreak`);
+      }
+      return warn(`page-break: unknown value ${JSON.stringify((prop as { value: unknown }).value)}`);
+    case "widow-orphan": {
+      // LaTeX `\widowpenalty` / `\clubpenalty` take 0–10000.  We
+      // scale the IR value (commonly 1–4) by 1000 for a sensible
+      // mapping; the value 0 disables, 4 is maximum discouragement.
+      const v = prop.value;
+      if (typeof v !== "number" || !Number.isFinite(v)) return warn(`widow-orphan: non-numeric`);
+      const penalty = Math.max(0, Math.min(10000, Math.round(v * 2500)));
+      return ok(`\\widowpenalty=${penalty}\\clubpenalty=${penalty}`);
+    }
+
+    // ─── Visibility ──────────────────────────────────────────────────────
+    case "display":
+      // CSS display values don't map onto LaTeX's "every paragraph
+      // is its own box" model.  Warn.
+      return warn(`display: no LaTeX equivalent (LaTeX has no inline/block dichotomy at the preamble level)`);
+    case "visible":
+      return prop.value
+        ? ok(`\\let\\formeVisible=\\relax`)
+        : ok(`\\let\\formeVisible=\\hphantom`);
+
+    // ─── Extension namespace ─────────────────────────────────────────────
+    default: {
+      const k = (prop as { kind: string }).kind;
+      return warn(`unhandled property kind ${JSON.stringify(k)}`);
+    }
+  }
+}
+
+// ─── Per-shape helpers ───────────────────────────────────────────────────
+
+function ok(commands: string): PropertyEmit {
+  return { ok: true, commands };
+}
+
+function warn(message: string): PropertyEmit {
+  return { ok: false, warning: message };
+}
+
+function lengthCommand(
+  cmd: string,
+  value: Length | { kind: "token-ref"; path: string },
+  tokens: TokenSet,
+  propName: string,
+): PropertyEmit {
+  const l = resolveLength(value, tokens);
+  if (!l) return warn(`${propName}: unresolved`);
+  const dim = lengthToLatex(l);
+  if (!dim) return warn(`${propName}: unit ${JSON.stringify(l.unit)} has no LaTeX dimension`);
+  return ok(`\\setlength{${cmd}}{${dim}}`);
+}
+
+/** Pick a sensible default LaTeX leading (1.2×) given a font size. */
+function leadingDefault(size: Length): string {
+  // Same unit as the input dimension so LaTeX doesn't promote to pt.
+  if (size.unit === "px") {
+    return `${num(size.value * 0.75 * 1.2)}pt`;
+  }
+  if (size.unit === "rem") {
+    return `${num(size.value * 1.2)}em`;
+  }
+  return `${num(size.value * 1.2)}${size.unit}`;
+}
+
+function num(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return Number(n.toFixed(4)).toString();
+}
+
+// Re-export for tests that want direct access without going through translate().
+export type { Color, FontStack };

--- a/code/packages/typescript/forme-style-to-latex/src/selector-mapper.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/selector-mapper.ts
@@ -1,0 +1,125 @@
+/**
+ * selector-mapper.ts — `Selector` → LaTeX macro name (FM04 §9.3).
+ *
+ * LaTeX has no equivalent of CSS selectors — there's no document
+ * tree to walk against in the preamble.  Instead each Style IR rule
+ * becomes a named macro the document body calls:
+ *
+ *   \newcommand{\formeNodeParagraph}{...style commands...}
+ *   ...
+ *   ...in the body...
+ *   {\formeNodeParagraph Some paragraph text.\par}
+ *
+ * Each *simple* selector kind produces a stable macro name:
+ *
+ *   node-type        → \formeNode<Type>           (e.g. \formeNodeParagraph)
+ *   node-type-level  → \formeHeading<level>       (e.g. \formeHeading1)
+ *   custom-kind      → \formeKind<sluggedName>
+ *   tag              → \formeTag<sluggedName>
+ *   id               → \formeId<sluggedName>
+ *   role             → \formeRole<sluggedName>
+ *
+ * Composition selectors (`and`, `or`, `not`, `child-of`, `descendant-of`,
+ * `adjacent`, `nth`) have no preamble-level equivalent — translating
+ * them would require runtime document-walking machinery LaTeX doesn't
+ * have at the macro level.  These return a `warning` result; the
+ * translator skips the rule per FM04 §9.6.
+ *
+ * Macro names are always TitleCase ASCII identifiers — `latexIdent`
+ * encodes anything outside `[A-Za-z]` as `Z<hex>Z` so the result is
+ * always a valid `\newcommand` argument.
+ *
+ * @module selector-mapper
+ */
+
+import type { Selector } from "@coding-adventures/forme-style-ir";
+import { latexIdent } from "./escape.js";
+
+/** Either a resolved macro name, or a warning explaining why we
+ *  can't make one. */
+export type SelectorEmit =
+  | { ok: true; macroName: string; description: string }
+  | { ok: false; warning: string };
+
+/**
+ * Format a `Selector` as a LaTeX macro name + a one-line description
+ * (used as a comment above the `\newcommand`).  Returns a warning
+ * for composition selectors that have no preamble equivalent.
+ */
+export function selectorToLatex(sel: Selector): SelectorEmit {
+  switch (sel.kind) {
+    case "node-type":
+      return {
+        ok: true,
+        macroName: `\\formeNode${capitalise(latexIdent(sel.type))}`,
+        description: `node type: ${sel.type}`,
+      };
+    case "node-type-level":
+      return {
+        ok: true,
+        macroName: `\\formeHeading${arabicToLetter(sel.level)}`,
+        description: `heading level: ${sel.level}`,
+      };
+    case "custom-kind":
+      return {
+        ok: true,
+        macroName: `\\formeKind${capitalise(latexIdent(sel.customKind))}`,
+        description: `custom kind: ${sel.customKind}`,
+      };
+    case "tag":
+      return {
+        ok: true,
+        macroName: `\\formeTag${capitalise(latexIdent(sel.tag))}`,
+        description: `tag: ${sel.tag}`,
+      };
+    case "id":
+      return {
+        ok: true,
+        macroName: `\\formeId${capitalise(latexIdent(sel.id))}`,
+        description: `id: ${sel.id}`,
+      };
+    case "role":
+      return {
+        ok: true,
+        macroName: `\\formeRole${capitalise(latexIdent(sel.role))}`,
+        description: `role: ${sel.role}`,
+      };
+    case "nth":
+    case "child-of":
+    case "descendant-of":
+    case "adjacent":
+    case "and":
+    case "or":
+    case "not":
+      return {
+        ok: false,
+        warning: `selector kind ${JSON.stringify(sel.kind)} has no LaTeX preamble equivalent (composition / structural selectors require runtime document-tree walking)`,
+      };
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function capitalise(s: string): string {
+  if (s.length === 0) return s;
+  return s[0]!.toUpperCase() + s.slice(1);
+}
+
+/**
+ * Map a small Arabic numeral to its LaTeX-safe English letter form.
+ * LaTeX commands can't contain digits — `\formeHeading1` is invalid.
+ * Heading levels are 1–6 by convention; the named-letter form keeps
+ * the common case readable.
+ *
+ * Out-of-range numerics (negative, fractional, NaN, Infinity) route
+ * through `latexIdent` for defence in depth.  Decimal points and
+ * minus signs (`-1`, `1.5`) aren't LaTeX *specials* — they wouldn't
+ * cause injection — but they ARE invalid in a `\command` name and
+ * would produce broken output.  `latexIdent` encodes them as
+ * `Z<hex>Z` so the resulting macro name is always a letter run.
+ */
+function arabicToLetter(n: number): string {
+  const names = ["Zero", "One", "Two", "Three", "Four", "Five", "Six"];
+  if (Number.isInteger(n) && n >= 0 && n < names.length) return names[n]!;
+  return latexIdent(String(n));
+}

--- a/code/packages/typescript/forme-style-to-latex/src/token-resolver.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/token-resolver.ts
@@ -1,0 +1,116 @@
+/**
+ * token-resolver.ts — `TokenRef` → concrete value resolution.
+ *
+ * Mirrors the resolver in `forme-style-to-css`'s token-resolver.ts —
+ * intentionally duplicated rather than depended-upon so each
+ * translator package is independent.  Same security posture
+ * (prototype-pollution deny-list + `hasOwnProperty` own-only).
+ *
+ * @module token-resolver
+ */
+
+import {
+  isTokenRef,
+  type Color, type FontStack, type Length, type Shadow,
+  type TokenRef, type TokenSet,
+} from "@coding-adventures/forme-style-ir";
+
+/** Max chain hops before we assume a cycle. */
+const MAX_RESOLVE_DEPTH = 8;
+
+/**
+ * Resolve a `TokenRef | T` to whatever it lands on (caller narrows).
+ * Returns null on missing path, cycle, or other failure.
+ */
+export function resolveRef(
+  ref: TokenRef,
+  tokens: TokenSet,
+  depth = 0,
+): unknown | null {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const value = walkPath(ref.path, tokens as unknown as Record<string, unknown>);
+  if (value === undefined) return null;
+  if (isTokenRef(value)) return resolveRef(value as TokenRef, tokens, depth + 1);
+  return value;
+}
+
+/**
+ * Walk a dotted path through an object tree.  Returns undefined on
+ * any missing or non-object segment, or on a prototype-pollution
+ * shield hit.
+ */
+function walkPath(path: string, root: Record<string, unknown>): unknown {
+  const parts = path.split(".");
+  let cursor: unknown = root;
+  for (const part of parts) {
+    if (typeof cursor !== "object" || cursor === null) return undefined;
+    if (part === "__proto__" || part === "constructor" || part === "prototype") return undefined;
+    const obj = cursor as Record<string, unknown>;
+    if (!Object.prototype.hasOwnProperty.call(obj, part)) return undefined;
+    cursor = obj[part];
+    if (cursor === undefined) return undefined;
+  }
+  return cursor;
+}
+
+// ─── Typed convenience wrappers ──────────────────────────────────────────
+
+export function resolveColor(v: Color | TokenRef, tokens: TokenSet): Color | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return isColor(r) ? r : null;
+}
+
+export function resolveLength(v: Length | TokenRef, tokens: TokenSet): Length | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return isLength(r) ? r : null;
+}
+
+export function resolveShadow(v: Shadow | TokenRef, tokens: TokenSet): Shadow | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return isShadow(r) ? r : null;
+}
+
+export function resolveFontStack(v: FontStack | TokenRef, tokens: TokenSet): FontStack | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return isFontStack(r) ? r : null;
+}
+
+export function resolveNumber(v: number | TokenRef, tokens: TokenSet): number | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return typeof r === "number" && Number.isFinite(r) ? r : null;
+}
+
+// ─── Type guards ────────────────────────────────────────────────────────
+
+function isColor(v: unknown): v is Color {
+  if (typeof v !== "object" || v === null) return false;
+  const k = (v as { kind?: unknown }).kind;
+  return k === "rgb" || k === "hsl" || k === "oklch" || k === "named";
+}
+
+function isLength(v: unknown): v is Length {
+  if (typeof v !== "object" || v === null) return false;
+  const u = (v as { unit?: unknown }).unit;
+  return typeof u === "string" && typeof (v as { value?: unknown }).value === "number";
+}
+
+function isShadow(v: unknown): v is Shadow {
+  if (typeof v !== "object" || v === null) return false;
+  const s = v as Record<string, unknown>;
+  return (
+    typeof s.offsetX === "object" && s.offsetX !== null
+    && typeof s.offsetY === "object" && s.offsetY !== null
+    && typeof s.blur === "object" && s.blur !== null
+    && typeof s.spread === "object" && s.spread !== null
+    && s.color !== undefined
+  );
+}
+
+function isFontStack(v: unknown): v is FontStack {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}

--- a/code/packages/typescript/forme-style-to-latex/src/translate.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/translate.ts
@@ -1,0 +1,257 @@
+/**
+ * translate.ts — `translateToLatex(doc, options)` (FM04 §9.3).
+ *
+ * The public entry point.  Walks `doc.rules` in declaration order
+ * and emits a LaTeX preamble fragment shaped like:
+ *
+ *   % forme-style-to-latex generated preamble
+ *   % --- context flags ---
+ *   \newif\ifprint \newif\ifscreen ... etc
+ *
+ *   % --- rules ---
+ *   % rule "body" — selector: node-type paragraph
+ *   \newcommand{\formeNodeParagraph}{%
+ *     \color{RGB}{31,35,40}%
+ *     \fontsize{12pt}{14.4pt}\selectfont%
+ *   }
+ *
+ *   % rule "headline-print" — selector: heading level 1, context: print
+ *   \ifprint
+ *   \newcommand{\formeHeadingOne}{%
+ *     \fontsize{18pt}{21.6pt}\selectfont%
+ *   }
+ *   \fi
+ *
+ * Filtering (mirrors the CSS translator):
+ *
+ * 1. `activeContexts` — rules with a `context` field apply only when
+ *    their context is in the active set.  Rules without `context`
+ *    always apply.  Unknown / `ext:*` contexts WARN + SKIP.
+ * 2. `usedRuleIds` — when set, only rules whose id is in the list
+ *    are emitted (per-page slicing input from FM06's AOT compiler).
+ *
+ * Rules whose selector has no LaTeX preamble equivalent
+ * (composition / structural selectors — `and`, `or`, `not`,
+ * `nth`, `child-of`, `descendant-of`, `adjacent`) emit a warning
+ * and are skipped per FM04 §9.6.
+ *
+ * Properties that warn-skip don't fail the rule — the rule still
+ * emits with whatever properties did succeed.  A rule with zero
+ * successful properties is suppressed (no empty `\newcommand`).
+ *
+ * Output is deterministic: same input → byte-identical bytes,
+ * driving FM03 reproducible builds.
+ *
+ * @module translate
+ */
+
+import {
+  isExtensionKind,
+  type StyleDocument, type StyleRule, type StyleRuleId, type StyleWarning,
+} from "@coding-adventures/forme-style-ir";
+import { propertyToLatex } from "./property-mappers.js";
+import { selectorToLatex } from "./selector-mapper.js";
+import { contextToLatex, CONTEXT_FLAG_DECLARATIONS } from "./context-mapper.js";
+import { escapeLatexText } from "./escape.js";
+
+// ─── Public options + result ─────────────────────────────────────────────
+
+/**
+ * Translator options.  Same shape as `forme-style-to-css`'s
+ * `TranslateOptions` — redeclared locally per FM04 §9.1 (each
+ * translator owns its own `TranslateOptions` / `TranslateResult`
+ * rather than importing from a shared package, avoiding a circular
+ * dependency for a single-method contract).
+ */
+export interface TranslateOptions {
+  readonly activeContexts: readonly string[];
+  readonly usedRuleIds?: readonly StyleRuleId[];
+  /**
+   * Optional LaTeX command-name prefix applied to every emitted
+   * macro.  Used by per-page scoping (`{\page<hash> \formeNodeParagraph
+   * ...}`).  The prefix is concatenated verbatim — caller must
+   * supply a valid LaTeX command-name fragment (`\foo`, no spaces,
+   * no specials).  Empty / undefined ⇒ no scoping.
+   *
+   * **Caller-trusted**: this value is not escaped.  The AOT compiler
+   * derives the prefix from a hash of the page route — already safe;
+   * anyone wiring this translator from a different source must
+   * escape themselves.
+   */
+  readonly scope?: string;
+}
+
+/**
+ * Translator output.  `output` is the LaTeX preamble fragment;
+ * `emittedRules` lists which rule ids actually made it (consumers
+ * intersect with their per-page `usedStyle`); `warnings` reports
+ * everything skipped or degraded.
+ */
+export interface TranslateResult<Out> {
+  readonly output: Out;
+  readonly emittedRules: readonly StyleRuleId[];
+  readonly warnings: readonly StyleWarning[];
+}
+
+/**
+ * Translate a `StyleDocument` into a LaTeX preamble fragment.
+ */
+export function translateToLatex(
+  doc: StyleDocument,
+  options: TranslateOptions,
+): TranslateResult<string> {
+  const activeContextSet = new Set(options.activeContexts);
+  const usedSet = options.usedRuleIds === undefined
+    ? null
+    : new Set<string>(options.usedRuleIds);
+  const scope = options.scope ?? "";
+
+  const warnings: StyleWarning[] = [];
+  const emittedRules: StyleRuleId[] = [];
+
+  // Bucket rules by context — same shape as the CSS translator.
+  //   "" → unconditional
+  //   "\\ifprint" → guarded by \ifprint ... \fi
+  const buckets = new Map<string, RuleEmit[]>();
+  buckets.set("", []);
+
+  for (const rule of doc.rules) {
+    if (usedSet !== null && !usedSet.has(rule.id)) continue;
+    if (rule.context !== undefined && !activeContextSet.has(rule.context)) continue;
+
+    let bucketKey = "";
+    if (rule.context !== undefined) {
+      const cond = contextToLatex(rule.context);
+      if (cond === null) {
+        warnings.push({
+          code: "EXT_CONTEXT_NOT_TRANSLATED",
+          message: `context ${JSON.stringify(rule.context)} has no built-in LaTeX mapping; rule skipped`,
+          ruleId: rule.id,
+        });
+        continue;
+      }
+      bucketKey = cond;
+    }
+
+    const block = emitRule(rule, doc, scope, warnings);
+    if (block === null) continue;     // every property warn-skipped or
+                                      // selector unmappable
+    let bucket = buckets.get(bucketKey);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(bucketKey, bucket);
+    }
+    bucket.push({ ruleId: rule.id, block });
+    emittedRules.push(rule.id);
+  }
+
+  // Assemble output.
+  const parts: string[] = [];
+  parts.push("% forme-style-to-latex generated preamble");
+  parts.push("");
+  parts.push("% --- context flags ---");
+  for (const decl of CONTEXT_FLAG_DECLARATIONS) parts.push(decl);
+  parts.push("");
+  parts.push("% --- rules ---");
+
+  // Unconditional first.
+  const unconditional = buckets.get("") ?? [];
+  for (const emit of unconditional) parts.push(emit.block);
+
+  // Then context-guarded buckets in insertion order.
+  for (const [key, emits] of buckets) {
+    if (key === "" || emits.length === 0) continue;
+    parts.push("");
+    parts.push(key);
+    for (const emit of emits) parts.push(emit.block);
+    parts.push("\\fi");
+  }
+
+  const output = parts.join("\n");
+  return {
+    output,
+    emittedRules: Object.freeze(emittedRules),
+    warnings: Object.freeze(warnings),
+  };
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+interface RuleEmit {
+  readonly ruleId: StyleRuleId;
+  readonly block: string;
+}
+
+/**
+ * Format one rule as `% comment\n\newcommand{<macro>}{<body>}`.
+ * Returns null if every property warn-skipped, or if the selector
+ * itself has no LaTeX equivalent.
+ */
+function emitRule(
+  rule: StyleRule,
+  doc: StyleDocument,
+  scope: string,
+  warnings: StyleWarning[],
+): string | null {
+  const selEmit = selectorToLatex(rule.selector);
+  if (!selEmit.ok) {
+    warnings.push({
+      code: "SELECTOR_SKIPPED",
+      message: selEmit.warning,
+      ruleId: rule.id,
+    });
+    return null;
+  }
+
+  const commands: string[] = [];
+  for (const prop of rule.properties) {
+    if (isExtensionKind(prop.kind)) {
+      warnings.push({
+        code: "EXT_PROPERTY_NOT_TRANSLATED",
+        message: `property kind ${JSON.stringify(prop.kind)} has no built-in LaTeX mapping; skipped`,
+        ruleId: rule.id,
+        propertyKind: prop.kind,
+      });
+      continue;
+    }
+
+    const emit = propertyToLatex(prop, doc.tokens);
+    if (emit.ok) {
+      // `prop.important` has no LaTeX equivalent.  We trail a comment
+      // on the line so traceability survives.
+      const importantTrailer = prop.important ? "  % !important" : "";
+      commands.push(`  ${emit.commands}%${importantTrailer}`);
+    } else {
+      warnings.push({
+        code: "PROPERTY_SKIPPED",
+        message: emit.warning,
+        ruleId: rule.id,
+        propertyKind: prop.kind,
+      });
+    }
+  }
+
+  if (commands.length === 0) return null;
+
+  // Apply scope by prepending the scope command to the macro name.
+  // scope="\\Scope" + macro="\\formeNodeParagraph" → "\\Scope\\formeNodeParagraph"
+  // (Caller is responsible for `scope` being a well-formed LaTeX
+  //  command-name fragment.)
+  const macroName = scope.length > 0
+    ? `${scope}${selEmit.macroName}`
+    : selEmit.macroName;
+
+  // Escape rule.id for the comment (it's a branded string but
+  // theoretically attacker-controllable via a hand-rolled IR).
+  const safeId = escapeLatexText(rule.id);
+  // The selector description is safe-by-construction in
+  // selector-mapper but escape defensively all the same.
+  const safeDesc = escapeLatexText(selEmit.description);
+
+  return [
+    `% rule "${safeId}" — ${safeDesc}`,
+    `\\newcommand{${macroName}}{%`,
+    ...commands,
+    `}`,
+  ].join("\n");
+}

--- a/code/packages/typescript/forme-style-to-latex/src/value-mappers.ts
+++ b/code/packages/typescript/forme-style-to-latex/src/value-mappers.ts
@@ -1,0 +1,179 @@
+/**
+ * value-mappers.ts — `Color`, `Length`, `FontStack` → LaTeX literals.
+ *
+ * LaTeX-specific quirks the IR has to defer to:
+ *
+ *   - **Color models.**  `xcolor` understands `rgb`, `RGB` (0–255),
+ *     `cmyk`, `gray`, `HTML`, and a small set of named colors.  Our
+ *     IR uses 0–255 `rgb`, so we pick `xcolor`'s `RGB` model (the
+ *     uppercase form — lowercase `rgb` expects 0–1 floats).
+ *   - **HSL / OKLCH** aren't first-class in `xcolor`.  We approximate
+ *     by converting HSL→RGB inline (lossless for our v0 use) and
+ *     warning on OKLCH (round-trip through sRGB is lossy and out of
+ *     scope here).  Named CSS colors fall back to `xcolor`'s built-in
+ *     name table when it has a match, else warn-and-skip.
+ *   - **Length units.**  LaTeX natively supports `pt`, `mm`, `cm`,
+ *     `in`, `ex`, `em`.  We pass these through.  `px` converts to
+ *     `pt` at the CSS standard (1px = 0.75pt; 96px = 72pt = 1in).
+ *     `rem` becomes `em` (CSS rem = root em; LaTeX em = current
+ *     font em — close enough for v0 — caller can override the
+ *     document's root font size to compensate).  `vh`/`vw`/`%`/`ch`
+ *     warn-and-skip — they need page-geometry context LaTeX doesn't
+ *     expose at the preamble level.
+ *   - **Font stacks.**  We emit the first family as `\setmainfont{...}`
+ *     (XeLaTeX / LuaLaTeX with `fontspec`).  Fallbacks are dropped
+ *     with a comment — LaTeX has no native fallback chain.  Caller
+ *     is expected to use a font that's installed (validator can't
+ *     check that).
+ *   - **Shadow.**  LaTeX has no native drop-shadow.  We warn-and-skip
+ *     at the property level rather than fake it with TikZ (which
+ *     pulls a heavy dependency).
+ *
+ * All string interpolation paths route through `escape.ts` first.
+ *
+ * @module value-mappers
+ */
+
+import type { Color, FontStack, Length } from "@coding-adventures/forme-style-ir";
+import { escapeLatexText } from "./escape.js";
+
+/** Conversion to fundamentally-LaTeX units.  null = no equivalent. */
+const LATEX_UNIT_PASSTHROUGH = new Set(["pt", "mm", "in", "ex", "em"]);
+
+/**
+ * Format a `Color` as an `xcolor` model+spec pair, e.g.
+ * `{RGB}{31,35,40}`.  Returns null when the color can't be expressed
+ * (oklch with no inline conversion; named color that xcolor doesn't
+ * recognise).
+ *
+ * Returned form is suitable for direct injection into
+ * `\definecolor{<name>}<here>` or `\color<here>{<name>}`.
+ */
+export function colorToLatex(c: Color): string | null {
+  switch (c.kind) {
+    case "rgb": {
+      // xcolor's `RGB` model takes 0–255 ints; we round to the
+      // nearest integer to be safe.
+      const r = clampInt(c.r), g = clampInt(c.g), b = clampInt(c.b);
+      return `{RGB}{${r},${g},${b}}`;
+    }
+    case "hsl": {
+      // Inline HSL→RGB.  Lossless within sRGB.
+      const { r, g, b } = hslToRgb(c.h, c.s, c.l);
+      return `{RGB}{${r},${g},${b}}`;
+    }
+    case "oklch":
+      // Round-trip through CIE conversion is outside our scope.
+      // Caller (property mapper) warn-skips at the call site.
+      return null;
+    case "named": {
+      const safe = NAMED_COLORS.get(c.name.toLowerCase());
+      return safe ?? null;
+    }
+  }
+}
+
+/**
+ * Format a `Length` as a LaTeX dimension, e.g. `12pt`, `1em`.
+ * Returns null for units LaTeX can't natively express (`vh`, `vw`,
+ * `%`, `ch`); caller warn-skips.
+ */
+export function lengthToLatex(l: Length): string | null {
+  if (LATEX_UNIT_PASSTHROUGH.has(l.unit)) {
+    return `${num(l.value)}${l.unit}`;
+  }
+  if (l.unit === "px") {
+    // 96px = 72pt → 1px = 0.75pt.
+    const pt = l.value * 0.75;
+    return `${num(pt)}pt`;
+  }
+  if (l.unit === "rem") {
+    // CSS rem ≈ LaTeX em (root vs current font — see module docstring).
+    return `${num(l.value)}em`;
+  }
+  // %, vh, vw, ch — no LaTeX equivalent without page-geometry context.
+  return null;
+}
+
+/**
+ * Format a `FontStack` as the *first* family's name (escaped for
+ * LaTeX text-mode).  Fallbacks are dropped — LaTeX has no native
+ * fallback chain.  The returned string is suitable for use inside
+ * `\setmainfont{...}` (fontspec).
+ *
+ * Returns null on an empty stack (defensive — the validator should
+ * have rejected it).
+ */
+export function fontStackToLatex(stack: FontStack): string | null {
+  if (stack.length === 0) return null;
+  return escapeLatexText(stack[0]!);
+}
+
+/**
+ * Format the *complete* font stack as a comment listing each
+ * fallback.  Useful for traceability: `% font-fallbacks: Inter,
+ * system-ui, sans-serif`.
+ */
+export function fontStackFallbacksComment(stack: FontStack): string {
+  if (stack.length <= 1) return "";
+  return `% font-fallbacks: ${stack.slice(1).map(escapeLatexText).join(", ")}`;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+/** Format a number with no trailing `.0` and bounded precision. */
+function num(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  // 4 decimals is more than enough for typography; avoids
+  // `0.10000000000000001`-style float noise in output.
+  return Number(n.toFixed(4)).toString();
+}
+
+function clampInt(x: number): number {
+  return Math.max(0, Math.min(255, Math.round(x)));
+}
+
+/**
+ * HSL → RGB (8-bit per channel).  Algorithm from CSS Color L3 / W3C
+ * "Algorithm for converting HSL to RGB".
+ */
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  const sFrac = s / 100;
+  const lFrac = l / 100;
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = sFrac * Math.min(lFrac, 1 - lFrac);
+  const f = (n: number) => lFrac - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  return {
+    r: clampInt(f(0) * 255),
+    g: clampInt(f(8) * 255),
+    b: clampInt(f(4) * 255),
+  };
+}
+
+/**
+ * A small subset of CSS named colors that `xcolor` recognises
+ * natively (the `dvipsnames` / `svgnames` option packages cover
+ * more, but require user-side `\usepackage` config we don't want
+ * to assume).  The values we emit are pre-resolved RGB triples
+ * so the output works with a bare `\usepackage{xcolor}`.
+ *
+ * Lowercase keys for case-insensitive lookup.
+ */
+const NAMED_COLORS: ReadonlyMap<string, string> = new Map([
+  ["black",       "{RGB}{0,0,0}"],
+  ["white",       "{RGB}{255,255,255}"],
+  ["red",         "{RGB}{255,0,0}"],
+  ["green",       "{RGB}{0,128,0}"],
+  ["blue",        "{RGB}{0,0,255}"],
+  ["yellow",      "{RGB}{255,255,0}"],
+  ["cyan",        "{RGB}{0,255,255}"],
+  ["magenta",     "{RGB}{255,0,255}"],
+  ["gray",        "{RGB}{128,128,128}"],
+  ["grey",        "{RGB}{128,128,128}"],
+  ["orange",      "{RGB}{255,165,0}"],
+  ["purple",      "{RGB}{128,0,128}"],
+  ["pink",        "{RGB}{255,192,203}"],
+  ["brown",       "{RGB}{165,42,42}"],
+  ["tomato",      "{RGB}{255,99,71}"],
+  ["transparent", "{RGB}{255,255,255}"],   // approximation; LaTeX has no alpha
+]);

--- a/code/packages/typescript/forme-style-to-latex/tests/context-mapper.test.ts
+++ b/code/packages/typescript/forme-style-to-latex/tests/context-mapper.test.ts
@@ -1,0 +1,44 @@
+/**
+ * context-mapper.test.ts — context → LaTeX conditional.
+ */
+
+import { describe, it, expect } from "vitest";
+import { contextToLatex, CONTEXT_FLAG_DECLARATIONS } from "../src/index.js";
+
+describe("contextToLatex — kernel-blessed contexts", () => {
+  it("maps the seven standard contexts to \\if<flag>", () => {
+    expect(contextToLatex("print")).toBe("\\ifprint");
+    expect(contextToLatex("screen")).toBe("\\ifscreen");
+    expect(contextToLatex("dark")).toBe("\\ifdark");
+    expect(contextToLatex("narrow")).toBe("\\ifnarrow");
+    expect(contextToLatex("wide")).toBe("\\ifwide");
+    expect(contextToLatex("reduced-motion")).toBe("\\ifreducedmotion");
+    expect(contextToLatex("high-contrast")).toBe("\\ifhighcontrast");
+  });
+
+  it("returns null for ext: contexts", () => {
+    expect(contextToLatex("ext:my-plugin:dark-blue")).toBeNull();
+  });
+
+  it("returns null for unrecognised contexts", () => {
+    expect(contextToLatex("typo")).toBeNull();
+  });
+});
+
+describe("CONTEXT_FLAG_DECLARATIONS", () => {
+  it("declares a \\newif\\if<flag> for every kernel context", () => {
+    expect(CONTEXT_FLAG_DECLARATIONS).toEqual([
+      "\\newif\\ifprint",
+      "\\newif\\ifscreen",
+      "\\newif\\ifdark",
+      "\\newif\\ifnarrow",
+      "\\newif\\ifwide",
+      "\\newif\\ifreducedmotion",
+      "\\newif\\ifhighcontrast",
+    ]);
+  });
+
+  it("is frozen (caller mutations don't leak into future calls)", () => {
+    expect(Object.isFrozen(CONTEXT_FLAG_DECLARATIONS)).toBe(true);
+  });
+});

--- a/code/packages/typescript/forme-style-to-latex/tests/escape.test.ts
+++ b/code/packages/typescript/forme-style-to-latex/tests/escape.test.ts
@@ -1,0 +1,129 @@
+/**
+ * escape.test.ts — LaTeX escaping pins.
+ *
+ * One test per LaTeX-special character + control-char stripping +
+ * identifier sanitisation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { escapeLatexText, latexIdent } from "../src/escape.js";
+
+describe("escapeLatexText — all ten LaTeX specials", () => {
+  it("escapes backslash first (so subsequent escapes don't collide)", () => {
+    expect(escapeLatexText("\\")).toBe("\\textbackslash{}");
+  });
+
+  it("escapes %", () => {
+    expect(escapeLatexText("50%")).toBe("50\\%");
+  });
+
+  it("escapes $", () => {
+    expect(escapeLatexText("$5")).toBe("\\$5");
+  });
+
+  it("escapes &", () => {
+    expect(escapeLatexText("a & b")).toBe("a \\& b");
+  });
+
+  it("escapes _", () => {
+    expect(escapeLatexText("snake_case")).toBe("snake\\_case");
+  });
+
+  it("escapes #", () => {
+    expect(escapeLatexText("#tag")).toBe("\\#tag");
+  });
+
+  it("escapes {", () => {
+    expect(escapeLatexText("a{b")).toBe("a\\{b");
+  });
+
+  it("escapes }", () => {
+    expect(escapeLatexText("a}b")).toBe("a\\}b");
+  });
+
+  it("escapes ^ as \\textasciicircum{}", () => {
+    expect(escapeLatexText("a^b")).toBe("a\\textasciicircum{}b");
+  });
+
+  it("escapes ~ as \\textasciitilde{}", () => {
+    expect(escapeLatexText("a~b")).toBe("a\\textasciitilde{}b");
+  });
+
+  it("escapes all ten in one string in the right order", () => {
+    // The big composite test — backslash escaping uses placeholders so
+    // its synthetic `\textbackslash{}` braces don't get double-escaped
+    // on later passes.
+    const input = `\\%$&_#{}^~`;
+    const out = escapeLatexText(input);
+    // Every literal in the input has been transformed to its
+    // canonical LaTeX-escape form, in input order:
+    //   \  → \textbackslash{}
+    //   %  → \%
+    //   $  → \$
+    //   &  → \&
+    //   _  → \_
+    //   #  → \#
+    //   {  → \{
+    //   }  → \}
+    //   ^  → \textasciicircum{}
+    //   ~  → \textasciitilde{}
+    expect(out).toBe(
+      "\\textbackslash{}\\%\\$\\&\\_\\#\\{\\}\\textasciicircum{}\\textasciitilde{}",
+    );
+  });
+
+  it("strips ASCII control characters (0x00-0x1F, 0x7F)", () => {
+    const input = "a\x00b\x01c\x1Fd\x7Fe\nf"; // \n is 0x0A — control
+    const out = escapeLatexText(input);
+    // Newline IS in 0x00-0x1F so it gets stripped.
+    expect(out).toBe("abcdef");
+  });
+
+  it("passes through plain ASCII letters unchanged", () => {
+    expect(escapeLatexText("Hello world 123")).toBe("Hello world 123");
+  });
+
+  it("idempotent for already-safe input", () => {
+    const safe = "Hello world 123";
+    expect(escapeLatexText(escapeLatexText(safe))).toBe(safe);
+  });
+
+  it("does NOT escape Unicode (only LaTeX specials are ASCII)", () => {
+    expect(escapeLatexText("café — résumé")).toBe("café — résumé");
+  });
+});
+
+describe("latexIdent — LaTeX command-name sanitisation", () => {
+  it("passes through all-letter input verbatim", () => {
+    expect(latexIdent("Paragraph")).toBe("Paragraph");
+  });
+
+  it("encodes digits as Z<hex>Z", () => {
+    expect(latexIdent("h1")).toBe(`hZ${"1".codePointAt(0)!.toString(16)}Z`);
+  });
+
+  it("encodes hyphens and other punctuation", () => {
+    const out = latexIdent("foo-bar");
+    // The hyphen (0x2d) becomes Z2dZ; rest passes through.
+    expect(out).toBe(`fooZ${(0x2d).toString(16)}Zbar`);
+  });
+
+  it("encodes LaTeX-special characters defensively", () => {
+    const out = latexIdent("a%b");
+    expect(out).toContain("Z25Z");                  // % is 0x25
+    expect(out.startsWith("a")).toBe(true);
+    expect(out.endsWith("b")).toBe(true);
+  });
+
+  it("rejects empty input as Zempty", () => {
+    expect(latexIdent("")).toBe("Zempty");
+  });
+
+  it("strips control characters first, then encodes", () => {
+    expect(latexIdent("a\x00b")).toBe("ab");
+  });
+
+  it("an all-control-character input becomes Zempty after stripping", () => {
+    expect(latexIdent("\x00\x01\x02")).toBe("Zempty");
+  });
+});

--- a/code/packages/typescript/forme-style-to-latex/tests/property-mappers.test.ts
+++ b/code/packages/typescript/forme-style-to-latex/tests/property-mappers.test.ts
@@ -1,0 +1,349 @@
+/**
+ * property-mappers.test.ts — every kernel property kind.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PROPERTY_KINDS, type StyleProperty, type TokenSet } from "@coding-adventures/forme-style-ir";
+import { propertyToLatex } from "../src/index.js";
+
+const tokens: TokenSet = {
+  colors:  { text: { kind: "rgb", r: 0, g: 0, b: 0 } },
+  typography: {
+    families: { body: ["Inter", "sans-serif"] },
+    scale:    { md: { unit: "pt", value: 12 } },
+    weights:  { regular: 400, bold: 700, black: 900 },
+    leading:  { normal: 1.5 },
+    tracking: { normal: { unit: "em", value: 0 } },
+  },
+  space:   { md: { unit: "pt", value: 6 } },
+  radii:   {},
+  shadows: {},
+};
+
+describe("propertyToLatex — color", () => {
+  it("color emits \\color{RGB}{...}", () => {
+    const r = propertyToLatex({ kind: "color", value: { kind: "rgb", r: 31, g: 35, b: 40 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\color{RGB}{31,35,40}");
+  });
+
+  it("color via token-ref resolves", () => {
+    const r = propertyToLatex({ kind: "color", value: { kind: "token-ref", path: "colors.text" } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\color{RGB}{0,0,0}");
+  });
+
+  it("color with oklch warns (model not expressible)", () => {
+    const r = propertyToLatex({ kind: "color", value: { kind: "oklch", l: 0.7, c: 0.15, h: 220 } }, tokens);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.warning).toMatch(/xcolor/);
+  });
+
+  it("color with unresolved ref warns", () => {
+    const r = propertyToLatex({ kind: "color", value: { kind: "token-ref", path: "colors.gone" } }, tokens);
+    expect(r.ok).toBe(false);
+  });
+
+  it("background / border-color / outline-color warn-skip (no preamble form)", () => {
+    for (const k of ["background", "border-color", "outline-color"] as const) {
+      const r = propertyToLatex(
+        { kind: k, value: { kind: "named", name: "red" } } as StyleProperty,
+        tokens,
+      );
+      expect(r.ok).toBe(false);
+    }
+  });
+});
+
+describe("propertyToLatex — typography", () => {
+  it("font-family emits \\setmainfont{...}", () => {
+    const r = propertyToLatex({ kind: "font-family", value: ["Inter", "sans-serif"] }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\setmainfont{Inter}");
+  });
+
+  it("font-family with unresolved ref warns", () => {
+    const r = propertyToLatex({ kind: "font-family", value: { kind: "token-ref", path: "typography.families.nope" } }, tokens);
+    expect(r.ok).toBe(false);
+  });
+
+  it("font-size emits \\fontsize with 1.2× leading default", () => {
+    const r = propertyToLatex({ kind: "font-size", value: { unit: "pt", value: 12 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\fontsize{12pt}{14.4pt}\\selectfont");
+  });
+
+  it("font-size in px converts to pt", () => {
+    const r = propertyToLatex({ kind: "font-size", value: { unit: "px", value: 16 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\fontsize{12pt}{14.4pt}\\selectfont");
+  });
+
+  it("font-size in rem maps to em", () => {
+    const r = propertyToLatex({ kind: "font-size", value: { unit: "rem", value: 1 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\fontsize{1em}{1.2em}\\selectfont");
+  });
+
+  it("font-size in vh warns", () => {
+    const r = propertyToLatex({ kind: "font-size", value: { unit: "vh", value: 10 } }, tokens);
+    expect(r.ok).toBe(false);
+  });
+
+  it("font-weight 400 → \\fontseries{m}", () => {
+    const r = propertyToLatex({ kind: "font-weight", value: 400 }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\fontseries{m}\\selectfont");
+  });
+
+  it("font-weight 700 → \\fontseries{b}", () => {
+    const r = propertyToLatex({ kind: "font-weight", value: 700 }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\fontseries{b}\\selectfont");
+  });
+
+  it("font-weight 900 → \\fontseries{bx}", () => {
+    const r = propertyToLatex({ kind: "font-weight", value: 900 }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\fontseries{bx}\\selectfont");
+  });
+
+  it("font-weight via token-ref", () => {
+    const r = propertyToLatex({ kind: "font-weight", value: { kind: "token-ref", path: "typography.weights.bold" } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\fontseries{b}\\selectfont");
+  });
+
+  it("font-weight unresolved warns", () => {
+    const r = propertyToLatex({ kind: "font-weight", value: { kind: "token-ref", path: "typography.weights.nope" } }, tokens);
+    expect(r.ok).toBe(false);
+  });
+
+  it("font-style italic / oblique / normal", () => {
+    expect((propertyToLatex({ kind: "font-style", value: "italic" }, tokens) as { commands: string }).commands).toBe("\\fontshape{it}\\selectfont");
+    expect((propertyToLatex({ kind: "font-style", value: "oblique" }, tokens) as { commands: string }).commands).toBe("\\fontshape{sl}\\selectfont");
+    expect((propertyToLatex({ kind: "font-style", value: "normal" }, tokens) as { commands: string }).commands).toBe("\\fontshape{n}\\selectfont");
+  });
+
+  it("text-transform uppercase / lowercase / none / capitalize", () => {
+    expect((propertyToLatex({ kind: "text-transform", value: "uppercase" }, tokens) as { commands: string }).commands).toContain("MakeUppercase");
+    expect((propertyToLatex({ kind: "text-transform", value: "lowercase" }, tokens) as { commands: string }).commands).toContain("MakeLowercase");
+    expect((propertyToLatex({ kind: "text-transform", value: "none" }, tokens) as { commands: string }).commands).toContain("relax");
+    expect(propertyToLatex({ kind: "text-transform", value: "capitalize" }, tokens).ok).toBe(false);
+  });
+
+  it("leading → \\linespread{n}", () => {
+    const r = propertyToLatex({ kind: "leading", value: 1.5 }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\linespread{1.5}\\selectfont");
+  });
+
+  it("leading unresolved warns", () => {
+    const r = propertyToLatex({ kind: "leading", value: { kind: "token-ref", path: "typography.leading.nope" } }, tokens);
+    expect(r.ok).toBe(false);
+  });
+
+  it("tracking warns (needs microtype)", () => {
+    expect(propertyToLatex({ kind: "tracking", value: { unit: "em", value: 0.05 } }, tokens).ok).toBe(false);
+  });
+
+  it("text-decoration underline / none / line-through / overline", () => {
+    expect((propertyToLatex({ kind: "text-decoration", value: { line: "underline" } }, tokens) as { commands: string }).commands).toContain("underline");
+    expect((propertyToLatex({ kind: "text-decoration", value: { line: "none" } }, tokens) as { commands: string }).commands).toContain("relax");
+    expect(propertyToLatex({ kind: "text-decoration", value: { line: "line-through" } }, tokens).ok).toBe(false);
+    expect(propertyToLatex({ kind: "text-decoration", value: { line: "overline" } }, tokens).ok).toBe(false);
+  });
+});
+
+describe("propertyToLatex — layout / spacing", () => {
+  it("space-before → \\setlength{\\parskip}{...}", () => {
+    const r = propertyToLatex({ kind: "space-before", value: { unit: "pt", value: 8 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\setlength{\\parskip}{8pt}");
+  });
+
+  it("space-after", () => {
+    const r = propertyToLatex({ kind: "space-after", value: { unit: "pt", value: 8 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\setlength{\\parskip}{8pt}");
+  });
+
+  it("indent → \\setlength{\\parindent}{...}", () => {
+    const r = propertyToLatex({ kind: "indent", value: { unit: "em", value: 1 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\setlength{\\parindent}{1em}");
+  });
+
+  it("indent with non-LaTeX unit warns", () => {
+    expect(propertyToLatex({ kind: "indent", value: { unit: "%", value: 10 } }, tokens).ok).toBe(false);
+  });
+
+  it("indent unresolved warns", () => {
+    expect(propertyToLatex({ kind: "indent", value: { kind: "token-ref", path: "space.nope" } }, tokens).ok).toBe(false);
+  });
+
+  it("padding warns (no preamble equivalent)", () => {
+    expect(propertyToLatex(
+      { kind: "padding", value: { top: { unit: "pt", value: 4 }, right: { unit: "pt", value: 4 }, bottom: { unit: "pt", value: 4 }, left: { unit: "pt", value: 4 } } },
+      tokens,
+    ).ok).toBe(false);
+  });
+
+  it("max-width → \\setlength{\\linewidth}{...}", () => {
+    const r = propertyToLatex({ kind: "max-width", value: { unit: "pt", value: 400 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\setlength{\\linewidth}{400pt}");
+  });
+
+  it("min-height warns", () => {
+    expect(propertyToLatex({ kind: "min-height", value: { unit: "pt", value: 100 } }, tokens).ok).toBe(false);
+  });
+
+  it("align start / end / center / justify", () => {
+    expect((propertyToLatex({ kind: "align", value: "start" }, tokens) as { commands: string }).commands).toBe("\\raggedright");
+    expect((propertyToLatex({ kind: "align", value: "end" }, tokens) as { commands: string }).commands).toBe("\\raggedleft");
+    expect((propertyToLatex({ kind: "align", value: "center" }, tokens) as { commands: string }).commands).toBe("\\centering");
+    expect((propertyToLatex({ kind: "align", value: "justify" }, tokens) as { commands: string }).commands).toContain("leftskip");
+  });
+
+  it("vertical-align warns", () => {
+    expect(propertyToLatex({ kind: "vertical-align", value: "middle" }, tokens).ok).toBe(false);
+  });
+});
+
+describe("propertyToLatex — decoration warn-skips", () => {
+  it.each(["border", "border-radius", "shadow", "opacity"] as const)("%s warns", (k) => {
+    let p: StyleProperty;
+    switch (k) {
+      case "border":         p = { kind: "border", value: { width: { unit: "pt", value: 1 }, style: "solid", color: { kind: "named", name: "black" } } }; break;
+      case "border-radius":  p = { kind: "border-radius", value: { unit: "pt", value: 4 } }; break;
+      case "shadow":         p = { kind: "shadow", value: { offsetX: { unit: "pt", value: 0 }, offsetY: { unit: "pt", value: 2 }, blur: { unit: "pt", value: 4 }, spread: { unit: "pt", value: 0 }, color: { kind: "named", name: "black" } } }; break;
+      case "opacity":        p = { kind: "opacity", value: 0.5 }; break;
+    }
+    expect(propertyToLatex(p, tokens).ok).toBe(false);
+  });
+});
+
+describe("propertyToLatex — page break", () => {
+  it("column-break before/after/avoid", () => {
+    expect((propertyToLatex({ kind: "column-break", value: "before" }, tokens) as { commands: string }).commands).toBe("\\columnbreak");
+    expect((propertyToLatex({ kind: "column-break", value: "after" }, tokens) as { commands: string }).commands).toBe("\\columnbreak");
+    expect((propertyToLatex({ kind: "column-break", value: "avoid" }, tokens) as { commands: string }).commands).toBe("\\nobreak");
+  });
+
+  it("page-break before/after/avoid", () => {
+    expect((propertyToLatex({ kind: "page-break", value: "before" }, tokens) as { commands: string }).commands).toBe("\\pagebreak");
+    expect((propertyToLatex({ kind: "page-break", value: "after" }, tokens) as { commands: string }).commands).toBe("\\pagebreak");
+    expect((propertyToLatex({ kind: "page-break", value: "avoid" }, tokens) as { commands: string }).commands).toBe("\\nopagebreak");
+  });
+
+  it("widow-orphan scales to 0-10000 penalty", () => {
+    const r = propertyToLatex({ kind: "widow-orphan", value: 4 }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\widowpenalty=10000\\clubpenalty=10000");
+  });
+
+  it("widow-orphan 0 = 0 penalty", () => {
+    const r = propertyToLatex({ kind: "widow-orphan", value: 0 }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\widowpenalty=0\\clubpenalty=0");
+  });
+});
+
+describe("propertyToLatex — visibility", () => {
+  it("display warns", () => {
+    expect(propertyToLatex({ kind: "display", value: "block" }, tokens).ok).toBe(false);
+  });
+
+  it("visible true / false", () => {
+    expect((propertyToLatex({ kind: "visible", value: true }, tokens) as { commands: string }).commands).toContain("relax");
+    expect((propertyToLatex({ kind: "visible", value: false }, tokens) as { commands: string }).commands).toContain("hphantom");
+  });
+});
+
+describe("propertyToLatex — extension kinds", () => {
+  it("unknown ext: kind emits warning", () => {
+    const r = propertyToLatex({ kind: "ext:plugin:foo" as never, value: "bar" } as unknown as StyleProperty, tokens);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("propertyToLatex — exhaustiveness over PROPERTY_KINDS", () => {
+  it("every kernel-known kind yields some result (ok or warning, not crash)", () => {
+    for (const k of PROPERTY_KINDS) {
+      // Build a minimal valid value per kind.  We don't care about
+      // ok/warning — we just want propertyToLatex never to throw.
+      let p: StyleProperty;
+      switch (k) {
+        case "color": case "background": case "border-color": case "outline-color":
+          p = { kind: k, value: { kind: "named", name: "black" } } as StyleProperty; break;
+        case "font-family":
+          p = { kind: k, value: ["Inter"] } as StyleProperty; break;
+        case "font-size": case "tracking": case "space-before": case "space-after":
+        case "indent": case "max-width": case "min-height": case "border-radius":
+          p = { kind: k, value: { unit: "pt", value: 1 } } as StyleProperty; break;
+        case "font-weight": case "leading": case "opacity": case "widow-orphan":
+          p = { kind: k, value: 1 } as StyleProperty; break;
+        case "font-style":
+          p = { kind: k, value: "normal" } as StyleProperty; break;
+        case "text-transform":
+          p = { kind: k, value: "none" } as StyleProperty; break;
+        case "text-decoration":
+          p = { kind: k, value: { line: "none" } } as StyleProperty; break;
+        case "padding":
+          p = { kind: k, value: { top: { unit: "pt", value: 0 }, right: { unit: "pt", value: 0 }, bottom: { unit: "pt", value: 0 }, left: { unit: "pt", value: 0 } } } as StyleProperty; break;
+        case "align":
+          p = { kind: k, value: "start" } as StyleProperty; break;
+        case "vertical-align":
+          p = { kind: k, value: "baseline" } as StyleProperty; break;
+        case "border":
+          p = { kind: k, value: { width: { unit: "pt", value: 1 }, style: "solid", color: { kind: "named", name: "black" } } } as StyleProperty; break;
+        case "shadow":
+          p = { kind: k, value: { offsetX: { unit: "pt", value: 0 }, offsetY: { unit: "pt", value: 0 }, blur: { unit: "pt", value: 0 }, spread: { unit: "pt", value: 0 }, color: { kind: "named", name: "black" } } } as StyleProperty; break;
+        case "column-break": case "page-break":
+          p = { kind: k, value: "before" } as StyleProperty; break;
+        case "display":
+          p = { kind: k, value: "block" } as StyleProperty; break;
+        case "visible":
+          p = { kind: k, value: true } as StyleProperty; break;
+      }
+      expect(() => propertyToLatex(p, tokens)).not.toThrow();
+    }
+  });
+});
+
+describe("propertyToLatex — defensive fallthroughs (typed-as-never branches)", () => {
+  // These pin the "unknown value" defensive returns inside each
+  // exhaustive switch.  The static types make these unreachable, but
+  // a hand-rolled IR that bypasses the validator could land here, and
+  // we want to confirm the code returns a warning rather than crashes.
+  it("font-style unknown value → warning", () => {
+    expect(propertyToLatex({ kind: "font-style", value: "wonky" as never }, tokens).ok).toBe(false);
+  });
+  it("text-transform unknown value → warning", () => {
+    expect(propertyToLatex({ kind: "text-transform", value: "wonky" as never }, tokens).ok).toBe(false);
+  });
+  it("text-decoration unknown line → warning", () => {
+    expect(propertyToLatex({ kind: "text-decoration", value: { line: "wonky" as never } }, tokens).ok).toBe(false);
+  });
+  it("align unknown value → warning", () => {
+    expect(propertyToLatex({ kind: "align", value: "wonky" as never }, tokens).ok).toBe(false);
+  });
+  it("column-break unknown value → warning", () => {
+    expect(propertyToLatex({ kind: "column-break", value: "wonky" as never }, tokens).ok).toBe(false);
+  });
+  it("page-break unknown value → warning", () => {
+    expect(propertyToLatex({ kind: "page-break", value: "wonky" as never }, tokens).ok).toBe(false);
+  });
+  it("widow-orphan non-numeric → warning", () => {
+    expect(propertyToLatex({ kind: "widow-orphan", value: "x" as never }, tokens).ok).toBe(false);
+  });
+});
+
+describe("propertyToLatex — important trailer is the translator's concern", () => {
+  it("propertyToLatex itself doesn't append !important (translator does)", () => {
+    const r = propertyToLatex({ kind: "leading", value: 1.5, important: true }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.commands).toBe("\\linespread{1.5}\\selectfont");
+  });
+});

--- a/code/packages/typescript/forme-style-to-latex/tests/selector-mapper.test.ts
+++ b/code/packages/typescript/forme-style-to-latex/tests/selector-mapper.test.ts
@@ -1,0 +1,137 @@
+/**
+ * selector-mapper.test.ts — Selector → LaTeX macro name.
+ */
+
+import { describe, it, expect } from "vitest";
+import { sel } from "@coding-adventures/forme-style-ir";
+import { selectorToLatex } from "../src/index.js";
+
+describe("selectorToLatex — simple selectors", () => {
+  it("node-type → \\formeNode<Type>", () => {
+    const emit = selectorToLatex(sel.type("paragraph"));
+    expect(emit.ok).toBe(true);
+    if (emit.ok) {
+      expect(emit.macroName).toBe("\\formeNodeParagraph");
+      expect(emit.description).toBe("node type: paragraph");
+    }
+  });
+
+  it("node-type-level → \\formeHeading<Word>", () => {
+    const emit = selectorToLatex({ kind: "node-type-level", level: 1 });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) expect(emit.macroName).toBe("\\formeHeadingOne");
+  });
+
+  it("node-type-level handles 2-6", () => {
+    const names = ["Two", "Three", "Four", "Five", "Six"];
+    for (let i = 0; i < names.length; i++) {
+      const emit = selectorToLatex({ kind: "node-type-level", level: i + 2 });
+      expect(emit.ok).toBe(true);
+      if (emit.ok) expect(emit.macroName).toBe(`\\formeHeading${names[i]}`);
+    }
+  });
+
+  it("node-type-level out-of-range encodes via latexIdent (Z<hex>Z)", () => {
+    const emit = selectorToLatex({ kind: "node-type-level", level: 12 });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) {
+      // "12" → "Z31ZZ32Z" (digits 1, 2 encoded)
+      expect(emit.macroName).toBe("\\formeHeadingZ31ZZ32Z");
+    }
+  });
+
+  it("node-type-level negative numerics encode safely (no raw '-')", () => {
+    const emit = selectorToLatex({ kind: "node-type-level", level: -1 });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) {
+      // No raw `-` (invalid in LaTeX command names).
+      expect(emit.macroName).not.toContain("-");
+    }
+  });
+
+  it("node-type-level fractional numerics encode safely (no raw '.')", () => {
+    const emit = selectorToLatex({ kind: "node-type-level", level: 1.5 });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) {
+      expect(emit.macroName).not.toContain(".");
+    }
+  });
+
+  it("custom-kind → \\formeKind<Slug>", () => {
+    const emit = selectorToLatex({ kind: "custom-kind", customKind: "Callout" });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) expect(emit.macroName).toBe("\\formeKindCallout");
+  });
+
+  it("tag → \\formeTag<Slug>", () => {
+    const emit = selectorToLatex({ kind: "tag", tag: "warning" });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) expect(emit.macroName).toBe("\\formeTagWarning");
+  });
+
+  it("id → \\formeId<Slug>", () => {
+    const emit = selectorToLatex({ kind: "id", id: "main" });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) expect(emit.macroName).toBe("\\formeIdMain");
+  });
+
+  it("role → \\formeRole<Slug>", () => {
+    const emit = selectorToLatex({ kind: "role", role: "note" });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) expect(emit.macroName).toBe("\\formeRoleNote");
+  });
+});
+
+describe("selectorToLatex — identifier sanitisation", () => {
+  it("hyphens in names are encoded so macro names stay valid", () => {
+    const emit = selectorToLatex(sel.type("block-quote"));
+    expect(emit.ok).toBe(true);
+    if (emit.ok) {
+      // Must NOT contain a literal hyphen in the macro name (LaTeX
+      // command-name grammar forbids it).
+      expect(emit.macroName).not.toContain("-");
+      // Must still contain the encoded form.
+      expect(emit.macroName).toContain("Z2dZ");
+    }
+  });
+
+  it("LaTeX-special chars in selector targets are encoded", () => {
+    const emit = selectorToLatex({ kind: "tag", tag: "a%b" });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) {
+      // No raw % survives.
+      expect(emit.macroName).not.toContain("%");
+      // Encoded with Z25Z (25 = hex for %).
+      expect(emit.macroName).toContain("Z25Z");
+    }
+  });
+
+  it("ASCII control characters are stripped before encoding", () => {
+    const emit = selectorToLatex({ kind: "id", id: "main\x00x" });
+    expect(emit.ok).toBe(true);
+    if (emit.ok) expect(emit.macroName).toBe("\\formeIdMainx");
+  });
+});
+
+describe("selectorToLatex — composition selectors warn-skip", () => {
+  it.each(["nth", "child-of", "descendant-of", "adjacent", "and", "or", "not"] as const)(
+    "%s returns warning",
+    (kind) => {
+      // Construct a minimal selector for each composition kind.
+      const inner = sel.type("p");
+      let s;
+      switch (kind) {
+        case "nth":           s = { kind: "nth" as const, n: 0, of: inner }; break;
+        case "child-of":      s = { kind: "child-of" as const, parent: inner, child: inner }; break;
+        case "descendant-of": s = { kind: "descendant-of" as const, ancestor: inner, descendant: inner }; break;
+        case "adjacent":      s = { kind: "adjacent" as const, previous: inner, following: inner }; break;
+        case "and":           s = { kind: "and" as const, all: [inner, inner] }; break;
+        case "or":            s = { kind: "or" as const, any: [inner, inner] }; break;
+        case "not":           s = { kind: "not" as const, inner }; break;
+      }
+      const emit = selectorToLatex(s);
+      expect(emit.ok).toBe(false);
+      if (!emit.ok) expect(emit.warning).toMatch(/composition|structural/);
+    },
+  );
+});

--- a/code/packages/typescript/forme-style-to-latex/tests/token-resolver.test.ts
+++ b/code/packages/typescript/forme-style-to-latex/tests/token-resolver.test.ts
@@ -1,0 +1,129 @@
+/**
+ * token-resolver.test.ts — TokenRef walker + prototype-pollution guards.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { TokenSet } from "@coding-adventures/forme-style-ir";
+import {
+  resolveRef, resolveColor, resolveLength, resolveShadow,
+  resolveFontStack, resolveNumber,
+} from "../src/index.js";
+
+const tokens: TokenSet = {
+  colors: {
+    text: { kind: "rgb", r: 0, g: 0, b: 0 },
+    link: { kind: "token-ref", path: "colors.text" },
+    // Cycle: a ↔ b.
+    a: { kind: "token-ref", path: "colors.b" },
+    b: { kind: "token-ref", path: "colors.a" },
+  },
+  typography: {
+    families: { body: ["Inter", "sans-serif"] },
+    scale:    { md: { unit: "pt", value: 12 } },
+    weights:  { regular: 400 },
+    leading:  { normal: 1.5 },
+    tracking: { normal: { unit: "em", value: 0 } },
+  },
+  space:   { md: { unit: "pt", value: 6 } },
+  radii:   {},
+  shadows: {
+    soft: {
+      offsetX: { unit: "pt", value: 0 },
+      offsetY: { unit: "pt", value: 2 },
+      blur:    { unit: "pt", value: 4 },
+      spread:  { unit: "pt", value: 0 },
+      color:   { kind: "rgb", r: 0, g: 0, b: 0 },
+    },
+  },
+};
+
+describe("resolveRef — happy path", () => {
+  it("resolves a direct ref", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.text" }, tokens))
+      .toEqual({ kind: "rgb", r: 0, g: 0, b: 0 });
+  });
+
+  it("follows a one-hop chain", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.link" }, tokens))
+      .toEqual({ kind: "rgb", r: 0, g: 0, b: 0 });
+  });
+
+  it("returns null on a cycle (depth-capped)", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.a" }, tokens)).toBeNull();
+  });
+
+  it("returns null on missing path", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.gone" }, tokens)).toBeNull();
+  });
+});
+
+describe("resolveRef — prototype-pollution defence", () => {
+  it("refuses __proto__ in path", () => {
+    expect(resolveRef({ kind: "token-ref", path: "__proto__.toString" }, tokens)).toBeNull();
+  });
+
+  it("refuses constructor", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.constructor.name" }, tokens)).toBeNull();
+  });
+
+  it("refuses prototype", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.prototype" }, tokens)).toBeNull();
+  });
+
+  it("hasOwnProperty defence: inherited keys are not followed", () => {
+    // `colors.toString` is inherited from Object.prototype.
+    expect(resolveRef({ kind: "token-ref", path: "colors.toString" }, tokens)).toBeNull();
+  });
+});
+
+describe("resolveRef — typed wrappers", () => {
+  it("resolveColor", () => {
+    expect(resolveColor({ kind: "token-ref", path: "colors.text" }, tokens))
+      .toEqual({ kind: "rgb", r: 0, g: 0, b: 0 });
+    expect(resolveColor({ kind: "rgb", r: 1, g: 2, b: 3 }, tokens))
+      .toEqual({ kind: "rgb", r: 1, g: 2, b: 3 });
+    expect(resolveColor({ kind: "token-ref", path: "colors.gone" }, tokens))
+      .toBeNull();
+  });
+
+  it("resolveLength", () => {
+    expect(resolveLength({ kind: "token-ref", path: "space.md" }, tokens))
+      .toEqual({ unit: "pt", value: 6 });
+    expect(resolveLength({ unit: "em", value: 1 }, tokens))
+      .toEqual({ unit: "em", value: 1 });
+  });
+
+  it("resolveShadow", () => {
+    const s = resolveShadow({ kind: "token-ref", path: "shadows.soft" }, tokens);
+    expect(s).not.toBeNull();
+    expect(s!.offsetY).toEqual({ unit: "pt", value: 2 });
+  });
+
+  it("resolveFontStack", () => {
+    expect(resolveFontStack({ kind: "token-ref", path: "typography.families.body" }, tokens))
+      .toEqual(["Inter", "sans-serif"]);
+  });
+
+  it("resolveNumber", () => {
+    expect(resolveNumber({ kind: "token-ref", path: "typography.weights.regular" }, tokens))
+      .toBe(400);
+  });
+
+  it("resolveNumber rejects NaN / Infinity", () => {
+    // Construct a token set with a broken weight value.
+    const broken: TokenSet = {
+      ...tokens,
+      typography: {
+        ...tokens.typography,
+        weights: { broken: NaN },
+      },
+    };
+    expect(resolveNumber({ kind: "token-ref", path: "typography.weights.broken" }, broken))
+      .toBeNull();
+  });
+
+  it("typed wrapper rejects type-mismatched leaves", () => {
+    // ask for a Color but path lands on a Length
+    expect(resolveColor({ kind: "token-ref", path: "space.md" }, tokens)).toBeNull();
+  });
+});

--- a/code/packages/typescript/forme-style-to-latex/tests/translate.test.ts
+++ b/code/packages/typescript/forme-style-to-latex/tests/translate.test.ts
@@ -1,0 +1,289 @@
+/**
+ * translate.test.ts — end-to-end `translateToLatex` behaviour.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  styleRuleId, sel, canonicalStyleDocument,
+  type StyleDocument, type StyleRule,
+} from "@coding-adventures/forme-style-ir";
+import { translateToLatex } from "../src/index.js";
+
+function baseDoc(): StyleDocument {
+  return {
+    kind: "StyleDocument",
+    tokens: {
+      colors: { text: { kind: "rgb", r: 31, g: 35, b: 40 } },
+      typography: {
+        families: { body: ["Inter", "sans-serif"] },
+        scale:    { md: { unit: "pt", value: 12 } },
+        weights:  { regular: 400, bold: 700 },
+        leading:  { normal: 1.5 },
+        tracking: { normal: { unit: "em", value: 0 } },
+      },
+      space:   {},
+      radii:   {},
+      shadows: {},
+    },
+    rules: [],
+    contexts: [],
+    theme: null,
+  };
+}
+
+function rule(id: string, sel0: StyleRule["selector"], props: StyleRule["properties"], context?: string): StyleRule {
+  return context !== undefined
+    ? { id: styleRuleId(id), selector: sel0, properties: props, context }
+    : { id: styleRuleId(id), selector: sel0, properties: props };
+}
+
+describe("translateToLatex — happy path", () => {
+  it("emits a header + context flags + rule macros", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("body", sel.type("paragraph"), [
+          { kind: "color", value: { kind: "token-ref", path: "colors.text" } },
+          { kind: "leading", value: 1.5 },
+        ]),
+      ],
+    };
+    const { output, emittedRules, warnings } = translateToLatex(doc, { activeContexts: [] });
+    expect(emittedRules).toEqual(["body"]);
+    expect(warnings).toEqual([]);
+    expect(output).toContain("% forme-style-to-latex generated preamble");
+    expect(output).toContain("\\newif\\ifprint");
+    expect(output).toContain("\\newcommand{\\formeNodeParagraph}{%");
+    expect(output).toContain("\\color{RGB}{31,35,40}");
+    expect(output).toContain("\\linespread{1.5}");
+  });
+
+  it("emits each context's bucket wrapped in \\if...\\fi", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("noctx", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }]),
+        rule("printonly", { kind: "node-type-level", level: 1 }, [{ kind: "leading", value: 2 }], "print"),
+      ],
+    };
+    const { output } = translateToLatex(doc, { activeContexts: ["print"] });
+    // Search for the conditional guard AFTER the rules section
+    // (otherwise we hit the `\newif\ifprint` declaration in the
+    // header, which is unrelated to the guard).
+    const rulesStart = output.indexOf("% --- rules ---");
+    const noctxIdx = output.indexOf("\\formeNodeParagraph", rulesStart);
+    const printIdx = output.indexOf("\\ifprint", rulesStart);
+    const headingIdx = output.indexOf("\\formeHeadingOne", rulesStart);
+    const fiIdx = output.indexOf("\\fi", rulesStart);
+    expect(noctxIdx).toBeGreaterThan(-1);
+    expect(printIdx).toBeGreaterThan(-1);
+    // Unconditional rule comes BEFORE the \ifprint block.
+    expect(noctxIdx).toBeLessThan(printIdx);
+    expect(printIdx).toBeLessThan(headingIdx);
+    expect(headingIdx).toBeLessThan(fiIdx);
+  });
+});
+
+describe("translateToLatex — filtering", () => {
+  it("rules with non-active contexts are filtered out", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("inactive", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }], "print"),
+      ],
+    };
+    const { emittedRules, output } = translateToLatex(doc, { activeContexts: [] });
+    expect(emittedRules).toEqual([]);
+    expect(output).not.toContain("\\formeNodeParagraph");
+  });
+
+  it("ext: contexts emit a warning and skip the rule", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("x", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }], "ext:plugin:special"),
+      ],
+    };
+    const { warnings, emittedRules } = translateToLatex(doc, { activeContexts: ["ext:plugin:special"] });
+    expect(emittedRules).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.code).toBe("EXT_CONTEXT_NOT_TRANSLATED");
+  });
+
+  it("usedRuleIds slicing — only listed ids emit", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("a", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }]),
+        rule("b", { kind: "node-type-level", level: 1 }, [{ kind: "leading", value: 2 }]),
+        rule("c", sel.type("blockquote"), [{ kind: "leading", value: 1.2 }]),
+      ],
+    };
+    const { emittedRules } = translateToLatex(doc, {
+      activeContexts: [],
+      usedRuleIds: [styleRuleId("a"), styleRuleId("c")],
+    });
+    expect([...emittedRules].sort()).toEqual(["a", "c"]);
+  });
+
+  it("usedRuleIds with empty list emits no rules", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [rule("a", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }])],
+    };
+    const { emittedRules } = translateToLatex(doc, { activeContexts: [], usedRuleIds: [] });
+    expect(emittedRules).toEqual([]);
+  });
+
+  it("rules with unmappable selectors warn and skip", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("cantmap", { kind: "child-of", parent: sel.type("article"), child: sel.type("p") }, [
+          { kind: "leading", value: 1.5 },
+        ]),
+      ],
+    };
+    const { warnings, emittedRules } = translateToLatex(doc, { activeContexts: [] });
+    expect(emittedRules).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.code).toBe("SELECTOR_SKIPPED");
+  });
+
+  it("rules where every property warn-skips are suppressed", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        // Both properties have no LaTeX preamble equivalent.
+        rule("nothing", sel.type("paragraph"), [
+          { kind: "opacity", value: 0.5 },
+          { kind: "shadow", value: { offsetX: { unit: "pt", value: 0 }, offsetY: { unit: "pt", value: 0 }, blur: { unit: "pt", value: 0 }, spread: { unit: "pt", value: 0 }, color: { kind: "named", name: "black" } } },
+        ]),
+      ],
+    };
+    const { emittedRules, output, warnings } = translateToLatex(doc, { activeContexts: [] });
+    expect(emittedRules).toEqual([]);
+    expect(output).not.toContain("\\newcommand{\\formeNodeParagraph}");
+    expect(warnings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("ext: property kinds emit a warning, the rule still emits other props", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("mixed", sel.type("paragraph"), [
+          { kind: "ext:plugin:thing", value: 1 } as never,
+          { kind: "leading", value: 1.5 },
+        ]),
+      ],
+    };
+    const { warnings, emittedRules, output } = translateToLatex(doc, { activeContexts: [] });
+    expect(emittedRules).toEqual(["mixed"]);
+    expect(warnings.some((w) => w.code === "EXT_PROPERTY_NOT_TRANSLATED")).toBe(true);
+    expect(output).toContain("\\linespread{1.5}");
+  });
+});
+
+describe("translateToLatex — scope", () => {
+  it("scope prefix concatenates to the macro name", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [rule("body", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }])],
+    };
+    const { output } = translateToLatex(doc, { activeContexts: [], scope: "\\page" });
+    expect(output).toContain("\\newcommand{\\page\\formeNodeParagraph}{%");
+  });
+});
+
+describe("translateToLatex — important trailer", () => {
+  it("renders a `% !important` trailing comment for important: true", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("important", sel.type("paragraph"), [
+          { kind: "leading", value: 1.5, important: true },
+        ]),
+      ],
+    };
+    const { output } = translateToLatex(doc, { activeContexts: [] });
+    expect(output).toContain("% !important");
+  });
+});
+
+describe("translateToLatex — reproducibility (FM03)", () => {
+  it("same input → byte-identical output", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("a", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }]),
+        rule("b", { kind: "node-type-level", level: 1 }, [{ kind: "color", value: { kind: "token-ref", path: "colors.text" } }], "print"),
+      ],
+    };
+    const opts = { activeContexts: ["print"] };
+    expect(translateToLatex(doc, opts).output)
+      .toBe(translateToLatex(doc, opts).output);
+  });
+
+  it("canonical document → canonical output", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [rule("body", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }])],
+    };
+    // Verify canonicalisation doesn't disturb the translator's output.
+    const c1 = canonicalStyleDocument(doc);
+    const c2 = canonicalStyleDocument(JSON.parse(c1) as StyleDocument);
+    expect(c1).toBe(c2);
+  });
+});
+
+describe("translateToLatex — output safety (LaTeX injection)", () => {
+  it("escapes LaTeX-specials in rule id comments", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("evil%id\\with#stuff", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }]),
+      ],
+    };
+    const { output } = translateToLatex(doc, { activeContexts: [] });
+    // The id appears in the comment, but the comment is one line — % becomes %.
+    // Wait: % is a LaTeX comment in the macro body, but in our generated
+    // comment line `% rule "..."`, the leading % is already a comment.
+    // BUT a `%` inside the quoted id portion would terminate the comment
+    // on second-line use; we still escape defensively.
+    expect(output).toContain("evil\\%id");
+    expect(output).toContain("\\textbackslash{}");
+  });
+
+  it("escapes LaTeX-specials in selector targets (via latexIdent)", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        // A node-type with a hostile name.  The validator would normally
+        // reject this; we test our defence-in-depth.
+        rule("x", sel.type("evil%name"), [{ kind: "leading", value: 1.5 }]),
+      ],
+    };
+    const { output } = translateToLatex(doc, { activeContexts: [] });
+    // The macro identifier (between `\newcommand{` and `}{%`) must
+    // not contain a raw %.  The `{%` at the end is the legitimate
+    // LaTeX "comment-out-EOL" marker that opens the macro body
+    // suppressing the newline.
+    const newcommandLine = output.split("\n").find((l) => l.startsWith("\\newcommand"))!;
+    const macroIdent = newcommandLine.slice("\\newcommand{".length, newcommandLine.indexOf("}{%"));
+    expect(macroIdent).not.toContain("%");
+    expect(macroIdent).toContain("Z25Z");   // % encoded as Z25Z
+  });
+
+  it("strips ASCII control chars from rule id comments", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("bad\x00null", sel.type("paragraph"), [{ kind: "leading", value: 1.5 }]),
+      ],
+    };
+    const { output } = translateToLatex(doc, { activeContexts: [] });
+    expect(output).toContain("badnull");
+    // eslint-disable-next-line no-control-regex
+    expect(output).not.toMatch(/\x00/);
+  });
+});

--- a/code/packages/typescript/forme-style-to-latex/tests/value-mappers.test.ts
+++ b/code/packages/typescript/forme-style-to-latex/tests/value-mappers.test.ts
@@ -1,0 +1,123 @@
+/**
+ * value-mappers.test.ts — Color / Length / FontStack → LaTeX.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  colorToLatex, lengthToLatex, fontStackToLatex, fontStackFallbacksComment,
+} from "../src/index.js";
+
+describe("colorToLatex", () => {
+  it("rgb opaque → xcolor RGB form", () => {
+    expect(colorToLatex({ kind: "rgb", r: 31, g: 35, b: 40 })).toBe("{RGB}{31,35,40}");
+  });
+
+  it("rgb clamps out-of-range channels", () => {
+    expect(colorToLatex({ kind: "rgb", r: -10, g: 999, b: 128 })).toBe("{RGB}{0,255,128}");
+  });
+
+  it("rgb rounds fractional channels", () => {
+    expect(colorToLatex({ kind: "rgb", r: 127.4, g: 127.6, b: 128 })).toBe("{RGB}{127,128,128}");
+  });
+
+  it("hsl converts to RGB (xcolor doesn't speak HSL natively)", () => {
+    // hsl(0, 100, 50) → pure red.
+    expect(colorToLatex({ kind: "hsl", h: 0, s: 100, l: 50 })).toBe("{RGB}{255,0,0}");
+  });
+
+  it("hsl gray", () => {
+    expect(colorToLatex({ kind: "hsl", h: 0, s: 0, l: 50 })).toBe("{RGB}{128,128,128}");
+  });
+
+  it("hsl black", () => {
+    expect(colorToLatex({ kind: "hsl", h: 0, s: 0, l: 0 })).toBe("{RGB}{0,0,0}");
+  });
+
+  it("hsl white", () => {
+    expect(colorToLatex({ kind: "hsl", h: 0, s: 0, l: 100 })).toBe("{RGB}{255,255,255}");
+  });
+
+  it("oklch returns null (lossy round-trip out of scope for v0)", () => {
+    expect(colorToLatex({ kind: "oklch", l: 0.7, c: 0.15, h: 220 })).toBeNull();
+  });
+
+  it("named known color resolves via the safe map", () => {
+    expect(colorToLatex({ kind: "named", name: "black" })).toBe("{RGB}{0,0,0}");
+    expect(colorToLatex({ kind: "named", name: "tomato" })).toBe("{RGB}{255,99,71}");
+  });
+
+  it("named lookup is case-insensitive", () => {
+    expect(colorToLatex({ kind: "named", name: "Tomato" })).toBe("{RGB}{255,99,71}");
+  });
+
+  it("named unknown returns null", () => {
+    expect(colorToLatex({ kind: "named", name: "asparagus" })).toBeNull();
+  });
+});
+
+describe("lengthToLatex", () => {
+  it("pt / mm / in / ex / em pass through unchanged", () => {
+    for (const u of ["pt", "mm", "in", "ex", "em"] as const) {
+      expect(lengthToLatex({ unit: u, value: 12 })).toBe(`12${u}`);
+    }
+  });
+
+  it("px converts to pt at 1px = 0.75pt", () => {
+    expect(lengthToLatex({ unit: "px", value: 16 })).toBe("12pt");
+  });
+
+  it("rem maps to em (v0 approximation; documented)", () => {
+    expect(lengthToLatex({ unit: "rem", value: 1.25 })).toBe("1.25em");
+  });
+
+  it("%, vh, vw, ch return null", () => {
+    for (const u of ["%", "vh", "vw", "ch"] as const) {
+      expect(lengthToLatex({ unit: u, value: 100 })).toBeNull();
+    }
+  });
+
+  it("negative values supported", () => {
+    expect(lengthToLatex({ unit: "pt", value: -2 })).toBe("-2pt");
+  });
+
+  it("fractional pt with bounded precision (4 dp)", () => {
+    expect(lengthToLatex({ unit: "pt", value: 0.12345 })).toBe("0.1235pt");
+  });
+});
+
+describe("fontStackToLatex", () => {
+  it("returns the first family escaped", () => {
+    expect(fontStackToLatex(["Inter", "system-ui", "sans-serif"])).toBe("Inter");
+  });
+
+  it("escapes LaTeX-specials in family names", () => {
+    expect(fontStackToLatex(["My_Font"])).toBe("My\\_Font");
+  });
+
+  it("strips control characters from family names", () => {
+    expect(fontStackToLatex(["bad\nname"])).toBe("badname");
+  });
+
+  it("returns null on empty stack (defensive)", () => {
+    expect(fontStackToLatex([])).toBeNull();
+  });
+});
+
+describe("fontStackFallbacksComment", () => {
+  it("emits a comment listing fallbacks", () => {
+    expect(fontStackFallbacksComment(["Inter", "system-ui", "sans-serif"]))
+      .toBe("% font-fallbacks: system-ui, sans-serif");
+  });
+
+  it("returns empty string for single-element stack", () => {
+    expect(fontStackFallbacksComment(["serif"])).toBe("");
+  });
+
+  it("returns empty string for empty stack", () => {
+    expect(fontStackFallbacksComment([])).toBe("");
+  });
+
+  it("escapes specials in fallback names", () => {
+    expect(fontStackFallbacksComment(["A", "B%C"])).toBe("% font-fallbacks: B\\%C");
+  });
+});

--- a/code/packages/typescript/forme-style-to-latex/tsconfig.json
+++ b/code/packages/typescript/forme-style-to-latex/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-style-to-latex/vitest.config.ts
+++ b/code/packages/typescript/forme-style-to-latex/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

The **second concrete FM04 backend translator** (after [`forme-style-to-css`](../forme-style-to-css)), validating the multi-backend story FM04 §9.1 promises.  Same IR, same `TranslateOptions` shape, same warn-and-skip robustness contract — completely different output target.

Takes a `StyleDocument` from [`forme-style-ir`](../forme-style-ir) and emits a LaTeX preamble fragment shaped like:

```latex
% forme-style-to-latex generated preamble
% --- context flags ---
\newif\ifprint \newif\ifscreen ...
% --- rules ---
% rule "body" — node type: paragraph
\newcommand{\formeNodeParagraph}{%
  \color{RGB}{31,35,40}%
  \linespread{1.5}\selectfont%
}
```

## Three mapping tables

| Layer       | Maps to                          | Skips                                                           |
|-------------|----------------------------------|-----------------------------------------------------------------|
| Selectors   | `\formeNode<Type>` / `\formeHeading<Word>` / `\formeKind` / `\formeTag` / `\formeId` / `\formeRole` | `and` / `or` / `not` / `nth` / `child-of` / `descendant-of` / `adjacent` (no preamble-level document walker) |
| Properties  | Native LaTeX for color / font* / leading / spacing / page-break / widow-orphan / align | `shadow` / `opacity` / `border*` / `padding` / `background` / `display` / `vertical-align` / `tracking` (no preamble form; use TikZ at the call site) |
| Contexts    | `\if<flag>` conditionals (kernel set declared via `\newif`) | `ext:*`                                                          |

## Unit conversions (documented)

- `pt`/`mm`/`in`/`ex`/`em` pass through.
- `px` → `pt` at 1px = 0.75pt (CSS standard).
- `rem` → `em` (LaTeX has no "root em"; document author tunes root font size).
- `%`/`vh`/`vw`/`ch` warn-skip (no page-geometry context in preamble).

## Security posture

Pre-push focused review = **PASS**.

1. **LaTeX injection.**  Every interpolated string routes through `escapeLatexText` (text-mode) or `latexIdent` (command-name).  All ten LaTeX specials (`\ % $ & _ # { } ^ ~`) covered.  Backslash and accent escapes use placeholder substitution so their synthetic `{` / `}` don't get double-escaped on the brace pass — a subtle bug pinned with a composite test.
2. **`walkPath` prototype-pollution.**  Same deny-list + `hasOwnProperty` defence as `forme-style-to-css`.  Three tests pin.
3. **Control-character stripping** (0x00–0x1F, 0x7F) on every escape helper.
4. **Defence-in-depth**: numeric heading levels route through `latexIdent` so a hand-rolled IR with `node-type-level: -1` or `1.5` can't produce raw `-` / `.` in macro names (cosmetic break, not injection).

`scope` is **caller-trusted** (concatenated verbatim) — same posture as the CSS translator.  Documented in JSDoc.

## Capabilities

`[]` — pure transform.  No I/O, no shell, no network.

## Tests

**155 tests across 7 files**, **100% line / 96.15% branch** coverage (above FM04 §14.4 ≥95% line target):

- `escape.test.ts` (18) — every LaTeX-special, control-char strip, identifier sanitisation, all-ten-in-one composite
- `value-mappers.test.ts` (25) — color models (RGB / HSL inline conversion / OKLCH warn-skip / named lookup), length units, font-stack escaping, fallback comments
- `selector-mapper.test.ts` (20) — simple kinds, identifier sanitisation, composition warn-skips, defensive numeric encoding
- `context-mapper.test.ts` (5) — kernel contexts + flag declarations
- `token-resolver.test.ts` (15) — happy path, prototype-pollution defence, typed wrappers, cycle cap, NaN rejection
- `property-mappers.test.ts` (52) — every kernel kind, exhaustive meta-check over `PROPERTY_KINDS`, defensive fallthroughs
- `translate.test.ts` (16) — end-to-end, filtering, scope, important, reproducibility, LaTeX-injection defence

## Spec adherence

Implements FM04 §9.3 LaTeX target end-to-end.  No spec divergences.

## v0 simplifications (documented in CHANGELOG)

- OKLCH warn-skips (lossy CIE/sRGB round-trip out of scope)
- LTR-only `align` (i18n layer is a future `ext:i18n:*` extension)
- `tracking` warns (needs `microtype`)
- `text-decoration: line-through` warns (needs `ulem`)

## Test plan

- [x] `vitest run --coverage` — 155 / 155 pass, 100% line / 96.15% branch
- [x] `tsc --noEmit` — clean
- [x] Security review — PASS (LaTeX injection, proto-pollution, control chars, defence-in-depth all addressed)
- [ ] CI: lint, build, security scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)