### PR TITLE
feat(twig-module-driver): LANG67 TW05-M all-module self-compilation → 173 total functions

### DIFF
--- a/code/packages/rust/twig-module-driver/CHANGELOG.md
+++ b/code/packages/rust/twig-module-driver/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog — twig-module-driver
 
+## [0.12.0] — 2026-05-17
+
+### Added (LANG67 — TW05-M all-module self-compilation)
+
+Extended `self-compile-all` in `code/twig/compiler/main.tw` from seven files
+(TW05-L, 171 total) to **all eleven** compiler source files (TW05-M, **173 total**)
+by adding `token.tw` (0 fn), `ast.tw` (0 fn), `iir-types.tw` (0 fn), and
+`main.tw` (2 fn).
+
+#### Why union/record modules contribute 0 functions
+
+`emit-program` only counts `DefExpr(LambdaExpr)` top-level forms.  Union and
+record declarations parse as `CallExpr` nodes; `emit-top-level-form` returns
+`nil` for those → skipped by `emit-program-loop`.
+
+#### No VM constant changes needed
+
+Largest file is still `cst-parser.tw` at 29 122 chars.  Additional instruction
+cost: 21 371 chars × 90 ≈ 1.92 M; new grand total ≈ 10.1 M << 32 M.
+
+New `#[cfg(test)] mod tw05m_tests` with 7 integration tests:
+
+| Test | What it verifies |
+|------|-----------------|
+| `self_compile_token_tw_returns_0` | `token.tw` (union/record-only) → 0 functions |
+| `self_compile_ast_tw_returns_0` | `ast.tw` (union-only) → 0 functions |
+| `self_compile_iir_types_tw_returns_0` | `iir-types.tw` (union/record-only) → 0 functions |
+| `self_compile_main_tw_returns_2` | `main.tw` → 2 functions (main, self-compile-all) |
+| `self_compile_all_returns_173` | `self-compile-all` on all 11 files → 173 functions |
+| `self_compile_tw05l_modules_regression` | TW05-L 7-file sum (independent) → 171 |
+| `existing_main_still_returns_2_after_tw05m` | TW05-I regression: `(main)` → 2 |
+
+### Changed
+
+`tw05j_tests::self_compile_all_returns_171`, `tw05k_tests::self_compile_all_returns_171`,
+and `tw05l_tests::self_compile_all_returns_171` all renamed to `self_compile_all_returns_173`
+and updated to expect 173 (the new `self-compile-all` total after TW05-M adds the
+remaining four modules).
+
+#### Updated function count table
+
+| File | Size | Functions |
+|------|------|-----------|
+| `span.tw` | 2 426 | 2 |
+| `token.tw` | 2 782 | 0 ← TW05-M |
+| `diagnostic.tw` | 2 446 | 3 |
+| `ast.tw` | 3 817 | 0 ← TW05-M |
+| `iir-types.tw` | 3 073 | 0 ← TW05-M |
+| `iir-builder.tw` | 6 278 | 8 |
+| `lexer.tw` | 8 593 | 25 |
+| `cst-parser.tw` | 29 122 | 69 |
+| `parser.tw` | 19 708 | 29 |
+| `emit.tw` | 22 697 | 35 |
+| `main.tw` | 11 699 | 2 ← TW05-M |
+| **Total** | 112 641 | **173** |
+
+---
+
 ## [0.11.0] — 2026-05-17
 
 ### Added (LANG66 — TW05-L cst-parser self-compilation)

--- a/code/packages/rust/twig-module-driver/Cargo.toml
+++ b/code/packages/rust/twig-module-driver/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name        = "twig-module-driver"
-version     = "0.11.0"
+version     = "0.12.0"
 edition     = "2021"
-description = "LANG56-LANG66 — multi-file module resolver for Twig.  Resolves (import …) declarations recursively, compiles and links all modules into a single IIRModule ready for twig-vm.  LANG57 adds TW05-D data-model tests; LANG58 adds TW05-E lexer+parser tests; LANG59 adds TW05-F IIR emitter tests; LANG60 adds TW05-G lambda+DefExpr tests; LANG61 adds TW05-H program emitter tests; LANG62 adds TW05-I first self-compilation check; LANG63 adds cst-parser to all test copy lists; LANG64 adds TW05-J multi-module self-compilation via host/read_file; LANG65 adds TW05-K extended self-compilation (parser.tw + emit.tw → 102 total functions); LANG66 adds TW05-L cst-parser self-compilation (cst-parser.tw → 171 total functions)."
+description = "LANG56-LANG67 — multi-file module resolver for Twig.  Resolves (import …) declarations recursively, compiles and links all modules into a single IIRModule ready for twig-vm.  LANG57 adds TW05-D data-model tests; LANG58 adds TW05-E lexer+parser tests; LANG59 adds TW05-F IIR emitter tests; LANG60 adds TW05-G lambda+DefExpr tests; LANG61 adds TW05-H program emitter tests; LANG62 adds TW05-I first self-compilation check; LANG63 adds cst-parser to all test copy lists; LANG64 adds TW05-J multi-module self-compilation via host/read_file; LANG65 adds TW05-K extended self-compilation (parser.tw + emit.tw → 102 total functions); LANG66 adds TW05-L cst-parser self-compilation (cst-parser.tw → 171 total functions); LANG67 adds TW05-M all-module self-compilation (all 11 files → 173 total functions)."
 
 [dependencies]
 twig-parser       = { path = "../twig-parser" }

--- a/code/packages/rust/twig-module-driver/src/lib.rs
+++ b/code/packages/rust/twig-module-driver/src/lib.rs
@@ -2507,20 +2507,20 @@ mod tw05j_tests {
             .replace('\n', "\\n")
     }
 
-    // ── Test 1: self-compile-all returns 171 (TW05-L extended) ──────────────
+    // ── Test 1: self-compile-all returns 173 (TW05-M updated) ──────────────
     //
-    // TW05-L extended self-compile-all from 6 files (102) to 7 files (171)
-    // by adding cst-parser.tw (69 functions, 29 122 chars).
-    // Stack: run_in_xlarge_stack (3 GiB); cst-parser.tw is the largest file
-    // at ~1.75 GiB worst-case debug stack.
-    // (Previously expected 102 before TW05-L added cst-parser.tw.)
+    // TW05-M extended self-compile-all from 7 files (171) to 11 files (173)
+    // by adding token.tw (0), ast.tw (0), iir-types.tw (0), and main.tw (2).
+    // Stack: run_in_xlarge_stack (3 GiB); cst-parser.tw remains the largest
+    // file at ~1.75 GiB worst-case debug stack.
+    // (Previously expected 171 before TW05-M added the 4 remaining modules.)
 
     #[test]
-    fn self_compile_all_returns_171() {
+    fn self_compile_all_returns_173() {
         // Compile all modules, write a main-test.tw that calls (self-compile-all),
-        // and verify the total function count is 171 (2+3+8+25+29+35+69).
+        // and verify the total function count is 173 (2+0+3+0+0+8+25+69+29+35+2).
         let src = compiler_src_dir();
-        let dir = make_tempdir("all171");
+        let dir = make_tempdir("all173");
         copy_all_tw_modules(&src, &dir);
 
         let src_str = twig_escape_path(&src);
@@ -2534,9 +2534,9 @@ mod tw05j_tests {
         let root = dir.join("compiler").join("main-test.tw");
         fs::write(&root, &main_test_src).unwrap();
 
-        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_171");
-        assert_eq!(v.to_string(), "171",
-            "expected 171 functions (2+3+8+25+29+35+69); got {v}");
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_173");
+        assert_eq!(v.to_string(), "173",
+            "expected 173 functions (2+0+3+0+0+8+25+69+29+35+2); got {v}");
     }
 
     // ── Test 2: span.tw from disk → 2 functions ──────────────────────────────
@@ -2738,17 +2738,17 @@ mod tw05k_tests {
         }
     }
 
-    // ── Test 1: self-compile-all returns 171 (TW05-L updated) ───────────────
+    // ── Test 1: self-compile-all returns 173 (TW05-M updated) ───────────────
     //
-    // After TW05-L, self-compile-all covers 7 files → 171 functions.
+    // After TW05-M, self-compile-all covers all 11 files → 173 functions.
 
     #[test]
-    fn self_compile_all_returns_171() {
-        // Full pipeline across 7 files → 2+3+8+25+29+35+69 = 171.
-        // Uses run_in_xlarge_stack (3 GiB); cst-parser.tw (29 122 chars) is now
-        // the largest file, requiring ~1.75 GiB debug-mode stack.
+    fn self_compile_all_returns_173() {
+        // Full pipeline across 11 files → 2+0+3+0+0+8+25+69+29+35+2 = 173.
+        // Uses run_in_xlarge_stack (3 GiB); cst-parser.tw (29 122 chars) is
+        // still the largest file, requiring ~1.75 GiB debug-mode stack.
         let src = compiler_src_dir();
-        let dir = make_tempdir("all171");
+        let dir = make_tempdir("all173");
         copy_all_tw_modules(&src, &dir);
 
         let src_str = twig_escape_path(&src);
@@ -2762,9 +2762,9 @@ mod tw05k_tests {
         let root = dir.join("compiler").join("main-test.tw");
         fs::write(&root, &main_test_src).unwrap();
 
-        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_171");
-        assert_eq!(v.to_string(), "171",
-            "expected 171 functions (2+3+8+25+29+35+69); got {v}");
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_173");
+        assert_eq!(v.to_string(), "173",
+            "expected 173 functions (2+0+3+0+0+8+25+69+29+35+2); got {v}");
     }
 
     // ── Test 2: parser.tw from disk → 29 functions ───────────────────────────
@@ -2988,14 +2988,14 @@ mod tw05l_tests {
             "expected 69 functions from cst-parser.tw; got {v}");
     }
 
-    // ── Test 2: self-compile-all returns 171 ─────────────────────────────────
+    // ── Test 2: self-compile-all returns 173 (TW05-M updated) ───────────────
 
     #[test]
-    fn self_compile_all_returns_171() {
-        // Full pipeline across 7 files → 2+3+8+25+29+35+69 = 171.
-        // Uses run_in_xlarge_stack (3 GiB); cst-parser.tw is the largest file.
+    fn self_compile_all_returns_173() {
+        // Full pipeline across 11 files → 2+0+3+0+0+8+25+69+29+35+2 = 173.
+        // Uses run_in_xlarge_stack (3 GiB); cst-parser.tw remains the largest.
         let src = compiler_src_dir();
-        let dir = make_tempdir("all171");
+        let dir = make_tempdir("all173");
         copy_all_tw_modules(&src, &dir);
 
         let src_str = twig_escape_path(&src);
@@ -3009,9 +3009,9 @@ mod tw05l_tests {
         let root = dir.join("compiler").join("main-test.tw");
         fs::write(&root, &main_test_src).unwrap();
 
-        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_171");
-        assert_eq!(v.to_string(), "171",
-            "expected 171 functions (2+3+8+25+29+35+69); got {v}");
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_173");
+        assert_eq!(v.to_string(), "173",
+            "expected 173 functions (2+0+3+0+0+8+25+69+29+35+2); got {v}");
     }
 
     // ── Test 3: TW05-K regression — original 6 files still produce 102 ───────
@@ -3080,6 +3080,307 @@ mod tw05l_tests {
         let root = dir.join("compiler").join("main.tw");
 
         let v = crate::run_in_large_stack(root, dir.clone(), "existing_main_still_returns_2_after_tw05l");
+        assert_eq!(v.to_string(), "2",
+            "TW05-I regression: expected (main) = 2; got {v}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tw05m_tests — TW05-M: All-Module Self-Compilation (11 files → 173 total)
+// ---------------------------------------------------------------------------
+//
+// TW05-M extends `self-compile-all` from seven files (TW05-L, 171 total) to
+// all eleven files in the compiler source tree (TW05-M, 173 total).
+//
+// Four new files:
+//   token.tw     (2 782 chars) → 0 functions  (union TokenKind + record Token)
+//   ast.tw       (3 817 chars) → 0 functions  (union Expr)
+//   iir-types.tw (3 073 chars) → 0 functions  (union TypeHint + record IirInstr)
+//   main.tw     (11 699 chars) → 2 functions  (main, self-compile-all)
+//
+// ## Why union/record modules produce 0 functions
+//
+// `emit-program` only emits `DefExpr(LambdaExpr)` top-level forms.
+// Union and record declarations parse as `CallExpr`; `emit-top-level-form`
+// returns `nil` for those and `emit-program-loop` skips them.
+//
+// ## VM limits
+//
+// Largest file is still `cst-parser.tw` at 29 122 chars.  All limits from
+// TW05-L (MAX_DISPATCH_DEPTH 131 072, MAX_INSTRUCTIONS_PER_RUN 2²⁵) remain
+// adequate.  Additional cost: 21 371 chars × 90 ≈ 1.92 M instructions;
+// new total ≈ 10.1 M << 32 M.
+
+#[cfg(test)]
+mod tw05m_tests {
+    use std::fs;
+    use std::path::Path;
+
+    fn compiler_src_dir() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent().unwrap()  // rust/
+            .parent().unwrap()  // packages/
+            .parent().unwrap()  // code/
+            .join("twig/compiler")
+            .canonicalize()
+            .expect("code/twig/compiler/ must exist")
+    }
+
+    fn make_tempdir(tag: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "twig_tw05m_{tag}_{}_{}", std::process::id(), nonce
+        ));
+        // Use create_dir (not create_dir_all) for atomic failure on collision —
+        // prevents TOCTOU / symlink-substitution attacks in temp directory setup.
+        std::fs::create_dir(&dir).unwrap_or_else(|e| {
+            panic!("make_tempdir: could not create {}: {e}", dir.display())
+        });
+        dir
+    }
+
+    /// Escape a filesystem path for embedding inside a Twig string literal.
+    ///
+    /// Three-step escaping (order matters):
+    ///   `\`  → `\\`  (Windows separators; must be first to avoid double-escaping)
+    ///   `"`  → `\"`  (would break out of the string literal)
+    ///   `\n` → `\n`  (newlines are legal in POSIX paths; Twig lexer stops at newline)
+    fn twig_escape_path(p: &std::path::Path) -> String {
+        p.to_str().unwrap()
+            .replace('\\', "\\\\")
+            .replace('"',  "\\\"")
+            .replace('\n', "\\n")
+    }
+
+    fn copy_tw(twig_src: &Path, dest_dir: &Path, name: &str) {
+        let src  = twig_src.join(format!("{name}.tw"));
+        let dest = dest_dir.join("compiler");
+        fs::create_dir_all(&dest).unwrap();
+        fs::copy(&src, dest.join(format!("{name}.tw")))
+            .unwrap_or_else(|e| panic!("copy {name}.tw: {e}"));
+    }
+
+    fn copy_all_tw_modules(twig_src: &Path, dest_dir: &Path) {
+        for name in &["span","token","diagnostic","ast","iir-types",
+                      "iir-builder","lexer","cst-parser","parser","emit","main"] {
+            copy_tw(twig_src, dest_dir, name);
+        }
+    }
+
+    // ── Test 1: token.tw from disk → 0 functions ─────────────────────────────
+    //
+    // token.tw contains only (union TokenKind ...) and (record Token ...).
+    // emit-program skips both (parsed as CallExpr) → returns empty list.
+
+    #[test]
+    fn self_compile_token_tw_returns_0() {
+        let src = compiler_src_dir();
+        let dir = make_tempdir("token_disk");
+        copy_all_tw_modules(&src, &dir);
+
+        let path_str = twig_escape_path(&src.join("token.tw"));
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/lexer compiler/parser compiler/emit)) \
+             (define (main) \
+               (length (emit-program (parse-program (lex-source \
+                 (host/read_file \"{path_str}\"))))))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_large_stack(root, dir.clone(), "self_compile_token_tw_returns_0");
+        assert_eq!(v.to_string(), "0",
+            "expected 0 functions from token.tw (union/record-only); got {v}");
+    }
+
+    // ── Test 2: ast.tw from disk → 0 functions ───────────────────────────────
+    //
+    // ast.tw contains only (union Expr ...) — no (define ...) forms.
+
+    #[test]
+    fn self_compile_ast_tw_returns_0() {
+        let src = compiler_src_dir();
+        let dir = make_tempdir("ast_disk");
+        copy_all_tw_modules(&src, &dir);
+
+        let path_str = twig_escape_path(&src.join("ast.tw"));
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/lexer compiler/parser compiler/emit)) \
+             (define (main) \
+               (length (emit-program (parse-program (lex-source \
+                 (host/read_file \"{path_str}\"))))))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_large_stack(root, dir.clone(), "self_compile_ast_tw_returns_0");
+        assert_eq!(v.to_string(), "0",
+            "expected 0 functions from ast.tw (union-only); got {v}");
+    }
+
+    // ── Test 3: iir-types.tw from disk → 0 functions ─────────────────────────
+    //
+    // iir-types.tw contains only (union TypeHint ...) and (record IirInstr ...).
+
+    #[test]
+    fn self_compile_iir_types_tw_returns_0() {
+        let src = compiler_src_dir();
+        let dir = make_tempdir("iirtypes_disk");
+        copy_all_tw_modules(&src, &dir);
+
+        let path_str = twig_escape_path(&src.join("iir-types.tw"));
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/lexer compiler/parser compiler/emit)) \
+             (define (main) \
+               (length (emit-program (parse-program (lex-source \
+                 (host/read_file \"{path_str}\"))))))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_large_stack(root, dir.clone(), "self_compile_iir_types_tw_returns_0");
+        assert_eq!(v.to_string(), "0",
+            "expected 0 functions from iir-types.tw (union/record-only); got {v}");
+    }
+
+    // ── Test 4: main.tw from disk → 2 functions ──────────────────────────────
+    //
+    // main.tw contains exactly two (define (fn params) body) forms:
+    //   (define (main) ...)           → emitted
+    //   (define (self-compile-all dir) ...) → emitted
+    // The body of self-compile-all references host/read_file, but these are
+    // just compiled to IIR call instructions — NOT executed.
+
+    #[test]
+    fn self_compile_main_tw_returns_2() {
+        let src = compiler_src_dir();
+        let dir = make_tempdir("main_disk");
+        copy_all_tw_modules(&src, &dir);
+
+        let path_str = twig_escape_path(&src.join("main.tw"));
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/lexer compiler/parser compiler/emit)) \
+             (define (main) \
+               (length (emit-program (parse-program (lex-source \
+                 (host/read_file \"{path_str}\"))))))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_large_stack(root, dir.clone(), "self_compile_main_tw_returns_2");
+        assert_eq!(v.to_string(), "2",
+            "expected 2 functions from main.tw (main + self-compile-all); got {v}");
+    }
+
+    // ── Test 5: self-compile-all returns 173 ─────────────────────────────────
+
+    #[test]
+    fn self_compile_all_returns_173() {
+        // Full pipeline across all 11 files →
+        //   2 + 0 + 3 + 0 + 0 + 8 + 25 + 69 + 29 + 35 + 2 = 173.
+        // Uses run_in_xlarge_stack (3 GiB); cst-parser.tw is still the
+        // largest file at ~1.75 GiB debug-mode stack.
+        let src = compiler_src_dir();
+        let dir = make_tempdir("all173");
+        copy_all_tw_modules(&src, &dir);
+
+        let src_str = twig_escape_path(&src);
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/main)) \
+             (define (main) (self-compile-all \"{src_str}\"))"
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_all_returns_173");
+        assert_eq!(v.to_string(), "173",
+            "expected 173 functions (2+0+3+0+0+8+25+69+29+35+2); got {v}");
+    }
+
+    // ── Test 6: TW05-L regression — original 7 files still produce 171 ───────
+    //
+    // Verify that the seven TW05-L modules still produce the correct count after
+    // the self-compile-all extension.  This test invokes the pipeline directly
+    // (not via self-compile-all) so it is independent of the main.tw update.
+
+    #[test]
+    fn self_compile_tw05l_modules_regression() {
+        let src = compiler_src_dir();
+        let dir = make_tempdir("tw05l_regression");
+        copy_all_tw_modules(&src, &dir);
+
+        let span_path    = twig_escape_path(&src.join("span.tw"));
+        let diag_path    = twig_escape_path(&src.join("diagnostic.tw"));
+        let builder_path = twig_escape_path(&src.join("iir-builder.tw"));
+        let lexer_path   = twig_escape_path(&src.join("lexer.tw"));
+        let cst_path     = twig_escape_path(&src.join("cst-parser.tw"));
+        let parser_path  = twig_escape_path(&src.join("parser.tw"));
+        let emit_path    = twig_escape_path(&src.join("emit.tw"));
+
+        // Build the Twig source string programmatically so paren count is clear.
+        let file = |path: &str| {
+            format!("(length (emit-program (parse-program (lex-source (host/read_file \"{path}\")))))")
+        };
+        let main_test_src = format!(
+            "(module compiler/main-test \
+              (typed lenient) \
+              (export main) \
+              (import compiler/lexer compiler/parser compiler/emit)) \
+             (define (main) \
+               (+ {span} \
+                  (+ {diag} \
+                     (+ {builder} \
+                        (+ {lexer} \
+                           (+ {cst} \
+                              (+ {parser} \
+                                 {emit})))))))",
+            span    = file(&span_path),
+            diag    = file(&diag_path),
+            builder = file(&builder_path),
+            lexer   = file(&lexer_path),
+            cst     = file(&cst_path),
+            parser  = file(&parser_path),
+            emit    = file(&emit_path),
+        );
+        let root = dir.join("compiler").join("main-test.tw");
+        fs::write(&root, &main_test_src).unwrap();
+
+        let v = crate::run_in_xlarge_stack(root, dir.clone(), "self_compile_tw05l_modules_regression");
+        assert_eq!(v.to_string(), "171",
+            "TW05-L regression: expected 171 (2+3+8+25+69+29+35) from original 7 modules; got {v}");
+    }
+
+    // ── Test 7: TW05-I regression — (main) still returns 2 after TW05-M ─────
+
+    #[test]
+    fn existing_main_still_returns_2_after_tw05m() {
+        // The original (main) entry point (TW05-I smoke test, stripped span.tw)
+        // must still return 2 unchanged after the TW05-M extension.
+        let src = compiler_src_dir();
+        let dir = make_tempdir("tw05m_regression_main");
+        copy_all_tw_modules(&src, &dir);
+        let root = dir.join("compiler").join("main.tw");
+
+        let v = crate::run_in_large_stack(root, dir.clone(), "existing_main_still_returns_2_after_tw05m");
         assert_eq!(v.to_string(), "2",
             "TW05-I regression: expected (main) = 2; got {v}");
     }

--- a/code/specs/LANG67-tw05m-all-modules-self-compilation.md
+++ b/code/specs/LANG67-tw05m-all-modules-self-compilation.md
@@ -1,0 +1,129 @@
+# LANG67 — TW05-M: All-Module Self-Compilation (11 files → 173 total functions)
+
+## Overview
+
+TW05-M extends the `self-compile-all` pipeline from **seven** files (TW05-L,
+171 total functions) to **eleven** files (TW05-M, **173** total functions)
+by adding the four remaining compiler modules:
+
+| Module | Chars | Functions | Notes |
+|--------|-------|-----------|-------|
+| `token.tw` | 2 782 | **0** | union-only (TokenKind + Token record) |
+| `ast.tw` | 3 817 | **0** | union-only (Expr union) |
+| `iir-types.tw` | 3 073 | **0** | union-only (TypeHint + IirInstr record) |
+| `main.tw` | 11 699 | **2** | `main` + `self-compile-all` |
+
+After this milestone `self-compile-all` compiles every `.tw` file in the
+compiler source tree and returns **173** total emitted function definitions.
+
+## Context
+
+TW05-L (LANG66) proved the pipeline on all seven modules that contain explicit
+`(define ...)` function forms.  The remaining four modules are either
+"0-fn union modules" (token, ast, iir-types — no `define` forms at all)
+or the root module itself (main.tw — 2 defines).
+
+### Why union/record modules produce 0 functions
+
+`emit-program` only counts `DefExpr(LambdaExpr)` top-level forms — i.e.
+`(define (fn params) body)` shorthand.  Union and record declarations
+(`(union ...)`, `(record ...)`) are parsed as `CallExpr` nodes by the
+self-hosted parser; `emit-top-level-form` returns `nil` for those,
+so `emit-program-loop` skips them.
+
+The four new files therefore contribute:
+- `token.tw`: 0 (one `(union ...)`, one `(record ...)`)
+- `ast.tw`: 0 (one `(union ...)`)
+- `iir-types.tw`: 0 (one `(union ...)`, one `(record ...)`)
+- `main.tw`: 2 (`(define (main) ...)` + `(define (self-compile-all dir) ...)`)
+
+## Updated function counts
+
+| File | Size (chars) | Functions | Notes |
+|------|-------------|----------|-------|
+| `span.tw`        |  2 426 |  2 | make-span, dummy-span |
+| `token.tw`       |  2 782 |  0 | 0-fn union module ← TW05-M |
+| `diagnostic.tw`  |  2 446 |  3 | make-error, make-warning, make-info |
+| `ast.tw`         |  3 817 |  0 | 0-fn union module ← TW05-M |
+| `iir-types.tw`   |  3 073 |  0 | 0-fn union module ← TW05-M |
+| `iir-builder.tw` |  6 278 |  8 | new-builder … finalise-builder |
+| `lexer.tw`       |  8 593 | 25 | lex-digit? … lex-source |
+| `cst-parser.tw`  | 29 122 | 69 | cst-match-TkLParen … cst-parse-program |
+| `parser.tw`      | 19 708 | 29 | parse-expr … parse-program |
+| `emit.tw`        | 22 697 | 35 | emit-const … emit-program |
+| `main.tw`        | 11 699 |  2 | main, self-compile-all ← TW05-M |
+| **Total**        |112 641 |**173** | |
+
+## Stack and VM limits — no changes needed
+
+The largest single file is still `cst-parser.tw` at 29 122 chars.
+All per-file measurements from TW05-L remain valid:
+
+| Constant | Value | TW05-L rationale |
+|----------|-------|-----------------|
+| `MAX_DISPATCH_DEPTH` | 131 072 | cst-parser.tw → ~65 K frames, 2× headroom |
+| `MAX_INSTRUCTIONS_PER_RUN` | 2²⁵ (32 M) | TW05-L 7-file total ~8.2 M |
+
+Additional instruction cost for TW05-M:
+- New chars: 2 782 + 3 817 + 3 073 + 11 699 = 21 371
+- Additional lex instructions: 21 371 × 90 ≈ 1.92 M
+- New grand total: ~8.2 M + 1.92 M ≈ **10.1 M** << 32 M ✓
+
+No VM constant changes are needed.
+
+## Changes
+
+### `code/twig/compiler/main.tw`
+
+`self-compile-all` extended with four additional `host/read_file` + pipeline
+calls for `token.tw`, `ast.tw`, `iir-types.tw`, and `main.tw`.  The return
+value changes from 171 → **173**.
+
+Header comment updated to document TW05-M scope.
+
+### `code/packages/rust/twig-module-driver/src/lib.rs`
+
+#### Existing `self_compile_all_returns_171` renames
+
+The following tests are updated to expect **173**:
+- `tw05j_tests::self_compile_all_returns_171` → `self_compile_all_returns_173`
+- `tw05k_tests::self_compile_all_returns_171` → `self_compile_all_returns_173`
+- `tw05l_tests::self_compile_all_returns_171` → `self_compile_all_returns_173`
+
+#### `mod tw05m_tests` (new)
+
+7 integration tests:
+
+| Test | File | Expected |
+|------|------|---------|
+| `self_compile_token_tw_returns_0` | `token.tw` (2 782 chars) | 0 |
+| `self_compile_ast_tw_returns_0` | `ast.tw` (3 817 chars) | 0 |
+| `self_compile_iir_types_tw_returns_0` | `iir-types.tw` (3 073 chars) | 0 |
+| `self_compile_main_tw_returns_2` | `main.tw` (11 699 chars) | 2 |
+| `self_compile_all_returns_173` | all 11 files via `self-compile-all` | 173 |
+| `self_compile_tw05l_modules_regression` | TW05-L 7-file sum (independent) | 171 |
+| `existing_main_still_returns_2_after_tw05m` | `(main)` | 2 |
+
+### `code/packages/rust/twig-module-driver/Cargo.toml`
+
+Version: 0.11.0 → 0.12.0
+
+### `code/packages/rust/twig-module-driver/CHANGELOG.md`
+
+Prepend `## [0.12.0]` entry.
+
+## Acceptance criteria
+
+- `(self-compile-all dir)` returns 173.
+- `cargo test -p twig-module-driver --lib -- tw05m` — all 7 tests pass.
+- `cargo test -p twig-module-driver --lib -- tw05l` — updated `self_compile_all_returns_173` passes.
+- `cargo test -p twig-module-driver --lib -- tw05k` — updated `self_compile_all_returns_173` passes.
+- `cargo test -p twig-module-driver --lib -- tw05j` — updated `self_compile_all_returns_173` passes.
+- `cargo build --workspace` — clean build.
+
+## Roadmap: what remains after LANG67
+
+| Milestone | Scope |
+|-----------|-------|
+| TW05-G | Fixed-point: stage1 IIR = stage2 IIR for all modules |
+| TW05-H | Strict mode: all modules `(typed strict)` |

--- a/code/twig/compiler/main.tw
+++ b/code/twig/compiler/main.tw
@@ -1,5 +1,5 @@
 ; # main.tw — Root Module + Smoke-Test Entry Point
-;             (LANG62/TW05-I + LANG64/TW05-J + LANG65/TW05-K + LANG66/TW05-L)
+;             (LANG62/TW05-I + LANG64/TW05-J + LANG65/TW05-K + LANG66/TW05-L + LANG67/TW05-M)
 ;
 ; This is the root module of the self-hosted compiler.  It imports all nine
 ; sub-modules (six data-model modules from TW05-D, lexer and parser from
@@ -8,13 +8,13 @@
 ;   `(main)` — TW05-I: exercises the full pipeline on a stripped in-memory
 ;              version of span.tw (returns 2, unchanged from TW05-H).
 ;
-;   `(self-compile-all dir)` — TW05-L: reads SEVEN real `.tw` files from
-;              disk via `host/read_file`, compiles each through the full
+;   `(self-compile-all dir)` — TW05-M: reads ALL ELEVEN real `.tw` files
+;              from disk via `host/read_file`, compiles each through the full
 ;              lex → parse → emit-program pipeline, and returns the sum
 ;              of emitted function counts
-;              (2 + 3 + 8 + 25 + 29 + 35 + 69 = 171).
-;              Extended in TW05-L (LANG66) from the six-file
-;              TW05-K (LANG65) set (which returned 102).
+;              (2 + 0 + 3 + 0 + 0 + 8 + 25 + 69 + 29 + 35 + 2 = 173).
+;              Extended in TW05-M (LANG67) from the seven-file
+;              TW05-L (LANG66) set (which returned 171).
 ;
 ; ## TW05-I pipeline (LANG62)
 ;
@@ -167,54 +167,53 @@
 
 ; ── self-compile-all ──────────────────────────────────────────────────────────
 ;
-; TW05-L milestone (extended from TW05-K): read seven compiler source files
-; from `dir` via `host/read_file`, compile each through the self-hosted
+; TW05-M milestone (extended from TW05-L): read ALL ELEVEN compiler source
+; files from `dir` via `host/read_file`, compile each through the self-hosted
 ; lex → parse → emit-program pipeline, and return the sum of emitted function
 ; counts.
 ;
 ; `dir` must be the absolute path to the directory containing the compiler
 ; `.tw` files (no trailing slash).
 ;
-; ## Files compiled and expected counts (TW05-L / LANG66)
+; ## Files compiled and expected counts (TW05-M / LANG67)
 ;
 ;   span.tw           2  defines  (make-span, dummy-span)
+;   token.tw          0  defines  union/record-only module ← TW05-M
 ;   diagnostic.tw     3  defines  (make-error, make-warning, make-info)
+;   ast.tw            0  defines  union-only module ← TW05-M
+;   iir-types.tw      0  defines  union/record-only module ← TW05-M
 ;   iir-builder.tw    8  defines  (new-builder, alloc-slot, …)
 ;   lexer.tw         25  defines  (lex-digit?, …, lex-source)
-;   parser.tw        29  defines  (parse-expr, …, parse-program)        ← TW05-K
-;   emit.tw          35  defines  (emit-const, …, emit-program)         ← TW05-K
 ;   cst-parser.tw    69  defines  (cst-match-TkLParen, …, cst-parse-program) ← TW05-L
+;   parser.tw        29  defines  (parse-expr, …, parse-program)
+;   emit.tw          35  defines  (emit-const, …, emit-program)
+;   main.tw           2  defines  (main, self-compile-all) ← TW05-M
 ;                   ───
-;                   171  total
+;                   173  total
 ;
-; TW05-K (LANG65) compiled only the first six modules (102 total).
-; TW05-J (LANG64) compiled only the first four modules (38 total).
+; TW05-L (LANG66) compiled seven modules (171 total).
+; TW05-K (LANG65) compiled six modules (102 total).
 ;
-; ## Why host/read_file is safe here
+; ## Why union/record modules contribute 0 functions
 ;
-; The Twig VM exposes `host/read_file` as a host call that reads the file
-; at the given path and returns its contents as a heap string.  The lexer
-; processes the full file content including comments (comments are consumed
-; by `lex-skip-comment` and do not produce tokens).
+; `emit-program` only emits `DefExpr(LambdaExpr)` top-level forms — i.e.,
+; `(define (fn params) body)` shorthand.  Union and record declarations
+; (`(union ...)`, `(record ...)`, `(module ...)`) are parsed as `CallExpr`
+; nodes; `emit-top-level-form` returns `nil` for those → skipped.
 ;
-; ## MAX_DISPATCH_DEPTH and stack requirement
+; ## Why main.tw contributes 2 functions
 ;
-; `lex-loop` recurses once per source character.  The largest file compiled
-; here is `cst-parser.tw` at 29 122 chars, requiring up to 29 122 dispatch
-; frames.  `MAX_DISPATCH_DEPTH = 65536` (set in LANG64) provides ample
-; headroom.
+; main.tw has two `(define (fn params) body)` forms: `main` and
+; `self-compile-all`.  When compiling main.tw through the pipeline, the
+; body of `self-compile-all` is emitted as IIR call instructions; the
+; embedded `host/read_file` calls are NOT executed — they are just compiled.
 ;
-; In debug builds, frame sizes are ~60 KiB →
-;   29 122 × 60 KiB ≈ 1.75 GiB.
-; Integration tests therefore use `run_in_xlarge_stack` (3 GiB thread),
-; giving ~1.7× headroom.
+; ## Stack and VM limits
 ;
-; ## Instruction budget
-;
-; Total source chars:
-;   2 426 + 2 446 + 6 278 + 8 593 + 19 708 + 22 697 + 29 122 = 91 270.
-; Lex: ~30 instrs/char × 91 270 ≈ 2.74 M.  Parse + emit ≈ 0.70 M.
-; Total ≈ 3.44 M << MAX_INSTRUCTIONS_PER_RUN = 8 M.
+; Largest file is still `cst-parser.tw` at 29 122 chars; all limits set in
+; LANG66 (MAX_DISPATCH_DEPTH 131 072, MAX_INSTRUCTIONS_PER_RUN 2²⁵) remain
+; adequate.  Additional instruction cost: 21 371 chars × 90 ≈ 1.92 M;
+; new grand total ≈ 10.1 M << 32 M.
 
 (define (self-compile-all dir)
   ; Read each source file from disk and compile through the pipeline.
@@ -223,31 +222,46 @@
   ;
   ; Files are compiled sequentially; peak stack depth = max single file depth
   ; (cst-parser.tw at 29 122 chars), not the sum of all files.
-  (let* ((span-src    (host/read_file (string-append dir "/span.tw")))
-         (diag-src    (host/read_file (string-append dir "/diagnostic.tw")))
-         (builder-src (host/read_file (string-append dir "/iir-builder.tw")))
-         (lexer-src   (host/read_file (string-append dir "/lexer.tw")))
-         (parser-src  (host/read_file (string-append dir "/parser.tw")))
-         (emit-src    (host/read_file (string-append dir "/emit.tw")))
-         (cst-src     (host/read_file (string-append dir "/cst-parser.tw")))
+  (let* ((span-src     (host/read_file (string-append dir "/span.tw")))
+         (token-src    (host/read_file (string-append dir "/token.tw")))
+         (diag-src     (host/read_file (string-append dir "/diagnostic.tw")))
+         (ast-src      (host/read_file (string-append dir "/ast.tw")))
+         (iirtypes-src (host/read_file (string-append dir "/iir-types.tw")))
+         (builder-src  (host/read_file (string-append dir "/iir-builder.tw")))
+         (lexer-src    (host/read_file (string-append dir "/lexer.tw")))
+         (cst-src      (host/read_file (string-append dir "/cst-parser.tw")))
+         (parser-src   (host/read_file (string-append dir "/parser.tw")))
+         (emit-src     (host/read_file (string-append dir "/emit.tw")))
+         (main-src     (host/read_file (string-append dir "/main.tw")))
 
          ; Compile each module: lex → parse → emit-program.
          ; emit-program returns a list of (fn-name . instrs) pairs —
          ; only DefExpr(LambdaExpr) top-level forms are emitted.
          ; Record/union/module declarations are parsed as CallExpr and skipped.
-         (span-fns    (emit-program (parse-program (lex-source span-src))))
-         (diag-fns    (emit-program (parse-program (lex-source diag-src))))
-         (builder-fns (emit-program (parse-program (lex-source builder-src))))
-         (lexer-fns   (emit-program (parse-program (lex-source lexer-src))))
-         (parser-fns  (emit-program (parse-program (lex-source parser-src))))
-         (emit-fns    (emit-program (parse-program (lex-source emit-src))))
-         (cst-fns     (emit-program (parse-program (lex-source cst-src)))))
+         ; token.tw, ast.tw, iir-types.tw → 0 each (union/record only).
+         ; main.tw → 2 (main + self-compile-all).
+         (span-fns     (emit-program (parse-program (lex-source span-src))))
+         (token-fns    (emit-program (parse-program (lex-source token-src))))
+         (diag-fns     (emit-program (parse-program (lex-source diag-src))))
+         (ast-fns      (emit-program (parse-program (lex-source ast-src))))
+         (iirtypes-fns (emit-program (parse-program (lex-source iirtypes-src))))
+         (builder-fns  (emit-program (parse-program (lex-source builder-src))))
+         (lexer-fns    (emit-program (parse-program (lex-source lexer-src))))
+         (cst-fns      (emit-program (parse-program (lex-source cst-src))))
+         (parser-fns   (emit-program (parse-program (lex-source parser-src))))
+         (emit-fns     (emit-program (parse-program (lex-source emit-src))))
+         (main-fns     (emit-program (parse-program (lex-source main-src)))))
 
-    ; Sum the function counts: 2 + 3 + 8 + 25 + 29 + 35 + 69 = 171.
+    ; Sum the function counts:
+    ;   2 + 0 + 3 + 0 + 0 + 8 + 25 + 69 + 29 + 35 + 2 = 173.
     (+ (length span-fns)
-       (+ (length diag-fns)
-          (+ (length builder-fns)
-             (+ (length lexer-fns)
-                (+ (length parser-fns)
-                   (+ (length emit-fns)
-                      (length cst-fns)))))))))
+       (+ (length token-fns)
+          (+ (length diag-fns)
+             (+ (length ast-fns)
+                (+ (length iirtypes-fns)
+                   (+ (length builder-fns)
+                      (+ (length lexer-fns)
+                         (+ (length cst-fns)
+                            (+ (length parser-fns)
+                               (+ (length emit-fns)
+                                  (length main-fns)))))))))))))


### PR DESCRIPTION
## Summary

- Extends `self-compile-all` from 7 files (TW05-L, 171 fns) to **all 11 compiler source files** (TW05-M, **173 fns**) by adding:
  - `token.tw` (2 782 chars) → **0 functions** (union `TokenKind` + record `Token` only — no `define` forms)
  - `ast.tw` (3 817 chars) → **0 functions** (union `Expr` only)
  - `iir-types.tw` (3 073 chars) → **0 functions** (union `TypeHint` + record `IirInstr` only)
  - `main.tw` (11 699 chars) → **2 functions** (`main` + `self-compile-all`)
- No VM constant changes needed: additional ~1.92 M instructions stays well within 32 M ceiling
- Renames `self_compile_all_returns_171` → `self_compile_all_returns_173` in tw05j/tw05k/tw05l test modules
- Adds `mod tw05m_tests` (7 integration tests): individual-file counts (0, 0, 0, 2), full 11-file total (173), TW05-L regression (171), TW05-I regression (main=2)

## Test plan

- [ ] `cargo test -p twig-module-driver --lib -- tw05m` — all 7 new tests pass
- [ ] `cargo test -p twig-module-driver --lib -- tw05l` — updated `self_compile_all_returns_173` passes
- [ ] `cargo test -p twig-module-driver --lib -- tw05k` — updated `self_compile_all_returns_173` passes
- [ ] `cargo test -p twig-module-driver --lib -- tw05j` — updated `self_compile_all_returns_173` passes
- [ ] `cargo build --workspace` — clean build

## Spec

`code/specs/LANG67-tw05m-all-modules-self-compilation.md`

## Version bumps

- `twig-module-driver`: 0.11.0 → 0.12.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)