### PR TITLE
[codex] Add WHATWG entity conformance sweep

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -41,6 +41,9 @@ documented in this file.
 - html5lib-style smoke fixture coverage for seeded character-reference
   continuations returning to both data and RCDATA, including missing-semicolon
   and absence-of-digits diagnostics.
+- A generated WHATWG `entities.json` fixture and Rust conformance test that
+  exercises every named character reference in data, attribute, and RCDATA
+  contexts, including semicolonless legacy and ambiguous-ampersand behavior.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -230,6 +230,18 @@ Today the package carries two suites:
 - `html-skeleton.json` for narrow bootstrap regression coverage
 - `html1.json` for the current Mosaic-era compatibility floor
 
+The checked-in `whatwg-entities.json` fixture is generated from the HTML
+Standard's `entities.json` table and is exercised directly by Rust tests across
+data, attribute, and RCDATA tokenizer contexts. Regenerate or check it with:
+
+```bash
+curl -L https://html.spec.whatwg.org/entities.json -o /tmp/entities.json
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py \
+  /tmp/entities.json
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py \
+  /tmp/entities.json --check
+```
+
 There is also an `upstream-html5lib-smoke.test` file that mirrors the raw
 html5lib tokenizer JSON shape in a small supported subset. The Rust test
 harness now targets a checked-in generated `html5lib-smoke.json` corpus, which

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -48,12 +48,28 @@ binary while production code continues to link only static Rust source.
 
 - `html-skeleton.json`: narrow bootstrap regression cases
 - `html1.json`: Mosaic-era compatibility-floor cases for the current default wrapper
+- `whatwg-entities.json`: generated HTML Standard named character reference
+  table used by Rust tests to exercise every entry in data, attribute, and
+  RCDATA contexts
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
   exercise the normalization path toward broader upstream corpora
 - `normalize_html5lib_fixtures.py`: importer that lowers supported raw
   html5lib-style tokenizer cases into Venture's portable fixture schema
+- `generate_whatwg_entities_fixture.py`: importer that lowers the HTML
+  Standard's `entities.json` table into the checked-in `whatwg-entities.json`
+  fixture
+
+Regenerate or verify the WHATWG entity fixture with:
+
+```bash
+curl -L https://html.spec.whatwg.org/entities.json -o /tmp/entities.json
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py \
+  /tmp/entities.json
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py \
+  /tmp/entities.json --check
+```
 
 ## Conformance Audit
 

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's checked-in WHATWG named character reference fixture.
+
+Download the current table from the HTML Standard and point this script at it:
+
+    curl -L https://html.spec.whatwg.org/entities.json -o /tmp/entities.json
+    python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py \
+      /tmp/entities.json
+
+The output is intentionally small and data-only so Rust tests can verify the
+static generated lexer without reaching out to the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-entities.json")
+SOURCE_URL = "https://html.spec.whatwg.org/entities.json"
+
+
+def main() -> int:
+    args = parse_args()
+    source = Path(args.entities_json).expanduser().resolve()
+    output = Path(args.output).expanduser().resolve()
+
+    entities = json.loads(source.read_text())
+    fixture = build_fixture(entities)
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it from {source}")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG named character reference fixture JSON."
+    )
+    parser.add_argument(
+        "entities_json",
+        help="Path to the WHATWG entities.json source table.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture(entities: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "format": "whatwg-html-entities/v1",
+        "source": SOURCE_URL,
+        "entities": [
+            {
+                "name": name,
+                "characters": data["characters"],
+                "codepoints": data["codepoints"],
+                "semicolon": name.endswith(";"),
+            }
+            for name, data in sorted(entities.items())
+        ],
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-entities.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-entities.json
@@ -1,0 +1,17947 @@
+{
+  "entities": [
+    {
+      "characters": "Æ",
+      "codepoints": [
+        198
+      ],
+      "name": "&AElig",
+      "semicolon": false
+    },
+    {
+      "characters": "Æ",
+      "codepoints": [
+        198
+      ],
+      "name": "&AElig;",
+      "semicolon": true
+    },
+    {
+      "characters": "&",
+      "codepoints": [
+        38
+      ],
+      "name": "&AMP",
+      "semicolon": false
+    },
+    {
+      "characters": "&",
+      "codepoints": [
+        38
+      ],
+      "name": "&AMP;",
+      "semicolon": true
+    },
+    {
+      "characters": "Á",
+      "codepoints": [
+        193
+      ],
+      "name": "&Aacute",
+      "semicolon": false
+    },
+    {
+      "characters": "Á",
+      "codepoints": [
+        193
+      ],
+      "name": "&Aacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ă",
+      "codepoints": [
+        258
+      ],
+      "name": "&Abreve;",
+      "semicolon": true
+    },
+    {
+      "characters": "Â",
+      "codepoints": [
+        194
+      ],
+      "name": "&Acirc",
+      "semicolon": false
+    },
+    {
+      "characters": "Â",
+      "codepoints": [
+        194
+      ],
+      "name": "&Acirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "А",
+      "codepoints": [
+        1040
+      ],
+      "name": "&Acy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔄",
+      "codepoints": [
+        120068
+      ],
+      "name": "&Afr;",
+      "semicolon": true
+    },
+    {
+      "characters": "À",
+      "codepoints": [
+        192
+      ],
+      "name": "&Agrave",
+      "semicolon": false
+    },
+    {
+      "characters": "À",
+      "codepoints": [
+        192
+      ],
+      "name": "&Agrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "Α",
+      "codepoints": [
+        913
+      ],
+      "name": "&Alpha;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ā",
+      "codepoints": [
+        256
+      ],
+      "name": "&Amacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩓",
+      "codepoints": [
+        10835
+      ],
+      "name": "&And;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ą",
+      "codepoints": [
+        260
+      ],
+      "name": "&Aogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔸",
+      "codepoints": [
+        120120
+      ],
+      "name": "&Aopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁡",
+      "codepoints": [
+        8289
+      ],
+      "name": "&ApplyFunction;",
+      "semicolon": true
+    },
+    {
+      "characters": "Å",
+      "codepoints": [
+        197
+      ],
+      "name": "&Aring",
+      "semicolon": false
+    },
+    {
+      "characters": "Å",
+      "codepoints": [
+        197
+      ],
+      "name": "&Aring;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒜",
+      "codepoints": [
+        119964
+      ],
+      "name": "&Ascr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≔",
+      "codepoints": [
+        8788
+      ],
+      "name": "&Assign;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ã",
+      "codepoints": [
+        195
+      ],
+      "name": "&Atilde",
+      "semicolon": false
+    },
+    {
+      "characters": "Ã",
+      "codepoints": [
+        195
+      ],
+      "name": "&Atilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ä",
+      "codepoints": [
+        196
+      ],
+      "name": "&Auml",
+      "semicolon": false
+    },
+    {
+      "characters": "Ä",
+      "codepoints": [
+        196
+      ],
+      "name": "&Auml;",
+      "semicolon": true
+    },
+    {
+      "characters": "∖",
+      "codepoints": [
+        8726
+      ],
+      "name": "&Backslash;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫧",
+      "codepoints": [
+        10983
+      ],
+      "name": "&Barv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌆",
+      "codepoints": [
+        8966
+      ],
+      "name": "&Barwed;",
+      "semicolon": true
+    },
+    {
+      "characters": "Б",
+      "codepoints": [
+        1041
+      ],
+      "name": "&Bcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "∵",
+      "codepoints": [
+        8757
+      ],
+      "name": "&Because;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℬ",
+      "codepoints": [
+        8492
+      ],
+      "name": "&Bernoullis;",
+      "semicolon": true
+    },
+    {
+      "characters": "Β",
+      "codepoints": [
+        914
+      ],
+      "name": "&Beta;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔅",
+      "codepoints": [
+        120069
+      ],
+      "name": "&Bfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔹",
+      "codepoints": [
+        120121
+      ],
+      "name": "&Bopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "˘",
+      "codepoints": [
+        728
+      ],
+      "name": "&Breve;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℬ",
+      "codepoints": [
+        8492
+      ],
+      "name": "&Bscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≎",
+      "codepoints": [
+        8782
+      ],
+      "name": "&Bumpeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ч",
+      "codepoints": [
+        1063
+      ],
+      "name": "&CHcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "©",
+      "codepoints": [
+        169
+      ],
+      "name": "&COPY",
+      "semicolon": false
+    },
+    {
+      "characters": "©",
+      "codepoints": [
+        169
+      ],
+      "name": "&COPY;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ć",
+      "codepoints": [
+        262
+      ],
+      "name": "&Cacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋒",
+      "codepoints": [
+        8914
+      ],
+      "name": "&Cap;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅅ",
+      "codepoints": [
+        8517
+      ],
+      "name": "&CapitalDifferentialD;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℭ",
+      "codepoints": [
+        8493
+      ],
+      "name": "&Cayleys;",
+      "semicolon": true
+    },
+    {
+      "characters": "Č",
+      "codepoints": [
+        268
+      ],
+      "name": "&Ccaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ç",
+      "codepoints": [
+        199
+      ],
+      "name": "&Ccedil",
+      "semicolon": false
+    },
+    {
+      "characters": "Ç",
+      "codepoints": [
+        199
+      ],
+      "name": "&Ccedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ĉ",
+      "codepoints": [
+        264
+      ],
+      "name": "&Ccirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "∰",
+      "codepoints": [
+        8752
+      ],
+      "name": "&Cconint;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ċ",
+      "codepoints": [
+        266
+      ],
+      "name": "&Cdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "¸",
+      "codepoints": [
+        184
+      ],
+      "name": "&Cedilla;",
+      "semicolon": true
+    },
+    {
+      "characters": "·",
+      "codepoints": [
+        183
+      ],
+      "name": "&CenterDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℭ",
+      "codepoints": [
+        8493
+      ],
+      "name": "&Cfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Χ",
+      "codepoints": [
+        935
+      ],
+      "name": "&Chi;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊙",
+      "codepoints": [
+        8857
+      ],
+      "name": "&CircleDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊖",
+      "codepoints": [
+        8854
+      ],
+      "name": "&CircleMinus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊕",
+      "codepoints": [
+        8853
+      ],
+      "name": "&CirclePlus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊗",
+      "codepoints": [
+        8855
+      ],
+      "name": "&CircleTimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "∲",
+      "codepoints": [
+        8754
+      ],
+      "name": "&ClockwiseContourIntegral;",
+      "semicolon": true
+    },
+    {
+      "characters": "”",
+      "codepoints": [
+        8221
+      ],
+      "name": "&CloseCurlyDoubleQuote;",
+      "semicolon": true
+    },
+    {
+      "characters": "’",
+      "codepoints": [
+        8217
+      ],
+      "name": "&CloseCurlyQuote;",
+      "semicolon": true
+    },
+    {
+      "characters": "∷",
+      "codepoints": [
+        8759
+      ],
+      "name": "&Colon;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩴",
+      "codepoints": [
+        10868
+      ],
+      "name": "&Colone;",
+      "semicolon": true
+    },
+    {
+      "characters": "≡",
+      "codepoints": [
+        8801
+      ],
+      "name": "&Congruent;",
+      "semicolon": true
+    },
+    {
+      "characters": "∯",
+      "codepoints": [
+        8751
+      ],
+      "name": "&Conint;",
+      "semicolon": true
+    },
+    {
+      "characters": "∮",
+      "codepoints": [
+        8750
+      ],
+      "name": "&ContourIntegral;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℂ",
+      "codepoints": [
+        8450
+      ],
+      "name": "&Copf;",
+      "semicolon": true
+    },
+    {
+      "characters": "∐",
+      "codepoints": [
+        8720
+      ],
+      "name": "&Coproduct;",
+      "semicolon": true
+    },
+    {
+      "characters": "∳",
+      "codepoints": [
+        8755
+      ],
+      "name": "&CounterClockwiseContourIntegral;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨯",
+      "codepoints": [
+        10799
+      ],
+      "name": "&Cross;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒞",
+      "codepoints": [
+        119966
+      ],
+      "name": "&Cscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋓",
+      "codepoints": [
+        8915
+      ],
+      "name": "&Cup;",
+      "semicolon": true
+    },
+    {
+      "characters": "≍",
+      "codepoints": [
+        8781
+      ],
+      "name": "&CupCap;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅅ",
+      "codepoints": [
+        8517
+      ],
+      "name": "&DD;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤑",
+      "codepoints": [
+        10513
+      ],
+      "name": "&DDotrahd;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ђ",
+      "codepoints": [
+        1026
+      ],
+      "name": "&DJcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ѕ",
+      "codepoints": [
+        1029
+      ],
+      "name": "&DScy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Џ",
+      "codepoints": [
+        1039
+      ],
+      "name": "&DZcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "‡",
+      "codepoints": [
+        8225
+      ],
+      "name": "&Dagger;",
+      "semicolon": true
+    },
+    {
+      "characters": "↡",
+      "codepoints": [
+        8609
+      ],
+      "name": "&Darr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫤",
+      "codepoints": [
+        10980
+      ],
+      "name": "&Dashv;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ď",
+      "codepoints": [
+        270
+      ],
+      "name": "&Dcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "Д",
+      "codepoints": [
+        1044
+      ],
+      "name": "&Dcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "∇",
+      "codepoints": [
+        8711
+      ],
+      "name": "&Del;",
+      "semicolon": true
+    },
+    {
+      "characters": "Δ",
+      "codepoints": [
+        916
+      ],
+      "name": "&Delta;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔇",
+      "codepoints": [
+        120071
+      ],
+      "name": "&Dfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "´",
+      "codepoints": [
+        180
+      ],
+      "name": "&DiacriticalAcute;",
+      "semicolon": true
+    },
+    {
+      "characters": "˙",
+      "codepoints": [
+        729
+      ],
+      "name": "&DiacriticalDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "˝",
+      "codepoints": [
+        733
+      ],
+      "name": "&DiacriticalDoubleAcute;",
+      "semicolon": true
+    },
+    {
+      "characters": "`",
+      "codepoints": [
+        96
+      ],
+      "name": "&DiacriticalGrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "˜",
+      "codepoints": [
+        732
+      ],
+      "name": "&DiacriticalTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋄",
+      "codepoints": [
+        8900
+      ],
+      "name": "&Diamond;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅆ",
+      "codepoints": [
+        8518
+      ],
+      "name": "&DifferentialD;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔻",
+      "codepoints": [
+        120123
+      ],
+      "name": "&Dopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "¨",
+      "codepoints": [
+        168
+      ],
+      "name": "&Dot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⃜",
+      "codepoints": [
+        8412
+      ],
+      "name": "&DotDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≐",
+      "codepoints": [
+        8784
+      ],
+      "name": "&DotEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "∯",
+      "codepoints": [
+        8751
+      ],
+      "name": "&DoubleContourIntegral;",
+      "semicolon": true
+    },
+    {
+      "characters": "¨",
+      "codepoints": [
+        168
+      ],
+      "name": "&DoubleDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇓",
+      "codepoints": [
+        8659
+      ],
+      "name": "&DoubleDownArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇐",
+      "codepoints": [
+        8656
+      ],
+      "name": "&DoubleLeftArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇔",
+      "codepoints": [
+        8660
+      ],
+      "name": "&DoubleLeftRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫤",
+      "codepoints": [
+        10980
+      ],
+      "name": "&DoubleLeftTee;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟸",
+      "codepoints": [
+        10232
+      ],
+      "name": "&DoubleLongLeftArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟺",
+      "codepoints": [
+        10234
+      ],
+      "name": "&DoubleLongLeftRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟹",
+      "codepoints": [
+        10233
+      ],
+      "name": "&DoubleLongRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇒",
+      "codepoints": [
+        8658
+      ],
+      "name": "&DoubleRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊨",
+      "codepoints": [
+        8872
+      ],
+      "name": "&DoubleRightTee;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇑",
+      "codepoints": [
+        8657
+      ],
+      "name": "&DoubleUpArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇕",
+      "codepoints": [
+        8661
+      ],
+      "name": "&DoubleUpDownArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "∥",
+      "codepoints": [
+        8741
+      ],
+      "name": "&DoubleVerticalBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "↓",
+      "codepoints": [
+        8595
+      ],
+      "name": "&DownArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤓",
+      "codepoints": [
+        10515
+      ],
+      "name": "&DownArrowBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇵",
+      "codepoints": [
+        8693
+      ],
+      "name": "&DownArrowUpArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "̑",
+      "codepoints": [
+        785
+      ],
+      "name": "&DownBreve;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥐",
+      "codepoints": [
+        10576
+      ],
+      "name": "&DownLeftRightVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥞",
+      "codepoints": [
+        10590
+      ],
+      "name": "&DownLeftTeeVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "↽",
+      "codepoints": [
+        8637
+      ],
+      "name": "&DownLeftVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥖",
+      "codepoints": [
+        10582
+      ],
+      "name": "&DownLeftVectorBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥟",
+      "codepoints": [
+        10591
+      ],
+      "name": "&DownRightTeeVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇁",
+      "codepoints": [
+        8641
+      ],
+      "name": "&DownRightVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥗",
+      "codepoints": [
+        10583
+      ],
+      "name": "&DownRightVectorBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊤",
+      "codepoints": [
+        8868
+      ],
+      "name": "&DownTee;",
+      "semicolon": true
+    },
+    {
+      "characters": "↧",
+      "codepoints": [
+        8615
+      ],
+      "name": "&DownTeeArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇓",
+      "codepoints": [
+        8659
+      ],
+      "name": "&Downarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒟",
+      "codepoints": [
+        119967
+      ],
+      "name": "&Dscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Đ",
+      "codepoints": [
+        272
+      ],
+      "name": "&Dstrok;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŋ",
+      "codepoints": [
+        330
+      ],
+      "name": "&ENG;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ð",
+      "codepoints": [
+        208
+      ],
+      "name": "&ETH",
+      "semicolon": false
+    },
+    {
+      "characters": "Ð",
+      "codepoints": [
+        208
+      ],
+      "name": "&ETH;",
+      "semicolon": true
+    },
+    {
+      "characters": "É",
+      "codepoints": [
+        201
+      ],
+      "name": "&Eacute",
+      "semicolon": false
+    },
+    {
+      "characters": "É",
+      "codepoints": [
+        201
+      ],
+      "name": "&Eacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ě",
+      "codepoints": [
+        282
+      ],
+      "name": "&Ecaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ê",
+      "codepoints": [
+        202
+      ],
+      "name": "&Ecirc",
+      "semicolon": false
+    },
+    {
+      "characters": "Ê",
+      "codepoints": [
+        202
+      ],
+      "name": "&Ecirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "Э",
+      "codepoints": [
+        1069
+      ],
+      "name": "&Ecy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ė",
+      "codepoints": [
+        278
+      ],
+      "name": "&Edot;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔈",
+      "codepoints": [
+        120072
+      ],
+      "name": "&Efr;",
+      "semicolon": true
+    },
+    {
+      "characters": "È",
+      "codepoints": [
+        200
+      ],
+      "name": "&Egrave",
+      "semicolon": false
+    },
+    {
+      "characters": "È",
+      "codepoints": [
+        200
+      ],
+      "name": "&Egrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "∈",
+      "codepoints": [
+        8712
+      ],
+      "name": "&Element;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ē",
+      "codepoints": [
+        274
+      ],
+      "name": "&Emacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "◻",
+      "codepoints": [
+        9723
+      ],
+      "name": "&EmptySmallSquare;",
+      "semicolon": true
+    },
+    {
+      "characters": "▫",
+      "codepoints": [
+        9643
+      ],
+      "name": "&EmptyVerySmallSquare;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ę",
+      "codepoints": [
+        280
+      ],
+      "name": "&Eogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔼",
+      "codepoints": [
+        120124
+      ],
+      "name": "&Eopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ε",
+      "codepoints": [
+        917
+      ],
+      "name": "&Epsilon;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩵",
+      "codepoints": [
+        10869
+      ],
+      "name": "&Equal;",
+      "semicolon": true
+    },
+    {
+      "characters": "≂",
+      "codepoints": [
+        8770
+      ],
+      "name": "&EqualTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇌",
+      "codepoints": [
+        8652
+      ],
+      "name": "&Equilibrium;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℰ",
+      "codepoints": [
+        8496
+      ],
+      "name": "&Escr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩳",
+      "codepoints": [
+        10867
+      ],
+      "name": "&Esim;",
+      "semicolon": true
+    },
+    {
+      "characters": "Η",
+      "codepoints": [
+        919
+      ],
+      "name": "&Eta;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ë",
+      "codepoints": [
+        203
+      ],
+      "name": "&Euml",
+      "semicolon": false
+    },
+    {
+      "characters": "Ë",
+      "codepoints": [
+        203
+      ],
+      "name": "&Euml;",
+      "semicolon": true
+    },
+    {
+      "characters": "∃",
+      "codepoints": [
+        8707
+      ],
+      "name": "&Exists;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅇ",
+      "codepoints": [
+        8519
+      ],
+      "name": "&ExponentialE;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ф",
+      "codepoints": [
+        1060
+      ],
+      "name": "&Fcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔉",
+      "codepoints": [
+        120073
+      ],
+      "name": "&Ffr;",
+      "semicolon": true
+    },
+    {
+      "characters": "◼",
+      "codepoints": [
+        9724
+      ],
+      "name": "&FilledSmallSquare;",
+      "semicolon": true
+    },
+    {
+      "characters": "▪",
+      "codepoints": [
+        9642
+      ],
+      "name": "&FilledVerySmallSquare;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔽",
+      "codepoints": [
+        120125
+      ],
+      "name": "&Fopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "∀",
+      "codepoints": [
+        8704
+      ],
+      "name": "&ForAll;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℱ",
+      "codepoints": [
+        8497
+      ],
+      "name": "&Fouriertrf;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℱ",
+      "codepoints": [
+        8497
+      ],
+      "name": "&Fscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ѓ",
+      "codepoints": [
+        1027
+      ],
+      "name": "&GJcy;",
+      "semicolon": true
+    },
+    {
+      "characters": ">",
+      "codepoints": [
+        62
+      ],
+      "name": "&GT",
+      "semicolon": false
+    },
+    {
+      "characters": ">",
+      "codepoints": [
+        62
+      ],
+      "name": "&GT;",
+      "semicolon": true
+    },
+    {
+      "characters": "Γ",
+      "codepoints": [
+        915
+      ],
+      "name": "&Gamma;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ϝ",
+      "codepoints": [
+        988
+      ],
+      "name": "&Gammad;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ğ",
+      "codepoints": [
+        286
+      ],
+      "name": "&Gbreve;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ģ",
+      "codepoints": [
+        290
+      ],
+      "name": "&Gcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ĝ",
+      "codepoints": [
+        284
+      ],
+      "name": "&Gcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "Г",
+      "codepoints": [
+        1043
+      ],
+      "name": "&Gcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ġ",
+      "codepoints": [
+        288
+      ],
+      "name": "&Gdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔊",
+      "codepoints": [
+        120074
+      ],
+      "name": "&Gfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋙",
+      "codepoints": [
+        8921
+      ],
+      "name": "&Gg;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔾",
+      "codepoints": [
+        120126
+      ],
+      "name": "&Gopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "≥",
+      "codepoints": [
+        8805
+      ],
+      "name": "&GreaterEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋛",
+      "codepoints": [
+        8923
+      ],
+      "name": "&GreaterEqualLess;",
+      "semicolon": true
+    },
+    {
+      "characters": "≧",
+      "codepoints": [
+        8807
+      ],
+      "name": "&GreaterFullEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪢",
+      "codepoints": [
+        10914
+      ],
+      "name": "&GreaterGreater;",
+      "semicolon": true
+    },
+    {
+      "characters": "≷",
+      "codepoints": [
+        8823
+      ],
+      "name": "&GreaterLess;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩾",
+      "codepoints": [
+        10878
+      ],
+      "name": "&GreaterSlantEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≳",
+      "codepoints": [
+        8819
+      ],
+      "name": "&GreaterTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒢",
+      "codepoints": [
+        119970
+      ],
+      "name": "&Gscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≫",
+      "codepoints": [
+        8811
+      ],
+      "name": "&Gt;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ъ",
+      "codepoints": [
+        1066
+      ],
+      "name": "&HARDcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ˇ",
+      "codepoints": [
+        711
+      ],
+      "name": "&Hacek;",
+      "semicolon": true
+    },
+    {
+      "characters": "^",
+      "codepoints": [
+        94
+      ],
+      "name": "&Hat;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ĥ",
+      "codepoints": [
+        292
+      ],
+      "name": "&Hcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℌ",
+      "codepoints": [
+        8460
+      ],
+      "name": "&Hfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℋ",
+      "codepoints": [
+        8459
+      ],
+      "name": "&HilbertSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℍ",
+      "codepoints": [
+        8461
+      ],
+      "name": "&Hopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "─",
+      "codepoints": [
+        9472
+      ],
+      "name": "&HorizontalLine;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℋ",
+      "codepoints": [
+        8459
+      ],
+      "name": "&Hscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ħ",
+      "codepoints": [
+        294
+      ],
+      "name": "&Hstrok;",
+      "semicolon": true
+    },
+    {
+      "characters": "≎",
+      "codepoints": [
+        8782
+      ],
+      "name": "&HumpDownHump;",
+      "semicolon": true
+    },
+    {
+      "characters": "≏",
+      "codepoints": [
+        8783
+      ],
+      "name": "&HumpEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "Е",
+      "codepoints": [
+        1045
+      ],
+      "name": "&IEcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ĳ",
+      "codepoints": [
+        306
+      ],
+      "name": "&IJlig;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ё",
+      "codepoints": [
+        1025
+      ],
+      "name": "&IOcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Í",
+      "codepoints": [
+        205
+      ],
+      "name": "&Iacute",
+      "semicolon": false
+    },
+    {
+      "characters": "Í",
+      "codepoints": [
+        205
+      ],
+      "name": "&Iacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "Î",
+      "codepoints": [
+        206
+      ],
+      "name": "&Icirc",
+      "semicolon": false
+    },
+    {
+      "characters": "Î",
+      "codepoints": [
+        206
+      ],
+      "name": "&Icirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "И",
+      "codepoints": [
+        1048
+      ],
+      "name": "&Icy;",
+      "semicolon": true
+    },
+    {
+      "characters": "İ",
+      "codepoints": [
+        304
+      ],
+      "name": "&Idot;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℑ",
+      "codepoints": [
+        8465
+      ],
+      "name": "&Ifr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ì",
+      "codepoints": [
+        204
+      ],
+      "name": "&Igrave",
+      "semicolon": false
+    },
+    {
+      "characters": "Ì",
+      "codepoints": [
+        204
+      ],
+      "name": "&Igrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℑ",
+      "codepoints": [
+        8465
+      ],
+      "name": "&Im;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ī",
+      "codepoints": [
+        298
+      ],
+      "name": "&Imacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅈ",
+      "codepoints": [
+        8520
+      ],
+      "name": "&ImaginaryI;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇒",
+      "codepoints": [
+        8658
+      ],
+      "name": "&Implies;",
+      "semicolon": true
+    },
+    {
+      "characters": "∬",
+      "codepoints": [
+        8748
+      ],
+      "name": "&Int;",
+      "semicolon": true
+    },
+    {
+      "characters": "∫",
+      "codepoints": [
+        8747
+      ],
+      "name": "&Integral;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋂",
+      "codepoints": [
+        8898
+      ],
+      "name": "&Intersection;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁣",
+      "codepoints": [
+        8291
+      ],
+      "name": "&InvisibleComma;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁢",
+      "codepoints": [
+        8290
+      ],
+      "name": "&InvisibleTimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "Į",
+      "codepoints": [
+        302
+      ],
+      "name": "&Iogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕀",
+      "codepoints": [
+        120128
+      ],
+      "name": "&Iopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ι",
+      "codepoints": [
+        921
+      ],
+      "name": "&Iota;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℐ",
+      "codepoints": [
+        8464
+      ],
+      "name": "&Iscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ĩ",
+      "codepoints": [
+        296
+      ],
+      "name": "&Itilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "І",
+      "codepoints": [
+        1030
+      ],
+      "name": "&Iukcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ï",
+      "codepoints": [
+        207
+      ],
+      "name": "&Iuml",
+      "semicolon": false
+    },
+    {
+      "characters": "Ï",
+      "codepoints": [
+        207
+      ],
+      "name": "&Iuml;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ĵ",
+      "codepoints": [
+        308
+      ],
+      "name": "&Jcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "Й",
+      "codepoints": [
+        1049
+      ],
+      "name": "&Jcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔍",
+      "codepoints": [
+        120077
+      ],
+      "name": "&Jfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕁",
+      "codepoints": [
+        120129
+      ],
+      "name": "&Jopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒥",
+      "codepoints": [
+        119973
+      ],
+      "name": "&Jscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ј",
+      "codepoints": [
+        1032
+      ],
+      "name": "&Jsercy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Є",
+      "codepoints": [
+        1028
+      ],
+      "name": "&Jukcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Х",
+      "codepoints": [
+        1061
+      ],
+      "name": "&KHcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ќ",
+      "codepoints": [
+        1036
+      ],
+      "name": "&KJcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Κ",
+      "codepoints": [
+        922
+      ],
+      "name": "&Kappa;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ķ",
+      "codepoints": [
+        310
+      ],
+      "name": "&Kcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "К",
+      "codepoints": [
+        1050
+      ],
+      "name": "&Kcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔎",
+      "codepoints": [
+        120078
+      ],
+      "name": "&Kfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕂",
+      "codepoints": [
+        120130
+      ],
+      "name": "&Kopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒦",
+      "codepoints": [
+        119974
+      ],
+      "name": "&Kscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Љ",
+      "codepoints": [
+        1033
+      ],
+      "name": "&LJcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "<",
+      "codepoints": [
+        60
+      ],
+      "name": "&LT",
+      "semicolon": false
+    },
+    {
+      "characters": "<",
+      "codepoints": [
+        60
+      ],
+      "name": "&LT;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ĺ",
+      "codepoints": [
+        313
+      ],
+      "name": "&Lacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "Λ",
+      "codepoints": [
+        923
+      ],
+      "name": "&Lambda;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟪",
+      "codepoints": [
+        10218
+      ],
+      "name": "&Lang;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℒ",
+      "codepoints": [
+        8466
+      ],
+      "name": "&Laplacetrf;",
+      "semicolon": true
+    },
+    {
+      "characters": "↞",
+      "codepoints": [
+        8606
+      ],
+      "name": "&Larr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ľ",
+      "codepoints": [
+        317
+      ],
+      "name": "&Lcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ļ",
+      "codepoints": [
+        315
+      ],
+      "name": "&Lcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "Л",
+      "codepoints": [
+        1051
+      ],
+      "name": "&Lcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟨",
+      "codepoints": [
+        10216
+      ],
+      "name": "&LeftAngleBracket;",
+      "semicolon": true
+    },
+    {
+      "characters": "←",
+      "codepoints": [
+        8592
+      ],
+      "name": "&LeftArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇤",
+      "codepoints": [
+        8676
+      ],
+      "name": "&LeftArrowBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇆",
+      "codepoints": [
+        8646
+      ],
+      "name": "&LeftArrowRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌈",
+      "codepoints": [
+        8968
+      ],
+      "name": "&LeftCeiling;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟦",
+      "codepoints": [
+        10214
+      ],
+      "name": "&LeftDoubleBracket;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥡",
+      "codepoints": [
+        10593
+      ],
+      "name": "&LeftDownTeeVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇃",
+      "codepoints": [
+        8643
+      ],
+      "name": "&LeftDownVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥙",
+      "codepoints": [
+        10585
+      ],
+      "name": "&LeftDownVectorBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌊",
+      "codepoints": [
+        8970
+      ],
+      "name": "&LeftFloor;",
+      "semicolon": true
+    },
+    {
+      "characters": "↔",
+      "codepoints": [
+        8596
+      ],
+      "name": "&LeftRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥎",
+      "codepoints": [
+        10574
+      ],
+      "name": "&LeftRightVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊣",
+      "codepoints": [
+        8867
+      ],
+      "name": "&LeftTee;",
+      "semicolon": true
+    },
+    {
+      "characters": "↤",
+      "codepoints": [
+        8612
+      ],
+      "name": "&LeftTeeArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥚",
+      "codepoints": [
+        10586
+      ],
+      "name": "&LeftTeeVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊲",
+      "codepoints": [
+        8882
+      ],
+      "name": "&LeftTriangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧏",
+      "codepoints": [
+        10703
+      ],
+      "name": "&LeftTriangleBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊴",
+      "codepoints": [
+        8884
+      ],
+      "name": "&LeftTriangleEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥑",
+      "codepoints": [
+        10577
+      ],
+      "name": "&LeftUpDownVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥠",
+      "codepoints": [
+        10592
+      ],
+      "name": "&LeftUpTeeVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "↿",
+      "codepoints": [
+        8639
+      ],
+      "name": "&LeftUpVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥘",
+      "codepoints": [
+        10584
+      ],
+      "name": "&LeftUpVectorBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "↼",
+      "codepoints": [
+        8636
+      ],
+      "name": "&LeftVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥒",
+      "codepoints": [
+        10578
+      ],
+      "name": "&LeftVectorBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇐",
+      "codepoints": [
+        8656
+      ],
+      "name": "&Leftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇔",
+      "codepoints": [
+        8660
+      ],
+      "name": "&Leftrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋚",
+      "codepoints": [
+        8922
+      ],
+      "name": "&LessEqualGreater;",
+      "semicolon": true
+    },
+    {
+      "characters": "≦",
+      "codepoints": [
+        8806
+      ],
+      "name": "&LessFullEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≶",
+      "codepoints": [
+        8822
+      ],
+      "name": "&LessGreater;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪡",
+      "codepoints": [
+        10913
+      ],
+      "name": "&LessLess;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩽",
+      "codepoints": [
+        10877
+      ],
+      "name": "&LessSlantEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≲",
+      "codepoints": [
+        8818
+      ],
+      "name": "&LessTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔏",
+      "codepoints": [
+        120079
+      ],
+      "name": "&Lfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋘",
+      "codepoints": [
+        8920
+      ],
+      "name": "&Ll;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇚",
+      "codepoints": [
+        8666
+      ],
+      "name": "&Lleftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŀ",
+      "codepoints": [
+        319
+      ],
+      "name": "&Lmidot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟵",
+      "codepoints": [
+        10229
+      ],
+      "name": "&LongLeftArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟷",
+      "codepoints": [
+        10231
+      ],
+      "name": "&LongLeftRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟶",
+      "codepoints": [
+        10230
+      ],
+      "name": "&LongRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟸",
+      "codepoints": [
+        10232
+      ],
+      "name": "&Longleftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟺",
+      "codepoints": [
+        10234
+      ],
+      "name": "&Longleftrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟹",
+      "codepoints": [
+        10233
+      ],
+      "name": "&Longrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕃",
+      "codepoints": [
+        120131
+      ],
+      "name": "&Lopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "↙",
+      "codepoints": [
+        8601
+      ],
+      "name": "&LowerLeftArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↘",
+      "codepoints": [
+        8600
+      ],
+      "name": "&LowerRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℒ",
+      "codepoints": [
+        8466
+      ],
+      "name": "&Lscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↰",
+      "codepoints": [
+        8624
+      ],
+      "name": "&Lsh;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ł",
+      "codepoints": [
+        321
+      ],
+      "name": "&Lstrok;",
+      "semicolon": true
+    },
+    {
+      "characters": "≪",
+      "codepoints": [
+        8810
+      ],
+      "name": "&Lt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤅",
+      "codepoints": [
+        10501
+      ],
+      "name": "&Map;",
+      "semicolon": true
+    },
+    {
+      "characters": "М",
+      "codepoints": [
+        1052
+      ],
+      "name": "&Mcy;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8287
+      ],
+      "name": "&MediumSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℳ",
+      "codepoints": [
+        8499
+      ],
+      "name": "&Mellintrf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔐",
+      "codepoints": [
+        120080
+      ],
+      "name": "&Mfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∓",
+      "codepoints": [
+        8723
+      ],
+      "name": "&MinusPlus;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕄",
+      "codepoints": [
+        120132
+      ],
+      "name": "&Mopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℳ",
+      "codepoints": [
+        8499
+      ],
+      "name": "&Mscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Μ",
+      "codepoints": [
+        924
+      ],
+      "name": "&Mu;",
+      "semicolon": true
+    },
+    {
+      "characters": "Њ",
+      "codepoints": [
+        1034
+      ],
+      "name": "&NJcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ń",
+      "codepoints": [
+        323
+      ],
+      "name": "&Nacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ň",
+      "codepoints": [
+        327
+      ],
+      "name": "&Ncaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ņ",
+      "codepoints": [
+        325
+      ],
+      "name": "&Ncedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "Н",
+      "codepoints": [
+        1053
+      ],
+      "name": "&Ncy;",
+      "semicolon": true
+    },
+    {
+      "characters": "​",
+      "codepoints": [
+        8203
+      ],
+      "name": "&NegativeMediumSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "​",
+      "codepoints": [
+        8203
+      ],
+      "name": "&NegativeThickSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "​",
+      "codepoints": [
+        8203
+      ],
+      "name": "&NegativeThinSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "​",
+      "codepoints": [
+        8203
+      ],
+      "name": "&NegativeVeryThinSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "≫",
+      "codepoints": [
+        8811
+      ],
+      "name": "&NestedGreaterGreater;",
+      "semicolon": true
+    },
+    {
+      "characters": "≪",
+      "codepoints": [
+        8810
+      ],
+      "name": "&NestedLessLess;",
+      "semicolon": true
+    },
+    {
+      "characters": "\n",
+      "codepoints": [
+        10
+      ],
+      "name": "&NewLine;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔑",
+      "codepoints": [
+        120081
+      ],
+      "name": "&Nfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁠",
+      "codepoints": [
+        8288
+      ],
+      "name": "&NoBreak;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        160
+      ],
+      "name": "&NonBreakingSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℕ",
+      "codepoints": [
+        8469
+      ],
+      "name": "&Nopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫬",
+      "codepoints": [
+        10988
+      ],
+      "name": "&Not;",
+      "semicolon": true
+    },
+    {
+      "characters": "≢",
+      "codepoints": [
+        8802
+      ],
+      "name": "&NotCongruent;",
+      "semicolon": true
+    },
+    {
+      "characters": "≭",
+      "codepoints": [
+        8813
+      ],
+      "name": "&NotCupCap;",
+      "semicolon": true
+    },
+    {
+      "characters": "∦",
+      "codepoints": [
+        8742
+      ],
+      "name": "&NotDoubleVerticalBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "∉",
+      "codepoints": [
+        8713
+      ],
+      "name": "&NotElement;",
+      "semicolon": true
+    },
+    {
+      "characters": "≠",
+      "codepoints": [
+        8800
+      ],
+      "name": "&NotEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≂̸",
+      "codepoints": [
+        8770,
+        824
+      ],
+      "name": "&NotEqualTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "∄",
+      "codepoints": [
+        8708
+      ],
+      "name": "&NotExists;",
+      "semicolon": true
+    },
+    {
+      "characters": "≯",
+      "codepoints": [
+        8815
+      ],
+      "name": "&NotGreater;",
+      "semicolon": true
+    },
+    {
+      "characters": "≱",
+      "codepoints": [
+        8817
+      ],
+      "name": "&NotGreaterEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≧̸",
+      "codepoints": [
+        8807,
+        824
+      ],
+      "name": "&NotGreaterFullEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≫̸",
+      "codepoints": [
+        8811,
+        824
+      ],
+      "name": "&NotGreaterGreater;",
+      "semicolon": true
+    },
+    {
+      "characters": "≹",
+      "codepoints": [
+        8825
+      ],
+      "name": "&NotGreaterLess;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩾̸",
+      "codepoints": [
+        10878,
+        824
+      ],
+      "name": "&NotGreaterSlantEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≵",
+      "codepoints": [
+        8821
+      ],
+      "name": "&NotGreaterTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "≎̸",
+      "codepoints": [
+        8782,
+        824
+      ],
+      "name": "&NotHumpDownHump;",
+      "semicolon": true
+    },
+    {
+      "characters": "≏̸",
+      "codepoints": [
+        8783,
+        824
+      ],
+      "name": "&NotHumpEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋪",
+      "codepoints": [
+        8938
+      ],
+      "name": "&NotLeftTriangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧏̸",
+      "codepoints": [
+        10703,
+        824
+      ],
+      "name": "&NotLeftTriangleBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋬",
+      "codepoints": [
+        8940
+      ],
+      "name": "&NotLeftTriangleEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≮",
+      "codepoints": [
+        8814
+      ],
+      "name": "&NotLess;",
+      "semicolon": true
+    },
+    {
+      "characters": "≰",
+      "codepoints": [
+        8816
+      ],
+      "name": "&NotLessEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≸",
+      "codepoints": [
+        8824
+      ],
+      "name": "&NotLessGreater;",
+      "semicolon": true
+    },
+    {
+      "characters": "≪̸",
+      "codepoints": [
+        8810,
+        824
+      ],
+      "name": "&NotLessLess;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩽̸",
+      "codepoints": [
+        10877,
+        824
+      ],
+      "name": "&NotLessSlantEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≴",
+      "codepoints": [
+        8820
+      ],
+      "name": "&NotLessTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪢̸",
+      "codepoints": [
+        10914,
+        824
+      ],
+      "name": "&NotNestedGreaterGreater;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪡̸",
+      "codepoints": [
+        10913,
+        824
+      ],
+      "name": "&NotNestedLessLess;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊀",
+      "codepoints": [
+        8832
+      ],
+      "name": "&NotPrecedes;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪯̸",
+      "codepoints": [
+        10927,
+        824
+      ],
+      "name": "&NotPrecedesEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋠",
+      "codepoints": [
+        8928
+      ],
+      "name": "&NotPrecedesSlantEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "∌",
+      "codepoints": [
+        8716
+      ],
+      "name": "&NotReverseElement;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋫",
+      "codepoints": [
+        8939
+      ],
+      "name": "&NotRightTriangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧐̸",
+      "codepoints": [
+        10704,
+        824
+      ],
+      "name": "&NotRightTriangleBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋭",
+      "codepoints": [
+        8941
+      ],
+      "name": "&NotRightTriangleEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊏̸",
+      "codepoints": [
+        8847,
+        824
+      ],
+      "name": "&NotSquareSubset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋢",
+      "codepoints": [
+        8930
+      ],
+      "name": "&NotSquareSubsetEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊐̸",
+      "codepoints": [
+        8848,
+        824
+      ],
+      "name": "&NotSquareSuperset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋣",
+      "codepoints": [
+        8931
+      ],
+      "name": "&NotSquareSupersetEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊂⃒",
+      "codepoints": [
+        8834,
+        8402
+      ],
+      "name": "&NotSubset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊈",
+      "codepoints": [
+        8840
+      ],
+      "name": "&NotSubsetEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊁",
+      "codepoints": [
+        8833
+      ],
+      "name": "&NotSucceeds;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪰̸",
+      "codepoints": [
+        10928,
+        824
+      ],
+      "name": "&NotSucceedsEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋡",
+      "codepoints": [
+        8929
+      ],
+      "name": "&NotSucceedsSlantEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≿̸",
+      "codepoints": [
+        8831,
+        824
+      ],
+      "name": "&NotSucceedsTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊃⃒",
+      "codepoints": [
+        8835,
+        8402
+      ],
+      "name": "&NotSuperset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊉",
+      "codepoints": [
+        8841
+      ],
+      "name": "&NotSupersetEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≁",
+      "codepoints": [
+        8769
+      ],
+      "name": "&NotTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "≄",
+      "codepoints": [
+        8772
+      ],
+      "name": "&NotTildeEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≇",
+      "codepoints": [
+        8775
+      ],
+      "name": "&NotTildeFullEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≉",
+      "codepoints": [
+        8777
+      ],
+      "name": "&NotTildeTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "∤",
+      "codepoints": [
+        8740
+      ],
+      "name": "&NotVerticalBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒩",
+      "codepoints": [
+        119977
+      ],
+      "name": "&Nscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ñ",
+      "codepoints": [
+        209
+      ],
+      "name": "&Ntilde",
+      "semicolon": false
+    },
+    {
+      "characters": "Ñ",
+      "codepoints": [
+        209
+      ],
+      "name": "&Ntilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ν",
+      "codepoints": [
+        925
+      ],
+      "name": "&Nu;",
+      "semicolon": true
+    },
+    {
+      "characters": "Œ",
+      "codepoints": [
+        338
+      ],
+      "name": "&OElig;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ó",
+      "codepoints": [
+        211
+      ],
+      "name": "&Oacute",
+      "semicolon": false
+    },
+    {
+      "characters": "Ó",
+      "codepoints": [
+        211
+      ],
+      "name": "&Oacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ô",
+      "codepoints": [
+        212
+      ],
+      "name": "&Ocirc",
+      "semicolon": false
+    },
+    {
+      "characters": "Ô",
+      "codepoints": [
+        212
+      ],
+      "name": "&Ocirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "О",
+      "codepoints": [
+        1054
+      ],
+      "name": "&Ocy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ő",
+      "codepoints": [
+        336
+      ],
+      "name": "&Odblac;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔒",
+      "codepoints": [
+        120082
+      ],
+      "name": "&Ofr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ò",
+      "codepoints": [
+        210
+      ],
+      "name": "&Ograve",
+      "semicolon": false
+    },
+    {
+      "characters": "Ò",
+      "codepoints": [
+        210
+      ],
+      "name": "&Ograve;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ō",
+      "codepoints": [
+        332
+      ],
+      "name": "&Omacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ω",
+      "codepoints": [
+        937
+      ],
+      "name": "&Omega;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ο",
+      "codepoints": [
+        927
+      ],
+      "name": "&Omicron;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕆",
+      "codepoints": [
+        120134
+      ],
+      "name": "&Oopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "“",
+      "codepoints": [
+        8220
+      ],
+      "name": "&OpenCurlyDoubleQuote;",
+      "semicolon": true
+    },
+    {
+      "characters": "‘",
+      "codepoints": [
+        8216
+      ],
+      "name": "&OpenCurlyQuote;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩔",
+      "codepoints": [
+        10836
+      ],
+      "name": "&Or;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒪",
+      "codepoints": [
+        119978
+      ],
+      "name": "&Oscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ø",
+      "codepoints": [
+        216
+      ],
+      "name": "&Oslash",
+      "semicolon": false
+    },
+    {
+      "characters": "Ø",
+      "codepoints": [
+        216
+      ],
+      "name": "&Oslash;",
+      "semicolon": true
+    },
+    {
+      "characters": "Õ",
+      "codepoints": [
+        213
+      ],
+      "name": "&Otilde",
+      "semicolon": false
+    },
+    {
+      "characters": "Õ",
+      "codepoints": [
+        213
+      ],
+      "name": "&Otilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨷",
+      "codepoints": [
+        10807
+      ],
+      "name": "&Otimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ö",
+      "codepoints": [
+        214
+      ],
+      "name": "&Ouml",
+      "semicolon": false
+    },
+    {
+      "characters": "Ö",
+      "codepoints": [
+        214
+      ],
+      "name": "&Ouml;",
+      "semicolon": true
+    },
+    {
+      "characters": "‾",
+      "codepoints": [
+        8254
+      ],
+      "name": "&OverBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⏞",
+      "codepoints": [
+        9182
+      ],
+      "name": "&OverBrace;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎴",
+      "codepoints": [
+        9140
+      ],
+      "name": "&OverBracket;",
+      "semicolon": true
+    },
+    {
+      "characters": "⏜",
+      "codepoints": [
+        9180
+      ],
+      "name": "&OverParenthesis;",
+      "semicolon": true
+    },
+    {
+      "characters": "∂",
+      "codepoints": [
+        8706
+      ],
+      "name": "&PartialD;",
+      "semicolon": true
+    },
+    {
+      "characters": "П",
+      "codepoints": [
+        1055
+      ],
+      "name": "&Pcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔓",
+      "codepoints": [
+        120083
+      ],
+      "name": "&Pfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Φ",
+      "codepoints": [
+        934
+      ],
+      "name": "&Phi;",
+      "semicolon": true
+    },
+    {
+      "characters": "Π",
+      "codepoints": [
+        928
+      ],
+      "name": "&Pi;",
+      "semicolon": true
+    },
+    {
+      "characters": "±",
+      "codepoints": [
+        177
+      ],
+      "name": "&PlusMinus;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℌ",
+      "codepoints": [
+        8460
+      ],
+      "name": "&Poincareplane;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℙ",
+      "codepoints": [
+        8473
+      ],
+      "name": "&Popf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪻",
+      "codepoints": [
+        10939
+      ],
+      "name": "&Pr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≺",
+      "codepoints": [
+        8826
+      ],
+      "name": "&Precedes;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪯",
+      "codepoints": [
+        10927
+      ],
+      "name": "&PrecedesEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≼",
+      "codepoints": [
+        8828
+      ],
+      "name": "&PrecedesSlantEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≾",
+      "codepoints": [
+        8830
+      ],
+      "name": "&PrecedesTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "″",
+      "codepoints": [
+        8243
+      ],
+      "name": "&Prime;",
+      "semicolon": true
+    },
+    {
+      "characters": "∏",
+      "codepoints": [
+        8719
+      ],
+      "name": "&Product;",
+      "semicolon": true
+    },
+    {
+      "characters": "∷",
+      "codepoints": [
+        8759
+      ],
+      "name": "&Proportion;",
+      "semicolon": true
+    },
+    {
+      "characters": "∝",
+      "codepoints": [
+        8733
+      ],
+      "name": "&Proportional;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒫",
+      "codepoints": [
+        119979
+      ],
+      "name": "&Pscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ψ",
+      "codepoints": [
+        936
+      ],
+      "name": "&Psi;",
+      "semicolon": true
+    },
+    {
+      "characters": "\"",
+      "codepoints": [
+        34
+      ],
+      "name": "&QUOT",
+      "semicolon": false
+    },
+    {
+      "characters": "\"",
+      "codepoints": [
+        34
+      ],
+      "name": "&QUOT;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔔",
+      "codepoints": [
+        120084
+      ],
+      "name": "&Qfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℚ",
+      "codepoints": [
+        8474
+      ],
+      "name": "&Qopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒬",
+      "codepoints": [
+        119980
+      ],
+      "name": "&Qscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤐",
+      "codepoints": [
+        10512
+      ],
+      "name": "&RBarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "®",
+      "codepoints": [
+        174
+      ],
+      "name": "&REG",
+      "semicolon": false
+    },
+    {
+      "characters": "®",
+      "codepoints": [
+        174
+      ],
+      "name": "&REG;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŕ",
+      "codepoints": [
+        340
+      ],
+      "name": "&Racute;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟫",
+      "codepoints": [
+        10219
+      ],
+      "name": "&Rang;",
+      "semicolon": true
+    },
+    {
+      "characters": "↠",
+      "codepoints": [
+        8608
+      ],
+      "name": "&Rarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤖",
+      "codepoints": [
+        10518
+      ],
+      "name": "&Rarrtl;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ř",
+      "codepoints": [
+        344
+      ],
+      "name": "&Rcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŗ",
+      "codepoints": [
+        342
+      ],
+      "name": "&Rcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "Р",
+      "codepoints": [
+        1056
+      ],
+      "name": "&Rcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℜ",
+      "codepoints": [
+        8476
+      ],
+      "name": "&Re;",
+      "semicolon": true
+    },
+    {
+      "characters": "∋",
+      "codepoints": [
+        8715
+      ],
+      "name": "&ReverseElement;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇋",
+      "codepoints": [
+        8651
+      ],
+      "name": "&ReverseEquilibrium;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥯",
+      "codepoints": [
+        10607
+      ],
+      "name": "&ReverseUpEquilibrium;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℜ",
+      "codepoints": [
+        8476
+      ],
+      "name": "&Rfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ρ",
+      "codepoints": [
+        929
+      ],
+      "name": "&Rho;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟩",
+      "codepoints": [
+        10217
+      ],
+      "name": "&RightAngleBracket;",
+      "semicolon": true
+    },
+    {
+      "characters": "→",
+      "codepoints": [
+        8594
+      ],
+      "name": "&RightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇥",
+      "codepoints": [
+        8677
+      ],
+      "name": "&RightArrowBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇄",
+      "codepoints": [
+        8644
+      ],
+      "name": "&RightArrowLeftArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌉",
+      "codepoints": [
+        8969
+      ],
+      "name": "&RightCeiling;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟧",
+      "codepoints": [
+        10215
+      ],
+      "name": "&RightDoubleBracket;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥝",
+      "codepoints": [
+        10589
+      ],
+      "name": "&RightDownTeeVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇂",
+      "codepoints": [
+        8642
+      ],
+      "name": "&RightDownVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥕",
+      "codepoints": [
+        10581
+      ],
+      "name": "&RightDownVectorBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌋",
+      "codepoints": [
+        8971
+      ],
+      "name": "&RightFloor;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊢",
+      "codepoints": [
+        8866
+      ],
+      "name": "&RightTee;",
+      "semicolon": true
+    },
+    {
+      "characters": "↦",
+      "codepoints": [
+        8614
+      ],
+      "name": "&RightTeeArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥛",
+      "codepoints": [
+        10587
+      ],
+      "name": "&RightTeeVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊳",
+      "codepoints": [
+        8883
+      ],
+      "name": "&RightTriangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧐",
+      "codepoints": [
+        10704
+      ],
+      "name": "&RightTriangleBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊵",
+      "codepoints": [
+        8885
+      ],
+      "name": "&RightTriangleEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥏",
+      "codepoints": [
+        10575
+      ],
+      "name": "&RightUpDownVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥜",
+      "codepoints": [
+        10588
+      ],
+      "name": "&RightUpTeeVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "↾",
+      "codepoints": [
+        8638
+      ],
+      "name": "&RightUpVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥔",
+      "codepoints": [
+        10580
+      ],
+      "name": "&RightUpVectorBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇀",
+      "codepoints": [
+        8640
+      ],
+      "name": "&RightVector;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥓",
+      "codepoints": [
+        10579
+      ],
+      "name": "&RightVectorBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇒",
+      "codepoints": [
+        8658
+      ],
+      "name": "&Rightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℝ",
+      "codepoints": [
+        8477
+      ],
+      "name": "&Ropf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥰",
+      "codepoints": [
+        10608
+      ],
+      "name": "&RoundImplies;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇛",
+      "codepoints": [
+        8667
+      ],
+      "name": "&Rrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℛ",
+      "codepoints": [
+        8475
+      ],
+      "name": "&Rscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↱",
+      "codepoints": [
+        8625
+      ],
+      "name": "&Rsh;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧴",
+      "codepoints": [
+        10740
+      ],
+      "name": "&RuleDelayed;",
+      "semicolon": true
+    },
+    {
+      "characters": "Щ",
+      "codepoints": [
+        1065
+      ],
+      "name": "&SHCHcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ш",
+      "codepoints": [
+        1064
+      ],
+      "name": "&SHcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ь",
+      "codepoints": [
+        1068
+      ],
+      "name": "&SOFTcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ś",
+      "codepoints": [
+        346
+      ],
+      "name": "&Sacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪼",
+      "codepoints": [
+        10940
+      ],
+      "name": "&Sc;",
+      "semicolon": true
+    },
+    {
+      "characters": "Š",
+      "codepoints": [
+        352
+      ],
+      "name": "&Scaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ş",
+      "codepoints": [
+        350
+      ],
+      "name": "&Scedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŝ",
+      "codepoints": [
+        348
+      ],
+      "name": "&Scirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "С",
+      "codepoints": [
+        1057
+      ],
+      "name": "&Scy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔖",
+      "codepoints": [
+        120086
+      ],
+      "name": "&Sfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↓",
+      "codepoints": [
+        8595
+      ],
+      "name": "&ShortDownArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "←",
+      "codepoints": [
+        8592
+      ],
+      "name": "&ShortLeftArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "→",
+      "codepoints": [
+        8594
+      ],
+      "name": "&ShortRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↑",
+      "codepoints": [
+        8593
+      ],
+      "name": "&ShortUpArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "Σ",
+      "codepoints": [
+        931
+      ],
+      "name": "&Sigma;",
+      "semicolon": true
+    },
+    {
+      "characters": "∘",
+      "codepoints": [
+        8728
+      ],
+      "name": "&SmallCircle;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕊",
+      "codepoints": [
+        120138
+      ],
+      "name": "&Sopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "√",
+      "codepoints": [
+        8730
+      ],
+      "name": "&Sqrt;",
+      "semicolon": true
+    },
+    {
+      "characters": "□",
+      "codepoints": [
+        9633
+      ],
+      "name": "&Square;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊓",
+      "codepoints": [
+        8851
+      ],
+      "name": "&SquareIntersection;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊏",
+      "codepoints": [
+        8847
+      ],
+      "name": "&SquareSubset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊑",
+      "codepoints": [
+        8849
+      ],
+      "name": "&SquareSubsetEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊐",
+      "codepoints": [
+        8848
+      ],
+      "name": "&SquareSuperset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊒",
+      "codepoints": [
+        8850
+      ],
+      "name": "&SquareSupersetEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊔",
+      "codepoints": [
+        8852
+      ],
+      "name": "&SquareUnion;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒮",
+      "codepoints": [
+        119982
+      ],
+      "name": "&Sscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋆",
+      "codepoints": [
+        8902
+      ],
+      "name": "&Star;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋐",
+      "codepoints": [
+        8912
+      ],
+      "name": "&Sub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋐",
+      "codepoints": [
+        8912
+      ],
+      "name": "&Subset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊆",
+      "codepoints": [
+        8838
+      ],
+      "name": "&SubsetEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≻",
+      "codepoints": [
+        8827
+      ],
+      "name": "&Succeeds;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪰",
+      "codepoints": [
+        10928
+      ],
+      "name": "&SucceedsEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≽",
+      "codepoints": [
+        8829
+      ],
+      "name": "&SucceedsSlantEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≿",
+      "codepoints": [
+        8831
+      ],
+      "name": "&SucceedsTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "∋",
+      "codepoints": [
+        8715
+      ],
+      "name": "&SuchThat;",
+      "semicolon": true
+    },
+    {
+      "characters": "∑",
+      "codepoints": [
+        8721
+      ],
+      "name": "&Sum;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋑",
+      "codepoints": [
+        8913
+      ],
+      "name": "&Sup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊃",
+      "codepoints": [
+        8835
+      ],
+      "name": "&Superset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊇",
+      "codepoints": [
+        8839
+      ],
+      "name": "&SupersetEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋑",
+      "codepoints": [
+        8913
+      ],
+      "name": "&Supset;",
+      "semicolon": true
+    },
+    {
+      "characters": "Þ",
+      "codepoints": [
+        222
+      ],
+      "name": "&THORN",
+      "semicolon": false
+    },
+    {
+      "characters": "Þ",
+      "codepoints": [
+        222
+      ],
+      "name": "&THORN;",
+      "semicolon": true
+    },
+    {
+      "characters": "™",
+      "codepoints": [
+        8482
+      ],
+      "name": "&TRADE;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ћ",
+      "codepoints": [
+        1035
+      ],
+      "name": "&TSHcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ц",
+      "codepoints": [
+        1062
+      ],
+      "name": "&TScy;",
+      "semicolon": true
+    },
+    {
+      "characters": "\t",
+      "codepoints": [
+        9
+      ],
+      "name": "&Tab;",
+      "semicolon": true
+    },
+    {
+      "characters": "Τ",
+      "codepoints": [
+        932
+      ],
+      "name": "&Tau;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ť",
+      "codepoints": [
+        356
+      ],
+      "name": "&Tcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ţ",
+      "codepoints": [
+        354
+      ],
+      "name": "&Tcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "Т",
+      "codepoints": [
+        1058
+      ],
+      "name": "&Tcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔗",
+      "codepoints": [
+        120087
+      ],
+      "name": "&Tfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∴",
+      "codepoints": [
+        8756
+      ],
+      "name": "&Therefore;",
+      "semicolon": true
+    },
+    {
+      "characters": "Θ",
+      "codepoints": [
+        920
+      ],
+      "name": "&Theta;",
+      "semicolon": true
+    },
+    {
+      "characters": "  ",
+      "codepoints": [
+        8287,
+        8202
+      ],
+      "name": "&ThickSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8201
+      ],
+      "name": "&ThinSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "∼",
+      "codepoints": [
+        8764
+      ],
+      "name": "&Tilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "≃",
+      "codepoints": [
+        8771
+      ],
+      "name": "&TildeEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≅",
+      "codepoints": [
+        8773
+      ],
+      "name": "&TildeFullEqual;",
+      "semicolon": true
+    },
+    {
+      "characters": "≈",
+      "codepoints": [
+        8776
+      ],
+      "name": "&TildeTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕋",
+      "codepoints": [
+        120139
+      ],
+      "name": "&Topf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⃛",
+      "codepoints": [
+        8411
+      ],
+      "name": "&TripleDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒯",
+      "codepoints": [
+        119983
+      ],
+      "name": "&Tscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŧ",
+      "codepoints": [
+        358
+      ],
+      "name": "&Tstrok;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ú",
+      "codepoints": [
+        218
+      ],
+      "name": "&Uacute",
+      "semicolon": false
+    },
+    {
+      "characters": "Ú",
+      "codepoints": [
+        218
+      ],
+      "name": "&Uacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "↟",
+      "codepoints": [
+        8607
+      ],
+      "name": "&Uarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥉",
+      "codepoints": [
+        10569
+      ],
+      "name": "&Uarrocir;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ў",
+      "codepoints": [
+        1038
+      ],
+      "name": "&Ubrcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŭ",
+      "codepoints": [
+        364
+      ],
+      "name": "&Ubreve;",
+      "semicolon": true
+    },
+    {
+      "characters": "Û",
+      "codepoints": [
+        219
+      ],
+      "name": "&Ucirc",
+      "semicolon": false
+    },
+    {
+      "characters": "Û",
+      "codepoints": [
+        219
+      ],
+      "name": "&Ucirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "У",
+      "codepoints": [
+        1059
+      ],
+      "name": "&Ucy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ű",
+      "codepoints": [
+        368
+      ],
+      "name": "&Udblac;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔘",
+      "codepoints": [
+        120088
+      ],
+      "name": "&Ufr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ù",
+      "codepoints": [
+        217
+      ],
+      "name": "&Ugrave",
+      "semicolon": false
+    },
+    {
+      "characters": "Ù",
+      "codepoints": [
+        217
+      ],
+      "name": "&Ugrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ū",
+      "codepoints": [
+        362
+      ],
+      "name": "&Umacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "_",
+      "codepoints": [
+        95
+      ],
+      "name": "&UnderBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⏟",
+      "codepoints": [
+        9183
+      ],
+      "name": "&UnderBrace;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎵",
+      "codepoints": [
+        9141
+      ],
+      "name": "&UnderBracket;",
+      "semicolon": true
+    },
+    {
+      "characters": "⏝",
+      "codepoints": [
+        9181
+      ],
+      "name": "&UnderParenthesis;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋃",
+      "codepoints": [
+        8899
+      ],
+      "name": "&Union;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊎",
+      "codepoints": [
+        8846
+      ],
+      "name": "&UnionPlus;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ų",
+      "codepoints": [
+        370
+      ],
+      "name": "&Uogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕌",
+      "codepoints": [
+        120140
+      ],
+      "name": "&Uopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "↑",
+      "codepoints": [
+        8593
+      ],
+      "name": "&UpArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤒",
+      "codepoints": [
+        10514
+      ],
+      "name": "&UpArrowBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇅",
+      "codepoints": [
+        8645
+      ],
+      "name": "&UpArrowDownArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↕",
+      "codepoints": [
+        8597
+      ],
+      "name": "&UpDownArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥮",
+      "codepoints": [
+        10606
+      ],
+      "name": "&UpEquilibrium;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊥",
+      "codepoints": [
+        8869
+      ],
+      "name": "&UpTee;",
+      "semicolon": true
+    },
+    {
+      "characters": "↥",
+      "codepoints": [
+        8613
+      ],
+      "name": "&UpTeeArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇑",
+      "codepoints": [
+        8657
+      ],
+      "name": "&Uparrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇕",
+      "codepoints": [
+        8661
+      ],
+      "name": "&Updownarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↖",
+      "codepoints": [
+        8598
+      ],
+      "name": "&UpperLeftArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↗",
+      "codepoints": [
+        8599
+      ],
+      "name": "&UpperRightArrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϒ",
+      "codepoints": [
+        978
+      ],
+      "name": "&Upsi;",
+      "semicolon": true
+    },
+    {
+      "characters": "Υ",
+      "codepoints": [
+        933
+      ],
+      "name": "&Upsilon;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ů",
+      "codepoints": [
+        366
+      ],
+      "name": "&Uring;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒰",
+      "codepoints": [
+        119984
+      ],
+      "name": "&Uscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ũ",
+      "codepoints": [
+        360
+      ],
+      "name": "&Utilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ü",
+      "codepoints": [
+        220
+      ],
+      "name": "&Uuml",
+      "semicolon": false
+    },
+    {
+      "characters": "Ü",
+      "codepoints": [
+        220
+      ],
+      "name": "&Uuml;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊫",
+      "codepoints": [
+        8875
+      ],
+      "name": "&VDash;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫫",
+      "codepoints": [
+        10987
+      ],
+      "name": "&Vbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "В",
+      "codepoints": [
+        1042
+      ],
+      "name": "&Vcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊩",
+      "codepoints": [
+        8873
+      ],
+      "name": "&Vdash;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫦",
+      "codepoints": [
+        10982
+      ],
+      "name": "&Vdashl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋁",
+      "codepoints": [
+        8897
+      ],
+      "name": "&Vee;",
+      "semicolon": true
+    },
+    {
+      "characters": "‖",
+      "codepoints": [
+        8214
+      ],
+      "name": "&Verbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "‖",
+      "codepoints": [
+        8214
+      ],
+      "name": "&Vert;",
+      "semicolon": true
+    },
+    {
+      "characters": "∣",
+      "codepoints": [
+        8739
+      ],
+      "name": "&VerticalBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "|",
+      "codepoints": [
+        124
+      ],
+      "name": "&VerticalLine;",
+      "semicolon": true
+    },
+    {
+      "characters": "❘",
+      "codepoints": [
+        10072
+      ],
+      "name": "&VerticalSeparator;",
+      "semicolon": true
+    },
+    {
+      "characters": "≀",
+      "codepoints": [
+        8768
+      ],
+      "name": "&VerticalTilde;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8202
+      ],
+      "name": "&VeryThinSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔙",
+      "codepoints": [
+        120089
+      ],
+      "name": "&Vfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕍",
+      "codepoints": [
+        120141
+      ],
+      "name": "&Vopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒱",
+      "codepoints": [
+        119985
+      ],
+      "name": "&Vscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊪",
+      "codepoints": [
+        8874
+      ],
+      "name": "&Vvdash;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŵ",
+      "codepoints": [
+        372
+      ],
+      "name": "&Wcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋀",
+      "codepoints": [
+        8896
+      ],
+      "name": "&Wedge;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔚",
+      "codepoints": [
+        120090
+      ],
+      "name": "&Wfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕎",
+      "codepoints": [
+        120142
+      ],
+      "name": "&Wopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒲",
+      "codepoints": [
+        119986
+      ],
+      "name": "&Wscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔛",
+      "codepoints": [
+        120091
+      ],
+      "name": "&Xfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ξ",
+      "codepoints": [
+        926
+      ],
+      "name": "&Xi;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕏",
+      "codepoints": [
+        120143
+      ],
+      "name": "&Xopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒳",
+      "codepoints": [
+        119987
+      ],
+      "name": "&Xscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Я",
+      "codepoints": [
+        1071
+      ],
+      "name": "&YAcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ї",
+      "codepoints": [
+        1031
+      ],
+      "name": "&YIcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ю",
+      "codepoints": [
+        1070
+      ],
+      "name": "&YUcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ý",
+      "codepoints": [
+        221
+      ],
+      "name": "&Yacute",
+      "semicolon": false
+    },
+    {
+      "characters": "Ý",
+      "codepoints": [
+        221
+      ],
+      "name": "&Yacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ŷ",
+      "codepoints": [
+        374
+      ],
+      "name": "&Ycirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ы",
+      "codepoints": [
+        1067
+      ],
+      "name": "&Ycy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔜",
+      "codepoints": [
+        120092
+      ],
+      "name": "&Yfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕐",
+      "codepoints": [
+        120144
+      ],
+      "name": "&Yopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒴",
+      "codepoints": [
+        119988
+      ],
+      "name": "&Yscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ÿ",
+      "codepoints": [
+        376
+      ],
+      "name": "&Yuml;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ж",
+      "codepoints": [
+        1046
+      ],
+      "name": "&ZHcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ź",
+      "codepoints": [
+        377
+      ],
+      "name": "&Zacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ž",
+      "codepoints": [
+        381
+      ],
+      "name": "&Zcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "З",
+      "codepoints": [
+        1047
+      ],
+      "name": "&Zcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ż",
+      "codepoints": [
+        379
+      ],
+      "name": "&Zdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "​",
+      "codepoints": [
+        8203
+      ],
+      "name": "&ZeroWidthSpace;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ζ",
+      "codepoints": [
+        918
+      ],
+      "name": "&Zeta;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℨ",
+      "codepoints": [
+        8488
+      ],
+      "name": "&Zfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℤ",
+      "codepoints": [
+        8484
+      ],
+      "name": "&Zopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒵",
+      "codepoints": [
+        119989
+      ],
+      "name": "&Zscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "á",
+      "codepoints": [
+        225
+      ],
+      "name": "&aacute",
+      "semicolon": false
+    },
+    {
+      "characters": "á",
+      "codepoints": [
+        225
+      ],
+      "name": "&aacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "ă",
+      "codepoints": [
+        259
+      ],
+      "name": "&abreve;",
+      "semicolon": true
+    },
+    {
+      "characters": "∾",
+      "codepoints": [
+        8766
+      ],
+      "name": "&ac;",
+      "semicolon": true
+    },
+    {
+      "characters": "∾̳",
+      "codepoints": [
+        8766,
+        819
+      ],
+      "name": "&acE;",
+      "semicolon": true
+    },
+    {
+      "characters": "∿",
+      "codepoints": [
+        8767
+      ],
+      "name": "&acd;",
+      "semicolon": true
+    },
+    {
+      "characters": "â",
+      "codepoints": [
+        226
+      ],
+      "name": "&acirc",
+      "semicolon": false
+    },
+    {
+      "characters": "â",
+      "codepoints": [
+        226
+      ],
+      "name": "&acirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "´",
+      "codepoints": [
+        180
+      ],
+      "name": "&acute",
+      "semicolon": false
+    },
+    {
+      "characters": "´",
+      "codepoints": [
+        180
+      ],
+      "name": "&acute;",
+      "semicolon": true
+    },
+    {
+      "characters": "а",
+      "codepoints": [
+        1072
+      ],
+      "name": "&acy;",
+      "semicolon": true
+    },
+    {
+      "characters": "æ",
+      "codepoints": [
+        230
+      ],
+      "name": "&aelig",
+      "semicolon": false
+    },
+    {
+      "characters": "æ",
+      "codepoints": [
+        230
+      ],
+      "name": "&aelig;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁡",
+      "codepoints": [
+        8289
+      ],
+      "name": "&af;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔞",
+      "codepoints": [
+        120094
+      ],
+      "name": "&afr;",
+      "semicolon": true
+    },
+    {
+      "characters": "à",
+      "codepoints": [
+        224
+      ],
+      "name": "&agrave",
+      "semicolon": false
+    },
+    {
+      "characters": "à",
+      "codepoints": [
+        224
+      ],
+      "name": "&agrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℵ",
+      "codepoints": [
+        8501
+      ],
+      "name": "&alefsym;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℵ",
+      "codepoints": [
+        8501
+      ],
+      "name": "&aleph;",
+      "semicolon": true
+    },
+    {
+      "characters": "α",
+      "codepoints": [
+        945
+      ],
+      "name": "&alpha;",
+      "semicolon": true
+    },
+    {
+      "characters": "ā",
+      "codepoints": [
+        257
+      ],
+      "name": "&amacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨿",
+      "codepoints": [
+        10815
+      ],
+      "name": "&amalg;",
+      "semicolon": true
+    },
+    {
+      "characters": "&",
+      "codepoints": [
+        38
+      ],
+      "name": "&amp",
+      "semicolon": false
+    },
+    {
+      "characters": "&",
+      "codepoints": [
+        38
+      ],
+      "name": "&amp;",
+      "semicolon": true
+    },
+    {
+      "characters": "∧",
+      "codepoints": [
+        8743
+      ],
+      "name": "&and;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩕",
+      "codepoints": [
+        10837
+      ],
+      "name": "&andand;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩜",
+      "codepoints": [
+        10844
+      ],
+      "name": "&andd;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩘",
+      "codepoints": [
+        10840
+      ],
+      "name": "&andslope;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩚",
+      "codepoints": [
+        10842
+      ],
+      "name": "&andv;",
+      "semicolon": true
+    },
+    {
+      "characters": "∠",
+      "codepoints": [
+        8736
+      ],
+      "name": "&ang;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦤",
+      "codepoints": [
+        10660
+      ],
+      "name": "&ange;",
+      "semicolon": true
+    },
+    {
+      "characters": "∠",
+      "codepoints": [
+        8736
+      ],
+      "name": "&angle;",
+      "semicolon": true
+    },
+    {
+      "characters": "∡",
+      "codepoints": [
+        8737
+      ],
+      "name": "&angmsd;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦨",
+      "codepoints": [
+        10664
+      ],
+      "name": "&angmsdaa;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦩",
+      "codepoints": [
+        10665
+      ],
+      "name": "&angmsdab;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦪",
+      "codepoints": [
+        10666
+      ],
+      "name": "&angmsdac;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦫",
+      "codepoints": [
+        10667
+      ],
+      "name": "&angmsdad;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦬",
+      "codepoints": [
+        10668
+      ],
+      "name": "&angmsdae;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦭",
+      "codepoints": [
+        10669
+      ],
+      "name": "&angmsdaf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦮",
+      "codepoints": [
+        10670
+      ],
+      "name": "&angmsdag;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦯",
+      "codepoints": [
+        10671
+      ],
+      "name": "&angmsdah;",
+      "semicolon": true
+    },
+    {
+      "characters": "∟",
+      "codepoints": [
+        8735
+      ],
+      "name": "&angrt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊾",
+      "codepoints": [
+        8894
+      ],
+      "name": "&angrtvb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦝",
+      "codepoints": [
+        10653
+      ],
+      "name": "&angrtvbd;",
+      "semicolon": true
+    },
+    {
+      "characters": "∢",
+      "codepoints": [
+        8738
+      ],
+      "name": "&angsph;",
+      "semicolon": true
+    },
+    {
+      "characters": "Å",
+      "codepoints": [
+        197
+      ],
+      "name": "&angst;",
+      "semicolon": true
+    },
+    {
+      "characters": "⍼",
+      "codepoints": [
+        9084
+      ],
+      "name": "&angzarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ą",
+      "codepoints": [
+        261
+      ],
+      "name": "&aogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕒",
+      "codepoints": [
+        120146
+      ],
+      "name": "&aopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "≈",
+      "codepoints": [
+        8776
+      ],
+      "name": "&ap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩰",
+      "codepoints": [
+        10864
+      ],
+      "name": "&apE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩯",
+      "codepoints": [
+        10863
+      ],
+      "name": "&apacir;",
+      "semicolon": true
+    },
+    {
+      "characters": "≊",
+      "codepoints": [
+        8778
+      ],
+      "name": "&ape;",
+      "semicolon": true
+    },
+    {
+      "characters": "≋",
+      "codepoints": [
+        8779
+      ],
+      "name": "&apid;",
+      "semicolon": true
+    },
+    {
+      "characters": "'",
+      "codepoints": [
+        39
+      ],
+      "name": "&apos;",
+      "semicolon": true
+    },
+    {
+      "characters": "≈",
+      "codepoints": [
+        8776
+      ],
+      "name": "&approx;",
+      "semicolon": true
+    },
+    {
+      "characters": "≊",
+      "codepoints": [
+        8778
+      ],
+      "name": "&approxeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "å",
+      "codepoints": [
+        229
+      ],
+      "name": "&aring",
+      "semicolon": false
+    },
+    {
+      "characters": "å",
+      "codepoints": [
+        229
+      ],
+      "name": "&aring;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒶",
+      "codepoints": [
+        119990
+      ],
+      "name": "&ascr;",
+      "semicolon": true
+    },
+    {
+      "characters": "*",
+      "codepoints": [
+        42
+      ],
+      "name": "&ast;",
+      "semicolon": true
+    },
+    {
+      "characters": "≈",
+      "codepoints": [
+        8776
+      ],
+      "name": "&asymp;",
+      "semicolon": true
+    },
+    {
+      "characters": "≍",
+      "codepoints": [
+        8781
+      ],
+      "name": "&asympeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "ã",
+      "codepoints": [
+        227
+      ],
+      "name": "&atilde",
+      "semicolon": false
+    },
+    {
+      "characters": "ã",
+      "codepoints": [
+        227
+      ],
+      "name": "&atilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "ä",
+      "codepoints": [
+        228
+      ],
+      "name": "&auml",
+      "semicolon": false
+    },
+    {
+      "characters": "ä",
+      "codepoints": [
+        228
+      ],
+      "name": "&auml;",
+      "semicolon": true
+    },
+    {
+      "characters": "∳",
+      "codepoints": [
+        8755
+      ],
+      "name": "&awconint;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨑",
+      "codepoints": [
+        10769
+      ],
+      "name": "&awint;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫭",
+      "codepoints": [
+        10989
+      ],
+      "name": "&bNot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≌",
+      "codepoints": [
+        8780
+      ],
+      "name": "&backcong;",
+      "semicolon": true
+    },
+    {
+      "characters": "϶",
+      "codepoints": [
+        1014
+      ],
+      "name": "&backepsilon;",
+      "semicolon": true
+    },
+    {
+      "characters": "‵",
+      "codepoints": [
+        8245
+      ],
+      "name": "&backprime;",
+      "semicolon": true
+    },
+    {
+      "characters": "∽",
+      "codepoints": [
+        8765
+      ],
+      "name": "&backsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋍",
+      "codepoints": [
+        8909
+      ],
+      "name": "&backsimeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊽",
+      "codepoints": [
+        8893
+      ],
+      "name": "&barvee;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌅",
+      "codepoints": [
+        8965
+      ],
+      "name": "&barwed;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌅",
+      "codepoints": [
+        8965
+      ],
+      "name": "&barwedge;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎵",
+      "codepoints": [
+        9141
+      ],
+      "name": "&bbrk;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎶",
+      "codepoints": [
+        9142
+      ],
+      "name": "&bbrktbrk;",
+      "semicolon": true
+    },
+    {
+      "characters": "≌",
+      "codepoints": [
+        8780
+      ],
+      "name": "&bcong;",
+      "semicolon": true
+    },
+    {
+      "characters": "б",
+      "codepoints": [
+        1073
+      ],
+      "name": "&bcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "„",
+      "codepoints": [
+        8222
+      ],
+      "name": "&bdquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "∵",
+      "codepoints": [
+        8757
+      ],
+      "name": "&becaus;",
+      "semicolon": true
+    },
+    {
+      "characters": "∵",
+      "codepoints": [
+        8757
+      ],
+      "name": "&because;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦰",
+      "codepoints": [
+        10672
+      ],
+      "name": "&bemptyv;",
+      "semicolon": true
+    },
+    {
+      "characters": "϶",
+      "codepoints": [
+        1014
+      ],
+      "name": "&bepsi;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℬ",
+      "codepoints": [
+        8492
+      ],
+      "name": "&bernou;",
+      "semicolon": true
+    },
+    {
+      "characters": "β",
+      "codepoints": [
+        946
+      ],
+      "name": "&beta;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℶ",
+      "codepoints": [
+        8502
+      ],
+      "name": "&beth;",
+      "semicolon": true
+    },
+    {
+      "characters": "≬",
+      "codepoints": [
+        8812
+      ],
+      "name": "&between;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔟",
+      "codepoints": [
+        120095
+      ],
+      "name": "&bfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋂",
+      "codepoints": [
+        8898
+      ],
+      "name": "&bigcap;",
+      "semicolon": true
+    },
+    {
+      "characters": "◯",
+      "codepoints": [
+        9711
+      ],
+      "name": "&bigcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋃",
+      "codepoints": [
+        8899
+      ],
+      "name": "&bigcup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨀",
+      "codepoints": [
+        10752
+      ],
+      "name": "&bigodot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨁",
+      "codepoints": [
+        10753
+      ],
+      "name": "&bigoplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨂",
+      "codepoints": [
+        10754
+      ],
+      "name": "&bigotimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨆",
+      "codepoints": [
+        10758
+      ],
+      "name": "&bigsqcup;",
+      "semicolon": true
+    },
+    {
+      "characters": "★",
+      "codepoints": [
+        9733
+      ],
+      "name": "&bigstar;",
+      "semicolon": true
+    },
+    {
+      "characters": "▽",
+      "codepoints": [
+        9661
+      ],
+      "name": "&bigtriangledown;",
+      "semicolon": true
+    },
+    {
+      "characters": "△",
+      "codepoints": [
+        9651
+      ],
+      "name": "&bigtriangleup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨄",
+      "codepoints": [
+        10756
+      ],
+      "name": "&biguplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋁",
+      "codepoints": [
+        8897
+      ],
+      "name": "&bigvee;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋀",
+      "codepoints": [
+        8896
+      ],
+      "name": "&bigwedge;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤍",
+      "codepoints": [
+        10509
+      ],
+      "name": "&bkarow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧫",
+      "codepoints": [
+        10731
+      ],
+      "name": "&blacklozenge;",
+      "semicolon": true
+    },
+    {
+      "characters": "▪",
+      "codepoints": [
+        9642
+      ],
+      "name": "&blacksquare;",
+      "semicolon": true
+    },
+    {
+      "characters": "▴",
+      "codepoints": [
+        9652
+      ],
+      "name": "&blacktriangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "▾",
+      "codepoints": [
+        9662
+      ],
+      "name": "&blacktriangledown;",
+      "semicolon": true
+    },
+    {
+      "characters": "◂",
+      "codepoints": [
+        9666
+      ],
+      "name": "&blacktriangleleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "▸",
+      "codepoints": [
+        9656
+      ],
+      "name": "&blacktriangleright;",
+      "semicolon": true
+    },
+    {
+      "characters": "␣",
+      "codepoints": [
+        9251
+      ],
+      "name": "&blank;",
+      "semicolon": true
+    },
+    {
+      "characters": "▒",
+      "codepoints": [
+        9618
+      ],
+      "name": "&blk12;",
+      "semicolon": true
+    },
+    {
+      "characters": "░",
+      "codepoints": [
+        9617
+      ],
+      "name": "&blk14;",
+      "semicolon": true
+    },
+    {
+      "characters": "▓",
+      "codepoints": [
+        9619
+      ],
+      "name": "&blk34;",
+      "semicolon": true
+    },
+    {
+      "characters": "█",
+      "codepoints": [
+        9608
+      ],
+      "name": "&block;",
+      "semicolon": true
+    },
+    {
+      "characters": "=⃥",
+      "codepoints": [
+        61,
+        8421
+      ],
+      "name": "&bne;",
+      "semicolon": true
+    },
+    {
+      "characters": "≡⃥",
+      "codepoints": [
+        8801,
+        8421
+      ],
+      "name": "&bnequiv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌐",
+      "codepoints": [
+        8976
+      ],
+      "name": "&bnot;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕓",
+      "codepoints": [
+        120147
+      ],
+      "name": "&bopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊥",
+      "codepoints": [
+        8869
+      ],
+      "name": "&bot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊥",
+      "codepoints": [
+        8869
+      ],
+      "name": "&bottom;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋈",
+      "codepoints": [
+        8904
+      ],
+      "name": "&bowtie;",
+      "semicolon": true
+    },
+    {
+      "characters": "╗",
+      "codepoints": [
+        9559
+      ],
+      "name": "&boxDL;",
+      "semicolon": true
+    },
+    {
+      "characters": "╔",
+      "codepoints": [
+        9556
+      ],
+      "name": "&boxDR;",
+      "semicolon": true
+    },
+    {
+      "characters": "╖",
+      "codepoints": [
+        9558
+      ],
+      "name": "&boxDl;",
+      "semicolon": true
+    },
+    {
+      "characters": "╓",
+      "codepoints": [
+        9555
+      ],
+      "name": "&boxDr;",
+      "semicolon": true
+    },
+    {
+      "characters": "═",
+      "codepoints": [
+        9552
+      ],
+      "name": "&boxH;",
+      "semicolon": true
+    },
+    {
+      "characters": "╦",
+      "codepoints": [
+        9574
+      ],
+      "name": "&boxHD;",
+      "semicolon": true
+    },
+    {
+      "characters": "╩",
+      "codepoints": [
+        9577
+      ],
+      "name": "&boxHU;",
+      "semicolon": true
+    },
+    {
+      "characters": "╤",
+      "codepoints": [
+        9572
+      ],
+      "name": "&boxHd;",
+      "semicolon": true
+    },
+    {
+      "characters": "╧",
+      "codepoints": [
+        9575
+      ],
+      "name": "&boxHu;",
+      "semicolon": true
+    },
+    {
+      "characters": "╝",
+      "codepoints": [
+        9565
+      ],
+      "name": "&boxUL;",
+      "semicolon": true
+    },
+    {
+      "characters": "╚",
+      "codepoints": [
+        9562
+      ],
+      "name": "&boxUR;",
+      "semicolon": true
+    },
+    {
+      "characters": "╜",
+      "codepoints": [
+        9564
+      ],
+      "name": "&boxUl;",
+      "semicolon": true
+    },
+    {
+      "characters": "╙",
+      "codepoints": [
+        9561
+      ],
+      "name": "&boxUr;",
+      "semicolon": true
+    },
+    {
+      "characters": "║",
+      "codepoints": [
+        9553
+      ],
+      "name": "&boxV;",
+      "semicolon": true
+    },
+    {
+      "characters": "╬",
+      "codepoints": [
+        9580
+      ],
+      "name": "&boxVH;",
+      "semicolon": true
+    },
+    {
+      "characters": "╣",
+      "codepoints": [
+        9571
+      ],
+      "name": "&boxVL;",
+      "semicolon": true
+    },
+    {
+      "characters": "╠",
+      "codepoints": [
+        9568
+      ],
+      "name": "&boxVR;",
+      "semicolon": true
+    },
+    {
+      "characters": "╫",
+      "codepoints": [
+        9579
+      ],
+      "name": "&boxVh;",
+      "semicolon": true
+    },
+    {
+      "characters": "╢",
+      "codepoints": [
+        9570
+      ],
+      "name": "&boxVl;",
+      "semicolon": true
+    },
+    {
+      "characters": "╟",
+      "codepoints": [
+        9567
+      ],
+      "name": "&boxVr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧉",
+      "codepoints": [
+        10697
+      ],
+      "name": "&boxbox;",
+      "semicolon": true
+    },
+    {
+      "characters": "╕",
+      "codepoints": [
+        9557
+      ],
+      "name": "&boxdL;",
+      "semicolon": true
+    },
+    {
+      "characters": "╒",
+      "codepoints": [
+        9554
+      ],
+      "name": "&boxdR;",
+      "semicolon": true
+    },
+    {
+      "characters": "┐",
+      "codepoints": [
+        9488
+      ],
+      "name": "&boxdl;",
+      "semicolon": true
+    },
+    {
+      "characters": "┌",
+      "codepoints": [
+        9484
+      ],
+      "name": "&boxdr;",
+      "semicolon": true
+    },
+    {
+      "characters": "─",
+      "codepoints": [
+        9472
+      ],
+      "name": "&boxh;",
+      "semicolon": true
+    },
+    {
+      "characters": "╥",
+      "codepoints": [
+        9573
+      ],
+      "name": "&boxhD;",
+      "semicolon": true
+    },
+    {
+      "characters": "╨",
+      "codepoints": [
+        9576
+      ],
+      "name": "&boxhU;",
+      "semicolon": true
+    },
+    {
+      "characters": "┬",
+      "codepoints": [
+        9516
+      ],
+      "name": "&boxhd;",
+      "semicolon": true
+    },
+    {
+      "characters": "┴",
+      "codepoints": [
+        9524
+      ],
+      "name": "&boxhu;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊟",
+      "codepoints": [
+        8863
+      ],
+      "name": "&boxminus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊞",
+      "codepoints": [
+        8862
+      ],
+      "name": "&boxplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊠",
+      "codepoints": [
+        8864
+      ],
+      "name": "&boxtimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "╛",
+      "codepoints": [
+        9563
+      ],
+      "name": "&boxuL;",
+      "semicolon": true
+    },
+    {
+      "characters": "╘",
+      "codepoints": [
+        9560
+      ],
+      "name": "&boxuR;",
+      "semicolon": true
+    },
+    {
+      "characters": "┘",
+      "codepoints": [
+        9496
+      ],
+      "name": "&boxul;",
+      "semicolon": true
+    },
+    {
+      "characters": "└",
+      "codepoints": [
+        9492
+      ],
+      "name": "&boxur;",
+      "semicolon": true
+    },
+    {
+      "characters": "│",
+      "codepoints": [
+        9474
+      ],
+      "name": "&boxv;",
+      "semicolon": true
+    },
+    {
+      "characters": "╪",
+      "codepoints": [
+        9578
+      ],
+      "name": "&boxvH;",
+      "semicolon": true
+    },
+    {
+      "characters": "╡",
+      "codepoints": [
+        9569
+      ],
+      "name": "&boxvL;",
+      "semicolon": true
+    },
+    {
+      "characters": "╞",
+      "codepoints": [
+        9566
+      ],
+      "name": "&boxvR;",
+      "semicolon": true
+    },
+    {
+      "characters": "┼",
+      "codepoints": [
+        9532
+      ],
+      "name": "&boxvh;",
+      "semicolon": true
+    },
+    {
+      "characters": "┤",
+      "codepoints": [
+        9508
+      ],
+      "name": "&boxvl;",
+      "semicolon": true
+    },
+    {
+      "characters": "├",
+      "codepoints": [
+        9500
+      ],
+      "name": "&boxvr;",
+      "semicolon": true
+    },
+    {
+      "characters": "‵",
+      "codepoints": [
+        8245
+      ],
+      "name": "&bprime;",
+      "semicolon": true
+    },
+    {
+      "characters": "˘",
+      "codepoints": [
+        728
+      ],
+      "name": "&breve;",
+      "semicolon": true
+    },
+    {
+      "characters": "¦",
+      "codepoints": [
+        166
+      ],
+      "name": "&brvbar",
+      "semicolon": false
+    },
+    {
+      "characters": "¦",
+      "codepoints": [
+        166
+      ],
+      "name": "&brvbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒷",
+      "codepoints": [
+        119991
+      ],
+      "name": "&bscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁏",
+      "codepoints": [
+        8271
+      ],
+      "name": "&bsemi;",
+      "semicolon": true
+    },
+    {
+      "characters": "∽",
+      "codepoints": [
+        8765
+      ],
+      "name": "&bsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋍",
+      "codepoints": [
+        8909
+      ],
+      "name": "&bsime;",
+      "semicolon": true
+    },
+    {
+      "characters": "\\",
+      "codepoints": [
+        92
+      ],
+      "name": "&bsol;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧅",
+      "codepoints": [
+        10693
+      ],
+      "name": "&bsolb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟈",
+      "codepoints": [
+        10184
+      ],
+      "name": "&bsolhsub;",
+      "semicolon": true
+    },
+    {
+      "characters": "•",
+      "codepoints": [
+        8226
+      ],
+      "name": "&bull;",
+      "semicolon": true
+    },
+    {
+      "characters": "•",
+      "codepoints": [
+        8226
+      ],
+      "name": "&bullet;",
+      "semicolon": true
+    },
+    {
+      "characters": "≎",
+      "codepoints": [
+        8782
+      ],
+      "name": "&bump;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪮",
+      "codepoints": [
+        10926
+      ],
+      "name": "&bumpE;",
+      "semicolon": true
+    },
+    {
+      "characters": "≏",
+      "codepoints": [
+        8783
+      ],
+      "name": "&bumpe;",
+      "semicolon": true
+    },
+    {
+      "characters": "≏",
+      "codepoints": [
+        8783
+      ],
+      "name": "&bumpeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "ć",
+      "codepoints": [
+        263
+      ],
+      "name": "&cacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "∩",
+      "codepoints": [
+        8745
+      ],
+      "name": "&cap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩄",
+      "codepoints": [
+        10820
+      ],
+      "name": "&capand;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩉",
+      "codepoints": [
+        10825
+      ],
+      "name": "&capbrcup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩋",
+      "codepoints": [
+        10827
+      ],
+      "name": "&capcap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩇",
+      "codepoints": [
+        10823
+      ],
+      "name": "&capcup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩀",
+      "codepoints": [
+        10816
+      ],
+      "name": "&capdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "∩︀",
+      "codepoints": [
+        8745,
+        65024
+      ],
+      "name": "&caps;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁁",
+      "codepoints": [
+        8257
+      ],
+      "name": "&caret;",
+      "semicolon": true
+    },
+    {
+      "characters": "ˇ",
+      "codepoints": [
+        711
+      ],
+      "name": "&caron;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩍",
+      "codepoints": [
+        10829
+      ],
+      "name": "&ccaps;",
+      "semicolon": true
+    },
+    {
+      "characters": "č",
+      "codepoints": [
+        269
+      ],
+      "name": "&ccaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "ç",
+      "codepoints": [
+        231
+      ],
+      "name": "&ccedil",
+      "semicolon": false
+    },
+    {
+      "characters": "ç",
+      "codepoints": [
+        231
+      ],
+      "name": "&ccedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "ĉ",
+      "codepoints": [
+        265
+      ],
+      "name": "&ccirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩌",
+      "codepoints": [
+        10828
+      ],
+      "name": "&ccups;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩐",
+      "codepoints": [
+        10832
+      ],
+      "name": "&ccupssm;",
+      "semicolon": true
+    },
+    {
+      "characters": "ċ",
+      "codepoints": [
+        267
+      ],
+      "name": "&cdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "¸",
+      "codepoints": [
+        184
+      ],
+      "name": "&cedil",
+      "semicolon": false
+    },
+    {
+      "characters": "¸",
+      "codepoints": [
+        184
+      ],
+      "name": "&cedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦲",
+      "codepoints": [
+        10674
+      ],
+      "name": "&cemptyv;",
+      "semicolon": true
+    },
+    {
+      "characters": "¢",
+      "codepoints": [
+        162
+      ],
+      "name": "&cent",
+      "semicolon": false
+    },
+    {
+      "characters": "¢",
+      "codepoints": [
+        162
+      ],
+      "name": "&cent;",
+      "semicolon": true
+    },
+    {
+      "characters": "·",
+      "codepoints": [
+        183
+      ],
+      "name": "&centerdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔠",
+      "codepoints": [
+        120096
+      ],
+      "name": "&cfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ч",
+      "codepoints": [
+        1095
+      ],
+      "name": "&chcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "✓",
+      "codepoints": [
+        10003
+      ],
+      "name": "&check;",
+      "semicolon": true
+    },
+    {
+      "characters": "✓",
+      "codepoints": [
+        10003
+      ],
+      "name": "&checkmark;",
+      "semicolon": true
+    },
+    {
+      "characters": "χ",
+      "codepoints": [
+        967
+      ],
+      "name": "&chi;",
+      "semicolon": true
+    },
+    {
+      "characters": "○",
+      "codepoints": [
+        9675
+      ],
+      "name": "&cir;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧃",
+      "codepoints": [
+        10691
+      ],
+      "name": "&cirE;",
+      "semicolon": true
+    },
+    {
+      "characters": "ˆ",
+      "codepoints": [
+        710
+      ],
+      "name": "&circ;",
+      "semicolon": true
+    },
+    {
+      "characters": "≗",
+      "codepoints": [
+        8791
+      ],
+      "name": "&circeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "↺",
+      "codepoints": [
+        8634
+      ],
+      "name": "&circlearrowleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "↻",
+      "codepoints": [
+        8635
+      ],
+      "name": "&circlearrowright;",
+      "semicolon": true
+    },
+    {
+      "characters": "®",
+      "codepoints": [
+        174
+      ],
+      "name": "&circledR;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ⓢ",
+      "codepoints": [
+        9416
+      ],
+      "name": "&circledS;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊛",
+      "codepoints": [
+        8859
+      ],
+      "name": "&circledast;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊚",
+      "codepoints": [
+        8858
+      ],
+      "name": "&circledcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊝",
+      "codepoints": [
+        8861
+      ],
+      "name": "&circleddash;",
+      "semicolon": true
+    },
+    {
+      "characters": "≗",
+      "codepoints": [
+        8791
+      ],
+      "name": "&cire;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨐",
+      "codepoints": [
+        10768
+      ],
+      "name": "&cirfnint;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫯",
+      "codepoints": [
+        10991
+      ],
+      "name": "&cirmid;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧂",
+      "codepoints": [
+        10690
+      ],
+      "name": "&cirscir;",
+      "semicolon": true
+    },
+    {
+      "characters": "♣",
+      "codepoints": [
+        9827
+      ],
+      "name": "&clubs;",
+      "semicolon": true
+    },
+    {
+      "characters": "♣",
+      "codepoints": [
+        9827
+      ],
+      "name": "&clubsuit;",
+      "semicolon": true
+    },
+    {
+      "characters": ":",
+      "codepoints": [
+        58
+      ],
+      "name": "&colon;",
+      "semicolon": true
+    },
+    {
+      "characters": "≔",
+      "codepoints": [
+        8788
+      ],
+      "name": "&colone;",
+      "semicolon": true
+    },
+    {
+      "characters": "≔",
+      "codepoints": [
+        8788
+      ],
+      "name": "&coloneq;",
+      "semicolon": true
+    },
+    {
+      "characters": ",",
+      "codepoints": [
+        44
+      ],
+      "name": "&comma;",
+      "semicolon": true
+    },
+    {
+      "characters": "@",
+      "codepoints": [
+        64
+      ],
+      "name": "&commat;",
+      "semicolon": true
+    },
+    {
+      "characters": "∁",
+      "codepoints": [
+        8705
+      ],
+      "name": "&comp;",
+      "semicolon": true
+    },
+    {
+      "characters": "∘",
+      "codepoints": [
+        8728
+      ],
+      "name": "&compfn;",
+      "semicolon": true
+    },
+    {
+      "characters": "∁",
+      "codepoints": [
+        8705
+      ],
+      "name": "&complement;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℂ",
+      "codepoints": [
+        8450
+      ],
+      "name": "&complexes;",
+      "semicolon": true
+    },
+    {
+      "characters": "≅",
+      "codepoints": [
+        8773
+      ],
+      "name": "&cong;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩭",
+      "codepoints": [
+        10861
+      ],
+      "name": "&congdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "∮",
+      "codepoints": [
+        8750
+      ],
+      "name": "&conint;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕔",
+      "codepoints": [
+        120148
+      ],
+      "name": "&copf;",
+      "semicolon": true
+    },
+    {
+      "characters": "∐",
+      "codepoints": [
+        8720
+      ],
+      "name": "&coprod;",
+      "semicolon": true
+    },
+    {
+      "characters": "©",
+      "codepoints": [
+        169
+      ],
+      "name": "&copy",
+      "semicolon": false
+    },
+    {
+      "characters": "©",
+      "codepoints": [
+        169
+      ],
+      "name": "&copy;",
+      "semicolon": true
+    },
+    {
+      "characters": "℗",
+      "codepoints": [
+        8471
+      ],
+      "name": "&copysr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↵",
+      "codepoints": [
+        8629
+      ],
+      "name": "&crarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "✗",
+      "codepoints": [
+        10007
+      ],
+      "name": "&cross;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒸",
+      "codepoints": [
+        119992
+      ],
+      "name": "&cscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫏",
+      "codepoints": [
+        10959
+      ],
+      "name": "&csub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫑",
+      "codepoints": [
+        10961
+      ],
+      "name": "&csube;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫐",
+      "codepoints": [
+        10960
+      ],
+      "name": "&csup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫒",
+      "codepoints": [
+        10962
+      ],
+      "name": "&csupe;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋯",
+      "codepoints": [
+        8943
+      ],
+      "name": "&ctdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤸",
+      "codepoints": [
+        10552
+      ],
+      "name": "&cudarrl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤵",
+      "codepoints": [
+        10549
+      ],
+      "name": "&cudarrr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋞",
+      "codepoints": [
+        8926
+      ],
+      "name": "&cuepr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋟",
+      "codepoints": [
+        8927
+      ],
+      "name": "&cuesc;",
+      "semicolon": true
+    },
+    {
+      "characters": "↶",
+      "codepoints": [
+        8630
+      ],
+      "name": "&cularr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤽",
+      "codepoints": [
+        10557
+      ],
+      "name": "&cularrp;",
+      "semicolon": true
+    },
+    {
+      "characters": "∪",
+      "codepoints": [
+        8746
+      ],
+      "name": "&cup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩈",
+      "codepoints": [
+        10824
+      ],
+      "name": "&cupbrcap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩆",
+      "codepoints": [
+        10822
+      ],
+      "name": "&cupcap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩊",
+      "codepoints": [
+        10826
+      ],
+      "name": "&cupcup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊍",
+      "codepoints": [
+        8845
+      ],
+      "name": "&cupdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩅",
+      "codepoints": [
+        10821
+      ],
+      "name": "&cupor;",
+      "semicolon": true
+    },
+    {
+      "characters": "∪︀",
+      "codepoints": [
+        8746,
+        65024
+      ],
+      "name": "&cups;",
+      "semicolon": true
+    },
+    {
+      "characters": "↷",
+      "codepoints": [
+        8631
+      ],
+      "name": "&curarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤼",
+      "codepoints": [
+        10556
+      ],
+      "name": "&curarrm;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋞",
+      "codepoints": [
+        8926
+      ],
+      "name": "&curlyeqprec;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋟",
+      "codepoints": [
+        8927
+      ],
+      "name": "&curlyeqsucc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋎",
+      "codepoints": [
+        8910
+      ],
+      "name": "&curlyvee;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋏",
+      "codepoints": [
+        8911
+      ],
+      "name": "&curlywedge;",
+      "semicolon": true
+    },
+    {
+      "characters": "¤",
+      "codepoints": [
+        164
+      ],
+      "name": "&curren",
+      "semicolon": false
+    },
+    {
+      "characters": "¤",
+      "codepoints": [
+        164
+      ],
+      "name": "&curren;",
+      "semicolon": true
+    },
+    {
+      "characters": "↶",
+      "codepoints": [
+        8630
+      ],
+      "name": "&curvearrowleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "↷",
+      "codepoints": [
+        8631
+      ],
+      "name": "&curvearrowright;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋎",
+      "codepoints": [
+        8910
+      ],
+      "name": "&cuvee;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋏",
+      "codepoints": [
+        8911
+      ],
+      "name": "&cuwed;",
+      "semicolon": true
+    },
+    {
+      "characters": "∲",
+      "codepoints": [
+        8754
+      ],
+      "name": "&cwconint;",
+      "semicolon": true
+    },
+    {
+      "characters": "∱",
+      "codepoints": [
+        8753
+      ],
+      "name": "&cwint;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌭",
+      "codepoints": [
+        9005
+      ],
+      "name": "&cylcty;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇓",
+      "codepoints": [
+        8659
+      ],
+      "name": "&dArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥥",
+      "codepoints": [
+        10597
+      ],
+      "name": "&dHar;",
+      "semicolon": true
+    },
+    {
+      "characters": "†",
+      "codepoints": [
+        8224
+      ],
+      "name": "&dagger;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℸ",
+      "codepoints": [
+        8504
+      ],
+      "name": "&daleth;",
+      "semicolon": true
+    },
+    {
+      "characters": "↓",
+      "codepoints": [
+        8595
+      ],
+      "name": "&darr;",
+      "semicolon": true
+    },
+    {
+      "characters": "‐",
+      "codepoints": [
+        8208
+      ],
+      "name": "&dash;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊣",
+      "codepoints": [
+        8867
+      ],
+      "name": "&dashv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤏",
+      "codepoints": [
+        10511
+      ],
+      "name": "&dbkarow;",
+      "semicolon": true
+    },
+    {
+      "characters": "˝",
+      "codepoints": [
+        733
+      ],
+      "name": "&dblac;",
+      "semicolon": true
+    },
+    {
+      "characters": "ď",
+      "codepoints": [
+        271
+      ],
+      "name": "&dcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "д",
+      "codepoints": [
+        1076
+      ],
+      "name": "&dcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅆ",
+      "codepoints": [
+        8518
+      ],
+      "name": "&dd;",
+      "semicolon": true
+    },
+    {
+      "characters": "‡",
+      "codepoints": [
+        8225
+      ],
+      "name": "&ddagger;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇊",
+      "codepoints": [
+        8650
+      ],
+      "name": "&ddarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩷",
+      "codepoints": [
+        10871
+      ],
+      "name": "&ddotseq;",
+      "semicolon": true
+    },
+    {
+      "characters": "°",
+      "codepoints": [
+        176
+      ],
+      "name": "&deg",
+      "semicolon": false
+    },
+    {
+      "characters": "°",
+      "codepoints": [
+        176
+      ],
+      "name": "&deg;",
+      "semicolon": true
+    },
+    {
+      "characters": "δ",
+      "codepoints": [
+        948
+      ],
+      "name": "&delta;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦱",
+      "codepoints": [
+        10673
+      ],
+      "name": "&demptyv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥿",
+      "codepoints": [
+        10623
+      ],
+      "name": "&dfisht;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔡",
+      "codepoints": [
+        120097
+      ],
+      "name": "&dfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇃",
+      "codepoints": [
+        8643
+      ],
+      "name": "&dharl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇂",
+      "codepoints": [
+        8642
+      ],
+      "name": "&dharr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋄",
+      "codepoints": [
+        8900
+      ],
+      "name": "&diam;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋄",
+      "codepoints": [
+        8900
+      ],
+      "name": "&diamond;",
+      "semicolon": true
+    },
+    {
+      "characters": "♦",
+      "codepoints": [
+        9830
+      ],
+      "name": "&diamondsuit;",
+      "semicolon": true
+    },
+    {
+      "characters": "♦",
+      "codepoints": [
+        9830
+      ],
+      "name": "&diams;",
+      "semicolon": true
+    },
+    {
+      "characters": "¨",
+      "codepoints": [
+        168
+      ],
+      "name": "&die;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϝ",
+      "codepoints": [
+        989
+      ],
+      "name": "&digamma;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋲",
+      "codepoints": [
+        8946
+      ],
+      "name": "&disin;",
+      "semicolon": true
+    },
+    {
+      "characters": "÷",
+      "codepoints": [
+        247
+      ],
+      "name": "&div;",
+      "semicolon": true
+    },
+    {
+      "characters": "÷",
+      "codepoints": [
+        247
+      ],
+      "name": "&divide",
+      "semicolon": false
+    },
+    {
+      "characters": "÷",
+      "codepoints": [
+        247
+      ],
+      "name": "&divide;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋇",
+      "codepoints": [
+        8903
+      ],
+      "name": "&divideontimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋇",
+      "codepoints": [
+        8903
+      ],
+      "name": "&divonx;",
+      "semicolon": true
+    },
+    {
+      "characters": "ђ",
+      "codepoints": [
+        1106
+      ],
+      "name": "&djcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌞",
+      "codepoints": [
+        8990
+      ],
+      "name": "&dlcorn;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌍",
+      "codepoints": [
+        8973
+      ],
+      "name": "&dlcrop;",
+      "semicolon": true
+    },
+    {
+      "characters": "$",
+      "codepoints": [
+        36
+      ],
+      "name": "&dollar;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕕",
+      "codepoints": [
+        120149
+      ],
+      "name": "&dopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "˙",
+      "codepoints": [
+        729
+      ],
+      "name": "&dot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≐",
+      "codepoints": [
+        8784
+      ],
+      "name": "&doteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≑",
+      "codepoints": [
+        8785
+      ],
+      "name": "&doteqdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "∸",
+      "codepoints": [
+        8760
+      ],
+      "name": "&dotminus;",
+      "semicolon": true
+    },
+    {
+      "characters": "∔",
+      "codepoints": [
+        8724
+      ],
+      "name": "&dotplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊡",
+      "codepoints": [
+        8865
+      ],
+      "name": "&dotsquare;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌆",
+      "codepoints": [
+        8966
+      ],
+      "name": "&doublebarwedge;",
+      "semicolon": true
+    },
+    {
+      "characters": "↓",
+      "codepoints": [
+        8595
+      ],
+      "name": "&downarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇊",
+      "codepoints": [
+        8650
+      ],
+      "name": "&downdownarrows;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇃",
+      "codepoints": [
+        8643
+      ],
+      "name": "&downharpoonleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇂",
+      "codepoints": [
+        8642
+      ],
+      "name": "&downharpoonright;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤐",
+      "codepoints": [
+        10512
+      ],
+      "name": "&drbkarow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌟",
+      "codepoints": [
+        8991
+      ],
+      "name": "&drcorn;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌌",
+      "codepoints": [
+        8972
+      ],
+      "name": "&drcrop;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒹",
+      "codepoints": [
+        119993
+      ],
+      "name": "&dscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ѕ",
+      "codepoints": [
+        1109
+      ],
+      "name": "&dscy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧶",
+      "codepoints": [
+        10742
+      ],
+      "name": "&dsol;",
+      "semicolon": true
+    },
+    {
+      "characters": "đ",
+      "codepoints": [
+        273
+      ],
+      "name": "&dstrok;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋱",
+      "codepoints": [
+        8945
+      ],
+      "name": "&dtdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "▿",
+      "codepoints": [
+        9663
+      ],
+      "name": "&dtri;",
+      "semicolon": true
+    },
+    {
+      "characters": "▾",
+      "codepoints": [
+        9662
+      ],
+      "name": "&dtrif;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇵",
+      "codepoints": [
+        8693
+      ],
+      "name": "&duarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥯",
+      "codepoints": [
+        10607
+      ],
+      "name": "&duhar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦦",
+      "codepoints": [
+        10662
+      ],
+      "name": "&dwangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "џ",
+      "codepoints": [
+        1119
+      ],
+      "name": "&dzcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟿",
+      "codepoints": [
+        10239
+      ],
+      "name": "&dzigrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩷",
+      "codepoints": [
+        10871
+      ],
+      "name": "&eDDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≑",
+      "codepoints": [
+        8785
+      ],
+      "name": "&eDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "é",
+      "codepoints": [
+        233
+      ],
+      "name": "&eacute",
+      "semicolon": false
+    },
+    {
+      "characters": "é",
+      "codepoints": [
+        233
+      ],
+      "name": "&eacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩮",
+      "codepoints": [
+        10862
+      ],
+      "name": "&easter;",
+      "semicolon": true
+    },
+    {
+      "characters": "ě",
+      "codepoints": [
+        283
+      ],
+      "name": "&ecaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "≖",
+      "codepoints": [
+        8790
+      ],
+      "name": "&ecir;",
+      "semicolon": true
+    },
+    {
+      "characters": "ê",
+      "codepoints": [
+        234
+      ],
+      "name": "&ecirc",
+      "semicolon": false
+    },
+    {
+      "characters": "ê",
+      "codepoints": [
+        234
+      ],
+      "name": "&ecirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "≕",
+      "codepoints": [
+        8789
+      ],
+      "name": "&ecolon;",
+      "semicolon": true
+    },
+    {
+      "characters": "э",
+      "codepoints": [
+        1101
+      ],
+      "name": "&ecy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ė",
+      "codepoints": [
+        279
+      ],
+      "name": "&edot;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅇ",
+      "codepoints": [
+        8519
+      ],
+      "name": "&ee;",
+      "semicolon": true
+    },
+    {
+      "characters": "≒",
+      "codepoints": [
+        8786
+      ],
+      "name": "&efDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔢",
+      "codepoints": [
+        120098
+      ],
+      "name": "&efr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪚",
+      "codepoints": [
+        10906
+      ],
+      "name": "&eg;",
+      "semicolon": true
+    },
+    {
+      "characters": "è",
+      "codepoints": [
+        232
+      ],
+      "name": "&egrave",
+      "semicolon": false
+    },
+    {
+      "characters": "è",
+      "codepoints": [
+        232
+      ],
+      "name": "&egrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪖",
+      "codepoints": [
+        10902
+      ],
+      "name": "&egs;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪘",
+      "codepoints": [
+        10904
+      ],
+      "name": "&egsdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪙",
+      "codepoints": [
+        10905
+      ],
+      "name": "&el;",
+      "semicolon": true
+    },
+    {
+      "characters": "⏧",
+      "codepoints": [
+        9191
+      ],
+      "name": "&elinters;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℓ",
+      "codepoints": [
+        8467
+      ],
+      "name": "&ell;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪕",
+      "codepoints": [
+        10901
+      ],
+      "name": "&els;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪗",
+      "codepoints": [
+        10903
+      ],
+      "name": "&elsdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "ē",
+      "codepoints": [
+        275
+      ],
+      "name": "&emacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∅",
+      "codepoints": [
+        8709
+      ],
+      "name": "&empty;",
+      "semicolon": true
+    },
+    {
+      "characters": "∅",
+      "codepoints": [
+        8709
+      ],
+      "name": "&emptyset;",
+      "semicolon": true
+    },
+    {
+      "characters": "∅",
+      "codepoints": [
+        8709
+      ],
+      "name": "&emptyv;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8196
+      ],
+      "name": "&emsp13;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8197
+      ],
+      "name": "&emsp14;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8195
+      ],
+      "name": "&emsp;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŋ",
+      "codepoints": [
+        331
+      ],
+      "name": "&eng;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8194
+      ],
+      "name": "&ensp;",
+      "semicolon": true
+    },
+    {
+      "characters": "ę",
+      "codepoints": [
+        281
+      ],
+      "name": "&eogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕖",
+      "codepoints": [
+        120150
+      ],
+      "name": "&eopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋕",
+      "codepoints": [
+        8917
+      ],
+      "name": "&epar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧣",
+      "codepoints": [
+        10723
+      ],
+      "name": "&eparsl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩱",
+      "codepoints": [
+        10865
+      ],
+      "name": "&eplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "ε",
+      "codepoints": [
+        949
+      ],
+      "name": "&epsi;",
+      "semicolon": true
+    },
+    {
+      "characters": "ε",
+      "codepoints": [
+        949
+      ],
+      "name": "&epsilon;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϵ",
+      "codepoints": [
+        1013
+      ],
+      "name": "&epsiv;",
+      "semicolon": true
+    },
+    {
+      "characters": "≖",
+      "codepoints": [
+        8790
+      ],
+      "name": "&eqcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "≕",
+      "codepoints": [
+        8789
+      ],
+      "name": "&eqcolon;",
+      "semicolon": true
+    },
+    {
+      "characters": "≂",
+      "codepoints": [
+        8770
+      ],
+      "name": "&eqsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪖",
+      "codepoints": [
+        10902
+      ],
+      "name": "&eqslantgtr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪕",
+      "codepoints": [
+        10901
+      ],
+      "name": "&eqslantless;",
+      "semicolon": true
+    },
+    {
+      "characters": "=",
+      "codepoints": [
+        61
+      ],
+      "name": "&equals;",
+      "semicolon": true
+    },
+    {
+      "characters": "≟",
+      "codepoints": [
+        8799
+      ],
+      "name": "&equest;",
+      "semicolon": true
+    },
+    {
+      "characters": "≡",
+      "codepoints": [
+        8801
+      ],
+      "name": "&equiv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩸",
+      "codepoints": [
+        10872
+      ],
+      "name": "&equivDD;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧥",
+      "codepoints": [
+        10725
+      ],
+      "name": "&eqvparsl;",
+      "semicolon": true
+    },
+    {
+      "characters": "≓",
+      "codepoints": [
+        8787
+      ],
+      "name": "&erDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥱",
+      "codepoints": [
+        10609
+      ],
+      "name": "&erarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℯ",
+      "codepoints": [
+        8495
+      ],
+      "name": "&escr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≐",
+      "codepoints": [
+        8784
+      ],
+      "name": "&esdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≂",
+      "codepoints": [
+        8770
+      ],
+      "name": "&esim;",
+      "semicolon": true
+    },
+    {
+      "characters": "η",
+      "codepoints": [
+        951
+      ],
+      "name": "&eta;",
+      "semicolon": true
+    },
+    {
+      "characters": "ð",
+      "codepoints": [
+        240
+      ],
+      "name": "&eth",
+      "semicolon": false
+    },
+    {
+      "characters": "ð",
+      "codepoints": [
+        240
+      ],
+      "name": "&eth;",
+      "semicolon": true
+    },
+    {
+      "characters": "ë",
+      "codepoints": [
+        235
+      ],
+      "name": "&euml",
+      "semicolon": false
+    },
+    {
+      "characters": "ë",
+      "codepoints": [
+        235
+      ],
+      "name": "&euml;",
+      "semicolon": true
+    },
+    {
+      "characters": "€",
+      "codepoints": [
+        8364
+      ],
+      "name": "&euro;",
+      "semicolon": true
+    },
+    {
+      "characters": "!",
+      "codepoints": [
+        33
+      ],
+      "name": "&excl;",
+      "semicolon": true
+    },
+    {
+      "characters": "∃",
+      "codepoints": [
+        8707
+      ],
+      "name": "&exist;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℰ",
+      "codepoints": [
+        8496
+      ],
+      "name": "&expectation;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅇ",
+      "codepoints": [
+        8519
+      ],
+      "name": "&exponentiale;",
+      "semicolon": true
+    },
+    {
+      "characters": "≒",
+      "codepoints": [
+        8786
+      ],
+      "name": "&fallingdotseq;",
+      "semicolon": true
+    },
+    {
+      "characters": "ф",
+      "codepoints": [
+        1092
+      ],
+      "name": "&fcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "♀",
+      "codepoints": [
+        9792
+      ],
+      "name": "&female;",
+      "semicolon": true
+    },
+    {
+      "characters": "ﬃ",
+      "codepoints": [
+        64259
+      ],
+      "name": "&ffilig;",
+      "semicolon": true
+    },
+    {
+      "characters": "ﬀ",
+      "codepoints": [
+        64256
+      ],
+      "name": "&fflig;",
+      "semicolon": true
+    },
+    {
+      "characters": "ﬄ",
+      "codepoints": [
+        64260
+      ],
+      "name": "&ffllig;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔣",
+      "codepoints": [
+        120099
+      ],
+      "name": "&ffr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ﬁ",
+      "codepoints": [
+        64257
+      ],
+      "name": "&filig;",
+      "semicolon": true
+    },
+    {
+      "characters": "fj",
+      "codepoints": [
+        102,
+        106
+      ],
+      "name": "&fjlig;",
+      "semicolon": true
+    },
+    {
+      "characters": "♭",
+      "codepoints": [
+        9837
+      ],
+      "name": "&flat;",
+      "semicolon": true
+    },
+    {
+      "characters": "ﬂ",
+      "codepoints": [
+        64258
+      ],
+      "name": "&fllig;",
+      "semicolon": true
+    },
+    {
+      "characters": "▱",
+      "codepoints": [
+        9649
+      ],
+      "name": "&fltns;",
+      "semicolon": true
+    },
+    {
+      "characters": "ƒ",
+      "codepoints": [
+        402
+      ],
+      "name": "&fnof;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕗",
+      "codepoints": [
+        120151
+      ],
+      "name": "&fopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "∀",
+      "codepoints": [
+        8704
+      ],
+      "name": "&forall;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋔",
+      "codepoints": [
+        8916
+      ],
+      "name": "&fork;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫙",
+      "codepoints": [
+        10969
+      ],
+      "name": "&forkv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨍",
+      "codepoints": [
+        10765
+      ],
+      "name": "&fpartint;",
+      "semicolon": true
+    },
+    {
+      "characters": "½",
+      "codepoints": [
+        189
+      ],
+      "name": "&frac12",
+      "semicolon": false
+    },
+    {
+      "characters": "½",
+      "codepoints": [
+        189
+      ],
+      "name": "&frac12;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅓",
+      "codepoints": [
+        8531
+      ],
+      "name": "&frac13;",
+      "semicolon": true
+    },
+    {
+      "characters": "¼",
+      "codepoints": [
+        188
+      ],
+      "name": "&frac14",
+      "semicolon": false
+    },
+    {
+      "characters": "¼",
+      "codepoints": [
+        188
+      ],
+      "name": "&frac14;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅕",
+      "codepoints": [
+        8533
+      ],
+      "name": "&frac15;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅙",
+      "codepoints": [
+        8537
+      ],
+      "name": "&frac16;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅛",
+      "codepoints": [
+        8539
+      ],
+      "name": "&frac18;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅔",
+      "codepoints": [
+        8532
+      ],
+      "name": "&frac23;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅖",
+      "codepoints": [
+        8534
+      ],
+      "name": "&frac25;",
+      "semicolon": true
+    },
+    {
+      "characters": "¾",
+      "codepoints": [
+        190
+      ],
+      "name": "&frac34",
+      "semicolon": false
+    },
+    {
+      "characters": "¾",
+      "codepoints": [
+        190
+      ],
+      "name": "&frac34;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅗",
+      "codepoints": [
+        8535
+      ],
+      "name": "&frac35;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅜",
+      "codepoints": [
+        8540
+      ],
+      "name": "&frac38;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅘",
+      "codepoints": [
+        8536
+      ],
+      "name": "&frac45;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅚",
+      "codepoints": [
+        8538
+      ],
+      "name": "&frac56;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅝",
+      "codepoints": [
+        8541
+      ],
+      "name": "&frac58;",
+      "semicolon": true
+    },
+    {
+      "characters": "⅞",
+      "codepoints": [
+        8542
+      ],
+      "name": "&frac78;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁄",
+      "codepoints": [
+        8260
+      ],
+      "name": "&frasl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌢",
+      "codepoints": [
+        8994
+      ],
+      "name": "&frown;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒻",
+      "codepoints": [
+        119995
+      ],
+      "name": "&fscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≧",
+      "codepoints": [
+        8807
+      ],
+      "name": "&gE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪌",
+      "codepoints": [
+        10892
+      ],
+      "name": "&gEl;",
+      "semicolon": true
+    },
+    {
+      "characters": "ǵ",
+      "codepoints": [
+        501
+      ],
+      "name": "&gacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "γ",
+      "codepoints": [
+        947
+      ],
+      "name": "&gamma;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϝ",
+      "codepoints": [
+        989
+      ],
+      "name": "&gammad;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪆",
+      "codepoints": [
+        10886
+      ],
+      "name": "&gap;",
+      "semicolon": true
+    },
+    {
+      "characters": "ğ",
+      "codepoints": [
+        287
+      ],
+      "name": "&gbreve;",
+      "semicolon": true
+    },
+    {
+      "characters": "ĝ",
+      "codepoints": [
+        285
+      ],
+      "name": "&gcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "г",
+      "codepoints": [
+        1075
+      ],
+      "name": "&gcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ġ",
+      "codepoints": [
+        289
+      ],
+      "name": "&gdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≥",
+      "codepoints": [
+        8805
+      ],
+      "name": "&ge;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋛",
+      "codepoints": [
+        8923
+      ],
+      "name": "&gel;",
+      "semicolon": true
+    },
+    {
+      "characters": "≥",
+      "codepoints": [
+        8805
+      ],
+      "name": "&geq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≧",
+      "codepoints": [
+        8807
+      ],
+      "name": "&geqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩾",
+      "codepoints": [
+        10878
+      ],
+      "name": "&geqslant;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩾",
+      "codepoints": [
+        10878
+      ],
+      "name": "&ges;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪩",
+      "codepoints": [
+        10921
+      ],
+      "name": "&gescc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪀",
+      "codepoints": [
+        10880
+      ],
+      "name": "&gesdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪂",
+      "codepoints": [
+        10882
+      ],
+      "name": "&gesdoto;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪄",
+      "codepoints": [
+        10884
+      ],
+      "name": "&gesdotol;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋛︀",
+      "codepoints": [
+        8923,
+        65024
+      ],
+      "name": "&gesl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪔",
+      "codepoints": [
+        10900
+      ],
+      "name": "&gesles;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔤",
+      "codepoints": [
+        120100
+      ],
+      "name": "&gfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≫",
+      "codepoints": [
+        8811
+      ],
+      "name": "&gg;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋙",
+      "codepoints": [
+        8921
+      ],
+      "name": "&ggg;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℷ",
+      "codepoints": [
+        8503
+      ],
+      "name": "&gimel;",
+      "semicolon": true
+    },
+    {
+      "characters": "ѓ",
+      "codepoints": [
+        1107
+      ],
+      "name": "&gjcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "≷",
+      "codepoints": [
+        8823
+      ],
+      "name": "&gl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪒",
+      "codepoints": [
+        10898
+      ],
+      "name": "&glE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪥",
+      "codepoints": [
+        10917
+      ],
+      "name": "&gla;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪤",
+      "codepoints": [
+        10916
+      ],
+      "name": "&glj;",
+      "semicolon": true
+    },
+    {
+      "characters": "≩",
+      "codepoints": [
+        8809
+      ],
+      "name": "&gnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪊",
+      "codepoints": [
+        10890
+      ],
+      "name": "&gnap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪊",
+      "codepoints": [
+        10890
+      ],
+      "name": "&gnapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪈",
+      "codepoints": [
+        10888
+      ],
+      "name": "&gne;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪈",
+      "codepoints": [
+        10888
+      ],
+      "name": "&gneq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≩",
+      "codepoints": [
+        8809
+      ],
+      "name": "&gneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋧",
+      "codepoints": [
+        8935
+      ],
+      "name": "&gnsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕘",
+      "codepoints": [
+        120152
+      ],
+      "name": "&gopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "`",
+      "codepoints": [
+        96
+      ],
+      "name": "&grave;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℊ",
+      "codepoints": [
+        8458
+      ],
+      "name": "&gscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≳",
+      "codepoints": [
+        8819
+      ],
+      "name": "&gsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪎",
+      "codepoints": [
+        10894
+      ],
+      "name": "&gsime;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪐",
+      "codepoints": [
+        10896
+      ],
+      "name": "&gsiml;",
+      "semicolon": true
+    },
+    {
+      "characters": ">",
+      "codepoints": [
+        62
+      ],
+      "name": "&gt",
+      "semicolon": false
+    },
+    {
+      "characters": ">",
+      "codepoints": [
+        62
+      ],
+      "name": "&gt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪧",
+      "codepoints": [
+        10919
+      ],
+      "name": "&gtcc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩺",
+      "codepoints": [
+        10874
+      ],
+      "name": "&gtcir;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋗",
+      "codepoints": [
+        8919
+      ],
+      "name": "&gtdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦕",
+      "codepoints": [
+        10645
+      ],
+      "name": "&gtlPar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩼",
+      "codepoints": [
+        10876
+      ],
+      "name": "&gtquest;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪆",
+      "codepoints": [
+        10886
+      ],
+      "name": "&gtrapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥸",
+      "codepoints": [
+        10616
+      ],
+      "name": "&gtrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋗",
+      "codepoints": [
+        8919
+      ],
+      "name": "&gtrdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋛",
+      "codepoints": [
+        8923
+      ],
+      "name": "&gtreqless;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪌",
+      "codepoints": [
+        10892
+      ],
+      "name": "&gtreqqless;",
+      "semicolon": true
+    },
+    {
+      "characters": "≷",
+      "codepoints": [
+        8823
+      ],
+      "name": "&gtrless;",
+      "semicolon": true
+    },
+    {
+      "characters": "≳",
+      "codepoints": [
+        8819
+      ],
+      "name": "&gtrsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "≩︀",
+      "codepoints": [
+        8809,
+        65024
+      ],
+      "name": "&gvertneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≩︀",
+      "codepoints": [
+        8809,
+        65024
+      ],
+      "name": "&gvnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇔",
+      "codepoints": [
+        8660
+      ],
+      "name": "&hArr;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8202
+      ],
+      "name": "&hairsp;",
+      "semicolon": true
+    },
+    {
+      "characters": "½",
+      "codepoints": [
+        189
+      ],
+      "name": "&half;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℋ",
+      "codepoints": [
+        8459
+      ],
+      "name": "&hamilt;",
+      "semicolon": true
+    },
+    {
+      "characters": "ъ",
+      "codepoints": [
+        1098
+      ],
+      "name": "&hardcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "↔",
+      "codepoints": [
+        8596
+      ],
+      "name": "&harr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥈",
+      "codepoints": [
+        10568
+      ],
+      "name": "&harrcir;",
+      "semicolon": true
+    },
+    {
+      "characters": "↭",
+      "codepoints": [
+        8621
+      ],
+      "name": "&harrw;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℏ",
+      "codepoints": [
+        8463
+      ],
+      "name": "&hbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "ĥ",
+      "codepoints": [
+        293
+      ],
+      "name": "&hcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "♥",
+      "codepoints": [
+        9829
+      ],
+      "name": "&hearts;",
+      "semicolon": true
+    },
+    {
+      "characters": "♥",
+      "codepoints": [
+        9829
+      ],
+      "name": "&heartsuit;",
+      "semicolon": true
+    },
+    {
+      "characters": "…",
+      "codepoints": [
+        8230
+      ],
+      "name": "&hellip;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊹",
+      "codepoints": [
+        8889
+      ],
+      "name": "&hercon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔥",
+      "codepoints": [
+        120101
+      ],
+      "name": "&hfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤥",
+      "codepoints": [
+        10533
+      ],
+      "name": "&hksearow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤦",
+      "codepoints": [
+        10534
+      ],
+      "name": "&hkswarow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇿",
+      "codepoints": [
+        8703
+      ],
+      "name": "&hoarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∻",
+      "codepoints": [
+        8763
+      ],
+      "name": "&homtht;",
+      "semicolon": true
+    },
+    {
+      "characters": "↩",
+      "codepoints": [
+        8617
+      ],
+      "name": "&hookleftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↪",
+      "codepoints": [
+        8618
+      ],
+      "name": "&hookrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕙",
+      "codepoints": [
+        120153
+      ],
+      "name": "&hopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "―",
+      "codepoints": [
+        8213
+      ],
+      "name": "&horbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒽",
+      "codepoints": [
+        119997
+      ],
+      "name": "&hscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℏ",
+      "codepoints": [
+        8463
+      ],
+      "name": "&hslash;",
+      "semicolon": true
+    },
+    {
+      "characters": "ħ",
+      "codepoints": [
+        295
+      ],
+      "name": "&hstrok;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁃",
+      "codepoints": [
+        8259
+      ],
+      "name": "&hybull;",
+      "semicolon": true
+    },
+    {
+      "characters": "‐",
+      "codepoints": [
+        8208
+      ],
+      "name": "&hyphen;",
+      "semicolon": true
+    },
+    {
+      "characters": "í",
+      "codepoints": [
+        237
+      ],
+      "name": "&iacute",
+      "semicolon": false
+    },
+    {
+      "characters": "í",
+      "codepoints": [
+        237
+      ],
+      "name": "&iacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁣",
+      "codepoints": [
+        8291
+      ],
+      "name": "&ic;",
+      "semicolon": true
+    },
+    {
+      "characters": "î",
+      "codepoints": [
+        238
+      ],
+      "name": "&icirc",
+      "semicolon": false
+    },
+    {
+      "characters": "î",
+      "codepoints": [
+        238
+      ],
+      "name": "&icirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "и",
+      "codepoints": [
+        1080
+      ],
+      "name": "&icy;",
+      "semicolon": true
+    },
+    {
+      "characters": "е",
+      "codepoints": [
+        1077
+      ],
+      "name": "&iecy;",
+      "semicolon": true
+    },
+    {
+      "characters": "¡",
+      "codepoints": [
+        161
+      ],
+      "name": "&iexcl",
+      "semicolon": false
+    },
+    {
+      "characters": "¡",
+      "codepoints": [
+        161
+      ],
+      "name": "&iexcl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇔",
+      "codepoints": [
+        8660
+      ],
+      "name": "&iff;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔦",
+      "codepoints": [
+        120102
+      ],
+      "name": "&ifr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ì",
+      "codepoints": [
+        236
+      ],
+      "name": "&igrave",
+      "semicolon": false
+    },
+    {
+      "characters": "ì",
+      "codepoints": [
+        236
+      ],
+      "name": "&igrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "ⅈ",
+      "codepoints": [
+        8520
+      ],
+      "name": "&ii;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨌",
+      "codepoints": [
+        10764
+      ],
+      "name": "&iiiint;",
+      "semicolon": true
+    },
+    {
+      "characters": "∭",
+      "codepoints": [
+        8749
+      ],
+      "name": "&iiint;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧜",
+      "codepoints": [
+        10716
+      ],
+      "name": "&iinfin;",
+      "semicolon": true
+    },
+    {
+      "characters": "℩",
+      "codepoints": [
+        8489
+      ],
+      "name": "&iiota;",
+      "semicolon": true
+    },
+    {
+      "characters": "ĳ",
+      "codepoints": [
+        307
+      ],
+      "name": "&ijlig;",
+      "semicolon": true
+    },
+    {
+      "characters": "ī",
+      "codepoints": [
+        299
+      ],
+      "name": "&imacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℑ",
+      "codepoints": [
+        8465
+      ],
+      "name": "&image;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℐ",
+      "codepoints": [
+        8464
+      ],
+      "name": "&imagline;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℑ",
+      "codepoints": [
+        8465
+      ],
+      "name": "&imagpart;",
+      "semicolon": true
+    },
+    {
+      "characters": "ı",
+      "codepoints": [
+        305
+      ],
+      "name": "&imath;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊷",
+      "codepoints": [
+        8887
+      ],
+      "name": "&imof;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ƶ",
+      "codepoints": [
+        437
+      ],
+      "name": "&imped;",
+      "semicolon": true
+    },
+    {
+      "characters": "∈",
+      "codepoints": [
+        8712
+      ],
+      "name": "&in;",
+      "semicolon": true
+    },
+    {
+      "characters": "℅",
+      "codepoints": [
+        8453
+      ],
+      "name": "&incare;",
+      "semicolon": true
+    },
+    {
+      "characters": "∞",
+      "codepoints": [
+        8734
+      ],
+      "name": "&infin;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧝",
+      "codepoints": [
+        10717
+      ],
+      "name": "&infintie;",
+      "semicolon": true
+    },
+    {
+      "characters": "ı",
+      "codepoints": [
+        305
+      ],
+      "name": "&inodot;",
+      "semicolon": true
+    },
+    {
+      "characters": "∫",
+      "codepoints": [
+        8747
+      ],
+      "name": "&int;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊺",
+      "codepoints": [
+        8890
+      ],
+      "name": "&intcal;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℤ",
+      "codepoints": [
+        8484
+      ],
+      "name": "&integers;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊺",
+      "codepoints": [
+        8890
+      ],
+      "name": "&intercal;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨗",
+      "codepoints": [
+        10775
+      ],
+      "name": "&intlarhk;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨼",
+      "codepoints": [
+        10812
+      ],
+      "name": "&intprod;",
+      "semicolon": true
+    },
+    {
+      "characters": "ё",
+      "codepoints": [
+        1105
+      ],
+      "name": "&iocy;",
+      "semicolon": true
+    },
+    {
+      "characters": "į",
+      "codepoints": [
+        303
+      ],
+      "name": "&iogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕚",
+      "codepoints": [
+        120154
+      ],
+      "name": "&iopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "ι",
+      "codepoints": [
+        953
+      ],
+      "name": "&iota;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨼",
+      "codepoints": [
+        10812
+      ],
+      "name": "&iprod;",
+      "semicolon": true
+    },
+    {
+      "characters": "¿",
+      "codepoints": [
+        191
+      ],
+      "name": "&iquest",
+      "semicolon": false
+    },
+    {
+      "characters": "¿",
+      "codepoints": [
+        191
+      ],
+      "name": "&iquest;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒾",
+      "codepoints": [
+        119998
+      ],
+      "name": "&iscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∈",
+      "codepoints": [
+        8712
+      ],
+      "name": "&isin;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋹",
+      "codepoints": [
+        8953
+      ],
+      "name": "&isinE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋵",
+      "codepoints": [
+        8949
+      ],
+      "name": "&isindot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋴",
+      "codepoints": [
+        8948
+      ],
+      "name": "&isins;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋳",
+      "codepoints": [
+        8947
+      ],
+      "name": "&isinsv;",
+      "semicolon": true
+    },
+    {
+      "characters": "∈",
+      "codepoints": [
+        8712
+      ],
+      "name": "&isinv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁢",
+      "codepoints": [
+        8290
+      ],
+      "name": "&it;",
+      "semicolon": true
+    },
+    {
+      "characters": "ĩ",
+      "codepoints": [
+        297
+      ],
+      "name": "&itilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "і",
+      "codepoints": [
+        1110
+      ],
+      "name": "&iukcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ï",
+      "codepoints": [
+        239
+      ],
+      "name": "&iuml",
+      "semicolon": false
+    },
+    {
+      "characters": "ï",
+      "codepoints": [
+        239
+      ],
+      "name": "&iuml;",
+      "semicolon": true
+    },
+    {
+      "characters": "ĵ",
+      "codepoints": [
+        309
+      ],
+      "name": "&jcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "й",
+      "codepoints": [
+        1081
+      ],
+      "name": "&jcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔧",
+      "codepoints": [
+        120103
+      ],
+      "name": "&jfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ȷ",
+      "codepoints": [
+        567
+      ],
+      "name": "&jmath;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕛",
+      "codepoints": [
+        120155
+      ],
+      "name": "&jopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝒿",
+      "codepoints": [
+        119999
+      ],
+      "name": "&jscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ј",
+      "codepoints": [
+        1112
+      ],
+      "name": "&jsercy;",
+      "semicolon": true
+    },
+    {
+      "characters": "є",
+      "codepoints": [
+        1108
+      ],
+      "name": "&jukcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "κ",
+      "codepoints": [
+        954
+      ],
+      "name": "&kappa;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϰ",
+      "codepoints": [
+        1008
+      ],
+      "name": "&kappav;",
+      "semicolon": true
+    },
+    {
+      "characters": "ķ",
+      "codepoints": [
+        311
+      ],
+      "name": "&kcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "к",
+      "codepoints": [
+        1082
+      ],
+      "name": "&kcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔨",
+      "codepoints": [
+        120104
+      ],
+      "name": "&kfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ĸ",
+      "codepoints": [
+        312
+      ],
+      "name": "&kgreen;",
+      "semicolon": true
+    },
+    {
+      "characters": "х",
+      "codepoints": [
+        1093
+      ],
+      "name": "&khcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ќ",
+      "codepoints": [
+        1116
+      ],
+      "name": "&kjcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕜",
+      "codepoints": [
+        120156
+      ],
+      "name": "&kopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓀",
+      "codepoints": [
+        120000
+      ],
+      "name": "&kscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇚",
+      "codepoints": [
+        8666
+      ],
+      "name": "&lAarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇐",
+      "codepoints": [
+        8656
+      ],
+      "name": "&lArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤛",
+      "codepoints": [
+        10523
+      ],
+      "name": "&lAtail;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤎",
+      "codepoints": [
+        10510
+      ],
+      "name": "&lBarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≦",
+      "codepoints": [
+        8806
+      ],
+      "name": "&lE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪋",
+      "codepoints": [
+        10891
+      ],
+      "name": "&lEg;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥢",
+      "codepoints": [
+        10594
+      ],
+      "name": "&lHar;",
+      "semicolon": true
+    },
+    {
+      "characters": "ĺ",
+      "codepoints": [
+        314
+      ],
+      "name": "&lacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦴",
+      "codepoints": [
+        10676
+      ],
+      "name": "&laemptyv;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℒ",
+      "codepoints": [
+        8466
+      ],
+      "name": "&lagran;",
+      "semicolon": true
+    },
+    {
+      "characters": "λ",
+      "codepoints": [
+        955
+      ],
+      "name": "&lambda;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟨",
+      "codepoints": [
+        10216
+      ],
+      "name": "&lang;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦑",
+      "codepoints": [
+        10641
+      ],
+      "name": "&langd;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟨",
+      "codepoints": [
+        10216
+      ],
+      "name": "&langle;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪅",
+      "codepoints": [
+        10885
+      ],
+      "name": "&lap;",
+      "semicolon": true
+    },
+    {
+      "characters": "«",
+      "codepoints": [
+        171
+      ],
+      "name": "&laquo",
+      "semicolon": false
+    },
+    {
+      "characters": "«",
+      "codepoints": [
+        171
+      ],
+      "name": "&laquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "←",
+      "codepoints": [
+        8592
+      ],
+      "name": "&larr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇤",
+      "codepoints": [
+        8676
+      ],
+      "name": "&larrb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤟",
+      "codepoints": [
+        10527
+      ],
+      "name": "&larrbfs;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤝",
+      "codepoints": [
+        10525
+      ],
+      "name": "&larrfs;",
+      "semicolon": true
+    },
+    {
+      "characters": "↩",
+      "codepoints": [
+        8617
+      ],
+      "name": "&larrhk;",
+      "semicolon": true
+    },
+    {
+      "characters": "↫",
+      "codepoints": [
+        8619
+      ],
+      "name": "&larrlp;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤹",
+      "codepoints": [
+        10553
+      ],
+      "name": "&larrpl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥳",
+      "codepoints": [
+        10611
+      ],
+      "name": "&larrsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "↢",
+      "codepoints": [
+        8610
+      ],
+      "name": "&larrtl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪫",
+      "codepoints": [
+        10923
+      ],
+      "name": "&lat;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤙",
+      "codepoints": [
+        10521
+      ],
+      "name": "&latail;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪭",
+      "codepoints": [
+        10925
+      ],
+      "name": "&late;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪭︀",
+      "codepoints": [
+        10925,
+        65024
+      ],
+      "name": "&lates;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤌",
+      "codepoints": [
+        10508
+      ],
+      "name": "&lbarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "❲",
+      "codepoints": [
+        10098
+      ],
+      "name": "&lbbrk;",
+      "semicolon": true
+    },
+    {
+      "characters": "{",
+      "codepoints": [
+        123
+      ],
+      "name": "&lbrace;",
+      "semicolon": true
+    },
+    {
+      "characters": "[",
+      "codepoints": [
+        91
+      ],
+      "name": "&lbrack;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦋",
+      "codepoints": [
+        10635
+      ],
+      "name": "&lbrke;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦏",
+      "codepoints": [
+        10639
+      ],
+      "name": "&lbrksld;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦍",
+      "codepoints": [
+        10637
+      ],
+      "name": "&lbrkslu;",
+      "semicolon": true
+    },
+    {
+      "characters": "ľ",
+      "codepoints": [
+        318
+      ],
+      "name": "&lcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "ļ",
+      "codepoints": [
+        316
+      ],
+      "name": "&lcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌈",
+      "codepoints": [
+        8968
+      ],
+      "name": "&lceil;",
+      "semicolon": true
+    },
+    {
+      "characters": "{",
+      "codepoints": [
+        123
+      ],
+      "name": "&lcub;",
+      "semicolon": true
+    },
+    {
+      "characters": "л",
+      "codepoints": [
+        1083
+      ],
+      "name": "&lcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤶",
+      "codepoints": [
+        10550
+      ],
+      "name": "&ldca;",
+      "semicolon": true
+    },
+    {
+      "characters": "“",
+      "codepoints": [
+        8220
+      ],
+      "name": "&ldquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "„",
+      "codepoints": [
+        8222
+      ],
+      "name": "&ldquor;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥧",
+      "codepoints": [
+        10599
+      ],
+      "name": "&ldrdhar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥋",
+      "codepoints": [
+        10571
+      ],
+      "name": "&ldrushar;",
+      "semicolon": true
+    },
+    {
+      "characters": "↲",
+      "codepoints": [
+        8626
+      ],
+      "name": "&ldsh;",
+      "semicolon": true
+    },
+    {
+      "characters": "≤",
+      "codepoints": [
+        8804
+      ],
+      "name": "&le;",
+      "semicolon": true
+    },
+    {
+      "characters": "←",
+      "codepoints": [
+        8592
+      ],
+      "name": "&leftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↢",
+      "codepoints": [
+        8610
+      ],
+      "name": "&leftarrowtail;",
+      "semicolon": true
+    },
+    {
+      "characters": "↽",
+      "codepoints": [
+        8637
+      ],
+      "name": "&leftharpoondown;",
+      "semicolon": true
+    },
+    {
+      "characters": "↼",
+      "codepoints": [
+        8636
+      ],
+      "name": "&leftharpoonup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇇",
+      "codepoints": [
+        8647
+      ],
+      "name": "&leftleftarrows;",
+      "semicolon": true
+    },
+    {
+      "characters": "↔",
+      "codepoints": [
+        8596
+      ],
+      "name": "&leftrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇆",
+      "codepoints": [
+        8646
+      ],
+      "name": "&leftrightarrows;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇋",
+      "codepoints": [
+        8651
+      ],
+      "name": "&leftrightharpoons;",
+      "semicolon": true
+    },
+    {
+      "characters": "↭",
+      "codepoints": [
+        8621
+      ],
+      "name": "&leftrightsquigarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋋",
+      "codepoints": [
+        8907
+      ],
+      "name": "&leftthreetimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋚",
+      "codepoints": [
+        8922
+      ],
+      "name": "&leg;",
+      "semicolon": true
+    },
+    {
+      "characters": "≤",
+      "codepoints": [
+        8804
+      ],
+      "name": "&leq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≦",
+      "codepoints": [
+        8806
+      ],
+      "name": "&leqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩽",
+      "codepoints": [
+        10877
+      ],
+      "name": "&leqslant;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩽",
+      "codepoints": [
+        10877
+      ],
+      "name": "&les;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪨",
+      "codepoints": [
+        10920
+      ],
+      "name": "&lescc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩿",
+      "codepoints": [
+        10879
+      ],
+      "name": "&lesdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪁",
+      "codepoints": [
+        10881
+      ],
+      "name": "&lesdoto;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪃",
+      "codepoints": [
+        10883
+      ],
+      "name": "&lesdotor;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋚︀",
+      "codepoints": [
+        8922,
+        65024
+      ],
+      "name": "&lesg;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪓",
+      "codepoints": [
+        10899
+      ],
+      "name": "&lesges;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪅",
+      "codepoints": [
+        10885
+      ],
+      "name": "&lessapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋖",
+      "codepoints": [
+        8918
+      ],
+      "name": "&lessdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋚",
+      "codepoints": [
+        8922
+      ],
+      "name": "&lesseqgtr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪋",
+      "codepoints": [
+        10891
+      ],
+      "name": "&lesseqqgtr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≶",
+      "codepoints": [
+        8822
+      ],
+      "name": "&lessgtr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≲",
+      "codepoints": [
+        8818
+      ],
+      "name": "&lesssim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥼",
+      "codepoints": [
+        10620
+      ],
+      "name": "&lfisht;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌊",
+      "codepoints": [
+        8970
+      ],
+      "name": "&lfloor;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔩",
+      "codepoints": [
+        120105
+      ],
+      "name": "&lfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≶",
+      "codepoints": [
+        8822
+      ],
+      "name": "&lg;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪑",
+      "codepoints": [
+        10897
+      ],
+      "name": "&lgE;",
+      "semicolon": true
+    },
+    {
+      "characters": "↽",
+      "codepoints": [
+        8637
+      ],
+      "name": "&lhard;",
+      "semicolon": true
+    },
+    {
+      "characters": "↼",
+      "codepoints": [
+        8636
+      ],
+      "name": "&lharu;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥪",
+      "codepoints": [
+        10602
+      ],
+      "name": "&lharul;",
+      "semicolon": true
+    },
+    {
+      "characters": "▄",
+      "codepoints": [
+        9604
+      ],
+      "name": "&lhblk;",
+      "semicolon": true
+    },
+    {
+      "characters": "љ",
+      "codepoints": [
+        1113
+      ],
+      "name": "&ljcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "≪",
+      "codepoints": [
+        8810
+      ],
+      "name": "&ll;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇇",
+      "codepoints": [
+        8647
+      ],
+      "name": "&llarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌞",
+      "codepoints": [
+        8990
+      ],
+      "name": "&llcorner;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥫",
+      "codepoints": [
+        10603
+      ],
+      "name": "&llhard;",
+      "semicolon": true
+    },
+    {
+      "characters": "◺",
+      "codepoints": [
+        9722
+      ],
+      "name": "&lltri;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŀ",
+      "codepoints": [
+        320
+      ],
+      "name": "&lmidot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎰",
+      "codepoints": [
+        9136
+      ],
+      "name": "&lmoust;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎰",
+      "codepoints": [
+        9136
+      ],
+      "name": "&lmoustache;",
+      "semicolon": true
+    },
+    {
+      "characters": "≨",
+      "codepoints": [
+        8808
+      ],
+      "name": "&lnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪉",
+      "codepoints": [
+        10889
+      ],
+      "name": "&lnap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪉",
+      "codepoints": [
+        10889
+      ],
+      "name": "&lnapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪇",
+      "codepoints": [
+        10887
+      ],
+      "name": "&lne;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪇",
+      "codepoints": [
+        10887
+      ],
+      "name": "&lneq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≨",
+      "codepoints": [
+        8808
+      ],
+      "name": "&lneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋦",
+      "codepoints": [
+        8934
+      ],
+      "name": "&lnsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟬",
+      "codepoints": [
+        10220
+      ],
+      "name": "&loang;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇽",
+      "codepoints": [
+        8701
+      ],
+      "name": "&loarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟦",
+      "codepoints": [
+        10214
+      ],
+      "name": "&lobrk;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟵",
+      "codepoints": [
+        10229
+      ],
+      "name": "&longleftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟷",
+      "codepoints": [
+        10231
+      ],
+      "name": "&longleftrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟼",
+      "codepoints": [
+        10236
+      ],
+      "name": "&longmapsto;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟶",
+      "codepoints": [
+        10230
+      ],
+      "name": "&longrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↫",
+      "codepoints": [
+        8619
+      ],
+      "name": "&looparrowleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "↬",
+      "codepoints": [
+        8620
+      ],
+      "name": "&looparrowright;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦅",
+      "codepoints": [
+        10629
+      ],
+      "name": "&lopar;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕝",
+      "codepoints": [
+        120157
+      ],
+      "name": "&lopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨭",
+      "codepoints": [
+        10797
+      ],
+      "name": "&loplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨴",
+      "codepoints": [
+        10804
+      ],
+      "name": "&lotimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "∗",
+      "codepoints": [
+        8727
+      ],
+      "name": "&lowast;",
+      "semicolon": true
+    },
+    {
+      "characters": "_",
+      "codepoints": [
+        95
+      ],
+      "name": "&lowbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "◊",
+      "codepoints": [
+        9674
+      ],
+      "name": "&loz;",
+      "semicolon": true
+    },
+    {
+      "characters": "◊",
+      "codepoints": [
+        9674
+      ],
+      "name": "&lozenge;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧫",
+      "codepoints": [
+        10731
+      ],
+      "name": "&lozf;",
+      "semicolon": true
+    },
+    {
+      "characters": "(",
+      "codepoints": [
+        40
+      ],
+      "name": "&lpar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦓",
+      "codepoints": [
+        10643
+      ],
+      "name": "&lparlt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇆",
+      "codepoints": [
+        8646
+      ],
+      "name": "&lrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌟",
+      "codepoints": [
+        8991
+      ],
+      "name": "&lrcorner;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇋",
+      "codepoints": [
+        8651
+      ],
+      "name": "&lrhar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥭",
+      "codepoints": [
+        10605
+      ],
+      "name": "&lrhard;",
+      "semicolon": true
+    },
+    {
+      "characters": "‎",
+      "codepoints": [
+        8206
+      ],
+      "name": "&lrm;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊿",
+      "codepoints": [
+        8895
+      ],
+      "name": "&lrtri;",
+      "semicolon": true
+    },
+    {
+      "characters": "‹",
+      "codepoints": [
+        8249
+      ],
+      "name": "&lsaquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓁",
+      "codepoints": [
+        120001
+      ],
+      "name": "&lscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↰",
+      "codepoints": [
+        8624
+      ],
+      "name": "&lsh;",
+      "semicolon": true
+    },
+    {
+      "characters": "≲",
+      "codepoints": [
+        8818
+      ],
+      "name": "&lsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪍",
+      "codepoints": [
+        10893
+      ],
+      "name": "&lsime;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪏",
+      "codepoints": [
+        10895
+      ],
+      "name": "&lsimg;",
+      "semicolon": true
+    },
+    {
+      "characters": "[",
+      "codepoints": [
+        91
+      ],
+      "name": "&lsqb;",
+      "semicolon": true
+    },
+    {
+      "characters": "‘",
+      "codepoints": [
+        8216
+      ],
+      "name": "&lsquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "‚",
+      "codepoints": [
+        8218
+      ],
+      "name": "&lsquor;",
+      "semicolon": true
+    },
+    {
+      "characters": "ł",
+      "codepoints": [
+        322
+      ],
+      "name": "&lstrok;",
+      "semicolon": true
+    },
+    {
+      "characters": "<",
+      "codepoints": [
+        60
+      ],
+      "name": "&lt",
+      "semicolon": false
+    },
+    {
+      "characters": "<",
+      "codepoints": [
+        60
+      ],
+      "name": "&lt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪦",
+      "codepoints": [
+        10918
+      ],
+      "name": "&ltcc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩹",
+      "codepoints": [
+        10873
+      ],
+      "name": "&ltcir;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋖",
+      "codepoints": [
+        8918
+      ],
+      "name": "&ltdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋋",
+      "codepoints": [
+        8907
+      ],
+      "name": "&lthree;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋉",
+      "codepoints": [
+        8905
+      ],
+      "name": "&ltimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥶",
+      "codepoints": [
+        10614
+      ],
+      "name": "&ltlarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩻",
+      "codepoints": [
+        10875
+      ],
+      "name": "&ltquest;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦖",
+      "codepoints": [
+        10646
+      ],
+      "name": "&ltrPar;",
+      "semicolon": true
+    },
+    {
+      "characters": "◃",
+      "codepoints": [
+        9667
+      ],
+      "name": "&ltri;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊴",
+      "codepoints": [
+        8884
+      ],
+      "name": "&ltrie;",
+      "semicolon": true
+    },
+    {
+      "characters": "◂",
+      "codepoints": [
+        9666
+      ],
+      "name": "&ltrif;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥊",
+      "codepoints": [
+        10570
+      ],
+      "name": "&lurdshar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥦",
+      "codepoints": [
+        10598
+      ],
+      "name": "&luruhar;",
+      "semicolon": true
+    },
+    {
+      "characters": "≨︀",
+      "codepoints": [
+        8808,
+        65024
+      ],
+      "name": "&lvertneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≨︀",
+      "codepoints": [
+        8808,
+        65024
+      ],
+      "name": "&lvnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "∺",
+      "codepoints": [
+        8762
+      ],
+      "name": "&mDDot;",
+      "semicolon": true
+    },
+    {
+      "characters": "¯",
+      "codepoints": [
+        175
+      ],
+      "name": "&macr",
+      "semicolon": false
+    },
+    {
+      "characters": "¯",
+      "codepoints": [
+        175
+      ],
+      "name": "&macr;",
+      "semicolon": true
+    },
+    {
+      "characters": "♂",
+      "codepoints": [
+        9794
+      ],
+      "name": "&male;",
+      "semicolon": true
+    },
+    {
+      "characters": "✠",
+      "codepoints": [
+        10016
+      ],
+      "name": "&malt;",
+      "semicolon": true
+    },
+    {
+      "characters": "✠",
+      "codepoints": [
+        10016
+      ],
+      "name": "&maltese;",
+      "semicolon": true
+    },
+    {
+      "characters": "↦",
+      "codepoints": [
+        8614
+      ],
+      "name": "&map;",
+      "semicolon": true
+    },
+    {
+      "characters": "↦",
+      "codepoints": [
+        8614
+      ],
+      "name": "&mapsto;",
+      "semicolon": true
+    },
+    {
+      "characters": "↧",
+      "codepoints": [
+        8615
+      ],
+      "name": "&mapstodown;",
+      "semicolon": true
+    },
+    {
+      "characters": "↤",
+      "codepoints": [
+        8612
+      ],
+      "name": "&mapstoleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "↥",
+      "codepoints": [
+        8613
+      ],
+      "name": "&mapstoup;",
+      "semicolon": true
+    },
+    {
+      "characters": "▮",
+      "codepoints": [
+        9646
+      ],
+      "name": "&marker;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨩",
+      "codepoints": [
+        10793
+      ],
+      "name": "&mcomma;",
+      "semicolon": true
+    },
+    {
+      "characters": "м",
+      "codepoints": [
+        1084
+      ],
+      "name": "&mcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "—",
+      "codepoints": [
+        8212
+      ],
+      "name": "&mdash;",
+      "semicolon": true
+    },
+    {
+      "characters": "∡",
+      "codepoints": [
+        8737
+      ],
+      "name": "&measuredangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔪",
+      "codepoints": [
+        120106
+      ],
+      "name": "&mfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "℧",
+      "codepoints": [
+        8487
+      ],
+      "name": "&mho;",
+      "semicolon": true
+    },
+    {
+      "characters": "µ",
+      "codepoints": [
+        181
+      ],
+      "name": "&micro",
+      "semicolon": false
+    },
+    {
+      "characters": "µ",
+      "codepoints": [
+        181
+      ],
+      "name": "&micro;",
+      "semicolon": true
+    },
+    {
+      "characters": "∣",
+      "codepoints": [
+        8739
+      ],
+      "name": "&mid;",
+      "semicolon": true
+    },
+    {
+      "characters": "*",
+      "codepoints": [
+        42
+      ],
+      "name": "&midast;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫰",
+      "codepoints": [
+        10992
+      ],
+      "name": "&midcir;",
+      "semicolon": true
+    },
+    {
+      "characters": "·",
+      "codepoints": [
+        183
+      ],
+      "name": "&middot",
+      "semicolon": false
+    },
+    {
+      "characters": "·",
+      "codepoints": [
+        183
+      ],
+      "name": "&middot;",
+      "semicolon": true
+    },
+    {
+      "characters": "−",
+      "codepoints": [
+        8722
+      ],
+      "name": "&minus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊟",
+      "codepoints": [
+        8863
+      ],
+      "name": "&minusb;",
+      "semicolon": true
+    },
+    {
+      "characters": "∸",
+      "codepoints": [
+        8760
+      ],
+      "name": "&minusd;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨪",
+      "codepoints": [
+        10794
+      ],
+      "name": "&minusdu;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫛",
+      "codepoints": [
+        10971
+      ],
+      "name": "&mlcp;",
+      "semicolon": true
+    },
+    {
+      "characters": "…",
+      "codepoints": [
+        8230
+      ],
+      "name": "&mldr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∓",
+      "codepoints": [
+        8723
+      ],
+      "name": "&mnplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊧",
+      "codepoints": [
+        8871
+      ],
+      "name": "&models;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕞",
+      "codepoints": [
+        120158
+      ],
+      "name": "&mopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "∓",
+      "codepoints": [
+        8723
+      ],
+      "name": "&mp;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓂",
+      "codepoints": [
+        120002
+      ],
+      "name": "&mscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∾",
+      "codepoints": [
+        8766
+      ],
+      "name": "&mstpos;",
+      "semicolon": true
+    },
+    {
+      "characters": "μ",
+      "codepoints": [
+        956
+      ],
+      "name": "&mu;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊸",
+      "codepoints": [
+        8888
+      ],
+      "name": "&multimap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊸",
+      "codepoints": [
+        8888
+      ],
+      "name": "&mumap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋙̸",
+      "codepoints": [
+        8921,
+        824
+      ],
+      "name": "&nGg;",
+      "semicolon": true
+    },
+    {
+      "characters": "≫⃒",
+      "codepoints": [
+        8811,
+        8402
+      ],
+      "name": "&nGt;",
+      "semicolon": true
+    },
+    {
+      "characters": "≫̸",
+      "codepoints": [
+        8811,
+        824
+      ],
+      "name": "&nGtv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇍",
+      "codepoints": [
+        8653
+      ],
+      "name": "&nLeftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇎",
+      "codepoints": [
+        8654
+      ],
+      "name": "&nLeftrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋘̸",
+      "codepoints": [
+        8920,
+        824
+      ],
+      "name": "&nLl;",
+      "semicolon": true
+    },
+    {
+      "characters": "≪⃒",
+      "codepoints": [
+        8810,
+        8402
+      ],
+      "name": "&nLt;",
+      "semicolon": true
+    },
+    {
+      "characters": "≪̸",
+      "codepoints": [
+        8810,
+        824
+      ],
+      "name": "&nLtv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇏",
+      "codepoints": [
+        8655
+      ],
+      "name": "&nRightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊯",
+      "codepoints": [
+        8879
+      ],
+      "name": "&nVDash;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊮",
+      "codepoints": [
+        8878
+      ],
+      "name": "&nVdash;",
+      "semicolon": true
+    },
+    {
+      "characters": "∇",
+      "codepoints": [
+        8711
+      ],
+      "name": "&nabla;",
+      "semicolon": true
+    },
+    {
+      "characters": "ń",
+      "codepoints": [
+        324
+      ],
+      "name": "&nacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "∠⃒",
+      "codepoints": [
+        8736,
+        8402
+      ],
+      "name": "&nang;",
+      "semicolon": true
+    },
+    {
+      "characters": "≉",
+      "codepoints": [
+        8777
+      ],
+      "name": "&nap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩰̸",
+      "codepoints": [
+        10864,
+        824
+      ],
+      "name": "&napE;",
+      "semicolon": true
+    },
+    {
+      "characters": "≋̸",
+      "codepoints": [
+        8779,
+        824
+      ],
+      "name": "&napid;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŉ",
+      "codepoints": [
+        329
+      ],
+      "name": "&napos;",
+      "semicolon": true
+    },
+    {
+      "characters": "≉",
+      "codepoints": [
+        8777
+      ],
+      "name": "&napprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "♮",
+      "codepoints": [
+        9838
+      ],
+      "name": "&natur;",
+      "semicolon": true
+    },
+    {
+      "characters": "♮",
+      "codepoints": [
+        9838
+      ],
+      "name": "&natural;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℕ",
+      "codepoints": [
+        8469
+      ],
+      "name": "&naturals;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        160
+      ],
+      "name": "&nbsp",
+      "semicolon": false
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        160
+      ],
+      "name": "&nbsp;",
+      "semicolon": true
+    },
+    {
+      "characters": "≎̸",
+      "codepoints": [
+        8782,
+        824
+      ],
+      "name": "&nbump;",
+      "semicolon": true
+    },
+    {
+      "characters": "≏̸",
+      "codepoints": [
+        8783,
+        824
+      ],
+      "name": "&nbumpe;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩃",
+      "codepoints": [
+        10819
+      ],
+      "name": "&ncap;",
+      "semicolon": true
+    },
+    {
+      "characters": "ň",
+      "codepoints": [
+        328
+      ],
+      "name": "&ncaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "ņ",
+      "codepoints": [
+        326
+      ],
+      "name": "&ncedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "≇",
+      "codepoints": [
+        8775
+      ],
+      "name": "&ncong;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩭̸",
+      "codepoints": [
+        10861,
+        824
+      ],
+      "name": "&ncongdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩂",
+      "codepoints": [
+        10818
+      ],
+      "name": "&ncup;",
+      "semicolon": true
+    },
+    {
+      "characters": "н",
+      "codepoints": [
+        1085
+      ],
+      "name": "&ncy;",
+      "semicolon": true
+    },
+    {
+      "characters": "–",
+      "codepoints": [
+        8211
+      ],
+      "name": "&ndash;",
+      "semicolon": true
+    },
+    {
+      "characters": "≠",
+      "codepoints": [
+        8800
+      ],
+      "name": "&ne;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇗",
+      "codepoints": [
+        8663
+      ],
+      "name": "&neArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤤",
+      "codepoints": [
+        10532
+      ],
+      "name": "&nearhk;",
+      "semicolon": true
+    },
+    {
+      "characters": "↗",
+      "codepoints": [
+        8599
+      ],
+      "name": "&nearr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↗",
+      "codepoints": [
+        8599
+      ],
+      "name": "&nearrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "≐̸",
+      "codepoints": [
+        8784,
+        824
+      ],
+      "name": "&nedot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≢",
+      "codepoints": [
+        8802
+      ],
+      "name": "&nequiv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤨",
+      "codepoints": [
+        10536
+      ],
+      "name": "&nesear;",
+      "semicolon": true
+    },
+    {
+      "characters": "≂̸",
+      "codepoints": [
+        8770,
+        824
+      ],
+      "name": "&nesim;",
+      "semicolon": true
+    },
+    {
+      "characters": "∄",
+      "codepoints": [
+        8708
+      ],
+      "name": "&nexist;",
+      "semicolon": true
+    },
+    {
+      "characters": "∄",
+      "codepoints": [
+        8708
+      ],
+      "name": "&nexists;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔫",
+      "codepoints": [
+        120107
+      ],
+      "name": "&nfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≧̸",
+      "codepoints": [
+        8807,
+        824
+      ],
+      "name": "&ngE;",
+      "semicolon": true
+    },
+    {
+      "characters": "≱",
+      "codepoints": [
+        8817
+      ],
+      "name": "&nge;",
+      "semicolon": true
+    },
+    {
+      "characters": "≱",
+      "codepoints": [
+        8817
+      ],
+      "name": "&ngeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≧̸",
+      "codepoints": [
+        8807,
+        824
+      ],
+      "name": "&ngeqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩾̸",
+      "codepoints": [
+        10878,
+        824
+      ],
+      "name": "&ngeqslant;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩾̸",
+      "codepoints": [
+        10878,
+        824
+      ],
+      "name": "&nges;",
+      "semicolon": true
+    },
+    {
+      "characters": "≵",
+      "codepoints": [
+        8821
+      ],
+      "name": "&ngsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "≯",
+      "codepoints": [
+        8815
+      ],
+      "name": "&ngt;",
+      "semicolon": true
+    },
+    {
+      "characters": "≯",
+      "codepoints": [
+        8815
+      ],
+      "name": "&ngtr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇎",
+      "codepoints": [
+        8654
+      ],
+      "name": "&nhArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↮",
+      "codepoints": [
+        8622
+      ],
+      "name": "&nharr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫲",
+      "codepoints": [
+        10994
+      ],
+      "name": "&nhpar;",
+      "semicolon": true
+    },
+    {
+      "characters": "∋",
+      "codepoints": [
+        8715
+      ],
+      "name": "&ni;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋼",
+      "codepoints": [
+        8956
+      ],
+      "name": "&nis;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋺",
+      "codepoints": [
+        8954
+      ],
+      "name": "&nisd;",
+      "semicolon": true
+    },
+    {
+      "characters": "∋",
+      "codepoints": [
+        8715
+      ],
+      "name": "&niv;",
+      "semicolon": true
+    },
+    {
+      "characters": "њ",
+      "codepoints": [
+        1114
+      ],
+      "name": "&njcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇍",
+      "codepoints": [
+        8653
+      ],
+      "name": "&nlArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≦̸",
+      "codepoints": [
+        8806,
+        824
+      ],
+      "name": "&nlE;",
+      "semicolon": true
+    },
+    {
+      "characters": "↚",
+      "codepoints": [
+        8602
+      ],
+      "name": "&nlarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "‥",
+      "codepoints": [
+        8229
+      ],
+      "name": "&nldr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≰",
+      "codepoints": [
+        8816
+      ],
+      "name": "&nle;",
+      "semicolon": true
+    },
+    {
+      "characters": "↚",
+      "codepoints": [
+        8602
+      ],
+      "name": "&nleftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↮",
+      "codepoints": [
+        8622
+      ],
+      "name": "&nleftrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "≰",
+      "codepoints": [
+        8816
+      ],
+      "name": "&nleq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≦̸",
+      "codepoints": [
+        8806,
+        824
+      ],
+      "name": "&nleqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩽̸",
+      "codepoints": [
+        10877,
+        824
+      ],
+      "name": "&nleqslant;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩽̸",
+      "codepoints": [
+        10877,
+        824
+      ],
+      "name": "&nles;",
+      "semicolon": true
+    },
+    {
+      "characters": "≮",
+      "codepoints": [
+        8814
+      ],
+      "name": "&nless;",
+      "semicolon": true
+    },
+    {
+      "characters": "≴",
+      "codepoints": [
+        8820
+      ],
+      "name": "&nlsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "≮",
+      "codepoints": [
+        8814
+      ],
+      "name": "&nlt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋪",
+      "codepoints": [
+        8938
+      ],
+      "name": "&nltri;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋬",
+      "codepoints": [
+        8940
+      ],
+      "name": "&nltrie;",
+      "semicolon": true
+    },
+    {
+      "characters": "∤",
+      "codepoints": [
+        8740
+      ],
+      "name": "&nmid;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕟",
+      "codepoints": [
+        120159
+      ],
+      "name": "&nopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "¬",
+      "codepoints": [
+        172
+      ],
+      "name": "&not",
+      "semicolon": false
+    },
+    {
+      "characters": "¬",
+      "codepoints": [
+        172
+      ],
+      "name": "&not;",
+      "semicolon": true
+    },
+    {
+      "characters": "∉",
+      "codepoints": [
+        8713
+      ],
+      "name": "&notin;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋹̸",
+      "codepoints": [
+        8953,
+        824
+      ],
+      "name": "&notinE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋵̸",
+      "codepoints": [
+        8949,
+        824
+      ],
+      "name": "&notindot;",
+      "semicolon": true
+    },
+    {
+      "characters": "∉",
+      "codepoints": [
+        8713
+      ],
+      "name": "&notinva;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋷",
+      "codepoints": [
+        8951
+      ],
+      "name": "&notinvb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋶",
+      "codepoints": [
+        8950
+      ],
+      "name": "&notinvc;",
+      "semicolon": true
+    },
+    {
+      "characters": "∌",
+      "codepoints": [
+        8716
+      ],
+      "name": "&notni;",
+      "semicolon": true
+    },
+    {
+      "characters": "∌",
+      "codepoints": [
+        8716
+      ],
+      "name": "&notniva;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋾",
+      "codepoints": [
+        8958
+      ],
+      "name": "&notnivb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋽",
+      "codepoints": [
+        8957
+      ],
+      "name": "&notnivc;",
+      "semicolon": true
+    },
+    {
+      "characters": "∦",
+      "codepoints": [
+        8742
+      ],
+      "name": "&npar;",
+      "semicolon": true
+    },
+    {
+      "characters": "∦",
+      "codepoints": [
+        8742
+      ],
+      "name": "&nparallel;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫽⃥",
+      "codepoints": [
+        11005,
+        8421
+      ],
+      "name": "&nparsl;",
+      "semicolon": true
+    },
+    {
+      "characters": "∂̸",
+      "codepoints": [
+        8706,
+        824
+      ],
+      "name": "&npart;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨔",
+      "codepoints": [
+        10772
+      ],
+      "name": "&npolint;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊀",
+      "codepoints": [
+        8832
+      ],
+      "name": "&npr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋠",
+      "codepoints": [
+        8928
+      ],
+      "name": "&nprcue;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪯̸",
+      "codepoints": [
+        10927,
+        824
+      ],
+      "name": "&npre;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊀",
+      "codepoints": [
+        8832
+      ],
+      "name": "&nprec;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪯̸",
+      "codepoints": [
+        10927,
+        824
+      ],
+      "name": "&npreceq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇏",
+      "codepoints": [
+        8655
+      ],
+      "name": "&nrArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↛",
+      "codepoints": [
+        8603
+      ],
+      "name": "&nrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤳̸",
+      "codepoints": [
+        10547,
+        824
+      ],
+      "name": "&nrarrc;",
+      "semicolon": true
+    },
+    {
+      "characters": "↝̸",
+      "codepoints": [
+        8605,
+        824
+      ],
+      "name": "&nrarrw;",
+      "semicolon": true
+    },
+    {
+      "characters": "↛",
+      "codepoints": [
+        8603
+      ],
+      "name": "&nrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋫",
+      "codepoints": [
+        8939
+      ],
+      "name": "&nrtri;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋭",
+      "codepoints": [
+        8941
+      ],
+      "name": "&nrtrie;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊁",
+      "codepoints": [
+        8833
+      ],
+      "name": "&nsc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋡",
+      "codepoints": [
+        8929
+      ],
+      "name": "&nsccue;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪰̸",
+      "codepoints": [
+        10928,
+        824
+      ],
+      "name": "&nsce;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓃",
+      "codepoints": [
+        120003
+      ],
+      "name": "&nscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∤",
+      "codepoints": [
+        8740
+      ],
+      "name": "&nshortmid;",
+      "semicolon": true
+    },
+    {
+      "characters": "∦",
+      "codepoints": [
+        8742
+      ],
+      "name": "&nshortparallel;",
+      "semicolon": true
+    },
+    {
+      "characters": "≁",
+      "codepoints": [
+        8769
+      ],
+      "name": "&nsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "≄",
+      "codepoints": [
+        8772
+      ],
+      "name": "&nsime;",
+      "semicolon": true
+    },
+    {
+      "characters": "≄",
+      "codepoints": [
+        8772
+      ],
+      "name": "&nsimeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "∤",
+      "codepoints": [
+        8740
+      ],
+      "name": "&nsmid;",
+      "semicolon": true
+    },
+    {
+      "characters": "∦",
+      "codepoints": [
+        8742
+      ],
+      "name": "&nspar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋢",
+      "codepoints": [
+        8930
+      ],
+      "name": "&nsqsube;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋣",
+      "codepoints": [
+        8931
+      ],
+      "name": "&nsqsupe;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊄",
+      "codepoints": [
+        8836
+      ],
+      "name": "&nsub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫅̸",
+      "codepoints": [
+        10949,
+        824
+      ],
+      "name": "&nsubE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊈",
+      "codepoints": [
+        8840
+      ],
+      "name": "&nsube;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊂⃒",
+      "codepoints": [
+        8834,
+        8402
+      ],
+      "name": "&nsubset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊈",
+      "codepoints": [
+        8840
+      ],
+      "name": "&nsubseteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫅̸",
+      "codepoints": [
+        10949,
+        824
+      ],
+      "name": "&nsubseteqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊁",
+      "codepoints": [
+        8833
+      ],
+      "name": "&nsucc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪰̸",
+      "codepoints": [
+        10928,
+        824
+      ],
+      "name": "&nsucceq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊅",
+      "codepoints": [
+        8837
+      ],
+      "name": "&nsup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫆̸",
+      "codepoints": [
+        10950,
+        824
+      ],
+      "name": "&nsupE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊉",
+      "codepoints": [
+        8841
+      ],
+      "name": "&nsupe;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊃⃒",
+      "codepoints": [
+        8835,
+        8402
+      ],
+      "name": "&nsupset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊉",
+      "codepoints": [
+        8841
+      ],
+      "name": "&nsupseteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫆̸",
+      "codepoints": [
+        10950,
+        824
+      ],
+      "name": "&nsupseteqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≹",
+      "codepoints": [
+        8825
+      ],
+      "name": "&ntgl;",
+      "semicolon": true
+    },
+    {
+      "characters": "ñ",
+      "codepoints": [
+        241
+      ],
+      "name": "&ntilde",
+      "semicolon": false
+    },
+    {
+      "characters": "ñ",
+      "codepoints": [
+        241
+      ],
+      "name": "&ntilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "≸",
+      "codepoints": [
+        8824
+      ],
+      "name": "&ntlg;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋪",
+      "codepoints": [
+        8938
+      ],
+      "name": "&ntriangleleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋬",
+      "codepoints": [
+        8940
+      ],
+      "name": "&ntrianglelefteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋫",
+      "codepoints": [
+        8939
+      ],
+      "name": "&ntriangleright;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋭",
+      "codepoints": [
+        8941
+      ],
+      "name": "&ntrianglerighteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "ν",
+      "codepoints": [
+        957
+      ],
+      "name": "&nu;",
+      "semicolon": true
+    },
+    {
+      "characters": "#",
+      "codepoints": [
+        35
+      ],
+      "name": "&num;",
+      "semicolon": true
+    },
+    {
+      "characters": "№",
+      "codepoints": [
+        8470
+      ],
+      "name": "&numero;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8199
+      ],
+      "name": "&numsp;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊭",
+      "codepoints": [
+        8877
+      ],
+      "name": "&nvDash;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤄",
+      "codepoints": [
+        10500
+      ],
+      "name": "&nvHarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≍⃒",
+      "codepoints": [
+        8781,
+        8402
+      ],
+      "name": "&nvap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊬",
+      "codepoints": [
+        8876
+      ],
+      "name": "&nvdash;",
+      "semicolon": true
+    },
+    {
+      "characters": "≥⃒",
+      "codepoints": [
+        8805,
+        8402
+      ],
+      "name": "&nvge;",
+      "semicolon": true
+    },
+    {
+      "characters": ">⃒",
+      "codepoints": [
+        62,
+        8402
+      ],
+      "name": "&nvgt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧞",
+      "codepoints": [
+        10718
+      ],
+      "name": "&nvinfin;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤂",
+      "codepoints": [
+        10498
+      ],
+      "name": "&nvlArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≤⃒",
+      "codepoints": [
+        8804,
+        8402
+      ],
+      "name": "&nvle;",
+      "semicolon": true
+    },
+    {
+      "characters": "<⃒",
+      "codepoints": [
+        60,
+        8402
+      ],
+      "name": "&nvlt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊴⃒",
+      "codepoints": [
+        8884,
+        8402
+      ],
+      "name": "&nvltrie;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤃",
+      "codepoints": [
+        10499
+      ],
+      "name": "&nvrArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊵⃒",
+      "codepoints": [
+        8885,
+        8402
+      ],
+      "name": "&nvrtrie;",
+      "semicolon": true
+    },
+    {
+      "characters": "∼⃒",
+      "codepoints": [
+        8764,
+        8402
+      ],
+      "name": "&nvsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇖",
+      "codepoints": [
+        8662
+      ],
+      "name": "&nwArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤣",
+      "codepoints": [
+        10531
+      ],
+      "name": "&nwarhk;",
+      "semicolon": true
+    },
+    {
+      "characters": "↖",
+      "codepoints": [
+        8598
+      ],
+      "name": "&nwarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↖",
+      "codepoints": [
+        8598
+      ],
+      "name": "&nwarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤧",
+      "codepoints": [
+        10535
+      ],
+      "name": "&nwnear;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ⓢ",
+      "codepoints": [
+        9416
+      ],
+      "name": "&oS;",
+      "semicolon": true
+    },
+    {
+      "characters": "ó",
+      "codepoints": [
+        243
+      ],
+      "name": "&oacute",
+      "semicolon": false
+    },
+    {
+      "characters": "ó",
+      "codepoints": [
+        243
+      ],
+      "name": "&oacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊛",
+      "codepoints": [
+        8859
+      ],
+      "name": "&oast;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊚",
+      "codepoints": [
+        8858
+      ],
+      "name": "&ocir;",
+      "semicolon": true
+    },
+    {
+      "characters": "ô",
+      "codepoints": [
+        244
+      ],
+      "name": "&ocirc",
+      "semicolon": false
+    },
+    {
+      "characters": "ô",
+      "codepoints": [
+        244
+      ],
+      "name": "&ocirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "о",
+      "codepoints": [
+        1086
+      ],
+      "name": "&ocy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊝",
+      "codepoints": [
+        8861
+      ],
+      "name": "&odash;",
+      "semicolon": true
+    },
+    {
+      "characters": "ő",
+      "codepoints": [
+        337
+      ],
+      "name": "&odblac;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨸",
+      "codepoints": [
+        10808
+      ],
+      "name": "&odiv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊙",
+      "codepoints": [
+        8857
+      ],
+      "name": "&odot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦼",
+      "codepoints": [
+        10684
+      ],
+      "name": "&odsold;",
+      "semicolon": true
+    },
+    {
+      "characters": "œ",
+      "codepoints": [
+        339
+      ],
+      "name": "&oelig;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦿",
+      "codepoints": [
+        10687
+      ],
+      "name": "&ofcir;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔬",
+      "codepoints": [
+        120108
+      ],
+      "name": "&ofr;",
+      "semicolon": true
+    },
+    {
+      "characters": "˛",
+      "codepoints": [
+        731
+      ],
+      "name": "&ogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "ò",
+      "codepoints": [
+        242
+      ],
+      "name": "&ograve",
+      "semicolon": false
+    },
+    {
+      "characters": "ò",
+      "codepoints": [
+        242
+      ],
+      "name": "&ograve;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧁",
+      "codepoints": [
+        10689
+      ],
+      "name": "&ogt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦵",
+      "codepoints": [
+        10677
+      ],
+      "name": "&ohbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "Ω",
+      "codepoints": [
+        937
+      ],
+      "name": "&ohm;",
+      "semicolon": true
+    },
+    {
+      "characters": "∮",
+      "codepoints": [
+        8750
+      ],
+      "name": "&oint;",
+      "semicolon": true
+    },
+    {
+      "characters": "↺",
+      "codepoints": [
+        8634
+      ],
+      "name": "&olarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦾",
+      "codepoints": [
+        10686
+      ],
+      "name": "&olcir;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦻",
+      "codepoints": [
+        10683
+      ],
+      "name": "&olcross;",
+      "semicolon": true
+    },
+    {
+      "characters": "‾",
+      "codepoints": [
+        8254
+      ],
+      "name": "&oline;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧀",
+      "codepoints": [
+        10688
+      ],
+      "name": "&olt;",
+      "semicolon": true
+    },
+    {
+      "characters": "ō",
+      "codepoints": [
+        333
+      ],
+      "name": "&omacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ω",
+      "codepoints": [
+        969
+      ],
+      "name": "&omega;",
+      "semicolon": true
+    },
+    {
+      "characters": "ο",
+      "codepoints": [
+        959
+      ],
+      "name": "&omicron;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦶",
+      "codepoints": [
+        10678
+      ],
+      "name": "&omid;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊖",
+      "codepoints": [
+        8854
+      ],
+      "name": "&ominus;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕠",
+      "codepoints": [
+        120160
+      ],
+      "name": "&oopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦷",
+      "codepoints": [
+        10679
+      ],
+      "name": "&opar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦹",
+      "codepoints": [
+        10681
+      ],
+      "name": "&operp;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊕",
+      "codepoints": [
+        8853
+      ],
+      "name": "&oplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "∨",
+      "codepoints": [
+        8744
+      ],
+      "name": "&or;",
+      "semicolon": true
+    },
+    {
+      "characters": "↻",
+      "codepoints": [
+        8635
+      ],
+      "name": "&orarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩝",
+      "codepoints": [
+        10845
+      ],
+      "name": "&ord;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℴ",
+      "codepoints": [
+        8500
+      ],
+      "name": "&order;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℴ",
+      "codepoints": [
+        8500
+      ],
+      "name": "&orderof;",
+      "semicolon": true
+    },
+    {
+      "characters": "ª",
+      "codepoints": [
+        170
+      ],
+      "name": "&ordf",
+      "semicolon": false
+    },
+    {
+      "characters": "ª",
+      "codepoints": [
+        170
+      ],
+      "name": "&ordf;",
+      "semicolon": true
+    },
+    {
+      "characters": "º",
+      "codepoints": [
+        186
+      ],
+      "name": "&ordm",
+      "semicolon": false
+    },
+    {
+      "characters": "º",
+      "codepoints": [
+        186
+      ],
+      "name": "&ordm;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊶",
+      "codepoints": [
+        8886
+      ],
+      "name": "&origof;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩖",
+      "codepoints": [
+        10838
+      ],
+      "name": "&oror;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩗",
+      "codepoints": [
+        10839
+      ],
+      "name": "&orslope;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩛",
+      "codepoints": [
+        10843
+      ],
+      "name": "&orv;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℴ",
+      "codepoints": [
+        8500
+      ],
+      "name": "&oscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ø",
+      "codepoints": [
+        248
+      ],
+      "name": "&oslash",
+      "semicolon": false
+    },
+    {
+      "characters": "ø",
+      "codepoints": [
+        248
+      ],
+      "name": "&oslash;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊘",
+      "codepoints": [
+        8856
+      ],
+      "name": "&osol;",
+      "semicolon": true
+    },
+    {
+      "characters": "õ",
+      "codepoints": [
+        245
+      ],
+      "name": "&otilde",
+      "semicolon": false
+    },
+    {
+      "characters": "õ",
+      "codepoints": [
+        245
+      ],
+      "name": "&otilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊗",
+      "codepoints": [
+        8855
+      ],
+      "name": "&otimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨶",
+      "codepoints": [
+        10806
+      ],
+      "name": "&otimesas;",
+      "semicolon": true
+    },
+    {
+      "characters": "ö",
+      "codepoints": [
+        246
+      ],
+      "name": "&ouml",
+      "semicolon": false
+    },
+    {
+      "characters": "ö",
+      "codepoints": [
+        246
+      ],
+      "name": "&ouml;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌽",
+      "codepoints": [
+        9021
+      ],
+      "name": "&ovbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "∥",
+      "codepoints": [
+        8741
+      ],
+      "name": "&par;",
+      "semicolon": true
+    },
+    {
+      "characters": "¶",
+      "codepoints": [
+        182
+      ],
+      "name": "&para",
+      "semicolon": false
+    },
+    {
+      "characters": "¶",
+      "codepoints": [
+        182
+      ],
+      "name": "&para;",
+      "semicolon": true
+    },
+    {
+      "characters": "∥",
+      "codepoints": [
+        8741
+      ],
+      "name": "&parallel;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫳",
+      "codepoints": [
+        10995
+      ],
+      "name": "&parsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫽",
+      "codepoints": [
+        11005
+      ],
+      "name": "&parsl;",
+      "semicolon": true
+    },
+    {
+      "characters": "∂",
+      "codepoints": [
+        8706
+      ],
+      "name": "&part;",
+      "semicolon": true
+    },
+    {
+      "characters": "п",
+      "codepoints": [
+        1087
+      ],
+      "name": "&pcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "%",
+      "codepoints": [
+        37
+      ],
+      "name": "&percnt;",
+      "semicolon": true
+    },
+    {
+      "characters": ".",
+      "codepoints": [
+        46
+      ],
+      "name": "&period;",
+      "semicolon": true
+    },
+    {
+      "characters": "‰",
+      "codepoints": [
+        8240
+      ],
+      "name": "&permil;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊥",
+      "codepoints": [
+        8869
+      ],
+      "name": "&perp;",
+      "semicolon": true
+    },
+    {
+      "characters": "‱",
+      "codepoints": [
+        8241
+      ],
+      "name": "&pertenk;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔭",
+      "codepoints": [
+        120109
+      ],
+      "name": "&pfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "φ",
+      "codepoints": [
+        966
+      ],
+      "name": "&phi;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϕ",
+      "codepoints": [
+        981
+      ],
+      "name": "&phiv;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℳ",
+      "codepoints": [
+        8499
+      ],
+      "name": "&phmmat;",
+      "semicolon": true
+    },
+    {
+      "characters": "☎",
+      "codepoints": [
+        9742
+      ],
+      "name": "&phone;",
+      "semicolon": true
+    },
+    {
+      "characters": "π",
+      "codepoints": [
+        960
+      ],
+      "name": "&pi;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋔",
+      "codepoints": [
+        8916
+      ],
+      "name": "&pitchfork;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϖ",
+      "codepoints": [
+        982
+      ],
+      "name": "&piv;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℏ",
+      "codepoints": [
+        8463
+      ],
+      "name": "&planck;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℎ",
+      "codepoints": [
+        8462
+      ],
+      "name": "&planckh;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℏ",
+      "codepoints": [
+        8463
+      ],
+      "name": "&plankv;",
+      "semicolon": true
+    },
+    {
+      "characters": "+",
+      "codepoints": [
+        43
+      ],
+      "name": "&plus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨣",
+      "codepoints": [
+        10787
+      ],
+      "name": "&plusacir;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊞",
+      "codepoints": [
+        8862
+      ],
+      "name": "&plusb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨢",
+      "codepoints": [
+        10786
+      ],
+      "name": "&pluscir;",
+      "semicolon": true
+    },
+    {
+      "characters": "∔",
+      "codepoints": [
+        8724
+      ],
+      "name": "&plusdo;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨥",
+      "codepoints": [
+        10789
+      ],
+      "name": "&plusdu;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩲",
+      "codepoints": [
+        10866
+      ],
+      "name": "&pluse;",
+      "semicolon": true
+    },
+    {
+      "characters": "±",
+      "codepoints": [
+        177
+      ],
+      "name": "&plusmn",
+      "semicolon": false
+    },
+    {
+      "characters": "±",
+      "codepoints": [
+        177
+      ],
+      "name": "&plusmn;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨦",
+      "codepoints": [
+        10790
+      ],
+      "name": "&plussim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨧",
+      "codepoints": [
+        10791
+      ],
+      "name": "&plustwo;",
+      "semicolon": true
+    },
+    {
+      "characters": "±",
+      "codepoints": [
+        177
+      ],
+      "name": "&pm;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨕",
+      "codepoints": [
+        10773
+      ],
+      "name": "&pointint;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕡",
+      "codepoints": [
+        120161
+      ],
+      "name": "&popf;",
+      "semicolon": true
+    },
+    {
+      "characters": "£",
+      "codepoints": [
+        163
+      ],
+      "name": "&pound",
+      "semicolon": false
+    },
+    {
+      "characters": "£",
+      "codepoints": [
+        163
+      ],
+      "name": "&pound;",
+      "semicolon": true
+    },
+    {
+      "characters": "≺",
+      "codepoints": [
+        8826
+      ],
+      "name": "&pr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪳",
+      "codepoints": [
+        10931
+      ],
+      "name": "&prE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪷",
+      "codepoints": [
+        10935
+      ],
+      "name": "&prap;",
+      "semicolon": true
+    },
+    {
+      "characters": "≼",
+      "codepoints": [
+        8828
+      ],
+      "name": "&prcue;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪯",
+      "codepoints": [
+        10927
+      ],
+      "name": "&pre;",
+      "semicolon": true
+    },
+    {
+      "characters": "≺",
+      "codepoints": [
+        8826
+      ],
+      "name": "&prec;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪷",
+      "codepoints": [
+        10935
+      ],
+      "name": "&precapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "≼",
+      "codepoints": [
+        8828
+      ],
+      "name": "&preccurlyeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪯",
+      "codepoints": [
+        10927
+      ],
+      "name": "&preceq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪹",
+      "codepoints": [
+        10937
+      ],
+      "name": "&precnapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪵",
+      "codepoints": [
+        10933
+      ],
+      "name": "&precneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋨",
+      "codepoints": [
+        8936
+      ],
+      "name": "&precnsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "≾",
+      "codepoints": [
+        8830
+      ],
+      "name": "&precsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "′",
+      "codepoints": [
+        8242
+      ],
+      "name": "&prime;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℙ",
+      "codepoints": [
+        8473
+      ],
+      "name": "&primes;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪵",
+      "codepoints": [
+        10933
+      ],
+      "name": "&prnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪹",
+      "codepoints": [
+        10937
+      ],
+      "name": "&prnap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋨",
+      "codepoints": [
+        8936
+      ],
+      "name": "&prnsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "∏",
+      "codepoints": [
+        8719
+      ],
+      "name": "&prod;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌮",
+      "codepoints": [
+        9006
+      ],
+      "name": "&profalar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌒",
+      "codepoints": [
+        8978
+      ],
+      "name": "&profline;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌓",
+      "codepoints": [
+        8979
+      ],
+      "name": "&profsurf;",
+      "semicolon": true
+    },
+    {
+      "characters": "∝",
+      "codepoints": [
+        8733
+      ],
+      "name": "&prop;",
+      "semicolon": true
+    },
+    {
+      "characters": "∝",
+      "codepoints": [
+        8733
+      ],
+      "name": "&propto;",
+      "semicolon": true
+    },
+    {
+      "characters": "≾",
+      "codepoints": [
+        8830
+      ],
+      "name": "&prsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊰",
+      "codepoints": [
+        8880
+      ],
+      "name": "&prurel;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓅",
+      "codepoints": [
+        120005
+      ],
+      "name": "&pscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ψ",
+      "codepoints": [
+        968
+      ],
+      "name": "&psi;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8200
+      ],
+      "name": "&puncsp;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔮",
+      "codepoints": [
+        120110
+      ],
+      "name": "&qfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨌",
+      "codepoints": [
+        10764
+      ],
+      "name": "&qint;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕢",
+      "codepoints": [
+        120162
+      ],
+      "name": "&qopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⁗",
+      "codepoints": [
+        8279
+      ],
+      "name": "&qprime;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓆",
+      "codepoints": [
+        120006
+      ],
+      "name": "&qscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℍ",
+      "codepoints": [
+        8461
+      ],
+      "name": "&quaternions;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨖",
+      "codepoints": [
+        10774
+      ],
+      "name": "&quatint;",
+      "semicolon": true
+    },
+    {
+      "characters": "?",
+      "codepoints": [
+        63
+      ],
+      "name": "&quest;",
+      "semicolon": true
+    },
+    {
+      "characters": "≟",
+      "codepoints": [
+        8799
+      ],
+      "name": "&questeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "\"",
+      "codepoints": [
+        34
+      ],
+      "name": "&quot",
+      "semicolon": false
+    },
+    {
+      "characters": "\"",
+      "codepoints": [
+        34
+      ],
+      "name": "&quot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇛",
+      "codepoints": [
+        8667
+      ],
+      "name": "&rAarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇒",
+      "codepoints": [
+        8658
+      ],
+      "name": "&rArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤜",
+      "codepoints": [
+        10524
+      ],
+      "name": "&rAtail;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤏",
+      "codepoints": [
+        10511
+      ],
+      "name": "&rBarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥤",
+      "codepoints": [
+        10596
+      ],
+      "name": "&rHar;",
+      "semicolon": true
+    },
+    {
+      "characters": "∽̱",
+      "codepoints": [
+        8765,
+        817
+      ],
+      "name": "&race;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŕ",
+      "codepoints": [
+        341
+      ],
+      "name": "&racute;",
+      "semicolon": true
+    },
+    {
+      "characters": "√",
+      "codepoints": [
+        8730
+      ],
+      "name": "&radic;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦳",
+      "codepoints": [
+        10675
+      ],
+      "name": "&raemptyv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟩",
+      "codepoints": [
+        10217
+      ],
+      "name": "&rang;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦒",
+      "codepoints": [
+        10642
+      ],
+      "name": "&rangd;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦥",
+      "codepoints": [
+        10661
+      ],
+      "name": "&range;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟩",
+      "codepoints": [
+        10217
+      ],
+      "name": "&rangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "»",
+      "codepoints": [
+        187
+      ],
+      "name": "&raquo",
+      "semicolon": false
+    },
+    {
+      "characters": "»",
+      "codepoints": [
+        187
+      ],
+      "name": "&raquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "→",
+      "codepoints": [
+        8594
+      ],
+      "name": "&rarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥵",
+      "codepoints": [
+        10613
+      ],
+      "name": "&rarrap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇥",
+      "codepoints": [
+        8677
+      ],
+      "name": "&rarrb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤠",
+      "codepoints": [
+        10528
+      ],
+      "name": "&rarrbfs;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤳",
+      "codepoints": [
+        10547
+      ],
+      "name": "&rarrc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤞",
+      "codepoints": [
+        10526
+      ],
+      "name": "&rarrfs;",
+      "semicolon": true
+    },
+    {
+      "characters": "↪",
+      "codepoints": [
+        8618
+      ],
+      "name": "&rarrhk;",
+      "semicolon": true
+    },
+    {
+      "characters": "↬",
+      "codepoints": [
+        8620
+      ],
+      "name": "&rarrlp;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥅",
+      "codepoints": [
+        10565
+      ],
+      "name": "&rarrpl;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥴",
+      "codepoints": [
+        10612
+      ],
+      "name": "&rarrsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "↣",
+      "codepoints": [
+        8611
+      ],
+      "name": "&rarrtl;",
+      "semicolon": true
+    },
+    {
+      "characters": "↝",
+      "codepoints": [
+        8605
+      ],
+      "name": "&rarrw;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤚",
+      "codepoints": [
+        10522
+      ],
+      "name": "&ratail;",
+      "semicolon": true
+    },
+    {
+      "characters": "∶",
+      "codepoints": [
+        8758
+      ],
+      "name": "&ratio;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℚ",
+      "codepoints": [
+        8474
+      ],
+      "name": "&rationals;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤍",
+      "codepoints": [
+        10509
+      ],
+      "name": "&rbarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "❳",
+      "codepoints": [
+        10099
+      ],
+      "name": "&rbbrk;",
+      "semicolon": true
+    },
+    {
+      "characters": "}",
+      "codepoints": [
+        125
+      ],
+      "name": "&rbrace;",
+      "semicolon": true
+    },
+    {
+      "characters": "]",
+      "codepoints": [
+        93
+      ],
+      "name": "&rbrack;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦌",
+      "codepoints": [
+        10636
+      ],
+      "name": "&rbrke;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦎",
+      "codepoints": [
+        10638
+      ],
+      "name": "&rbrksld;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦐",
+      "codepoints": [
+        10640
+      ],
+      "name": "&rbrkslu;",
+      "semicolon": true
+    },
+    {
+      "characters": "ř",
+      "codepoints": [
+        345
+      ],
+      "name": "&rcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŗ",
+      "codepoints": [
+        343
+      ],
+      "name": "&rcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌉",
+      "codepoints": [
+        8969
+      ],
+      "name": "&rceil;",
+      "semicolon": true
+    },
+    {
+      "characters": "}",
+      "codepoints": [
+        125
+      ],
+      "name": "&rcub;",
+      "semicolon": true
+    },
+    {
+      "characters": "р",
+      "codepoints": [
+        1088
+      ],
+      "name": "&rcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤷",
+      "codepoints": [
+        10551
+      ],
+      "name": "&rdca;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥩",
+      "codepoints": [
+        10601
+      ],
+      "name": "&rdldhar;",
+      "semicolon": true
+    },
+    {
+      "characters": "”",
+      "codepoints": [
+        8221
+      ],
+      "name": "&rdquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "”",
+      "codepoints": [
+        8221
+      ],
+      "name": "&rdquor;",
+      "semicolon": true
+    },
+    {
+      "characters": "↳",
+      "codepoints": [
+        8627
+      ],
+      "name": "&rdsh;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℜ",
+      "codepoints": [
+        8476
+      ],
+      "name": "&real;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℛ",
+      "codepoints": [
+        8475
+      ],
+      "name": "&realine;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℜ",
+      "codepoints": [
+        8476
+      ],
+      "name": "&realpart;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℝ",
+      "codepoints": [
+        8477
+      ],
+      "name": "&reals;",
+      "semicolon": true
+    },
+    {
+      "characters": "▭",
+      "codepoints": [
+        9645
+      ],
+      "name": "&rect;",
+      "semicolon": true
+    },
+    {
+      "characters": "®",
+      "codepoints": [
+        174
+      ],
+      "name": "&reg",
+      "semicolon": false
+    },
+    {
+      "characters": "®",
+      "codepoints": [
+        174
+      ],
+      "name": "&reg;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥽",
+      "codepoints": [
+        10621
+      ],
+      "name": "&rfisht;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌋",
+      "codepoints": [
+        8971
+      ],
+      "name": "&rfloor;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔯",
+      "codepoints": [
+        120111
+      ],
+      "name": "&rfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇁",
+      "codepoints": [
+        8641
+      ],
+      "name": "&rhard;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇀",
+      "codepoints": [
+        8640
+      ],
+      "name": "&rharu;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥬",
+      "codepoints": [
+        10604
+      ],
+      "name": "&rharul;",
+      "semicolon": true
+    },
+    {
+      "characters": "ρ",
+      "codepoints": [
+        961
+      ],
+      "name": "&rho;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϱ",
+      "codepoints": [
+        1009
+      ],
+      "name": "&rhov;",
+      "semicolon": true
+    },
+    {
+      "characters": "→",
+      "codepoints": [
+        8594
+      ],
+      "name": "&rightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↣",
+      "codepoints": [
+        8611
+      ],
+      "name": "&rightarrowtail;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇁",
+      "codepoints": [
+        8641
+      ],
+      "name": "&rightharpoondown;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇀",
+      "codepoints": [
+        8640
+      ],
+      "name": "&rightharpoonup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇄",
+      "codepoints": [
+        8644
+      ],
+      "name": "&rightleftarrows;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇌",
+      "codepoints": [
+        8652
+      ],
+      "name": "&rightleftharpoons;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇉",
+      "codepoints": [
+        8649
+      ],
+      "name": "&rightrightarrows;",
+      "semicolon": true
+    },
+    {
+      "characters": "↝",
+      "codepoints": [
+        8605
+      ],
+      "name": "&rightsquigarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋌",
+      "codepoints": [
+        8908
+      ],
+      "name": "&rightthreetimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "˚",
+      "codepoints": [
+        730
+      ],
+      "name": "&ring;",
+      "semicolon": true
+    },
+    {
+      "characters": "≓",
+      "codepoints": [
+        8787
+      ],
+      "name": "&risingdotseq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇄",
+      "codepoints": [
+        8644
+      ],
+      "name": "&rlarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇌",
+      "codepoints": [
+        8652
+      ],
+      "name": "&rlhar;",
+      "semicolon": true
+    },
+    {
+      "characters": "‏",
+      "codepoints": [
+        8207
+      ],
+      "name": "&rlm;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎱",
+      "codepoints": [
+        9137
+      ],
+      "name": "&rmoust;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎱",
+      "codepoints": [
+        9137
+      ],
+      "name": "&rmoustache;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫮",
+      "codepoints": [
+        10990
+      ],
+      "name": "&rnmid;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟭",
+      "codepoints": [
+        10221
+      ],
+      "name": "&roang;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇾",
+      "codepoints": [
+        8702
+      ],
+      "name": "&roarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟧",
+      "codepoints": [
+        10215
+      ],
+      "name": "&robrk;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦆",
+      "codepoints": [
+        10630
+      ],
+      "name": "&ropar;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕣",
+      "codepoints": [
+        120163
+      ],
+      "name": "&ropf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨮",
+      "codepoints": [
+        10798
+      ],
+      "name": "&roplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨵",
+      "codepoints": [
+        10805
+      ],
+      "name": "&rotimes;",
+      "semicolon": true
+    },
+    {
+      "characters": ")",
+      "codepoints": [
+        41
+      ],
+      "name": "&rpar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦔",
+      "codepoints": [
+        10644
+      ],
+      "name": "&rpargt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨒",
+      "codepoints": [
+        10770
+      ],
+      "name": "&rppolint;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇉",
+      "codepoints": [
+        8649
+      ],
+      "name": "&rrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "›",
+      "codepoints": [
+        8250
+      ],
+      "name": "&rsaquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓇",
+      "codepoints": [
+        120007
+      ],
+      "name": "&rscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↱",
+      "codepoints": [
+        8625
+      ],
+      "name": "&rsh;",
+      "semicolon": true
+    },
+    {
+      "characters": "]",
+      "codepoints": [
+        93
+      ],
+      "name": "&rsqb;",
+      "semicolon": true
+    },
+    {
+      "characters": "’",
+      "codepoints": [
+        8217
+      ],
+      "name": "&rsquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "’",
+      "codepoints": [
+        8217
+      ],
+      "name": "&rsquor;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋌",
+      "codepoints": [
+        8908
+      ],
+      "name": "&rthree;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋊",
+      "codepoints": [
+        8906
+      ],
+      "name": "&rtimes;",
+      "semicolon": true
+    },
+    {
+      "characters": "▹",
+      "codepoints": [
+        9657
+      ],
+      "name": "&rtri;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊵",
+      "codepoints": [
+        8885
+      ],
+      "name": "&rtrie;",
+      "semicolon": true
+    },
+    {
+      "characters": "▸",
+      "codepoints": [
+        9656
+      ],
+      "name": "&rtrif;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧎",
+      "codepoints": [
+        10702
+      ],
+      "name": "&rtriltri;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥨",
+      "codepoints": [
+        10600
+      ],
+      "name": "&ruluhar;",
+      "semicolon": true
+    },
+    {
+      "characters": "℞",
+      "codepoints": [
+        8478
+      ],
+      "name": "&rx;",
+      "semicolon": true
+    },
+    {
+      "characters": "ś",
+      "codepoints": [
+        347
+      ],
+      "name": "&sacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "‚",
+      "codepoints": [
+        8218
+      ],
+      "name": "&sbquo;",
+      "semicolon": true
+    },
+    {
+      "characters": "≻",
+      "codepoints": [
+        8827
+      ],
+      "name": "&sc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪴",
+      "codepoints": [
+        10932
+      ],
+      "name": "&scE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪸",
+      "codepoints": [
+        10936
+      ],
+      "name": "&scap;",
+      "semicolon": true
+    },
+    {
+      "characters": "š",
+      "codepoints": [
+        353
+      ],
+      "name": "&scaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "≽",
+      "codepoints": [
+        8829
+      ],
+      "name": "&sccue;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪰",
+      "codepoints": [
+        10928
+      ],
+      "name": "&sce;",
+      "semicolon": true
+    },
+    {
+      "characters": "ş",
+      "codepoints": [
+        351
+      ],
+      "name": "&scedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŝ",
+      "codepoints": [
+        349
+      ],
+      "name": "&scirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪶",
+      "codepoints": [
+        10934
+      ],
+      "name": "&scnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪺",
+      "codepoints": [
+        10938
+      ],
+      "name": "&scnap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋩",
+      "codepoints": [
+        8937
+      ],
+      "name": "&scnsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨓",
+      "codepoints": [
+        10771
+      ],
+      "name": "&scpolint;",
+      "semicolon": true
+    },
+    {
+      "characters": "≿",
+      "codepoints": [
+        8831
+      ],
+      "name": "&scsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "с",
+      "codepoints": [
+        1089
+      ],
+      "name": "&scy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋅",
+      "codepoints": [
+        8901
+      ],
+      "name": "&sdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊡",
+      "codepoints": [
+        8865
+      ],
+      "name": "&sdotb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩦",
+      "codepoints": [
+        10854
+      ],
+      "name": "&sdote;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇘",
+      "codepoints": [
+        8664
+      ],
+      "name": "&seArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤥",
+      "codepoints": [
+        10533
+      ],
+      "name": "&searhk;",
+      "semicolon": true
+    },
+    {
+      "characters": "↘",
+      "codepoints": [
+        8600
+      ],
+      "name": "&searr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↘",
+      "codepoints": [
+        8600
+      ],
+      "name": "&searrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "§",
+      "codepoints": [
+        167
+      ],
+      "name": "&sect",
+      "semicolon": false
+    },
+    {
+      "characters": "§",
+      "codepoints": [
+        167
+      ],
+      "name": "&sect;",
+      "semicolon": true
+    },
+    {
+      "characters": ";",
+      "codepoints": [
+        59
+      ],
+      "name": "&semi;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤩",
+      "codepoints": [
+        10537
+      ],
+      "name": "&seswar;",
+      "semicolon": true
+    },
+    {
+      "characters": "∖",
+      "codepoints": [
+        8726
+      ],
+      "name": "&setminus;",
+      "semicolon": true
+    },
+    {
+      "characters": "∖",
+      "codepoints": [
+        8726
+      ],
+      "name": "&setmn;",
+      "semicolon": true
+    },
+    {
+      "characters": "✶",
+      "codepoints": [
+        10038
+      ],
+      "name": "&sext;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔰",
+      "codepoints": [
+        120112
+      ],
+      "name": "&sfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌢",
+      "codepoints": [
+        8994
+      ],
+      "name": "&sfrown;",
+      "semicolon": true
+    },
+    {
+      "characters": "♯",
+      "codepoints": [
+        9839
+      ],
+      "name": "&sharp;",
+      "semicolon": true
+    },
+    {
+      "characters": "щ",
+      "codepoints": [
+        1097
+      ],
+      "name": "&shchcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ш",
+      "codepoints": [
+        1096
+      ],
+      "name": "&shcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "∣",
+      "codepoints": [
+        8739
+      ],
+      "name": "&shortmid;",
+      "semicolon": true
+    },
+    {
+      "characters": "∥",
+      "codepoints": [
+        8741
+      ],
+      "name": "&shortparallel;",
+      "semicolon": true
+    },
+    {
+      "characters": "­",
+      "codepoints": [
+        173
+      ],
+      "name": "&shy",
+      "semicolon": false
+    },
+    {
+      "characters": "­",
+      "codepoints": [
+        173
+      ],
+      "name": "&shy;",
+      "semicolon": true
+    },
+    {
+      "characters": "σ",
+      "codepoints": [
+        963
+      ],
+      "name": "&sigma;",
+      "semicolon": true
+    },
+    {
+      "characters": "ς",
+      "codepoints": [
+        962
+      ],
+      "name": "&sigmaf;",
+      "semicolon": true
+    },
+    {
+      "characters": "ς",
+      "codepoints": [
+        962
+      ],
+      "name": "&sigmav;",
+      "semicolon": true
+    },
+    {
+      "characters": "∼",
+      "codepoints": [
+        8764
+      ],
+      "name": "&sim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩪",
+      "codepoints": [
+        10858
+      ],
+      "name": "&simdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≃",
+      "codepoints": [
+        8771
+      ],
+      "name": "&sime;",
+      "semicolon": true
+    },
+    {
+      "characters": "≃",
+      "codepoints": [
+        8771
+      ],
+      "name": "&simeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪞",
+      "codepoints": [
+        10910
+      ],
+      "name": "&simg;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪠",
+      "codepoints": [
+        10912
+      ],
+      "name": "&simgE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪝",
+      "codepoints": [
+        10909
+      ],
+      "name": "&siml;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪟",
+      "codepoints": [
+        10911
+      ],
+      "name": "&simlE;",
+      "semicolon": true
+    },
+    {
+      "characters": "≆",
+      "codepoints": [
+        8774
+      ],
+      "name": "&simne;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨤",
+      "codepoints": [
+        10788
+      ],
+      "name": "&simplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥲",
+      "codepoints": [
+        10610
+      ],
+      "name": "&simrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "←",
+      "codepoints": [
+        8592
+      ],
+      "name": "&slarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∖",
+      "codepoints": [
+        8726
+      ],
+      "name": "&smallsetminus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨳",
+      "codepoints": [
+        10803
+      ],
+      "name": "&smashp;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧤",
+      "codepoints": [
+        10724
+      ],
+      "name": "&smeparsl;",
+      "semicolon": true
+    },
+    {
+      "characters": "∣",
+      "codepoints": [
+        8739
+      ],
+      "name": "&smid;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌣",
+      "codepoints": [
+        8995
+      ],
+      "name": "&smile;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪪",
+      "codepoints": [
+        10922
+      ],
+      "name": "&smt;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪬",
+      "codepoints": [
+        10924
+      ],
+      "name": "&smte;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪬︀",
+      "codepoints": [
+        10924,
+        65024
+      ],
+      "name": "&smtes;",
+      "semicolon": true
+    },
+    {
+      "characters": "ь",
+      "codepoints": [
+        1100
+      ],
+      "name": "&softcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "/",
+      "codepoints": [
+        47
+      ],
+      "name": "&sol;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧄",
+      "codepoints": [
+        10692
+      ],
+      "name": "&solb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌿",
+      "codepoints": [
+        9023
+      ],
+      "name": "&solbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕤",
+      "codepoints": [
+        120164
+      ],
+      "name": "&sopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "♠",
+      "codepoints": [
+        9824
+      ],
+      "name": "&spades;",
+      "semicolon": true
+    },
+    {
+      "characters": "♠",
+      "codepoints": [
+        9824
+      ],
+      "name": "&spadesuit;",
+      "semicolon": true
+    },
+    {
+      "characters": "∥",
+      "codepoints": [
+        8741
+      ],
+      "name": "&spar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊓",
+      "codepoints": [
+        8851
+      ],
+      "name": "&sqcap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊓︀",
+      "codepoints": [
+        8851,
+        65024
+      ],
+      "name": "&sqcaps;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊔",
+      "codepoints": [
+        8852
+      ],
+      "name": "&sqcup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊔︀",
+      "codepoints": [
+        8852,
+        65024
+      ],
+      "name": "&sqcups;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊏",
+      "codepoints": [
+        8847
+      ],
+      "name": "&sqsub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊑",
+      "codepoints": [
+        8849
+      ],
+      "name": "&sqsube;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊏",
+      "codepoints": [
+        8847
+      ],
+      "name": "&sqsubset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊑",
+      "codepoints": [
+        8849
+      ],
+      "name": "&sqsubseteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊐",
+      "codepoints": [
+        8848
+      ],
+      "name": "&sqsup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊒",
+      "codepoints": [
+        8850
+      ],
+      "name": "&sqsupe;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊐",
+      "codepoints": [
+        8848
+      ],
+      "name": "&sqsupset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊒",
+      "codepoints": [
+        8850
+      ],
+      "name": "&sqsupseteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "□",
+      "codepoints": [
+        9633
+      ],
+      "name": "&squ;",
+      "semicolon": true
+    },
+    {
+      "characters": "□",
+      "codepoints": [
+        9633
+      ],
+      "name": "&square;",
+      "semicolon": true
+    },
+    {
+      "characters": "▪",
+      "codepoints": [
+        9642
+      ],
+      "name": "&squarf;",
+      "semicolon": true
+    },
+    {
+      "characters": "▪",
+      "codepoints": [
+        9642
+      ],
+      "name": "&squf;",
+      "semicolon": true
+    },
+    {
+      "characters": "→",
+      "codepoints": [
+        8594
+      ],
+      "name": "&srarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓈",
+      "codepoints": [
+        120008
+      ],
+      "name": "&sscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∖",
+      "codepoints": [
+        8726
+      ],
+      "name": "&ssetmn;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌣",
+      "codepoints": [
+        8995
+      ],
+      "name": "&ssmile;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋆",
+      "codepoints": [
+        8902
+      ],
+      "name": "&sstarf;",
+      "semicolon": true
+    },
+    {
+      "characters": "☆",
+      "codepoints": [
+        9734
+      ],
+      "name": "&star;",
+      "semicolon": true
+    },
+    {
+      "characters": "★",
+      "codepoints": [
+        9733
+      ],
+      "name": "&starf;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϵ",
+      "codepoints": [
+        1013
+      ],
+      "name": "&straightepsilon;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϕ",
+      "codepoints": [
+        981
+      ],
+      "name": "&straightphi;",
+      "semicolon": true
+    },
+    {
+      "characters": "¯",
+      "codepoints": [
+        175
+      ],
+      "name": "&strns;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊂",
+      "codepoints": [
+        8834
+      ],
+      "name": "&sub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫅",
+      "codepoints": [
+        10949
+      ],
+      "name": "&subE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪽",
+      "codepoints": [
+        10941
+      ],
+      "name": "&subdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊆",
+      "codepoints": [
+        8838
+      ],
+      "name": "&sube;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫃",
+      "codepoints": [
+        10947
+      ],
+      "name": "&subedot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫁",
+      "codepoints": [
+        10945
+      ],
+      "name": "&submult;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫋",
+      "codepoints": [
+        10955
+      ],
+      "name": "&subnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊊",
+      "codepoints": [
+        8842
+      ],
+      "name": "&subne;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪿",
+      "codepoints": [
+        10943
+      ],
+      "name": "&subplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥹",
+      "codepoints": [
+        10617
+      ],
+      "name": "&subrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊂",
+      "codepoints": [
+        8834
+      ],
+      "name": "&subset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊆",
+      "codepoints": [
+        8838
+      ],
+      "name": "&subseteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫅",
+      "codepoints": [
+        10949
+      ],
+      "name": "&subseteqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊊",
+      "codepoints": [
+        8842
+      ],
+      "name": "&subsetneq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫋",
+      "codepoints": [
+        10955
+      ],
+      "name": "&subsetneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫇",
+      "codepoints": [
+        10951
+      ],
+      "name": "&subsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫕",
+      "codepoints": [
+        10965
+      ],
+      "name": "&subsub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫓",
+      "codepoints": [
+        10963
+      ],
+      "name": "&subsup;",
+      "semicolon": true
+    },
+    {
+      "characters": "≻",
+      "codepoints": [
+        8827
+      ],
+      "name": "&succ;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪸",
+      "codepoints": [
+        10936
+      ],
+      "name": "&succapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "≽",
+      "codepoints": [
+        8829
+      ],
+      "name": "&succcurlyeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪰",
+      "codepoints": [
+        10928
+      ],
+      "name": "&succeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪺",
+      "codepoints": [
+        10938
+      ],
+      "name": "&succnapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪶",
+      "codepoints": [
+        10934
+      ],
+      "name": "&succneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋩",
+      "codepoints": [
+        8937
+      ],
+      "name": "&succnsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "≿",
+      "codepoints": [
+        8831
+      ],
+      "name": "&succsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "∑",
+      "codepoints": [
+        8721
+      ],
+      "name": "&sum;",
+      "semicolon": true
+    },
+    {
+      "characters": "♪",
+      "codepoints": [
+        9834
+      ],
+      "name": "&sung;",
+      "semicolon": true
+    },
+    {
+      "characters": "¹",
+      "codepoints": [
+        185
+      ],
+      "name": "&sup1",
+      "semicolon": false
+    },
+    {
+      "characters": "¹",
+      "codepoints": [
+        185
+      ],
+      "name": "&sup1;",
+      "semicolon": true
+    },
+    {
+      "characters": "²",
+      "codepoints": [
+        178
+      ],
+      "name": "&sup2",
+      "semicolon": false
+    },
+    {
+      "characters": "²",
+      "codepoints": [
+        178
+      ],
+      "name": "&sup2;",
+      "semicolon": true
+    },
+    {
+      "characters": "³",
+      "codepoints": [
+        179
+      ],
+      "name": "&sup3",
+      "semicolon": false
+    },
+    {
+      "characters": "³",
+      "codepoints": [
+        179
+      ],
+      "name": "&sup3;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊃",
+      "codepoints": [
+        8835
+      ],
+      "name": "&sup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫆",
+      "codepoints": [
+        10950
+      ],
+      "name": "&supE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⪾",
+      "codepoints": [
+        10942
+      ],
+      "name": "&supdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫘",
+      "codepoints": [
+        10968
+      ],
+      "name": "&supdsub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊇",
+      "codepoints": [
+        8839
+      ],
+      "name": "&supe;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫄",
+      "codepoints": [
+        10948
+      ],
+      "name": "&supedot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟉",
+      "codepoints": [
+        10185
+      ],
+      "name": "&suphsol;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫗",
+      "codepoints": [
+        10967
+      ],
+      "name": "&suphsub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥻",
+      "codepoints": [
+        10619
+      ],
+      "name": "&suplarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫂",
+      "codepoints": [
+        10946
+      ],
+      "name": "&supmult;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫌",
+      "codepoints": [
+        10956
+      ],
+      "name": "&supnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊋",
+      "codepoints": [
+        8843
+      ],
+      "name": "&supne;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫀",
+      "codepoints": [
+        10944
+      ],
+      "name": "&supplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊃",
+      "codepoints": [
+        8835
+      ],
+      "name": "&supset;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊇",
+      "codepoints": [
+        8839
+      ],
+      "name": "&supseteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫆",
+      "codepoints": [
+        10950
+      ],
+      "name": "&supseteqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊋",
+      "codepoints": [
+        8843
+      ],
+      "name": "&supsetneq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫌",
+      "codepoints": [
+        10956
+      ],
+      "name": "&supsetneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫈",
+      "codepoints": [
+        10952
+      ],
+      "name": "&supsim;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫔",
+      "codepoints": [
+        10964
+      ],
+      "name": "&supsub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫖",
+      "codepoints": [
+        10966
+      ],
+      "name": "&supsup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇙",
+      "codepoints": [
+        8665
+      ],
+      "name": "&swArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤦",
+      "codepoints": [
+        10534
+      ],
+      "name": "&swarhk;",
+      "semicolon": true
+    },
+    {
+      "characters": "↙",
+      "codepoints": [
+        8601
+      ],
+      "name": "&swarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "↙",
+      "codepoints": [
+        8601
+      ],
+      "name": "&swarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤪",
+      "codepoints": [
+        10538
+      ],
+      "name": "&swnwar;",
+      "semicolon": true
+    },
+    {
+      "characters": "ß",
+      "codepoints": [
+        223
+      ],
+      "name": "&szlig",
+      "semicolon": false
+    },
+    {
+      "characters": "ß",
+      "codepoints": [
+        223
+      ],
+      "name": "&szlig;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌖",
+      "codepoints": [
+        8982
+      ],
+      "name": "&target;",
+      "semicolon": true
+    },
+    {
+      "characters": "τ",
+      "codepoints": [
+        964
+      ],
+      "name": "&tau;",
+      "semicolon": true
+    },
+    {
+      "characters": "⎴",
+      "codepoints": [
+        9140
+      ],
+      "name": "&tbrk;",
+      "semicolon": true
+    },
+    {
+      "characters": "ť",
+      "codepoints": [
+        357
+      ],
+      "name": "&tcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "ţ",
+      "codepoints": [
+        355
+      ],
+      "name": "&tcedil;",
+      "semicolon": true
+    },
+    {
+      "characters": "т",
+      "codepoints": [
+        1090
+      ],
+      "name": "&tcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⃛",
+      "codepoints": [
+        8411
+      ],
+      "name": "&tdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌕",
+      "codepoints": [
+        8981
+      ],
+      "name": "&telrec;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔱",
+      "codepoints": [
+        120113
+      ],
+      "name": "&tfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "∴",
+      "codepoints": [
+        8756
+      ],
+      "name": "&there4;",
+      "semicolon": true
+    },
+    {
+      "characters": "∴",
+      "codepoints": [
+        8756
+      ],
+      "name": "&therefore;",
+      "semicolon": true
+    },
+    {
+      "characters": "θ",
+      "codepoints": [
+        952
+      ],
+      "name": "&theta;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϑ",
+      "codepoints": [
+        977
+      ],
+      "name": "&thetasym;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϑ",
+      "codepoints": [
+        977
+      ],
+      "name": "&thetav;",
+      "semicolon": true
+    },
+    {
+      "characters": "≈",
+      "codepoints": [
+        8776
+      ],
+      "name": "&thickapprox;",
+      "semicolon": true
+    },
+    {
+      "characters": "∼",
+      "codepoints": [
+        8764
+      ],
+      "name": "&thicksim;",
+      "semicolon": true
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        8201
+      ],
+      "name": "&thinsp;",
+      "semicolon": true
+    },
+    {
+      "characters": "≈",
+      "codepoints": [
+        8776
+      ],
+      "name": "&thkap;",
+      "semicolon": true
+    },
+    {
+      "characters": "∼",
+      "codepoints": [
+        8764
+      ],
+      "name": "&thksim;",
+      "semicolon": true
+    },
+    {
+      "characters": "þ",
+      "codepoints": [
+        254
+      ],
+      "name": "&thorn",
+      "semicolon": false
+    },
+    {
+      "characters": "þ",
+      "codepoints": [
+        254
+      ],
+      "name": "&thorn;",
+      "semicolon": true
+    },
+    {
+      "characters": "˜",
+      "codepoints": [
+        732
+      ],
+      "name": "&tilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "×",
+      "codepoints": [
+        215
+      ],
+      "name": "&times",
+      "semicolon": false
+    },
+    {
+      "characters": "×",
+      "codepoints": [
+        215
+      ],
+      "name": "&times;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊠",
+      "codepoints": [
+        8864
+      ],
+      "name": "&timesb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨱",
+      "codepoints": [
+        10801
+      ],
+      "name": "&timesbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨰",
+      "codepoints": [
+        10800
+      ],
+      "name": "&timesd;",
+      "semicolon": true
+    },
+    {
+      "characters": "∭",
+      "codepoints": [
+        8749
+      ],
+      "name": "&tint;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤨",
+      "codepoints": [
+        10536
+      ],
+      "name": "&toea;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊤",
+      "codepoints": [
+        8868
+      ],
+      "name": "&top;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌶",
+      "codepoints": [
+        9014
+      ],
+      "name": "&topbot;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫱",
+      "codepoints": [
+        10993
+      ],
+      "name": "&topcir;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕥",
+      "codepoints": [
+        120165
+      ],
+      "name": "&topf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫚",
+      "codepoints": [
+        10970
+      ],
+      "name": "&topfork;",
+      "semicolon": true
+    },
+    {
+      "characters": "⤩",
+      "codepoints": [
+        10537
+      ],
+      "name": "&tosa;",
+      "semicolon": true
+    },
+    {
+      "characters": "‴",
+      "codepoints": [
+        8244
+      ],
+      "name": "&tprime;",
+      "semicolon": true
+    },
+    {
+      "characters": "™",
+      "codepoints": [
+        8482
+      ],
+      "name": "&trade;",
+      "semicolon": true
+    },
+    {
+      "characters": "▵",
+      "codepoints": [
+        9653
+      ],
+      "name": "&triangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "▿",
+      "codepoints": [
+        9663
+      ],
+      "name": "&triangledown;",
+      "semicolon": true
+    },
+    {
+      "characters": "◃",
+      "codepoints": [
+        9667
+      ],
+      "name": "&triangleleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊴",
+      "codepoints": [
+        8884
+      ],
+      "name": "&trianglelefteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "≜",
+      "codepoints": [
+        8796
+      ],
+      "name": "&triangleq;",
+      "semicolon": true
+    },
+    {
+      "characters": "▹",
+      "codepoints": [
+        9657
+      ],
+      "name": "&triangleright;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊵",
+      "codepoints": [
+        8885
+      ],
+      "name": "&trianglerighteq;",
+      "semicolon": true
+    },
+    {
+      "characters": "◬",
+      "codepoints": [
+        9708
+      ],
+      "name": "&tridot;",
+      "semicolon": true
+    },
+    {
+      "characters": "≜",
+      "codepoints": [
+        8796
+      ],
+      "name": "&trie;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨺",
+      "codepoints": [
+        10810
+      ],
+      "name": "&triminus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨹",
+      "codepoints": [
+        10809
+      ],
+      "name": "&triplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⧍",
+      "codepoints": [
+        10701
+      ],
+      "name": "&trisb;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨻",
+      "codepoints": [
+        10811
+      ],
+      "name": "&tritime;",
+      "semicolon": true
+    },
+    {
+      "characters": "⏢",
+      "codepoints": [
+        9186
+      ],
+      "name": "&trpezium;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓉",
+      "codepoints": [
+        120009
+      ],
+      "name": "&tscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ц",
+      "codepoints": [
+        1094
+      ],
+      "name": "&tscy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ћ",
+      "codepoints": [
+        1115
+      ],
+      "name": "&tshcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŧ",
+      "codepoints": [
+        359
+      ],
+      "name": "&tstrok;",
+      "semicolon": true
+    },
+    {
+      "characters": "≬",
+      "codepoints": [
+        8812
+      ],
+      "name": "&twixt;",
+      "semicolon": true
+    },
+    {
+      "characters": "↞",
+      "codepoints": [
+        8606
+      ],
+      "name": "&twoheadleftarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↠",
+      "codepoints": [
+        8608
+      ],
+      "name": "&twoheadrightarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇑",
+      "codepoints": [
+        8657
+      ],
+      "name": "&uArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥣",
+      "codepoints": [
+        10595
+      ],
+      "name": "&uHar;",
+      "semicolon": true
+    },
+    {
+      "characters": "ú",
+      "codepoints": [
+        250
+      ],
+      "name": "&uacute",
+      "semicolon": false
+    },
+    {
+      "characters": "ú",
+      "codepoints": [
+        250
+      ],
+      "name": "&uacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "↑",
+      "codepoints": [
+        8593
+      ],
+      "name": "&uarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ў",
+      "codepoints": [
+        1118
+      ],
+      "name": "&ubrcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŭ",
+      "codepoints": [
+        365
+      ],
+      "name": "&ubreve;",
+      "semicolon": true
+    },
+    {
+      "characters": "û",
+      "codepoints": [
+        251
+      ],
+      "name": "&ucirc",
+      "semicolon": false
+    },
+    {
+      "characters": "û",
+      "codepoints": [
+        251
+      ],
+      "name": "&ucirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "у",
+      "codepoints": [
+        1091
+      ],
+      "name": "&ucy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇅",
+      "codepoints": [
+        8645
+      ],
+      "name": "&udarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ű",
+      "codepoints": [
+        369
+      ],
+      "name": "&udblac;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥮",
+      "codepoints": [
+        10606
+      ],
+      "name": "&udhar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⥾",
+      "codepoints": [
+        10622
+      ],
+      "name": "&ufisht;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔲",
+      "codepoints": [
+        120114
+      ],
+      "name": "&ufr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ù",
+      "codepoints": [
+        249
+      ],
+      "name": "&ugrave",
+      "semicolon": false
+    },
+    {
+      "characters": "ù",
+      "codepoints": [
+        249
+      ],
+      "name": "&ugrave;",
+      "semicolon": true
+    },
+    {
+      "characters": "↿",
+      "codepoints": [
+        8639
+      ],
+      "name": "&uharl;",
+      "semicolon": true
+    },
+    {
+      "characters": "↾",
+      "codepoints": [
+        8638
+      ],
+      "name": "&uharr;",
+      "semicolon": true
+    },
+    {
+      "characters": "▀",
+      "codepoints": [
+        9600
+      ],
+      "name": "&uhblk;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌜",
+      "codepoints": [
+        8988
+      ],
+      "name": "&ulcorn;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌜",
+      "codepoints": [
+        8988
+      ],
+      "name": "&ulcorner;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌏",
+      "codepoints": [
+        8975
+      ],
+      "name": "&ulcrop;",
+      "semicolon": true
+    },
+    {
+      "characters": "◸",
+      "codepoints": [
+        9720
+      ],
+      "name": "&ultri;",
+      "semicolon": true
+    },
+    {
+      "characters": "ū",
+      "codepoints": [
+        363
+      ],
+      "name": "&umacr;",
+      "semicolon": true
+    },
+    {
+      "characters": "¨",
+      "codepoints": [
+        168
+      ],
+      "name": "&uml",
+      "semicolon": false
+    },
+    {
+      "characters": "¨",
+      "codepoints": [
+        168
+      ],
+      "name": "&uml;",
+      "semicolon": true
+    },
+    {
+      "characters": "ų",
+      "codepoints": [
+        371
+      ],
+      "name": "&uogon;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕦",
+      "codepoints": [
+        120166
+      ],
+      "name": "&uopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "↑",
+      "codepoints": [
+        8593
+      ],
+      "name": "&uparrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↕",
+      "codepoints": [
+        8597
+      ],
+      "name": "&updownarrow;",
+      "semicolon": true
+    },
+    {
+      "characters": "↿",
+      "codepoints": [
+        8639
+      ],
+      "name": "&upharpoonleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "↾",
+      "codepoints": [
+        8638
+      ],
+      "name": "&upharpoonright;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊎",
+      "codepoints": [
+        8846
+      ],
+      "name": "&uplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "υ",
+      "codepoints": [
+        965
+      ],
+      "name": "&upsi;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϒ",
+      "codepoints": [
+        978
+      ],
+      "name": "&upsih;",
+      "semicolon": true
+    },
+    {
+      "characters": "υ",
+      "codepoints": [
+        965
+      ],
+      "name": "&upsilon;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇈",
+      "codepoints": [
+        8648
+      ],
+      "name": "&upuparrows;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌝",
+      "codepoints": [
+        8989
+      ],
+      "name": "&urcorn;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌝",
+      "codepoints": [
+        8989
+      ],
+      "name": "&urcorner;",
+      "semicolon": true
+    },
+    {
+      "characters": "⌎",
+      "codepoints": [
+        8974
+      ],
+      "name": "&urcrop;",
+      "semicolon": true
+    },
+    {
+      "characters": "ů",
+      "codepoints": [
+        367
+      ],
+      "name": "&uring;",
+      "semicolon": true
+    },
+    {
+      "characters": "◹",
+      "codepoints": [
+        9721
+      ],
+      "name": "&urtri;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓊",
+      "codepoints": [
+        120010
+      ],
+      "name": "&uscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋰",
+      "codepoints": [
+        8944
+      ],
+      "name": "&utdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "ũ",
+      "codepoints": [
+        361
+      ],
+      "name": "&utilde;",
+      "semicolon": true
+    },
+    {
+      "characters": "▵",
+      "codepoints": [
+        9653
+      ],
+      "name": "&utri;",
+      "semicolon": true
+    },
+    {
+      "characters": "▴",
+      "codepoints": [
+        9652
+      ],
+      "name": "&utrif;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇈",
+      "codepoints": [
+        8648
+      ],
+      "name": "&uuarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ü",
+      "codepoints": [
+        252
+      ],
+      "name": "&uuml",
+      "semicolon": false
+    },
+    {
+      "characters": "ü",
+      "codepoints": [
+        252
+      ],
+      "name": "&uuml;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦧",
+      "codepoints": [
+        10663
+      ],
+      "name": "&uwangle;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇕",
+      "codepoints": [
+        8661
+      ],
+      "name": "&vArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫨",
+      "codepoints": [
+        10984
+      ],
+      "name": "&vBar;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫩",
+      "codepoints": [
+        10985
+      ],
+      "name": "&vBarv;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊨",
+      "codepoints": [
+        8872
+      ],
+      "name": "&vDash;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦜",
+      "codepoints": [
+        10652
+      ],
+      "name": "&vangrt;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϵ",
+      "codepoints": [
+        1013
+      ],
+      "name": "&varepsilon;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϰ",
+      "codepoints": [
+        1008
+      ],
+      "name": "&varkappa;",
+      "semicolon": true
+    },
+    {
+      "characters": "∅",
+      "codepoints": [
+        8709
+      ],
+      "name": "&varnothing;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϕ",
+      "codepoints": [
+        981
+      ],
+      "name": "&varphi;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϖ",
+      "codepoints": [
+        982
+      ],
+      "name": "&varpi;",
+      "semicolon": true
+    },
+    {
+      "characters": "∝",
+      "codepoints": [
+        8733
+      ],
+      "name": "&varpropto;",
+      "semicolon": true
+    },
+    {
+      "characters": "↕",
+      "codepoints": [
+        8597
+      ],
+      "name": "&varr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϱ",
+      "codepoints": [
+        1009
+      ],
+      "name": "&varrho;",
+      "semicolon": true
+    },
+    {
+      "characters": "ς",
+      "codepoints": [
+        962
+      ],
+      "name": "&varsigma;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊊︀",
+      "codepoints": [
+        8842,
+        65024
+      ],
+      "name": "&varsubsetneq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫋︀",
+      "codepoints": [
+        10955,
+        65024
+      ],
+      "name": "&varsubsetneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊋︀",
+      "codepoints": [
+        8843,
+        65024
+      ],
+      "name": "&varsupsetneq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫌︀",
+      "codepoints": [
+        10956,
+        65024
+      ],
+      "name": "&varsupsetneqq;",
+      "semicolon": true
+    },
+    {
+      "characters": "ϑ",
+      "codepoints": [
+        977
+      ],
+      "name": "&vartheta;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊲",
+      "codepoints": [
+        8882
+      ],
+      "name": "&vartriangleleft;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊳",
+      "codepoints": [
+        8883
+      ],
+      "name": "&vartriangleright;",
+      "semicolon": true
+    },
+    {
+      "characters": "в",
+      "codepoints": [
+        1074
+      ],
+      "name": "&vcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊢",
+      "codepoints": [
+        8866
+      ],
+      "name": "&vdash;",
+      "semicolon": true
+    },
+    {
+      "characters": "∨",
+      "codepoints": [
+        8744
+      ],
+      "name": "&vee;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊻",
+      "codepoints": [
+        8891
+      ],
+      "name": "&veebar;",
+      "semicolon": true
+    },
+    {
+      "characters": "≚",
+      "codepoints": [
+        8794
+      ],
+      "name": "&veeeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋮",
+      "codepoints": [
+        8942
+      ],
+      "name": "&vellip;",
+      "semicolon": true
+    },
+    {
+      "characters": "|",
+      "codepoints": [
+        124
+      ],
+      "name": "&verbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "|",
+      "codepoints": [
+        124
+      ],
+      "name": "&vert;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔳",
+      "codepoints": [
+        120115
+      ],
+      "name": "&vfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊲",
+      "codepoints": [
+        8882
+      ],
+      "name": "&vltri;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊂⃒",
+      "codepoints": [
+        8834,
+        8402
+      ],
+      "name": "&vnsub;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊃⃒",
+      "codepoints": [
+        8835,
+        8402
+      ],
+      "name": "&vnsup;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕧",
+      "codepoints": [
+        120167
+      ],
+      "name": "&vopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "∝",
+      "codepoints": [
+        8733
+      ],
+      "name": "&vprop;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊳",
+      "codepoints": [
+        8883
+      ],
+      "name": "&vrtri;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓋",
+      "codepoints": [
+        120011
+      ],
+      "name": "&vscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫋︀",
+      "codepoints": [
+        10955,
+        65024
+      ],
+      "name": "&vsubnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊊︀",
+      "codepoints": [
+        8842,
+        65024
+      ],
+      "name": "&vsubne;",
+      "semicolon": true
+    },
+    {
+      "characters": "⫌︀",
+      "codepoints": [
+        10956,
+        65024
+      ],
+      "name": "&vsupnE;",
+      "semicolon": true
+    },
+    {
+      "characters": "⊋︀",
+      "codepoints": [
+        8843,
+        65024
+      ],
+      "name": "&vsupne;",
+      "semicolon": true
+    },
+    {
+      "characters": "⦚",
+      "codepoints": [
+        10650
+      ],
+      "name": "&vzigzag;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŵ",
+      "codepoints": [
+        373
+      ],
+      "name": "&wcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⩟",
+      "codepoints": [
+        10847
+      ],
+      "name": "&wedbar;",
+      "semicolon": true
+    },
+    {
+      "characters": "∧",
+      "codepoints": [
+        8743
+      ],
+      "name": "&wedge;",
+      "semicolon": true
+    },
+    {
+      "characters": "≙",
+      "codepoints": [
+        8793
+      ],
+      "name": "&wedgeq;",
+      "semicolon": true
+    },
+    {
+      "characters": "℘",
+      "codepoints": [
+        8472
+      ],
+      "name": "&weierp;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔴",
+      "codepoints": [
+        120116
+      ],
+      "name": "&wfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕨",
+      "codepoints": [
+        120168
+      ],
+      "name": "&wopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "℘",
+      "codepoints": [
+        8472
+      ],
+      "name": "&wp;",
+      "semicolon": true
+    },
+    {
+      "characters": "≀",
+      "codepoints": [
+        8768
+      ],
+      "name": "&wr;",
+      "semicolon": true
+    },
+    {
+      "characters": "≀",
+      "codepoints": [
+        8768
+      ],
+      "name": "&wreath;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓌",
+      "codepoints": [
+        120012
+      ],
+      "name": "&wscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋂",
+      "codepoints": [
+        8898
+      ],
+      "name": "&xcap;",
+      "semicolon": true
+    },
+    {
+      "characters": "◯",
+      "codepoints": [
+        9711
+      ],
+      "name": "&xcirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋃",
+      "codepoints": [
+        8899
+      ],
+      "name": "&xcup;",
+      "semicolon": true
+    },
+    {
+      "characters": "▽",
+      "codepoints": [
+        9661
+      ],
+      "name": "&xdtri;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔵",
+      "codepoints": [
+        120117
+      ],
+      "name": "&xfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟺",
+      "codepoints": [
+        10234
+      ],
+      "name": "&xhArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟷",
+      "codepoints": [
+        10231
+      ],
+      "name": "&xharr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ξ",
+      "codepoints": [
+        958
+      ],
+      "name": "&xi;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟸",
+      "codepoints": [
+        10232
+      ],
+      "name": "&xlArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟵",
+      "codepoints": [
+        10229
+      ],
+      "name": "&xlarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟼",
+      "codepoints": [
+        10236
+      ],
+      "name": "&xmap;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋻",
+      "codepoints": [
+        8955
+      ],
+      "name": "&xnis;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨀",
+      "codepoints": [
+        10752
+      ],
+      "name": "&xodot;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕩",
+      "codepoints": [
+        120169
+      ],
+      "name": "&xopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨁",
+      "codepoints": [
+        10753
+      ],
+      "name": "&xoplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨂",
+      "codepoints": [
+        10754
+      ],
+      "name": "&xotime;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟹",
+      "codepoints": [
+        10233
+      ],
+      "name": "&xrArr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⟶",
+      "codepoints": [
+        10230
+      ],
+      "name": "&xrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓍",
+      "codepoints": [
+        120013
+      ],
+      "name": "&xscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨆",
+      "codepoints": [
+        10758
+      ],
+      "name": "&xsqcup;",
+      "semicolon": true
+    },
+    {
+      "characters": "⨄",
+      "codepoints": [
+        10756
+      ],
+      "name": "&xuplus;",
+      "semicolon": true
+    },
+    {
+      "characters": "△",
+      "codepoints": [
+        9651
+      ],
+      "name": "&xutri;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋁",
+      "codepoints": [
+        8897
+      ],
+      "name": "&xvee;",
+      "semicolon": true
+    },
+    {
+      "characters": "⋀",
+      "codepoints": [
+        8896
+      ],
+      "name": "&xwedge;",
+      "semicolon": true
+    },
+    {
+      "characters": "ý",
+      "codepoints": [
+        253
+      ],
+      "name": "&yacute",
+      "semicolon": false
+    },
+    {
+      "characters": "ý",
+      "codepoints": [
+        253
+      ],
+      "name": "&yacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "я",
+      "codepoints": [
+        1103
+      ],
+      "name": "&yacy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ŷ",
+      "codepoints": [
+        375
+      ],
+      "name": "&ycirc;",
+      "semicolon": true
+    },
+    {
+      "characters": "ы",
+      "codepoints": [
+        1099
+      ],
+      "name": "&ycy;",
+      "semicolon": true
+    },
+    {
+      "characters": "¥",
+      "codepoints": [
+        165
+      ],
+      "name": "&yen",
+      "semicolon": false
+    },
+    {
+      "characters": "¥",
+      "codepoints": [
+        165
+      ],
+      "name": "&yen;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔶",
+      "codepoints": [
+        120118
+      ],
+      "name": "&yfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ї",
+      "codepoints": [
+        1111
+      ],
+      "name": "&yicy;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕪",
+      "codepoints": [
+        120170
+      ],
+      "name": "&yopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓎",
+      "codepoints": [
+        120014
+      ],
+      "name": "&yscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ю",
+      "codepoints": [
+        1102
+      ],
+      "name": "&yucy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ÿ",
+      "codepoints": [
+        255
+      ],
+      "name": "&yuml",
+      "semicolon": false
+    },
+    {
+      "characters": "ÿ",
+      "codepoints": [
+        255
+      ],
+      "name": "&yuml;",
+      "semicolon": true
+    },
+    {
+      "characters": "ź",
+      "codepoints": [
+        378
+      ],
+      "name": "&zacute;",
+      "semicolon": true
+    },
+    {
+      "characters": "ž",
+      "codepoints": [
+        382
+      ],
+      "name": "&zcaron;",
+      "semicolon": true
+    },
+    {
+      "characters": "з",
+      "codepoints": [
+        1079
+      ],
+      "name": "&zcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "ż",
+      "codepoints": [
+        380
+      ],
+      "name": "&zdot;",
+      "semicolon": true
+    },
+    {
+      "characters": "ℨ",
+      "codepoints": [
+        8488
+      ],
+      "name": "&zeetrf;",
+      "semicolon": true
+    },
+    {
+      "characters": "ζ",
+      "codepoints": [
+        950
+      ],
+      "name": "&zeta;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝔷",
+      "codepoints": [
+        120119
+      ],
+      "name": "&zfr;",
+      "semicolon": true
+    },
+    {
+      "characters": "ж",
+      "codepoints": [
+        1078
+      ],
+      "name": "&zhcy;",
+      "semicolon": true
+    },
+    {
+      "characters": "⇝",
+      "codepoints": [
+        8669
+      ],
+      "name": "&zigrarr;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝕫",
+      "codepoints": [
+        120171
+      ],
+      "name": "&zopf;",
+      "semicolon": true
+    },
+    {
+      "characters": "𝓏",
+      "codepoints": [
+        120015
+      ],
+      "name": "&zscr;",
+      "semicolon": true
+    },
+    {
+      "characters": "‍",
+      "codepoints": [
+        8205
+      ],
+      "name": "&zwj;",
+      "semicolon": true
+    },
+    {
+      "characters": "‌",
+      "codepoints": [
+        8204
+      ],
+      "name": "&zwnj;",
+      "semicolon": true
+    }
+  ],
+  "format": "whatwg-html-entities/v1",
+  "source": "https://html.spec.whatwg.org/entities.json"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_entities_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_entities_test.rs
@@ -1,0 +1,187 @@
+use coding_adventures_html_lexer::{
+    create_html_lexer, create_html_lexer_with_context, HtmlLexContext, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_ENTITIES: &str = include_str!("fixtures/whatwg-entities.json");
+const MISSING_SEMICOLON: &str = "missing-semicolon-after-character-reference";
+
+#[derive(Debug, Deserialize)]
+struct EntitySuite {
+    format: String,
+    source: String,
+    entities: Vec<EntityCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EntityCase {
+    name: String,
+    characters: String,
+    codepoints: Vec<u32>,
+    semicolon: bool,
+}
+
+#[test]
+fn whatwg_named_character_references_decode_in_data_state() {
+    let suite = load_suite();
+    assert_eq!(suite.format, "whatwg-html-entities/v1");
+    assert_eq!(suite.source, "https://html.spec.whatwg.org/entities.json");
+    assert_eq!(suite.entities.len(), 2231);
+
+    for entity in &suite.entities {
+        assert_characters_match_codepoints(entity);
+        let source = format!("before {} after", entity.name);
+        let expected = format!("before {} after", entity.characters);
+        let (tokens, diagnostics) = lex_data(&source);
+
+        assert_eq!(
+            tokens,
+            vec![Token::Text(expected), Token::Eof],
+            "entity {}",
+            entity.name
+        );
+        assert_missing_semicolon_shape(entity, diagnostics, &entity.name);
+    }
+}
+
+#[test]
+fn whatwg_named_character_references_decode_in_attributes() {
+    let suite = load_suite();
+
+    for entity in &suite.entities {
+        let source = if entity.semicolon {
+            format!("<p title=before{}after>", entity.name)
+        } else {
+            format!("<p title=before{}/after>", entity.name)
+        };
+        let expected = if entity.semicolon {
+            format!("before{}after", entity.characters)
+        } else {
+            format!("before{}/after", entity.characters)
+        };
+        let (tokens, diagnostics) = lex_data(&source);
+
+        assert_eq!(
+            single_title_attribute(&tokens),
+            expected,
+            "entity {}",
+            entity.name
+        );
+        assert_missing_semicolon_shape(entity, diagnostics, &entity.name);
+    }
+}
+
+#[test]
+fn semicolonless_legacy_references_stay_literal_when_ambiguous_in_attributes() {
+    let suite = load_suite();
+
+    for entity in suite.entities.iter().filter(|entity| !entity.semicolon) {
+        let source = format!("<p title=before{}after>", entity.name);
+        let (tokens, diagnostics) = lex_data(&source);
+
+        assert_eq!(
+            single_title_attribute(&tokens),
+            format!("before{}after", entity.name),
+            "entity {}",
+            entity.name
+        );
+        assert!(
+            diagnostics.iter().all(|code| code != MISSING_SEMICOLON),
+            "ambiguous attribute reference {} should not report missing semicolon: {:?}",
+            entity.name,
+            diagnostics
+        );
+    }
+}
+
+#[test]
+fn whatwg_named_character_references_decode_in_rcdata() {
+    let suite = load_suite();
+
+    for entity in &suite.entities {
+        let source = format!("before {} after", entity.name);
+        let expected = format!("before {} after", entity.characters);
+        let (tokens, diagnostics) = lex_title_rcdata(&source);
+
+        assert_eq!(
+            tokens,
+            vec![Token::Text(expected), Token::Eof],
+            "entity {}",
+            entity.name
+        );
+        assert_missing_semicolon_shape(entity, diagnostics, &entity.name);
+    }
+}
+
+fn load_suite() -> EntitySuite {
+    serde_json::from_str(WHATWG_ENTITIES).expect("WHATWG entities fixture should parse")
+}
+
+fn assert_characters_match_codepoints(entity: &EntityCase) {
+    let actual = entity
+        .characters
+        .chars()
+        .map(|ch| ch as u32)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, entity.codepoints, "entity {}", entity.name);
+}
+
+fn lex_data(source: &str) -> (Vec<Token>, Vec<String>) {
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    lexer.push(source).expect("push should succeed");
+    lexer.finish().expect("finish should succeed");
+    let diagnostics = lexer
+        .diagnostics()
+        .iter()
+        .map(|diagnostic| diagnostic.code.clone())
+        .collect::<Vec<_>>();
+    (lexer.drain_tokens(), diagnostics)
+}
+
+fn lex_title_rcdata(source: &str) -> (Vec<Token>, Vec<String>) {
+    let context = HtmlLexContext::for_element_text("title").expect("title should map to RCDATA");
+    let mut lexer = create_html_lexer_with_context(&context).expect("HTML lexer should build");
+    lexer.push(source).expect("push should succeed");
+    lexer.finish().expect("finish should succeed");
+    let diagnostics = lexer
+        .diagnostics()
+        .iter()
+        .map(|diagnostic| diagnostic.code.clone())
+        .collect::<Vec<_>>();
+    (lexer.drain_tokens(), diagnostics)
+}
+
+fn single_title_attribute(tokens: &[Token]) -> String {
+    match tokens {
+        [Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        }, Token::Eof] => {
+            assert_eq!(name, "p");
+            assert!(!self_closing);
+            assert_eq!(attributes.len(), 1);
+            assert_eq!(attributes[0].name, "title");
+            attributes[0].value.clone()
+        }
+        other => panic!("expected one start tag plus EOF, got {other:?}"),
+    }
+}
+
+fn assert_missing_semicolon_shape(entity: &EntityCase, diagnostics: Vec<String>, input: &str) {
+    if entity.semicolon {
+        assert!(
+            diagnostics.iter().all(|code| code != MISSING_SEMICOLON),
+            "semicolon entity {} should not report missing semicolon: {:?}",
+            input,
+            diagnostics
+        );
+    } else {
+        assert!(
+            diagnostics.iter().any(|code| code == MISSING_SEMICOLON),
+            "semicolonless entity {} should report missing semicolon: {:?}",
+            input,
+            diagnostics
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG entities.json fixture for all 2,231 named character reference entries
- exercise every entry through data-state, attribute, and RCDATA lexer contexts
- cover semicolonless legacy references and ambiguous-ampersand preservation in attributes
- document the regeneration/check workflow for the fixture

## Verification
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py /tmp/whatwg-entities-codex.json --check