### PR TITLE
feat(forme-style-to-terminal): FM04 §9.4 terminal ANSI backend translator

### DIFF
--- a/code/packages/typescript/forme-style-to-terminal/BUILD
+++ b/code/packages/typescript/forme-style-to-terminal/BUILD
@@ -1,0 +1,4 @@
+cd ../document-ast && npm install --silent
+cd ../forme-types && npm install --silent
+cd ../forme-style-ir && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-style-to-terminal/CHANGELOG.md
+++ b/code/packages/typescript/forme-style-to-terminal/CHANGELOG.md
@@ -1,0 +1,134 @@
+# Changelog — @coding-adventures/forme-style-to-terminal
+
+## 0.1.0 — 2026-05-17
+
+Initial release.  Fifth package of the FM04 Style IR family —
+the third concrete backend translator (after `forme-style-to-css`
+and `forme-style-to-latex`), completing the v0 multi-backend story.
+
+### Added
+
+- `translateToTerminal(doc, options): TranslateResult<string>` —
+  public entry point per FM04 §9.4.  Emits a TS module source
+  string exporting `formeStyles: ReadonlyMap<string, AnsiStyle>`
+  where `AnsiStyle = { prefix, suffix }`.  Consumers wrap document
+  content with `entry.prefix + content + entry.suffix`.
+- `TranslateOptions`: `activeContexts`, `usedRuleIds?`, `scope?`.
+  Same shape as CSS / LaTeX translators, redeclared locally per
+  FM04 §9.1.
+- `TranslateResult<string>`: `output`, `emittedRules`, `warnings`.
+- Property mappers (`property-mappers.ts`) — exhaustive `switch`
+  over every kernel-known `StyleProperty.kind` (29 kinds).  Native
+  SGR for color / background / font-weight / font-style /
+  text-decoration / visible-conceal; warn-skip for everything that
+  needs page geometry (padding, max-width, border-*, shadow,
+  opacity, page-break, etc.) — terminals are a character grid.
+- Selector mapper (`selector-mapper.ts`) — produces a human-readable
+  description string for each Selector (used in per-rule comments).
+  No selector→key mapping happens here; consumers look up by rule
+  id.
+- Context mapper (`context-mapper.ts`) — `contextRecognised(name)`
+  returns true for kernel-blessed contexts, false for `ext:*`.
+  No per-context emission machinery: the translator filters rules
+  through `activeContexts` and emits the survivors flat.
+- Token resolver (`token-resolver.ts`) — same FM04 §3.5 walker as
+  the CSS / LaTeX translators, with the same proto-pollution
+  defence (deny-list + `hasOwnProperty`).  Cycles cap at 8 hops.
+- Value mappers (`value-mappers.ts`) — `Color` → `[R, G, B]` triple
+  (HSL inline-converts; OKLCH warn-skips; named via small safe map);
+  plus `colorToSgrFg` / `colorToSgrBg` convenience wrappers for the
+  full `38;2;...` / `48;2;...` SGR prefixes.
+- Escape helpers (`escape.ts`) — `stripAnsiUnsafe` (strips ESC, C1
+  CSI, C1 OSC, ASCII control bytes 0x00–0x1F + 0x7F + C1 0x80–0x9F);
+  `escapeTsString` (escapes `\` and `"` for double-quoted TS string
+  literal, single-pass per CodeQL's incomplete-string-escaping rule);
+  `sanitiseKey` (alias of `escapeTsString` for intent).
+
+### Spec adherence
+
+Implements FM04 §9.4 reference terminal translator end-to-end.
+All three mapping tables (properties, selectors, contexts) covered
+with documented warn-skip for the cases terminals can't natively
+express.
+
+### Behavioural notes
+
+- **Output is a TS module source string.**  Unusual compared to
+  the CSS / LaTeX translators (which emit content directly); the
+  rationale: terminals have no preamble — wrappers must be applied
+  per-rule at content-emit time, so the most useful artefact is a
+  lookup table.
+- **Rules where every property warn-skipped still emit** with an
+  empty `prefix` / `suffix`.  Consumers can look up the rule id
+  and get a no-op wrap (less surprising than a Map miss).  But the
+  id is NOT added to `emittedRules` — the AOT compiler doesn't
+  need to track rules that produce no visual change.
+- **`important` has no terminal equivalent** (terminals have no
+  cascade).  Honoured as a no-op.
+- **24-bit truecolour only.**  Future option may add a 256-colour
+  / 16-colour quantised fallback for older terminals.
+
+### Spec divergences (documented)
+
+- **`forme-style-to-terminal` does NOT define `StyleTranslator<Out>`
+  abstract interface.**  Same rationale as the other backends:
+  per FM04 §9.1 the interface lives next to each translator.
+
+### v0 simplifications (documented)
+
+- **24-bit truecolour only** — modern terminals all support it.
+- **OKLCH warn-skips** — CIE round-trip out of scope.
+- **No SGR idempotence elision** — consumer is responsible for not
+  double-wrapping the same rule on the same content.
+
+### Security posture
+
+Pre-push focused security review areas:
+
+- **ANSI escape-sequence injection.**  Every caller-controlled
+  string interpolated into the output routes through
+  `stripAnsiUnsafe` (strips ESC 0x1B, C1 CSI 0x9B, C1 OSC 0x9D,
+  all ASCII control bytes 0x00–0x1F + 0x7F, and the full C1 range
+  0x80–0x9F).  Even a hand-rolled IR bypassing the validator's
+  grammar cannot drive cursor moves, screen clears, or arbitrary
+  SGR through us.
+- **TS-string-literal escaping.**  Map keys and SGR strings land
+  in double-quoted JS literals; `escapeTsString` handles `\` and
+  `"` in a single pass (the form CodeQL's
+  incomplete-string-escaping rule accepts).
+- **Prototype-pollution in `walkPath`.**  Same defence as the CSS
+  / LaTeX translators: deny-listed segments + own-key
+  `hasOwnProperty.call`.
+- **Defensive numeric coercion.**  `colorToRgbTriple` treats `NaN`
+  / `Infinity` channels as 0 rather than letting them propagate
+  into the SGR sequence as `NaN` literal text.
+- **Recursion depth cap.**  `selectorDescription` recurses on
+  composition selectors; an adversarial hand-rolled IR could nest
+  10k+ deep and blow the JS call stack.  `MAX_DESC_DEPTH = 64`
+  matches the spirit of `token-resolver`'s `MAX_RESOLVE_DEPTH`;
+  past the cap we return a `…(truncated)` marker rather than
+  throw.  One test pins the behaviour.
+
+### Tests
+
+128 tests across 7 files:
+
+- `escape.test.ts` (15 — ANSI-unsafe stripping for every dangerous
+  byte range; TS-string escaping for `\` and `"`; passthrough for
+  Unicode > 0x9F)
+- `value-mappers.test.ts` (13 — color models, clamping, NaN
+  defensiveness, named-color lookup, SGR fg/bg prefixes)
+- `selector-mapper.test.ts` (19 — every Selector kind including
+  composition; defensive control-char sanitisation; depth cap pin)
+- `context-mapper.test.ts` (3 — kernel contexts; ext: rejection;
+  unknown / empty)
+- `token-resolver.test.ts` (18 — happy path, proto-pollution
+  defence including inherited-key check, typed wrappers for all
+  five leaf types, cycle cap, NaN rejection)
+- `property-mappers.test.ts` (44 — every kernel kind, exhaustive
+  meta-check over `PROPERTY_KINDS`, defensive fallthroughs)
+- `translate.test.ts` (16 — end-to-end happy path, filtering,
+  scope, reproducibility, ANSI / TS-string injection defence)
+
+Coverage: **100% line / 97.43% branch** — above the FM04 §14.4
+≥95% line target.

--- a/code/packages/typescript/forme-style-to-terminal/README.md
+++ b/code/packages/typescript/forme-style-to-terminal/README.md
@@ -1,0 +1,167 @@
+# @coding-adventures/forme-style-to-terminal
+
+The **third FM04 backend translator**.  Takes a `StyleDocument` from
+[`@coding-adventures/forme-style-ir`](../forme-style-ir) and emits a
+**TypeScript module source string** that, when imported, exposes a
+`ReadonlyMap<RuleId, { prefix, suffix }>` — per-rule ANSI SGR
+wrappers the consumer drops around document content.
+
+Implements [FM04 §9.4](../../specs/FM04-forme-style-ir.md).  The
+third concrete backend (after [CSS](../forme-style-to-css) and
+[LaTeX](../forme-style-to-latex)), making the multi-backend story
+real: same IR, three independent targets, zero inter-package
+coupling.
+
+## Quick start
+
+```ts
+import { translateToTerminal } from "@coding-adventures/forme-style-to-terminal";
+import {
+  emptyStyleDocument, styleRuleId, sel,
+} from "@coding-adventures/forme-style-ir";
+
+const doc = {
+  ...emptyStyleDocument(),
+  tokens: {
+    ...emptyStyleDocument().tokens,
+    colors: { text: { kind: "rgb", r: 31, g: 35, b: 40 } },
+  },
+  rules: [
+    {
+      id: styleRuleId("body"),
+      selector: sel.type("paragraph"),
+      properties: [
+        { kind: "color", value: { kind: "token-ref", path: "colors.text" } },
+        { kind: "font-weight", value: 700 },
+      ],
+    },
+  ],
+};
+
+const { output, emittedRules, warnings } = translateToTerminal(doc, {
+  activeContexts: ["screen"],
+});
+
+// `output` is a TS module source string:
+//
+//   export interface AnsiStyle {
+//     readonly prefix: string;
+//     readonly suffix: string;
+//   }
+//   export const formeStyles: ReadonlyMap<string, AnsiStyle> = new Map([
+//     // rule "body" — node-type:paragraph
+//     ["body", { prefix: "\x1b[38;2;31;35;40;1m", suffix: "\x1b[0m" }],
+//   ]);
+
+// In the consumer (terminal renderer):
+//   import { formeStyles } from "./generated";
+//   const style = formeStyles.get(node.usedStyle);
+//   if (style) process.stdout.write(style.prefix + text + style.suffix);
+```
+
+## Translation strategy (FM04 §9.4)
+
+**Selectors are NOT mapped to anything.**  Terminals have no
+document tree.  The Map key in the output is the **rule id** —
+opaque, unique — and the consumer looks it up by id when rendering
+a node whose `usedStyle` set contains that id.  Composition
+selectors (`and`, `or`, `nth`, `child-of`, …) appear in the
+per-rule comment as informational descriptions only.
+
+**Properties → SGR fragments.**  Each rule combines all its
+property's SGR parameters into a single `\x1b[<n>;<n>;<n>m`
+sequence and the consumer wraps the text with a trailing
+`\x1b[0m` reset.
+
+| Style IR kind     | SGR                                  |
+|-------------------|--------------------------------------|
+| `color`           | `38;2;R;G;B` (foreground truecolour) |
+| `background`      | `48;2;R;G;B` (background truecolour) |
+| `font-weight` ≥600| `1` (bold)                           |
+| `font-style` italic/oblique | `3` (italic)               |
+| `text-decoration: underline`    | `4`                    |
+| `text-decoration: line-through` | `9`                    |
+| `text-decoration: overline`     | `53`                   |
+| `visible: false`  | `8` (conceal)                        |
+
+Everything else — `padding`, `margin`, `border`, `shadow`,
+`opacity`, `font-size`, `font-family`, `align`, `vertical-align`,
+`max-width`, `min-height`, page-breaks, etc. — **warn-skips**.
+Terminals are a character grid with no concept of pixel layout,
+typography choice, or page geometry.
+
+**Contexts** filter rules through `activeContexts` (same shape as
+the CSS/LaTeX translators).  There is no per-context conditional
+emission machinery — the terminal IS what it is at render time;
+the consumer chooses which contexts to activate by listing them.
+`ext:*` contexts warn-skip per FM04 §9.6.
+
+## Color models
+
+| IR model | Terminal form                                 |
+|----------|-----------------------------------------------|
+| `rgb`    | direct (clamped + rounded to 0–255 ints)      |
+| `hsl`    | converted inline (lossless within sRGB)       |
+| `oklch`  | **warn-skip** (CIE round-trip out of scope v0)|
+| `named`  | small built-in safe map (~15 common names)    |
+
+## ANSI escape-sequence injection defence
+
+Two attack surfaces, both addressed:
+
+1. **Caller-controlled bytes never reach the terminal as control
+   sequences.**  Every string interpolated into the output
+   (`rule.id` for Map keys, selector descriptions for comments)
+   routes through `stripAnsiUnsafe` (ESC, C1 CSI, C1 OSC,
+   0x00–0x1F, 0x7F–0x9F) first.  Even if a hand-rolled IR bypasses
+   the validator's grammar, the consumer's terminal cannot be
+   driven by attacker-controlled escape sequences.
+
+2. **TS-string-literal escaping.**  The output is a JS/TS module
+   source; the Map keys and SGR strings land in double-quoted
+   string literals.  A raw `\` or `"` in the input would terminate
+   the literal early or alter neighbouring escape semantics.  The
+   `escapeTsString` helper handles both, single-pass.
+
+3. **`walkPath` prototype-pollution.**  Same deny-list + own-key
+   `hasOwnProperty.call` defence as the CSS and LaTeX translators.
+
+`scope` is **caller-trusted** (escaped for the TS string literal,
+but otherwise concatenated verbatim).  Same posture as the CSS /
+LaTeX translators' `scope`.
+
+## Spec divergences
+
+None.  Implements FM04 §9.4 end-to-end.
+
+## v0 simplifications (documented)
+
+- **24-bit truecolour only.**  Future option may add a 256-colour
+  or 16-colour quantised fallback for older terminals.  Modern
+  terminal emulators (iTerm2, kitty, Windows Terminal, GNOME
+  Terminal ≥3.12, …) all support 24-bit.
+- **OKLCH warn-skips** (CIE round-trip out of scope).
+- **No SGR italic-on-italic / bold-on-bold idempotence elision** —
+  the consumer is responsible for not double-wrapping the same
+  rule on the same content.
+
+## Tests
+
+128 tests across 7 files:
+
+- `escape.test.ts` (15 — ANSI-unsafe stripping for every dangerous
+  byte range; TS-string escaping for `\` and `"`)
+- `value-mappers.test.ts` (13 — color models, clamping, NaN
+  defensiveness, named-color lookup, SGR fg/bg prefixes)
+- `selector-mapper.test.ts` (19 — every Selector kind; composition
+  forms; defensive control-char sanitisation; depth cap)
+- `context-mapper.test.ts` (3 — kernel contexts; ext: rejection)
+- `token-resolver.test.ts` (18 — happy path, proto-pollution
+  defence, typed wrappers for all five leaf types)
+- `property-mappers.test.ts` (44 — every kernel kind, exhaustive
+  meta-check, defensive fallthroughs)
+- `translate.test.ts` (16 — end-to-end, filtering, scope,
+  reproducibility, ANSI-injection defence)
+
+Coverage: **100% line / 97.43% branch** — above the FM04 §14.4
+≥95% line target.

--- a/code/packages/typescript/forme-style-to-terminal/package-lock.json
+++ b/code/packages/typescript/forme-style-to-terminal/package-lock.json
@@ -1,0 +1,2337 @@
+{
+  "name": "@coding-adventures/forme-style-to-terminal",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-style-to-terminal",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-style-ir": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-types": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-style-ir": {
+      "resolved": "../forme-style-ir",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-types": {
+      "resolved": "../forme-types",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-style-to-terminal/package.json
+++ b/code/packages/typescript/forme-style-to-terminal/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/forme-style-to-terminal",
+  "version": "0.1.0",
+  "description": "Style IR → terminal ANSI translator: takes a forme-style-ir StyleDocument and emits a TS module source string that exports per-rule { prefix, suffix } ANSI SGR sequences (FM04 §9.4).",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+    "@coding-adventures/forme-types": "file:../forme-types"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-style-to-terminal/required_capabilities.json
+++ b/code/packages/typescript/forme-style-to-terminal/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-style-to-terminal",
+  "capabilities": [],
+  "justification": "Pure transform: StyleDocument → TypeScript module source string.  No I/O, no network, no env, no shell.  Same posture as forme-style-ir / forme-style-to-css / forme-style-to-latex."
+}

--- a/code/packages/typescript/forme-style-to-terminal/src/context-mapper.ts
+++ b/code/packages/typescript/forme-style-to-terminal/src/context-mapper.ts
@@ -1,0 +1,44 @@
+/**
+ * context-mapper.ts — context name → terminal-relevance verdict (FM04 §9.4).
+ *
+ * Terminals don't have CSS-style `@media` queries or LaTeX-style
+ * `\if<flag>` conditionals — the terminal IS what it is at render
+ * time.  Context handling is therefore *filter-only*: the translator
+ * keeps a rule if its context is in `activeContexts`, drops it
+ * otherwise.  No per-bucket emission machinery.
+ *
+ * Of the seven kernel contexts:
+ *
+ *   - **screen** — terminals are always "screen".  Always relevant.
+ *   - **dark** / **high-contrast** — terminals may be either; the
+ *     consumer says so via `activeContexts`.  Relevant when active.
+ *   - **print** / **narrow** / **wide** / **reduced-motion** — no
+ *     terminal equivalent.  If a rule carries one of these contexts
+ *     and the context is in `activeContexts`, we honour the request
+ *     and emit the rule; if not, we drop it (same as any context).
+ *     We don't emit a warning — the caller knows what they're doing
+ *     by listing them.
+ *   - **ext:\*** — warn-skip per FM04 §9.6 (translator doesn't know
+ *     the extension's semantics).
+ *
+ * So `contextToTerminal(name)` returns true for kernel contexts and
+ * null for `ext:*`.  The translator's filter logic is the standard
+ * `activeContexts.has(rule.context)` check; this module exists
+ * mainly to flag ext: contexts for warn-skip.
+ *
+ * @module context-mapper
+ */
+
+import {
+  isExtensionContext, isRecognisedContext,
+} from "@coding-adventures/forme-style-ir";
+
+/**
+ * Decide whether a context name is recognised at the terminal
+ * translator level.  Returns true for any kernel-blessed context,
+ * false for `ext:*` (caller warn-skips).
+ */
+export function contextRecognised(name: string): boolean {
+  if (isExtensionContext(name)) return false;
+  return isRecognisedContext(name);
+}

--- a/code/packages/typescript/forme-style-to-terminal/src/escape.ts
+++ b/code/packages/typescript/forme-style-to-terminal/src/escape.ts
@@ -1,0 +1,88 @@
+/**
+ * escape.ts — string sanitisation for terminal output.
+ *
+ * Two distinct concerns:
+ *
+ *   1. **ANSI escape-sequence injection.**  Anything we emit to a
+ *      terminal that contains ESC (0x1b) or C1 CSI (0x9b) can move
+ *      the cursor, clear the screen, change foreground colour for
+ *      everything after, or — in extreme historical cases — execute
+ *      keystrokes via DECSC/DECRC trickery.  We MUST strip these
+ *      bytes from any caller-controlled string that lands in the
+ *      output.
+ *
+ *   2. **TypeScript string-literal escaping.**  Our output is a TS
+ *      module source string.  Caller-controlled data lands in
+ *      double-quoted JS string literals (e.g. rule ids become Map
+ *      keys).  A raw `"` or `\` in the input would terminate the
+ *      literal early or alter the escape semantics of nearby bytes.
+ *      We escape with the standard JS rules: `\\` first (so later
+ *      `\"` escapes don't collide), then `\"`.
+ *
+ * Both passes also strip ASCII control characters (0x00–0x1F, 0x7F)
+ * — they shouldn't appear in a legitimate rule id, and they're a
+ * common vector for terminal-injection attacks.
+ *
+ * @module escape
+ */
+
+/**
+ * The full set of bytes that can introduce, modify, or escape from a
+ * terminal escape sequence.  Stripped unconditionally from every
+ * caller-controlled string before further processing.
+ *
+ * Includes:
+ *   - ESC (0x1B)        — introduces CSI / OSC / DCS / etc.
+ *   - C1 CSI (0x9B)     — single-byte equivalent of `ESC [` in
+ *                         8-bit-clean environments
+ *   - All other ASCII control bytes (0x00–0x1F, 0x7F) — defence in
+ *     depth; nothing legitimate has them
+ *   - C1 controls (0x80–0x9F) — DCS (0x90), OSC (0x9D), ST (0x9C),
+ *     and friends; not all terminals interpret them, but stripping
+ *     is cheap and avoids assumptions
+ *
+ * The class is built explicitly to satisfy CodeQL's
+ * incomplete-string-escaping rule (it wants to see "this regex
+ * strips dangerous bytes" as a single, complete pass).
+ */
+// eslint-disable-next-line no-control-regex
+const DANGEROUS_BYTES_RE = /[\x00-\x1F\x7F-\x9F]/g;
+
+/**
+ * Strip every byte that could introduce or alter an ANSI escape
+ * sequence.  Used as the first pass before either text or
+ * TS-string-literal escaping.
+ */
+export function stripAnsiUnsafe(s: string): string {
+  return s.replace(DANGEROUS_BYTES_RE, "");
+}
+
+/**
+ * Escape a string for use inside a double-quoted TypeScript string
+ * literal in the generated module.  Strips ANSI-unsafe bytes first,
+ * then escapes `\` and `"`.
+ *
+ * One-pass implementation via the
+ * `[<class>]/g, (ch) => map[ch]` form — same pattern CodeQL accepts
+ * without complaint.
+ */
+const TS_STRING_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "\\": "\\\\",
+  "\"": "\\\"",
+});
+// Match `\` or `"` — the two characters that need escaping inside a
+// double-quoted JS/TS string.  Single pass, no order-dependent chain.
+const TS_STRING_SPECIAL_RE = /[\\"]/g;
+
+export function escapeTsString(s: string): string {
+  return stripAnsiUnsafe(s).replace(TS_STRING_SPECIAL_RE, (ch) => TS_STRING_ESCAPE_MAP[ch]!);
+}
+
+/**
+ * Sanitise a string for use as a Map key.  Same as `escapeTsString`
+ * — different name documents the intent at the call site (keys vs.
+ * values).
+ */
+export function sanitiseKey(s: string): string {
+  return escapeTsString(s);
+}

--- a/code/packages/typescript/forme-style-to-terminal/src/index.ts
+++ b/code/packages/typescript/forme-style-to-terminal/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * @coding-adventures/forme-style-to-terminal
+ *
+ * Third FM04 backend translator: Style IR → terminal ANSI.
+ *
+ * ```ts
+ * import { translateToTerminal } from "@coding-adventures/forme-style-to-terminal";
+ * import { emptyStyleDocument, styleRuleId, sel } from "@coding-adventures/forme-style-ir";
+ *
+ * const doc = emptyStyleDocument();
+ * // … populate doc.tokens and doc.rules …
+ *
+ * const { output, emittedRules, warnings } = translateToTerminal(doc, {
+ *   activeContexts: ["screen"],
+ * });
+ *
+ * // output is a TS module source string exporting
+ * //   const formeStyles: ReadonlyMap<string, AnsiStyle>
+ * // where AnsiStyle is { prefix: string; suffix: string }.
+ * // Consumers wrap document content with prefix + content + suffix.
+ * ```
+ *
+ * Translation strategy (FM04 §9.4):
+ *
+ * - **Selectors** become Map keys (the rule id, optionally prefixed
+ *   by `scope`).  Composition selectors don't drive output — they
+ *   appear in the per-rule comment for traceability.
+ * - **Properties** map to 24-bit truecolour SGR for color /
+ *   background, plus bold / italic / underline / strikethrough /
+ *   overline / conceal toggles.  Everything that needs page
+ *   geometry (padding, max-width, page-break, etc.) warn-skips —
+ *   terminals are a character grid.
+ * - **Contexts** filter rules through `activeContexts` (kernel set
+ *   only; `ext:*` warn-skips).  No per-context conditional emission
+ *   machinery — the terminal IS what it is at render time.
+ *
+ * Same FM04 §9.6 robustness as the other translators: pure
+ * (deterministic), never throws on shape, warn-skips on unknown
+ * kinds / unresolved refs / non-expressible values.
+ *
+ * @module index
+ */
+
+export { translateToTerminal } from "./translate.js";
+export type { TranslateOptions, TranslateResult } from "./translate.js";
+
+// Mappers re-exported so plugins can compose them when building
+// extension-property translators of their own.
+export {
+  colorToRgbTriple, colorToSgrFg, colorToSgrBg,
+} from "./value-mappers.js";
+export { selectorDescription } from "./selector-mapper.js";
+export { contextRecognised } from "./context-mapper.js";
+export { propertyToTerminal } from "./property-mappers.js";
+export type { PropertyEmit } from "./property-mappers.js";
+export {
+  resolveRef,
+  resolveColor, resolveLength, resolveShadow, resolveFontStack, resolveNumber,
+} from "./token-resolver.js";
+export {
+  stripAnsiUnsafe, escapeTsString, sanitiseKey,
+} from "./escape.js";

--- a/code/packages/typescript/forme-style-to-terminal/src/property-mappers.ts
+++ b/code/packages/typescript/forme-style-to-terminal/src/property-mappers.ts
@@ -1,0 +1,160 @@
+/**
+ * property-mappers.ts — one or more SGR parameter strings per Style
+ * IR property (FM04 §9.4).
+ *
+ * Each mapper returns a list of numeric SGR parameter strings (e.g.
+ * `["1"]` for bold, `["38;2;31;35;40"]` for fg colour); the
+ * translator joins them all with `;` and wraps in `\x1b[...m` per
+ * rule.  Some properties contribute multiple SGR fragments (rare —
+ * `text-decoration` may pair underline + colour).
+ *
+ * Most properties **warn-skip** — terminals are a character grid
+ * with no concept of pixel layout, padding, borders, or page breaks.
+ * What DOES survive:
+ *
+ *   color           → SGR 38;2;R;G;B (fg truecolour)
+ *   background      → SGR 48;2;R;G;B (bg truecolour)
+ *   font-weight     → SGR 1 (bold) when >= 600
+ *   font-style      → SGR 3 (italic) when italic/oblique
+ *   text-decoration → SGR 4 (underline) / 9 (strikethrough)
+ *   visible: false  → SGR 8 (concealed)
+ *
+ * Everything else warn-skips with a documented message.  The
+ * "important" flag has no terminal equivalent (terminals don't
+ * cascade) and is honoured as a no-op comment trailer at the
+ * translator level.
+ *
+ * @module property-mappers
+ */
+
+import type {
+  StyleProperty, TokenSet,
+} from "@coding-adventures/forme-style-ir";
+import { colorToSgrFg, colorToSgrBg } from "./value-mappers.js";
+import {
+  resolveColor, resolveNumber,
+} from "./token-resolver.js";
+
+/** One emit: zero-or-more SGR fragments, or a warning. */
+export type PropertyEmit =
+  | { ok: true; sgr: readonly string[] }
+  | { ok: false; warning: string };
+
+/**
+ * Map one `StyleProperty` to a list of SGR parameter strings.
+ * Empty list IS a valid success (means "the rule is allowed to
+ * exist but contributes no SGR" — caller treats it as no-op).
+ */
+export function propertyToTerminal(
+  prop: StyleProperty,
+  tokens: TokenSet,
+): PropertyEmit {
+  switch (prop.kind) {
+    // ─── Color / fill ────────────────────────────────────────────────────
+    case "color": {
+      const c = resolveColor(prop.value, tokens);
+      if (!c) return warn(`color: unresolved`);
+      const sgr = colorToSgrFg(c);
+      if (!sgr) return warn(`color: model not expressible as terminal RGB`);
+      return ok([sgr]);
+    }
+    case "background": {
+      const c = resolveColor(prop.value, tokens);
+      if (!c) return warn(`background: unresolved`);
+      const sgr = colorToSgrBg(c);
+      if (!sgr) return warn(`background: model not expressible as terminal RGB`);
+      return ok([sgr]);
+    }
+    case "border-color":
+    case "outline-color":
+      return warn(`${prop.kind}: no terminal equivalent (terminals have no border / outline model)`);
+
+    // ─── Typography ──────────────────────────────────────────────────────
+    case "font-family":
+      return warn(`font-family: no terminal equivalent (terminal renders in its configured font)`);
+    case "font-size":
+      return warn(`font-size: no terminal equivalent (terminal uses its configured cell size)`);
+    case "font-weight": {
+      const n = resolveNumber(prop.value, tokens);
+      if (n === null) return warn(`font-weight: unresolved`);
+      // CSS weights: 400 is normal, 700 is bold; the common semantic
+      // threshold is ≥600 for "bold-ish".  Below that, no SGR (normal).
+      return n >= 600 ? ok(["1"]) : ok([]);
+    }
+    case "font-style":
+      switch (prop.value) {
+        case "italic":
+        case "oblique": return ok(["3"]);
+        case "normal":  return ok([]);
+      }
+      return warn(`font-style: unknown value ${JSON.stringify((prop as { value: unknown }).value)}`);
+    case "text-transform":
+      // ANSI has no text-transform — terminals don't reflow content
+      // through a transform pipeline; the document's text bytes
+      // arrive as-is.  Caller would have to pre-transform.
+      return warn(`text-transform: no terminal equivalent (apply at document-content time)`);
+    case "leading":
+    case "tracking":
+      return warn(`${prop.kind}: no terminal equivalent (line-height / letter-spacing not expressible at SGR level)`);
+    case "text-decoration":
+      switch (prop.value.line) {
+        case "underline":    return ok(["4"]);
+        case "line-through": return ok(["9"]);
+        case "none":         return ok([]);
+        case "overline":     return ok(["53"]);   // SGR 53 (overline) is in ECMA-48 + supported by most modern terminals.
+      }
+      return warn(`text-decoration: unknown line ${JSON.stringify((prop.value as { line: unknown }).line)}`);
+
+    // ─── Layout / spacing (none survive) ─────────────────────────────────
+    case "space-before":
+    case "space-after":
+    case "indent":
+    case "padding":
+    case "max-width":
+    case "min-height":
+    case "align":
+    case "vertical-align":
+      return warn(`${prop.kind}: no terminal equivalent (terminals don't have a layout box model)`);
+
+    // ─── Decoration (none survive) ───────────────────────────────────────
+    case "border":
+    case "border-radius":
+    case "shadow":
+    case "opacity":
+      return warn(`${prop.kind}: no terminal equivalent (decorative properties require a graphics-capable backend)`);
+
+    // ─── Page break ──────────────────────────────────────────────────────
+    case "column-break":
+    case "page-break":
+    case "widow-orphan":
+      return warn(`${prop.kind}: no terminal equivalent (terminals scroll; there's no page concept)`);
+
+    // ─── Visibility ──────────────────────────────────────────────────────
+    case "display":
+      // CSS `display: none` could map to SGR 8 (conceal), but the
+      // CSS semantics are richer (also "remove from layout") and
+      // collapsing the two is misleading.  Warn-skip; the consumer
+      // should make the decision at content-emit time.
+      return warn(`display: no terminal equivalent (use \`visible: false\` if you mean SGR conceal)`);
+    case "visible":
+      // SGR 8 = conceal; the text is still emitted (terminal SGR
+      // doesn't suppress bytes), but it's rendered as invisible.
+      return prop.value ? ok([]) : ok(["8"]);
+
+    // ─── Extension namespace ─────────────────────────────────────────────
+    default: {
+      const k = (prop as { kind: string }).kind;
+      return warn(`unhandled property kind ${JSON.stringify(k)}`);
+    }
+  }
+}
+
+// ─── Per-shape helpers ───────────────────────────────────────────────────
+
+function ok(sgr: readonly string[]): PropertyEmit {
+  return { ok: true, sgr };
+}
+
+function warn(message: string): PropertyEmit {
+  return { ok: false, warning: message };
+}

--- a/code/packages/typescript/forme-style-to-terminal/src/selector-mapper.ts
+++ b/code/packages/typescript/forme-style-to-terminal/src/selector-mapper.ts
@@ -1,0 +1,76 @@
+/**
+ * selector-mapper.ts — Selector → description string (FM04 §9.4).
+ *
+ * Terminals don't have a document tree to walk against.  The Map
+ * key in our output is the **rule id** (already opaque + unique),
+ * NOT a selector slug — consumers look up by id when they reach a
+ * node in their own document model whose `usedStyle` set contains
+ * that id.
+ *
+ * This module therefore produces a human-readable *description*
+ * string only, suitable as a comment in the generated output for
+ * traceability ("rule X applies to: heading level 1").  Composition
+ * selectors (and/or/not/...) get a structural rendering ("and(p,
+ * .intro)") rather than warn-skip — they don't need to drive output
+ * machinery; they just narrate.
+ *
+ * @module selector-mapper
+ */
+
+import type { Selector } from "@coding-adventures/forme-style-ir";
+
+/**
+ * Defensive depth cap matching `token-resolver.ts`'s
+ * `MAX_RESOLVE_DEPTH`.  Real selectors hit single-digit depth;
+ * an adversarial hand-rolled IR could nest composition operators
+ * arbitrarily, blowing the JS call stack.  At the limit we return
+ * a truncation marker rather than throw — the translator never
+ * crashes on shape (FM04 §9.6).
+ */
+const MAX_DESC_DEPTH = 64;
+
+/**
+ * Format a `Selector` as a one-line human-readable description.
+ * Never returns an empty string and never throws.
+ *
+ * @param sel    selector to describe
+ * @param depth  recursion depth — internal; default 0
+ */
+export function selectorDescription(sel: Selector, depth = 0): string {
+  if (depth > MAX_DESC_DEPTH) return "…(truncated)";
+  switch (sel.kind) {
+    case "node-type":        return `node-type:${safe(sel.type)}`;
+    case "node-type-level":  return `heading-level:${sel.level}`;
+    case "custom-kind":      return `custom-kind:${safe(sel.customKind)}`;
+    case "tag":              return `tag:${safe(sel.tag)}`;
+    case "id":               return `id:${safe(sel.id)}`;
+    case "role":             return `role:${safe(sel.role)}`;
+    case "nth": {
+      const inner = selectorDescription(sel.of, depth + 1);
+      const idx = typeof sel.n === "number"
+        ? `${sel.n}`
+        : `${sel.n.a}n${sel.n.b >= 0 ? "+" : ""}${sel.n.b}${sel.n.fromEnd ? " from-end" : ""}`;
+      return `nth(${idx}, ${inner})`;
+    }
+    case "child-of":         return `child-of(${selectorDescription(sel.parent, depth + 1)}, ${selectorDescription(sel.child, depth + 1)})`;
+    case "descendant-of":    return `descendant-of(${selectorDescription(sel.ancestor, depth + 1)}, ${selectorDescription(sel.descendant, depth + 1)})`;
+    case "adjacent":         return `adjacent(${selectorDescription(sel.previous, depth + 1)}, ${selectorDescription(sel.following, depth + 1)})`;
+    case "and":              return `and(${sel.all.map((s) => selectorDescription(s, depth + 1)).join(", ")})`;
+    case "or":               return `or(${sel.any.map((s) => selectorDescription(s, depth + 1)).join(", ")})`;
+    case "not":              return `not(${selectorDescription(sel.inner, depth + 1)})`;
+  }
+}
+
+/**
+ * Sanitise a free-form name for inclusion in a description string.
+ * Strip ANSI-unsafe control bytes so a hand-rolled IR that bypasses
+ * the validator can't inject a cursor-move into the *comment* of
+ * the generated source.
+ *
+ * (The TS-string-escape pass on the output side ALSO neutralises
+ * the bytes — defense in depth.)
+ */
+function safe(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\x00-\x1F\x7F-\x9F]/g, "");
+}

--- a/code/packages/typescript/forme-style-to-terminal/src/token-resolver.ts
+++ b/code/packages/typescript/forme-style-to-terminal/src/token-resolver.ts
@@ -1,0 +1,104 @@
+/**
+ * token-resolver.ts — `TokenRef` → concrete value resolution.
+ *
+ * Same shape as `forme-style-to-css` / `forme-style-to-latex` —
+ * intentionally duplicated rather than depended-upon so each
+ * translator package is independent.  Same prototype-pollution
+ * defence (deny-list + `hasOwnProperty`).
+ *
+ * @module token-resolver
+ */
+
+import {
+  isTokenRef,
+  type Color, type FontStack, type Length, type Shadow,
+  type TokenRef, type TokenSet,
+} from "@coding-adventures/forme-style-ir";
+
+const MAX_RESOLVE_DEPTH = 8;
+
+export function resolveRef(
+  ref: TokenRef,
+  tokens: TokenSet,
+  depth = 0,
+): unknown | null {
+  if (depth > MAX_RESOLVE_DEPTH) return null;
+  const value = walkPath(ref.path, tokens as unknown as Record<string, unknown>);
+  if (value === undefined) return null;
+  if (isTokenRef(value)) return resolveRef(value as TokenRef, tokens, depth + 1);
+  return value;
+}
+
+function walkPath(path: string, root: Record<string, unknown>): unknown {
+  const parts = path.split(".");
+  let cursor: unknown = root;
+  for (const part of parts) {
+    if (typeof cursor !== "object" || cursor === null) return undefined;
+    if (part === "__proto__" || part === "constructor" || part === "prototype") return undefined;
+    const obj = cursor as Record<string, unknown>;
+    if (!Object.prototype.hasOwnProperty.call(obj, part)) return undefined;
+    cursor = obj[part];
+    if (cursor === undefined) return undefined;
+  }
+  return cursor;
+}
+
+// ─── Typed convenience wrappers ──────────────────────────────────────────
+
+export function resolveColor(v: Color | TokenRef, tokens: TokenSet): Color | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return isColor(r) ? r : null;
+}
+
+export function resolveLength(v: Length | TokenRef, tokens: TokenSet): Length | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return isLength(r) ? r : null;
+}
+
+export function resolveShadow(v: Shadow | TokenRef, tokens: TokenSet): Shadow | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return isShadow(r) ? r : null;
+}
+
+export function resolveFontStack(v: FontStack | TokenRef, tokens: TokenSet): FontStack | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return isFontStack(r) ? r : null;
+}
+
+export function resolveNumber(v: number | TokenRef, tokens: TokenSet): number | null {
+  if (!isTokenRef(v)) return v;
+  const r = resolveRef(v, tokens);
+  return typeof r === "number" && Number.isFinite(r) ? r : null;
+}
+
+function isColor(v: unknown): v is Color {
+  if (typeof v !== "object" || v === null) return false;
+  const k = (v as { kind?: unknown }).kind;
+  return k === "rgb" || k === "hsl" || k === "oklch" || k === "named";
+}
+
+function isLength(v: unknown): v is Length {
+  if (typeof v !== "object" || v === null) return false;
+  const u = (v as { unit?: unknown }).unit;
+  return typeof u === "string" && typeof (v as { value?: unknown }).value === "number";
+}
+
+function isShadow(v: unknown): v is Shadow {
+  if (typeof v !== "object" || v === null) return false;
+  const s = v as Record<string, unknown>;
+  return (
+    typeof s.offsetX === "object" && s.offsetX !== null
+    && typeof s.offsetY === "object" && s.offsetY !== null
+    && typeof s.blur === "object" && s.blur !== null
+    && typeof s.spread === "object" && s.spread !== null
+    && s.color !== undefined
+  );
+}
+
+function isFontStack(v: unknown): v is FontStack {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}

--- a/code/packages/typescript/forme-style-to-terminal/src/translate.ts
+++ b/code/packages/typescript/forme-style-to-terminal/src/translate.ts
@@ -1,0 +1,196 @@
+/**
+ * translate.ts — `translateToTerminal(doc, options)` (FM04 §9.4).
+ *
+ * The public entry point.  Walks `doc.rules` and emits a TypeScript
+ * module source string shaped like:
+ *
+ *   // forme-style-to-terminal generated
+ *   //
+ *   // Per-rule ANSI SGR wrappers.  Consumers look up by rule id and
+ *   // emit `entry.prefix + content + entry.suffix` around the
+ *   // styled text.
+ *
+ *   export interface AnsiStyle {
+ *     readonly prefix: string;   // SGR setting style
+ *     readonly suffix: string;   // SGR reset (always \x1b[0m)
+ *   }
+ *
+ *   export const formeStyles: ReadonlyMap<string, AnsiStyle> = new Map([
+ *     // rule "body" — node-type:paragraph
+ *     ["body", { prefix: "\x1b[38;2;31;35;40m", suffix: "\x1b[0m" }],
+ *     // rule "headline" — heading-level:1
+ *     ["headline", { prefix: "\x1b[1;38;2;9;105;218m", suffix: "\x1b[0m" }],
+ *   ]);
+ *
+ * Filtering is the same shape as the CSS / LaTeX translators:
+ *
+ *   1. `activeContexts` — rules with a `context` field apply only
+ *      when their context is in the active set (or has no context).
+ *      Unknown / `ext:*` contexts WARN + SKIP.
+ *   2. `usedRuleIds` — when set, only those rule ids emit (FM06
+ *      per-page slicing).
+ *
+ * Per-property warn-skips don't fail the rule — the rule still
+ * emits with whatever SGR fragments did succeed.  A rule with NO
+ * successful SGR fragments (every property warn-skipped, or all
+ * succeeded but contributed no SGR) emits with an empty prefix
+ * (`prefix: ""`) — the consumer's wrapping is then a no-op.
+ *
+ * **Security**: all caller-controlled strings (rule ids, selector
+ * descriptions) route through `escapeTsString` so neither a raw
+ * ANSI ESC nor a TS-string-literal escape (`\` / `"`) can land in
+ * the output.  Colour values are integer SGR parameters — safe by
+ * construction.
+ *
+ * @module translate
+ */
+
+import {
+  isExtensionKind,
+  type StyleDocument, type StyleRule, type StyleRuleId, type StyleWarning,
+} from "@coding-adventures/forme-style-ir";
+import { propertyToTerminal } from "./property-mappers.js";
+import { selectorDescription } from "./selector-mapper.js";
+import { contextRecognised } from "./context-mapper.js";
+import { escapeTsString, sanitiseKey } from "./escape.js";
+
+// ─── Public options + result ─────────────────────────────────────────────
+
+/**
+ * Translator options.  Same shape as the CSS / LaTeX translators —
+ * redeclared locally per FM04 §9.1.
+ */
+export interface TranslateOptions {
+  readonly activeContexts: readonly string[];
+  readonly usedRuleIds?: readonly StyleRuleId[];
+  /**
+   * Optional prefix string concatenated in front of every Map key.
+   * Used by per-page scoping (e.g. `scope = "page-abc123."` →
+   * `"page-abc123.body"`).
+   *
+   * **Caller-trusted**: this value is escaped for the TS string
+   * literal (the standard `\` / `"` escapes apply) but is otherwise
+   * concatenated verbatim.  The AOT compiler that drives this stage
+   * derives the prefix from a hash of the page route — already safe;
+   * anyone wiring this translator from a different source must
+   * sanitise themselves.
+   */
+  readonly scope?: string;
+}
+
+/**
+ * Translator output.  `output` is the TS module source string;
+ * `emittedRules` lists which rule ids actually made it.
+ */
+export interface TranslateResult<Out> {
+  readonly output: Out;
+  readonly emittedRules: readonly StyleRuleId[];
+  readonly warnings: readonly StyleWarning[];
+}
+
+/**
+ * Translate a `StyleDocument` into a TypeScript module source string
+ * exporting a `Map<RuleId, AnsiStyle>`.
+ */
+export function translateToTerminal(
+  doc: StyleDocument,
+  options: TranslateOptions,
+): TranslateResult<string> {
+  const activeContextSet = new Set(options.activeContexts);
+  const usedSet = options.usedRuleIds === undefined
+    ? null
+    : new Set<string>(options.usedRuleIds);
+  const scope = options.scope ?? "";
+
+  const warnings: StyleWarning[] = [];
+  const emittedRules: StyleRuleId[] = [];
+  const entries: string[] = [];
+
+  for (const rule of doc.rules) {
+    if (usedSet !== null && !usedSet.has(rule.id)) continue;
+
+    if (rule.context !== undefined) {
+      if (!contextRecognised(rule.context)) {
+        warnings.push({
+          code: "EXT_CONTEXT_NOT_TRANSLATED",
+          message: `context ${JSON.stringify(rule.context)} has no built-in terminal mapping; rule skipped`,
+          ruleId: rule.id,
+        });
+        continue;
+      }
+      if (!activeContextSet.has(rule.context)) continue;
+    }
+
+    const sgrFragments: string[] = [];
+    for (const prop of rule.properties) {
+      if (isExtensionKind(prop.kind)) {
+        warnings.push({
+          code: "EXT_PROPERTY_NOT_TRANSLATED",
+          message: `property kind ${JSON.stringify(prop.kind)} has no built-in terminal mapping; skipped`,
+          ruleId: rule.id,
+          propertyKind: prop.kind,
+        });
+        continue;
+      }
+
+      const emit = propertyToTerminal(prop, doc.tokens);
+      if (emit.ok) {
+        for (const sgr of emit.sgr) sgrFragments.push(sgr);
+      } else {
+        warnings.push({
+          code: "PROPERTY_SKIPPED",
+          message: emit.warning,
+          ruleId: rule.id,
+          propertyKind: prop.kind,
+        });
+      }
+    }
+
+    // A rule that warn-skipped EVERYTHING still emits — with empty
+    // prefix — so consumers can look it up and get a no-op wrap.
+    // This matches the CSS/LaTeX translators' "emit-if-anything-
+    // survived" rule INVERTED for terminal because Map lookup
+    // failing would be more confusing than a no-op.  We still don't
+    // add the id to emittedRules when there's nothing to emit —
+    // that signals "we acknowledged but had nothing".
+    const prefix = sgrFragments.length === 0
+      ? ""
+      : `\\x1b[${sgrFragments.join(";")}m`;
+    const suffix = sgrFragments.length === 0 ? "" : "\\x1b[0m";
+
+    // Only count rules that produced *some* output in emittedRules.
+    if (sgrFragments.length > 0) emittedRules.push(rule.id);
+
+    const safeKey   = sanitiseKey(`${scope}${rule.id}`);
+    const safeDesc  = escapeTsString(selectorDescription(rule.selector));
+    const safeRuleId = escapeTsString(rule.id);
+    entries.push(
+      `  // rule "${safeRuleId}" — ${safeDesc}\n` +
+      `  ["${safeKey}", { prefix: "${prefix}", suffix: "${suffix}" }],`,
+    );
+  }
+
+  const output = [
+    "// forme-style-to-terminal generated",
+    "//",
+    "// Per-rule ANSI SGR wrappers.  Consumers look up by rule id and",
+    "// emit `entry.prefix + content + entry.suffix` around the styled",
+    "// text.  The prefix/suffix pair forms one SGR \"set then reset\".",
+    "",
+    "export interface AnsiStyle {",
+    "  readonly prefix: string;",
+    "  readonly suffix: string;",
+    "}",
+    "",
+    "export const formeStyles: ReadonlyMap<string, AnsiStyle> = new Map([",
+    ...entries,
+    "]);",
+    "",
+  ].join("\n");
+
+  return {
+    output,
+    emittedRules: Object.freeze(emittedRules),
+    warnings: Object.freeze(warnings),
+  };
+}

--- a/code/packages/typescript/forme-style-to-terminal/src/value-mappers.ts
+++ b/code/packages/typescript/forme-style-to-terminal/src/value-mappers.ts
@@ -1,0 +1,125 @@
+/**
+ * value-mappers.ts — `Color` → ANSI SGR parameter triple.
+ *
+ * Terminals that support 24-bit truecolour ("xterm-direct" / "ansi
+ * truecolor", widely available since ~2018) accept SGR sequences of
+ * the form:
+ *
+ *   \x1b[38;2;R;G;Bm    — set foreground to RGB
+ *   \x1b[48;2;R;G;Bm    — set background to RGB
+ *
+ * where R/G/B are 0–255 integers.  All four IR color models reduce
+ * to an RGB triple at output time:
+ *
+ *   rgb   → pass through (clamped + rounded to 0–255 ints)
+ *   hsl   → HSL→RGB conversion inline (lossless within sRGB)
+ *   oklch → warn-skip for v0 (CIE round-trip out of scope)
+ *   named → small built-in safe map of common CSS names → RGB
+ *
+ * Length and FontStack are not expressible in terminals — terminals
+ * are a character grid (no pixels, no font choice from inside the
+ * stream), so the property mappers handle them as warn-skips
+ * without calling these functions.
+ *
+ * @module value-mappers
+ */
+
+import type { Color } from "@coding-adventures/forme-style-ir";
+
+/**
+ * Format a `Color` as an SGR parameter triple suitable for joining
+ * into a `38;2;...` (foreground) or `48;2;...` (background) sequence.
+ *
+ * Returns a triple `[R, G, B]` of 0–255 integers — caller assembles
+ * the full SGR string.  Returns null for OKLCH (out of scope v0)
+ * or for named colors not in the safe map.
+ */
+export function colorToRgbTriple(c: Color): readonly [number, number, number] | null {
+  switch (c.kind) {
+    case "rgb":
+      return [clampInt(c.r), clampInt(c.g), clampInt(c.b)];
+    case "hsl":
+      return hslToRgb(c.h, c.s, c.l);
+    case "oklch":
+      // CIE round-trip through sRGB is out of scope for v0.
+      return null;
+    case "named": {
+      const safe = NAMED_COLORS.get(c.name.toLowerCase());
+      return safe ?? null;
+    }
+  }
+}
+
+/**
+ * Format the full SGR fragment for a foreground color, including
+ * the `38;2;` prefix.  Returns null when `colorToRgbTriple` fails.
+ *
+ * Example: `colorToSgrFg({ kind: "rgb", r: 31, g: 35, b: 40 })`
+ *          → `"38;2;31;35;40"`
+ */
+export function colorToSgrFg(c: Color): string | null {
+  const triple = colorToRgbTriple(c);
+  if (!triple) return null;
+  return `38;2;${triple[0]};${triple[1]};${triple[2]}`;
+}
+
+/** Same as `colorToSgrFg` but for background (SGR `48;2;...`). */
+export function colorToSgrBg(c: Color): string | null {
+  const triple = colorToRgbTriple(c);
+  if (!triple) return null;
+  return `48;2;${triple[0]};${triple[1]};${triple[2]}`;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function clampInt(x: number): number {
+  // `Math.round(NaN)` is NaN; `Math.max(0, NaN)` is NaN; cap with
+  // `Number.isFinite` instead so NaN → 0 (defensive — validator
+  // should reject, but we belt-and-brace).
+  if (!Number.isFinite(x)) return 0;
+  return Math.max(0, Math.min(255, Math.round(x)));
+}
+
+/**
+ * HSL → RGB (8-bit per channel).  Algorithm from CSS Color L3 / W3C
+ * "Algorithm for converting HSL to RGB".  Returns a `[r, g, b]`
+ * triple of 0–255 integers.
+ */
+function hslToRgb(h: number, s: number, l: number): readonly [number, number, number] {
+  const sFrac = s / 100;
+  const lFrac = l / 100;
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = sFrac * Math.min(lFrac, 1 - lFrac);
+  const f = (n: number) => lFrac - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  return [clampInt(f(0) * 255), clampInt(f(8) * 255), clampInt(f(4) * 255)];
+}
+
+/**
+ * Small built-in safe map of CSS named colors → RGB triples.  Same
+ * subset as `forme-style-to-latex`; expanding would require shipping
+ * the full SVG / X11 name table (~140 entries) which is overkill for
+ * the terminal use case.
+ *
+ * Lowercase keys for case-insensitive lookup.
+ */
+const NAMED_COLORS: ReadonlyMap<string, readonly [number, number, number]> = new Map([
+  ["black",       [0, 0, 0]],
+  ["white",       [255, 255, 255]],
+  ["red",         [255, 0, 0]],
+  ["green",       [0, 128, 0]],
+  ["blue",        [0, 0, 255]],
+  ["yellow",      [255, 255, 0]],
+  ["cyan",        [0, 255, 255]],
+  ["magenta",     [255, 0, 255]],
+  ["gray",        [128, 128, 128]],
+  ["grey",        [128, 128, 128]],
+  ["orange",      [255, 165, 0]],
+  ["purple",      [128, 0, 128]],
+  ["pink",        [255, 192, 203]],
+  ["brown",       [165, 42, 42]],
+  ["tomato",      [255, 99, 71]],
+  // Terminals can't render alpha; treat transparent as default
+  // (we just don't emit a color — but the property mapper still
+  // calls us, so map to white to keep behaviour predictable).
+  ["transparent", [255, 255, 255]],
+]);

--- a/code/packages/typescript/forme-style-to-terminal/tests/context-mapper.test.ts
+++ b/code/packages/typescript/forme-style-to-terminal/tests/context-mapper.test.ts
@@ -1,0 +1,24 @@
+/**
+ * context-mapper.test.ts — terminal context-relevance verdict.
+ */
+
+import { describe, it, expect } from "vitest";
+import { STANDARD_CONTEXTS } from "@coding-adventures/forme-style-ir";
+import { contextRecognised } from "../src/index.js";
+
+describe("contextRecognised", () => {
+  it("returns true for every kernel-blessed context", () => {
+    for (const c of STANDARD_CONTEXTS) {
+      expect(contextRecognised(c)).toBe(true);
+    }
+  });
+
+  it("returns false for ext: contexts", () => {
+    expect(contextRecognised("ext:plugin:custom")).toBe(false);
+  });
+
+  it("returns false for unknown / typo contexts", () => {
+    expect(contextRecognised("prnit")).toBe(false);
+    expect(contextRecognised("")).toBe(false);
+  });
+});

--- a/code/packages/typescript/forme-style-to-terminal/tests/escape.test.ts
+++ b/code/packages/typescript/forme-style-to-terminal/tests/escape.test.ts
@@ -1,0 +1,79 @@
+/**
+ * escape.test.ts — ANSI-unsafe stripping + TS-string-literal escaping.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  stripAnsiUnsafe, escapeTsString, sanitiseKey,
+} from "../src/index.js";
+
+describe("stripAnsiUnsafe", () => {
+  it("strips ESC (0x1B)", () => {
+    expect(stripAnsiUnsafe("a\x1bb")).toBe("ab");
+  });
+
+  it("strips C1 CSI (0x9B)", () => {
+    expect(stripAnsiUnsafe("a\x9bb")).toBe("ab");
+  });
+
+  it("strips C1 OSC (0x9D)", () => {
+    expect(stripAnsiUnsafe("a\x9db")).toBe("ab");
+  });
+
+  it("strips ASCII control characters 0x00-0x1F", () => {
+    const s = Array.from({ length: 32 }, (_, i) => String.fromCharCode(i)).join("");
+    expect(stripAnsiUnsafe("a" + s + "b")).toBe("ab");
+  });
+
+  it("strips DEL (0x7F)", () => {
+    expect(stripAnsiUnsafe("a\x7fb")).toBe("ab");
+  });
+
+  it("strips C1 range 0x80-0x9F", () => {
+    const s = Array.from({ length: 32 }, (_, i) => String.fromCharCode(0x80 + i)).join("");
+    expect(stripAnsiUnsafe("a" + s + "b")).toBe("ab");
+  });
+
+  it("passes through printable ASCII unchanged", () => {
+    expect(stripAnsiUnsafe("Hello World 123")).toBe("Hello World 123");
+  });
+
+  it("passes through Unicode > 0x9F", () => {
+    expect(stripAnsiUnsafe("café — résumé")).toBe("café — résumé");
+  });
+});
+
+describe("escapeTsString", () => {
+  it("escapes backslash to double-backslash", () => {
+    expect(escapeTsString("a\\b")).toBe("a\\\\b");
+  });
+
+  it("escapes double-quote to backslash-quote", () => {
+    expect(escapeTsString(`a"b`)).toBe(`a\\"b`);
+  });
+
+  it("escapes both, backslash-first (no collision)", () => {
+    expect(escapeTsString(`a\\"b`)).toBe(`a\\\\\\"b`);
+  });
+
+  it("strips ANSI-unsafe bytes before escaping", () => {
+    expect(escapeTsString("a\x1bb")).toBe("ab");
+  });
+
+  it("passes through plain ASCII unchanged", () => {
+    expect(escapeTsString("Hello World")).toBe("Hello World");
+  });
+
+  it("does not escape single quote (not a TS string-literal special in double-quoted form)", () => {
+    expect(escapeTsString("a'b")).toBe("a'b");
+  });
+});
+
+describe("sanitiseKey", () => {
+  it("is functionally identical to escapeTsString (same defences)", () => {
+    const samples = [`hello`, `a\\b`, `a"b`, `a\x1bb`, ``];
+    for (const s of samples) {
+      expect(sanitiseKey(s)).toBe(escapeTsString(s));
+    }
+  });
+});

--- a/code/packages/typescript/forme-style-to-terminal/tests/property-mappers.test.ts
+++ b/code/packages/typescript/forme-style-to-terminal/tests/property-mappers.test.ts
@@ -1,0 +1,227 @@
+/**
+ * property-mappers.test.ts — every kernel property kind.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PROPERTY_KINDS, type StyleProperty, type TokenSet } from "@coding-adventures/forme-style-ir";
+import { propertyToTerminal } from "../src/index.js";
+
+const tokens: TokenSet = {
+  colors:  { text: { kind: "rgb", r: 0, g: 0, b: 0 } },
+  typography: {
+    families: { body: ["Inter"] },
+    scale:    { md: { unit: "pt", value: 12 } },
+    weights:  { regular: 400, bold: 700, black: 900 },
+    leading:  { normal: 1.5 },
+    tracking: { normal: { unit: "em", value: 0 } },
+  },
+  space:   {},
+  radii:   {},
+  shadows: {},
+};
+
+describe("propertyToTerminal — color", () => {
+  it("color emits fg SGR", () => {
+    const r = propertyToTerminal({ kind: "color", value: { kind: "rgb", r: 31, g: 35, b: 40 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.sgr).toEqual(["38;2;31;35;40"]);
+  });
+
+  it("color via token-ref resolves", () => {
+    const r = propertyToTerminal({ kind: "color", value: { kind: "token-ref", path: "colors.text" } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.sgr).toEqual(["38;2;0;0;0"]);
+  });
+
+  it("color OKLCH warns", () => {
+    expect(propertyToTerminal({ kind: "color", value: { kind: "oklch", l: 0.5, c: 0.1, h: 0 } }, tokens).ok).toBe(false);
+  });
+
+  it("color unresolved warns", () => {
+    expect(propertyToTerminal({ kind: "color", value: { kind: "token-ref", path: "colors.gone" } }, tokens).ok).toBe(false);
+  });
+
+  it("background emits bg SGR", () => {
+    const r = propertyToTerminal({ kind: "background", value: { kind: "rgb", r: 255, g: 255, b: 255 } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.sgr).toEqual(["48;2;255;255;255"]);
+  });
+
+  it("background unresolved warns", () => {
+    expect(propertyToTerminal({ kind: "background", value: { kind: "token-ref", path: "colors.nope" } }, tokens).ok).toBe(false);
+  });
+
+  it("background OKLCH warns", () => {
+    expect(propertyToTerminal({ kind: "background", value: { kind: "oklch", l: 0.5, c: 0.1, h: 0 } }, tokens).ok).toBe(false);
+  });
+
+  it("border-color / outline-color warn-skip", () => {
+    for (const k of ["border-color", "outline-color"] as const) {
+      expect(propertyToTerminal({ kind: k, value: { kind: "named", name: "red" } } as StyleProperty, tokens).ok).toBe(false);
+    }
+  });
+});
+
+describe("propertyToTerminal — typography", () => {
+  it("font-family warns", () => {
+    expect(propertyToTerminal({ kind: "font-family", value: ["Inter"] }, tokens).ok).toBe(false);
+  });
+
+  it("font-size warns", () => {
+    expect(propertyToTerminal({ kind: "font-size", value: { unit: "pt", value: 12 } }, tokens).ok).toBe(false);
+  });
+
+  it("font-weight >= 600 emits bold SGR 1", () => {
+    const r = propertyToTerminal({ kind: "font-weight", value: 700 }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.sgr).toEqual(["1"]);
+  });
+
+  it("font-weight < 600 emits no SGR (success, empty)", () => {
+    const r = propertyToTerminal({ kind: "font-weight", value: 400 }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.sgr).toEqual([]);
+  });
+
+  it("font-weight via token-ref", () => {
+    const r = propertyToTerminal({ kind: "font-weight", value: { kind: "token-ref", path: "typography.weights.bold" } }, tokens);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.sgr).toEqual(["1"]);
+  });
+
+  it("font-weight unresolved warns", () => {
+    expect(propertyToTerminal({ kind: "font-weight", value: { kind: "token-ref", path: "typography.weights.nope" } }, tokens).ok).toBe(false);
+  });
+
+  it("font-style italic / oblique → SGR 3", () => {
+    expect((propertyToTerminal({ kind: "font-style", value: "italic" }, tokens) as { sgr: string[] }).sgr).toEqual(["3"]);
+    expect((propertyToTerminal({ kind: "font-style", value: "oblique" }, tokens) as { sgr: string[] }).sgr).toEqual(["3"]);
+  });
+
+  it("font-style normal emits empty SGR (success)", () => {
+    expect((propertyToTerminal({ kind: "font-style", value: "normal" }, tokens) as { sgr: string[] }).sgr).toEqual([]);
+  });
+
+  it("font-style unknown value warns", () => {
+    expect(propertyToTerminal({ kind: "font-style", value: "wonky" as never }, tokens).ok).toBe(false);
+  });
+
+  it("text-transform warns (no terminal equivalent)", () => {
+    expect(propertyToTerminal({ kind: "text-transform", value: "uppercase" }, tokens).ok).toBe(false);
+  });
+
+  it("leading / tracking warn", () => {
+    expect(propertyToTerminal({ kind: "leading", value: 1.5 }, tokens).ok).toBe(false);
+    expect(propertyToTerminal({ kind: "tracking", value: { unit: "em", value: 0.05 } }, tokens).ok).toBe(false);
+  });
+
+  it("text-decoration underline → SGR 4", () => {
+    expect((propertyToTerminal({ kind: "text-decoration", value: { line: "underline" } }, tokens) as { sgr: string[] }).sgr).toEqual(["4"]);
+  });
+
+  it("text-decoration line-through → SGR 9", () => {
+    expect((propertyToTerminal({ kind: "text-decoration", value: { line: "line-through" } }, tokens) as { sgr: string[] }).sgr).toEqual(["9"]);
+  });
+
+  it("text-decoration overline → SGR 53", () => {
+    expect((propertyToTerminal({ kind: "text-decoration", value: { line: "overline" } }, tokens) as { sgr: string[] }).sgr).toEqual(["53"]);
+  });
+
+  it("text-decoration none emits empty SGR", () => {
+    expect((propertyToTerminal({ kind: "text-decoration", value: { line: "none" } }, tokens) as { sgr: string[] }).sgr).toEqual([]);
+  });
+
+  it("text-decoration unknown line warns", () => {
+    expect(propertyToTerminal({ kind: "text-decoration", value: { line: "wonky" as never } }, tokens).ok).toBe(false);
+  });
+});
+
+describe("propertyToTerminal — layout / decoration / page-break (all warn)", () => {
+  it.each(["space-before", "space-after", "indent", "padding", "max-width", "min-height",
+           "align", "vertical-align", "border", "border-radius", "shadow", "opacity",
+           "column-break", "page-break", "widow-orphan"] as const)("%s warns", (k) => {
+    let p: StyleProperty;
+    switch (k) {
+      case "space-before": case "space-after": case "indent": case "max-width": case "min-height":
+      case "border-radius":
+        p = { kind: k, value: { unit: "pt", value: 1 } } as StyleProperty; break;
+      case "padding":
+        p = { kind: k, value: { top: { unit: "pt", value: 0 }, right: { unit: "pt", value: 0 }, bottom: { unit: "pt", value: 0 }, left: { unit: "pt", value: 0 } } } as StyleProperty; break;
+      case "align":
+        p = { kind: k, value: "start" } as StyleProperty; break;
+      case "vertical-align":
+        p = { kind: k, value: "baseline" } as StyleProperty; break;
+      case "border":
+        p = { kind: k, value: { width: { unit: "pt", value: 1 }, style: "solid", color: { kind: "named", name: "black" } } } as StyleProperty; break;
+      case "shadow":
+        p = { kind: k, value: { offsetX: { unit: "pt", value: 0 }, offsetY: { unit: "pt", value: 0 }, blur: { unit: "pt", value: 0 }, spread: { unit: "pt", value: 0 }, color: { kind: "named", name: "black" } } } as StyleProperty; break;
+      case "opacity": case "widow-orphan":
+        p = { kind: k, value: 1 } as StyleProperty; break;
+      case "column-break": case "page-break":
+        p = { kind: k, value: "before" } as StyleProperty; break;
+    }
+    expect(propertyToTerminal(p, tokens).ok).toBe(false);
+  });
+});
+
+describe("propertyToTerminal — visibility", () => {
+  it("display warns (semantic mismatch with visible)", () => {
+    expect(propertyToTerminal({ kind: "display", value: "none" }, tokens).ok).toBe(false);
+  });
+
+  it("visible: true → no SGR (default state)", () => {
+    expect((propertyToTerminal({ kind: "visible", value: true }, tokens) as { sgr: string[] }).sgr).toEqual([]);
+  });
+
+  it("visible: false → SGR 8 (conceal)", () => {
+    expect((propertyToTerminal({ kind: "visible", value: false }, tokens) as { sgr: string[] }).sgr).toEqual(["8"]);
+  });
+});
+
+describe("propertyToTerminal — extension kinds", () => {
+  it("ext: kind warns", () => {
+    expect(propertyToTerminal({ kind: "ext:plugin:foo", value: 1 } as unknown as StyleProperty, tokens).ok).toBe(false);
+  });
+});
+
+describe("propertyToTerminal — exhaustiveness over PROPERTY_KINDS", () => {
+  it("every kernel kind yields a result (ok or warn, never throws)", () => {
+    for (const k of PROPERTY_KINDS) {
+      let p: StyleProperty;
+      switch (k) {
+        case "color": case "background": case "border-color": case "outline-color":
+          p = { kind: k, value: { kind: "named", name: "black" } } as StyleProperty; break;
+        case "font-family":
+          p = { kind: k, value: ["Inter"] } as StyleProperty; break;
+        case "font-size": case "tracking": case "space-before": case "space-after":
+        case "indent": case "max-width": case "min-height": case "border-radius":
+          p = { kind: k, value: { unit: "pt", value: 1 } } as StyleProperty; break;
+        case "font-weight": case "leading": case "opacity": case "widow-orphan":
+          p = { kind: k, value: 1 } as StyleProperty; break;
+        case "font-style":
+          p = { kind: k, value: "normal" } as StyleProperty; break;
+        case "text-transform":
+          p = { kind: k, value: "none" } as StyleProperty; break;
+        case "text-decoration":
+          p = { kind: k, value: { line: "none" } } as StyleProperty; break;
+        case "padding":
+          p = { kind: k, value: { top: { unit: "pt", value: 0 }, right: { unit: "pt", value: 0 }, bottom: { unit: "pt", value: 0 }, left: { unit: "pt", value: 0 } } } as StyleProperty; break;
+        case "align":
+          p = { kind: k, value: "start" } as StyleProperty; break;
+        case "vertical-align":
+          p = { kind: k, value: "baseline" } as StyleProperty; break;
+        case "border":
+          p = { kind: k, value: { width: { unit: "pt", value: 1 }, style: "solid", color: { kind: "named", name: "black" } } } as StyleProperty; break;
+        case "shadow":
+          p = { kind: k, value: { offsetX: { unit: "pt", value: 0 }, offsetY: { unit: "pt", value: 0 }, blur: { unit: "pt", value: 0 }, spread: { unit: "pt", value: 0 }, color: { kind: "named", name: "black" } } } as StyleProperty; break;
+        case "column-break": case "page-break":
+          p = { kind: k, value: "before" } as StyleProperty; break;
+        case "display":
+          p = { kind: k, value: "block" } as StyleProperty; break;
+        case "visible":
+          p = { kind: k, value: true } as StyleProperty; break;
+      }
+      expect(() => propertyToTerminal(p, tokens)).not.toThrow();
+    }
+  });
+});

--- a/code/packages/typescript/forme-style-to-terminal/tests/selector-mapper.test.ts
+++ b/code/packages/typescript/forme-style-to-terminal/tests/selector-mapper.test.ts
@@ -1,0 +1,94 @@
+/**
+ * selector-mapper.test.ts — selectorDescription (informational comments).
+ */
+
+import { describe, it, expect } from "vitest";
+import { sel } from "@coding-adventures/forme-style-ir";
+import { selectorDescription } from "../src/index.js";
+
+describe("selectorDescription — simple kinds", () => {
+  it("node-type", () => {
+    expect(selectorDescription(sel.type("paragraph"))).toBe("node-type:paragraph");
+  });
+  it("node-type-level", () => {
+    expect(selectorDescription({ kind: "node-type-level", level: 1 })).toBe("heading-level:1");
+  });
+  it("custom-kind", () => {
+    expect(selectorDescription({ kind: "custom-kind", customKind: "Callout" })).toBe("custom-kind:Callout");
+  });
+  it("tag", () => {
+    expect(selectorDescription({ kind: "tag", tag: "warning" })).toBe("tag:warning");
+  });
+  it("id", () => {
+    expect(selectorDescription({ kind: "id", id: "main" })).toBe("id:main");
+  });
+  it("role", () => {
+    expect(selectorDescription({ kind: "role", role: "note" })).toBe("role:note");
+  });
+});
+
+describe("selectorDescription — composition", () => {
+  const p = sel.type("p");
+  const h1 = { kind: "node-type-level" as const, level: 1 };
+
+  it("nth with numeric index", () => {
+    expect(selectorDescription({ kind: "nth", n: 0, of: p })).toBe("nth(0, node-type:p)");
+  });
+  it("nth with an+b formula", () => {
+    expect(selectorDescription({ kind: "nth", n: { a: 2, b: 1 }, of: p })).toBe("nth(2n+1, node-type:p)");
+  });
+  it("nth with negative b", () => {
+    expect(selectorDescription({ kind: "nth", n: { a: 3, b: -2 }, of: p })).toBe("nth(3n-2, node-type:p)");
+  });
+  it("nth with fromEnd flag", () => {
+    expect(selectorDescription({ kind: "nth", n: { a: 1, b: 0, fromEnd: true }, of: p }))
+      .toBe("nth(1n+0 from-end, node-type:p)");
+  });
+  it("child-of", () => {
+    expect(selectorDescription({ kind: "child-of", parent: p, child: h1 }))
+      .toBe("child-of(node-type:p, heading-level:1)");
+  });
+  it("descendant-of", () => {
+    expect(selectorDescription({ kind: "descendant-of", ancestor: p, descendant: h1 }))
+      .toBe("descendant-of(node-type:p, heading-level:1)");
+  });
+  it("adjacent", () => {
+    expect(selectorDescription({ kind: "adjacent", previous: p, following: h1 }))
+      .toBe("adjacent(node-type:p, heading-level:1)");
+  });
+  it("and", () => {
+    expect(selectorDescription({ kind: "and", all: [p, h1] })).toBe("and(node-type:p, heading-level:1)");
+  });
+  it("or", () => {
+    expect(selectorDescription({ kind: "or", any: [p, h1] })).toBe("or(node-type:p, heading-level:1)");
+  });
+  it("not", () => {
+    expect(selectorDescription({ kind: "not", inner: p })).toBe("not(node-type:p)");
+  });
+});
+
+describe("selectorDescription — depth cap (FM04 §9.6)", () => {
+  it("a deeply nested selector returns a truncation marker rather than overflowing", () => {
+    // Build a `not(not(not(...)))` chain 200 levels deep — well past
+    // MAX_DESC_DEPTH (64).  Should NOT throw.
+    let s: Parameters<typeof selectorDescription>[0] = sel.type("paragraph");
+    for (let i = 0; i < 200; i++) {
+      s = { kind: "not", inner: s };
+    }
+    const out = selectorDescription(s);
+    expect(out).toContain("…(truncated)");
+  });
+});
+
+describe("selectorDescription — defensive sanitisation", () => {
+  it("strips ANSI-unsafe bytes from selector targets", () => {
+    expect(selectorDescription(sel.type("evil\x1bname"))).toBe("node-type:evilname");
+  });
+
+  it("strips control chars from custom-kind / tag / id / role", () => {
+    expect(selectorDescription({ kind: "custom-kind", customKind: "x\x00y" })).toBe("custom-kind:xy");
+    expect(selectorDescription({ kind: "tag", tag: "x\x9by" })).toBe("tag:xy");
+    expect(selectorDescription({ kind: "id", id: "x\x7fy" })).toBe("id:xy");
+    expect(selectorDescription({ kind: "role", role: "x\x1by" })).toBe("role:xy");
+  });
+});

--- a/code/packages/typescript/forme-style-to-terminal/tests/token-resolver.test.ts
+++ b/code/packages/typescript/forme-style-to-terminal/tests/token-resolver.test.ts
@@ -1,0 +1,135 @@
+/**
+ * token-resolver.test.ts — walker + proto-pollution guards.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { TokenSet } from "@coding-adventures/forme-style-ir";
+import {
+  resolveRef, resolveColor, resolveLength, resolveNumber,
+  resolveShadow, resolveFontStack,
+} from "../src/index.js";
+
+const tokens: TokenSet = {
+  colors: {
+    text: { kind: "rgb", r: 0, g: 0, b: 0 },
+    link: { kind: "token-ref", path: "colors.text" },
+    a: { kind: "token-ref", path: "colors.b" },
+    b: { kind: "token-ref", path: "colors.a" },
+  },
+  typography: {
+    families: { body: ["Inter"] },
+    scale:    { md: { unit: "pt", value: 12 } },
+    weights:  { regular: 400 },
+    leading:  { normal: 1.5 },
+    tracking: { normal: { unit: "em", value: 0 } },
+  },
+  space:   { md: { unit: "pt", value: 6 } },
+  radii:   {},
+  shadows: {
+    soft: {
+      offsetX: { unit: "pt", value: 0 },
+      offsetY: { unit: "pt", value: 2 },
+      blur:    { unit: "pt", value: 4 },
+      spread:  { unit: "pt", value: 0 },
+      color:   { kind: "rgb", r: 0, g: 0, b: 0 },
+    },
+  },
+};
+
+describe("resolveRef", () => {
+  it("resolves direct ref", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.text" }, tokens)).toEqual({ kind: "rgb", r: 0, g: 0, b: 0 });
+  });
+
+  it("follows chain", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.link" }, tokens)).toEqual({ kind: "rgb", r: 0, g: 0, b: 0 });
+  });
+
+  it("cycle returns null", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.a" }, tokens)).toBeNull();
+  });
+
+  it("missing path returns null", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.gone" }, tokens)).toBeNull();
+  });
+});
+
+describe("resolveRef — proto-pollution defence", () => {
+  it("refuses __proto__", () => {
+    expect(resolveRef({ kind: "token-ref", path: "__proto__.toString" }, tokens)).toBeNull();
+  });
+
+  it("refuses constructor", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.constructor.name" }, tokens)).toBeNull();
+  });
+
+  it("refuses prototype", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.prototype" }, tokens)).toBeNull();
+  });
+
+  it("inherited keys are not followed", () => {
+    expect(resolveRef({ kind: "token-ref", path: "colors.toString" }, tokens)).toBeNull();
+  });
+});
+
+describe("typed wrappers", () => {
+  it("resolveColor", () => {
+    expect(resolveColor({ kind: "token-ref", path: "colors.text" }, tokens))
+      .toEqual({ kind: "rgb", r: 0, g: 0, b: 0 });
+    expect(resolveColor({ kind: "rgb", r: 1, g: 2, b: 3 }, tokens))
+      .toEqual({ kind: "rgb", r: 1, g: 2, b: 3 });
+    expect(resolveColor({ kind: "token-ref", path: "colors.gone" }, tokens)).toBeNull();
+  });
+
+  it("resolveLength", () => {
+    expect(resolveLength({ kind: "token-ref", path: "space.md" }, tokens)).toEqual({ unit: "pt", value: 6 });
+    expect(resolveLength({ unit: "em", value: 1 }, tokens)).toEqual({ unit: "em", value: 1 });
+  });
+
+  it("resolveNumber rejects NaN", () => {
+    const broken: TokenSet = {
+      ...tokens,
+      typography: { ...tokens.typography, weights: { broken: NaN } },
+    };
+    expect(resolveNumber({ kind: "token-ref", path: "typography.weights.broken" }, broken)).toBeNull();
+  });
+
+  it("typed wrapper rejects type-mismatched leaves", () => {
+    expect(resolveColor({ kind: "token-ref", path: "space.md" }, tokens)).toBeNull();
+  });
+
+  it("resolveShadow follows the ref", () => {
+    const s = resolveShadow({ kind: "token-ref", path: "shadows.soft" }, tokens);
+    expect(s).not.toBeNull();
+    expect(s!.offsetY).toEqual({ unit: "pt", value: 2 });
+  });
+
+  it("resolveShadow passes through a concrete value", () => {
+    const concrete = {
+      offsetX: { unit: "pt", value: 1 } as const,
+      offsetY: { unit: "pt", value: 1 } as const,
+      blur:    { unit: "pt", value: 1 } as const,
+      spread:  { unit: "pt", value: 1 } as const,
+      color:   { kind: "named" as const, name: "red" },
+    };
+    expect(resolveShadow(concrete, tokens)).toBe(concrete);
+  });
+
+  it("resolveShadow rejects type-mismatched leaves", () => {
+    expect(resolveShadow({ kind: "token-ref", path: "colors.text" }, tokens)).toBeNull();
+  });
+
+  it("resolveFontStack follows the ref", () => {
+    expect(resolveFontStack({ kind: "token-ref", path: "typography.families.body" }, tokens))
+      .toEqual(["Inter"]);
+  });
+
+  it("resolveFontStack passes through a concrete array", () => {
+    const arr = ["Inter", "sans-serif"];
+    expect(resolveFontStack(arr, tokens)).toBe(arr);
+  });
+
+  it("resolveFontStack rejects type-mismatched leaves", () => {
+    expect(resolveFontStack({ kind: "token-ref", path: "colors.text" }, tokens)).toBeNull();
+  });
+});

--- a/code/packages/typescript/forme-style-to-terminal/tests/translate.test.ts
+++ b/code/packages/typescript/forme-style-to-terminal/tests/translate.test.ts
@@ -1,0 +1,248 @@
+/**
+ * translate.test.ts — end-to-end translateToTerminal.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  styleRuleId, sel,
+  type StyleDocument, type StyleRule,
+} from "@coding-adventures/forme-style-ir";
+import { translateToTerminal } from "../src/index.js";
+
+function baseDoc(): StyleDocument {
+  return {
+    kind: "StyleDocument",
+    tokens: {
+      colors: { text: { kind: "rgb", r: 31, g: 35, b: 40 } },
+      typography: {
+        families: { body: ["Inter"] },
+        scale:    { md: { unit: "pt", value: 12 } },
+        weights:  { regular: 400, bold: 700 },
+        leading:  { normal: 1.5 },
+        tracking: { normal: { unit: "em", value: 0 } },
+      },
+      space:   {},
+      radii:   {},
+      shadows: {},
+    },
+    rules: [],
+    contexts: [],
+    theme: null,
+  };
+}
+
+function rule(id: string, sel0: StyleRule["selector"], props: StyleRule["properties"], context?: string): StyleRule {
+  return context !== undefined
+    ? { id: styleRuleId(id), selector: sel0, properties: props, context }
+    : { id: styleRuleId(id), selector: sel0, properties: props };
+}
+
+describe("translateToTerminal — happy path", () => {
+  it("emits a TS module fragment with a single rule's SGR wrap", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("body", sel.type("paragraph"), [
+          { kind: "color", value: { kind: "token-ref", path: "colors.text" } },
+          { kind: "font-weight", value: 700 },
+        ]),
+      ],
+    };
+    const { output, emittedRules, warnings } = translateToTerminal(doc, { activeContexts: [] });
+    expect(emittedRules).toEqual(["body"]);
+    expect(warnings).toEqual([]);
+    expect(output).toContain("export const formeStyles");
+    expect(output).toContain("// rule \"body\" — node-type:paragraph");
+    // The two SGR fragments combined: 38;2;31;35;40 (color), 1 (bold).
+    // Property iteration order is color-first, then font-weight.
+    expect(output).toContain('["body", { prefix: "\\x1b[38;2;31;35;40;1m", suffix: "\\x1b[0m" }],');
+  });
+
+  it("emits an interface declaration in the header", () => {
+    const { output } = translateToTerminal(baseDoc(), { activeContexts: [] });
+    expect(output).toContain("export interface AnsiStyle {");
+    expect(output).toContain("readonly prefix: string;");
+    expect(output).toContain("readonly suffix: string;");
+  });
+
+  it("emits an empty Map when there are no rules", () => {
+    const { output, emittedRules } = translateToTerminal(baseDoc(), { activeContexts: [] });
+    expect(emittedRules).toEqual([]);
+    expect(output).toContain("new Map([");
+    expect(output).toContain("]);");
+  });
+});
+
+describe("translateToTerminal — filtering", () => {
+  it("rules with non-active contexts are filtered out", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("inactive", sel.type("paragraph"), [{ kind: "font-weight", value: 700 }], "print"),
+      ],
+    };
+    const { emittedRules, output } = translateToTerminal(doc, { activeContexts: [] });
+    expect(emittedRules).toEqual([]);
+    expect(output).not.toContain('"inactive"');
+  });
+
+  it("rule emits when its context is in activeContexts", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("dark-mode", sel.type("paragraph"), [{ kind: "color", value: { kind: "named", name: "white" } }], "dark"),
+      ],
+    };
+    const { emittedRules, output } = translateToTerminal(doc, { activeContexts: ["dark"] });
+    expect(emittedRules).toEqual(["dark-mode"]);
+    expect(output).toContain('"dark-mode"');
+  });
+
+  it("ext: contexts emit a warning and skip the rule", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("x", sel.type("paragraph"), [{ kind: "font-weight", value: 700 }], "ext:plugin:custom"),
+      ],
+    };
+    const { warnings, emittedRules } = translateToTerminal(doc, { activeContexts: ["ext:plugin:custom"] });
+    expect(emittedRules).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.code).toBe("EXT_CONTEXT_NOT_TRANSLATED");
+  });
+
+  it("usedRuleIds slices the output", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("a", sel.type("p"), [{ kind: "font-weight", value: 700 }]),
+        rule("b", sel.type("h"), [{ kind: "font-weight", value: 700 }]),
+        rule("c", sel.type("x"), [{ kind: "font-weight", value: 700 }]),
+      ],
+    };
+    const { emittedRules } = translateToTerminal(doc, {
+      activeContexts: [],
+      usedRuleIds: [styleRuleId("a"), styleRuleId("c")],
+    });
+    expect([...emittedRules].sort()).toEqual(["a", "c"]);
+  });
+
+  it("usedRuleIds with empty list emits no rules", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [rule("a", sel.type("p"), [{ kind: "font-weight", value: 700 }])],
+    };
+    const { emittedRules } = translateToTerminal(doc, { activeContexts: [], usedRuleIds: [] });
+    expect(emittedRules).toEqual([]);
+  });
+
+  it("ext: property kinds emit a warning; rule still emits other props", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("mixed", sel.type("paragraph"), [
+          { kind: "ext:plugin:thing", value: 1 } as never,
+          { kind: "font-weight", value: 700 },
+        ]),
+      ],
+    };
+    const { warnings, emittedRules } = translateToTerminal(doc, { activeContexts: [] });
+    expect(emittedRules).toEqual(["mixed"]);
+    expect(warnings.some((w) => w.code === "EXT_PROPERTY_NOT_TRANSLATED")).toBe(true);
+  });
+
+  it("rules where everything warn-skips still emit (with empty prefix), but NOT in emittedRules", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("noop", sel.type("paragraph"), [
+          { kind: "padding", value: { top: { unit: "pt", value: 0 }, right: { unit: "pt", value: 0 }, bottom: { unit: "pt", value: 0 }, left: { unit: "pt", value: 0 } } },
+        ]),
+      ],
+    };
+    const { emittedRules, output, warnings } = translateToTerminal(doc, { activeContexts: [] });
+    // The id IS present in the output (consumers shouldn't get
+    // surprised by Map lookup misses) but with empty prefix/suffix.
+    expect(output).toContain('["noop", { prefix: "", suffix: "" }],');
+    // emittedRules excludes no-op rules — the AOT compiler doesn't
+    // need to wrap content that produces no styling change.
+    expect(emittedRules).toEqual([]);
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("translateToTerminal — scope", () => {
+  it("scope prefix is prepended to the Map key", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [rule("body", sel.type("paragraph"), [{ kind: "font-weight", value: 700 }])],
+    };
+    const { output } = translateToTerminal(doc, { activeContexts: [], scope: "page-abc123." });
+    expect(output).toContain('["page-abc123.body"');
+  });
+});
+
+describe("translateToTerminal — reproducibility (FM03)", () => {
+  it("same input → byte-identical output", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [
+        rule("a", sel.type("p"), [{ kind: "color", value: { kind: "named", name: "red" } }]),
+        rule("b", { kind: "node-type-level", level: 1 }, [{ kind: "font-weight", value: 700 }]),
+      ],
+    };
+    const opts = { activeContexts: [] };
+    expect(translateToTerminal(doc, opts).output).toBe(translateToTerminal(doc, opts).output);
+  });
+});
+
+describe("translateToTerminal — output safety (ANSI / TS-string injection)", () => {
+  it("strips ESC from rule ids before they reach the Map key or comment", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [rule("evil\x1b[31m", sel.type("paragraph"), [{ kind: "font-weight", value: 700 }])],
+    };
+    const { output } = translateToTerminal(doc, { activeContexts: [] });
+    // No raw 0x1B should appear in the output.
+    // eslint-disable-next-line no-control-regex
+    expect(output).not.toMatch(/\x1b(?!\[)/);   // (apart from the literal \x1b[ we emit as text, which is the 4 bytes \, x, 1, b)
+    // The id appears with the ESC stripped.
+    expect(output).toContain("evil[31m");
+  });
+
+  it("escapes backslash and quote in rule ids (TS string-literal safety)", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [rule(`he"llo\\world`, sel.type("paragraph"), [{ kind: "font-weight", value: 700 }])],
+    };
+    const { output } = translateToTerminal(doc, { activeContexts: [] });
+    expect(output).toContain(`he\\"llo\\\\world`);
+    // None of these would break the JS string literal — verify by
+    // parsing the line as JS.
+    const line = output.split("\n").find((l) => l.includes("he\\\"llo\\\\world"))!;
+    // Strip leading whitespace + trailing comma.
+    const trimmed = line.replace(/^\s+/, "").replace(/,$/, "");
+    expect(() => Function(`"use strict"; return ${trimmed};`)()).not.toThrow();
+  });
+
+  it("strips ESC from selector descriptions before they reach the comment", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      rules: [rule("x", sel.type("evil\x1bname"), [{ kind: "font-weight", value: 700 }])],
+    };
+    const { output } = translateToTerminal(doc, { activeContexts: [] });
+    expect(output).toContain("// rule \"x\" — node-type:evilname");
+  });
+
+  it("color components are always integer SGR parameters (no injection from numeric coercion)", () => {
+    const doc: StyleDocument = {
+      ...baseDoc(),
+      // r is `NaN` (somehow); colorToRgbTriple defensively coerces to 0.
+      rules: [rule("nanrule", sel.type("p"), [{ kind: "color", value: { kind: "rgb", r: NaN, g: 100, b: 200 } }])],
+    };
+    const { output } = translateToTerminal(doc, { activeContexts: [] });
+    // SGR fragment is well-formed — no `NaN` substring.
+    expect(output).toContain("38;2;0;100;200");
+    expect(output).not.toContain("NaN");
+  });
+});

--- a/code/packages/typescript/forme-style-to-terminal/tests/value-mappers.test.ts
+++ b/code/packages/typescript/forme-style-to-terminal/tests/value-mappers.test.ts
@@ -1,0 +1,67 @@
+/**
+ * value-mappers.test.ts — Color → SGR triple / fragment.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  colorToRgbTriple, colorToSgrFg, colorToSgrBg,
+} from "../src/index.js";
+
+describe("colorToRgbTriple", () => {
+  it("rgb passes through", () => {
+    expect(colorToRgbTriple({ kind: "rgb", r: 31, g: 35, b: 40 })).toEqual([31, 35, 40]);
+  });
+
+  it("rgb clamps below 0 and above 255", () => {
+    expect(colorToRgbTriple({ kind: "rgb", r: -10, g: 999, b: 128 })).toEqual([0, 255, 128]);
+  });
+
+  it("rgb rounds fractional channels", () => {
+    expect(colorToRgbTriple({ kind: "rgb", r: 127.4, g: 127.6, b: 128 })).toEqual([127, 128, 128]);
+  });
+
+  it("rgb treats NaN as 0 (defensive)", () => {
+    expect(colorToRgbTriple({ kind: "rgb", r: NaN, g: 100, b: 200 })).toEqual([0, 100, 200]);
+  });
+
+  it("hsl pure red", () => {
+    expect(colorToRgbTriple({ kind: "hsl", h: 0, s: 100, l: 50 })).toEqual([255, 0, 0]);
+  });
+
+  it("hsl pure black / white", () => {
+    expect(colorToRgbTriple({ kind: "hsl", h: 0, s: 0, l: 0 })).toEqual([0, 0, 0]);
+    expect(colorToRgbTriple({ kind: "hsl", h: 0, s: 0, l: 100 })).toEqual([255, 255, 255]);
+  });
+
+  it("oklch returns null (v0 out-of-scope)", () => {
+    expect(colorToRgbTriple({ kind: "oklch", l: 0.7, c: 0.15, h: 220 })).toBeNull();
+  });
+
+  it("named known colors resolve", () => {
+    expect(colorToRgbTriple({ kind: "named", name: "black" })).toEqual([0, 0, 0]);
+    expect(colorToRgbTriple({ kind: "named", name: "tomato" })).toEqual([255, 99, 71]);
+  });
+
+  it("named lookup is case-insensitive", () => {
+    expect(colorToRgbTriple({ kind: "named", name: "ToMaTo" })).toEqual([255, 99, 71]);
+  });
+
+  it("named unknown returns null", () => {
+    expect(colorToRgbTriple({ kind: "named", name: "asparagus" })).toBeNull();
+  });
+});
+
+describe("colorToSgrFg / colorToSgrBg", () => {
+  it("fg sequence has the 38;2; prefix", () => {
+    expect(colorToSgrFg({ kind: "rgb", r: 31, g: 35, b: 40 })).toBe("38;2;31;35;40");
+  });
+
+  it("bg sequence has the 48;2; prefix", () => {
+    expect(colorToSgrBg({ kind: "rgb", r: 31, g: 35, b: 40 })).toBe("48;2;31;35;40");
+  });
+
+  it("returns null when color isn't representable", () => {
+    expect(colorToSgrFg({ kind: "oklch", l: 0.5, c: 0.1, h: 0 })).toBeNull();
+    expect(colorToSgrBg({ kind: "named", name: "asparagus" })).toBeNull();
+  });
+});

--- a/code/packages/typescript/forme-style-to-terminal/tsconfig.json
+++ b/code/packages/typescript/forme-style-to-terminal/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-style-to-terminal/vitest.config.ts
+++ b/code/packages/typescript/forme-style-to-terminal/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

The **third concrete FM04 backend translator** (after [CSS](../forme-style-to-css) and [LaTeX](../forme-style-to-latex)), completing the v0 multi-backend story.  Same IR, three independent targets, zero inter-package coupling — proves the IR is genuinely target-agnostic.

Takes a `StyleDocument` from [`forme-style-ir`](../forme-style-ir) and emits a **TypeScript module source string** that, when imported, exposes a `ReadonlyMap<RuleId, { prefix, suffix }>` of per-rule ANSI SGR wrappers.  Consumers do `prefix + content + suffix` to style document text.

```ts
// generated output sketch
export interface AnsiStyle { readonly prefix: string; readonly suffix: string; }
export const formeStyles: ReadonlyMap<string, AnsiStyle> = new Map([
  // rule "body" — node-type:paragraph
  ["body", { prefix: "\x1b[38;2;31;35;40;1m", suffix: "\x1b[0m" }],
]);
```

## Why a different output shape?

CSS / LaTeX both emit a self-contained "preamble" that the renderer drops in once.  Terminals have no preamble — wrappers must be applied per-rule at content-emit time.  So the most useful artefact is a lookup table the consumer pulls keys from.

## Three mapping tables

| Layer       | Maps to                                | Skips                                  |
|-------------|----------------------------------------|----------------------------------------|
| Selectors   | comment-only descriptions; Map key is the rule id (terminals have no document tree) | n/a (descriptions never fail)        |
| Properties  | 24-bit truecolour SGR (color/bg); bold (1) / italic (3) / underline (4) / strikethrough (9) / overline (53) / conceal (8) toggles | padding / margin / border-* / shadow / opacity / page-break / font-size / font-family / align / vertical-align / max-width / min-height — everything that needs page geometry |
| Contexts    | filter rules through `activeContexts` (kernel set only) | `ext:*`                              |

## Security posture

Pre-push focused review = **PASS**.

1. **ANSI escape-sequence injection.**  Every caller-controlled string interpolated into the output routes through `stripAnsiUnsafe` (ESC 0x1B, C1 CSI 0x9B, C1 OSC 0x9D, ASCII control bytes 0x00–0x1F + 0x7F, full C1 range 0x80–0x9F).  Attacker-controlled bytes cannot drive cursor moves / screen clears / arbitrary SGR through us.
2. **TS-string-literal escaping.**  Map keys and SGR strings land in double-quoted JS literals; `escapeTsString` handles `\` and `"` in a single pass (CodeQL incomplete-string-escaping rule-friendly form).
3. **`walkPath` prototype-pollution.**  Same deny-list + own-key `hasOwnProperty.call` defence as the CSS / LaTeX translators.
4. **Defensive numeric coercion.**  `colorToRgbTriple` treats `NaN` / `Infinity` channels as 0 rather than letting them propagate into the SGR sequence as literal `NaN` text.
5. **Defence-in-depth.**  `selectorDescription` has `MAX_DESC_DEPTH = 64` matching `token-resolver`'s `MAX_RESOLVE_DEPTH`; past the cap we return `…(truncated)` rather than overflow the JS call stack on adversarial deeply-nested selectors.

## Capabilities

`[]` — pure transform.  No I/O, no shell, no network.

## Tests

**128 tests across 7 files**, **100% line / 97.43% branch** coverage (above FM04 §14.4 ≥95% line target):

- `escape.test.ts` (15) — ANSI-unsafe stripping for every dangerous byte range; TS-string escaping for `\` and `"`; Unicode passthrough
- `value-mappers.test.ts` (13) — color models, clamping, NaN defensiveness, named-color lookup, SGR fg/bg prefixes
- `selector-mapper.test.ts` (19) — every Selector kind including composition; defensive control-char sanitisation; depth cap
- `context-mapper.test.ts` (3) — kernel contexts; `ext:*` rejection
- `token-resolver.test.ts` (18) — happy path, proto-pollution defence, typed wrappers for all five leaf types, cycle cap, NaN rejection
- `property-mappers.test.ts` (44) — every kernel kind, exhaustive meta-check over `PROPERTY_KINDS`, defensive fallthroughs
- `translate.test.ts` (16) — end-to-end, filtering, scope, reproducibility, ANSI / TS-string injection defence (verifies output is valid runnable JS)

## Spec adherence

Implements FM04 §9.4 terminal target end-to-end.  No spec divergences.

## v0 simplifications (documented in CHANGELOG)

- 24-bit truecolour only (modern terminals all support it)
- OKLCH warn-skips (CIE round-trip out of scope)
- No SGR idempotence elision (consumer's job not to double-wrap)

## Test plan

- [x] `vitest run --coverage` — 128 / 128 pass, 100% line / 97.43% branch
- [x] `tsc --noEmit` — clean
- [x] Security review — PASS (ANSI injection, proto-pollution, control chars, depth cap all addressed)
- [ ] CI: lint, build, security scans (CodeQL pattern was the fix point on the LaTeX PR — verified the same single-pass `.replace` form here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)