### PR TITLE
feat(board-vm): add UNO R4 watchdog metadata

### DIFF
--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -85,6 +85,14 @@ pub struct RtcInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WatchdogInfo {
+    pub instance: u8,
+    pub name: &'static str,
+    pub peripheral: &'static str,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DigitalPinInfo {
     pub pin: u8,
     pub label: &'static str,
@@ -141,6 +149,7 @@ pub struct BoardTargetInfo {
     pub uart_buses: &'static [UartBusInfo],
     pub can_buses: &'static [CanBusInfo],
     pub rtc: Option<RtcInfo>,
+    pub watchdog: Option<WatchdogInfo>,
     pub wireless: &'static [WirelessInterfaceInfo],
     pub capabilities: &'static [&'static str],
 }
@@ -317,6 +326,7 @@ pub const UNO_R4_WIFI_UART_BUSES: [UartBusInfo; 3] =
 pub const UNO_R4_CAN_BUSES: [CanBusInfo; 1] =
     map_uno_r4_can_buses(board_vm_uno_r4::UNO_R4_CAN_BUSES);
 pub const UNO_R4_RTC: RtcInfo = uno_r4_rtc(board_vm_uno_r4::UNO_R4_RTC);
+pub const UNO_R4_WATCHDOG: WatchdogInfo = uno_r4_watchdog(board_vm_uno_r4::UNO_R4_WATCHDOG);
 
 pub const ESP32_DIGITAL_PINS: [DigitalPinInfo; 30] =
     map_esp32_digital_pins(board_vm_esp32::ESP32_DEVKIT_V1_DIGITAL_PINS);
@@ -475,6 +485,15 @@ const fn uno_r4_rtc(rtc: board_vm_uno_r4::RtcDescriptor) -> RtcInfo {
     }
 }
 
+const fn uno_r4_watchdog(watchdog: board_vm_uno_r4::WatchdogDescriptor) -> WatchdogInfo {
+    WatchdogInfo {
+        instance: watchdog.instance,
+        name: watchdog.name,
+        peripheral: watchdog.peripheral,
+        notes: watchdog.notes,
+    }
+}
+
 const fn map_esp32_digital_pins<const N: usize>(
     source: [board_vm_esp32::DigitalPinDescriptor; N],
 ) -> [DigitalPinInfo; N] {
@@ -557,6 +576,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         uart_buses: &UNO_R4_MINIMA_UART_BUSES,
         can_buses: &UNO_R4_CAN_BUSES,
         rtc: Some(UNO_R4_RTC),
+        watchdog: Some(UNO_R4_WATCHDOG),
         wireless: &[],
         capabilities: &UNO_R4_MINIMA_CAPABILITIES,
     },
@@ -585,6 +605,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         uart_buses: &UNO_R4_WIFI_UART_BUSES,
         can_buses: &UNO_R4_CAN_BUSES,
         rtc: Some(UNO_R4_RTC),
+        watchdog: Some(UNO_R4_WATCHDOG),
         wireless: &UNO_R4_WIFI_WIRELESS,
         capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
@@ -610,6 +631,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         uart_buses: &[],
         can_buses: &[],
         rtc: None,
+        watchdog: None,
         wireless: &ESP32_WIRELESS,
         capabilities: &ESP32_CAPABILITIES,
     },
@@ -638,6 +660,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         uart_buses: &[],
         can_buses: &[],
         rtc: None,
+        watchdog: None,
         wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
@@ -666,6 +689,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         uart_buses: &[],
         can_buses: &[],
         rtc: None,
+        watchdog: None,
         wireless: &PICO_W_WIRELESS,
         capabilities: &PICO_W_CAPABILITIES,
     },
@@ -825,6 +849,23 @@ mod tests {
         assert_eq!(find_target("esp32-devkit-v1").unwrap().rtc, None);
         assert_eq!(find_target("raspberry-pi-pico").unwrap().rtc, None);
         assert_eq!(find_target("raspberry-pi-pico-w").unwrap().rtc, None);
+    }
+
+    #[test]
+    fn registry_exposes_watchdog_metadata() {
+        let minima = find_target("arduino-uno-r4-minima").unwrap();
+        assert_eq!(minima.watchdog, Some(UNO_R4_WATCHDOG));
+        assert_eq!(minima.watchdog.unwrap().instance, 0);
+        assert_eq!(minima.watchdog.unwrap().name, "WDT");
+        assert_eq!(minima.watchdog.unwrap().peripheral, "RA4M1 WDT");
+
+        let wifi = find_target("arduino-uno-r4-wifi").unwrap();
+        assert_eq!(wifi.watchdog, minima.watchdog);
+        assert!(wifi.watchdog.unwrap().notes.contains("watchdog timer"));
+
+        assert_eq!(find_target("esp32-devkit-v1").unwrap().watchdog, None);
+        assert_eq!(find_target("raspberry-pi-pico").unwrap().watchdog, None);
+        assert_eq!(find_target("raspberry-pi-pico-w").unwrap().watchdog, None);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -69,6 +69,7 @@ pub struct TargetDescriptor {
     pub uart_buses: &'static [UartBusDescriptor],
     pub can_buses: &'static [CanBusDescriptor],
     pub rtc: Option<RtcDescriptor>,
+    pub watchdog: Option<WatchdogDescriptor>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,6 +127,14 @@ pub struct CanBusDescriptor {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RtcDescriptor {
+    pub instance: u8,
+    pub name: &'static str,
+    pub peripheral: &'static str,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WatchdogDescriptor {
     pub instance: u8,
     pub name: &'static str,
     pub peripheral: &'static str,
@@ -415,6 +424,13 @@ pub const UNO_R4_RTC: RtcDescriptor = RtcDescriptor {
     notes: "Single real-time clock instance exposed by the UNO R4 core",
 };
 
+pub const UNO_R4_WATCHDOG: WatchdogDescriptor = WatchdogDescriptor {
+    instance: 0,
+    name: "WDT",
+    peripheral: "RA4M1 WDT",
+    notes: "Renesas watchdog timer exposed through the UNO R4 core WDT library",
+};
+
 pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     board_id: "arduino-uno-r4-minima",
     display_name: "Arduino Uno R4 Minima",
@@ -444,6 +460,7 @@ pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     uart_buses: &UNO_R4_MINIMA_UART_BUSES,
     can_buses: &UNO_R4_CAN_BUSES,
     rtc: Some(UNO_R4_RTC),
+    watchdog: Some(UNO_R4_WATCHDOG),
 };
 
 pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
@@ -476,6 +493,7 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
     uart_buses: &UNO_R4_WIFI_UART_BUSES,
     can_buses: &UNO_R4_CAN_BUSES,
     rtc: Some(UNO_R4_RTC),
+    watchdog: Some(UNO_R4_WATCHDOG),
 };
 
 pub trait UnoR4Backend {
@@ -1323,6 +1341,18 @@ mod tests {
         assert_eq!(rtc.name, "RTC");
         assert_eq!(rtc.peripheral, "RA4M1 RTC");
         assert!(rtc.notes.contains("real-time clock"));
+    }
+
+    #[test]
+    fn knows_uno_r4_watchdog() {
+        assert_eq!(UNO_R4_MINIMA.watchdog, Some(UNO_R4_WATCHDOG));
+        assert_eq!(UNO_R4_WIFI.watchdog, Some(UNO_R4_WATCHDOG));
+
+        let watchdog = UNO_R4_WIFI.watchdog.unwrap();
+        assert_eq!(watchdog.instance, 0);
+        assert_eq!(watchdog.name, "WDT");
+        assert_eq!(watchdog.peripheral, "RA4M1 WDT");
+        assert!(watchdog.notes.contains("watchdog timer"));
     }
 
     #[test]

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -35,7 +35,7 @@ Source snapshot:
 | CAN | CAN0 TX D10, RX D13 | descriptor metadata implemented; bytecode capability pending | `can.open`, `can.write`, `can.read` |
 | RTC | one RTC instance in the core | descriptor metadata implemented; bytecode capability pending | `rtc.now`, `rtc.set`, alarms/events later |
 | EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | pending | `program.store` and possibly `kv.store` |
-| Watchdog | Renesas WDT library | pending | `watchdog.configure`, `watchdog.kick` |
+| Watchdog | Renesas WDT library | descriptor metadata implemented; bytecode capability pending | `watchdog.configure`, `watchdog.kick` |
 | OPAMP | UNO R4 OPAMP library | pending | analog board-specific capability after ADC/DAC |
 | WiFi | WiFiS3 library through onboard network module | pending | network/transport capabilities, not direct Ruby bypass |
 | USB/HID | TinyUSB device support | pending | transport/device descriptors first; HID later |
@@ -84,9 +84,12 @@ reject conflicting handles.
    UNO R4 `CAN0` on D10/TX and D13/RX while `can.open`, `can.write`, and
    `can.read` remain the next CAN capability tranche. RTC now has descriptor
    metadata for the single UNO R4 `RA4M1 RTC` instance while `rtc.now` and
-   `rtc.set` remain a later capability tranche. The next independent tranche
-   can move on to CAN byte I/O, RTC bytecode operations, watchdog,
-   EEPROM/store, or WiFi/network metadata and capability slices.
+   `rtc.set` remain a later capability tranche. Watchdog now has descriptor
+   metadata for the UNO R4 `RA4M1 WDT` instance while `watchdog.configure` and
+   `watchdog.kick` remain a later capability tranche. The next independent
+   tranche can move on to CAN byte I/O, RTC bytecode operations, watchdog
+   bytecode operations, EEPROM/store, or WiFi/network metadata and capability
+   slices.
 
 Every tranche should include the same layers: spec entry, IR capability id,
 runtime HAL method, UNO R4 target descriptor, firmware backend, host builder,


### PR DESCRIPTION
## Summary
- add a UNO R4 watchdog descriptor for the RA4M1 WDT instance
- expose watchdog metadata through the board target registry while keeping watchdog.configure/watchdog.kick pending
- update BVM07 to mark watchdog descriptor metadata as implemented and watchdog bytecode operations as next

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-watchdog-metadata cargo fmt -p board-vm-uno-r4 -p board-vm-targets
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-watchdog-metadata cargo test -p board-vm-uno-r4 -p board-vm-targets
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check