### PR TITLE
feat(board-vm): add UNO R4 RTC metadata

### DIFF
--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -77,6 +77,14 @@ pub struct CanBusInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RtcInfo {
+    pub instance: u8,
+    pub name: &'static str,
+    pub peripheral: &'static str,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DigitalPinInfo {
     pub pin: u8,
     pub label: &'static str,
@@ -132,6 +140,7 @@ pub struct BoardTargetInfo {
     pub spi_buses: &'static [SpiBusInfo],
     pub uart_buses: &'static [UartBusInfo],
     pub can_buses: &'static [CanBusInfo],
+    pub rtc: Option<RtcInfo>,
     pub wireless: &'static [WirelessInterfaceInfo],
     pub capabilities: &'static [&'static str],
 }
@@ -307,6 +316,7 @@ pub const UNO_R4_WIFI_UART_BUSES: [UartBusInfo; 3] =
     map_uno_r4_uart_buses(board_vm_uno_r4::UNO_R4_WIFI_UART_BUSES);
 pub const UNO_R4_CAN_BUSES: [CanBusInfo; 1] =
     map_uno_r4_can_buses(board_vm_uno_r4::UNO_R4_CAN_BUSES);
+pub const UNO_R4_RTC: RtcInfo = uno_r4_rtc(board_vm_uno_r4::UNO_R4_RTC);
 
 pub const ESP32_DIGITAL_PINS: [DigitalPinInfo; 30] =
     map_esp32_digital_pins(board_vm_esp32::ESP32_DEVKIT_V1_DIGITAL_PINS);
@@ -456,6 +466,15 @@ const fn map_uno_r4_can_buses<const N: usize>(
     buses
 }
 
+const fn uno_r4_rtc(rtc: board_vm_uno_r4::RtcDescriptor) -> RtcInfo {
+    RtcInfo {
+        instance: rtc.instance,
+        name: rtc.name,
+        peripheral: rtc.peripheral,
+        notes: rtc.notes,
+    }
+}
+
 const fn map_esp32_digital_pins<const N: usize>(
     source: [board_vm_esp32::DigitalPinDescriptor; N],
 ) -> [DigitalPinInfo; N] {
@@ -537,6 +556,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         spi_buses: &UNO_R4_SPI_BUSES,
         uart_buses: &UNO_R4_MINIMA_UART_BUSES,
         can_buses: &UNO_R4_CAN_BUSES,
+        rtc: Some(UNO_R4_RTC),
         wireless: &[],
         capabilities: &UNO_R4_MINIMA_CAPABILITIES,
     },
@@ -564,6 +584,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         spi_buses: &UNO_R4_SPI_BUSES,
         uart_buses: &UNO_R4_WIFI_UART_BUSES,
         can_buses: &UNO_R4_CAN_BUSES,
+        rtc: Some(UNO_R4_RTC),
         wireless: &UNO_R4_WIFI_WIRELESS,
         capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
@@ -588,6 +609,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         spi_buses: &[],
         uart_buses: &[],
         can_buses: &[],
+        rtc: None,
         wireless: &ESP32_WIRELESS,
         capabilities: &ESP32_CAPABILITIES,
     },
@@ -615,6 +637,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         spi_buses: &[],
         uart_buses: &[],
         can_buses: &[],
+        rtc: None,
         wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
@@ -642,6 +665,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         spi_buses: &[],
         uart_buses: &[],
         can_buses: &[],
+        rtc: None,
         wireless: &PICO_W_WIRELESS,
         capabilities: &PICO_W_CAPABILITIES,
     },
@@ -784,6 +808,23 @@ mod tests {
             .unwrap()
             .can_buses
             .is_empty());
+    }
+
+    #[test]
+    fn registry_exposes_rtc_metadata() {
+        let minima = find_target("arduino-uno-r4-minima").unwrap();
+        assert_eq!(minima.rtc, Some(UNO_R4_RTC));
+        assert_eq!(minima.rtc.unwrap().instance, 0);
+        assert_eq!(minima.rtc.unwrap().name, "RTC");
+        assert_eq!(minima.rtc.unwrap().peripheral, "RA4M1 RTC");
+
+        let wifi = find_target("arduino-uno-r4-wifi").unwrap();
+        assert_eq!(wifi.rtc, minima.rtc);
+        assert!(wifi.rtc.unwrap().notes.contains("real-time clock"));
+
+        assert_eq!(find_target("esp32-devkit-v1").unwrap().rtc, None);
+        assert_eq!(find_target("raspberry-pi-pico").unwrap().rtc, None);
+        assert_eq!(find_target("raspberry-pi-pico-w").unwrap().rtc, None);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -68,6 +68,7 @@ pub struct TargetDescriptor {
     pub spi_buses: &'static [SpiBusDescriptor],
     pub uart_buses: &'static [UartBusDescriptor],
     pub can_buses: &'static [CanBusDescriptor],
+    pub rtc: Option<RtcDescriptor>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -120,6 +121,14 @@ pub struct CanBusDescriptor {
     pub tx_pin: u8,
     pub rx_pin: u8,
     pub controller: &'static str,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RtcDescriptor {
+    pub instance: u8,
+    pub name: &'static str,
+    pub peripheral: &'static str,
     pub notes: &'static str,
 }
 
@@ -399,6 +408,13 @@ pub const UNO_R4_CAN_BUS: CanBusDescriptor = CanBusDescriptor {
 
 pub const UNO_R4_CAN_BUSES: [CanBusDescriptor; 1] = [UNO_R4_CAN_BUS];
 
+pub const UNO_R4_RTC: RtcDescriptor = RtcDescriptor {
+    instance: 0,
+    name: "RTC",
+    peripheral: "RA4M1 RTC",
+    notes: "Single real-time clock instance exposed by the UNO R4 core",
+};
+
 pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     board_id: "arduino-uno-r4-minima",
     display_name: "Arduino Uno R4 Minima",
@@ -427,6 +443,7 @@ pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     spi_buses: &UNO_R4_SPI_BUSES,
     uart_buses: &UNO_R4_MINIMA_UART_BUSES,
     can_buses: &UNO_R4_CAN_BUSES,
+    rtc: Some(UNO_R4_RTC),
 };
 
 pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
@@ -458,6 +475,7 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
     spi_buses: &UNO_R4_SPI_BUSES,
     uart_buses: &UNO_R4_WIFI_UART_BUSES,
     can_buses: &UNO_R4_CAN_BUSES,
+    rtc: Some(UNO_R4_RTC),
 };
 
 pub trait UnoR4Backend {
@@ -1293,6 +1311,18 @@ mod tests {
         assert_eq!(can.controller, "RA4M1 CAN0");
         assert!(can.notes.contains("SPI"));
         assert!(can.notes.contains("onboard LED"));
+    }
+
+    #[test]
+    fn knows_uno_r4_rtc() {
+        assert_eq!(UNO_R4_MINIMA.rtc, Some(UNO_R4_RTC));
+        assert_eq!(UNO_R4_WIFI.rtc, Some(UNO_R4_RTC));
+
+        let rtc = UNO_R4_WIFI.rtc.unwrap();
+        assert_eq!(rtc.instance, 0);
+        assert_eq!(rtc.name, "RTC");
+        assert_eq!(rtc.peripheral, "RA4M1 RTC");
+        assert!(rtc.notes.contains("real-time clock"));
     }
 
     #[test]

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -33,7 +33,7 @@ Source snapshot:
 | SPI master | COPI D11, CIPO D12, SCK D13, conventional CS D10 | bus metadata, handle open, bounded write-then-read transfer, and transfer-backed read/write SDK commands implemented | `spi.open`, `spi.transfer`; SDK `spi.write`/`spi.read` lower to transfer |
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | descriptor metadata, handle open, and single-byte write/read implemented | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | descriptor metadata implemented; bytecode capability pending | `can.open`, `can.write`, `can.read` |
-| RTC | one RTC instance in the core | pending | `rtc.now`, `rtc.set`, alarms/events later |
+| RTC | one RTC instance in the core | descriptor metadata implemented; bytecode capability pending | `rtc.now`, `rtc.set`, alarms/events later |
 | EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | pending | `program.store` and possibly `kv.store` |
 | Watchdog | Renesas WDT library | pending | `watchdog.configure`, `watchdog.kick` |
 | OPAMP | UNO R4 OPAMP library | pending | analog board-specific capability after ADC/DAC |
@@ -82,9 +82,11 @@ reject conflicting handles.
    `Serial3`, while `uart.open`, `uart.write`, and `uart.read` establish the
    first UART handle and byte I/O tranche. CAN now has descriptor metadata for
    UNO R4 `CAN0` on D10/TX and D13/RX while `can.open`, `can.write`, and
-   `can.read` remain the next CAN capability tranche. The next independent
-   tranche can move on to CAN byte I/O, RTC, watchdog, EEPROM/store, or
-   WiFi/network metadata and capability slices.
+   `can.read` remain the next CAN capability tranche. RTC now has descriptor
+   metadata for the single UNO R4 `RA4M1 RTC` instance while `rtc.now` and
+   `rtc.set` remain a later capability tranche. The next independent tranche
+   can move on to CAN byte I/O, RTC bytecode operations, watchdog,
+   EEPROM/store, or WiFi/network metadata and capability slices.
 
 Every tranche should include the same layers: spec entry, IR capability id,
 runtime HAL method, UNO R4 target descriptor, firmware backend, host builder,


### PR DESCRIPTION
## Summary
- add a UNO R4 RTC descriptor for the single RA4M1 RTC instance
- expose RTC metadata through the board target registry while keeping rtc.now/rtc.set pending
- update BVM07 to mark RTC descriptor metadata as implemented and RTC bytecode operations as next

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-rtc-metadata cargo fmt -p board-vm-uno-r4 -p board-vm-targets
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-rtc-metadata cargo test -p board-vm-uno-r4 -p board-vm-targets
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check