### PR TITLE
[codex] Add WHATWG numeric reference conformance sweep

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -44,6 +44,9 @@ documented in this file.
 - A generated WHATWG `entities.json` fixture and Rust conformance test that
   exercises every named character reference in data, attribute, and RCDATA
   contexts, including semicolonless legacy and ambiguous-ampersand behavior.
+- A generated WHATWG numeric character reference edge fixture and Rust
+  conformance test that exercises decimal, hexadecimal, semicolon, and
+  missing-semicolon forms across data, attribute, and RCDATA contexts.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -242,6 +242,17 @@ python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fi
   /tmp/entities.json --check
 ```
 
+The checked-in `whatwg-numeric-references.json` fixture exercises the finite
+edge classes of the HTML numeric character reference algorithm: null, controls,
+Windows-1252 control remaps, surrogates, noncharacters, scalar boundaries, and
+outside-range values. Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py \
+  --check
+```
+
 There is also an `upstream-html5lib-smoke.test` file that mirrors the raw
 html5lib tokenizer JSON shape in a small supported subset. The Rust test
 harness now targets a checked-in generated `html5lib-smoke.json` corpus, which

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -51,6 +51,10 @@ binary while production code continues to link only static Rust source.
 - `whatwg-entities.json`: generated HTML Standard named character reference
   table used by Rust tests to exercise every entry in data, attribute, and
   RCDATA contexts
+- `whatwg-numeric-references.json`: generated HTML Standard numeric character
+  reference edge table used by Rust tests to exercise decimal, hexadecimal,
+  semicolon, and missing-semicolon forms across data, attribute, and RCDATA
+  contexts
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
@@ -60,6 +64,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_entities_fixture.py`: importer that lowers the HTML
   Standard's `entities.json` table into the checked-in `whatwg-entities.json`
   fixture
+- `generate_whatwg_numeric_references_fixture.py`: importer that generates the
+  finite numeric character reference edge table for the checked-in
+  `whatwg-numeric-references.json` fixture
 
 Regenerate or verify the WHATWG entity fixture with:
 
@@ -69,6 +76,14 @@ python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fi
   /tmp/entities.json
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py \
   /tmp/entities.json --check
+```
+
+Regenerate or verify the WHATWG numeric-reference fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py \
+  --check
 ```
 
 ## Conformance Audit

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG numeric character reference edge fixture.
+
+The numeric character reference algorithm is finite around its interesting
+error classes: null, controls, Windows-1252 remaps, surrogates, noncharacters,
+Unicode boundaries, and outside-range values. This fixture encodes those edge
+classes directly so Rust tests can sweep decimal/hexadecimal and
+semicolon/missing-semicolon forms without duplicating the expectation table by
+hand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-numeric-references.json")
+
+WINDOWS_1252_REPLACEMENTS = {
+    0x80: 0x20AC,
+    0x82: 0x201A,
+    0x83: 0x0192,
+    0x84: 0x201E,
+    0x85: 0x2026,
+    0x86: 0x2020,
+    0x87: 0x2021,
+    0x88: 0x02C6,
+    0x89: 0x2030,
+    0x8A: 0x0160,
+    0x8B: 0x2039,
+    0x8C: 0x0152,
+    0x8E: 0x017D,
+    0x91: 0x2018,
+    0x92: 0x2019,
+    0x93: 0x201C,
+    0x94: 0x201D,
+    0x95: 0x2022,
+    0x96: 0x2013,
+    0x97: 0x2014,
+    0x98: 0x02DC,
+    0x99: 0x2122,
+    0x9A: 0x0161,
+    0x9B: 0x203A,
+    0x9C: 0x0153,
+    0x9E: 0x017E,
+    0x9F: 0x0178,
+}
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG numeric character reference edge fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    cases = [case_for_value(value) for value in numeric_values()]
+    return {
+        "format": "whatwg-html-numeric-character-references/v1",
+        "description": (
+            "Numeric character reference edge classes from the WHATWG HTML "
+            "tokenization algorithm."
+        ),
+        "cases": cases,
+    }
+
+
+def numeric_values() -> list[int]:
+    values: set[int] = set()
+
+    values.update(range(0x00, 0x20))
+    values.update(range(0x7F, 0xA0))
+    values.update(range(0xD800, 0xE000))
+    values.update(range(0xFDD0, 0xFDF0))
+
+    for plane in range(0x00, 0x11):
+        base = plane << 16
+        values.add(base + 0xFFFE)
+        values.add(base + 0xFFFF)
+        if base + 0xFFFD <= 0x10FFFF:
+            values.add(base + 0xFFFD)
+
+    values.update(
+        {
+            0x20,
+            0x41,
+            0x7E,
+            0xA0,
+            0xD7FE,
+            0xD7FF,
+            0xE000,
+            0xE001,
+            0xFDCF,
+            0xFDF0,
+            0x10000,
+            0x1F600,
+            0x10FFFD,
+            0x10FFFE,
+            0x10FFFF,
+            0x110000,
+            0xFFFFFFFF,
+        }
+    )
+
+    return sorted(values)
+
+
+def case_for_value(value: int) -> dict[str, object]:
+    codepoints, diagnostics = decode_numeric_reference(value)
+    return {
+        "value": value,
+        "decimal": f"&#{value};",
+        "hex": f"&#x{value:X};",
+        "decimal_missing_semicolon": f"&#{value}",
+        "hex_missing_semicolon": f"&#X{value:X}",
+        "characters": "".join(chr(codepoint) for codepoint in codepoints),
+        "codepoints": codepoints,
+        "diagnostics": diagnostics,
+    }
+
+
+def decode_numeric_reference(value: int) -> tuple[list[int], list[str]]:
+    if value == 0:
+        return [0xFFFD], ["null-character-reference"]
+
+    if value > 0x10FFFF:
+        return [0xFFFD], ["character-reference-outside-unicode-range"]
+
+    if 0xD800 <= value <= 0xDFFF:
+        return [0xFFFD], ["surrogate-character-reference"]
+
+    diagnostics: list[str] = []
+    if is_noncharacter(value):
+        diagnostics.append("noncharacter-character-reference")
+
+    replacement = WINDOWS_1252_REPLACEMENTS.get(value)
+    if replacement is not None:
+        diagnostics.append("control-character-reference")
+        return [replacement], diagnostics
+
+    if is_control_character_reference(value):
+        diagnostics.append("control-character-reference")
+
+    return [value], diagnostics
+
+
+def is_noncharacter(value: int) -> bool:
+    return (0xFDD0 <= value <= 0xFDEF) or any(
+        value == (plane << 16) + suffix
+        for plane in range(0x00, 0x11)
+        for suffix in (0xFFFE, 0xFFFF)
+    )
+
+
+def is_control_character_reference(value: int) -> bool:
+    return value == 0x0D or (is_control(value) and not is_ascii_whitespace_control(value))
+
+
+def is_control(value: int) -> bool:
+    return value <= 0x1F or 0x7F <= value <= 0x9F
+
+
+def is_ascii_whitespace_control(value: int) -> bool:
+    return value in {0x09, 0x0A, 0x0C, 0x20}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-numeric-references.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-numeric-references.json
@@ -1,0 +1,30882 @@
+{
+  "cases": [
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#0;",
+      "decimal_missing_semicolon": "&#0",
+      "diagnostics": [
+        "null-character-reference"
+      ],
+      "hex": "&#x0;",
+      "hex_missing_semicolon": "&#X0",
+      "value": 0
+    },
+    {
+      "characters": "\u0001",
+      "codepoints": [
+        1
+      ],
+      "decimal": "&#1;",
+      "decimal_missing_semicolon": "&#1",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x1;",
+      "hex_missing_semicolon": "&#X1",
+      "value": 1
+    },
+    {
+      "characters": "\u0002",
+      "codepoints": [
+        2
+      ],
+      "decimal": "&#2;",
+      "decimal_missing_semicolon": "&#2",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x2;",
+      "hex_missing_semicolon": "&#X2",
+      "value": 2
+    },
+    {
+      "characters": "\u0003",
+      "codepoints": [
+        3
+      ],
+      "decimal": "&#3;",
+      "decimal_missing_semicolon": "&#3",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x3;",
+      "hex_missing_semicolon": "&#X3",
+      "value": 3
+    },
+    {
+      "characters": "\u0004",
+      "codepoints": [
+        4
+      ],
+      "decimal": "&#4;",
+      "decimal_missing_semicolon": "&#4",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x4;",
+      "hex_missing_semicolon": "&#X4",
+      "value": 4
+    },
+    {
+      "characters": "\u0005",
+      "codepoints": [
+        5
+      ],
+      "decimal": "&#5;",
+      "decimal_missing_semicolon": "&#5",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x5;",
+      "hex_missing_semicolon": "&#X5",
+      "value": 5
+    },
+    {
+      "characters": "\u0006",
+      "codepoints": [
+        6
+      ],
+      "decimal": "&#6;",
+      "decimal_missing_semicolon": "&#6",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x6;",
+      "hex_missing_semicolon": "&#X6",
+      "value": 6
+    },
+    {
+      "characters": "\u0007",
+      "codepoints": [
+        7
+      ],
+      "decimal": "&#7;",
+      "decimal_missing_semicolon": "&#7",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x7;",
+      "hex_missing_semicolon": "&#X7",
+      "value": 7
+    },
+    {
+      "characters": "\b",
+      "codepoints": [
+        8
+      ],
+      "decimal": "&#8;",
+      "decimal_missing_semicolon": "&#8",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x8;",
+      "hex_missing_semicolon": "&#X8",
+      "value": 8
+    },
+    {
+      "characters": "\t",
+      "codepoints": [
+        9
+      ],
+      "decimal": "&#9;",
+      "decimal_missing_semicolon": "&#9",
+      "diagnostics": [],
+      "hex": "&#x9;",
+      "hex_missing_semicolon": "&#X9",
+      "value": 9
+    },
+    {
+      "characters": "\n",
+      "codepoints": [
+        10
+      ],
+      "decimal": "&#10;",
+      "decimal_missing_semicolon": "&#10",
+      "diagnostics": [],
+      "hex": "&#xA;",
+      "hex_missing_semicolon": "&#XA",
+      "value": 10
+    },
+    {
+      "characters": "\u000b",
+      "codepoints": [
+        11
+      ],
+      "decimal": "&#11;",
+      "decimal_missing_semicolon": "&#11",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#xB;",
+      "hex_missing_semicolon": "&#XB",
+      "value": 11
+    },
+    {
+      "characters": "\f",
+      "codepoints": [
+        12
+      ],
+      "decimal": "&#12;",
+      "decimal_missing_semicolon": "&#12",
+      "diagnostics": [],
+      "hex": "&#xC;",
+      "hex_missing_semicolon": "&#XC",
+      "value": 12
+    },
+    {
+      "characters": "\r",
+      "codepoints": [
+        13
+      ],
+      "decimal": "&#13;",
+      "decimal_missing_semicolon": "&#13",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#xD;",
+      "hex_missing_semicolon": "&#XD",
+      "value": 13
+    },
+    {
+      "characters": "\u000e",
+      "codepoints": [
+        14
+      ],
+      "decimal": "&#14;",
+      "decimal_missing_semicolon": "&#14",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#xE;",
+      "hex_missing_semicolon": "&#XE",
+      "value": 14
+    },
+    {
+      "characters": "\u000f",
+      "codepoints": [
+        15
+      ],
+      "decimal": "&#15;",
+      "decimal_missing_semicolon": "&#15",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#xF;",
+      "hex_missing_semicolon": "&#XF",
+      "value": 15
+    },
+    {
+      "characters": "\u0010",
+      "codepoints": [
+        16
+      ],
+      "decimal": "&#16;",
+      "decimal_missing_semicolon": "&#16",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x10;",
+      "hex_missing_semicolon": "&#X10",
+      "value": 16
+    },
+    {
+      "characters": "\u0011",
+      "codepoints": [
+        17
+      ],
+      "decimal": "&#17;",
+      "decimal_missing_semicolon": "&#17",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x11;",
+      "hex_missing_semicolon": "&#X11",
+      "value": 17
+    },
+    {
+      "characters": "\u0012",
+      "codepoints": [
+        18
+      ],
+      "decimal": "&#18;",
+      "decimal_missing_semicolon": "&#18",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x12;",
+      "hex_missing_semicolon": "&#X12",
+      "value": 18
+    },
+    {
+      "characters": "\u0013",
+      "codepoints": [
+        19
+      ],
+      "decimal": "&#19;",
+      "decimal_missing_semicolon": "&#19",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x13;",
+      "hex_missing_semicolon": "&#X13",
+      "value": 19
+    },
+    {
+      "characters": "\u0014",
+      "codepoints": [
+        20
+      ],
+      "decimal": "&#20;",
+      "decimal_missing_semicolon": "&#20",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x14;",
+      "hex_missing_semicolon": "&#X14",
+      "value": 20
+    },
+    {
+      "characters": "\u0015",
+      "codepoints": [
+        21
+      ],
+      "decimal": "&#21;",
+      "decimal_missing_semicolon": "&#21",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x15;",
+      "hex_missing_semicolon": "&#X15",
+      "value": 21
+    },
+    {
+      "characters": "\u0016",
+      "codepoints": [
+        22
+      ],
+      "decimal": "&#22;",
+      "decimal_missing_semicolon": "&#22",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x16;",
+      "hex_missing_semicolon": "&#X16",
+      "value": 22
+    },
+    {
+      "characters": "\u0017",
+      "codepoints": [
+        23
+      ],
+      "decimal": "&#23;",
+      "decimal_missing_semicolon": "&#23",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x17;",
+      "hex_missing_semicolon": "&#X17",
+      "value": 23
+    },
+    {
+      "characters": "\u0018",
+      "codepoints": [
+        24
+      ],
+      "decimal": "&#24;",
+      "decimal_missing_semicolon": "&#24",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x18;",
+      "hex_missing_semicolon": "&#X18",
+      "value": 24
+    },
+    {
+      "characters": "\u0019",
+      "codepoints": [
+        25
+      ],
+      "decimal": "&#25;",
+      "decimal_missing_semicolon": "&#25",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x19;",
+      "hex_missing_semicolon": "&#X19",
+      "value": 25
+    },
+    {
+      "characters": "\u001a",
+      "codepoints": [
+        26
+      ],
+      "decimal": "&#26;",
+      "decimal_missing_semicolon": "&#26",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x1A;",
+      "hex_missing_semicolon": "&#X1A",
+      "value": 26
+    },
+    {
+      "characters": "\u001b",
+      "codepoints": [
+        27
+      ],
+      "decimal": "&#27;",
+      "decimal_missing_semicolon": "&#27",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x1B;",
+      "hex_missing_semicolon": "&#X1B",
+      "value": 27
+    },
+    {
+      "characters": "\u001c",
+      "codepoints": [
+        28
+      ],
+      "decimal": "&#28;",
+      "decimal_missing_semicolon": "&#28",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x1C;",
+      "hex_missing_semicolon": "&#X1C",
+      "value": 28
+    },
+    {
+      "characters": "\u001d",
+      "codepoints": [
+        29
+      ],
+      "decimal": "&#29;",
+      "decimal_missing_semicolon": "&#29",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x1D;",
+      "hex_missing_semicolon": "&#X1D",
+      "value": 29
+    },
+    {
+      "characters": "\u001e",
+      "codepoints": [
+        30
+      ],
+      "decimal": "&#30;",
+      "decimal_missing_semicolon": "&#30",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x1E;",
+      "hex_missing_semicolon": "&#X1E",
+      "value": 30
+    },
+    {
+      "characters": "\u001f",
+      "codepoints": [
+        31
+      ],
+      "decimal": "&#31;",
+      "decimal_missing_semicolon": "&#31",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x1F;",
+      "hex_missing_semicolon": "&#X1F",
+      "value": 31
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        32
+      ],
+      "decimal": "&#32;",
+      "decimal_missing_semicolon": "&#32",
+      "diagnostics": [],
+      "hex": "&#x20;",
+      "hex_missing_semicolon": "&#X20",
+      "value": 32
+    },
+    {
+      "characters": "A",
+      "codepoints": [
+        65
+      ],
+      "decimal": "&#65;",
+      "decimal_missing_semicolon": "&#65",
+      "diagnostics": [],
+      "hex": "&#x41;",
+      "hex_missing_semicolon": "&#X41",
+      "value": 65
+    },
+    {
+      "characters": "~",
+      "codepoints": [
+        126
+      ],
+      "decimal": "&#126;",
+      "decimal_missing_semicolon": "&#126",
+      "diagnostics": [],
+      "hex": "&#x7E;",
+      "hex_missing_semicolon": "&#X7E",
+      "value": 126
+    },
+    {
+      "characters": "",
+      "codepoints": [
+        127
+      ],
+      "decimal": "&#127;",
+      "decimal_missing_semicolon": "&#127",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x7F;",
+      "hex_missing_semicolon": "&#X7F",
+      "value": 127
+    },
+    {
+      "characters": "€",
+      "codepoints": [
+        8364
+      ],
+      "decimal": "&#128;",
+      "decimal_missing_semicolon": "&#128",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x80;",
+      "hex_missing_semicolon": "&#X80",
+      "value": 128
+    },
+    {
+      "characters": "",
+      "codepoints": [
+        129
+      ],
+      "decimal": "&#129;",
+      "decimal_missing_semicolon": "&#129",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x81;",
+      "hex_missing_semicolon": "&#X81",
+      "value": 129
+    },
+    {
+      "characters": "‚",
+      "codepoints": [
+        8218
+      ],
+      "decimal": "&#130;",
+      "decimal_missing_semicolon": "&#130",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x82;",
+      "hex_missing_semicolon": "&#X82",
+      "value": 130
+    },
+    {
+      "characters": "ƒ",
+      "codepoints": [
+        402
+      ],
+      "decimal": "&#131;",
+      "decimal_missing_semicolon": "&#131",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x83;",
+      "hex_missing_semicolon": "&#X83",
+      "value": 131
+    },
+    {
+      "characters": "„",
+      "codepoints": [
+        8222
+      ],
+      "decimal": "&#132;",
+      "decimal_missing_semicolon": "&#132",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x84;",
+      "hex_missing_semicolon": "&#X84",
+      "value": 132
+    },
+    {
+      "characters": "…",
+      "codepoints": [
+        8230
+      ],
+      "decimal": "&#133;",
+      "decimal_missing_semicolon": "&#133",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x85;",
+      "hex_missing_semicolon": "&#X85",
+      "value": 133
+    },
+    {
+      "characters": "†",
+      "codepoints": [
+        8224
+      ],
+      "decimal": "&#134;",
+      "decimal_missing_semicolon": "&#134",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x86;",
+      "hex_missing_semicolon": "&#X86",
+      "value": 134
+    },
+    {
+      "characters": "‡",
+      "codepoints": [
+        8225
+      ],
+      "decimal": "&#135;",
+      "decimal_missing_semicolon": "&#135",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x87;",
+      "hex_missing_semicolon": "&#X87",
+      "value": 135
+    },
+    {
+      "characters": "ˆ",
+      "codepoints": [
+        710
+      ],
+      "decimal": "&#136;",
+      "decimal_missing_semicolon": "&#136",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x88;",
+      "hex_missing_semicolon": "&#X88",
+      "value": 136
+    },
+    {
+      "characters": "‰",
+      "codepoints": [
+        8240
+      ],
+      "decimal": "&#137;",
+      "decimal_missing_semicolon": "&#137",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x89;",
+      "hex_missing_semicolon": "&#X89",
+      "value": 137
+    },
+    {
+      "characters": "Š",
+      "codepoints": [
+        352
+      ],
+      "decimal": "&#138;",
+      "decimal_missing_semicolon": "&#138",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x8A;",
+      "hex_missing_semicolon": "&#X8A",
+      "value": 138
+    },
+    {
+      "characters": "‹",
+      "codepoints": [
+        8249
+      ],
+      "decimal": "&#139;",
+      "decimal_missing_semicolon": "&#139",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x8B;",
+      "hex_missing_semicolon": "&#X8B",
+      "value": 139
+    },
+    {
+      "characters": "Œ",
+      "codepoints": [
+        338
+      ],
+      "decimal": "&#140;",
+      "decimal_missing_semicolon": "&#140",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x8C;",
+      "hex_missing_semicolon": "&#X8C",
+      "value": 140
+    },
+    {
+      "characters": "",
+      "codepoints": [
+        141
+      ],
+      "decimal": "&#141;",
+      "decimal_missing_semicolon": "&#141",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x8D;",
+      "hex_missing_semicolon": "&#X8D",
+      "value": 141
+    },
+    {
+      "characters": "Ž",
+      "codepoints": [
+        381
+      ],
+      "decimal": "&#142;",
+      "decimal_missing_semicolon": "&#142",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x8E;",
+      "hex_missing_semicolon": "&#X8E",
+      "value": 142
+    },
+    {
+      "characters": "",
+      "codepoints": [
+        143
+      ],
+      "decimal": "&#143;",
+      "decimal_missing_semicolon": "&#143",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x8F;",
+      "hex_missing_semicolon": "&#X8F",
+      "value": 143
+    },
+    {
+      "characters": "",
+      "codepoints": [
+        144
+      ],
+      "decimal": "&#144;",
+      "decimal_missing_semicolon": "&#144",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x90;",
+      "hex_missing_semicolon": "&#X90",
+      "value": 144
+    },
+    {
+      "characters": "‘",
+      "codepoints": [
+        8216
+      ],
+      "decimal": "&#145;",
+      "decimal_missing_semicolon": "&#145",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x91;",
+      "hex_missing_semicolon": "&#X91",
+      "value": 145
+    },
+    {
+      "characters": "’",
+      "codepoints": [
+        8217
+      ],
+      "decimal": "&#146;",
+      "decimal_missing_semicolon": "&#146",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x92;",
+      "hex_missing_semicolon": "&#X92",
+      "value": 146
+    },
+    {
+      "characters": "“",
+      "codepoints": [
+        8220
+      ],
+      "decimal": "&#147;",
+      "decimal_missing_semicolon": "&#147",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x93;",
+      "hex_missing_semicolon": "&#X93",
+      "value": 147
+    },
+    {
+      "characters": "”",
+      "codepoints": [
+        8221
+      ],
+      "decimal": "&#148;",
+      "decimal_missing_semicolon": "&#148",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x94;",
+      "hex_missing_semicolon": "&#X94",
+      "value": 148
+    },
+    {
+      "characters": "•",
+      "codepoints": [
+        8226
+      ],
+      "decimal": "&#149;",
+      "decimal_missing_semicolon": "&#149",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x95;",
+      "hex_missing_semicolon": "&#X95",
+      "value": 149
+    },
+    {
+      "characters": "–",
+      "codepoints": [
+        8211
+      ],
+      "decimal": "&#150;",
+      "decimal_missing_semicolon": "&#150",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x96;",
+      "hex_missing_semicolon": "&#X96",
+      "value": 150
+    },
+    {
+      "characters": "—",
+      "codepoints": [
+        8212
+      ],
+      "decimal": "&#151;",
+      "decimal_missing_semicolon": "&#151",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x97;",
+      "hex_missing_semicolon": "&#X97",
+      "value": 151
+    },
+    {
+      "characters": "˜",
+      "codepoints": [
+        732
+      ],
+      "decimal": "&#152;",
+      "decimal_missing_semicolon": "&#152",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x98;",
+      "hex_missing_semicolon": "&#X98",
+      "value": 152
+    },
+    {
+      "characters": "™",
+      "codepoints": [
+        8482
+      ],
+      "decimal": "&#153;",
+      "decimal_missing_semicolon": "&#153",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x99;",
+      "hex_missing_semicolon": "&#X99",
+      "value": 153
+    },
+    {
+      "characters": "š",
+      "codepoints": [
+        353
+      ],
+      "decimal": "&#154;",
+      "decimal_missing_semicolon": "&#154",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x9A;",
+      "hex_missing_semicolon": "&#X9A",
+      "value": 154
+    },
+    {
+      "characters": "›",
+      "codepoints": [
+        8250
+      ],
+      "decimal": "&#155;",
+      "decimal_missing_semicolon": "&#155",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x9B;",
+      "hex_missing_semicolon": "&#X9B",
+      "value": 155
+    },
+    {
+      "characters": "œ",
+      "codepoints": [
+        339
+      ],
+      "decimal": "&#156;",
+      "decimal_missing_semicolon": "&#156",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x9C;",
+      "hex_missing_semicolon": "&#X9C",
+      "value": 156
+    },
+    {
+      "characters": "",
+      "codepoints": [
+        157
+      ],
+      "decimal": "&#157;",
+      "decimal_missing_semicolon": "&#157",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x9D;",
+      "hex_missing_semicolon": "&#X9D",
+      "value": 157
+    },
+    {
+      "characters": "ž",
+      "codepoints": [
+        382
+      ],
+      "decimal": "&#158;",
+      "decimal_missing_semicolon": "&#158",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x9E;",
+      "hex_missing_semicolon": "&#X9E",
+      "value": 158
+    },
+    {
+      "characters": "Ÿ",
+      "codepoints": [
+        376
+      ],
+      "decimal": "&#159;",
+      "decimal_missing_semicolon": "&#159",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "hex": "&#x9F;",
+      "hex_missing_semicolon": "&#X9F",
+      "value": 159
+    },
+    {
+      "characters": " ",
+      "codepoints": [
+        160
+      ],
+      "decimal": "&#160;",
+      "decimal_missing_semicolon": "&#160",
+      "diagnostics": [],
+      "hex": "&#xA0;",
+      "hex_missing_semicolon": "&#XA0",
+      "value": 160
+    },
+    {
+      "characters": "퟾",
+      "codepoints": [
+        55294
+      ],
+      "decimal": "&#55294;",
+      "decimal_missing_semicolon": "&#55294",
+      "diagnostics": [],
+      "hex": "&#xD7FE;",
+      "hex_missing_semicolon": "&#XD7FE",
+      "value": 55294
+    },
+    {
+      "characters": "퟿",
+      "codepoints": [
+        55295
+      ],
+      "decimal": "&#55295;",
+      "decimal_missing_semicolon": "&#55295",
+      "diagnostics": [],
+      "hex": "&#xD7FF;",
+      "hex_missing_semicolon": "&#XD7FF",
+      "value": 55295
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55296;",
+      "decimal_missing_semicolon": "&#55296",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD800;",
+      "hex_missing_semicolon": "&#XD800",
+      "value": 55296
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55297;",
+      "decimal_missing_semicolon": "&#55297",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD801;",
+      "hex_missing_semicolon": "&#XD801",
+      "value": 55297
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55298;",
+      "decimal_missing_semicolon": "&#55298",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD802;",
+      "hex_missing_semicolon": "&#XD802",
+      "value": 55298
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55299;",
+      "decimal_missing_semicolon": "&#55299",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD803;",
+      "hex_missing_semicolon": "&#XD803",
+      "value": 55299
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55300;",
+      "decimal_missing_semicolon": "&#55300",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD804;",
+      "hex_missing_semicolon": "&#XD804",
+      "value": 55300
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55301;",
+      "decimal_missing_semicolon": "&#55301",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD805;",
+      "hex_missing_semicolon": "&#XD805",
+      "value": 55301
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55302;",
+      "decimal_missing_semicolon": "&#55302",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD806;",
+      "hex_missing_semicolon": "&#XD806",
+      "value": 55302
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55303;",
+      "decimal_missing_semicolon": "&#55303",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD807;",
+      "hex_missing_semicolon": "&#XD807",
+      "value": 55303
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55304;",
+      "decimal_missing_semicolon": "&#55304",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD808;",
+      "hex_missing_semicolon": "&#XD808",
+      "value": 55304
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55305;",
+      "decimal_missing_semicolon": "&#55305",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD809;",
+      "hex_missing_semicolon": "&#XD809",
+      "value": 55305
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55306;",
+      "decimal_missing_semicolon": "&#55306",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD80A;",
+      "hex_missing_semicolon": "&#XD80A",
+      "value": 55306
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55307;",
+      "decimal_missing_semicolon": "&#55307",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD80B;",
+      "hex_missing_semicolon": "&#XD80B",
+      "value": 55307
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55308;",
+      "decimal_missing_semicolon": "&#55308",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD80C;",
+      "hex_missing_semicolon": "&#XD80C",
+      "value": 55308
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55309;",
+      "decimal_missing_semicolon": "&#55309",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD80D;",
+      "hex_missing_semicolon": "&#XD80D",
+      "value": 55309
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55310;",
+      "decimal_missing_semicolon": "&#55310",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD80E;",
+      "hex_missing_semicolon": "&#XD80E",
+      "value": 55310
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55311;",
+      "decimal_missing_semicolon": "&#55311",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD80F;",
+      "hex_missing_semicolon": "&#XD80F",
+      "value": 55311
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55312;",
+      "decimal_missing_semicolon": "&#55312",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD810;",
+      "hex_missing_semicolon": "&#XD810",
+      "value": 55312
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55313;",
+      "decimal_missing_semicolon": "&#55313",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD811;",
+      "hex_missing_semicolon": "&#XD811",
+      "value": 55313
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55314;",
+      "decimal_missing_semicolon": "&#55314",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD812;",
+      "hex_missing_semicolon": "&#XD812",
+      "value": 55314
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55315;",
+      "decimal_missing_semicolon": "&#55315",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD813;",
+      "hex_missing_semicolon": "&#XD813",
+      "value": 55315
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55316;",
+      "decimal_missing_semicolon": "&#55316",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD814;",
+      "hex_missing_semicolon": "&#XD814",
+      "value": 55316
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55317;",
+      "decimal_missing_semicolon": "&#55317",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD815;",
+      "hex_missing_semicolon": "&#XD815",
+      "value": 55317
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55318;",
+      "decimal_missing_semicolon": "&#55318",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD816;",
+      "hex_missing_semicolon": "&#XD816",
+      "value": 55318
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55319;",
+      "decimal_missing_semicolon": "&#55319",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD817;",
+      "hex_missing_semicolon": "&#XD817",
+      "value": 55319
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55320;",
+      "decimal_missing_semicolon": "&#55320",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD818;",
+      "hex_missing_semicolon": "&#XD818",
+      "value": 55320
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55321;",
+      "decimal_missing_semicolon": "&#55321",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD819;",
+      "hex_missing_semicolon": "&#XD819",
+      "value": 55321
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55322;",
+      "decimal_missing_semicolon": "&#55322",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD81A;",
+      "hex_missing_semicolon": "&#XD81A",
+      "value": 55322
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55323;",
+      "decimal_missing_semicolon": "&#55323",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD81B;",
+      "hex_missing_semicolon": "&#XD81B",
+      "value": 55323
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55324;",
+      "decimal_missing_semicolon": "&#55324",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD81C;",
+      "hex_missing_semicolon": "&#XD81C",
+      "value": 55324
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55325;",
+      "decimal_missing_semicolon": "&#55325",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD81D;",
+      "hex_missing_semicolon": "&#XD81D",
+      "value": 55325
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55326;",
+      "decimal_missing_semicolon": "&#55326",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD81E;",
+      "hex_missing_semicolon": "&#XD81E",
+      "value": 55326
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55327;",
+      "decimal_missing_semicolon": "&#55327",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD81F;",
+      "hex_missing_semicolon": "&#XD81F",
+      "value": 55327
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55328;",
+      "decimal_missing_semicolon": "&#55328",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD820;",
+      "hex_missing_semicolon": "&#XD820",
+      "value": 55328
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55329;",
+      "decimal_missing_semicolon": "&#55329",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD821;",
+      "hex_missing_semicolon": "&#XD821",
+      "value": 55329
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55330;",
+      "decimal_missing_semicolon": "&#55330",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD822;",
+      "hex_missing_semicolon": "&#XD822",
+      "value": 55330
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55331;",
+      "decimal_missing_semicolon": "&#55331",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD823;",
+      "hex_missing_semicolon": "&#XD823",
+      "value": 55331
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55332;",
+      "decimal_missing_semicolon": "&#55332",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD824;",
+      "hex_missing_semicolon": "&#XD824",
+      "value": 55332
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55333;",
+      "decimal_missing_semicolon": "&#55333",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD825;",
+      "hex_missing_semicolon": "&#XD825",
+      "value": 55333
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55334;",
+      "decimal_missing_semicolon": "&#55334",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD826;",
+      "hex_missing_semicolon": "&#XD826",
+      "value": 55334
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55335;",
+      "decimal_missing_semicolon": "&#55335",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD827;",
+      "hex_missing_semicolon": "&#XD827",
+      "value": 55335
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55336;",
+      "decimal_missing_semicolon": "&#55336",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD828;",
+      "hex_missing_semicolon": "&#XD828",
+      "value": 55336
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55337;",
+      "decimal_missing_semicolon": "&#55337",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD829;",
+      "hex_missing_semicolon": "&#XD829",
+      "value": 55337
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55338;",
+      "decimal_missing_semicolon": "&#55338",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD82A;",
+      "hex_missing_semicolon": "&#XD82A",
+      "value": 55338
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55339;",
+      "decimal_missing_semicolon": "&#55339",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD82B;",
+      "hex_missing_semicolon": "&#XD82B",
+      "value": 55339
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55340;",
+      "decimal_missing_semicolon": "&#55340",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD82C;",
+      "hex_missing_semicolon": "&#XD82C",
+      "value": 55340
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55341;",
+      "decimal_missing_semicolon": "&#55341",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD82D;",
+      "hex_missing_semicolon": "&#XD82D",
+      "value": 55341
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55342;",
+      "decimal_missing_semicolon": "&#55342",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD82E;",
+      "hex_missing_semicolon": "&#XD82E",
+      "value": 55342
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55343;",
+      "decimal_missing_semicolon": "&#55343",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD82F;",
+      "hex_missing_semicolon": "&#XD82F",
+      "value": 55343
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55344;",
+      "decimal_missing_semicolon": "&#55344",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD830;",
+      "hex_missing_semicolon": "&#XD830",
+      "value": 55344
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55345;",
+      "decimal_missing_semicolon": "&#55345",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD831;",
+      "hex_missing_semicolon": "&#XD831",
+      "value": 55345
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55346;",
+      "decimal_missing_semicolon": "&#55346",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD832;",
+      "hex_missing_semicolon": "&#XD832",
+      "value": 55346
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55347;",
+      "decimal_missing_semicolon": "&#55347",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD833;",
+      "hex_missing_semicolon": "&#XD833",
+      "value": 55347
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55348;",
+      "decimal_missing_semicolon": "&#55348",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD834;",
+      "hex_missing_semicolon": "&#XD834",
+      "value": 55348
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55349;",
+      "decimal_missing_semicolon": "&#55349",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD835;",
+      "hex_missing_semicolon": "&#XD835",
+      "value": 55349
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55350;",
+      "decimal_missing_semicolon": "&#55350",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD836;",
+      "hex_missing_semicolon": "&#XD836",
+      "value": 55350
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55351;",
+      "decimal_missing_semicolon": "&#55351",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD837;",
+      "hex_missing_semicolon": "&#XD837",
+      "value": 55351
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55352;",
+      "decimal_missing_semicolon": "&#55352",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD838;",
+      "hex_missing_semicolon": "&#XD838",
+      "value": 55352
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55353;",
+      "decimal_missing_semicolon": "&#55353",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD839;",
+      "hex_missing_semicolon": "&#XD839",
+      "value": 55353
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55354;",
+      "decimal_missing_semicolon": "&#55354",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD83A;",
+      "hex_missing_semicolon": "&#XD83A",
+      "value": 55354
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55355;",
+      "decimal_missing_semicolon": "&#55355",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD83B;",
+      "hex_missing_semicolon": "&#XD83B",
+      "value": 55355
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55356;",
+      "decimal_missing_semicolon": "&#55356",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD83C;",
+      "hex_missing_semicolon": "&#XD83C",
+      "value": 55356
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55357;",
+      "decimal_missing_semicolon": "&#55357",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD83D;",
+      "hex_missing_semicolon": "&#XD83D",
+      "value": 55357
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55358;",
+      "decimal_missing_semicolon": "&#55358",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD83E;",
+      "hex_missing_semicolon": "&#XD83E",
+      "value": 55358
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55359;",
+      "decimal_missing_semicolon": "&#55359",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD83F;",
+      "hex_missing_semicolon": "&#XD83F",
+      "value": 55359
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55360;",
+      "decimal_missing_semicolon": "&#55360",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD840;",
+      "hex_missing_semicolon": "&#XD840",
+      "value": 55360
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55361;",
+      "decimal_missing_semicolon": "&#55361",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD841;",
+      "hex_missing_semicolon": "&#XD841",
+      "value": 55361
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55362;",
+      "decimal_missing_semicolon": "&#55362",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD842;",
+      "hex_missing_semicolon": "&#XD842",
+      "value": 55362
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55363;",
+      "decimal_missing_semicolon": "&#55363",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD843;",
+      "hex_missing_semicolon": "&#XD843",
+      "value": 55363
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55364;",
+      "decimal_missing_semicolon": "&#55364",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD844;",
+      "hex_missing_semicolon": "&#XD844",
+      "value": 55364
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55365;",
+      "decimal_missing_semicolon": "&#55365",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD845;",
+      "hex_missing_semicolon": "&#XD845",
+      "value": 55365
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55366;",
+      "decimal_missing_semicolon": "&#55366",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD846;",
+      "hex_missing_semicolon": "&#XD846",
+      "value": 55366
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55367;",
+      "decimal_missing_semicolon": "&#55367",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD847;",
+      "hex_missing_semicolon": "&#XD847",
+      "value": 55367
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55368;",
+      "decimal_missing_semicolon": "&#55368",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD848;",
+      "hex_missing_semicolon": "&#XD848",
+      "value": 55368
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55369;",
+      "decimal_missing_semicolon": "&#55369",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD849;",
+      "hex_missing_semicolon": "&#XD849",
+      "value": 55369
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55370;",
+      "decimal_missing_semicolon": "&#55370",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD84A;",
+      "hex_missing_semicolon": "&#XD84A",
+      "value": 55370
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55371;",
+      "decimal_missing_semicolon": "&#55371",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD84B;",
+      "hex_missing_semicolon": "&#XD84B",
+      "value": 55371
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55372;",
+      "decimal_missing_semicolon": "&#55372",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD84C;",
+      "hex_missing_semicolon": "&#XD84C",
+      "value": 55372
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55373;",
+      "decimal_missing_semicolon": "&#55373",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD84D;",
+      "hex_missing_semicolon": "&#XD84D",
+      "value": 55373
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55374;",
+      "decimal_missing_semicolon": "&#55374",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD84E;",
+      "hex_missing_semicolon": "&#XD84E",
+      "value": 55374
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55375;",
+      "decimal_missing_semicolon": "&#55375",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD84F;",
+      "hex_missing_semicolon": "&#XD84F",
+      "value": 55375
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55376;",
+      "decimal_missing_semicolon": "&#55376",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD850;",
+      "hex_missing_semicolon": "&#XD850",
+      "value": 55376
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55377;",
+      "decimal_missing_semicolon": "&#55377",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD851;",
+      "hex_missing_semicolon": "&#XD851",
+      "value": 55377
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55378;",
+      "decimal_missing_semicolon": "&#55378",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD852;",
+      "hex_missing_semicolon": "&#XD852",
+      "value": 55378
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55379;",
+      "decimal_missing_semicolon": "&#55379",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD853;",
+      "hex_missing_semicolon": "&#XD853",
+      "value": 55379
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55380;",
+      "decimal_missing_semicolon": "&#55380",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD854;",
+      "hex_missing_semicolon": "&#XD854",
+      "value": 55380
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55381;",
+      "decimal_missing_semicolon": "&#55381",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD855;",
+      "hex_missing_semicolon": "&#XD855",
+      "value": 55381
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55382;",
+      "decimal_missing_semicolon": "&#55382",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD856;",
+      "hex_missing_semicolon": "&#XD856",
+      "value": 55382
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55383;",
+      "decimal_missing_semicolon": "&#55383",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD857;",
+      "hex_missing_semicolon": "&#XD857",
+      "value": 55383
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55384;",
+      "decimal_missing_semicolon": "&#55384",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD858;",
+      "hex_missing_semicolon": "&#XD858",
+      "value": 55384
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55385;",
+      "decimal_missing_semicolon": "&#55385",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD859;",
+      "hex_missing_semicolon": "&#XD859",
+      "value": 55385
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55386;",
+      "decimal_missing_semicolon": "&#55386",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD85A;",
+      "hex_missing_semicolon": "&#XD85A",
+      "value": 55386
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55387;",
+      "decimal_missing_semicolon": "&#55387",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD85B;",
+      "hex_missing_semicolon": "&#XD85B",
+      "value": 55387
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55388;",
+      "decimal_missing_semicolon": "&#55388",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD85C;",
+      "hex_missing_semicolon": "&#XD85C",
+      "value": 55388
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55389;",
+      "decimal_missing_semicolon": "&#55389",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD85D;",
+      "hex_missing_semicolon": "&#XD85D",
+      "value": 55389
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55390;",
+      "decimal_missing_semicolon": "&#55390",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD85E;",
+      "hex_missing_semicolon": "&#XD85E",
+      "value": 55390
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55391;",
+      "decimal_missing_semicolon": "&#55391",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD85F;",
+      "hex_missing_semicolon": "&#XD85F",
+      "value": 55391
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55392;",
+      "decimal_missing_semicolon": "&#55392",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD860;",
+      "hex_missing_semicolon": "&#XD860",
+      "value": 55392
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55393;",
+      "decimal_missing_semicolon": "&#55393",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD861;",
+      "hex_missing_semicolon": "&#XD861",
+      "value": 55393
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55394;",
+      "decimal_missing_semicolon": "&#55394",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD862;",
+      "hex_missing_semicolon": "&#XD862",
+      "value": 55394
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55395;",
+      "decimal_missing_semicolon": "&#55395",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD863;",
+      "hex_missing_semicolon": "&#XD863",
+      "value": 55395
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55396;",
+      "decimal_missing_semicolon": "&#55396",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD864;",
+      "hex_missing_semicolon": "&#XD864",
+      "value": 55396
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55397;",
+      "decimal_missing_semicolon": "&#55397",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD865;",
+      "hex_missing_semicolon": "&#XD865",
+      "value": 55397
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55398;",
+      "decimal_missing_semicolon": "&#55398",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD866;",
+      "hex_missing_semicolon": "&#XD866",
+      "value": 55398
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55399;",
+      "decimal_missing_semicolon": "&#55399",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD867;",
+      "hex_missing_semicolon": "&#XD867",
+      "value": 55399
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55400;",
+      "decimal_missing_semicolon": "&#55400",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD868;",
+      "hex_missing_semicolon": "&#XD868",
+      "value": 55400
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55401;",
+      "decimal_missing_semicolon": "&#55401",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD869;",
+      "hex_missing_semicolon": "&#XD869",
+      "value": 55401
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55402;",
+      "decimal_missing_semicolon": "&#55402",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD86A;",
+      "hex_missing_semicolon": "&#XD86A",
+      "value": 55402
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55403;",
+      "decimal_missing_semicolon": "&#55403",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD86B;",
+      "hex_missing_semicolon": "&#XD86B",
+      "value": 55403
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55404;",
+      "decimal_missing_semicolon": "&#55404",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD86C;",
+      "hex_missing_semicolon": "&#XD86C",
+      "value": 55404
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55405;",
+      "decimal_missing_semicolon": "&#55405",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD86D;",
+      "hex_missing_semicolon": "&#XD86D",
+      "value": 55405
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55406;",
+      "decimal_missing_semicolon": "&#55406",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD86E;",
+      "hex_missing_semicolon": "&#XD86E",
+      "value": 55406
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55407;",
+      "decimal_missing_semicolon": "&#55407",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD86F;",
+      "hex_missing_semicolon": "&#XD86F",
+      "value": 55407
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55408;",
+      "decimal_missing_semicolon": "&#55408",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD870;",
+      "hex_missing_semicolon": "&#XD870",
+      "value": 55408
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55409;",
+      "decimal_missing_semicolon": "&#55409",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD871;",
+      "hex_missing_semicolon": "&#XD871",
+      "value": 55409
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55410;",
+      "decimal_missing_semicolon": "&#55410",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD872;",
+      "hex_missing_semicolon": "&#XD872",
+      "value": 55410
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55411;",
+      "decimal_missing_semicolon": "&#55411",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD873;",
+      "hex_missing_semicolon": "&#XD873",
+      "value": 55411
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55412;",
+      "decimal_missing_semicolon": "&#55412",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD874;",
+      "hex_missing_semicolon": "&#XD874",
+      "value": 55412
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55413;",
+      "decimal_missing_semicolon": "&#55413",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD875;",
+      "hex_missing_semicolon": "&#XD875",
+      "value": 55413
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55414;",
+      "decimal_missing_semicolon": "&#55414",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD876;",
+      "hex_missing_semicolon": "&#XD876",
+      "value": 55414
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55415;",
+      "decimal_missing_semicolon": "&#55415",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD877;",
+      "hex_missing_semicolon": "&#XD877",
+      "value": 55415
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55416;",
+      "decimal_missing_semicolon": "&#55416",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD878;",
+      "hex_missing_semicolon": "&#XD878",
+      "value": 55416
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55417;",
+      "decimal_missing_semicolon": "&#55417",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD879;",
+      "hex_missing_semicolon": "&#XD879",
+      "value": 55417
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55418;",
+      "decimal_missing_semicolon": "&#55418",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD87A;",
+      "hex_missing_semicolon": "&#XD87A",
+      "value": 55418
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55419;",
+      "decimal_missing_semicolon": "&#55419",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD87B;",
+      "hex_missing_semicolon": "&#XD87B",
+      "value": 55419
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55420;",
+      "decimal_missing_semicolon": "&#55420",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD87C;",
+      "hex_missing_semicolon": "&#XD87C",
+      "value": 55420
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55421;",
+      "decimal_missing_semicolon": "&#55421",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD87D;",
+      "hex_missing_semicolon": "&#XD87D",
+      "value": 55421
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55422;",
+      "decimal_missing_semicolon": "&#55422",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD87E;",
+      "hex_missing_semicolon": "&#XD87E",
+      "value": 55422
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55423;",
+      "decimal_missing_semicolon": "&#55423",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD87F;",
+      "hex_missing_semicolon": "&#XD87F",
+      "value": 55423
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55424;",
+      "decimal_missing_semicolon": "&#55424",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD880;",
+      "hex_missing_semicolon": "&#XD880",
+      "value": 55424
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55425;",
+      "decimal_missing_semicolon": "&#55425",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD881;",
+      "hex_missing_semicolon": "&#XD881",
+      "value": 55425
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55426;",
+      "decimal_missing_semicolon": "&#55426",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD882;",
+      "hex_missing_semicolon": "&#XD882",
+      "value": 55426
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55427;",
+      "decimal_missing_semicolon": "&#55427",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD883;",
+      "hex_missing_semicolon": "&#XD883",
+      "value": 55427
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55428;",
+      "decimal_missing_semicolon": "&#55428",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD884;",
+      "hex_missing_semicolon": "&#XD884",
+      "value": 55428
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55429;",
+      "decimal_missing_semicolon": "&#55429",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD885;",
+      "hex_missing_semicolon": "&#XD885",
+      "value": 55429
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55430;",
+      "decimal_missing_semicolon": "&#55430",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD886;",
+      "hex_missing_semicolon": "&#XD886",
+      "value": 55430
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55431;",
+      "decimal_missing_semicolon": "&#55431",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD887;",
+      "hex_missing_semicolon": "&#XD887",
+      "value": 55431
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55432;",
+      "decimal_missing_semicolon": "&#55432",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD888;",
+      "hex_missing_semicolon": "&#XD888",
+      "value": 55432
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55433;",
+      "decimal_missing_semicolon": "&#55433",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD889;",
+      "hex_missing_semicolon": "&#XD889",
+      "value": 55433
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55434;",
+      "decimal_missing_semicolon": "&#55434",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD88A;",
+      "hex_missing_semicolon": "&#XD88A",
+      "value": 55434
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55435;",
+      "decimal_missing_semicolon": "&#55435",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD88B;",
+      "hex_missing_semicolon": "&#XD88B",
+      "value": 55435
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55436;",
+      "decimal_missing_semicolon": "&#55436",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD88C;",
+      "hex_missing_semicolon": "&#XD88C",
+      "value": 55436
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55437;",
+      "decimal_missing_semicolon": "&#55437",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD88D;",
+      "hex_missing_semicolon": "&#XD88D",
+      "value": 55437
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55438;",
+      "decimal_missing_semicolon": "&#55438",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD88E;",
+      "hex_missing_semicolon": "&#XD88E",
+      "value": 55438
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55439;",
+      "decimal_missing_semicolon": "&#55439",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD88F;",
+      "hex_missing_semicolon": "&#XD88F",
+      "value": 55439
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55440;",
+      "decimal_missing_semicolon": "&#55440",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD890;",
+      "hex_missing_semicolon": "&#XD890",
+      "value": 55440
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55441;",
+      "decimal_missing_semicolon": "&#55441",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD891;",
+      "hex_missing_semicolon": "&#XD891",
+      "value": 55441
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55442;",
+      "decimal_missing_semicolon": "&#55442",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD892;",
+      "hex_missing_semicolon": "&#XD892",
+      "value": 55442
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55443;",
+      "decimal_missing_semicolon": "&#55443",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD893;",
+      "hex_missing_semicolon": "&#XD893",
+      "value": 55443
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55444;",
+      "decimal_missing_semicolon": "&#55444",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD894;",
+      "hex_missing_semicolon": "&#XD894",
+      "value": 55444
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55445;",
+      "decimal_missing_semicolon": "&#55445",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD895;",
+      "hex_missing_semicolon": "&#XD895",
+      "value": 55445
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55446;",
+      "decimal_missing_semicolon": "&#55446",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD896;",
+      "hex_missing_semicolon": "&#XD896",
+      "value": 55446
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55447;",
+      "decimal_missing_semicolon": "&#55447",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD897;",
+      "hex_missing_semicolon": "&#XD897",
+      "value": 55447
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55448;",
+      "decimal_missing_semicolon": "&#55448",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD898;",
+      "hex_missing_semicolon": "&#XD898",
+      "value": 55448
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55449;",
+      "decimal_missing_semicolon": "&#55449",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD899;",
+      "hex_missing_semicolon": "&#XD899",
+      "value": 55449
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55450;",
+      "decimal_missing_semicolon": "&#55450",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD89A;",
+      "hex_missing_semicolon": "&#XD89A",
+      "value": 55450
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55451;",
+      "decimal_missing_semicolon": "&#55451",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD89B;",
+      "hex_missing_semicolon": "&#XD89B",
+      "value": 55451
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55452;",
+      "decimal_missing_semicolon": "&#55452",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD89C;",
+      "hex_missing_semicolon": "&#XD89C",
+      "value": 55452
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55453;",
+      "decimal_missing_semicolon": "&#55453",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD89D;",
+      "hex_missing_semicolon": "&#XD89D",
+      "value": 55453
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55454;",
+      "decimal_missing_semicolon": "&#55454",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD89E;",
+      "hex_missing_semicolon": "&#XD89E",
+      "value": 55454
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55455;",
+      "decimal_missing_semicolon": "&#55455",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD89F;",
+      "hex_missing_semicolon": "&#XD89F",
+      "value": 55455
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55456;",
+      "decimal_missing_semicolon": "&#55456",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A0;",
+      "hex_missing_semicolon": "&#XD8A0",
+      "value": 55456
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55457;",
+      "decimal_missing_semicolon": "&#55457",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A1;",
+      "hex_missing_semicolon": "&#XD8A1",
+      "value": 55457
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55458;",
+      "decimal_missing_semicolon": "&#55458",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A2;",
+      "hex_missing_semicolon": "&#XD8A2",
+      "value": 55458
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55459;",
+      "decimal_missing_semicolon": "&#55459",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A3;",
+      "hex_missing_semicolon": "&#XD8A3",
+      "value": 55459
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55460;",
+      "decimal_missing_semicolon": "&#55460",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A4;",
+      "hex_missing_semicolon": "&#XD8A4",
+      "value": 55460
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55461;",
+      "decimal_missing_semicolon": "&#55461",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A5;",
+      "hex_missing_semicolon": "&#XD8A5",
+      "value": 55461
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55462;",
+      "decimal_missing_semicolon": "&#55462",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A6;",
+      "hex_missing_semicolon": "&#XD8A6",
+      "value": 55462
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55463;",
+      "decimal_missing_semicolon": "&#55463",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A7;",
+      "hex_missing_semicolon": "&#XD8A7",
+      "value": 55463
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55464;",
+      "decimal_missing_semicolon": "&#55464",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A8;",
+      "hex_missing_semicolon": "&#XD8A8",
+      "value": 55464
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55465;",
+      "decimal_missing_semicolon": "&#55465",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8A9;",
+      "hex_missing_semicolon": "&#XD8A9",
+      "value": 55465
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55466;",
+      "decimal_missing_semicolon": "&#55466",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8AA;",
+      "hex_missing_semicolon": "&#XD8AA",
+      "value": 55466
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55467;",
+      "decimal_missing_semicolon": "&#55467",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8AB;",
+      "hex_missing_semicolon": "&#XD8AB",
+      "value": 55467
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55468;",
+      "decimal_missing_semicolon": "&#55468",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8AC;",
+      "hex_missing_semicolon": "&#XD8AC",
+      "value": 55468
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55469;",
+      "decimal_missing_semicolon": "&#55469",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8AD;",
+      "hex_missing_semicolon": "&#XD8AD",
+      "value": 55469
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55470;",
+      "decimal_missing_semicolon": "&#55470",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8AE;",
+      "hex_missing_semicolon": "&#XD8AE",
+      "value": 55470
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55471;",
+      "decimal_missing_semicolon": "&#55471",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8AF;",
+      "hex_missing_semicolon": "&#XD8AF",
+      "value": 55471
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55472;",
+      "decimal_missing_semicolon": "&#55472",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B0;",
+      "hex_missing_semicolon": "&#XD8B0",
+      "value": 55472
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55473;",
+      "decimal_missing_semicolon": "&#55473",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B1;",
+      "hex_missing_semicolon": "&#XD8B1",
+      "value": 55473
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55474;",
+      "decimal_missing_semicolon": "&#55474",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B2;",
+      "hex_missing_semicolon": "&#XD8B2",
+      "value": 55474
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55475;",
+      "decimal_missing_semicolon": "&#55475",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B3;",
+      "hex_missing_semicolon": "&#XD8B3",
+      "value": 55475
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55476;",
+      "decimal_missing_semicolon": "&#55476",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B4;",
+      "hex_missing_semicolon": "&#XD8B4",
+      "value": 55476
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55477;",
+      "decimal_missing_semicolon": "&#55477",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B5;",
+      "hex_missing_semicolon": "&#XD8B5",
+      "value": 55477
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55478;",
+      "decimal_missing_semicolon": "&#55478",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B6;",
+      "hex_missing_semicolon": "&#XD8B6",
+      "value": 55478
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55479;",
+      "decimal_missing_semicolon": "&#55479",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B7;",
+      "hex_missing_semicolon": "&#XD8B7",
+      "value": 55479
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55480;",
+      "decimal_missing_semicolon": "&#55480",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B8;",
+      "hex_missing_semicolon": "&#XD8B8",
+      "value": 55480
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55481;",
+      "decimal_missing_semicolon": "&#55481",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8B9;",
+      "hex_missing_semicolon": "&#XD8B9",
+      "value": 55481
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55482;",
+      "decimal_missing_semicolon": "&#55482",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8BA;",
+      "hex_missing_semicolon": "&#XD8BA",
+      "value": 55482
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55483;",
+      "decimal_missing_semicolon": "&#55483",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8BB;",
+      "hex_missing_semicolon": "&#XD8BB",
+      "value": 55483
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55484;",
+      "decimal_missing_semicolon": "&#55484",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8BC;",
+      "hex_missing_semicolon": "&#XD8BC",
+      "value": 55484
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55485;",
+      "decimal_missing_semicolon": "&#55485",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8BD;",
+      "hex_missing_semicolon": "&#XD8BD",
+      "value": 55485
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55486;",
+      "decimal_missing_semicolon": "&#55486",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8BE;",
+      "hex_missing_semicolon": "&#XD8BE",
+      "value": 55486
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55487;",
+      "decimal_missing_semicolon": "&#55487",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8BF;",
+      "hex_missing_semicolon": "&#XD8BF",
+      "value": 55487
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55488;",
+      "decimal_missing_semicolon": "&#55488",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C0;",
+      "hex_missing_semicolon": "&#XD8C0",
+      "value": 55488
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55489;",
+      "decimal_missing_semicolon": "&#55489",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C1;",
+      "hex_missing_semicolon": "&#XD8C1",
+      "value": 55489
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55490;",
+      "decimal_missing_semicolon": "&#55490",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C2;",
+      "hex_missing_semicolon": "&#XD8C2",
+      "value": 55490
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55491;",
+      "decimal_missing_semicolon": "&#55491",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C3;",
+      "hex_missing_semicolon": "&#XD8C3",
+      "value": 55491
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55492;",
+      "decimal_missing_semicolon": "&#55492",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C4;",
+      "hex_missing_semicolon": "&#XD8C4",
+      "value": 55492
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55493;",
+      "decimal_missing_semicolon": "&#55493",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C5;",
+      "hex_missing_semicolon": "&#XD8C5",
+      "value": 55493
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55494;",
+      "decimal_missing_semicolon": "&#55494",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C6;",
+      "hex_missing_semicolon": "&#XD8C6",
+      "value": 55494
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55495;",
+      "decimal_missing_semicolon": "&#55495",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C7;",
+      "hex_missing_semicolon": "&#XD8C7",
+      "value": 55495
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55496;",
+      "decimal_missing_semicolon": "&#55496",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C8;",
+      "hex_missing_semicolon": "&#XD8C8",
+      "value": 55496
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55497;",
+      "decimal_missing_semicolon": "&#55497",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8C9;",
+      "hex_missing_semicolon": "&#XD8C9",
+      "value": 55497
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55498;",
+      "decimal_missing_semicolon": "&#55498",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8CA;",
+      "hex_missing_semicolon": "&#XD8CA",
+      "value": 55498
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55499;",
+      "decimal_missing_semicolon": "&#55499",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8CB;",
+      "hex_missing_semicolon": "&#XD8CB",
+      "value": 55499
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55500;",
+      "decimal_missing_semicolon": "&#55500",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8CC;",
+      "hex_missing_semicolon": "&#XD8CC",
+      "value": 55500
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55501;",
+      "decimal_missing_semicolon": "&#55501",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8CD;",
+      "hex_missing_semicolon": "&#XD8CD",
+      "value": 55501
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55502;",
+      "decimal_missing_semicolon": "&#55502",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8CE;",
+      "hex_missing_semicolon": "&#XD8CE",
+      "value": 55502
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55503;",
+      "decimal_missing_semicolon": "&#55503",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8CF;",
+      "hex_missing_semicolon": "&#XD8CF",
+      "value": 55503
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55504;",
+      "decimal_missing_semicolon": "&#55504",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D0;",
+      "hex_missing_semicolon": "&#XD8D0",
+      "value": 55504
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55505;",
+      "decimal_missing_semicolon": "&#55505",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D1;",
+      "hex_missing_semicolon": "&#XD8D1",
+      "value": 55505
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55506;",
+      "decimal_missing_semicolon": "&#55506",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D2;",
+      "hex_missing_semicolon": "&#XD8D2",
+      "value": 55506
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55507;",
+      "decimal_missing_semicolon": "&#55507",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D3;",
+      "hex_missing_semicolon": "&#XD8D3",
+      "value": 55507
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55508;",
+      "decimal_missing_semicolon": "&#55508",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D4;",
+      "hex_missing_semicolon": "&#XD8D4",
+      "value": 55508
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55509;",
+      "decimal_missing_semicolon": "&#55509",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D5;",
+      "hex_missing_semicolon": "&#XD8D5",
+      "value": 55509
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55510;",
+      "decimal_missing_semicolon": "&#55510",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D6;",
+      "hex_missing_semicolon": "&#XD8D6",
+      "value": 55510
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55511;",
+      "decimal_missing_semicolon": "&#55511",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D7;",
+      "hex_missing_semicolon": "&#XD8D7",
+      "value": 55511
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55512;",
+      "decimal_missing_semicolon": "&#55512",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D8;",
+      "hex_missing_semicolon": "&#XD8D8",
+      "value": 55512
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55513;",
+      "decimal_missing_semicolon": "&#55513",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8D9;",
+      "hex_missing_semicolon": "&#XD8D9",
+      "value": 55513
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55514;",
+      "decimal_missing_semicolon": "&#55514",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8DA;",
+      "hex_missing_semicolon": "&#XD8DA",
+      "value": 55514
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55515;",
+      "decimal_missing_semicolon": "&#55515",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8DB;",
+      "hex_missing_semicolon": "&#XD8DB",
+      "value": 55515
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55516;",
+      "decimal_missing_semicolon": "&#55516",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8DC;",
+      "hex_missing_semicolon": "&#XD8DC",
+      "value": 55516
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55517;",
+      "decimal_missing_semicolon": "&#55517",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8DD;",
+      "hex_missing_semicolon": "&#XD8DD",
+      "value": 55517
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55518;",
+      "decimal_missing_semicolon": "&#55518",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8DE;",
+      "hex_missing_semicolon": "&#XD8DE",
+      "value": 55518
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55519;",
+      "decimal_missing_semicolon": "&#55519",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8DF;",
+      "hex_missing_semicolon": "&#XD8DF",
+      "value": 55519
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55520;",
+      "decimal_missing_semicolon": "&#55520",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E0;",
+      "hex_missing_semicolon": "&#XD8E0",
+      "value": 55520
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55521;",
+      "decimal_missing_semicolon": "&#55521",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E1;",
+      "hex_missing_semicolon": "&#XD8E1",
+      "value": 55521
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55522;",
+      "decimal_missing_semicolon": "&#55522",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E2;",
+      "hex_missing_semicolon": "&#XD8E2",
+      "value": 55522
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55523;",
+      "decimal_missing_semicolon": "&#55523",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E3;",
+      "hex_missing_semicolon": "&#XD8E3",
+      "value": 55523
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55524;",
+      "decimal_missing_semicolon": "&#55524",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E4;",
+      "hex_missing_semicolon": "&#XD8E4",
+      "value": 55524
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55525;",
+      "decimal_missing_semicolon": "&#55525",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E5;",
+      "hex_missing_semicolon": "&#XD8E5",
+      "value": 55525
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55526;",
+      "decimal_missing_semicolon": "&#55526",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E6;",
+      "hex_missing_semicolon": "&#XD8E6",
+      "value": 55526
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55527;",
+      "decimal_missing_semicolon": "&#55527",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E7;",
+      "hex_missing_semicolon": "&#XD8E7",
+      "value": 55527
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55528;",
+      "decimal_missing_semicolon": "&#55528",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E8;",
+      "hex_missing_semicolon": "&#XD8E8",
+      "value": 55528
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55529;",
+      "decimal_missing_semicolon": "&#55529",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8E9;",
+      "hex_missing_semicolon": "&#XD8E9",
+      "value": 55529
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55530;",
+      "decimal_missing_semicolon": "&#55530",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8EA;",
+      "hex_missing_semicolon": "&#XD8EA",
+      "value": 55530
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55531;",
+      "decimal_missing_semicolon": "&#55531",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8EB;",
+      "hex_missing_semicolon": "&#XD8EB",
+      "value": 55531
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55532;",
+      "decimal_missing_semicolon": "&#55532",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8EC;",
+      "hex_missing_semicolon": "&#XD8EC",
+      "value": 55532
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55533;",
+      "decimal_missing_semicolon": "&#55533",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8ED;",
+      "hex_missing_semicolon": "&#XD8ED",
+      "value": 55533
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55534;",
+      "decimal_missing_semicolon": "&#55534",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8EE;",
+      "hex_missing_semicolon": "&#XD8EE",
+      "value": 55534
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55535;",
+      "decimal_missing_semicolon": "&#55535",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8EF;",
+      "hex_missing_semicolon": "&#XD8EF",
+      "value": 55535
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55536;",
+      "decimal_missing_semicolon": "&#55536",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F0;",
+      "hex_missing_semicolon": "&#XD8F0",
+      "value": 55536
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55537;",
+      "decimal_missing_semicolon": "&#55537",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F1;",
+      "hex_missing_semicolon": "&#XD8F1",
+      "value": 55537
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55538;",
+      "decimal_missing_semicolon": "&#55538",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F2;",
+      "hex_missing_semicolon": "&#XD8F2",
+      "value": 55538
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55539;",
+      "decimal_missing_semicolon": "&#55539",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F3;",
+      "hex_missing_semicolon": "&#XD8F3",
+      "value": 55539
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55540;",
+      "decimal_missing_semicolon": "&#55540",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F4;",
+      "hex_missing_semicolon": "&#XD8F4",
+      "value": 55540
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55541;",
+      "decimal_missing_semicolon": "&#55541",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F5;",
+      "hex_missing_semicolon": "&#XD8F5",
+      "value": 55541
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55542;",
+      "decimal_missing_semicolon": "&#55542",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F6;",
+      "hex_missing_semicolon": "&#XD8F6",
+      "value": 55542
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55543;",
+      "decimal_missing_semicolon": "&#55543",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F7;",
+      "hex_missing_semicolon": "&#XD8F7",
+      "value": 55543
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55544;",
+      "decimal_missing_semicolon": "&#55544",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F8;",
+      "hex_missing_semicolon": "&#XD8F8",
+      "value": 55544
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55545;",
+      "decimal_missing_semicolon": "&#55545",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8F9;",
+      "hex_missing_semicolon": "&#XD8F9",
+      "value": 55545
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55546;",
+      "decimal_missing_semicolon": "&#55546",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8FA;",
+      "hex_missing_semicolon": "&#XD8FA",
+      "value": 55546
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55547;",
+      "decimal_missing_semicolon": "&#55547",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8FB;",
+      "hex_missing_semicolon": "&#XD8FB",
+      "value": 55547
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55548;",
+      "decimal_missing_semicolon": "&#55548",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8FC;",
+      "hex_missing_semicolon": "&#XD8FC",
+      "value": 55548
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55549;",
+      "decimal_missing_semicolon": "&#55549",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8FD;",
+      "hex_missing_semicolon": "&#XD8FD",
+      "value": 55549
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55550;",
+      "decimal_missing_semicolon": "&#55550",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8FE;",
+      "hex_missing_semicolon": "&#XD8FE",
+      "value": 55550
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55551;",
+      "decimal_missing_semicolon": "&#55551",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD8FF;",
+      "hex_missing_semicolon": "&#XD8FF",
+      "value": 55551
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55552;",
+      "decimal_missing_semicolon": "&#55552",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD900;",
+      "hex_missing_semicolon": "&#XD900",
+      "value": 55552
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55553;",
+      "decimal_missing_semicolon": "&#55553",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD901;",
+      "hex_missing_semicolon": "&#XD901",
+      "value": 55553
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55554;",
+      "decimal_missing_semicolon": "&#55554",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD902;",
+      "hex_missing_semicolon": "&#XD902",
+      "value": 55554
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55555;",
+      "decimal_missing_semicolon": "&#55555",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD903;",
+      "hex_missing_semicolon": "&#XD903",
+      "value": 55555
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55556;",
+      "decimal_missing_semicolon": "&#55556",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD904;",
+      "hex_missing_semicolon": "&#XD904",
+      "value": 55556
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55557;",
+      "decimal_missing_semicolon": "&#55557",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD905;",
+      "hex_missing_semicolon": "&#XD905",
+      "value": 55557
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55558;",
+      "decimal_missing_semicolon": "&#55558",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD906;",
+      "hex_missing_semicolon": "&#XD906",
+      "value": 55558
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55559;",
+      "decimal_missing_semicolon": "&#55559",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD907;",
+      "hex_missing_semicolon": "&#XD907",
+      "value": 55559
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55560;",
+      "decimal_missing_semicolon": "&#55560",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD908;",
+      "hex_missing_semicolon": "&#XD908",
+      "value": 55560
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55561;",
+      "decimal_missing_semicolon": "&#55561",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD909;",
+      "hex_missing_semicolon": "&#XD909",
+      "value": 55561
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55562;",
+      "decimal_missing_semicolon": "&#55562",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD90A;",
+      "hex_missing_semicolon": "&#XD90A",
+      "value": 55562
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55563;",
+      "decimal_missing_semicolon": "&#55563",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD90B;",
+      "hex_missing_semicolon": "&#XD90B",
+      "value": 55563
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55564;",
+      "decimal_missing_semicolon": "&#55564",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD90C;",
+      "hex_missing_semicolon": "&#XD90C",
+      "value": 55564
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55565;",
+      "decimal_missing_semicolon": "&#55565",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD90D;",
+      "hex_missing_semicolon": "&#XD90D",
+      "value": 55565
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55566;",
+      "decimal_missing_semicolon": "&#55566",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD90E;",
+      "hex_missing_semicolon": "&#XD90E",
+      "value": 55566
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55567;",
+      "decimal_missing_semicolon": "&#55567",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD90F;",
+      "hex_missing_semicolon": "&#XD90F",
+      "value": 55567
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55568;",
+      "decimal_missing_semicolon": "&#55568",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD910;",
+      "hex_missing_semicolon": "&#XD910",
+      "value": 55568
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55569;",
+      "decimal_missing_semicolon": "&#55569",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD911;",
+      "hex_missing_semicolon": "&#XD911",
+      "value": 55569
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55570;",
+      "decimal_missing_semicolon": "&#55570",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD912;",
+      "hex_missing_semicolon": "&#XD912",
+      "value": 55570
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55571;",
+      "decimal_missing_semicolon": "&#55571",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD913;",
+      "hex_missing_semicolon": "&#XD913",
+      "value": 55571
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55572;",
+      "decimal_missing_semicolon": "&#55572",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD914;",
+      "hex_missing_semicolon": "&#XD914",
+      "value": 55572
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55573;",
+      "decimal_missing_semicolon": "&#55573",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD915;",
+      "hex_missing_semicolon": "&#XD915",
+      "value": 55573
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55574;",
+      "decimal_missing_semicolon": "&#55574",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD916;",
+      "hex_missing_semicolon": "&#XD916",
+      "value": 55574
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55575;",
+      "decimal_missing_semicolon": "&#55575",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD917;",
+      "hex_missing_semicolon": "&#XD917",
+      "value": 55575
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55576;",
+      "decimal_missing_semicolon": "&#55576",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD918;",
+      "hex_missing_semicolon": "&#XD918",
+      "value": 55576
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55577;",
+      "decimal_missing_semicolon": "&#55577",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD919;",
+      "hex_missing_semicolon": "&#XD919",
+      "value": 55577
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55578;",
+      "decimal_missing_semicolon": "&#55578",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD91A;",
+      "hex_missing_semicolon": "&#XD91A",
+      "value": 55578
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55579;",
+      "decimal_missing_semicolon": "&#55579",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD91B;",
+      "hex_missing_semicolon": "&#XD91B",
+      "value": 55579
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55580;",
+      "decimal_missing_semicolon": "&#55580",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD91C;",
+      "hex_missing_semicolon": "&#XD91C",
+      "value": 55580
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55581;",
+      "decimal_missing_semicolon": "&#55581",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD91D;",
+      "hex_missing_semicolon": "&#XD91D",
+      "value": 55581
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55582;",
+      "decimal_missing_semicolon": "&#55582",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD91E;",
+      "hex_missing_semicolon": "&#XD91E",
+      "value": 55582
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55583;",
+      "decimal_missing_semicolon": "&#55583",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD91F;",
+      "hex_missing_semicolon": "&#XD91F",
+      "value": 55583
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55584;",
+      "decimal_missing_semicolon": "&#55584",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD920;",
+      "hex_missing_semicolon": "&#XD920",
+      "value": 55584
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55585;",
+      "decimal_missing_semicolon": "&#55585",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD921;",
+      "hex_missing_semicolon": "&#XD921",
+      "value": 55585
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55586;",
+      "decimal_missing_semicolon": "&#55586",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD922;",
+      "hex_missing_semicolon": "&#XD922",
+      "value": 55586
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55587;",
+      "decimal_missing_semicolon": "&#55587",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD923;",
+      "hex_missing_semicolon": "&#XD923",
+      "value": 55587
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55588;",
+      "decimal_missing_semicolon": "&#55588",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD924;",
+      "hex_missing_semicolon": "&#XD924",
+      "value": 55588
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55589;",
+      "decimal_missing_semicolon": "&#55589",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD925;",
+      "hex_missing_semicolon": "&#XD925",
+      "value": 55589
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55590;",
+      "decimal_missing_semicolon": "&#55590",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD926;",
+      "hex_missing_semicolon": "&#XD926",
+      "value": 55590
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55591;",
+      "decimal_missing_semicolon": "&#55591",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD927;",
+      "hex_missing_semicolon": "&#XD927",
+      "value": 55591
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55592;",
+      "decimal_missing_semicolon": "&#55592",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD928;",
+      "hex_missing_semicolon": "&#XD928",
+      "value": 55592
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55593;",
+      "decimal_missing_semicolon": "&#55593",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD929;",
+      "hex_missing_semicolon": "&#XD929",
+      "value": 55593
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55594;",
+      "decimal_missing_semicolon": "&#55594",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD92A;",
+      "hex_missing_semicolon": "&#XD92A",
+      "value": 55594
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55595;",
+      "decimal_missing_semicolon": "&#55595",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD92B;",
+      "hex_missing_semicolon": "&#XD92B",
+      "value": 55595
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55596;",
+      "decimal_missing_semicolon": "&#55596",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD92C;",
+      "hex_missing_semicolon": "&#XD92C",
+      "value": 55596
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55597;",
+      "decimal_missing_semicolon": "&#55597",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD92D;",
+      "hex_missing_semicolon": "&#XD92D",
+      "value": 55597
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55598;",
+      "decimal_missing_semicolon": "&#55598",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD92E;",
+      "hex_missing_semicolon": "&#XD92E",
+      "value": 55598
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55599;",
+      "decimal_missing_semicolon": "&#55599",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD92F;",
+      "hex_missing_semicolon": "&#XD92F",
+      "value": 55599
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55600;",
+      "decimal_missing_semicolon": "&#55600",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD930;",
+      "hex_missing_semicolon": "&#XD930",
+      "value": 55600
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55601;",
+      "decimal_missing_semicolon": "&#55601",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD931;",
+      "hex_missing_semicolon": "&#XD931",
+      "value": 55601
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55602;",
+      "decimal_missing_semicolon": "&#55602",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD932;",
+      "hex_missing_semicolon": "&#XD932",
+      "value": 55602
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55603;",
+      "decimal_missing_semicolon": "&#55603",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD933;",
+      "hex_missing_semicolon": "&#XD933",
+      "value": 55603
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55604;",
+      "decimal_missing_semicolon": "&#55604",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD934;",
+      "hex_missing_semicolon": "&#XD934",
+      "value": 55604
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55605;",
+      "decimal_missing_semicolon": "&#55605",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD935;",
+      "hex_missing_semicolon": "&#XD935",
+      "value": 55605
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55606;",
+      "decimal_missing_semicolon": "&#55606",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD936;",
+      "hex_missing_semicolon": "&#XD936",
+      "value": 55606
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55607;",
+      "decimal_missing_semicolon": "&#55607",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD937;",
+      "hex_missing_semicolon": "&#XD937",
+      "value": 55607
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55608;",
+      "decimal_missing_semicolon": "&#55608",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD938;",
+      "hex_missing_semicolon": "&#XD938",
+      "value": 55608
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55609;",
+      "decimal_missing_semicolon": "&#55609",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD939;",
+      "hex_missing_semicolon": "&#XD939",
+      "value": 55609
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55610;",
+      "decimal_missing_semicolon": "&#55610",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD93A;",
+      "hex_missing_semicolon": "&#XD93A",
+      "value": 55610
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55611;",
+      "decimal_missing_semicolon": "&#55611",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD93B;",
+      "hex_missing_semicolon": "&#XD93B",
+      "value": 55611
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55612;",
+      "decimal_missing_semicolon": "&#55612",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD93C;",
+      "hex_missing_semicolon": "&#XD93C",
+      "value": 55612
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55613;",
+      "decimal_missing_semicolon": "&#55613",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD93D;",
+      "hex_missing_semicolon": "&#XD93D",
+      "value": 55613
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55614;",
+      "decimal_missing_semicolon": "&#55614",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD93E;",
+      "hex_missing_semicolon": "&#XD93E",
+      "value": 55614
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55615;",
+      "decimal_missing_semicolon": "&#55615",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD93F;",
+      "hex_missing_semicolon": "&#XD93F",
+      "value": 55615
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55616;",
+      "decimal_missing_semicolon": "&#55616",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD940;",
+      "hex_missing_semicolon": "&#XD940",
+      "value": 55616
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55617;",
+      "decimal_missing_semicolon": "&#55617",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD941;",
+      "hex_missing_semicolon": "&#XD941",
+      "value": 55617
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55618;",
+      "decimal_missing_semicolon": "&#55618",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD942;",
+      "hex_missing_semicolon": "&#XD942",
+      "value": 55618
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55619;",
+      "decimal_missing_semicolon": "&#55619",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD943;",
+      "hex_missing_semicolon": "&#XD943",
+      "value": 55619
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55620;",
+      "decimal_missing_semicolon": "&#55620",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD944;",
+      "hex_missing_semicolon": "&#XD944",
+      "value": 55620
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55621;",
+      "decimal_missing_semicolon": "&#55621",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD945;",
+      "hex_missing_semicolon": "&#XD945",
+      "value": 55621
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55622;",
+      "decimal_missing_semicolon": "&#55622",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD946;",
+      "hex_missing_semicolon": "&#XD946",
+      "value": 55622
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55623;",
+      "decimal_missing_semicolon": "&#55623",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD947;",
+      "hex_missing_semicolon": "&#XD947",
+      "value": 55623
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55624;",
+      "decimal_missing_semicolon": "&#55624",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD948;",
+      "hex_missing_semicolon": "&#XD948",
+      "value": 55624
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55625;",
+      "decimal_missing_semicolon": "&#55625",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD949;",
+      "hex_missing_semicolon": "&#XD949",
+      "value": 55625
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55626;",
+      "decimal_missing_semicolon": "&#55626",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD94A;",
+      "hex_missing_semicolon": "&#XD94A",
+      "value": 55626
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55627;",
+      "decimal_missing_semicolon": "&#55627",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD94B;",
+      "hex_missing_semicolon": "&#XD94B",
+      "value": 55627
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55628;",
+      "decimal_missing_semicolon": "&#55628",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD94C;",
+      "hex_missing_semicolon": "&#XD94C",
+      "value": 55628
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55629;",
+      "decimal_missing_semicolon": "&#55629",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD94D;",
+      "hex_missing_semicolon": "&#XD94D",
+      "value": 55629
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55630;",
+      "decimal_missing_semicolon": "&#55630",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD94E;",
+      "hex_missing_semicolon": "&#XD94E",
+      "value": 55630
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55631;",
+      "decimal_missing_semicolon": "&#55631",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD94F;",
+      "hex_missing_semicolon": "&#XD94F",
+      "value": 55631
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55632;",
+      "decimal_missing_semicolon": "&#55632",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD950;",
+      "hex_missing_semicolon": "&#XD950",
+      "value": 55632
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55633;",
+      "decimal_missing_semicolon": "&#55633",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD951;",
+      "hex_missing_semicolon": "&#XD951",
+      "value": 55633
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55634;",
+      "decimal_missing_semicolon": "&#55634",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD952;",
+      "hex_missing_semicolon": "&#XD952",
+      "value": 55634
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55635;",
+      "decimal_missing_semicolon": "&#55635",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD953;",
+      "hex_missing_semicolon": "&#XD953",
+      "value": 55635
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55636;",
+      "decimal_missing_semicolon": "&#55636",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD954;",
+      "hex_missing_semicolon": "&#XD954",
+      "value": 55636
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55637;",
+      "decimal_missing_semicolon": "&#55637",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD955;",
+      "hex_missing_semicolon": "&#XD955",
+      "value": 55637
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55638;",
+      "decimal_missing_semicolon": "&#55638",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD956;",
+      "hex_missing_semicolon": "&#XD956",
+      "value": 55638
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55639;",
+      "decimal_missing_semicolon": "&#55639",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD957;",
+      "hex_missing_semicolon": "&#XD957",
+      "value": 55639
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55640;",
+      "decimal_missing_semicolon": "&#55640",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD958;",
+      "hex_missing_semicolon": "&#XD958",
+      "value": 55640
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55641;",
+      "decimal_missing_semicolon": "&#55641",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD959;",
+      "hex_missing_semicolon": "&#XD959",
+      "value": 55641
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55642;",
+      "decimal_missing_semicolon": "&#55642",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD95A;",
+      "hex_missing_semicolon": "&#XD95A",
+      "value": 55642
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55643;",
+      "decimal_missing_semicolon": "&#55643",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD95B;",
+      "hex_missing_semicolon": "&#XD95B",
+      "value": 55643
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55644;",
+      "decimal_missing_semicolon": "&#55644",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD95C;",
+      "hex_missing_semicolon": "&#XD95C",
+      "value": 55644
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55645;",
+      "decimal_missing_semicolon": "&#55645",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD95D;",
+      "hex_missing_semicolon": "&#XD95D",
+      "value": 55645
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55646;",
+      "decimal_missing_semicolon": "&#55646",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD95E;",
+      "hex_missing_semicolon": "&#XD95E",
+      "value": 55646
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55647;",
+      "decimal_missing_semicolon": "&#55647",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD95F;",
+      "hex_missing_semicolon": "&#XD95F",
+      "value": 55647
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55648;",
+      "decimal_missing_semicolon": "&#55648",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD960;",
+      "hex_missing_semicolon": "&#XD960",
+      "value": 55648
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55649;",
+      "decimal_missing_semicolon": "&#55649",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD961;",
+      "hex_missing_semicolon": "&#XD961",
+      "value": 55649
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55650;",
+      "decimal_missing_semicolon": "&#55650",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD962;",
+      "hex_missing_semicolon": "&#XD962",
+      "value": 55650
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55651;",
+      "decimal_missing_semicolon": "&#55651",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD963;",
+      "hex_missing_semicolon": "&#XD963",
+      "value": 55651
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55652;",
+      "decimal_missing_semicolon": "&#55652",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD964;",
+      "hex_missing_semicolon": "&#XD964",
+      "value": 55652
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55653;",
+      "decimal_missing_semicolon": "&#55653",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD965;",
+      "hex_missing_semicolon": "&#XD965",
+      "value": 55653
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55654;",
+      "decimal_missing_semicolon": "&#55654",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD966;",
+      "hex_missing_semicolon": "&#XD966",
+      "value": 55654
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55655;",
+      "decimal_missing_semicolon": "&#55655",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD967;",
+      "hex_missing_semicolon": "&#XD967",
+      "value": 55655
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55656;",
+      "decimal_missing_semicolon": "&#55656",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD968;",
+      "hex_missing_semicolon": "&#XD968",
+      "value": 55656
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55657;",
+      "decimal_missing_semicolon": "&#55657",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD969;",
+      "hex_missing_semicolon": "&#XD969",
+      "value": 55657
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55658;",
+      "decimal_missing_semicolon": "&#55658",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD96A;",
+      "hex_missing_semicolon": "&#XD96A",
+      "value": 55658
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55659;",
+      "decimal_missing_semicolon": "&#55659",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD96B;",
+      "hex_missing_semicolon": "&#XD96B",
+      "value": 55659
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55660;",
+      "decimal_missing_semicolon": "&#55660",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD96C;",
+      "hex_missing_semicolon": "&#XD96C",
+      "value": 55660
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55661;",
+      "decimal_missing_semicolon": "&#55661",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD96D;",
+      "hex_missing_semicolon": "&#XD96D",
+      "value": 55661
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55662;",
+      "decimal_missing_semicolon": "&#55662",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD96E;",
+      "hex_missing_semicolon": "&#XD96E",
+      "value": 55662
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55663;",
+      "decimal_missing_semicolon": "&#55663",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD96F;",
+      "hex_missing_semicolon": "&#XD96F",
+      "value": 55663
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55664;",
+      "decimal_missing_semicolon": "&#55664",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD970;",
+      "hex_missing_semicolon": "&#XD970",
+      "value": 55664
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55665;",
+      "decimal_missing_semicolon": "&#55665",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD971;",
+      "hex_missing_semicolon": "&#XD971",
+      "value": 55665
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55666;",
+      "decimal_missing_semicolon": "&#55666",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD972;",
+      "hex_missing_semicolon": "&#XD972",
+      "value": 55666
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55667;",
+      "decimal_missing_semicolon": "&#55667",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD973;",
+      "hex_missing_semicolon": "&#XD973",
+      "value": 55667
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55668;",
+      "decimal_missing_semicolon": "&#55668",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD974;",
+      "hex_missing_semicolon": "&#XD974",
+      "value": 55668
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55669;",
+      "decimal_missing_semicolon": "&#55669",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD975;",
+      "hex_missing_semicolon": "&#XD975",
+      "value": 55669
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55670;",
+      "decimal_missing_semicolon": "&#55670",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD976;",
+      "hex_missing_semicolon": "&#XD976",
+      "value": 55670
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55671;",
+      "decimal_missing_semicolon": "&#55671",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD977;",
+      "hex_missing_semicolon": "&#XD977",
+      "value": 55671
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55672;",
+      "decimal_missing_semicolon": "&#55672",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD978;",
+      "hex_missing_semicolon": "&#XD978",
+      "value": 55672
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55673;",
+      "decimal_missing_semicolon": "&#55673",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD979;",
+      "hex_missing_semicolon": "&#XD979",
+      "value": 55673
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55674;",
+      "decimal_missing_semicolon": "&#55674",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD97A;",
+      "hex_missing_semicolon": "&#XD97A",
+      "value": 55674
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55675;",
+      "decimal_missing_semicolon": "&#55675",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD97B;",
+      "hex_missing_semicolon": "&#XD97B",
+      "value": 55675
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55676;",
+      "decimal_missing_semicolon": "&#55676",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD97C;",
+      "hex_missing_semicolon": "&#XD97C",
+      "value": 55676
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55677;",
+      "decimal_missing_semicolon": "&#55677",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD97D;",
+      "hex_missing_semicolon": "&#XD97D",
+      "value": 55677
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55678;",
+      "decimal_missing_semicolon": "&#55678",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD97E;",
+      "hex_missing_semicolon": "&#XD97E",
+      "value": 55678
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55679;",
+      "decimal_missing_semicolon": "&#55679",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD97F;",
+      "hex_missing_semicolon": "&#XD97F",
+      "value": 55679
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55680;",
+      "decimal_missing_semicolon": "&#55680",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD980;",
+      "hex_missing_semicolon": "&#XD980",
+      "value": 55680
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55681;",
+      "decimal_missing_semicolon": "&#55681",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD981;",
+      "hex_missing_semicolon": "&#XD981",
+      "value": 55681
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55682;",
+      "decimal_missing_semicolon": "&#55682",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD982;",
+      "hex_missing_semicolon": "&#XD982",
+      "value": 55682
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55683;",
+      "decimal_missing_semicolon": "&#55683",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD983;",
+      "hex_missing_semicolon": "&#XD983",
+      "value": 55683
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55684;",
+      "decimal_missing_semicolon": "&#55684",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD984;",
+      "hex_missing_semicolon": "&#XD984",
+      "value": 55684
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55685;",
+      "decimal_missing_semicolon": "&#55685",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD985;",
+      "hex_missing_semicolon": "&#XD985",
+      "value": 55685
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55686;",
+      "decimal_missing_semicolon": "&#55686",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD986;",
+      "hex_missing_semicolon": "&#XD986",
+      "value": 55686
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55687;",
+      "decimal_missing_semicolon": "&#55687",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD987;",
+      "hex_missing_semicolon": "&#XD987",
+      "value": 55687
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55688;",
+      "decimal_missing_semicolon": "&#55688",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD988;",
+      "hex_missing_semicolon": "&#XD988",
+      "value": 55688
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55689;",
+      "decimal_missing_semicolon": "&#55689",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD989;",
+      "hex_missing_semicolon": "&#XD989",
+      "value": 55689
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55690;",
+      "decimal_missing_semicolon": "&#55690",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD98A;",
+      "hex_missing_semicolon": "&#XD98A",
+      "value": 55690
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55691;",
+      "decimal_missing_semicolon": "&#55691",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD98B;",
+      "hex_missing_semicolon": "&#XD98B",
+      "value": 55691
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55692;",
+      "decimal_missing_semicolon": "&#55692",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD98C;",
+      "hex_missing_semicolon": "&#XD98C",
+      "value": 55692
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55693;",
+      "decimal_missing_semicolon": "&#55693",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD98D;",
+      "hex_missing_semicolon": "&#XD98D",
+      "value": 55693
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55694;",
+      "decimal_missing_semicolon": "&#55694",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD98E;",
+      "hex_missing_semicolon": "&#XD98E",
+      "value": 55694
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55695;",
+      "decimal_missing_semicolon": "&#55695",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD98F;",
+      "hex_missing_semicolon": "&#XD98F",
+      "value": 55695
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55696;",
+      "decimal_missing_semicolon": "&#55696",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD990;",
+      "hex_missing_semicolon": "&#XD990",
+      "value": 55696
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55697;",
+      "decimal_missing_semicolon": "&#55697",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD991;",
+      "hex_missing_semicolon": "&#XD991",
+      "value": 55697
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55698;",
+      "decimal_missing_semicolon": "&#55698",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD992;",
+      "hex_missing_semicolon": "&#XD992",
+      "value": 55698
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55699;",
+      "decimal_missing_semicolon": "&#55699",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD993;",
+      "hex_missing_semicolon": "&#XD993",
+      "value": 55699
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55700;",
+      "decimal_missing_semicolon": "&#55700",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD994;",
+      "hex_missing_semicolon": "&#XD994",
+      "value": 55700
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55701;",
+      "decimal_missing_semicolon": "&#55701",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD995;",
+      "hex_missing_semicolon": "&#XD995",
+      "value": 55701
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55702;",
+      "decimal_missing_semicolon": "&#55702",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD996;",
+      "hex_missing_semicolon": "&#XD996",
+      "value": 55702
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55703;",
+      "decimal_missing_semicolon": "&#55703",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD997;",
+      "hex_missing_semicolon": "&#XD997",
+      "value": 55703
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55704;",
+      "decimal_missing_semicolon": "&#55704",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD998;",
+      "hex_missing_semicolon": "&#XD998",
+      "value": 55704
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55705;",
+      "decimal_missing_semicolon": "&#55705",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD999;",
+      "hex_missing_semicolon": "&#XD999",
+      "value": 55705
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55706;",
+      "decimal_missing_semicolon": "&#55706",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD99A;",
+      "hex_missing_semicolon": "&#XD99A",
+      "value": 55706
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55707;",
+      "decimal_missing_semicolon": "&#55707",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD99B;",
+      "hex_missing_semicolon": "&#XD99B",
+      "value": 55707
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55708;",
+      "decimal_missing_semicolon": "&#55708",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD99C;",
+      "hex_missing_semicolon": "&#XD99C",
+      "value": 55708
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55709;",
+      "decimal_missing_semicolon": "&#55709",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD99D;",
+      "hex_missing_semicolon": "&#XD99D",
+      "value": 55709
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55710;",
+      "decimal_missing_semicolon": "&#55710",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD99E;",
+      "hex_missing_semicolon": "&#XD99E",
+      "value": 55710
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55711;",
+      "decimal_missing_semicolon": "&#55711",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD99F;",
+      "hex_missing_semicolon": "&#XD99F",
+      "value": 55711
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55712;",
+      "decimal_missing_semicolon": "&#55712",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A0;",
+      "hex_missing_semicolon": "&#XD9A0",
+      "value": 55712
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55713;",
+      "decimal_missing_semicolon": "&#55713",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A1;",
+      "hex_missing_semicolon": "&#XD9A1",
+      "value": 55713
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55714;",
+      "decimal_missing_semicolon": "&#55714",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A2;",
+      "hex_missing_semicolon": "&#XD9A2",
+      "value": 55714
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55715;",
+      "decimal_missing_semicolon": "&#55715",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A3;",
+      "hex_missing_semicolon": "&#XD9A3",
+      "value": 55715
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55716;",
+      "decimal_missing_semicolon": "&#55716",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A4;",
+      "hex_missing_semicolon": "&#XD9A4",
+      "value": 55716
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55717;",
+      "decimal_missing_semicolon": "&#55717",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A5;",
+      "hex_missing_semicolon": "&#XD9A5",
+      "value": 55717
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55718;",
+      "decimal_missing_semicolon": "&#55718",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A6;",
+      "hex_missing_semicolon": "&#XD9A6",
+      "value": 55718
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55719;",
+      "decimal_missing_semicolon": "&#55719",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A7;",
+      "hex_missing_semicolon": "&#XD9A7",
+      "value": 55719
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55720;",
+      "decimal_missing_semicolon": "&#55720",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A8;",
+      "hex_missing_semicolon": "&#XD9A8",
+      "value": 55720
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55721;",
+      "decimal_missing_semicolon": "&#55721",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9A9;",
+      "hex_missing_semicolon": "&#XD9A9",
+      "value": 55721
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55722;",
+      "decimal_missing_semicolon": "&#55722",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9AA;",
+      "hex_missing_semicolon": "&#XD9AA",
+      "value": 55722
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55723;",
+      "decimal_missing_semicolon": "&#55723",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9AB;",
+      "hex_missing_semicolon": "&#XD9AB",
+      "value": 55723
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55724;",
+      "decimal_missing_semicolon": "&#55724",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9AC;",
+      "hex_missing_semicolon": "&#XD9AC",
+      "value": 55724
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55725;",
+      "decimal_missing_semicolon": "&#55725",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9AD;",
+      "hex_missing_semicolon": "&#XD9AD",
+      "value": 55725
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55726;",
+      "decimal_missing_semicolon": "&#55726",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9AE;",
+      "hex_missing_semicolon": "&#XD9AE",
+      "value": 55726
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55727;",
+      "decimal_missing_semicolon": "&#55727",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9AF;",
+      "hex_missing_semicolon": "&#XD9AF",
+      "value": 55727
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55728;",
+      "decimal_missing_semicolon": "&#55728",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B0;",
+      "hex_missing_semicolon": "&#XD9B0",
+      "value": 55728
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55729;",
+      "decimal_missing_semicolon": "&#55729",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B1;",
+      "hex_missing_semicolon": "&#XD9B1",
+      "value": 55729
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55730;",
+      "decimal_missing_semicolon": "&#55730",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B2;",
+      "hex_missing_semicolon": "&#XD9B2",
+      "value": 55730
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55731;",
+      "decimal_missing_semicolon": "&#55731",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B3;",
+      "hex_missing_semicolon": "&#XD9B3",
+      "value": 55731
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55732;",
+      "decimal_missing_semicolon": "&#55732",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B4;",
+      "hex_missing_semicolon": "&#XD9B4",
+      "value": 55732
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55733;",
+      "decimal_missing_semicolon": "&#55733",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B5;",
+      "hex_missing_semicolon": "&#XD9B5",
+      "value": 55733
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55734;",
+      "decimal_missing_semicolon": "&#55734",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B6;",
+      "hex_missing_semicolon": "&#XD9B6",
+      "value": 55734
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55735;",
+      "decimal_missing_semicolon": "&#55735",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B7;",
+      "hex_missing_semicolon": "&#XD9B7",
+      "value": 55735
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55736;",
+      "decimal_missing_semicolon": "&#55736",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B8;",
+      "hex_missing_semicolon": "&#XD9B8",
+      "value": 55736
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55737;",
+      "decimal_missing_semicolon": "&#55737",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9B9;",
+      "hex_missing_semicolon": "&#XD9B9",
+      "value": 55737
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55738;",
+      "decimal_missing_semicolon": "&#55738",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9BA;",
+      "hex_missing_semicolon": "&#XD9BA",
+      "value": 55738
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55739;",
+      "decimal_missing_semicolon": "&#55739",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9BB;",
+      "hex_missing_semicolon": "&#XD9BB",
+      "value": 55739
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55740;",
+      "decimal_missing_semicolon": "&#55740",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9BC;",
+      "hex_missing_semicolon": "&#XD9BC",
+      "value": 55740
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55741;",
+      "decimal_missing_semicolon": "&#55741",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9BD;",
+      "hex_missing_semicolon": "&#XD9BD",
+      "value": 55741
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55742;",
+      "decimal_missing_semicolon": "&#55742",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9BE;",
+      "hex_missing_semicolon": "&#XD9BE",
+      "value": 55742
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55743;",
+      "decimal_missing_semicolon": "&#55743",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9BF;",
+      "hex_missing_semicolon": "&#XD9BF",
+      "value": 55743
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55744;",
+      "decimal_missing_semicolon": "&#55744",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C0;",
+      "hex_missing_semicolon": "&#XD9C0",
+      "value": 55744
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55745;",
+      "decimal_missing_semicolon": "&#55745",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C1;",
+      "hex_missing_semicolon": "&#XD9C1",
+      "value": 55745
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55746;",
+      "decimal_missing_semicolon": "&#55746",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C2;",
+      "hex_missing_semicolon": "&#XD9C2",
+      "value": 55746
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55747;",
+      "decimal_missing_semicolon": "&#55747",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C3;",
+      "hex_missing_semicolon": "&#XD9C3",
+      "value": 55747
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55748;",
+      "decimal_missing_semicolon": "&#55748",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C4;",
+      "hex_missing_semicolon": "&#XD9C4",
+      "value": 55748
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55749;",
+      "decimal_missing_semicolon": "&#55749",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C5;",
+      "hex_missing_semicolon": "&#XD9C5",
+      "value": 55749
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55750;",
+      "decimal_missing_semicolon": "&#55750",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C6;",
+      "hex_missing_semicolon": "&#XD9C6",
+      "value": 55750
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55751;",
+      "decimal_missing_semicolon": "&#55751",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C7;",
+      "hex_missing_semicolon": "&#XD9C7",
+      "value": 55751
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55752;",
+      "decimal_missing_semicolon": "&#55752",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C8;",
+      "hex_missing_semicolon": "&#XD9C8",
+      "value": 55752
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55753;",
+      "decimal_missing_semicolon": "&#55753",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9C9;",
+      "hex_missing_semicolon": "&#XD9C9",
+      "value": 55753
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55754;",
+      "decimal_missing_semicolon": "&#55754",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9CA;",
+      "hex_missing_semicolon": "&#XD9CA",
+      "value": 55754
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55755;",
+      "decimal_missing_semicolon": "&#55755",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9CB;",
+      "hex_missing_semicolon": "&#XD9CB",
+      "value": 55755
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55756;",
+      "decimal_missing_semicolon": "&#55756",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9CC;",
+      "hex_missing_semicolon": "&#XD9CC",
+      "value": 55756
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55757;",
+      "decimal_missing_semicolon": "&#55757",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9CD;",
+      "hex_missing_semicolon": "&#XD9CD",
+      "value": 55757
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55758;",
+      "decimal_missing_semicolon": "&#55758",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9CE;",
+      "hex_missing_semicolon": "&#XD9CE",
+      "value": 55758
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55759;",
+      "decimal_missing_semicolon": "&#55759",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9CF;",
+      "hex_missing_semicolon": "&#XD9CF",
+      "value": 55759
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55760;",
+      "decimal_missing_semicolon": "&#55760",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D0;",
+      "hex_missing_semicolon": "&#XD9D0",
+      "value": 55760
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55761;",
+      "decimal_missing_semicolon": "&#55761",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D1;",
+      "hex_missing_semicolon": "&#XD9D1",
+      "value": 55761
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55762;",
+      "decimal_missing_semicolon": "&#55762",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D2;",
+      "hex_missing_semicolon": "&#XD9D2",
+      "value": 55762
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55763;",
+      "decimal_missing_semicolon": "&#55763",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D3;",
+      "hex_missing_semicolon": "&#XD9D3",
+      "value": 55763
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55764;",
+      "decimal_missing_semicolon": "&#55764",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D4;",
+      "hex_missing_semicolon": "&#XD9D4",
+      "value": 55764
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55765;",
+      "decimal_missing_semicolon": "&#55765",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D5;",
+      "hex_missing_semicolon": "&#XD9D5",
+      "value": 55765
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55766;",
+      "decimal_missing_semicolon": "&#55766",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D6;",
+      "hex_missing_semicolon": "&#XD9D6",
+      "value": 55766
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55767;",
+      "decimal_missing_semicolon": "&#55767",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D7;",
+      "hex_missing_semicolon": "&#XD9D7",
+      "value": 55767
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55768;",
+      "decimal_missing_semicolon": "&#55768",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D8;",
+      "hex_missing_semicolon": "&#XD9D8",
+      "value": 55768
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55769;",
+      "decimal_missing_semicolon": "&#55769",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9D9;",
+      "hex_missing_semicolon": "&#XD9D9",
+      "value": 55769
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55770;",
+      "decimal_missing_semicolon": "&#55770",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9DA;",
+      "hex_missing_semicolon": "&#XD9DA",
+      "value": 55770
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55771;",
+      "decimal_missing_semicolon": "&#55771",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9DB;",
+      "hex_missing_semicolon": "&#XD9DB",
+      "value": 55771
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55772;",
+      "decimal_missing_semicolon": "&#55772",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9DC;",
+      "hex_missing_semicolon": "&#XD9DC",
+      "value": 55772
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55773;",
+      "decimal_missing_semicolon": "&#55773",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9DD;",
+      "hex_missing_semicolon": "&#XD9DD",
+      "value": 55773
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55774;",
+      "decimal_missing_semicolon": "&#55774",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9DE;",
+      "hex_missing_semicolon": "&#XD9DE",
+      "value": 55774
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55775;",
+      "decimal_missing_semicolon": "&#55775",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9DF;",
+      "hex_missing_semicolon": "&#XD9DF",
+      "value": 55775
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55776;",
+      "decimal_missing_semicolon": "&#55776",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E0;",
+      "hex_missing_semicolon": "&#XD9E0",
+      "value": 55776
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55777;",
+      "decimal_missing_semicolon": "&#55777",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E1;",
+      "hex_missing_semicolon": "&#XD9E1",
+      "value": 55777
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55778;",
+      "decimal_missing_semicolon": "&#55778",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E2;",
+      "hex_missing_semicolon": "&#XD9E2",
+      "value": 55778
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55779;",
+      "decimal_missing_semicolon": "&#55779",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E3;",
+      "hex_missing_semicolon": "&#XD9E3",
+      "value": 55779
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55780;",
+      "decimal_missing_semicolon": "&#55780",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E4;",
+      "hex_missing_semicolon": "&#XD9E4",
+      "value": 55780
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55781;",
+      "decimal_missing_semicolon": "&#55781",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E5;",
+      "hex_missing_semicolon": "&#XD9E5",
+      "value": 55781
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55782;",
+      "decimal_missing_semicolon": "&#55782",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E6;",
+      "hex_missing_semicolon": "&#XD9E6",
+      "value": 55782
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55783;",
+      "decimal_missing_semicolon": "&#55783",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E7;",
+      "hex_missing_semicolon": "&#XD9E7",
+      "value": 55783
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55784;",
+      "decimal_missing_semicolon": "&#55784",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E8;",
+      "hex_missing_semicolon": "&#XD9E8",
+      "value": 55784
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55785;",
+      "decimal_missing_semicolon": "&#55785",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9E9;",
+      "hex_missing_semicolon": "&#XD9E9",
+      "value": 55785
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55786;",
+      "decimal_missing_semicolon": "&#55786",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9EA;",
+      "hex_missing_semicolon": "&#XD9EA",
+      "value": 55786
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55787;",
+      "decimal_missing_semicolon": "&#55787",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9EB;",
+      "hex_missing_semicolon": "&#XD9EB",
+      "value": 55787
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55788;",
+      "decimal_missing_semicolon": "&#55788",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9EC;",
+      "hex_missing_semicolon": "&#XD9EC",
+      "value": 55788
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55789;",
+      "decimal_missing_semicolon": "&#55789",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9ED;",
+      "hex_missing_semicolon": "&#XD9ED",
+      "value": 55789
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55790;",
+      "decimal_missing_semicolon": "&#55790",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9EE;",
+      "hex_missing_semicolon": "&#XD9EE",
+      "value": 55790
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55791;",
+      "decimal_missing_semicolon": "&#55791",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9EF;",
+      "hex_missing_semicolon": "&#XD9EF",
+      "value": 55791
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55792;",
+      "decimal_missing_semicolon": "&#55792",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F0;",
+      "hex_missing_semicolon": "&#XD9F0",
+      "value": 55792
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55793;",
+      "decimal_missing_semicolon": "&#55793",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F1;",
+      "hex_missing_semicolon": "&#XD9F1",
+      "value": 55793
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55794;",
+      "decimal_missing_semicolon": "&#55794",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F2;",
+      "hex_missing_semicolon": "&#XD9F2",
+      "value": 55794
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55795;",
+      "decimal_missing_semicolon": "&#55795",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F3;",
+      "hex_missing_semicolon": "&#XD9F3",
+      "value": 55795
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55796;",
+      "decimal_missing_semicolon": "&#55796",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F4;",
+      "hex_missing_semicolon": "&#XD9F4",
+      "value": 55796
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55797;",
+      "decimal_missing_semicolon": "&#55797",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F5;",
+      "hex_missing_semicolon": "&#XD9F5",
+      "value": 55797
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55798;",
+      "decimal_missing_semicolon": "&#55798",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F6;",
+      "hex_missing_semicolon": "&#XD9F6",
+      "value": 55798
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55799;",
+      "decimal_missing_semicolon": "&#55799",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F7;",
+      "hex_missing_semicolon": "&#XD9F7",
+      "value": 55799
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55800;",
+      "decimal_missing_semicolon": "&#55800",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F8;",
+      "hex_missing_semicolon": "&#XD9F8",
+      "value": 55800
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55801;",
+      "decimal_missing_semicolon": "&#55801",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9F9;",
+      "hex_missing_semicolon": "&#XD9F9",
+      "value": 55801
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55802;",
+      "decimal_missing_semicolon": "&#55802",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9FA;",
+      "hex_missing_semicolon": "&#XD9FA",
+      "value": 55802
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55803;",
+      "decimal_missing_semicolon": "&#55803",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9FB;",
+      "hex_missing_semicolon": "&#XD9FB",
+      "value": 55803
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55804;",
+      "decimal_missing_semicolon": "&#55804",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9FC;",
+      "hex_missing_semicolon": "&#XD9FC",
+      "value": 55804
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55805;",
+      "decimal_missing_semicolon": "&#55805",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9FD;",
+      "hex_missing_semicolon": "&#XD9FD",
+      "value": 55805
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55806;",
+      "decimal_missing_semicolon": "&#55806",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9FE;",
+      "hex_missing_semicolon": "&#XD9FE",
+      "value": 55806
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55807;",
+      "decimal_missing_semicolon": "&#55807",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xD9FF;",
+      "hex_missing_semicolon": "&#XD9FF",
+      "value": 55807
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55808;",
+      "decimal_missing_semicolon": "&#55808",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA00;",
+      "hex_missing_semicolon": "&#XDA00",
+      "value": 55808
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55809;",
+      "decimal_missing_semicolon": "&#55809",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA01;",
+      "hex_missing_semicolon": "&#XDA01",
+      "value": 55809
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55810;",
+      "decimal_missing_semicolon": "&#55810",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA02;",
+      "hex_missing_semicolon": "&#XDA02",
+      "value": 55810
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55811;",
+      "decimal_missing_semicolon": "&#55811",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA03;",
+      "hex_missing_semicolon": "&#XDA03",
+      "value": 55811
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55812;",
+      "decimal_missing_semicolon": "&#55812",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA04;",
+      "hex_missing_semicolon": "&#XDA04",
+      "value": 55812
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55813;",
+      "decimal_missing_semicolon": "&#55813",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA05;",
+      "hex_missing_semicolon": "&#XDA05",
+      "value": 55813
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55814;",
+      "decimal_missing_semicolon": "&#55814",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA06;",
+      "hex_missing_semicolon": "&#XDA06",
+      "value": 55814
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55815;",
+      "decimal_missing_semicolon": "&#55815",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA07;",
+      "hex_missing_semicolon": "&#XDA07",
+      "value": 55815
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55816;",
+      "decimal_missing_semicolon": "&#55816",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA08;",
+      "hex_missing_semicolon": "&#XDA08",
+      "value": 55816
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55817;",
+      "decimal_missing_semicolon": "&#55817",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA09;",
+      "hex_missing_semicolon": "&#XDA09",
+      "value": 55817
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55818;",
+      "decimal_missing_semicolon": "&#55818",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA0A;",
+      "hex_missing_semicolon": "&#XDA0A",
+      "value": 55818
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55819;",
+      "decimal_missing_semicolon": "&#55819",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA0B;",
+      "hex_missing_semicolon": "&#XDA0B",
+      "value": 55819
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55820;",
+      "decimal_missing_semicolon": "&#55820",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA0C;",
+      "hex_missing_semicolon": "&#XDA0C",
+      "value": 55820
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55821;",
+      "decimal_missing_semicolon": "&#55821",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA0D;",
+      "hex_missing_semicolon": "&#XDA0D",
+      "value": 55821
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55822;",
+      "decimal_missing_semicolon": "&#55822",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA0E;",
+      "hex_missing_semicolon": "&#XDA0E",
+      "value": 55822
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55823;",
+      "decimal_missing_semicolon": "&#55823",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA0F;",
+      "hex_missing_semicolon": "&#XDA0F",
+      "value": 55823
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55824;",
+      "decimal_missing_semicolon": "&#55824",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA10;",
+      "hex_missing_semicolon": "&#XDA10",
+      "value": 55824
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55825;",
+      "decimal_missing_semicolon": "&#55825",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA11;",
+      "hex_missing_semicolon": "&#XDA11",
+      "value": 55825
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55826;",
+      "decimal_missing_semicolon": "&#55826",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA12;",
+      "hex_missing_semicolon": "&#XDA12",
+      "value": 55826
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55827;",
+      "decimal_missing_semicolon": "&#55827",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA13;",
+      "hex_missing_semicolon": "&#XDA13",
+      "value": 55827
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55828;",
+      "decimal_missing_semicolon": "&#55828",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA14;",
+      "hex_missing_semicolon": "&#XDA14",
+      "value": 55828
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55829;",
+      "decimal_missing_semicolon": "&#55829",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA15;",
+      "hex_missing_semicolon": "&#XDA15",
+      "value": 55829
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55830;",
+      "decimal_missing_semicolon": "&#55830",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA16;",
+      "hex_missing_semicolon": "&#XDA16",
+      "value": 55830
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55831;",
+      "decimal_missing_semicolon": "&#55831",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA17;",
+      "hex_missing_semicolon": "&#XDA17",
+      "value": 55831
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55832;",
+      "decimal_missing_semicolon": "&#55832",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA18;",
+      "hex_missing_semicolon": "&#XDA18",
+      "value": 55832
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55833;",
+      "decimal_missing_semicolon": "&#55833",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA19;",
+      "hex_missing_semicolon": "&#XDA19",
+      "value": 55833
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55834;",
+      "decimal_missing_semicolon": "&#55834",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA1A;",
+      "hex_missing_semicolon": "&#XDA1A",
+      "value": 55834
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55835;",
+      "decimal_missing_semicolon": "&#55835",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA1B;",
+      "hex_missing_semicolon": "&#XDA1B",
+      "value": 55835
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55836;",
+      "decimal_missing_semicolon": "&#55836",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA1C;",
+      "hex_missing_semicolon": "&#XDA1C",
+      "value": 55836
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55837;",
+      "decimal_missing_semicolon": "&#55837",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA1D;",
+      "hex_missing_semicolon": "&#XDA1D",
+      "value": 55837
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55838;",
+      "decimal_missing_semicolon": "&#55838",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA1E;",
+      "hex_missing_semicolon": "&#XDA1E",
+      "value": 55838
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55839;",
+      "decimal_missing_semicolon": "&#55839",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA1F;",
+      "hex_missing_semicolon": "&#XDA1F",
+      "value": 55839
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55840;",
+      "decimal_missing_semicolon": "&#55840",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA20;",
+      "hex_missing_semicolon": "&#XDA20",
+      "value": 55840
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55841;",
+      "decimal_missing_semicolon": "&#55841",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA21;",
+      "hex_missing_semicolon": "&#XDA21",
+      "value": 55841
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55842;",
+      "decimal_missing_semicolon": "&#55842",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA22;",
+      "hex_missing_semicolon": "&#XDA22",
+      "value": 55842
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55843;",
+      "decimal_missing_semicolon": "&#55843",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA23;",
+      "hex_missing_semicolon": "&#XDA23",
+      "value": 55843
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55844;",
+      "decimal_missing_semicolon": "&#55844",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA24;",
+      "hex_missing_semicolon": "&#XDA24",
+      "value": 55844
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55845;",
+      "decimal_missing_semicolon": "&#55845",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA25;",
+      "hex_missing_semicolon": "&#XDA25",
+      "value": 55845
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55846;",
+      "decimal_missing_semicolon": "&#55846",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA26;",
+      "hex_missing_semicolon": "&#XDA26",
+      "value": 55846
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55847;",
+      "decimal_missing_semicolon": "&#55847",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA27;",
+      "hex_missing_semicolon": "&#XDA27",
+      "value": 55847
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55848;",
+      "decimal_missing_semicolon": "&#55848",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA28;",
+      "hex_missing_semicolon": "&#XDA28",
+      "value": 55848
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55849;",
+      "decimal_missing_semicolon": "&#55849",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA29;",
+      "hex_missing_semicolon": "&#XDA29",
+      "value": 55849
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55850;",
+      "decimal_missing_semicolon": "&#55850",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA2A;",
+      "hex_missing_semicolon": "&#XDA2A",
+      "value": 55850
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55851;",
+      "decimal_missing_semicolon": "&#55851",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA2B;",
+      "hex_missing_semicolon": "&#XDA2B",
+      "value": 55851
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55852;",
+      "decimal_missing_semicolon": "&#55852",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA2C;",
+      "hex_missing_semicolon": "&#XDA2C",
+      "value": 55852
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55853;",
+      "decimal_missing_semicolon": "&#55853",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA2D;",
+      "hex_missing_semicolon": "&#XDA2D",
+      "value": 55853
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55854;",
+      "decimal_missing_semicolon": "&#55854",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA2E;",
+      "hex_missing_semicolon": "&#XDA2E",
+      "value": 55854
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55855;",
+      "decimal_missing_semicolon": "&#55855",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA2F;",
+      "hex_missing_semicolon": "&#XDA2F",
+      "value": 55855
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55856;",
+      "decimal_missing_semicolon": "&#55856",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA30;",
+      "hex_missing_semicolon": "&#XDA30",
+      "value": 55856
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55857;",
+      "decimal_missing_semicolon": "&#55857",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA31;",
+      "hex_missing_semicolon": "&#XDA31",
+      "value": 55857
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55858;",
+      "decimal_missing_semicolon": "&#55858",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA32;",
+      "hex_missing_semicolon": "&#XDA32",
+      "value": 55858
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55859;",
+      "decimal_missing_semicolon": "&#55859",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA33;",
+      "hex_missing_semicolon": "&#XDA33",
+      "value": 55859
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55860;",
+      "decimal_missing_semicolon": "&#55860",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA34;",
+      "hex_missing_semicolon": "&#XDA34",
+      "value": 55860
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55861;",
+      "decimal_missing_semicolon": "&#55861",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA35;",
+      "hex_missing_semicolon": "&#XDA35",
+      "value": 55861
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55862;",
+      "decimal_missing_semicolon": "&#55862",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA36;",
+      "hex_missing_semicolon": "&#XDA36",
+      "value": 55862
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55863;",
+      "decimal_missing_semicolon": "&#55863",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA37;",
+      "hex_missing_semicolon": "&#XDA37",
+      "value": 55863
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55864;",
+      "decimal_missing_semicolon": "&#55864",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA38;",
+      "hex_missing_semicolon": "&#XDA38",
+      "value": 55864
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55865;",
+      "decimal_missing_semicolon": "&#55865",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA39;",
+      "hex_missing_semicolon": "&#XDA39",
+      "value": 55865
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55866;",
+      "decimal_missing_semicolon": "&#55866",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA3A;",
+      "hex_missing_semicolon": "&#XDA3A",
+      "value": 55866
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55867;",
+      "decimal_missing_semicolon": "&#55867",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA3B;",
+      "hex_missing_semicolon": "&#XDA3B",
+      "value": 55867
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55868;",
+      "decimal_missing_semicolon": "&#55868",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA3C;",
+      "hex_missing_semicolon": "&#XDA3C",
+      "value": 55868
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55869;",
+      "decimal_missing_semicolon": "&#55869",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA3D;",
+      "hex_missing_semicolon": "&#XDA3D",
+      "value": 55869
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55870;",
+      "decimal_missing_semicolon": "&#55870",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA3E;",
+      "hex_missing_semicolon": "&#XDA3E",
+      "value": 55870
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55871;",
+      "decimal_missing_semicolon": "&#55871",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA3F;",
+      "hex_missing_semicolon": "&#XDA3F",
+      "value": 55871
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55872;",
+      "decimal_missing_semicolon": "&#55872",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA40;",
+      "hex_missing_semicolon": "&#XDA40",
+      "value": 55872
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55873;",
+      "decimal_missing_semicolon": "&#55873",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA41;",
+      "hex_missing_semicolon": "&#XDA41",
+      "value": 55873
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55874;",
+      "decimal_missing_semicolon": "&#55874",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA42;",
+      "hex_missing_semicolon": "&#XDA42",
+      "value": 55874
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55875;",
+      "decimal_missing_semicolon": "&#55875",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA43;",
+      "hex_missing_semicolon": "&#XDA43",
+      "value": 55875
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55876;",
+      "decimal_missing_semicolon": "&#55876",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA44;",
+      "hex_missing_semicolon": "&#XDA44",
+      "value": 55876
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55877;",
+      "decimal_missing_semicolon": "&#55877",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA45;",
+      "hex_missing_semicolon": "&#XDA45",
+      "value": 55877
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55878;",
+      "decimal_missing_semicolon": "&#55878",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA46;",
+      "hex_missing_semicolon": "&#XDA46",
+      "value": 55878
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55879;",
+      "decimal_missing_semicolon": "&#55879",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA47;",
+      "hex_missing_semicolon": "&#XDA47",
+      "value": 55879
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55880;",
+      "decimal_missing_semicolon": "&#55880",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA48;",
+      "hex_missing_semicolon": "&#XDA48",
+      "value": 55880
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55881;",
+      "decimal_missing_semicolon": "&#55881",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA49;",
+      "hex_missing_semicolon": "&#XDA49",
+      "value": 55881
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55882;",
+      "decimal_missing_semicolon": "&#55882",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA4A;",
+      "hex_missing_semicolon": "&#XDA4A",
+      "value": 55882
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55883;",
+      "decimal_missing_semicolon": "&#55883",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA4B;",
+      "hex_missing_semicolon": "&#XDA4B",
+      "value": 55883
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55884;",
+      "decimal_missing_semicolon": "&#55884",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA4C;",
+      "hex_missing_semicolon": "&#XDA4C",
+      "value": 55884
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55885;",
+      "decimal_missing_semicolon": "&#55885",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA4D;",
+      "hex_missing_semicolon": "&#XDA4D",
+      "value": 55885
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55886;",
+      "decimal_missing_semicolon": "&#55886",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA4E;",
+      "hex_missing_semicolon": "&#XDA4E",
+      "value": 55886
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55887;",
+      "decimal_missing_semicolon": "&#55887",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA4F;",
+      "hex_missing_semicolon": "&#XDA4F",
+      "value": 55887
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55888;",
+      "decimal_missing_semicolon": "&#55888",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA50;",
+      "hex_missing_semicolon": "&#XDA50",
+      "value": 55888
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55889;",
+      "decimal_missing_semicolon": "&#55889",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA51;",
+      "hex_missing_semicolon": "&#XDA51",
+      "value": 55889
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55890;",
+      "decimal_missing_semicolon": "&#55890",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA52;",
+      "hex_missing_semicolon": "&#XDA52",
+      "value": 55890
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55891;",
+      "decimal_missing_semicolon": "&#55891",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA53;",
+      "hex_missing_semicolon": "&#XDA53",
+      "value": 55891
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55892;",
+      "decimal_missing_semicolon": "&#55892",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA54;",
+      "hex_missing_semicolon": "&#XDA54",
+      "value": 55892
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55893;",
+      "decimal_missing_semicolon": "&#55893",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA55;",
+      "hex_missing_semicolon": "&#XDA55",
+      "value": 55893
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55894;",
+      "decimal_missing_semicolon": "&#55894",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA56;",
+      "hex_missing_semicolon": "&#XDA56",
+      "value": 55894
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55895;",
+      "decimal_missing_semicolon": "&#55895",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA57;",
+      "hex_missing_semicolon": "&#XDA57",
+      "value": 55895
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55896;",
+      "decimal_missing_semicolon": "&#55896",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA58;",
+      "hex_missing_semicolon": "&#XDA58",
+      "value": 55896
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55897;",
+      "decimal_missing_semicolon": "&#55897",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA59;",
+      "hex_missing_semicolon": "&#XDA59",
+      "value": 55897
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55898;",
+      "decimal_missing_semicolon": "&#55898",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA5A;",
+      "hex_missing_semicolon": "&#XDA5A",
+      "value": 55898
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55899;",
+      "decimal_missing_semicolon": "&#55899",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA5B;",
+      "hex_missing_semicolon": "&#XDA5B",
+      "value": 55899
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55900;",
+      "decimal_missing_semicolon": "&#55900",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA5C;",
+      "hex_missing_semicolon": "&#XDA5C",
+      "value": 55900
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55901;",
+      "decimal_missing_semicolon": "&#55901",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA5D;",
+      "hex_missing_semicolon": "&#XDA5D",
+      "value": 55901
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55902;",
+      "decimal_missing_semicolon": "&#55902",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA5E;",
+      "hex_missing_semicolon": "&#XDA5E",
+      "value": 55902
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55903;",
+      "decimal_missing_semicolon": "&#55903",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA5F;",
+      "hex_missing_semicolon": "&#XDA5F",
+      "value": 55903
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55904;",
+      "decimal_missing_semicolon": "&#55904",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA60;",
+      "hex_missing_semicolon": "&#XDA60",
+      "value": 55904
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55905;",
+      "decimal_missing_semicolon": "&#55905",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA61;",
+      "hex_missing_semicolon": "&#XDA61",
+      "value": 55905
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55906;",
+      "decimal_missing_semicolon": "&#55906",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA62;",
+      "hex_missing_semicolon": "&#XDA62",
+      "value": 55906
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55907;",
+      "decimal_missing_semicolon": "&#55907",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA63;",
+      "hex_missing_semicolon": "&#XDA63",
+      "value": 55907
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55908;",
+      "decimal_missing_semicolon": "&#55908",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA64;",
+      "hex_missing_semicolon": "&#XDA64",
+      "value": 55908
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55909;",
+      "decimal_missing_semicolon": "&#55909",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA65;",
+      "hex_missing_semicolon": "&#XDA65",
+      "value": 55909
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55910;",
+      "decimal_missing_semicolon": "&#55910",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA66;",
+      "hex_missing_semicolon": "&#XDA66",
+      "value": 55910
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55911;",
+      "decimal_missing_semicolon": "&#55911",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA67;",
+      "hex_missing_semicolon": "&#XDA67",
+      "value": 55911
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55912;",
+      "decimal_missing_semicolon": "&#55912",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA68;",
+      "hex_missing_semicolon": "&#XDA68",
+      "value": 55912
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55913;",
+      "decimal_missing_semicolon": "&#55913",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA69;",
+      "hex_missing_semicolon": "&#XDA69",
+      "value": 55913
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55914;",
+      "decimal_missing_semicolon": "&#55914",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA6A;",
+      "hex_missing_semicolon": "&#XDA6A",
+      "value": 55914
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55915;",
+      "decimal_missing_semicolon": "&#55915",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA6B;",
+      "hex_missing_semicolon": "&#XDA6B",
+      "value": 55915
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55916;",
+      "decimal_missing_semicolon": "&#55916",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA6C;",
+      "hex_missing_semicolon": "&#XDA6C",
+      "value": 55916
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55917;",
+      "decimal_missing_semicolon": "&#55917",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA6D;",
+      "hex_missing_semicolon": "&#XDA6D",
+      "value": 55917
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55918;",
+      "decimal_missing_semicolon": "&#55918",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA6E;",
+      "hex_missing_semicolon": "&#XDA6E",
+      "value": 55918
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55919;",
+      "decimal_missing_semicolon": "&#55919",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA6F;",
+      "hex_missing_semicolon": "&#XDA6F",
+      "value": 55919
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55920;",
+      "decimal_missing_semicolon": "&#55920",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA70;",
+      "hex_missing_semicolon": "&#XDA70",
+      "value": 55920
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55921;",
+      "decimal_missing_semicolon": "&#55921",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA71;",
+      "hex_missing_semicolon": "&#XDA71",
+      "value": 55921
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55922;",
+      "decimal_missing_semicolon": "&#55922",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA72;",
+      "hex_missing_semicolon": "&#XDA72",
+      "value": 55922
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55923;",
+      "decimal_missing_semicolon": "&#55923",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA73;",
+      "hex_missing_semicolon": "&#XDA73",
+      "value": 55923
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55924;",
+      "decimal_missing_semicolon": "&#55924",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA74;",
+      "hex_missing_semicolon": "&#XDA74",
+      "value": 55924
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55925;",
+      "decimal_missing_semicolon": "&#55925",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA75;",
+      "hex_missing_semicolon": "&#XDA75",
+      "value": 55925
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55926;",
+      "decimal_missing_semicolon": "&#55926",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA76;",
+      "hex_missing_semicolon": "&#XDA76",
+      "value": 55926
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55927;",
+      "decimal_missing_semicolon": "&#55927",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA77;",
+      "hex_missing_semicolon": "&#XDA77",
+      "value": 55927
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55928;",
+      "decimal_missing_semicolon": "&#55928",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA78;",
+      "hex_missing_semicolon": "&#XDA78",
+      "value": 55928
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55929;",
+      "decimal_missing_semicolon": "&#55929",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA79;",
+      "hex_missing_semicolon": "&#XDA79",
+      "value": 55929
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55930;",
+      "decimal_missing_semicolon": "&#55930",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA7A;",
+      "hex_missing_semicolon": "&#XDA7A",
+      "value": 55930
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55931;",
+      "decimal_missing_semicolon": "&#55931",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA7B;",
+      "hex_missing_semicolon": "&#XDA7B",
+      "value": 55931
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55932;",
+      "decimal_missing_semicolon": "&#55932",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA7C;",
+      "hex_missing_semicolon": "&#XDA7C",
+      "value": 55932
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55933;",
+      "decimal_missing_semicolon": "&#55933",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA7D;",
+      "hex_missing_semicolon": "&#XDA7D",
+      "value": 55933
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55934;",
+      "decimal_missing_semicolon": "&#55934",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA7E;",
+      "hex_missing_semicolon": "&#XDA7E",
+      "value": 55934
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55935;",
+      "decimal_missing_semicolon": "&#55935",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA7F;",
+      "hex_missing_semicolon": "&#XDA7F",
+      "value": 55935
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55936;",
+      "decimal_missing_semicolon": "&#55936",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA80;",
+      "hex_missing_semicolon": "&#XDA80",
+      "value": 55936
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55937;",
+      "decimal_missing_semicolon": "&#55937",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA81;",
+      "hex_missing_semicolon": "&#XDA81",
+      "value": 55937
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55938;",
+      "decimal_missing_semicolon": "&#55938",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA82;",
+      "hex_missing_semicolon": "&#XDA82",
+      "value": 55938
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55939;",
+      "decimal_missing_semicolon": "&#55939",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA83;",
+      "hex_missing_semicolon": "&#XDA83",
+      "value": 55939
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55940;",
+      "decimal_missing_semicolon": "&#55940",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA84;",
+      "hex_missing_semicolon": "&#XDA84",
+      "value": 55940
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55941;",
+      "decimal_missing_semicolon": "&#55941",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA85;",
+      "hex_missing_semicolon": "&#XDA85",
+      "value": 55941
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55942;",
+      "decimal_missing_semicolon": "&#55942",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA86;",
+      "hex_missing_semicolon": "&#XDA86",
+      "value": 55942
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55943;",
+      "decimal_missing_semicolon": "&#55943",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA87;",
+      "hex_missing_semicolon": "&#XDA87",
+      "value": 55943
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55944;",
+      "decimal_missing_semicolon": "&#55944",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA88;",
+      "hex_missing_semicolon": "&#XDA88",
+      "value": 55944
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55945;",
+      "decimal_missing_semicolon": "&#55945",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA89;",
+      "hex_missing_semicolon": "&#XDA89",
+      "value": 55945
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55946;",
+      "decimal_missing_semicolon": "&#55946",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA8A;",
+      "hex_missing_semicolon": "&#XDA8A",
+      "value": 55946
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55947;",
+      "decimal_missing_semicolon": "&#55947",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA8B;",
+      "hex_missing_semicolon": "&#XDA8B",
+      "value": 55947
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55948;",
+      "decimal_missing_semicolon": "&#55948",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA8C;",
+      "hex_missing_semicolon": "&#XDA8C",
+      "value": 55948
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55949;",
+      "decimal_missing_semicolon": "&#55949",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA8D;",
+      "hex_missing_semicolon": "&#XDA8D",
+      "value": 55949
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55950;",
+      "decimal_missing_semicolon": "&#55950",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA8E;",
+      "hex_missing_semicolon": "&#XDA8E",
+      "value": 55950
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55951;",
+      "decimal_missing_semicolon": "&#55951",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA8F;",
+      "hex_missing_semicolon": "&#XDA8F",
+      "value": 55951
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55952;",
+      "decimal_missing_semicolon": "&#55952",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA90;",
+      "hex_missing_semicolon": "&#XDA90",
+      "value": 55952
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55953;",
+      "decimal_missing_semicolon": "&#55953",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA91;",
+      "hex_missing_semicolon": "&#XDA91",
+      "value": 55953
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55954;",
+      "decimal_missing_semicolon": "&#55954",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA92;",
+      "hex_missing_semicolon": "&#XDA92",
+      "value": 55954
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55955;",
+      "decimal_missing_semicolon": "&#55955",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA93;",
+      "hex_missing_semicolon": "&#XDA93",
+      "value": 55955
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55956;",
+      "decimal_missing_semicolon": "&#55956",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA94;",
+      "hex_missing_semicolon": "&#XDA94",
+      "value": 55956
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55957;",
+      "decimal_missing_semicolon": "&#55957",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA95;",
+      "hex_missing_semicolon": "&#XDA95",
+      "value": 55957
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55958;",
+      "decimal_missing_semicolon": "&#55958",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA96;",
+      "hex_missing_semicolon": "&#XDA96",
+      "value": 55958
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55959;",
+      "decimal_missing_semicolon": "&#55959",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA97;",
+      "hex_missing_semicolon": "&#XDA97",
+      "value": 55959
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55960;",
+      "decimal_missing_semicolon": "&#55960",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA98;",
+      "hex_missing_semicolon": "&#XDA98",
+      "value": 55960
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55961;",
+      "decimal_missing_semicolon": "&#55961",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA99;",
+      "hex_missing_semicolon": "&#XDA99",
+      "value": 55961
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55962;",
+      "decimal_missing_semicolon": "&#55962",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA9A;",
+      "hex_missing_semicolon": "&#XDA9A",
+      "value": 55962
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55963;",
+      "decimal_missing_semicolon": "&#55963",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA9B;",
+      "hex_missing_semicolon": "&#XDA9B",
+      "value": 55963
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55964;",
+      "decimal_missing_semicolon": "&#55964",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA9C;",
+      "hex_missing_semicolon": "&#XDA9C",
+      "value": 55964
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55965;",
+      "decimal_missing_semicolon": "&#55965",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA9D;",
+      "hex_missing_semicolon": "&#XDA9D",
+      "value": 55965
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55966;",
+      "decimal_missing_semicolon": "&#55966",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA9E;",
+      "hex_missing_semicolon": "&#XDA9E",
+      "value": 55966
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55967;",
+      "decimal_missing_semicolon": "&#55967",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDA9F;",
+      "hex_missing_semicolon": "&#XDA9F",
+      "value": 55967
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55968;",
+      "decimal_missing_semicolon": "&#55968",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA0;",
+      "hex_missing_semicolon": "&#XDAA0",
+      "value": 55968
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55969;",
+      "decimal_missing_semicolon": "&#55969",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA1;",
+      "hex_missing_semicolon": "&#XDAA1",
+      "value": 55969
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55970;",
+      "decimal_missing_semicolon": "&#55970",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA2;",
+      "hex_missing_semicolon": "&#XDAA2",
+      "value": 55970
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55971;",
+      "decimal_missing_semicolon": "&#55971",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA3;",
+      "hex_missing_semicolon": "&#XDAA3",
+      "value": 55971
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55972;",
+      "decimal_missing_semicolon": "&#55972",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA4;",
+      "hex_missing_semicolon": "&#XDAA4",
+      "value": 55972
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55973;",
+      "decimal_missing_semicolon": "&#55973",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA5;",
+      "hex_missing_semicolon": "&#XDAA5",
+      "value": 55973
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55974;",
+      "decimal_missing_semicolon": "&#55974",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA6;",
+      "hex_missing_semicolon": "&#XDAA6",
+      "value": 55974
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55975;",
+      "decimal_missing_semicolon": "&#55975",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA7;",
+      "hex_missing_semicolon": "&#XDAA7",
+      "value": 55975
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55976;",
+      "decimal_missing_semicolon": "&#55976",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA8;",
+      "hex_missing_semicolon": "&#XDAA8",
+      "value": 55976
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55977;",
+      "decimal_missing_semicolon": "&#55977",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAA9;",
+      "hex_missing_semicolon": "&#XDAA9",
+      "value": 55977
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55978;",
+      "decimal_missing_semicolon": "&#55978",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAAA;",
+      "hex_missing_semicolon": "&#XDAAA",
+      "value": 55978
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55979;",
+      "decimal_missing_semicolon": "&#55979",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAAB;",
+      "hex_missing_semicolon": "&#XDAAB",
+      "value": 55979
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55980;",
+      "decimal_missing_semicolon": "&#55980",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAAC;",
+      "hex_missing_semicolon": "&#XDAAC",
+      "value": 55980
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55981;",
+      "decimal_missing_semicolon": "&#55981",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAAD;",
+      "hex_missing_semicolon": "&#XDAAD",
+      "value": 55981
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55982;",
+      "decimal_missing_semicolon": "&#55982",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAAE;",
+      "hex_missing_semicolon": "&#XDAAE",
+      "value": 55982
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55983;",
+      "decimal_missing_semicolon": "&#55983",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAAF;",
+      "hex_missing_semicolon": "&#XDAAF",
+      "value": 55983
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55984;",
+      "decimal_missing_semicolon": "&#55984",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB0;",
+      "hex_missing_semicolon": "&#XDAB0",
+      "value": 55984
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55985;",
+      "decimal_missing_semicolon": "&#55985",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB1;",
+      "hex_missing_semicolon": "&#XDAB1",
+      "value": 55985
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55986;",
+      "decimal_missing_semicolon": "&#55986",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB2;",
+      "hex_missing_semicolon": "&#XDAB2",
+      "value": 55986
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55987;",
+      "decimal_missing_semicolon": "&#55987",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB3;",
+      "hex_missing_semicolon": "&#XDAB3",
+      "value": 55987
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55988;",
+      "decimal_missing_semicolon": "&#55988",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB4;",
+      "hex_missing_semicolon": "&#XDAB4",
+      "value": 55988
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55989;",
+      "decimal_missing_semicolon": "&#55989",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB5;",
+      "hex_missing_semicolon": "&#XDAB5",
+      "value": 55989
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55990;",
+      "decimal_missing_semicolon": "&#55990",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB6;",
+      "hex_missing_semicolon": "&#XDAB6",
+      "value": 55990
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55991;",
+      "decimal_missing_semicolon": "&#55991",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB7;",
+      "hex_missing_semicolon": "&#XDAB7",
+      "value": 55991
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55992;",
+      "decimal_missing_semicolon": "&#55992",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB8;",
+      "hex_missing_semicolon": "&#XDAB8",
+      "value": 55992
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55993;",
+      "decimal_missing_semicolon": "&#55993",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAB9;",
+      "hex_missing_semicolon": "&#XDAB9",
+      "value": 55993
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55994;",
+      "decimal_missing_semicolon": "&#55994",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDABA;",
+      "hex_missing_semicolon": "&#XDABA",
+      "value": 55994
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55995;",
+      "decimal_missing_semicolon": "&#55995",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDABB;",
+      "hex_missing_semicolon": "&#XDABB",
+      "value": 55995
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55996;",
+      "decimal_missing_semicolon": "&#55996",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDABC;",
+      "hex_missing_semicolon": "&#XDABC",
+      "value": 55996
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55997;",
+      "decimal_missing_semicolon": "&#55997",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDABD;",
+      "hex_missing_semicolon": "&#XDABD",
+      "value": 55997
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55998;",
+      "decimal_missing_semicolon": "&#55998",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDABE;",
+      "hex_missing_semicolon": "&#XDABE",
+      "value": 55998
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#55999;",
+      "decimal_missing_semicolon": "&#55999",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDABF;",
+      "hex_missing_semicolon": "&#XDABF",
+      "value": 55999
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56000;",
+      "decimal_missing_semicolon": "&#56000",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC0;",
+      "hex_missing_semicolon": "&#XDAC0",
+      "value": 56000
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56001;",
+      "decimal_missing_semicolon": "&#56001",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC1;",
+      "hex_missing_semicolon": "&#XDAC1",
+      "value": 56001
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56002;",
+      "decimal_missing_semicolon": "&#56002",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC2;",
+      "hex_missing_semicolon": "&#XDAC2",
+      "value": 56002
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56003;",
+      "decimal_missing_semicolon": "&#56003",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC3;",
+      "hex_missing_semicolon": "&#XDAC3",
+      "value": 56003
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56004;",
+      "decimal_missing_semicolon": "&#56004",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC4;",
+      "hex_missing_semicolon": "&#XDAC4",
+      "value": 56004
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56005;",
+      "decimal_missing_semicolon": "&#56005",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC5;",
+      "hex_missing_semicolon": "&#XDAC5",
+      "value": 56005
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56006;",
+      "decimal_missing_semicolon": "&#56006",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC6;",
+      "hex_missing_semicolon": "&#XDAC6",
+      "value": 56006
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56007;",
+      "decimal_missing_semicolon": "&#56007",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC7;",
+      "hex_missing_semicolon": "&#XDAC7",
+      "value": 56007
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56008;",
+      "decimal_missing_semicolon": "&#56008",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC8;",
+      "hex_missing_semicolon": "&#XDAC8",
+      "value": 56008
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56009;",
+      "decimal_missing_semicolon": "&#56009",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAC9;",
+      "hex_missing_semicolon": "&#XDAC9",
+      "value": 56009
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56010;",
+      "decimal_missing_semicolon": "&#56010",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDACA;",
+      "hex_missing_semicolon": "&#XDACA",
+      "value": 56010
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56011;",
+      "decimal_missing_semicolon": "&#56011",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDACB;",
+      "hex_missing_semicolon": "&#XDACB",
+      "value": 56011
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56012;",
+      "decimal_missing_semicolon": "&#56012",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDACC;",
+      "hex_missing_semicolon": "&#XDACC",
+      "value": 56012
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56013;",
+      "decimal_missing_semicolon": "&#56013",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDACD;",
+      "hex_missing_semicolon": "&#XDACD",
+      "value": 56013
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56014;",
+      "decimal_missing_semicolon": "&#56014",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDACE;",
+      "hex_missing_semicolon": "&#XDACE",
+      "value": 56014
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56015;",
+      "decimal_missing_semicolon": "&#56015",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDACF;",
+      "hex_missing_semicolon": "&#XDACF",
+      "value": 56015
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56016;",
+      "decimal_missing_semicolon": "&#56016",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD0;",
+      "hex_missing_semicolon": "&#XDAD0",
+      "value": 56016
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56017;",
+      "decimal_missing_semicolon": "&#56017",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD1;",
+      "hex_missing_semicolon": "&#XDAD1",
+      "value": 56017
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56018;",
+      "decimal_missing_semicolon": "&#56018",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD2;",
+      "hex_missing_semicolon": "&#XDAD2",
+      "value": 56018
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56019;",
+      "decimal_missing_semicolon": "&#56019",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD3;",
+      "hex_missing_semicolon": "&#XDAD3",
+      "value": 56019
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56020;",
+      "decimal_missing_semicolon": "&#56020",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD4;",
+      "hex_missing_semicolon": "&#XDAD4",
+      "value": 56020
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56021;",
+      "decimal_missing_semicolon": "&#56021",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD5;",
+      "hex_missing_semicolon": "&#XDAD5",
+      "value": 56021
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56022;",
+      "decimal_missing_semicolon": "&#56022",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD6;",
+      "hex_missing_semicolon": "&#XDAD6",
+      "value": 56022
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56023;",
+      "decimal_missing_semicolon": "&#56023",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD7;",
+      "hex_missing_semicolon": "&#XDAD7",
+      "value": 56023
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56024;",
+      "decimal_missing_semicolon": "&#56024",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD8;",
+      "hex_missing_semicolon": "&#XDAD8",
+      "value": 56024
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56025;",
+      "decimal_missing_semicolon": "&#56025",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAD9;",
+      "hex_missing_semicolon": "&#XDAD9",
+      "value": 56025
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56026;",
+      "decimal_missing_semicolon": "&#56026",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDADA;",
+      "hex_missing_semicolon": "&#XDADA",
+      "value": 56026
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56027;",
+      "decimal_missing_semicolon": "&#56027",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDADB;",
+      "hex_missing_semicolon": "&#XDADB",
+      "value": 56027
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56028;",
+      "decimal_missing_semicolon": "&#56028",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDADC;",
+      "hex_missing_semicolon": "&#XDADC",
+      "value": 56028
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56029;",
+      "decimal_missing_semicolon": "&#56029",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDADD;",
+      "hex_missing_semicolon": "&#XDADD",
+      "value": 56029
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56030;",
+      "decimal_missing_semicolon": "&#56030",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDADE;",
+      "hex_missing_semicolon": "&#XDADE",
+      "value": 56030
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56031;",
+      "decimal_missing_semicolon": "&#56031",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDADF;",
+      "hex_missing_semicolon": "&#XDADF",
+      "value": 56031
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56032;",
+      "decimal_missing_semicolon": "&#56032",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE0;",
+      "hex_missing_semicolon": "&#XDAE0",
+      "value": 56032
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56033;",
+      "decimal_missing_semicolon": "&#56033",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE1;",
+      "hex_missing_semicolon": "&#XDAE1",
+      "value": 56033
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56034;",
+      "decimal_missing_semicolon": "&#56034",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE2;",
+      "hex_missing_semicolon": "&#XDAE2",
+      "value": 56034
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56035;",
+      "decimal_missing_semicolon": "&#56035",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE3;",
+      "hex_missing_semicolon": "&#XDAE3",
+      "value": 56035
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56036;",
+      "decimal_missing_semicolon": "&#56036",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE4;",
+      "hex_missing_semicolon": "&#XDAE4",
+      "value": 56036
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56037;",
+      "decimal_missing_semicolon": "&#56037",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE5;",
+      "hex_missing_semicolon": "&#XDAE5",
+      "value": 56037
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56038;",
+      "decimal_missing_semicolon": "&#56038",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE6;",
+      "hex_missing_semicolon": "&#XDAE6",
+      "value": 56038
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56039;",
+      "decimal_missing_semicolon": "&#56039",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE7;",
+      "hex_missing_semicolon": "&#XDAE7",
+      "value": 56039
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56040;",
+      "decimal_missing_semicolon": "&#56040",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE8;",
+      "hex_missing_semicolon": "&#XDAE8",
+      "value": 56040
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56041;",
+      "decimal_missing_semicolon": "&#56041",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAE9;",
+      "hex_missing_semicolon": "&#XDAE9",
+      "value": 56041
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56042;",
+      "decimal_missing_semicolon": "&#56042",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAEA;",
+      "hex_missing_semicolon": "&#XDAEA",
+      "value": 56042
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56043;",
+      "decimal_missing_semicolon": "&#56043",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAEB;",
+      "hex_missing_semicolon": "&#XDAEB",
+      "value": 56043
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56044;",
+      "decimal_missing_semicolon": "&#56044",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAEC;",
+      "hex_missing_semicolon": "&#XDAEC",
+      "value": 56044
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56045;",
+      "decimal_missing_semicolon": "&#56045",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAED;",
+      "hex_missing_semicolon": "&#XDAED",
+      "value": 56045
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56046;",
+      "decimal_missing_semicolon": "&#56046",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAEE;",
+      "hex_missing_semicolon": "&#XDAEE",
+      "value": 56046
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56047;",
+      "decimal_missing_semicolon": "&#56047",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAEF;",
+      "hex_missing_semicolon": "&#XDAEF",
+      "value": 56047
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56048;",
+      "decimal_missing_semicolon": "&#56048",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF0;",
+      "hex_missing_semicolon": "&#XDAF0",
+      "value": 56048
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56049;",
+      "decimal_missing_semicolon": "&#56049",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF1;",
+      "hex_missing_semicolon": "&#XDAF1",
+      "value": 56049
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56050;",
+      "decimal_missing_semicolon": "&#56050",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF2;",
+      "hex_missing_semicolon": "&#XDAF2",
+      "value": 56050
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56051;",
+      "decimal_missing_semicolon": "&#56051",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF3;",
+      "hex_missing_semicolon": "&#XDAF3",
+      "value": 56051
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56052;",
+      "decimal_missing_semicolon": "&#56052",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF4;",
+      "hex_missing_semicolon": "&#XDAF4",
+      "value": 56052
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56053;",
+      "decimal_missing_semicolon": "&#56053",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF5;",
+      "hex_missing_semicolon": "&#XDAF5",
+      "value": 56053
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56054;",
+      "decimal_missing_semicolon": "&#56054",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF6;",
+      "hex_missing_semicolon": "&#XDAF6",
+      "value": 56054
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56055;",
+      "decimal_missing_semicolon": "&#56055",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF7;",
+      "hex_missing_semicolon": "&#XDAF7",
+      "value": 56055
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56056;",
+      "decimal_missing_semicolon": "&#56056",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF8;",
+      "hex_missing_semicolon": "&#XDAF8",
+      "value": 56056
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56057;",
+      "decimal_missing_semicolon": "&#56057",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAF9;",
+      "hex_missing_semicolon": "&#XDAF9",
+      "value": 56057
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56058;",
+      "decimal_missing_semicolon": "&#56058",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAFA;",
+      "hex_missing_semicolon": "&#XDAFA",
+      "value": 56058
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56059;",
+      "decimal_missing_semicolon": "&#56059",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAFB;",
+      "hex_missing_semicolon": "&#XDAFB",
+      "value": 56059
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56060;",
+      "decimal_missing_semicolon": "&#56060",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAFC;",
+      "hex_missing_semicolon": "&#XDAFC",
+      "value": 56060
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56061;",
+      "decimal_missing_semicolon": "&#56061",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAFD;",
+      "hex_missing_semicolon": "&#XDAFD",
+      "value": 56061
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56062;",
+      "decimal_missing_semicolon": "&#56062",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAFE;",
+      "hex_missing_semicolon": "&#XDAFE",
+      "value": 56062
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56063;",
+      "decimal_missing_semicolon": "&#56063",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDAFF;",
+      "hex_missing_semicolon": "&#XDAFF",
+      "value": 56063
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56064;",
+      "decimal_missing_semicolon": "&#56064",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB00;",
+      "hex_missing_semicolon": "&#XDB00",
+      "value": 56064
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56065;",
+      "decimal_missing_semicolon": "&#56065",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB01;",
+      "hex_missing_semicolon": "&#XDB01",
+      "value": 56065
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56066;",
+      "decimal_missing_semicolon": "&#56066",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB02;",
+      "hex_missing_semicolon": "&#XDB02",
+      "value": 56066
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56067;",
+      "decimal_missing_semicolon": "&#56067",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB03;",
+      "hex_missing_semicolon": "&#XDB03",
+      "value": 56067
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56068;",
+      "decimal_missing_semicolon": "&#56068",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB04;",
+      "hex_missing_semicolon": "&#XDB04",
+      "value": 56068
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56069;",
+      "decimal_missing_semicolon": "&#56069",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB05;",
+      "hex_missing_semicolon": "&#XDB05",
+      "value": 56069
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56070;",
+      "decimal_missing_semicolon": "&#56070",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB06;",
+      "hex_missing_semicolon": "&#XDB06",
+      "value": 56070
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56071;",
+      "decimal_missing_semicolon": "&#56071",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB07;",
+      "hex_missing_semicolon": "&#XDB07",
+      "value": 56071
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56072;",
+      "decimal_missing_semicolon": "&#56072",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB08;",
+      "hex_missing_semicolon": "&#XDB08",
+      "value": 56072
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56073;",
+      "decimal_missing_semicolon": "&#56073",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB09;",
+      "hex_missing_semicolon": "&#XDB09",
+      "value": 56073
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56074;",
+      "decimal_missing_semicolon": "&#56074",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB0A;",
+      "hex_missing_semicolon": "&#XDB0A",
+      "value": 56074
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56075;",
+      "decimal_missing_semicolon": "&#56075",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB0B;",
+      "hex_missing_semicolon": "&#XDB0B",
+      "value": 56075
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56076;",
+      "decimal_missing_semicolon": "&#56076",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB0C;",
+      "hex_missing_semicolon": "&#XDB0C",
+      "value": 56076
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56077;",
+      "decimal_missing_semicolon": "&#56077",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB0D;",
+      "hex_missing_semicolon": "&#XDB0D",
+      "value": 56077
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56078;",
+      "decimal_missing_semicolon": "&#56078",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB0E;",
+      "hex_missing_semicolon": "&#XDB0E",
+      "value": 56078
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56079;",
+      "decimal_missing_semicolon": "&#56079",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB0F;",
+      "hex_missing_semicolon": "&#XDB0F",
+      "value": 56079
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56080;",
+      "decimal_missing_semicolon": "&#56080",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB10;",
+      "hex_missing_semicolon": "&#XDB10",
+      "value": 56080
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56081;",
+      "decimal_missing_semicolon": "&#56081",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB11;",
+      "hex_missing_semicolon": "&#XDB11",
+      "value": 56081
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56082;",
+      "decimal_missing_semicolon": "&#56082",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB12;",
+      "hex_missing_semicolon": "&#XDB12",
+      "value": 56082
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56083;",
+      "decimal_missing_semicolon": "&#56083",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB13;",
+      "hex_missing_semicolon": "&#XDB13",
+      "value": 56083
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56084;",
+      "decimal_missing_semicolon": "&#56084",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB14;",
+      "hex_missing_semicolon": "&#XDB14",
+      "value": 56084
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56085;",
+      "decimal_missing_semicolon": "&#56085",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB15;",
+      "hex_missing_semicolon": "&#XDB15",
+      "value": 56085
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56086;",
+      "decimal_missing_semicolon": "&#56086",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB16;",
+      "hex_missing_semicolon": "&#XDB16",
+      "value": 56086
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56087;",
+      "decimal_missing_semicolon": "&#56087",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB17;",
+      "hex_missing_semicolon": "&#XDB17",
+      "value": 56087
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56088;",
+      "decimal_missing_semicolon": "&#56088",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB18;",
+      "hex_missing_semicolon": "&#XDB18",
+      "value": 56088
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56089;",
+      "decimal_missing_semicolon": "&#56089",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB19;",
+      "hex_missing_semicolon": "&#XDB19",
+      "value": 56089
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56090;",
+      "decimal_missing_semicolon": "&#56090",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB1A;",
+      "hex_missing_semicolon": "&#XDB1A",
+      "value": 56090
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56091;",
+      "decimal_missing_semicolon": "&#56091",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB1B;",
+      "hex_missing_semicolon": "&#XDB1B",
+      "value": 56091
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56092;",
+      "decimal_missing_semicolon": "&#56092",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB1C;",
+      "hex_missing_semicolon": "&#XDB1C",
+      "value": 56092
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56093;",
+      "decimal_missing_semicolon": "&#56093",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB1D;",
+      "hex_missing_semicolon": "&#XDB1D",
+      "value": 56093
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56094;",
+      "decimal_missing_semicolon": "&#56094",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB1E;",
+      "hex_missing_semicolon": "&#XDB1E",
+      "value": 56094
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56095;",
+      "decimal_missing_semicolon": "&#56095",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB1F;",
+      "hex_missing_semicolon": "&#XDB1F",
+      "value": 56095
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56096;",
+      "decimal_missing_semicolon": "&#56096",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB20;",
+      "hex_missing_semicolon": "&#XDB20",
+      "value": 56096
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56097;",
+      "decimal_missing_semicolon": "&#56097",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB21;",
+      "hex_missing_semicolon": "&#XDB21",
+      "value": 56097
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56098;",
+      "decimal_missing_semicolon": "&#56098",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB22;",
+      "hex_missing_semicolon": "&#XDB22",
+      "value": 56098
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56099;",
+      "decimal_missing_semicolon": "&#56099",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB23;",
+      "hex_missing_semicolon": "&#XDB23",
+      "value": 56099
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56100;",
+      "decimal_missing_semicolon": "&#56100",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB24;",
+      "hex_missing_semicolon": "&#XDB24",
+      "value": 56100
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56101;",
+      "decimal_missing_semicolon": "&#56101",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB25;",
+      "hex_missing_semicolon": "&#XDB25",
+      "value": 56101
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56102;",
+      "decimal_missing_semicolon": "&#56102",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB26;",
+      "hex_missing_semicolon": "&#XDB26",
+      "value": 56102
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56103;",
+      "decimal_missing_semicolon": "&#56103",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB27;",
+      "hex_missing_semicolon": "&#XDB27",
+      "value": 56103
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56104;",
+      "decimal_missing_semicolon": "&#56104",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB28;",
+      "hex_missing_semicolon": "&#XDB28",
+      "value": 56104
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56105;",
+      "decimal_missing_semicolon": "&#56105",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB29;",
+      "hex_missing_semicolon": "&#XDB29",
+      "value": 56105
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56106;",
+      "decimal_missing_semicolon": "&#56106",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB2A;",
+      "hex_missing_semicolon": "&#XDB2A",
+      "value": 56106
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56107;",
+      "decimal_missing_semicolon": "&#56107",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB2B;",
+      "hex_missing_semicolon": "&#XDB2B",
+      "value": 56107
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56108;",
+      "decimal_missing_semicolon": "&#56108",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB2C;",
+      "hex_missing_semicolon": "&#XDB2C",
+      "value": 56108
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56109;",
+      "decimal_missing_semicolon": "&#56109",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB2D;",
+      "hex_missing_semicolon": "&#XDB2D",
+      "value": 56109
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56110;",
+      "decimal_missing_semicolon": "&#56110",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB2E;",
+      "hex_missing_semicolon": "&#XDB2E",
+      "value": 56110
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56111;",
+      "decimal_missing_semicolon": "&#56111",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB2F;",
+      "hex_missing_semicolon": "&#XDB2F",
+      "value": 56111
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56112;",
+      "decimal_missing_semicolon": "&#56112",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB30;",
+      "hex_missing_semicolon": "&#XDB30",
+      "value": 56112
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56113;",
+      "decimal_missing_semicolon": "&#56113",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB31;",
+      "hex_missing_semicolon": "&#XDB31",
+      "value": 56113
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56114;",
+      "decimal_missing_semicolon": "&#56114",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB32;",
+      "hex_missing_semicolon": "&#XDB32",
+      "value": 56114
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56115;",
+      "decimal_missing_semicolon": "&#56115",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB33;",
+      "hex_missing_semicolon": "&#XDB33",
+      "value": 56115
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56116;",
+      "decimal_missing_semicolon": "&#56116",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB34;",
+      "hex_missing_semicolon": "&#XDB34",
+      "value": 56116
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56117;",
+      "decimal_missing_semicolon": "&#56117",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB35;",
+      "hex_missing_semicolon": "&#XDB35",
+      "value": 56117
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56118;",
+      "decimal_missing_semicolon": "&#56118",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB36;",
+      "hex_missing_semicolon": "&#XDB36",
+      "value": 56118
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56119;",
+      "decimal_missing_semicolon": "&#56119",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB37;",
+      "hex_missing_semicolon": "&#XDB37",
+      "value": 56119
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56120;",
+      "decimal_missing_semicolon": "&#56120",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB38;",
+      "hex_missing_semicolon": "&#XDB38",
+      "value": 56120
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56121;",
+      "decimal_missing_semicolon": "&#56121",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB39;",
+      "hex_missing_semicolon": "&#XDB39",
+      "value": 56121
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56122;",
+      "decimal_missing_semicolon": "&#56122",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB3A;",
+      "hex_missing_semicolon": "&#XDB3A",
+      "value": 56122
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56123;",
+      "decimal_missing_semicolon": "&#56123",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB3B;",
+      "hex_missing_semicolon": "&#XDB3B",
+      "value": 56123
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56124;",
+      "decimal_missing_semicolon": "&#56124",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB3C;",
+      "hex_missing_semicolon": "&#XDB3C",
+      "value": 56124
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56125;",
+      "decimal_missing_semicolon": "&#56125",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB3D;",
+      "hex_missing_semicolon": "&#XDB3D",
+      "value": 56125
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56126;",
+      "decimal_missing_semicolon": "&#56126",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB3E;",
+      "hex_missing_semicolon": "&#XDB3E",
+      "value": 56126
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56127;",
+      "decimal_missing_semicolon": "&#56127",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB3F;",
+      "hex_missing_semicolon": "&#XDB3F",
+      "value": 56127
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56128;",
+      "decimal_missing_semicolon": "&#56128",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB40;",
+      "hex_missing_semicolon": "&#XDB40",
+      "value": 56128
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56129;",
+      "decimal_missing_semicolon": "&#56129",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB41;",
+      "hex_missing_semicolon": "&#XDB41",
+      "value": 56129
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56130;",
+      "decimal_missing_semicolon": "&#56130",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB42;",
+      "hex_missing_semicolon": "&#XDB42",
+      "value": 56130
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56131;",
+      "decimal_missing_semicolon": "&#56131",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB43;",
+      "hex_missing_semicolon": "&#XDB43",
+      "value": 56131
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56132;",
+      "decimal_missing_semicolon": "&#56132",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB44;",
+      "hex_missing_semicolon": "&#XDB44",
+      "value": 56132
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56133;",
+      "decimal_missing_semicolon": "&#56133",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB45;",
+      "hex_missing_semicolon": "&#XDB45",
+      "value": 56133
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56134;",
+      "decimal_missing_semicolon": "&#56134",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB46;",
+      "hex_missing_semicolon": "&#XDB46",
+      "value": 56134
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56135;",
+      "decimal_missing_semicolon": "&#56135",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB47;",
+      "hex_missing_semicolon": "&#XDB47",
+      "value": 56135
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56136;",
+      "decimal_missing_semicolon": "&#56136",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB48;",
+      "hex_missing_semicolon": "&#XDB48",
+      "value": 56136
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56137;",
+      "decimal_missing_semicolon": "&#56137",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB49;",
+      "hex_missing_semicolon": "&#XDB49",
+      "value": 56137
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56138;",
+      "decimal_missing_semicolon": "&#56138",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB4A;",
+      "hex_missing_semicolon": "&#XDB4A",
+      "value": 56138
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56139;",
+      "decimal_missing_semicolon": "&#56139",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB4B;",
+      "hex_missing_semicolon": "&#XDB4B",
+      "value": 56139
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56140;",
+      "decimal_missing_semicolon": "&#56140",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB4C;",
+      "hex_missing_semicolon": "&#XDB4C",
+      "value": 56140
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56141;",
+      "decimal_missing_semicolon": "&#56141",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB4D;",
+      "hex_missing_semicolon": "&#XDB4D",
+      "value": 56141
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56142;",
+      "decimal_missing_semicolon": "&#56142",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB4E;",
+      "hex_missing_semicolon": "&#XDB4E",
+      "value": 56142
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56143;",
+      "decimal_missing_semicolon": "&#56143",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB4F;",
+      "hex_missing_semicolon": "&#XDB4F",
+      "value": 56143
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56144;",
+      "decimal_missing_semicolon": "&#56144",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB50;",
+      "hex_missing_semicolon": "&#XDB50",
+      "value": 56144
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56145;",
+      "decimal_missing_semicolon": "&#56145",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB51;",
+      "hex_missing_semicolon": "&#XDB51",
+      "value": 56145
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56146;",
+      "decimal_missing_semicolon": "&#56146",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB52;",
+      "hex_missing_semicolon": "&#XDB52",
+      "value": 56146
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56147;",
+      "decimal_missing_semicolon": "&#56147",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB53;",
+      "hex_missing_semicolon": "&#XDB53",
+      "value": 56147
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56148;",
+      "decimal_missing_semicolon": "&#56148",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB54;",
+      "hex_missing_semicolon": "&#XDB54",
+      "value": 56148
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56149;",
+      "decimal_missing_semicolon": "&#56149",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB55;",
+      "hex_missing_semicolon": "&#XDB55",
+      "value": 56149
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56150;",
+      "decimal_missing_semicolon": "&#56150",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB56;",
+      "hex_missing_semicolon": "&#XDB56",
+      "value": 56150
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56151;",
+      "decimal_missing_semicolon": "&#56151",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB57;",
+      "hex_missing_semicolon": "&#XDB57",
+      "value": 56151
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56152;",
+      "decimal_missing_semicolon": "&#56152",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB58;",
+      "hex_missing_semicolon": "&#XDB58",
+      "value": 56152
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56153;",
+      "decimal_missing_semicolon": "&#56153",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB59;",
+      "hex_missing_semicolon": "&#XDB59",
+      "value": 56153
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56154;",
+      "decimal_missing_semicolon": "&#56154",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB5A;",
+      "hex_missing_semicolon": "&#XDB5A",
+      "value": 56154
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56155;",
+      "decimal_missing_semicolon": "&#56155",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB5B;",
+      "hex_missing_semicolon": "&#XDB5B",
+      "value": 56155
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56156;",
+      "decimal_missing_semicolon": "&#56156",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB5C;",
+      "hex_missing_semicolon": "&#XDB5C",
+      "value": 56156
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56157;",
+      "decimal_missing_semicolon": "&#56157",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB5D;",
+      "hex_missing_semicolon": "&#XDB5D",
+      "value": 56157
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56158;",
+      "decimal_missing_semicolon": "&#56158",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB5E;",
+      "hex_missing_semicolon": "&#XDB5E",
+      "value": 56158
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56159;",
+      "decimal_missing_semicolon": "&#56159",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB5F;",
+      "hex_missing_semicolon": "&#XDB5F",
+      "value": 56159
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56160;",
+      "decimal_missing_semicolon": "&#56160",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB60;",
+      "hex_missing_semicolon": "&#XDB60",
+      "value": 56160
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56161;",
+      "decimal_missing_semicolon": "&#56161",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB61;",
+      "hex_missing_semicolon": "&#XDB61",
+      "value": 56161
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56162;",
+      "decimal_missing_semicolon": "&#56162",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB62;",
+      "hex_missing_semicolon": "&#XDB62",
+      "value": 56162
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56163;",
+      "decimal_missing_semicolon": "&#56163",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB63;",
+      "hex_missing_semicolon": "&#XDB63",
+      "value": 56163
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56164;",
+      "decimal_missing_semicolon": "&#56164",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB64;",
+      "hex_missing_semicolon": "&#XDB64",
+      "value": 56164
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56165;",
+      "decimal_missing_semicolon": "&#56165",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB65;",
+      "hex_missing_semicolon": "&#XDB65",
+      "value": 56165
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56166;",
+      "decimal_missing_semicolon": "&#56166",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB66;",
+      "hex_missing_semicolon": "&#XDB66",
+      "value": 56166
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56167;",
+      "decimal_missing_semicolon": "&#56167",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB67;",
+      "hex_missing_semicolon": "&#XDB67",
+      "value": 56167
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56168;",
+      "decimal_missing_semicolon": "&#56168",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB68;",
+      "hex_missing_semicolon": "&#XDB68",
+      "value": 56168
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56169;",
+      "decimal_missing_semicolon": "&#56169",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB69;",
+      "hex_missing_semicolon": "&#XDB69",
+      "value": 56169
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56170;",
+      "decimal_missing_semicolon": "&#56170",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB6A;",
+      "hex_missing_semicolon": "&#XDB6A",
+      "value": 56170
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56171;",
+      "decimal_missing_semicolon": "&#56171",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB6B;",
+      "hex_missing_semicolon": "&#XDB6B",
+      "value": 56171
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56172;",
+      "decimal_missing_semicolon": "&#56172",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB6C;",
+      "hex_missing_semicolon": "&#XDB6C",
+      "value": 56172
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56173;",
+      "decimal_missing_semicolon": "&#56173",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB6D;",
+      "hex_missing_semicolon": "&#XDB6D",
+      "value": 56173
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56174;",
+      "decimal_missing_semicolon": "&#56174",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB6E;",
+      "hex_missing_semicolon": "&#XDB6E",
+      "value": 56174
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56175;",
+      "decimal_missing_semicolon": "&#56175",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB6F;",
+      "hex_missing_semicolon": "&#XDB6F",
+      "value": 56175
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56176;",
+      "decimal_missing_semicolon": "&#56176",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB70;",
+      "hex_missing_semicolon": "&#XDB70",
+      "value": 56176
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56177;",
+      "decimal_missing_semicolon": "&#56177",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB71;",
+      "hex_missing_semicolon": "&#XDB71",
+      "value": 56177
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56178;",
+      "decimal_missing_semicolon": "&#56178",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB72;",
+      "hex_missing_semicolon": "&#XDB72",
+      "value": 56178
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56179;",
+      "decimal_missing_semicolon": "&#56179",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB73;",
+      "hex_missing_semicolon": "&#XDB73",
+      "value": 56179
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56180;",
+      "decimal_missing_semicolon": "&#56180",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB74;",
+      "hex_missing_semicolon": "&#XDB74",
+      "value": 56180
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56181;",
+      "decimal_missing_semicolon": "&#56181",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB75;",
+      "hex_missing_semicolon": "&#XDB75",
+      "value": 56181
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56182;",
+      "decimal_missing_semicolon": "&#56182",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB76;",
+      "hex_missing_semicolon": "&#XDB76",
+      "value": 56182
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56183;",
+      "decimal_missing_semicolon": "&#56183",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB77;",
+      "hex_missing_semicolon": "&#XDB77",
+      "value": 56183
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56184;",
+      "decimal_missing_semicolon": "&#56184",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB78;",
+      "hex_missing_semicolon": "&#XDB78",
+      "value": 56184
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56185;",
+      "decimal_missing_semicolon": "&#56185",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB79;",
+      "hex_missing_semicolon": "&#XDB79",
+      "value": 56185
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56186;",
+      "decimal_missing_semicolon": "&#56186",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB7A;",
+      "hex_missing_semicolon": "&#XDB7A",
+      "value": 56186
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56187;",
+      "decimal_missing_semicolon": "&#56187",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB7B;",
+      "hex_missing_semicolon": "&#XDB7B",
+      "value": 56187
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56188;",
+      "decimal_missing_semicolon": "&#56188",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB7C;",
+      "hex_missing_semicolon": "&#XDB7C",
+      "value": 56188
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56189;",
+      "decimal_missing_semicolon": "&#56189",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB7D;",
+      "hex_missing_semicolon": "&#XDB7D",
+      "value": 56189
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56190;",
+      "decimal_missing_semicolon": "&#56190",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB7E;",
+      "hex_missing_semicolon": "&#XDB7E",
+      "value": 56190
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56191;",
+      "decimal_missing_semicolon": "&#56191",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB7F;",
+      "hex_missing_semicolon": "&#XDB7F",
+      "value": 56191
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56192;",
+      "decimal_missing_semicolon": "&#56192",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB80;",
+      "hex_missing_semicolon": "&#XDB80",
+      "value": 56192
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56193;",
+      "decimal_missing_semicolon": "&#56193",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB81;",
+      "hex_missing_semicolon": "&#XDB81",
+      "value": 56193
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56194;",
+      "decimal_missing_semicolon": "&#56194",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB82;",
+      "hex_missing_semicolon": "&#XDB82",
+      "value": 56194
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56195;",
+      "decimal_missing_semicolon": "&#56195",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB83;",
+      "hex_missing_semicolon": "&#XDB83",
+      "value": 56195
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56196;",
+      "decimal_missing_semicolon": "&#56196",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB84;",
+      "hex_missing_semicolon": "&#XDB84",
+      "value": 56196
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56197;",
+      "decimal_missing_semicolon": "&#56197",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB85;",
+      "hex_missing_semicolon": "&#XDB85",
+      "value": 56197
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56198;",
+      "decimal_missing_semicolon": "&#56198",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB86;",
+      "hex_missing_semicolon": "&#XDB86",
+      "value": 56198
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56199;",
+      "decimal_missing_semicolon": "&#56199",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB87;",
+      "hex_missing_semicolon": "&#XDB87",
+      "value": 56199
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56200;",
+      "decimal_missing_semicolon": "&#56200",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB88;",
+      "hex_missing_semicolon": "&#XDB88",
+      "value": 56200
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56201;",
+      "decimal_missing_semicolon": "&#56201",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB89;",
+      "hex_missing_semicolon": "&#XDB89",
+      "value": 56201
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56202;",
+      "decimal_missing_semicolon": "&#56202",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB8A;",
+      "hex_missing_semicolon": "&#XDB8A",
+      "value": 56202
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56203;",
+      "decimal_missing_semicolon": "&#56203",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB8B;",
+      "hex_missing_semicolon": "&#XDB8B",
+      "value": 56203
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56204;",
+      "decimal_missing_semicolon": "&#56204",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB8C;",
+      "hex_missing_semicolon": "&#XDB8C",
+      "value": 56204
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56205;",
+      "decimal_missing_semicolon": "&#56205",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB8D;",
+      "hex_missing_semicolon": "&#XDB8D",
+      "value": 56205
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56206;",
+      "decimal_missing_semicolon": "&#56206",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB8E;",
+      "hex_missing_semicolon": "&#XDB8E",
+      "value": 56206
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56207;",
+      "decimal_missing_semicolon": "&#56207",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB8F;",
+      "hex_missing_semicolon": "&#XDB8F",
+      "value": 56207
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56208;",
+      "decimal_missing_semicolon": "&#56208",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB90;",
+      "hex_missing_semicolon": "&#XDB90",
+      "value": 56208
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56209;",
+      "decimal_missing_semicolon": "&#56209",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB91;",
+      "hex_missing_semicolon": "&#XDB91",
+      "value": 56209
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56210;",
+      "decimal_missing_semicolon": "&#56210",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB92;",
+      "hex_missing_semicolon": "&#XDB92",
+      "value": 56210
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56211;",
+      "decimal_missing_semicolon": "&#56211",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB93;",
+      "hex_missing_semicolon": "&#XDB93",
+      "value": 56211
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56212;",
+      "decimal_missing_semicolon": "&#56212",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB94;",
+      "hex_missing_semicolon": "&#XDB94",
+      "value": 56212
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56213;",
+      "decimal_missing_semicolon": "&#56213",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB95;",
+      "hex_missing_semicolon": "&#XDB95",
+      "value": 56213
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56214;",
+      "decimal_missing_semicolon": "&#56214",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB96;",
+      "hex_missing_semicolon": "&#XDB96",
+      "value": 56214
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56215;",
+      "decimal_missing_semicolon": "&#56215",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB97;",
+      "hex_missing_semicolon": "&#XDB97",
+      "value": 56215
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56216;",
+      "decimal_missing_semicolon": "&#56216",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB98;",
+      "hex_missing_semicolon": "&#XDB98",
+      "value": 56216
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56217;",
+      "decimal_missing_semicolon": "&#56217",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB99;",
+      "hex_missing_semicolon": "&#XDB99",
+      "value": 56217
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56218;",
+      "decimal_missing_semicolon": "&#56218",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB9A;",
+      "hex_missing_semicolon": "&#XDB9A",
+      "value": 56218
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56219;",
+      "decimal_missing_semicolon": "&#56219",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB9B;",
+      "hex_missing_semicolon": "&#XDB9B",
+      "value": 56219
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56220;",
+      "decimal_missing_semicolon": "&#56220",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB9C;",
+      "hex_missing_semicolon": "&#XDB9C",
+      "value": 56220
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56221;",
+      "decimal_missing_semicolon": "&#56221",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB9D;",
+      "hex_missing_semicolon": "&#XDB9D",
+      "value": 56221
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56222;",
+      "decimal_missing_semicolon": "&#56222",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB9E;",
+      "hex_missing_semicolon": "&#XDB9E",
+      "value": 56222
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56223;",
+      "decimal_missing_semicolon": "&#56223",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDB9F;",
+      "hex_missing_semicolon": "&#XDB9F",
+      "value": 56223
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56224;",
+      "decimal_missing_semicolon": "&#56224",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA0;",
+      "hex_missing_semicolon": "&#XDBA0",
+      "value": 56224
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56225;",
+      "decimal_missing_semicolon": "&#56225",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA1;",
+      "hex_missing_semicolon": "&#XDBA1",
+      "value": 56225
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56226;",
+      "decimal_missing_semicolon": "&#56226",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA2;",
+      "hex_missing_semicolon": "&#XDBA2",
+      "value": 56226
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56227;",
+      "decimal_missing_semicolon": "&#56227",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA3;",
+      "hex_missing_semicolon": "&#XDBA3",
+      "value": 56227
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56228;",
+      "decimal_missing_semicolon": "&#56228",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA4;",
+      "hex_missing_semicolon": "&#XDBA4",
+      "value": 56228
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56229;",
+      "decimal_missing_semicolon": "&#56229",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA5;",
+      "hex_missing_semicolon": "&#XDBA5",
+      "value": 56229
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56230;",
+      "decimal_missing_semicolon": "&#56230",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA6;",
+      "hex_missing_semicolon": "&#XDBA6",
+      "value": 56230
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56231;",
+      "decimal_missing_semicolon": "&#56231",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA7;",
+      "hex_missing_semicolon": "&#XDBA7",
+      "value": 56231
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56232;",
+      "decimal_missing_semicolon": "&#56232",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA8;",
+      "hex_missing_semicolon": "&#XDBA8",
+      "value": 56232
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56233;",
+      "decimal_missing_semicolon": "&#56233",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBA9;",
+      "hex_missing_semicolon": "&#XDBA9",
+      "value": 56233
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56234;",
+      "decimal_missing_semicolon": "&#56234",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBAA;",
+      "hex_missing_semicolon": "&#XDBAA",
+      "value": 56234
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56235;",
+      "decimal_missing_semicolon": "&#56235",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBAB;",
+      "hex_missing_semicolon": "&#XDBAB",
+      "value": 56235
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56236;",
+      "decimal_missing_semicolon": "&#56236",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBAC;",
+      "hex_missing_semicolon": "&#XDBAC",
+      "value": 56236
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56237;",
+      "decimal_missing_semicolon": "&#56237",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBAD;",
+      "hex_missing_semicolon": "&#XDBAD",
+      "value": 56237
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56238;",
+      "decimal_missing_semicolon": "&#56238",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBAE;",
+      "hex_missing_semicolon": "&#XDBAE",
+      "value": 56238
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56239;",
+      "decimal_missing_semicolon": "&#56239",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBAF;",
+      "hex_missing_semicolon": "&#XDBAF",
+      "value": 56239
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56240;",
+      "decimal_missing_semicolon": "&#56240",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB0;",
+      "hex_missing_semicolon": "&#XDBB0",
+      "value": 56240
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56241;",
+      "decimal_missing_semicolon": "&#56241",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB1;",
+      "hex_missing_semicolon": "&#XDBB1",
+      "value": 56241
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56242;",
+      "decimal_missing_semicolon": "&#56242",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB2;",
+      "hex_missing_semicolon": "&#XDBB2",
+      "value": 56242
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56243;",
+      "decimal_missing_semicolon": "&#56243",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB3;",
+      "hex_missing_semicolon": "&#XDBB3",
+      "value": 56243
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56244;",
+      "decimal_missing_semicolon": "&#56244",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB4;",
+      "hex_missing_semicolon": "&#XDBB4",
+      "value": 56244
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56245;",
+      "decimal_missing_semicolon": "&#56245",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB5;",
+      "hex_missing_semicolon": "&#XDBB5",
+      "value": 56245
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56246;",
+      "decimal_missing_semicolon": "&#56246",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB6;",
+      "hex_missing_semicolon": "&#XDBB6",
+      "value": 56246
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56247;",
+      "decimal_missing_semicolon": "&#56247",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB7;",
+      "hex_missing_semicolon": "&#XDBB7",
+      "value": 56247
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56248;",
+      "decimal_missing_semicolon": "&#56248",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB8;",
+      "hex_missing_semicolon": "&#XDBB8",
+      "value": 56248
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56249;",
+      "decimal_missing_semicolon": "&#56249",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBB9;",
+      "hex_missing_semicolon": "&#XDBB9",
+      "value": 56249
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56250;",
+      "decimal_missing_semicolon": "&#56250",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBBA;",
+      "hex_missing_semicolon": "&#XDBBA",
+      "value": 56250
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56251;",
+      "decimal_missing_semicolon": "&#56251",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBBB;",
+      "hex_missing_semicolon": "&#XDBBB",
+      "value": 56251
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56252;",
+      "decimal_missing_semicolon": "&#56252",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBBC;",
+      "hex_missing_semicolon": "&#XDBBC",
+      "value": 56252
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56253;",
+      "decimal_missing_semicolon": "&#56253",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBBD;",
+      "hex_missing_semicolon": "&#XDBBD",
+      "value": 56253
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56254;",
+      "decimal_missing_semicolon": "&#56254",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBBE;",
+      "hex_missing_semicolon": "&#XDBBE",
+      "value": 56254
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56255;",
+      "decimal_missing_semicolon": "&#56255",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBBF;",
+      "hex_missing_semicolon": "&#XDBBF",
+      "value": 56255
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56256;",
+      "decimal_missing_semicolon": "&#56256",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC0;",
+      "hex_missing_semicolon": "&#XDBC0",
+      "value": 56256
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56257;",
+      "decimal_missing_semicolon": "&#56257",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC1;",
+      "hex_missing_semicolon": "&#XDBC1",
+      "value": 56257
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56258;",
+      "decimal_missing_semicolon": "&#56258",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC2;",
+      "hex_missing_semicolon": "&#XDBC2",
+      "value": 56258
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56259;",
+      "decimal_missing_semicolon": "&#56259",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC3;",
+      "hex_missing_semicolon": "&#XDBC3",
+      "value": 56259
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56260;",
+      "decimal_missing_semicolon": "&#56260",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC4;",
+      "hex_missing_semicolon": "&#XDBC4",
+      "value": 56260
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56261;",
+      "decimal_missing_semicolon": "&#56261",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC5;",
+      "hex_missing_semicolon": "&#XDBC5",
+      "value": 56261
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56262;",
+      "decimal_missing_semicolon": "&#56262",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC6;",
+      "hex_missing_semicolon": "&#XDBC6",
+      "value": 56262
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56263;",
+      "decimal_missing_semicolon": "&#56263",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC7;",
+      "hex_missing_semicolon": "&#XDBC7",
+      "value": 56263
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56264;",
+      "decimal_missing_semicolon": "&#56264",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC8;",
+      "hex_missing_semicolon": "&#XDBC8",
+      "value": 56264
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56265;",
+      "decimal_missing_semicolon": "&#56265",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBC9;",
+      "hex_missing_semicolon": "&#XDBC9",
+      "value": 56265
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56266;",
+      "decimal_missing_semicolon": "&#56266",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBCA;",
+      "hex_missing_semicolon": "&#XDBCA",
+      "value": 56266
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56267;",
+      "decimal_missing_semicolon": "&#56267",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBCB;",
+      "hex_missing_semicolon": "&#XDBCB",
+      "value": 56267
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56268;",
+      "decimal_missing_semicolon": "&#56268",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBCC;",
+      "hex_missing_semicolon": "&#XDBCC",
+      "value": 56268
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56269;",
+      "decimal_missing_semicolon": "&#56269",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBCD;",
+      "hex_missing_semicolon": "&#XDBCD",
+      "value": 56269
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56270;",
+      "decimal_missing_semicolon": "&#56270",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBCE;",
+      "hex_missing_semicolon": "&#XDBCE",
+      "value": 56270
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56271;",
+      "decimal_missing_semicolon": "&#56271",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBCF;",
+      "hex_missing_semicolon": "&#XDBCF",
+      "value": 56271
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56272;",
+      "decimal_missing_semicolon": "&#56272",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD0;",
+      "hex_missing_semicolon": "&#XDBD0",
+      "value": 56272
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56273;",
+      "decimal_missing_semicolon": "&#56273",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD1;",
+      "hex_missing_semicolon": "&#XDBD1",
+      "value": 56273
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56274;",
+      "decimal_missing_semicolon": "&#56274",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD2;",
+      "hex_missing_semicolon": "&#XDBD2",
+      "value": 56274
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56275;",
+      "decimal_missing_semicolon": "&#56275",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD3;",
+      "hex_missing_semicolon": "&#XDBD3",
+      "value": 56275
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56276;",
+      "decimal_missing_semicolon": "&#56276",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD4;",
+      "hex_missing_semicolon": "&#XDBD4",
+      "value": 56276
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56277;",
+      "decimal_missing_semicolon": "&#56277",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD5;",
+      "hex_missing_semicolon": "&#XDBD5",
+      "value": 56277
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56278;",
+      "decimal_missing_semicolon": "&#56278",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD6;",
+      "hex_missing_semicolon": "&#XDBD6",
+      "value": 56278
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56279;",
+      "decimal_missing_semicolon": "&#56279",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD7;",
+      "hex_missing_semicolon": "&#XDBD7",
+      "value": 56279
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56280;",
+      "decimal_missing_semicolon": "&#56280",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD8;",
+      "hex_missing_semicolon": "&#XDBD8",
+      "value": 56280
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56281;",
+      "decimal_missing_semicolon": "&#56281",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBD9;",
+      "hex_missing_semicolon": "&#XDBD9",
+      "value": 56281
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56282;",
+      "decimal_missing_semicolon": "&#56282",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBDA;",
+      "hex_missing_semicolon": "&#XDBDA",
+      "value": 56282
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56283;",
+      "decimal_missing_semicolon": "&#56283",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBDB;",
+      "hex_missing_semicolon": "&#XDBDB",
+      "value": 56283
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56284;",
+      "decimal_missing_semicolon": "&#56284",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBDC;",
+      "hex_missing_semicolon": "&#XDBDC",
+      "value": 56284
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56285;",
+      "decimal_missing_semicolon": "&#56285",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBDD;",
+      "hex_missing_semicolon": "&#XDBDD",
+      "value": 56285
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56286;",
+      "decimal_missing_semicolon": "&#56286",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBDE;",
+      "hex_missing_semicolon": "&#XDBDE",
+      "value": 56286
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56287;",
+      "decimal_missing_semicolon": "&#56287",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBDF;",
+      "hex_missing_semicolon": "&#XDBDF",
+      "value": 56287
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56288;",
+      "decimal_missing_semicolon": "&#56288",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE0;",
+      "hex_missing_semicolon": "&#XDBE0",
+      "value": 56288
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56289;",
+      "decimal_missing_semicolon": "&#56289",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE1;",
+      "hex_missing_semicolon": "&#XDBE1",
+      "value": 56289
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56290;",
+      "decimal_missing_semicolon": "&#56290",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE2;",
+      "hex_missing_semicolon": "&#XDBE2",
+      "value": 56290
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56291;",
+      "decimal_missing_semicolon": "&#56291",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE3;",
+      "hex_missing_semicolon": "&#XDBE3",
+      "value": 56291
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56292;",
+      "decimal_missing_semicolon": "&#56292",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE4;",
+      "hex_missing_semicolon": "&#XDBE4",
+      "value": 56292
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56293;",
+      "decimal_missing_semicolon": "&#56293",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE5;",
+      "hex_missing_semicolon": "&#XDBE5",
+      "value": 56293
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56294;",
+      "decimal_missing_semicolon": "&#56294",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE6;",
+      "hex_missing_semicolon": "&#XDBE6",
+      "value": 56294
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56295;",
+      "decimal_missing_semicolon": "&#56295",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE7;",
+      "hex_missing_semicolon": "&#XDBE7",
+      "value": 56295
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56296;",
+      "decimal_missing_semicolon": "&#56296",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE8;",
+      "hex_missing_semicolon": "&#XDBE8",
+      "value": 56296
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56297;",
+      "decimal_missing_semicolon": "&#56297",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBE9;",
+      "hex_missing_semicolon": "&#XDBE9",
+      "value": 56297
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56298;",
+      "decimal_missing_semicolon": "&#56298",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBEA;",
+      "hex_missing_semicolon": "&#XDBEA",
+      "value": 56298
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56299;",
+      "decimal_missing_semicolon": "&#56299",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBEB;",
+      "hex_missing_semicolon": "&#XDBEB",
+      "value": 56299
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56300;",
+      "decimal_missing_semicolon": "&#56300",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBEC;",
+      "hex_missing_semicolon": "&#XDBEC",
+      "value": 56300
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56301;",
+      "decimal_missing_semicolon": "&#56301",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBED;",
+      "hex_missing_semicolon": "&#XDBED",
+      "value": 56301
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56302;",
+      "decimal_missing_semicolon": "&#56302",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBEE;",
+      "hex_missing_semicolon": "&#XDBEE",
+      "value": 56302
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56303;",
+      "decimal_missing_semicolon": "&#56303",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBEF;",
+      "hex_missing_semicolon": "&#XDBEF",
+      "value": 56303
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56304;",
+      "decimal_missing_semicolon": "&#56304",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF0;",
+      "hex_missing_semicolon": "&#XDBF0",
+      "value": 56304
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56305;",
+      "decimal_missing_semicolon": "&#56305",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF1;",
+      "hex_missing_semicolon": "&#XDBF1",
+      "value": 56305
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56306;",
+      "decimal_missing_semicolon": "&#56306",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF2;",
+      "hex_missing_semicolon": "&#XDBF2",
+      "value": 56306
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56307;",
+      "decimal_missing_semicolon": "&#56307",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF3;",
+      "hex_missing_semicolon": "&#XDBF3",
+      "value": 56307
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56308;",
+      "decimal_missing_semicolon": "&#56308",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF4;",
+      "hex_missing_semicolon": "&#XDBF4",
+      "value": 56308
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56309;",
+      "decimal_missing_semicolon": "&#56309",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF5;",
+      "hex_missing_semicolon": "&#XDBF5",
+      "value": 56309
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56310;",
+      "decimal_missing_semicolon": "&#56310",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF6;",
+      "hex_missing_semicolon": "&#XDBF6",
+      "value": 56310
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56311;",
+      "decimal_missing_semicolon": "&#56311",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF7;",
+      "hex_missing_semicolon": "&#XDBF7",
+      "value": 56311
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56312;",
+      "decimal_missing_semicolon": "&#56312",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF8;",
+      "hex_missing_semicolon": "&#XDBF8",
+      "value": 56312
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56313;",
+      "decimal_missing_semicolon": "&#56313",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBF9;",
+      "hex_missing_semicolon": "&#XDBF9",
+      "value": 56313
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56314;",
+      "decimal_missing_semicolon": "&#56314",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBFA;",
+      "hex_missing_semicolon": "&#XDBFA",
+      "value": 56314
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56315;",
+      "decimal_missing_semicolon": "&#56315",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBFB;",
+      "hex_missing_semicolon": "&#XDBFB",
+      "value": 56315
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56316;",
+      "decimal_missing_semicolon": "&#56316",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBFC;",
+      "hex_missing_semicolon": "&#XDBFC",
+      "value": 56316
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56317;",
+      "decimal_missing_semicolon": "&#56317",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBFD;",
+      "hex_missing_semicolon": "&#XDBFD",
+      "value": 56317
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56318;",
+      "decimal_missing_semicolon": "&#56318",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBFE;",
+      "hex_missing_semicolon": "&#XDBFE",
+      "value": 56318
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56319;",
+      "decimal_missing_semicolon": "&#56319",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDBFF;",
+      "hex_missing_semicolon": "&#XDBFF",
+      "value": 56319
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56320;",
+      "decimal_missing_semicolon": "&#56320",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC00;",
+      "hex_missing_semicolon": "&#XDC00",
+      "value": 56320
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56321;",
+      "decimal_missing_semicolon": "&#56321",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC01;",
+      "hex_missing_semicolon": "&#XDC01",
+      "value": 56321
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56322;",
+      "decimal_missing_semicolon": "&#56322",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC02;",
+      "hex_missing_semicolon": "&#XDC02",
+      "value": 56322
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56323;",
+      "decimal_missing_semicolon": "&#56323",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC03;",
+      "hex_missing_semicolon": "&#XDC03",
+      "value": 56323
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56324;",
+      "decimal_missing_semicolon": "&#56324",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC04;",
+      "hex_missing_semicolon": "&#XDC04",
+      "value": 56324
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56325;",
+      "decimal_missing_semicolon": "&#56325",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC05;",
+      "hex_missing_semicolon": "&#XDC05",
+      "value": 56325
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56326;",
+      "decimal_missing_semicolon": "&#56326",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC06;",
+      "hex_missing_semicolon": "&#XDC06",
+      "value": 56326
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56327;",
+      "decimal_missing_semicolon": "&#56327",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC07;",
+      "hex_missing_semicolon": "&#XDC07",
+      "value": 56327
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56328;",
+      "decimal_missing_semicolon": "&#56328",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC08;",
+      "hex_missing_semicolon": "&#XDC08",
+      "value": 56328
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56329;",
+      "decimal_missing_semicolon": "&#56329",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC09;",
+      "hex_missing_semicolon": "&#XDC09",
+      "value": 56329
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56330;",
+      "decimal_missing_semicolon": "&#56330",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC0A;",
+      "hex_missing_semicolon": "&#XDC0A",
+      "value": 56330
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56331;",
+      "decimal_missing_semicolon": "&#56331",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC0B;",
+      "hex_missing_semicolon": "&#XDC0B",
+      "value": 56331
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56332;",
+      "decimal_missing_semicolon": "&#56332",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC0C;",
+      "hex_missing_semicolon": "&#XDC0C",
+      "value": 56332
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56333;",
+      "decimal_missing_semicolon": "&#56333",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC0D;",
+      "hex_missing_semicolon": "&#XDC0D",
+      "value": 56333
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56334;",
+      "decimal_missing_semicolon": "&#56334",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC0E;",
+      "hex_missing_semicolon": "&#XDC0E",
+      "value": 56334
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56335;",
+      "decimal_missing_semicolon": "&#56335",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC0F;",
+      "hex_missing_semicolon": "&#XDC0F",
+      "value": 56335
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56336;",
+      "decimal_missing_semicolon": "&#56336",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC10;",
+      "hex_missing_semicolon": "&#XDC10",
+      "value": 56336
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56337;",
+      "decimal_missing_semicolon": "&#56337",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC11;",
+      "hex_missing_semicolon": "&#XDC11",
+      "value": 56337
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56338;",
+      "decimal_missing_semicolon": "&#56338",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC12;",
+      "hex_missing_semicolon": "&#XDC12",
+      "value": 56338
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56339;",
+      "decimal_missing_semicolon": "&#56339",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC13;",
+      "hex_missing_semicolon": "&#XDC13",
+      "value": 56339
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56340;",
+      "decimal_missing_semicolon": "&#56340",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC14;",
+      "hex_missing_semicolon": "&#XDC14",
+      "value": 56340
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56341;",
+      "decimal_missing_semicolon": "&#56341",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC15;",
+      "hex_missing_semicolon": "&#XDC15",
+      "value": 56341
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56342;",
+      "decimal_missing_semicolon": "&#56342",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC16;",
+      "hex_missing_semicolon": "&#XDC16",
+      "value": 56342
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56343;",
+      "decimal_missing_semicolon": "&#56343",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC17;",
+      "hex_missing_semicolon": "&#XDC17",
+      "value": 56343
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56344;",
+      "decimal_missing_semicolon": "&#56344",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC18;",
+      "hex_missing_semicolon": "&#XDC18",
+      "value": 56344
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56345;",
+      "decimal_missing_semicolon": "&#56345",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC19;",
+      "hex_missing_semicolon": "&#XDC19",
+      "value": 56345
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56346;",
+      "decimal_missing_semicolon": "&#56346",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC1A;",
+      "hex_missing_semicolon": "&#XDC1A",
+      "value": 56346
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56347;",
+      "decimal_missing_semicolon": "&#56347",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC1B;",
+      "hex_missing_semicolon": "&#XDC1B",
+      "value": 56347
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56348;",
+      "decimal_missing_semicolon": "&#56348",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC1C;",
+      "hex_missing_semicolon": "&#XDC1C",
+      "value": 56348
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56349;",
+      "decimal_missing_semicolon": "&#56349",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC1D;",
+      "hex_missing_semicolon": "&#XDC1D",
+      "value": 56349
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56350;",
+      "decimal_missing_semicolon": "&#56350",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC1E;",
+      "hex_missing_semicolon": "&#XDC1E",
+      "value": 56350
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56351;",
+      "decimal_missing_semicolon": "&#56351",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC1F;",
+      "hex_missing_semicolon": "&#XDC1F",
+      "value": 56351
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56352;",
+      "decimal_missing_semicolon": "&#56352",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC20;",
+      "hex_missing_semicolon": "&#XDC20",
+      "value": 56352
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56353;",
+      "decimal_missing_semicolon": "&#56353",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC21;",
+      "hex_missing_semicolon": "&#XDC21",
+      "value": 56353
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56354;",
+      "decimal_missing_semicolon": "&#56354",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC22;",
+      "hex_missing_semicolon": "&#XDC22",
+      "value": 56354
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56355;",
+      "decimal_missing_semicolon": "&#56355",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC23;",
+      "hex_missing_semicolon": "&#XDC23",
+      "value": 56355
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56356;",
+      "decimal_missing_semicolon": "&#56356",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC24;",
+      "hex_missing_semicolon": "&#XDC24",
+      "value": 56356
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56357;",
+      "decimal_missing_semicolon": "&#56357",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC25;",
+      "hex_missing_semicolon": "&#XDC25",
+      "value": 56357
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56358;",
+      "decimal_missing_semicolon": "&#56358",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC26;",
+      "hex_missing_semicolon": "&#XDC26",
+      "value": 56358
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56359;",
+      "decimal_missing_semicolon": "&#56359",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC27;",
+      "hex_missing_semicolon": "&#XDC27",
+      "value": 56359
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56360;",
+      "decimal_missing_semicolon": "&#56360",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC28;",
+      "hex_missing_semicolon": "&#XDC28",
+      "value": 56360
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56361;",
+      "decimal_missing_semicolon": "&#56361",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC29;",
+      "hex_missing_semicolon": "&#XDC29",
+      "value": 56361
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56362;",
+      "decimal_missing_semicolon": "&#56362",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC2A;",
+      "hex_missing_semicolon": "&#XDC2A",
+      "value": 56362
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56363;",
+      "decimal_missing_semicolon": "&#56363",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC2B;",
+      "hex_missing_semicolon": "&#XDC2B",
+      "value": 56363
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56364;",
+      "decimal_missing_semicolon": "&#56364",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC2C;",
+      "hex_missing_semicolon": "&#XDC2C",
+      "value": 56364
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56365;",
+      "decimal_missing_semicolon": "&#56365",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC2D;",
+      "hex_missing_semicolon": "&#XDC2D",
+      "value": 56365
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56366;",
+      "decimal_missing_semicolon": "&#56366",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC2E;",
+      "hex_missing_semicolon": "&#XDC2E",
+      "value": 56366
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56367;",
+      "decimal_missing_semicolon": "&#56367",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC2F;",
+      "hex_missing_semicolon": "&#XDC2F",
+      "value": 56367
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56368;",
+      "decimal_missing_semicolon": "&#56368",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC30;",
+      "hex_missing_semicolon": "&#XDC30",
+      "value": 56368
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56369;",
+      "decimal_missing_semicolon": "&#56369",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC31;",
+      "hex_missing_semicolon": "&#XDC31",
+      "value": 56369
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56370;",
+      "decimal_missing_semicolon": "&#56370",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC32;",
+      "hex_missing_semicolon": "&#XDC32",
+      "value": 56370
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56371;",
+      "decimal_missing_semicolon": "&#56371",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC33;",
+      "hex_missing_semicolon": "&#XDC33",
+      "value": 56371
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56372;",
+      "decimal_missing_semicolon": "&#56372",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC34;",
+      "hex_missing_semicolon": "&#XDC34",
+      "value": 56372
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56373;",
+      "decimal_missing_semicolon": "&#56373",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC35;",
+      "hex_missing_semicolon": "&#XDC35",
+      "value": 56373
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56374;",
+      "decimal_missing_semicolon": "&#56374",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC36;",
+      "hex_missing_semicolon": "&#XDC36",
+      "value": 56374
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56375;",
+      "decimal_missing_semicolon": "&#56375",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC37;",
+      "hex_missing_semicolon": "&#XDC37",
+      "value": 56375
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56376;",
+      "decimal_missing_semicolon": "&#56376",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC38;",
+      "hex_missing_semicolon": "&#XDC38",
+      "value": 56376
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56377;",
+      "decimal_missing_semicolon": "&#56377",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC39;",
+      "hex_missing_semicolon": "&#XDC39",
+      "value": 56377
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56378;",
+      "decimal_missing_semicolon": "&#56378",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC3A;",
+      "hex_missing_semicolon": "&#XDC3A",
+      "value": 56378
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56379;",
+      "decimal_missing_semicolon": "&#56379",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC3B;",
+      "hex_missing_semicolon": "&#XDC3B",
+      "value": 56379
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56380;",
+      "decimal_missing_semicolon": "&#56380",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC3C;",
+      "hex_missing_semicolon": "&#XDC3C",
+      "value": 56380
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56381;",
+      "decimal_missing_semicolon": "&#56381",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC3D;",
+      "hex_missing_semicolon": "&#XDC3D",
+      "value": 56381
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56382;",
+      "decimal_missing_semicolon": "&#56382",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC3E;",
+      "hex_missing_semicolon": "&#XDC3E",
+      "value": 56382
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56383;",
+      "decimal_missing_semicolon": "&#56383",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC3F;",
+      "hex_missing_semicolon": "&#XDC3F",
+      "value": 56383
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56384;",
+      "decimal_missing_semicolon": "&#56384",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC40;",
+      "hex_missing_semicolon": "&#XDC40",
+      "value": 56384
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56385;",
+      "decimal_missing_semicolon": "&#56385",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC41;",
+      "hex_missing_semicolon": "&#XDC41",
+      "value": 56385
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56386;",
+      "decimal_missing_semicolon": "&#56386",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC42;",
+      "hex_missing_semicolon": "&#XDC42",
+      "value": 56386
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56387;",
+      "decimal_missing_semicolon": "&#56387",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC43;",
+      "hex_missing_semicolon": "&#XDC43",
+      "value": 56387
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56388;",
+      "decimal_missing_semicolon": "&#56388",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC44;",
+      "hex_missing_semicolon": "&#XDC44",
+      "value": 56388
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56389;",
+      "decimal_missing_semicolon": "&#56389",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC45;",
+      "hex_missing_semicolon": "&#XDC45",
+      "value": 56389
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56390;",
+      "decimal_missing_semicolon": "&#56390",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC46;",
+      "hex_missing_semicolon": "&#XDC46",
+      "value": 56390
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56391;",
+      "decimal_missing_semicolon": "&#56391",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC47;",
+      "hex_missing_semicolon": "&#XDC47",
+      "value": 56391
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56392;",
+      "decimal_missing_semicolon": "&#56392",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC48;",
+      "hex_missing_semicolon": "&#XDC48",
+      "value": 56392
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56393;",
+      "decimal_missing_semicolon": "&#56393",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC49;",
+      "hex_missing_semicolon": "&#XDC49",
+      "value": 56393
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56394;",
+      "decimal_missing_semicolon": "&#56394",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC4A;",
+      "hex_missing_semicolon": "&#XDC4A",
+      "value": 56394
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56395;",
+      "decimal_missing_semicolon": "&#56395",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC4B;",
+      "hex_missing_semicolon": "&#XDC4B",
+      "value": 56395
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56396;",
+      "decimal_missing_semicolon": "&#56396",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC4C;",
+      "hex_missing_semicolon": "&#XDC4C",
+      "value": 56396
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56397;",
+      "decimal_missing_semicolon": "&#56397",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC4D;",
+      "hex_missing_semicolon": "&#XDC4D",
+      "value": 56397
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56398;",
+      "decimal_missing_semicolon": "&#56398",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC4E;",
+      "hex_missing_semicolon": "&#XDC4E",
+      "value": 56398
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56399;",
+      "decimal_missing_semicolon": "&#56399",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC4F;",
+      "hex_missing_semicolon": "&#XDC4F",
+      "value": 56399
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56400;",
+      "decimal_missing_semicolon": "&#56400",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC50;",
+      "hex_missing_semicolon": "&#XDC50",
+      "value": 56400
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56401;",
+      "decimal_missing_semicolon": "&#56401",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC51;",
+      "hex_missing_semicolon": "&#XDC51",
+      "value": 56401
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56402;",
+      "decimal_missing_semicolon": "&#56402",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC52;",
+      "hex_missing_semicolon": "&#XDC52",
+      "value": 56402
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56403;",
+      "decimal_missing_semicolon": "&#56403",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC53;",
+      "hex_missing_semicolon": "&#XDC53",
+      "value": 56403
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56404;",
+      "decimal_missing_semicolon": "&#56404",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC54;",
+      "hex_missing_semicolon": "&#XDC54",
+      "value": 56404
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56405;",
+      "decimal_missing_semicolon": "&#56405",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC55;",
+      "hex_missing_semicolon": "&#XDC55",
+      "value": 56405
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56406;",
+      "decimal_missing_semicolon": "&#56406",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC56;",
+      "hex_missing_semicolon": "&#XDC56",
+      "value": 56406
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56407;",
+      "decimal_missing_semicolon": "&#56407",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC57;",
+      "hex_missing_semicolon": "&#XDC57",
+      "value": 56407
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56408;",
+      "decimal_missing_semicolon": "&#56408",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC58;",
+      "hex_missing_semicolon": "&#XDC58",
+      "value": 56408
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56409;",
+      "decimal_missing_semicolon": "&#56409",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC59;",
+      "hex_missing_semicolon": "&#XDC59",
+      "value": 56409
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56410;",
+      "decimal_missing_semicolon": "&#56410",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC5A;",
+      "hex_missing_semicolon": "&#XDC5A",
+      "value": 56410
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56411;",
+      "decimal_missing_semicolon": "&#56411",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC5B;",
+      "hex_missing_semicolon": "&#XDC5B",
+      "value": 56411
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56412;",
+      "decimal_missing_semicolon": "&#56412",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC5C;",
+      "hex_missing_semicolon": "&#XDC5C",
+      "value": 56412
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56413;",
+      "decimal_missing_semicolon": "&#56413",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC5D;",
+      "hex_missing_semicolon": "&#XDC5D",
+      "value": 56413
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56414;",
+      "decimal_missing_semicolon": "&#56414",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC5E;",
+      "hex_missing_semicolon": "&#XDC5E",
+      "value": 56414
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56415;",
+      "decimal_missing_semicolon": "&#56415",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC5F;",
+      "hex_missing_semicolon": "&#XDC5F",
+      "value": 56415
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56416;",
+      "decimal_missing_semicolon": "&#56416",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC60;",
+      "hex_missing_semicolon": "&#XDC60",
+      "value": 56416
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56417;",
+      "decimal_missing_semicolon": "&#56417",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC61;",
+      "hex_missing_semicolon": "&#XDC61",
+      "value": 56417
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56418;",
+      "decimal_missing_semicolon": "&#56418",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC62;",
+      "hex_missing_semicolon": "&#XDC62",
+      "value": 56418
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56419;",
+      "decimal_missing_semicolon": "&#56419",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC63;",
+      "hex_missing_semicolon": "&#XDC63",
+      "value": 56419
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56420;",
+      "decimal_missing_semicolon": "&#56420",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC64;",
+      "hex_missing_semicolon": "&#XDC64",
+      "value": 56420
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56421;",
+      "decimal_missing_semicolon": "&#56421",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC65;",
+      "hex_missing_semicolon": "&#XDC65",
+      "value": 56421
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56422;",
+      "decimal_missing_semicolon": "&#56422",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC66;",
+      "hex_missing_semicolon": "&#XDC66",
+      "value": 56422
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56423;",
+      "decimal_missing_semicolon": "&#56423",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC67;",
+      "hex_missing_semicolon": "&#XDC67",
+      "value": 56423
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56424;",
+      "decimal_missing_semicolon": "&#56424",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC68;",
+      "hex_missing_semicolon": "&#XDC68",
+      "value": 56424
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56425;",
+      "decimal_missing_semicolon": "&#56425",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC69;",
+      "hex_missing_semicolon": "&#XDC69",
+      "value": 56425
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56426;",
+      "decimal_missing_semicolon": "&#56426",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC6A;",
+      "hex_missing_semicolon": "&#XDC6A",
+      "value": 56426
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56427;",
+      "decimal_missing_semicolon": "&#56427",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC6B;",
+      "hex_missing_semicolon": "&#XDC6B",
+      "value": 56427
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56428;",
+      "decimal_missing_semicolon": "&#56428",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC6C;",
+      "hex_missing_semicolon": "&#XDC6C",
+      "value": 56428
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56429;",
+      "decimal_missing_semicolon": "&#56429",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC6D;",
+      "hex_missing_semicolon": "&#XDC6D",
+      "value": 56429
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56430;",
+      "decimal_missing_semicolon": "&#56430",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC6E;",
+      "hex_missing_semicolon": "&#XDC6E",
+      "value": 56430
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56431;",
+      "decimal_missing_semicolon": "&#56431",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC6F;",
+      "hex_missing_semicolon": "&#XDC6F",
+      "value": 56431
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56432;",
+      "decimal_missing_semicolon": "&#56432",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC70;",
+      "hex_missing_semicolon": "&#XDC70",
+      "value": 56432
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56433;",
+      "decimal_missing_semicolon": "&#56433",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC71;",
+      "hex_missing_semicolon": "&#XDC71",
+      "value": 56433
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56434;",
+      "decimal_missing_semicolon": "&#56434",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC72;",
+      "hex_missing_semicolon": "&#XDC72",
+      "value": 56434
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56435;",
+      "decimal_missing_semicolon": "&#56435",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC73;",
+      "hex_missing_semicolon": "&#XDC73",
+      "value": 56435
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56436;",
+      "decimal_missing_semicolon": "&#56436",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC74;",
+      "hex_missing_semicolon": "&#XDC74",
+      "value": 56436
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56437;",
+      "decimal_missing_semicolon": "&#56437",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC75;",
+      "hex_missing_semicolon": "&#XDC75",
+      "value": 56437
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56438;",
+      "decimal_missing_semicolon": "&#56438",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC76;",
+      "hex_missing_semicolon": "&#XDC76",
+      "value": 56438
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56439;",
+      "decimal_missing_semicolon": "&#56439",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC77;",
+      "hex_missing_semicolon": "&#XDC77",
+      "value": 56439
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56440;",
+      "decimal_missing_semicolon": "&#56440",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC78;",
+      "hex_missing_semicolon": "&#XDC78",
+      "value": 56440
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56441;",
+      "decimal_missing_semicolon": "&#56441",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC79;",
+      "hex_missing_semicolon": "&#XDC79",
+      "value": 56441
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56442;",
+      "decimal_missing_semicolon": "&#56442",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC7A;",
+      "hex_missing_semicolon": "&#XDC7A",
+      "value": 56442
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56443;",
+      "decimal_missing_semicolon": "&#56443",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC7B;",
+      "hex_missing_semicolon": "&#XDC7B",
+      "value": 56443
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56444;",
+      "decimal_missing_semicolon": "&#56444",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC7C;",
+      "hex_missing_semicolon": "&#XDC7C",
+      "value": 56444
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56445;",
+      "decimal_missing_semicolon": "&#56445",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC7D;",
+      "hex_missing_semicolon": "&#XDC7D",
+      "value": 56445
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56446;",
+      "decimal_missing_semicolon": "&#56446",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC7E;",
+      "hex_missing_semicolon": "&#XDC7E",
+      "value": 56446
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56447;",
+      "decimal_missing_semicolon": "&#56447",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC7F;",
+      "hex_missing_semicolon": "&#XDC7F",
+      "value": 56447
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56448;",
+      "decimal_missing_semicolon": "&#56448",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC80;",
+      "hex_missing_semicolon": "&#XDC80",
+      "value": 56448
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56449;",
+      "decimal_missing_semicolon": "&#56449",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC81;",
+      "hex_missing_semicolon": "&#XDC81",
+      "value": 56449
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56450;",
+      "decimal_missing_semicolon": "&#56450",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC82;",
+      "hex_missing_semicolon": "&#XDC82",
+      "value": 56450
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56451;",
+      "decimal_missing_semicolon": "&#56451",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC83;",
+      "hex_missing_semicolon": "&#XDC83",
+      "value": 56451
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56452;",
+      "decimal_missing_semicolon": "&#56452",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC84;",
+      "hex_missing_semicolon": "&#XDC84",
+      "value": 56452
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56453;",
+      "decimal_missing_semicolon": "&#56453",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC85;",
+      "hex_missing_semicolon": "&#XDC85",
+      "value": 56453
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56454;",
+      "decimal_missing_semicolon": "&#56454",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC86;",
+      "hex_missing_semicolon": "&#XDC86",
+      "value": 56454
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56455;",
+      "decimal_missing_semicolon": "&#56455",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC87;",
+      "hex_missing_semicolon": "&#XDC87",
+      "value": 56455
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56456;",
+      "decimal_missing_semicolon": "&#56456",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC88;",
+      "hex_missing_semicolon": "&#XDC88",
+      "value": 56456
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56457;",
+      "decimal_missing_semicolon": "&#56457",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC89;",
+      "hex_missing_semicolon": "&#XDC89",
+      "value": 56457
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56458;",
+      "decimal_missing_semicolon": "&#56458",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC8A;",
+      "hex_missing_semicolon": "&#XDC8A",
+      "value": 56458
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56459;",
+      "decimal_missing_semicolon": "&#56459",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC8B;",
+      "hex_missing_semicolon": "&#XDC8B",
+      "value": 56459
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56460;",
+      "decimal_missing_semicolon": "&#56460",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC8C;",
+      "hex_missing_semicolon": "&#XDC8C",
+      "value": 56460
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56461;",
+      "decimal_missing_semicolon": "&#56461",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC8D;",
+      "hex_missing_semicolon": "&#XDC8D",
+      "value": 56461
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56462;",
+      "decimal_missing_semicolon": "&#56462",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC8E;",
+      "hex_missing_semicolon": "&#XDC8E",
+      "value": 56462
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56463;",
+      "decimal_missing_semicolon": "&#56463",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC8F;",
+      "hex_missing_semicolon": "&#XDC8F",
+      "value": 56463
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56464;",
+      "decimal_missing_semicolon": "&#56464",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC90;",
+      "hex_missing_semicolon": "&#XDC90",
+      "value": 56464
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56465;",
+      "decimal_missing_semicolon": "&#56465",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC91;",
+      "hex_missing_semicolon": "&#XDC91",
+      "value": 56465
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56466;",
+      "decimal_missing_semicolon": "&#56466",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC92;",
+      "hex_missing_semicolon": "&#XDC92",
+      "value": 56466
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56467;",
+      "decimal_missing_semicolon": "&#56467",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC93;",
+      "hex_missing_semicolon": "&#XDC93",
+      "value": 56467
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56468;",
+      "decimal_missing_semicolon": "&#56468",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC94;",
+      "hex_missing_semicolon": "&#XDC94",
+      "value": 56468
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56469;",
+      "decimal_missing_semicolon": "&#56469",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC95;",
+      "hex_missing_semicolon": "&#XDC95",
+      "value": 56469
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56470;",
+      "decimal_missing_semicolon": "&#56470",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC96;",
+      "hex_missing_semicolon": "&#XDC96",
+      "value": 56470
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56471;",
+      "decimal_missing_semicolon": "&#56471",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC97;",
+      "hex_missing_semicolon": "&#XDC97",
+      "value": 56471
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56472;",
+      "decimal_missing_semicolon": "&#56472",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC98;",
+      "hex_missing_semicolon": "&#XDC98",
+      "value": 56472
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56473;",
+      "decimal_missing_semicolon": "&#56473",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC99;",
+      "hex_missing_semicolon": "&#XDC99",
+      "value": 56473
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56474;",
+      "decimal_missing_semicolon": "&#56474",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC9A;",
+      "hex_missing_semicolon": "&#XDC9A",
+      "value": 56474
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56475;",
+      "decimal_missing_semicolon": "&#56475",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC9B;",
+      "hex_missing_semicolon": "&#XDC9B",
+      "value": 56475
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56476;",
+      "decimal_missing_semicolon": "&#56476",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC9C;",
+      "hex_missing_semicolon": "&#XDC9C",
+      "value": 56476
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56477;",
+      "decimal_missing_semicolon": "&#56477",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC9D;",
+      "hex_missing_semicolon": "&#XDC9D",
+      "value": 56477
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56478;",
+      "decimal_missing_semicolon": "&#56478",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC9E;",
+      "hex_missing_semicolon": "&#XDC9E",
+      "value": 56478
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56479;",
+      "decimal_missing_semicolon": "&#56479",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDC9F;",
+      "hex_missing_semicolon": "&#XDC9F",
+      "value": 56479
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56480;",
+      "decimal_missing_semicolon": "&#56480",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA0;",
+      "hex_missing_semicolon": "&#XDCA0",
+      "value": 56480
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56481;",
+      "decimal_missing_semicolon": "&#56481",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA1;",
+      "hex_missing_semicolon": "&#XDCA1",
+      "value": 56481
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56482;",
+      "decimal_missing_semicolon": "&#56482",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA2;",
+      "hex_missing_semicolon": "&#XDCA2",
+      "value": 56482
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56483;",
+      "decimal_missing_semicolon": "&#56483",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA3;",
+      "hex_missing_semicolon": "&#XDCA3",
+      "value": 56483
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56484;",
+      "decimal_missing_semicolon": "&#56484",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA4;",
+      "hex_missing_semicolon": "&#XDCA4",
+      "value": 56484
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56485;",
+      "decimal_missing_semicolon": "&#56485",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA5;",
+      "hex_missing_semicolon": "&#XDCA5",
+      "value": 56485
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56486;",
+      "decimal_missing_semicolon": "&#56486",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA6;",
+      "hex_missing_semicolon": "&#XDCA6",
+      "value": 56486
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56487;",
+      "decimal_missing_semicolon": "&#56487",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA7;",
+      "hex_missing_semicolon": "&#XDCA7",
+      "value": 56487
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56488;",
+      "decimal_missing_semicolon": "&#56488",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA8;",
+      "hex_missing_semicolon": "&#XDCA8",
+      "value": 56488
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56489;",
+      "decimal_missing_semicolon": "&#56489",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCA9;",
+      "hex_missing_semicolon": "&#XDCA9",
+      "value": 56489
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56490;",
+      "decimal_missing_semicolon": "&#56490",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCAA;",
+      "hex_missing_semicolon": "&#XDCAA",
+      "value": 56490
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56491;",
+      "decimal_missing_semicolon": "&#56491",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCAB;",
+      "hex_missing_semicolon": "&#XDCAB",
+      "value": 56491
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56492;",
+      "decimal_missing_semicolon": "&#56492",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCAC;",
+      "hex_missing_semicolon": "&#XDCAC",
+      "value": 56492
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56493;",
+      "decimal_missing_semicolon": "&#56493",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCAD;",
+      "hex_missing_semicolon": "&#XDCAD",
+      "value": 56493
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56494;",
+      "decimal_missing_semicolon": "&#56494",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCAE;",
+      "hex_missing_semicolon": "&#XDCAE",
+      "value": 56494
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56495;",
+      "decimal_missing_semicolon": "&#56495",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCAF;",
+      "hex_missing_semicolon": "&#XDCAF",
+      "value": 56495
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56496;",
+      "decimal_missing_semicolon": "&#56496",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB0;",
+      "hex_missing_semicolon": "&#XDCB0",
+      "value": 56496
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56497;",
+      "decimal_missing_semicolon": "&#56497",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB1;",
+      "hex_missing_semicolon": "&#XDCB1",
+      "value": 56497
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56498;",
+      "decimal_missing_semicolon": "&#56498",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB2;",
+      "hex_missing_semicolon": "&#XDCB2",
+      "value": 56498
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56499;",
+      "decimal_missing_semicolon": "&#56499",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB3;",
+      "hex_missing_semicolon": "&#XDCB3",
+      "value": 56499
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56500;",
+      "decimal_missing_semicolon": "&#56500",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB4;",
+      "hex_missing_semicolon": "&#XDCB4",
+      "value": 56500
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56501;",
+      "decimal_missing_semicolon": "&#56501",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB5;",
+      "hex_missing_semicolon": "&#XDCB5",
+      "value": 56501
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56502;",
+      "decimal_missing_semicolon": "&#56502",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB6;",
+      "hex_missing_semicolon": "&#XDCB6",
+      "value": 56502
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56503;",
+      "decimal_missing_semicolon": "&#56503",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB7;",
+      "hex_missing_semicolon": "&#XDCB7",
+      "value": 56503
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56504;",
+      "decimal_missing_semicolon": "&#56504",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB8;",
+      "hex_missing_semicolon": "&#XDCB8",
+      "value": 56504
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56505;",
+      "decimal_missing_semicolon": "&#56505",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCB9;",
+      "hex_missing_semicolon": "&#XDCB9",
+      "value": 56505
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56506;",
+      "decimal_missing_semicolon": "&#56506",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCBA;",
+      "hex_missing_semicolon": "&#XDCBA",
+      "value": 56506
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56507;",
+      "decimal_missing_semicolon": "&#56507",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCBB;",
+      "hex_missing_semicolon": "&#XDCBB",
+      "value": 56507
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56508;",
+      "decimal_missing_semicolon": "&#56508",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCBC;",
+      "hex_missing_semicolon": "&#XDCBC",
+      "value": 56508
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56509;",
+      "decimal_missing_semicolon": "&#56509",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCBD;",
+      "hex_missing_semicolon": "&#XDCBD",
+      "value": 56509
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56510;",
+      "decimal_missing_semicolon": "&#56510",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCBE;",
+      "hex_missing_semicolon": "&#XDCBE",
+      "value": 56510
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56511;",
+      "decimal_missing_semicolon": "&#56511",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCBF;",
+      "hex_missing_semicolon": "&#XDCBF",
+      "value": 56511
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56512;",
+      "decimal_missing_semicolon": "&#56512",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC0;",
+      "hex_missing_semicolon": "&#XDCC0",
+      "value": 56512
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56513;",
+      "decimal_missing_semicolon": "&#56513",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC1;",
+      "hex_missing_semicolon": "&#XDCC1",
+      "value": 56513
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56514;",
+      "decimal_missing_semicolon": "&#56514",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC2;",
+      "hex_missing_semicolon": "&#XDCC2",
+      "value": 56514
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56515;",
+      "decimal_missing_semicolon": "&#56515",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC3;",
+      "hex_missing_semicolon": "&#XDCC3",
+      "value": 56515
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56516;",
+      "decimal_missing_semicolon": "&#56516",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC4;",
+      "hex_missing_semicolon": "&#XDCC4",
+      "value": 56516
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56517;",
+      "decimal_missing_semicolon": "&#56517",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC5;",
+      "hex_missing_semicolon": "&#XDCC5",
+      "value": 56517
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56518;",
+      "decimal_missing_semicolon": "&#56518",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC6;",
+      "hex_missing_semicolon": "&#XDCC6",
+      "value": 56518
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56519;",
+      "decimal_missing_semicolon": "&#56519",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC7;",
+      "hex_missing_semicolon": "&#XDCC7",
+      "value": 56519
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56520;",
+      "decimal_missing_semicolon": "&#56520",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC8;",
+      "hex_missing_semicolon": "&#XDCC8",
+      "value": 56520
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56521;",
+      "decimal_missing_semicolon": "&#56521",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCC9;",
+      "hex_missing_semicolon": "&#XDCC9",
+      "value": 56521
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56522;",
+      "decimal_missing_semicolon": "&#56522",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCCA;",
+      "hex_missing_semicolon": "&#XDCCA",
+      "value": 56522
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56523;",
+      "decimal_missing_semicolon": "&#56523",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCCB;",
+      "hex_missing_semicolon": "&#XDCCB",
+      "value": 56523
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56524;",
+      "decimal_missing_semicolon": "&#56524",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCCC;",
+      "hex_missing_semicolon": "&#XDCCC",
+      "value": 56524
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56525;",
+      "decimal_missing_semicolon": "&#56525",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCCD;",
+      "hex_missing_semicolon": "&#XDCCD",
+      "value": 56525
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56526;",
+      "decimal_missing_semicolon": "&#56526",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCCE;",
+      "hex_missing_semicolon": "&#XDCCE",
+      "value": 56526
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56527;",
+      "decimal_missing_semicolon": "&#56527",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCCF;",
+      "hex_missing_semicolon": "&#XDCCF",
+      "value": 56527
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56528;",
+      "decimal_missing_semicolon": "&#56528",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD0;",
+      "hex_missing_semicolon": "&#XDCD0",
+      "value": 56528
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56529;",
+      "decimal_missing_semicolon": "&#56529",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD1;",
+      "hex_missing_semicolon": "&#XDCD1",
+      "value": 56529
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56530;",
+      "decimal_missing_semicolon": "&#56530",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD2;",
+      "hex_missing_semicolon": "&#XDCD2",
+      "value": 56530
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56531;",
+      "decimal_missing_semicolon": "&#56531",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD3;",
+      "hex_missing_semicolon": "&#XDCD3",
+      "value": 56531
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56532;",
+      "decimal_missing_semicolon": "&#56532",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD4;",
+      "hex_missing_semicolon": "&#XDCD4",
+      "value": 56532
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56533;",
+      "decimal_missing_semicolon": "&#56533",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD5;",
+      "hex_missing_semicolon": "&#XDCD5",
+      "value": 56533
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56534;",
+      "decimal_missing_semicolon": "&#56534",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD6;",
+      "hex_missing_semicolon": "&#XDCD6",
+      "value": 56534
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56535;",
+      "decimal_missing_semicolon": "&#56535",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD7;",
+      "hex_missing_semicolon": "&#XDCD7",
+      "value": 56535
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56536;",
+      "decimal_missing_semicolon": "&#56536",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD8;",
+      "hex_missing_semicolon": "&#XDCD8",
+      "value": 56536
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56537;",
+      "decimal_missing_semicolon": "&#56537",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCD9;",
+      "hex_missing_semicolon": "&#XDCD9",
+      "value": 56537
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56538;",
+      "decimal_missing_semicolon": "&#56538",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCDA;",
+      "hex_missing_semicolon": "&#XDCDA",
+      "value": 56538
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56539;",
+      "decimal_missing_semicolon": "&#56539",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCDB;",
+      "hex_missing_semicolon": "&#XDCDB",
+      "value": 56539
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56540;",
+      "decimal_missing_semicolon": "&#56540",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCDC;",
+      "hex_missing_semicolon": "&#XDCDC",
+      "value": 56540
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56541;",
+      "decimal_missing_semicolon": "&#56541",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCDD;",
+      "hex_missing_semicolon": "&#XDCDD",
+      "value": 56541
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56542;",
+      "decimal_missing_semicolon": "&#56542",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCDE;",
+      "hex_missing_semicolon": "&#XDCDE",
+      "value": 56542
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56543;",
+      "decimal_missing_semicolon": "&#56543",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCDF;",
+      "hex_missing_semicolon": "&#XDCDF",
+      "value": 56543
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56544;",
+      "decimal_missing_semicolon": "&#56544",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE0;",
+      "hex_missing_semicolon": "&#XDCE0",
+      "value": 56544
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56545;",
+      "decimal_missing_semicolon": "&#56545",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE1;",
+      "hex_missing_semicolon": "&#XDCE1",
+      "value": 56545
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56546;",
+      "decimal_missing_semicolon": "&#56546",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE2;",
+      "hex_missing_semicolon": "&#XDCE2",
+      "value": 56546
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56547;",
+      "decimal_missing_semicolon": "&#56547",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE3;",
+      "hex_missing_semicolon": "&#XDCE3",
+      "value": 56547
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56548;",
+      "decimal_missing_semicolon": "&#56548",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE4;",
+      "hex_missing_semicolon": "&#XDCE4",
+      "value": 56548
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56549;",
+      "decimal_missing_semicolon": "&#56549",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE5;",
+      "hex_missing_semicolon": "&#XDCE5",
+      "value": 56549
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56550;",
+      "decimal_missing_semicolon": "&#56550",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE6;",
+      "hex_missing_semicolon": "&#XDCE6",
+      "value": 56550
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56551;",
+      "decimal_missing_semicolon": "&#56551",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE7;",
+      "hex_missing_semicolon": "&#XDCE7",
+      "value": 56551
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56552;",
+      "decimal_missing_semicolon": "&#56552",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE8;",
+      "hex_missing_semicolon": "&#XDCE8",
+      "value": 56552
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56553;",
+      "decimal_missing_semicolon": "&#56553",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCE9;",
+      "hex_missing_semicolon": "&#XDCE9",
+      "value": 56553
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56554;",
+      "decimal_missing_semicolon": "&#56554",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCEA;",
+      "hex_missing_semicolon": "&#XDCEA",
+      "value": 56554
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56555;",
+      "decimal_missing_semicolon": "&#56555",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCEB;",
+      "hex_missing_semicolon": "&#XDCEB",
+      "value": 56555
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56556;",
+      "decimal_missing_semicolon": "&#56556",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCEC;",
+      "hex_missing_semicolon": "&#XDCEC",
+      "value": 56556
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56557;",
+      "decimal_missing_semicolon": "&#56557",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCED;",
+      "hex_missing_semicolon": "&#XDCED",
+      "value": 56557
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56558;",
+      "decimal_missing_semicolon": "&#56558",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCEE;",
+      "hex_missing_semicolon": "&#XDCEE",
+      "value": 56558
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56559;",
+      "decimal_missing_semicolon": "&#56559",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCEF;",
+      "hex_missing_semicolon": "&#XDCEF",
+      "value": 56559
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56560;",
+      "decimal_missing_semicolon": "&#56560",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF0;",
+      "hex_missing_semicolon": "&#XDCF0",
+      "value": 56560
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56561;",
+      "decimal_missing_semicolon": "&#56561",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF1;",
+      "hex_missing_semicolon": "&#XDCF1",
+      "value": 56561
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56562;",
+      "decimal_missing_semicolon": "&#56562",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF2;",
+      "hex_missing_semicolon": "&#XDCF2",
+      "value": 56562
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56563;",
+      "decimal_missing_semicolon": "&#56563",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF3;",
+      "hex_missing_semicolon": "&#XDCF3",
+      "value": 56563
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56564;",
+      "decimal_missing_semicolon": "&#56564",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF4;",
+      "hex_missing_semicolon": "&#XDCF4",
+      "value": 56564
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56565;",
+      "decimal_missing_semicolon": "&#56565",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF5;",
+      "hex_missing_semicolon": "&#XDCF5",
+      "value": 56565
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56566;",
+      "decimal_missing_semicolon": "&#56566",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF6;",
+      "hex_missing_semicolon": "&#XDCF6",
+      "value": 56566
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56567;",
+      "decimal_missing_semicolon": "&#56567",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF7;",
+      "hex_missing_semicolon": "&#XDCF7",
+      "value": 56567
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56568;",
+      "decimal_missing_semicolon": "&#56568",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF8;",
+      "hex_missing_semicolon": "&#XDCF8",
+      "value": 56568
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56569;",
+      "decimal_missing_semicolon": "&#56569",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCF9;",
+      "hex_missing_semicolon": "&#XDCF9",
+      "value": 56569
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56570;",
+      "decimal_missing_semicolon": "&#56570",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCFA;",
+      "hex_missing_semicolon": "&#XDCFA",
+      "value": 56570
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56571;",
+      "decimal_missing_semicolon": "&#56571",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCFB;",
+      "hex_missing_semicolon": "&#XDCFB",
+      "value": 56571
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56572;",
+      "decimal_missing_semicolon": "&#56572",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCFC;",
+      "hex_missing_semicolon": "&#XDCFC",
+      "value": 56572
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56573;",
+      "decimal_missing_semicolon": "&#56573",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCFD;",
+      "hex_missing_semicolon": "&#XDCFD",
+      "value": 56573
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56574;",
+      "decimal_missing_semicolon": "&#56574",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCFE;",
+      "hex_missing_semicolon": "&#XDCFE",
+      "value": 56574
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56575;",
+      "decimal_missing_semicolon": "&#56575",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDCFF;",
+      "hex_missing_semicolon": "&#XDCFF",
+      "value": 56575
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56576;",
+      "decimal_missing_semicolon": "&#56576",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD00;",
+      "hex_missing_semicolon": "&#XDD00",
+      "value": 56576
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56577;",
+      "decimal_missing_semicolon": "&#56577",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD01;",
+      "hex_missing_semicolon": "&#XDD01",
+      "value": 56577
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56578;",
+      "decimal_missing_semicolon": "&#56578",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD02;",
+      "hex_missing_semicolon": "&#XDD02",
+      "value": 56578
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56579;",
+      "decimal_missing_semicolon": "&#56579",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD03;",
+      "hex_missing_semicolon": "&#XDD03",
+      "value": 56579
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56580;",
+      "decimal_missing_semicolon": "&#56580",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD04;",
+      "hex_missing_semicolon": "&#XDD04",
+      "value": 56580
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56581;",
+      "decimal_missing_semicolon": "&#56581",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD05;",
+      "hex_missing_semicolon": "&#XDD05",
+      "value": 56581
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56582;",
+      "decimal_missing_semicolon": "&#56582",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD06;",
+      "hex_missing_semicolon": "&#XDD06",
+      "value": 56582
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56583;",
+      "decimal_missing_semicolon": "&#56583",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD07;",
+      "hex_missing_semicolon": "&#XDD07",
+      "value": 56583
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56584;",
+      "decimal_missing_semicolon": "&#56584",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD08;",
+      "hex_missing_semicolon": "&#XDD08",
+      "value": 56584
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56585;",
+      "decimal_missing_semicolon": "&#56585",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD09;",
+      "hex_missing_semicolon": "&#XDD09",
+      "value": 56585
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56586;",
+      "decimal_missing_semicolon": "&#56586",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD0A;",
+      "hex_missing_semicolon": "&#XDD0A",
+      "value": 56586
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56587;",
+      "decimal_missing_semicolon": "&#56587",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD0B;",
+      "hex_missing_semicolon": "&#XDD0B",
+      "value": 56587
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56588;",
+      "decimal_missing_semicolon": "&#56588",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD0C;",
+      "hex_missing_semicolon": "&#XDD0C",
+      "value": 56588
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56589;",
+      "decimal_missing_semicolon": "&#56589",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD0D;",
+      "hex_missing_semicolon": "&#XDD0D",
+      "value": 56589
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56590;",
+      "decimal_missing_semicolon": "&#56590",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD0E;",
+      "hex_missing_semicolon": "&#XDD0E",
+      "value": 56590
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56591;",
+      "decimal_missing_semicolon": "&#56591",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD0F;",
+      "hex_missing_semicolon": "&#XDD0F",
+      "value": 56591
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56592;",
+      "decimal_missing_semicolon": "&#56592",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD10;",
+      "hex_missing_semicolon": "&#XDD10",
+      "value": 56592
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56593;",
+      "decimal_missing_semicolon": "&#56593",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD11;",
+      "hex_missing_semicolon": "&#XDD11",
+      "value": 56593
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56594;",
+      "decimal_missing_semicolon": "&#56594",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD12;",
+      "hex_missing_semicolon": "&#XDD12",
+      "value": 56594
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56595;",
+      "decimal_missing_semicolon": "&#56595",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD13;",
+      "hex_missing_semicolon": "&#XDD13",
+      "value": 56595
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56596;",
+      "decimal_missing_semicolon": "&#56596",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD14;",
+      "hex_missing_semicolon": "&#XDD14",
+      "value": 56596
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56597;",
+      "decimal_missing_semicolon": "&#56597",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD15;",
+      "hex_missing_semicolon": "&#XDD15",
+      "value": 56597
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56598;",
+      "decimal_missing_semicolon": "&#56598",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD16;",
+      "hex_missing_semicolon": "&#XDD16",
+      "value": 56598
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56599;",
+      "decimal_missing_semicolon": "&#56599",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD17;",
+      "hex_missing_semicolon": "&#XDD17",
+      "value": 56599
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56600;",
+      "decimal_missing_semicolon": "&#56600",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD18;",
+      "hex_missing_semicolon": "&#XDD18",
+      "value": 56600
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56601;",
+      "decimal_missing_semicolon": "&#56601",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD19;",
+      "hex_missing_semicolon": "&#XDD19",
+      "value": 56601
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56602;",
+      "decimal_missing_semicolon": "&#56602",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD1A;",
+      "hex_missing_semicolon": "&#XDD1A",
+      "value": 56602
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56603;",
+      "decimal_missing_semicolon": "&#56603",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD1B;",
+      "hex_missing_semicolon": "&#XDD1B",
+      "value": 56603
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56604;",
+      "decimal_missing_semicolon": "&#56604",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD1C;",
+      "hex_missing_semicolon": "&#XDD1C",
+      "value": 56604
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56605;",
+      "decimal_missing_semicolon": "&#56605",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD1D;",
+      "hex_missing_semicolon": "&#XDD1D",
+      "value": 56605
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56606;",
+      "decimal_missing_semicolon": "&#56606",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD1E;",
+      "hex_missing_semicolon": "&#XDD1E",
+      "value": 56606
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56607;",
+      "decimal_missing_semicolon": "&#56607",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD1F;",
+      "hex_missing_semicolon": "&#XDD1F",
+      "value": 56607
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56608;",
+      "decimal_missing_semicolon": "&#56608",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD20;",
+      "hex_missing_semicolon": "&#XDD20",
+      "value": 56608
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56609;",
+      "decimal_missing_semicolon": "&#56609",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD21;",
+      "hex_missing_semicolon": "&#XDD21",
+      "value": 56609
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56610;",
+      "decimal_missing_semicolon": "&#56610",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD22;",
+      "hex_missing_semicolon": "&#XDD22",
+      "value": 56610
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56611;",
+      "decimal_missing_semicolon": "&#56611",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD23;",
+      "hex_missing_semicolon": "&#XDD23",
+      "value": 56611
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56612;",
+      "decimal_missing_semicolon": "&#56612",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD24;",
+      "hex_missing_semicolon": "&#XDD24",
+      "value": 56612
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56613;",
+      "decimal_missing_semicolon": "&#56613",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD25;",
+      "hex_missing_semicolon": "&#XDD25",
+      "value": 56613
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56614;",
+      "decimal_missing_semicolon": "&#56614",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD26;",
+      "hex_missing_semicolon": "&#XDD26",
+      "value": 56614
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56615;",
+      "decimal_missing_semicolon": "&#56615",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD27;",
+      "hex_missing_semicolon": "&#XDD27",
+      "value": 56615
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56616;",
+      "decimal_missing_semicolon": "&#56616",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD28;",
+      "hex_missing_semicolon": "&#XDD28",
+      "value": 56616
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56617;",
+      "decimal_missing_semicolon": "&#56617",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD29;",
+      "hex_missing_semicolon": "&#XDD29",
+      "value": 56617
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56618;",
+      "decimal_missing_semicolon": "&#56618",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD2A;",
+      "hex_missing_semicolon": "&#XDD2A",
+      "value": 56618
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56619;",
+      "decimal_missing_semicolon": "&#56619",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD2B;",
+      "hex_missing_semicolon": "&#XDD2B",
+      "value": 56619
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56620;",
+      "decimal_missing_semicolon": "&#56620",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD2C;",
+      "hex_missing_semicolon": "&#XDD2C",
+      "value": 56620
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56621;",
+      "decimal_missing_semicolon": "&#56621",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD2D;",
+      "hex_missing_semicolon": "&#XDD2D",
+      "value": 56621
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56622;",
+      "decimal_missing_semicolon": "&#56622",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD2E;",
+      "hex_missing_semicolon": "&#XDD2E",
+      "value": 56622
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56623;",
+      "decimal_missing_semicolon": "&#56623",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD2F;",
+      "hex_missing_semicolon": "&#XDD2F",
+      "value": 56623
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56624;",
+      "decimal_missing_semicolon": "&#56624",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD30;",
+      "hex_missing_semicolon": "&#XDD30",
+      "value": 56624
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56625;",
+      "decimal_missing_semicolon": "&#56625",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD31;",
+      "hex_missing_semicolon": "&#XDD31",
+      "value": 56625
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56626;",
+      "decimal_missing_semicolon": "&#56626",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD32;",
+      "hex_missing_semicolon": "&#XDD32",
+      "value": 56626
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56627;",
+      "decimal_missing_semicolon": "&#56627",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD33;",
+      "hex_missing_semicolon": "&#XDD33",
+      "value": 56627
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56628;",
+      "decimal_missing_semicolon": "&#56628",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD34;",
+      "hex_missing_semicolon": "&#XDD34",
+      "value": 56628
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56629;",
+      "decimal_missing_semicolon": "&#56629",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD35;",
+      "hex_missing_semicolon": "&#XDD35",
+      "value": 56629
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56630;",
+      "decimal_missing_semicolon": "&#56630",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD36;",
+      "hex_missing_semicolon": "&#XDD36",
+      "value": 56630
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56631;",
+      "decimal_missing_semicolon": "&#56631",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD37;",
+      "hex_missing_semicolon": "&#XDD37",
+      "value": 56631
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56632;",
+      "decimal_missing_semicolon": "&#56632",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD38;",
+      "hex_missing_semicolon": "&#XDD38",
+      "value": 56632
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56633;",
+      "decimal_missing_semicolon": "&#56633",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD39;",
+      "hex_missing_semicolon": "&#XDD39",
+      "value": 56633
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56634;",
+      "decimal_missing_semicolon": "&#56634",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD3A;",
+      "hex_missing_semicolon": "&#XDD3A",
+      "value": 56634
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56635;",
+      "decimal_missing_semicolon": "&#56635",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD3B;",
+      "hex_missing_semicolon": "&#XDD3B",
+      "value": 56635
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56636;",
+      "decimal_missing_semicolon": "&#56636",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD3C;",
+      "hex_missing_semicolon": "&#XDD3C",
+      "value": 56636
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56637;",
+      "decimal_missing_semicolon": "&#56637",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD3D;",
+      "hex_missing_semicolon": "&#XDD3D",
+      "value": 56637
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56638;",
+      "decimal_missing_semicolon": "&#56638",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD3E;",
+      "hex_missing_semicolon": "&#XDD3E",
+      "value": 56638
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56639;",
+      "decimal_missing_semicolon": "&#56639",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD3F;",
+      "hex_missing_semicolon": "&#XDD3F",
+      "value": 56639
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56640;",
+      "decimal_missing_semicolon": "&#56640",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD40;",
+      "hex_missing_semicolon": "&#XDD40",
+      "value": 56640
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56641;",
+      "decimal_missing_semicolon": "&#56641",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD41;",
+      "hex_missing_semicolon": "&#XDD41",
+      "value": 56641
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56642;",
+      "decimal_missing_semicolon": "&#56642",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD42;",
+      "hex_missing_semicolon": "&#XDD42",
+      "value": 56642
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56643;",
+      "decimal_missing_semicolon": "&#56643",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD43;",
+      "hex_missing_semicolon": "&#XDD43",
+      "value": 56643
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56644;",
+      "decimal_missing_semicolon": "&#56644",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD44;",
+      "hex_missing_semicolon": "&#XDD44",
+      "value": 56644
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56645;",
+      "decimal_missing_semicolon": "&#56645",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD45;",
+      "hex_missing_semicolon": "&#XDD45",
+      "value": 56645
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56646;",
+      "decimal_missing_semicolon": "&#56646",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD46;",
+      "hex_missing_semicolon": "&#XDD46",
+      "value": 56646
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56647;",
+      "decimal_missing_semicolon": "&#56647",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD47;",
+      "hex_missing_semicolon": "&#XDD47",
+      "value": 56647
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56648;",
+      "decimal_missing_semicolon": "&#56648",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD48;",
+      "hex_missing_semicolon": "&#XDD48",
+      "value": 56648
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56649;",
+      "decimal_missing_semicolon": "&#56649",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD49;",
+      "hex_missing_semicolon": "&#XDD49",
+      "value": 56649
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56650;",
+      "decimal_missing_semicolon": "&#56650",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD4A;",
+      "hex_missing_semicolon": "&#XDD4A",
+      "value": 56650
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56651;",
+      "decimal_missing_semicolon": "&#56651",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD4B;",
+      "hex_missing_semicolon": "&#XDD4B",
+      "value": 56651
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56652;",
+      "decimal_missing_semicolon": "&#56652",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD4C;",
+      "hex_missing_semicolon": "&#XDD4C",
+      "value": 56652
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56653;",
+      "decimal_missing_semicolon": "&#56653",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD4D;",
+      "hex_missing_semicolon": "&#XDD4D",
+      "value": 56653
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56654;",
+      "decimal_missing_semicolon": "&#56654",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD4E;",
+      "hex_missing_semicolon": "&#XDD4E",
+      "value": 56654
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56655;",
+      "decimal_missing_semicolon": "&#56655",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD4F;",
+      "hex_missing_semicolon": "&#XDD4F",
+      "value": 56655
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56656;",
+      "decimal_missing_semicolon": "&#56656",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD50;",
+      "hex_missing_semicolon": "&#XDD50",
+      "value": 56656
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56657;",
+      "decimal_missing_semicolon": "&#56657",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD51;",
+      "hex_missing_semicolon": "&#XDD51",
+      "value": 56657
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56658;",
+      "decimal_missing_semicolon": "&#56658",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD52;",
+      "hex_missing_semicolon": "&#XDD52",
+      "value": 56658
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56659;",
+      "decimal_missing_semicolon": "&#56659",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD53;",
+      "hex_missing_semicolon": "&#XDD53",
+      "value": 56659
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56660;",
+      "decimal_missing_semicolon": "&#56660",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD54;",
+      "hex_missing_semicolon": "&#XDD54",
+      "value": 56660
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56661;",
+      "decimal_missing_semicolon": "&#56661",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD55;",
+      "hex_missing_semicolon": "&#XDD55",
+      "value": 56661
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56662;",
+      "decimal_missing_semicolon": "&#56662",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD56;",
+      "hex_missing_semicolon": "&#XDD56",
+      "value": 56662
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56663;",
+      "decimal_missing_semicolon": "&#56663",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD57;",
+      "hex_missing_semicolon": "&#XDD57",
+      "value": 56663
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56664;",
+      "decimal_missing_semicolon": "&#56664",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD58;",
+      "hex_missing_semicolon": "&#XDD58",
+      "value": 56664
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56665;",
+      "decimal_missing_semicolon": "&#56665",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD59;",
+      "hex_missing_semicolon": "&#XDD59",
+      "value": 56665
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56666;",
+      "decimal_missing_semicolon": "&#56666",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD5A;",
+      "hex_missing_semicolon": "&#XDD5A",
+      "value": 56666
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56667;",
+      "decimal_missing_semicolon": "&#56667",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD5B;",
+      "hex_missing_semicolon": "&#XDD5B",
+      "value": 56667
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56668;",
+      "decimal_missing_semicolon": "&#56668",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD5C;",
+      "hex_missing_semicolon": "&#XDD5C",
+      "value": 56668
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56669;",
+      "decimal_missing_semicolon": "&#56669",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD5D;",
+      "hex_missing_semicolon": "&#XDD5D",
+      "value": 56669
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56670;",
+      "decimal_missing_semicolon": "&#56670",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD5E;",
+      "hex_missing_semicolon": "&#XDD5E",
+      "value": 56670
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56671;",
+      "decimal_missing_semicolon": "&#56671",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD5F;",
+      "hex_missing_semicolon": "&#XDD5F",
+      "value": 56671
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56672;",
+      "decimal_missing_semicolon": "&#56672",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD60;",
+      "hex_missing_semicolon": "&#XDD60",
+      "value": 56672
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56673;",
+      "decimal_missing_semicolon": "&#56673",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD61;",
+      "hex_missing_semicolon": "&#XDD61",
+      "value": 56673
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56674;",
+      "decimal_missing_semicolon": "&#56674",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD62;",
+      "hex_missing_semicolon": "&#XDD62",
+      "value": 56674
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56675;",
+      "decimal_missing_semicolon": "&#56675",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD63;",
+      "hex_missing_semicolon": "&#XDD63",
+      "value": 56675
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56676;",
+      "decimal_missing_semicolon": "&#56676",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD64;",
+      "hex_missing_semicolon": "&#XDD64",
+      "value": 56676
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56677;",
+      "decimal_missing_semicolon": "&#56677",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD65;",
+      "hex_missing_semicolon": "&#XDD65",
+      "value": 56677
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56678;",
+      "decimal_missing_semicolon": "&#56678",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD66;",
+      "hex_missing_semicolon": "&#XDD66",
+      "value": 56678
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56679;",
+      "decimal_missing_semicolon": "&#56679",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD67;",
+      "hex_missing_semicolon": "&#XDD67",
+      "value": 56679
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56680;",
+      "decimal_missing_semicolon": "&#56680",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD68;",
+      "hex_missing_semicolon": "&#XDD68",
+      "value": 56680
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56681;",
+      "decimal_missing_semicolon": "&#56681",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD69;",
+      "hex_missing_semicolon": "&#XDD69",
+      "value": 56681
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56682;",
+      "decimal_missing_semicolon": "&#56682",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD6A;",
+      "hex_missing_semicolon": "&#XDD6A",
+      "value": 56682
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56683;",
+      "decimal_missing_semicolon": "&#56683",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD6B;",
+      "hex_missing_semicolon": "&#XDD6B",
+      "value": 56683
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56684;",
+      "decimal_missing_semicolon": "&#56684",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD6C;",
+      "hex_missing_semicolon": "&#XDD6C",
+      "value": 56684
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56685;",
+      "decimal_missing_semicolon": "&#56685",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD6D;",
+      "hex_missing_semicolon": "&#XDD6D",
+      "value": 56685
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56686;",
+      "decimal_missing_semicolon": "&#56686",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD6E;",
+      "hex_missing_semicolon": "&#XDD6E",
+      "value": 56686
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56687;",
+      "decimal_missing_semicolon": "&#56687",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD6F;",
+      "hex_missing_semicolon": "&#XDD6F",
+      "value": 56687
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56688;",
+      "decimal_missing_semicolon": "&#56688",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD70;",
+      "hex_missing_semicolon": "&#XDD70",
+      "value": 56688
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56689;",
+      "decimal_missing_semicolon": "&#56689",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD71;",
+      "hex_missing_semicolon": "&#XDD71",
+      "value": 56689
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56690;",
+      "decimal_missing_semicolon": "&#56690",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD72;",
+      "hex_missing_semicolon": "&#XDD72",
+      "value": 56690
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56691;",
+      "decimal_missing_semicolon": "&#56691",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD73;",
+      "hex_missing_semicolon": "&#XDD73",
+      "value": 56691
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56692;",
+      "decimal_missing_semicolon": "&#56692",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD74;",
+      "hex_missing_semicolon": "&#XDD74",
+      "value": 56692
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56693;",
+      "decimal_missing_semicolon": "&#56693",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD75;",
+      "hex_missing_semicolon": "&#XDD75",
+      "value": 56693
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56694;",
+      "decimal_missing_semicolon": "&#56694",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD76;",
+      "hex_missing_semicolon": "&#XDD76",
+      "value": 56694
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56695;",
+      "decimal_missing_semicolon": "&#56695",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD77;",
+      "hex_missing_semicolon": "&#XDD77",
+      "value": 56695
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56696;",
+      "decimal_missing_semicolon": "&#56696",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD78;",
+      "hex_missing_semicolon": "&#XDD78",
+      "value": 56696
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56697;",
+      "decimal_missing_semicolon": "&#56697",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD79;",
+      "hex_missing_semicolon": "&#XDD79",
+      "value": 56697
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56698;",
+      "decimal_missing_semicolon": "&#56698",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD7A;",
+      "hex_missing_semicolon": "&#XDD7A",
+      "value": 56698
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56699;",
+      "decimal_missing_semicolon": "&#56699",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD7B;",
+      "hex_missing_semicolon": "&#XDD7B",
+      "value": 56699
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56700;",
+      "decimal_missing_semicolon": "&#56700",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD7C;",
+      "hex_missing_semicolon": "&#XDD7C",
+      "value": 56700
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56701;",
+      "decimal_missing_semicolon": "&#56701",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD7D;",
+      "hex_missing_semicolon": "&#XDD7D",
+      "value": 56701
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56702;",
+      "decimal_missing_semicolon": "&#56702",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD7E;",
+      "hex_missing_semicolon": "&#XDD7E",
+      "value": 56702
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56703;",
+      "decimal_missing_semicolon": "&#56703",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD7F;",
+      "hex_missing_semicolon": "&#XDD7F",
+      "value": 56703
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56704;",
+      "decimal_missing_semicolon": "&#56704",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD80;",
+      "hex_missing_semicolon": "&#XDD80",
+      "value": 56704
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56705;",
+      "decimal_missing_semicolon": "&#56705",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD81;",
+      "hex_missing_semicolon": "&#XDD81",
+      "value": 56705
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56706;",
+      "decimal_missing_semicolon": "&#56706",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD82;",
+      "hex_missing_semicolon": "&#XDD82",
+      "value": 56706
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56707;",
+      "decimal_missing_semicolon": "&#56707",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD83;",
+      "hex_missing_semicolon": "&#XDD83",
+      "value": 56707
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56708;",
+      "decimal_missing_semicolon": "&#56708",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD84;",
+      "hex_missing_semicolon": "&#XDD84",
+      "value": 56708
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56709;",
+      "decimal_missing_semicolon": "&#56709",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD85;",
+      "hex_missing_semicolon": "&#XDD85",
+      "value": 56709
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56710;",
+      "decimal_missing_semicolon": "&#56710",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD86;",
+      "hex_missing_semicolon": "&#XDD86",
+      "value": 56710
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56711;",
+      "decimal_missing_semicolon": "&#56711",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD87;",
+      "hex_missing_semicolon": "&#XDD87",
+      "value": 56711
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56712;",
+      "decimal_missing_semicolon": "&#56712",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD88;",
+      "hex_missing_semicolon": "&#XDD88",
+      "value": 56712
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56713;",
+      "decimal_missing_semicolon": "&#56713",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD89;",
+      "hex_missing_semicolon": "&#XDD89",
+      "value": 56713
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56714;",
+      "decimal_missing_semicolon": "&#56714",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD8A;",
+      "hex_missing_semicolon": "&#XDD8A",
+      "value": 56714
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56715;",
+      "decimal_missing_semicolon": "&#56715",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD8B;",
+      "hex_missing_semicolon": "&#XDD8B",
+      "value": 56715
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56716;",
+      "decimal_missing_semicolon": "&#56716",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD8C;",
+      "hex_missing_semicolon": "&#XDD8C",
+      "value": 56716
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56717;",
+      "decimal_missing_semicolon": "&#56717",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD8D;",
+      "hex_missing_semicolon": "&#XDD8D",
+      "value": 56717
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56718;",
+      "decimal_missing_semicolon": "&#56718",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD8E;",
+      "hex_missing_semicolon": "&#XDD8E",
+      "value": 56718
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56719;",
+      "decimal_missing_semicolon": "&#56719",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD8F;",
+      "hex_missing_semicolon": "&#XDD8F",
+      "value": 56719
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56720;",
+      "decimal_missing_semicolon": "&#56720",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD90;",
+      "hex_missing_semicolon": "&#XDD90",
+      "value": 56720
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56721;",
+      "decimal_missing_semicolon": "&#56721",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD91;",
+      "hex_missing_semicolon": "&#XDD91",
+      "value": 56721
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56722;",
+      "decimal_missing_semicolon": "&#56722",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD92;",
+      "hex_missing_semicolon": "&#XDD92",
+      "value": 56722
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56723;",
+      "decimal_missing_semicolon": "&#56723",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD93;",
+      "hex_missing_semicolon": "&#XDD93",
+      "value": 56723
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56724;",
+      "decimal_missing_semicolon": "&#56724",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD94;",
+      "hex_missing_semicolon": "&#XDD94",
+      "value": 56724
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56725;",
+      "decimal_missing_semicolon": "&#56725",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD95;",
+      "hex_missing_semicolon": "&#XDD95",
+      "value": 56725
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56726;",
+      "decimal_missing_semicolon": "&#56726",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD96;",
+      "hex_missing_semicolon": "&#XDD96",
+      "value": 56726
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56727;",
+      "decimal_missing_semicolon": "&#56727",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD97;",
+      "hex_missing_semicolon": "&#XDD97",
+      "value": 56727
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56728;",
+      "decimal_missing_semicolon": "&#56728",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD98;",
+      "hex_missing_semicolon": "&#XDD98",
+      "value": 56728
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56729;",
+      "decimal_missing_semicolon": "&#56729",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD99;",
+      "hex_missing_semicolon": "&#XDD99",
+      "value": 56729
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56730;",
+      "decimal_missing_semicolon": "&#56730",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD9A;",
+      "hex_missing_semicolon": "&#XDD9A",
+      "value": 56730
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56731;",
+      "decimal_missing_semicolon": "&#56731",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD9B;",
+      "hex_missing_semicolon": "&#XDD9B",
+      "value": 56731
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56732;",
+      "decimal_missing_semicolon": "&#56732",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD9C;",
+      "hex_missing_semicolon": "&#XDD9C",
+      "value": 56732
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56733;",
+      "decimal_missing_semicolon": "&#56733",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD9D;",
+      "hex_missing_semicolon": "&#XDD9D",
+      "value": 56733
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56734;",
+      "decimal_missing_semicolon": "&#56734",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD9E;",
+      "hex_missing_semicolon": "&#XDD9E",
+      "value": 56734
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56735;",
+      "decimal_missing_semicolon": "&#56735",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDD9F;",
+      "hex_missing_semicolon": "&#XDD9F",
+      "value": 56735
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56736;",
+      "decimal_missing_semicolon": "&#56736",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA0;",
+      "hex_missing_semicolon": "&#XDDA0",
+      "value": 56736
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56737;",
+      "decimal_missing_semicolon": "&#56737",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA1;",
+      "hex_missing_semicolon": "&#XDDA1",
+      "value": 56737
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56738;",
+      "decimal_missing_semicolon": "&#56738",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA2;",
+      "hex_missing_semicolon": "&#XDDA2",
+      "value": 56738
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56739;",
+      "decimal_missing_semicolon": "&#56739",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA3;",
+      "hex_missing_semicolon": "&#XDDA3",
+      "value": 56739
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56740;",
+      "decimal_missing_semicolon": "&#56740",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA4;",
+      "hex_missing_semicolon": "&#XDDA4",
+      "value": 56740
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56741;",
+      "decimal_missing_semicolon": "&#56741",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA5;",
+      "hex_missing_semicolon": "&#XDDA5",
+      "value": 56741
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56742;",
+      "decimal_missing_semicolon": "&#56742",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA6;",
+      "hex_missing_semicolon": "&#XDDA6",
+      "value": 56742
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56743;",
+      "decimal_missing_semicolon": "&#56743",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA7;",
+      "hex_missing_semicolon": "&#XDDA7",
+      "value": 56743
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56744;",
+      "decimal_missing_semicolon": "&#56744",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA8;",
+      "hex_missing_semicolon": "&#XDDA8",
+      "value": 56744
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56745;",
+      "decimal_missing_semicolon": "&#56745",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDA9;",
+      "hex_missing_semicolon": "&#XDDA9",
+      "value": 56745
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56746;",
+      "decimal_missing_semicolon": "&#56746",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDAA;",
+      "hex_missing_semicolon": "&#XDDAA",
+      "value": 56746
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56747;",
+      "decimal_missing_semicolon": "&#56747",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDAB;",
+      "hex_missing_semicolon": "&#XDDAB",
+      "value": 56747
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56748;",
+      "decimal_missing_semicolon": "&#56748",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDAC;",
+      "hex_missing_semicolon": "&#XDDAC",
+      "value": 56748
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56749;",
+      "decimal_missing_semicolon": "&#56749",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDAD;",
+      "hex_missing_semicolon": "&#XDDAD",
+      "value": 56749
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56750;",
+      "decimal_missing_semicolon": "&#56750",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDAE;",
+      "hex_missing_semicolon": "&#XDDAE",
+      "value": 56750
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56751;",
+      "decimal_missing_semicolon": "&#56751",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDAF;",
+      "hex_missing_semicolon": "&#XDDAF",
+      "value": 56751
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56752;",
+      "decimal_missing_semicolon": "&#56752",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB0;",
+      "hex_missing_semicolon": "&#XDDB0",
+      "value": 56752
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56753;",
+      "decimal_missing_semicolon": "&#56753",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB1;",
+      "hex_missing_semicolon": "&#XDDB1",
+      "value": 56753
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56754;",
+      "decimal_missing_semicolon": "&#56754",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB2;",
+      "hex_missing_semicolon": "&#XDDB2",
+      "value": 56754
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56755;",
+      "decimal_missing_semicolon": "&#56755",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB3;",
+      "hex_missing_semicolon": "&#XDDB3",
+      "value": 56755
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56756;",
+      "decimal_missing_semicolon": "&#56756",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB4;",
+      "hex_missing_semicolon": "&#XDDB4",
+      "value": 56756
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56757;",
+      "decimal_missing_semicolon": "&#56757",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB5;",
+      "hex_missing_semicolon": "&#XDDB5",
+      "value": 56757
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56758;",
+      "decimal_missing_semicolon": "&#56758",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB6;",
+      "hex_missing_semicolon": "&#XDDB6",
+      "value": 56758
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56759;",
+      "decimal_missing_semicolon": "&#56759",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB7;",
+      "hex_missing_semicolon": "&#XDDB7",
+      "value": 56759
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56760;",
+      "decimal_missing_semicolon": "&#56760",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB8;",
+      "hex_missing_semicolon": "&#XDDB8",
+      "value": 56760
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56761;",
+      "decimal_missing_semicolon": "&#56761",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDB9;",
+      "hex_missing_semicolon": "&#XDDB9",
+      "value": 56761
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56762;",
+      "decimal_missing_semicolon": "&#56762",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDBA;",
+      "hex_missing_semicolon": "&#XDDBA",
+      "value": 56762
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56763;",
+      "decimal_missing_semicolon": "&#56763",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDBB;",
+      "hex_missing_semicolon": "&#XDDBB",
+      "value": 56763
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56764;",
+      "decimal_missing_semicolon": "&#56764",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDBC;",
+      "hex_missing_semicolon": "&#XDDBC",
+      "value": 56764
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56765;",
+      "decimal_missing_semicolon": "&#56765",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDBD;",
+      "hex_missing_semicolon": "&#XDDBD",
+      "value": 56765
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56766;",
+      "decimal_missing_semicolon": "&#56766",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDBE;",
+      "hex_missing_semicolon": "&#XDDBE",
+      "value": 56766
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56767;",
+      "decimal_missing_semicolon": "&#56767",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDBF;",
+      "hex_missing_semicolon": "&#XDDBF",
+      "value": 56767
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56768;",
+      "decimal_missing_semicolon": "&#56768",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC0;",
+      "hex_missing_semicolon": "&#XDDC0",
+      "value": 56768
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56769;",
+      "decimal_missing_semicolon": "&#56769",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC1;",
+      "hex_missing_semicolon": "&#XDDC1",
+      "value": 56769
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56770;",
+      "decimal_missing_semicolon": "&#56770",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC2;",
+      "hex_missing_semicolon": "&#XDDC2",
+      "value": 56770
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56771;",
+      "decimal_missing_semicolon": "&#56771",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC3;",
+      "hex_missing_semicolon": "&#XDDC3",
+      "value": 56771
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56772;",
+      "decimal_missing_semicolon": "&#56772",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC4;",
+      "hex_missing_semicolon": "&#XDDC4",
+      "value": 56772
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56773;",
+      "decimal_missing_semicolon": "&#56773",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC5;",
+      "hex_missing_semicolon": "&#XDDC5",
+      "value": 56773
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56774;",
+      "decimal_missing_semicolon": "&#56774",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC6;",
+      "hex_missing_semicolon": "&#XDDC6",
+      "value": 56774
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56775;",
+      "decimal_missing_semicolon": "&#56775",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC7;",
+      "hex_missing_semicolon": "&#XDDC7",
+      "value": 56775
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56776;",
+      "decimal_missing_semicolon": "&#56776",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC8;",
+      "hex_missing_semicolon": "&#XDDC8",
+      "value": 56776
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56777;",
+      "decimal_missing_semicolon": "&#56777",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDC9;",
+      "hex_missing_semicolon": "&#XDDC9",
+      "value": 56777
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56778;",
+      "decimal_missing_semicolon": "&#56778",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDCA;",
+      "hex_missing_semicolon": "&#XDDCA",
+      "value": 56778
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56779;",
+      "decimal_missing_semicolon": "&#56779",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDCB;",
+      "hex_missing_semicolon": "&#XDDCB",
+      "value": 56779
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56780;",
+      "decimal_missing_semicolon": "&#56780",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDCC;",
+      "hex_missing_semicolon": "&#XDDCC",
+      "value": 56780
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56781;",
+      "decimal_missing_semicolon": "&#56781",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDCD;",
+      "hex_missing_semicolon": "&#XDDCD",
+      "value": 56781
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56782;",
+      "decimal_missing_semicolon": "&#56782",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDCE;",
+      "hex_missing_semicolon": "&#XDDCE",
+      "value": 56782
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56783;",
+      "decimal_missing_semicolon": "&#56783",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDCF;",
+      "hex_missing_semicolon": "&#XDDCF",
+      "value": 56783
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56784;",
+      "decimal_missing_semicolon": "&#56784",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD0;",
+      "hex_missing_semicolon": "&#XDDD0",
+      "value": 56784
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56785;",
+      "decimal_missing_semicolon": "&#56785",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD1;",
+      "hex_missing_semicolon": "&#XDDD1",
+      "value": 56785
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56786;",
+      "decimal_missing_semicolon": "&#56786",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD2;",
+      "hex_missing_semicolon": "&#XDDD2",
+      "value": 56786
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56787;",
+      "decimal_missing_semicolon": "&#56787",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD3;",
+      "hex_missing_semicolon": "&#XDDD3",
+      "value": 56787
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56788;",
+      "decimal_missing_semicolon": "&#56788",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD4;",
+      "hex_missing_semicolon": "&#XDDD4",
+      "value": 56788
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56789;",
+      "decimal_missing_semicolon": "&#56789",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD5;",
+      "hex_missing_semicolon": "&#XDDD5",
+      "value": 56789
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56790;",
+      "decimal_missing_semicolon": "&#56790",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD6;",
+      "hex_missing_semicolon": "&#XDDD6",
+      "value": 56790
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56791;",
+      "decimal_missing_semicolon": "&#56791",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD7;",
+      "hex_missing_semicolon": "&#XDDD7",
+      "value": 56791
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56792;",
+      "decimal_missing_semicolon": "&#56792",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD8;",
+      "hex_missing_semicolon": "&#XDDD8",
+      "value": 56792
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56793;",
+      "decimal_missing_semicolon": "&#56793",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDD9;",
+      "hex_missing_semicolon": "&#XDDD9",
+      "value": 56793
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56794;",
+      "decimal_missing_semicolon": "&#56794",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDDA;",
+      "hex_missing_semicolon": "&#XDDDA",
+      "value": 56794
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56795;",
+      "decimal_missing_semicolon": "&#56795",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDDB;",
+      "hex_missing_semicolon": "&#XDDDB",
+      "value": 56795
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56796;",
+      "decimal_missing_semicolon": "&#56796",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDDC;",
+      "hex_missing_semicolon": "&#XDDDC",
+      "value": 56796
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56797;",
+      "decimal_missing_semicolon": "&#56797",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDDD;",
+      "hex_missing_semicolon": "&#XDDDD",
+      "value": 56797
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56798;",
+      "decimal_missing_semicolon": "&#56798",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDDE;",
+      "hex_missing_semicolon": "&#XDDDE",
+      "value": 56798
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56799;",
+      "decimal_missing_semicolon": "&#56799",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDDF;",
+      "hex_missing_semicolon": "&#XDDDF",
+      "value": 56799
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56800;",
+      "decimal_missing_semicolon": "&#56800",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE0;",
+      "hex_missing_semicolon": "&#XDDE0",
+      "value": 56800
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56801;",
+      "decimal_missing_semicolon": "&#56801",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE1;",
+      "hex_missing_semicolon": "&#XDDE1",
+      "value": 56801
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56802;",
+      "decimal_missing_semicolon": "&#56802",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE2;",
+      "hex_missing_semicolon": "&#XDDE2",
+      "value": 56802
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56803;",
+      "decimal_missing_semicolon": "&#56803",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE3;",
+      "hex_missing_semicolon": "&#XDDE3",
+      "value": 56803
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56804;",
+      "decimal_missing_semicolon": "&#56804",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE4;",
+      "hex_missing_semicolon": "&#XDDE4",
+      "value": 56804
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56805;",
+      "decimal_missing_semicolon": "&#56805",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE5;",
+      "hex_missing_semicolon": "&#XDDE5",
+      "value": 56805
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56806;",
+      "decimal_missing_semicolon": "&#56806",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE6;",
+      "hex_missing_semicolon": "&#XDDE6",
+      "value": 56806
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56807;",
+      "decimal_missing_semicolon": "&#56807",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE7;",
+      "hex_missing_semicolon": "&#XDDE7",
+      "value": 56807
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56808;",
+      "decimal_missing_semicolon": "&#56808",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE8;",
+      "hex_missing_semicolon": "&#XDDE8",
+      "value": 56808
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56809;",
+      "decimal_missing_semicolon": "&#56809",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDE9;",
+      "hex_missing_semicolon": "&#XDDE9",
+      "value": 56809
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56810;",
+      "decimal_missing_semicolon": "&#56810",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDEA;",
+      "hex_missing_semicolon": "&#XDDEA",
+      "value": 56810
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56811;",
+      "decimal_missing_semicolon": "&#56811",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDEB;",
+      "hex_missing_semicolon": "&#XDDEB",
+      "value": 56811
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56812;",
+      "decimal_missing_semicolon": "&#56812",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDEC;",
+      "hex_missing_semicolon": "&#XDDEC",
+      "value": 56812
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56813;",
+      "decimal_missing_semicolon": "&#56813",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDED;",
+      "hex_missing_semicolon": "&#XDDED",
+      "value": 56813
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56814;",
+      "decimal_missing_semicolon": "&#56814",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDEE;",
+      "hex_missing_semicolon": "&#XDDEE",
+      "value": 56814
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56815;",
+      "decimal_missing_semicolon": "&#56815",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDEF;",
+      "hex_missing_semicolon": "&#XDDEF",
+      "value": 56815
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56816;",
+      "decimal_missing_semicolon": "&#56816",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF0;",
+      "hex_missing_semicolon": "&#XDDF0",
+      "value": 56816
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56817;",
+      "decimal_missing_semicolon": "&#56817",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF1;",
+      "hex_missing_semicolon": "&#XDDF1",
+      "value": 56817
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56818;",
+      "decimal_missing_semicolon": "&#56818",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF2;",
+      "hex_missing_semicolon": "&#XDDF2",
+      "value": 56818
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56819;",
+      "decimal_missing_semicolon": "&#56819",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF3;",
+      "hex_missing_semicolon": "&#XDDF3",
+      "value": 56819
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56820;",
+      "decimal_missing_semicolon": "&#56820",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF4;",
+      "hex_missing_semicolon": "&#XDDF4",
+      "value": 56820
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56821;",
+      "decimal_missing_semicolon": "&#56821",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF5;",
+      "hex_missing_semicolon": "&#XDDF5",
+      "value": 56821
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56822;",
+      "decimal_missing_semicolon": "&#56822",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF6;",
+      "hex_missing_semicolon": "&#XDDF6",
+      "value": 56822
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56823;",
+      "decimal_missing_semicolon": "&#56823",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF7;",
+      "hex_missing_semicolon": "&#XDDF7",
+      "value": 56823
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56824;",
+      "decimal_missing_semicolon": "&#56824",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF8;",
+      "hex_missing_semicolon": "&#XDDF8",
+      "value": 56824
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56825;",
+      "decimal_missing_semicolon": "&#56825",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDF9;",
+      "hex_missing_semicolon": "&#XDDF9",
+      "value": 56825
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56826;",
+      "decimal_missing_semicolon": "&#56826",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDFA;",
+      "hex_missing_semicolon": "&#XDDFA",
+      "value": 56826
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56827;",
+      "decimal_missing_semicolon": "&#56827",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDFB;",
+      "hex_missing_semicolon": "&#XDDFB",
+      "value": 56827
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56828;",
+      "decimal_missing_semicolon": "&#56828",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDFC;",
+      "hex_missing_semicolon": "&#XDDFC",
+      "value": 56828
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56829;",
+      "decimal_missing_semicolon": "&#56829",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDFD;",
+      "hex_missing_semicolon": "&#XDDFD",
+      "value": 56829
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56830;",
+      "decimal_missing_semicolon": "&#56830",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDFE;",
+      "hex_missing_semicolon": "&#XDDFE",
+      "value": 56830
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56831;",
+      "decimal_missing_semicolon": "&#56831",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDDFF;",
+      "hex_missing_semicolon": "&#XDDFF",
+      "value": 56831
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56832;",
+      "decimal_missing_semicolon": "&#56832",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE00;",
+      "hex_missing_semicolon": "&#XDE00",
+      "value": 56832
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56833;",
+      "decimal_missing_semicolon": "&#56833",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE01;",
+      "hex_missing_semicolon": "&#XDE01",
+      "value": 56833
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56834;",
+      "decimal_missing_semicolon": "&#56834",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE02;",
+      "hex_missing_semicolon": "&#XDE02",
+      "value": 56834
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56835;",
+      "decimal_missing_semicolon": "&#56835",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE03;",
+      "hex_missing_semicolon": "&#XDE03",
+      "value": 56835
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56836;",
+      "decimal_missing_semicolon": "&#56836",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE04;",
+      "hex_missing_semicolon": "&#XDE04",
+      "value": 56836
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56837;",
+      "decimal_missing_semicolon": "&#56837",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE05;",
+      "hex_missing_semicolon": "&#XDE05",
+      "value": 56837
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56838;",
+      "decimal_missing_semicolon": "&#56838",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE06;",
+      "hex_missing_semicolon": "&#XDE06",
+      "value": 56838
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56839;",
+      "decimal_missing_semicolon": "&#56839",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE07;",
+      "hex_missing_semicolon": "&#XDE07",
+      "value": 56839
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56840;",
+      "decimal_missing_semicolon": "&#56840",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE08;",
+      "hex_missing_semicolon": "&#XDE08",
+      "value": 56840
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56841;",
+      "decimal_missing_semicolon": "&#56841",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE09;",
+      "hex_missing_semicolon": "&#XDE09",
+      "value": 56841
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56842;",
+      "decimal_missing_semicolon": "&#56842",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE0A;",
+      "hex_missing_semicolon": "&#XDE0A",
+      "value": 56842
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56843;",
+      "decimal_missing_semicolon": "&#56843",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE0B;",
+      "hex_missing_semicolon": "&#XDE0B",
+      "value": 56843
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56844;",
+      "decimal_missing_semicolon": "&#56844",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE0C;",
+      "hex_missing_semicolon": "&#XDE0C",
+      "value": 56844
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56845;",
+      "decimal_missing_semicolon": "&#56845",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE0D;",
+      "hex_missing_semicolon": "&#XDE0D",
+      "value": 56845
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56846;",
+      "decimal_missing_semicolon": "&#56846",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE0E;",
+      "hex_missing_semicolon": "&#XDE0E",
+      "value": 56846
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56847;",
+      "decimal_missing_semicolon": "&#56847",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE0F;",
+      "hex_missing_semicolon": "&#XDE0F",
+      "value": 56847
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56848;",
+      "decimal_missing_semicolon": "&#56848",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE10;",
+      "hex_missing_semicolon": "&#XDE10",
+      "value": 56848
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56849;",
+      "decimal_missing_semicolon": "&#56849",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE11;",
+      "hex_missing_semicolon": "&#XDE11",
+      "value": 56849
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56850;",
+      "decimal_missing_semicolon": "&#56850",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE12;",
+      "hex_missing_semicolon": "&#XDE12",
+      "value": 56850
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56851;",
+      "decimal_missing_semicolon": "&#56851",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE13;",
+      "hex_missing_semicolon": "&#XDE13",
+      "value": 56851
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56852;",
+      "decimal_missing_semicolon": "&#56852",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE14;",
+      "hex_missing_semicolon": "&#XDE14",
+      "value": 56852
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56853;",
+      "decimal_missing_semicolon": "&#56853",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE15;",
+      "hex_missing_semicolon": "&#XDE15",
+      "value": 56853
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56854;",
+      "decimal_missing_semicolon": "&#56854",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE16;",
+      "hex_missing_semicolon": "&#XDE16",
+      "value": 56854
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56855;",
+      "decimal_missing_semicolon": "&#56855",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE17;",
+      "hex_missing_semicolon": "&#XDE17",
+      "value": 56855
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56856;",
+      "decimal_missing_semicolon": "&#56856",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE18;",
+      "hex_missing_semicolon": "&#XDE18",
+      "value": 56856
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56857;",
+      "decimal_missing_semicolon": "&#56857",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE19;",
+      "hex_missing_semicolon": "&#XDE19",
+      "value": 56857
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56858;",
+      "decimal_missing_semicolon": "&#56858",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE1A;",
+      "hex_missing_semicolon": "&#XDE1A",
+      "value": 56858
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56859;",
+      "decimal_missing_semicolon": "&#56859",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE1B;",
+      "hex_missing_semicolon": "&#XDE1B",
+      "value": 56859
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56860;",
+      "decimal_missing_semicolon": "&#56860",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE1C;",
+      "hex_missing_semicolon": "&#XDE1C",
+      "value": 56860
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56861;",
+      "decimal_missing_semicolon": "&#56861",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE1D;",
+      "hex_missing_semicolon": "&#XDE1D",
+      "value": 56861
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56862;",
+      "decimal_missing_semicolon": "&#56862",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE1E;",
+      "hex_missing_semicolon": "&#XDE1E",
+      "value": 56862
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56863;",
+      "decimal_missing_semicolon": "&#56863",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE1F;",
+      "hex_missing_semicolon": "&#XDE1F",
+      "value": 56863
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56864;",
+      "decimal_missing_semicolon": "&#56864",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE20;",
+      "hex_missing_semicolon": "&#XDE20",
+      "value": 56864
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56865;",
+      "decimal_missing_semicolon": "&#56865",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE21;",
+      "hex_missing_semicolon": "&#XDE21",
+      "value": 56865
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56866;",
+      "decimal_missing_semicolon": "&#56866",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE22;",
+      "hex_missing_semicolon": "&#XDE22",
+      "value": 56866
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56867;",
+      "decimal_missing_semicolon": "&#56867",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE23;",
+      "hex_missing_semicolon": "&#XDE23",
+      "value": 56867
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56868;",
+      "decimal_missing_semicolon": "&#56868",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE24;",
+      "hex_missing_semicolon": "&#XDE24",
+      "value": 56868
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56869;",
+      "decimal_missing_semicolon": "&#56869",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE25;",
+      "hex_missing_semicolon": "&#XDE25",
+      "value": 56869
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56870;",
+      "decimal_missing_semicolon": "&#56870",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE26;",
+      "hex_missing_semicolon": "&#XDE26",
+      "value": 56870
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56871;",
+      "decimal_missing_semicolon": "&#56871",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE27;",
+      "hex_missing_semicolon": "&#XDE27",
+      "value": 56871
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56872;",
+      "decimal_missing_semicolon": "&#56872",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE28;",
+      "hex_missing_semicolon": "&#XDE28",
+      "value": 56872
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56873;",
+      "decimal_missing_semicolon": "&#56873",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE29;",
+      "hex_missing_semicolon": "&#XDE29",
+      "value": 56873
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56874;",
+      "decimal_missing_semicolon": "&#56874",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE2A;",
+      "hex_missing_semicolon": "&#XDE2A",
+      "value": 56874
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56875;",
+      "decimal_missing_semicolon": "&#56875",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE2B;",
+      "hex_missing_semicolon": "&#XDE2B",
+      "value": 56875
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56876;",
+      "decimal_missing_semicolon": "&#56876",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE2C;",
+      "hex_missing_semicolon": "&#XDE2C",
+      "value": 56876
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56877;",
+      "decimal_missing_semicolon": "&#56877",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE2D;",
+      "hex_missing_semicolon": "&#XDE2D",
+      "value": 56877
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56878;",
+      "decimal_missing_semicolon": "&#56878",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE2E;",
+      "hex_missing_semicolon": "&#XDE2E",
+      "value": 56878
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56879;",
+      "decimal_missing_semicolon": "&#56879",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE2F;",
+      "hex_missing_semicolon": "&#XDE2F",
+      "value": 56879
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56880;",
+      "decimal_missing_semicolon": "&#56880",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE30;",
+      "hex_missing_semicolon": "&#XDE30",
+      "value": 56880
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56881;",
+      "decimal_missing_semicolon": "&#56881",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE31;",
+      "hex_missing_semicolon": "&#XDE31",
+      "value": 56881
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56882;",
+      "decimal_missing_semicolon": "&#56882",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE32;",
+      "hex_missing_semicolon": "&#XDE32",
+      "value": 56882
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56883;",
+      "decimal_missing_semicolon": "&#56883",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE33;",
+      "hex_missing_semicolon": "&#XDE33",
+      "value": 56883
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56884;",
+      "decimal_missing_semicolon": "&#56884",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE34;",
+      "hex_missing_semicolon": "&#XDE34",
+      "value": 56884
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56885;",
+      "decimal_missing_semicolon": "&#56885",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE35;",
+      "hex_missing_semicolon": "&#XDE35",
+      "value": 56885
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56886;",
+      "decimal_missing_semicolon": "&#56886",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE36;",
+      "hex_missing_semicolon": "&#XDE36",
+      "value": 56886
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56887;",
+      "decimal_missing_semicolon": "&#56887",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE37;",
+      "hex_missing_semicolon": "&#XDE37",
+      "value": 56887
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56888;",
+      "decimal_missing_semicolon": "&#56888",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE38;",
+      "hex_missing_semicolon": "&#XDE38",
+      "value": 56888
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56889;",
+      "decimal_missing_semicolon": "&#56889",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE39;",
+      "hex_missing_semicolon": "&#XDE39",
+      "value": 56889
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56890;",
+      "decimal_missing_semicolon": "&#56890",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE3A;",
+      "hex_missing_semicolon": "&#XDE3A",
+      "value": 56890
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56891;",
+      "decimal_missing_semicolon": "&#56891",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE3B;",
+      "hex_missing_semicolon": "&#XDE3B",
+      "value": 56891
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56892;",
+      "decimal_missing_semicolon": "&#56892",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE3C;",
+      "hex_missing_semicolon": "&#XDE3C",
+      "value": 56892
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56893;",
+      "decimal_missing_semicolon": "&#56893",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE3D;",
+      "hex_missing_semicolon": "&#XDE3D",
+      "value": 56893
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56894;",
+      "decimal_missing_semicolon": "&#56894",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE3E;",
+      "hex_missing_semicolon": "&#XDE3E",
+      "value": 56894
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56895;",
+      "decimal_missing_semicolon": "&#56895",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE3F;",
+      "hex_missing_semicolon": "&#XDE3F",
+      "value": 56895
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56896;",
+      "decimal_missing_semicolon": "&#56896",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE40;",
+      "hex_missing_semicolon": "&#XDE40",
+      "value": 56896
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56897;",
+      "decimal_missing_semicolon": "&#56897",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE41;",
+      "hex_missing_semicolon": "&#XDE41",
+      "value": 56897
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56898;",
+      "decimal_missing_semicolon": "&#56898",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE42;",
+      "hex_missing_semicolon": "&#XDE42",
+      "value": 56898
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56899;",
+      "decimal_missing_semicolon": "&#56899",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE43;",
+      "hex_missing_semicolon": "&#XDE43",
+      "value": 56899
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56900;",
+      "decimal_missing_semicolon": "&#56900",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE44;",
+      "hex_missing_semicolon": "&#XDE44",
+      "value": 56900
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56901;",
+      "decimal_missing_semicolon": "&#56901",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE45;",
+      "hex_missing_semicolon": "&#XDE45",
+      "value": 56901
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56902;",
+      "decimal_missing_semicolon": "&#56902",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE46;",
+      "hex_missing_semicolon": "&#XDE46",
+      "value": 56902
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56903;",
+      "decimal_missing_semicolon": "&#56903",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE47;",
+      "hex_missing_semicolon": "&#XDE47",
+      "value": 56903
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56904;",
+      "decimal_missing_semicolon": "&#56904",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE48;",
+      "hex_missing_semicolon": "&#XDE48",
+      "value": 56904
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56905;",
+      "decimal_missing_semicolon": "&#56905",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE49;",
+      "hex_missing_semicolon": "&#XDE49",
+      "value": 56905
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56906;",
+      "decimal_missing_semicolon": "&#56906",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE4A;",
+      "hex_missing_semicolon": "&#XDE4A",
+      "value": 56906
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56907;",
+      "decimal_missing_semicolon": "&#56907",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE4B;",
+      "hex_missing_semicolon": "&#XDE4B",
+      "value": 56907
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56908;",
+      "decimal_missing_semicolon": "&#56908",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE4C;",
+      "hex_missing_semicolon": "&#XDE4C",
+      "value": 56908
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56909;",
+      "decimal_missing_semicolon": "&#56909",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE4D;",
+      "hex_missing_semicolon": "&#XDE4D",
+      "value": 56909
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56910;",
+      "decimal_missing_semicolon": "&#56910",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE4E;",
+      "hex_missing_semicolon": "&#XDE4E",
+      "value": 56910
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56911;",
+      "decimal_missing_semicolon": "&#56911",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE4F;",
+      "hex_missing_semicolon": "&#XDE4F",
+      "value": 56911
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56912;",
+      "decimal_missing_semicolon": "&#56912",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE50;",
+      "hex_missing_semicolon": "&#XDE50",
+      "value": 56912
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56913;",
+      "decimal_missing_semicolon": "&#56913",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE51;",
+      "hex_missing_semicolon": "&#XDE51",
+      "value": 56913
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56914;",
+      "decimal_missing_semicolon": "&#56914",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE52;",
+      "hex_missing_semicolon": "&#XDE52",
+      "value": 56914
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56915;",
+      "decimal_missing_semicolon": "&#56915",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE53;",
+      "hex_missing_semicolon": "&#XDE53",
+      "value": 56915
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56916;",
+      "decimal_missing_semicolon": "&#56916",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE54;",
+      "hex_missing_semicolon": "&#XDE54",
+      "value": 56916
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56917;",
+      "decimal_missing_semicolon": "&#56917",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE55;",
+      "hex_missing_semicolon": "&#XDE55",
+      "value": 56917
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56918;",
+      "decimal_missing_semicolon": "&#56918",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE56;",
+      "hex_missing_semicolon": "&#XDE56",
+      "value": 56918
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56919;",
+      "decimal_missing_semicolon": "&#56919",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE57;",
+      "hex_missing_semicolon": "&#XDE57",
+      "value": 56919
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56920;",
+      "decimal_missing_semicolon": "&#56920",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE58;",
+      "hex_missing_semicolon": "&#XDE58",
+      "value": 56920
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56921;",
+      "decimal_missing_semicolon": "&#56921",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE59;",
+      "hex_missing_semicolon": "&#XDE59",
+      "value": 56921
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56922;",
+      "decimal_missing_semicolon": "&#56922",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE5A;",
+      "hex_missing_semicolon": "&#XDE5A",
+      "value": 56922
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56923;",
+      "decimal_missing_semicolon": "&#56923",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE5B;",
+      "hex_missing_semicolon": "&#XDE5B",
+      "value": 56923
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56924;",
+      "decimal_missing_semicolon": "&#56924",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE5C;",
+      "hex_missing_semicolon": "&#XDE5C",
+      "value": 56924
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56925;",
+      "decimal_missing_semicolon": "&#56925",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE5D;",
+      "hex_missing_semicolon": "&#XDE5D",
+      "value": 56925
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56926;",
+      "decimal_missing_semicolon": "&#56926",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE5E;",
+      "hex_missing_semicolon": "&#XDE5E",
+      "value": 56926
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56927;",
+      "decimal_missing_semicolon": "&#56927",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE5F;",
+      "hex_missing_semicolon": "&#XDE5F",
+      "value": 56927
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56928;",
+      "decimal_missing_semicolon": "&#56928",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE60;",
+      "hex_missing_semicolon": "&#XDE60",
+      "value": 56928
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56929;",
+      "decimal_missing_semicolon": "&#56929",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE61;",
+      "hex_missing_semicolon": "&#XDE61",
+      "value": 56929
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56930;",
+      "decimal_missing_semicolon": "&#56930",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE62;",
+      "hex_missing_semicolon": "&#XDE62",
+      "value": 56930
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56931;",
+      "decimal_missing_semicolon": "&#56931",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE63;",
+      "hex_missing_semicolon": "&#XDE63",
+      "value": 56931
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56932;",
+      "decimal_missing_semicolon": "&#56932",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE64;",
+      "hex_missing_semicolon": "&#XDE64",
+      "value": 56932
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56933;",
+      "decimal_missing_semicolon": "&#56933",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE65;",
+      "hex_missing_semicolon": "&#XDE65",
+      "value": 56933
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56934;",
+      "decimal_missing_semicolon": "&#56934",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE66;",
+      "hex_missing_semicolon": "&#XDE66",
+      "value": 56934
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56935;",
+      "decimal_missing_semicolon": "&#56935",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE67;",
+      "hex_missing_semicolon": "&#XDE67",
+      "value": 56935
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56936;",
+      "decimal_missing_semicolon": "&#56936",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE68;",
+      "hex_missing_semicolon": "&#XDE68",
+      "value": 56936
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56937;",
+      "decimal_missing_semicolon": "&#56937",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE69;",
+      "hex_missing_semicolon": "&#XDE69",
+      "value": 56937
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56938;",
+      "decimal_missing_semicolon": "&#56938",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE6A;",
+      "hex_missing_semicolon": "&#XDE6A",
+      "value": 56938
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56939;",
+      "decimal_missing_semicolon": "&#56939",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE6B;",
+      "hex_missing_semicolon": "&#XDE6B",
+      "value": 56939
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56940;",
+      "decimal_missing_semicolon": "&#56940",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE6C;",
+      "hex_missing_semicolon": "&#XDE6C",
+      "value": 56940
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56941;",
+      "decimal_missing_semicolon": "&#56941",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE6D;",
+      "hex_missing_semicolon": "&#XDE6D",
+      "value": 56941
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56942;",
+      "decimal_missing_semicolon": "&#56942",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE6E;",
+      "hex_missing_semicolon": "&#XDE6E",
+      "value": 56942
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56943;",
+      "decimal_missing_semicolon": "&#56943",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE6F;",
+      "hex_missing_semicolon": "&#XDE6F",
+      "value": 56943
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56944;",
+      "decimal_missing_semicolon": "&#56944",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE70;",
+      "hex_missing_semicolon": "&#XDE70",
+      "value": 56944
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56945;",
+      "decimal_missing_semicolon": "&#56945",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE71;",
+      "hex_missing_semicolon": "&#XDE71",
+      "value": 56945
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56946;",
+      "decimal_missing_semicolon": "&#56946",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE72;",
+      "hex_missing_semicolon": "&#XDE72",
+      "value": 56946
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56947;",
+      "decimal_missing_semicolon": "&#56947",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE73;",
+      "hex_missing_semicolon": "&#XDE73",
+      "value": 56947
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56948;",
+      "decimal_missing_semicolon": "&#56948",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE74;",
+      "hex_missing_semicolon": "&#XDE74",
+      "value": 56948
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56949;",
+      "decimal_missing_semicolon": "&#56949",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE75;",
+      "hex_missing_semicolon": "&#XDE75",
+      "value": 56949
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56950;",
+      "decimal_missing_semicolon": "&#56950",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE76;",
+      "hex_missing_semicolon": "&#XDE76",
+      "value": 56950
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56951;",
+      "decimal_missing_semicolon": "&#56951",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE77;",
+      "hex_missing_semicolon": "&#XDE77",
+      "value": 56951
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56952;",
+      "decimal_missing_semicolon": "&#56952",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE78;",
+      "hex_missing_semicolon": "&#XDE78",
+      "value": 56952
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56953;",
+      "decimal_missing_semicolon": "&#56953",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE79;",
+      "hex_missing_semicolon": "&#XDE79",
+      "value": 56953
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56954;",
+      "decimal_missing_semicolon": "&#56954",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE7A;",
+      "hex_missing_semicolon": "&#XDE7A",
+      "value": 56954
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56955;",
+      "decimal_missing_semicolon": "&#56955",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE7B;",
+      "hex_missing_semicolon": "&#XDE7B",
+      "value": 56955
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56956;",
+      "decimal_missing_semicolon": "&#56956",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE7C;",
+      "hex_missing_semicolon": "&#XDE7C",
+      "value": 56956
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56957;",
+      "decimal_missing_semicolon": "&#56957",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE7D;",
+      "hex_missing_semicolon": "&#XDE7D",
+      "value": 56957
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56958;",
+      "decimal_missing_semicolon": "&#56958",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE7E;",
+      "hex_missing_semicolon": "&#XDE7E",
+      "value": 56958
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56959;",
+      "decimal_missing_semicolon": "&#56959",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE7F;",
+      "hex_missing_semicolon": "&#XDE7F",
+      "value": 56959
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56960;",
+      "decimal_missing_semicolon": "&#56960",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE80;",
+      "hex_missing_semicolon": "&#XDE80",
+      "value": 56960
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56961;",
+      "decimal_missing_semicolon": "&#56961",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE81;",
+      "hex_missing_semicolon": "&#XDE81",
+      "value": 56961
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56962;",
+      "decimal_missing_semicolon": "&#56962",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE82;",
+      "hex_missing_semicolon": "&#XDE82",
+      "value": 56962
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56963;",
+      "decimal_missing_semicolon": "&#56963",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE83;",
+      "hex_missing_semicolon": "&#XDE83",
+      "value": 56963
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56964;",
+      "decimal_missing_semicolon": "&#56964",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE84;",
+      "hex_missing_semicolon": "&#XDE84",
+      "value": 56964
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56965;",
+      "decimal_missing_semicolon": "&#56965",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE85;",
+      "hex_missing_semicolon": "&#XDE85",
+      "value": 56965
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56966;",
+      "decimal_missing_semicolon": "&#56966",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE86;",
+      "hex_missing_semicolon": "&#XDE86",
+      "value": 56966
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56967;",
+      "decimal_missing_semicolon": "&#56967",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE87;",
+      "hex_missing_semicolon": "&#XDE87",
+      "value": 56967
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56968;",
+      "decimal_missing_semicolon": "&#56968",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE88;",
+      "hex_missing_semicolon": "&#XDE88",
+      "value": 56968
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56969;",
+      "decimal_missing_semicolon": "&#56969",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE89;",
+      "hex_missing_semicolon": "&#XDE89",
+      "value": 56969
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56970;",
+      "decimal_missing_semicolon": "&#56970",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE8A;",
+      "hex_missing_semicolon": "&#XDE8A",
+      "value": 56970
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56971;",
+      "decimal_missing_semicolon": "&#56971",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE8B;",
+      "hex_missing_semicolon": "&#XDE8B",
+      "value": 56971
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56972;",
+      "decimal_missing_semicolon": "&#56972",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE8C;",
+      "hex_missing_semicolon": "&#XDE8C",
+      "value": 56972
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56973;",
+      "decimal_missing_semicolon": "&#56973",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE8D;",
+      "hex_missing_semicolon": "&#XDE8D",
+      "value": 56973
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56974;",
+      "decimal_missing_semicolon": "&#56974",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE8E;",
+      "hex_missing_semicolon": "&#XDE8E",
+      "value": 56974
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56975;",
+      "decimal_missing_semicolon": "&#56975",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE8F;",
+      "hex_missing_semicolon": "&#XDE8F",
+      "value": 56975
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56976;",
+      "decimal_missing_semicolon": "&#56976",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE90;",
+      "hex_missing_semicolon": "&#XDE90",
+      "value": 56976
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56977;",
+      "decimal_missing_semicolon": "&#56977",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE91;",
+      "hex_missing_semicolon": "&#XDE91",
+      "value": 56977
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56978;",
+      "decimal_missing_semicolon": "&#56978",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE92;",
+      "hex_missing_semicolon": "&#XDE92",
+      "value": 56978
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56979;",
+      "decimal_missing_semicolon": "&#56979",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE93;",
+      "hex_missing_semicolon": "&#XDE93",
+      "value": 56979
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56980;",
+      "decimal_missing_semicolon": "&#56980",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE94;",
+      "hex_missing_semicolon": "&#XDE94",
+      "value": 56980
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56981;",
+      "decimal_missing_semicolon": "&#56981",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE95;",
+      "hex_missing_semicolon": "&#XDE95",
+      "value": 56981
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56982;",
+      "decimal_missing_semicolon": "&#56982",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE96;",
+      "hex_missing_semicolon": "&#XDE96",
+      "value": 56982
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56983;",
+      "decimal_missing_semicolon": "&#56983",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE97;",
+      "hex_missing_semicolon": "&#XDE97",
+      "value": 56983
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56984;",
+      "decimal_missing_semicolon": "&#56984",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE98;",
+      "hex_missing_semicolon": "&#XDE98",
+      "value": 56984
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56985;",
+      "decimal_missing_semicolon": "&#56985",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE99;",
+      "hex_missing_semicolon": "&#XDE99",
+      "value": 56985
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56986;",
+      "decimal_missing_semicolon": "&#56986",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE9A;",
+      "hex_missing_semicolon": "&#XDE9A",
+      "value": 56986
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56987;",
+      "decimal_missing_semicolon": "&#56987",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE9B;",
+      "hex_missing_semicolon": "&#XDE9B",
+      "value": 56987
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56988;",
+      "decimal_missing_semicolon": "&#56988",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE9C;",
+      "hex_missing_semicolon": "&#XDE9C",
+      "value": 56988
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56989;",
+      "decimal_missing_semicolon": "&#56989",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE9D;",
+      "hex_missing_semicolon": "&#XDE9D",
+      "value": 56989
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56990;",
+      "decimal_missing_semicolon": "&#56990",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE9E;",
+      "hex_missing_semicolon": "&#XDE9E",
+      "value": 56990
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56991;",
+      "decimal_missing_semicolon": "&#56991",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDE9F;",
+      "hex_missing_semicolon": "&#XDE9F",
+      "value": 56991
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56992;",
+      "decimal_missing_semicolon": "&#56992",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA0;",
+      "hex_missing_semicolon": "&#XDEA0",
+      "value": 56992
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56993;",
+      "decimal_missing_semicolon": "&#56993",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA1;",
+      "hex_missing_semicolon": "&#XDEA1",
+      "value": 56993
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56994;",
+      "decimal_missing_semicolon": "&#56994",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA2;",
+      "hex_missing_semicolon": "&#XDEA2",
+      "value": 56994
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56995;",
+      "decimal_missing_semicolon": "&#56995",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA3;",
+      "hex_missing_semicolon": "&#XDEA3",
+      "value": 56995
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56996;",
+      "decimal_missing_semicolon": "&#56996",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA4;",
+      "hex_missing_semicolon": "&#XDEA4",
+      "value": 56996
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56997;",
+      "decimal_missing_semicolon": "&#56997",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA5;",
+      "hex_missing_semicolon": "&#XDEA5",
+      "value": 56997
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56998;",
+      "decimal_missing_semicolon": "&#56998",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA6;",
+      "hex_missing_semicolon": "&#XDEA6",
+      "value": 56998
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#56999;",
+      "decimal_missing_semicolon": "&#56999",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA7;",
+      "hex_missing_semicolon": "&#XDEA7",
+      "value": 56999
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57000;",
+      "decimal_missing_semicolon": "&#57000",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA8;",
+      "hex_missing_semicolon": "&#XDEA8",
+      "value": 57000
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57001;",
+      "decimal_missing_semicolon": "&#57001",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEA9;",
+      "hex_missing_semicolon": "&#XDEA9",
+      "value": 57001
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57002;",
+      "decimal_missing_semicolon": "&#57002",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEAA;",
+      "hex_missing_semicolon": "&#XDEAA",
+      "value": 57002
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57003;",
+      "decimal_missing_semicolon": "&#57003",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEAB;",
+      "hex_missing_semicolon": "&#XDEAB",
+      "value": 57003
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57004;",
+      "decimal_missing_semicolon": "&#57004",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEAC;",
+      "hex_missing_semicolon": "&#XDEAC",
+      "value": 57004
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57005;",
+      "decimal_missing_semicolon": "&#57005",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEAD;",
+      "hex_missing_semicolon": "&#XDEAD",
+      "value": 57005
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57006;",
+      "decimal_missing_semicolon": "&#57006",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEAE;",
+      "hex_missing_semicolon": "&#XDEAE",
+      "value": 57006
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57007;",
+      "decimal_missing_semicolon": "&#57007",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEAF;",
+      "hex_missing_semicolon": "&#XDEAF",
+      "value": 57007
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57008;",
+      "decimal_missing_semicolon": "&#57008",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB0;",
+      "hex_missing_semicolon": "&#XDEB0",
+      "value": 57008
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57009;",
+      "decimal_missing_semicolon": "&#57009",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB1;",
+      "hex_missing_semicolon": "&#XDEB1",
+      "value": 57009
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57010;",
+      "decimal_missing_semicolon": "&#57010",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB2;",
+      "hex_missing_semicolon": "&#XDEB2",
+      "value": 57010
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57011;",
+      "decimal_missing_semicolon": "&#57011",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB3;",
+      "hex_missing_semicolon": "&#XDEB3",
+      "value": 57011
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57012;",
+      "decimal_missing_semicolon": "&#57012",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB4;",
+      "hex_missing_semicolon": "&#XDEB4",
+      "value": 57012
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57013;",
+      "decimal_missing_semicolon": "&#57013",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB5;",
+      "hex_missing_semicolon": "&#XDEB5",
+      "value": 57013
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57014;",
+      "decimal_missing_semicolon": "&#57014",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB6;",
+      "hex_missing_semicolon": "&#XDEB6",
+      "value": 57014
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57015;",
+      "decimal_missing_semicolon": "&#57015",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB7;",
+      "hex_missing_semicolon": "&#XDEB7",
+      "value": 57015
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57016;",
+      "decimal_missing_semicolon": "&#57016",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB8;",
+      "hex_missing_semicolon": "&#XDEB8",
+      "value": 57016
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57017;",
+      "decimal_missing_semicolon": "&#57017",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEB9;",
+      "hex_missing_semicolon": "&#XDEB9",
+      "value": 57017
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57018;",
+      "decimal_missing_semicolon": "&#57018",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEBA;",
+      "hex_missing_semicolon": "&#XDEBA",
+      "value": 57018
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57019;",
+      "decimal_missing_semicolon": "&#57019",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEBB;",
+      "hex_missing_semicolon": "&#XDEBB",
+      "value": 57019
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57020;",
+      "decimal_missing_semicolon": "&#57020",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEBC;",
+      "hex_missing_semicolon": "&#XDEBC",
+      "value": 57020
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57021;",
+      "decimal_missing_semicolon": "&#57021",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEBD;",
+      "hex_missing_semicolon": "&#XDEBD",
+      "value": 57021
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57022;",
+      "decimal_missing_semicolon": "&#57022",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEBE;",
+      "hex_missing_semicolon": "&#XDEBE",
+      "value": 57022
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57023;",
+      "decimal_missing_semicolon": "&#57023",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEBF;",
+      "hex_missing_semicolon": "&#XDEBF",
+      "value": 57023
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57024;",
+      "decimal_missing_semicolon": "&#57024",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC0;",
+      "hex_missing_semicolon": "&#XDEC0",
+      "value": 57024
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57025;",
+      "decimal_missing_semicolon": "&#57025",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC1;",
+      "hex_missing_semicolon": "&#XDEC1",
+      "value": 57025
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57026;",
+      "decimal_missing_semicolon": "&#57026",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC2;",
+      "hex_missing_semicolon": "&#XDEC2",
+      "value": 57026
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57027;",
+      "decimal_missing_semicolon": "&#57027",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC3;",
+      "hex_missing_semicolon": "&#XDEC3",
+      "value": 57027
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57028;",
+      "decimal_missing_semicolon": "&#57028",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC4;",
+      "hex_missing_semicolon": "&#XDEC4",
+      "value": 57028
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57029;",
+      "decimal_missing_semicolon": "&#57029",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC5;",
+      "hex_missing_semicolon": "&#XDEC5",
+      "value": 57029
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57030;",
+      "decimal_missing_semicolon": "&#57030",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC6;",
+      "hex_missing_semicolon": "&#XDEC6",
+      "value": 57030
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57031;",
+      "decimal_missing_semicolon": "&#57031",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC7;",
+      "hex_missing_semicolon": "&#XDEC7",
+      "value": 57031
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57032;",
+      "decimal_missing_semicolon": "&#57032",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC8;",
+      "hex_missing_semicolon": "&#XDEC8",
+      "value": 57032
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57033;",
+      "decimal_missing_semicolon": "&#57033",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEC9;",
+      "hex_missing_semicolon": "&#XDEC9",
+      "value": 57033
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57034;",
+      "decimal_missing_semicolon": "&#57034",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDECA;",
+      "hex_missing_semicolon": "&#XDECA",
+      "value": 57034
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57035;",
+      "decimal_missing_semicolon": "&#57035",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDECB;",
+      "hex_missing_semicolon": "&#XDECB",
+      "value": 57035
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57036;",
+      "decimal_missing_semicolon": "&#57036",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDECC;",
+      "hex_missing_semicolon": "&#XDECC",
+      "value": 57036
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57037;",
+      "decimal_missing_semicolon": "&#57037",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDECD;",
+      "hex_missing_semicolon": "&#XDECD",
+      "value": 57037
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57038;",
+      "decimal_missing_semicolon": "&#57038",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDECE;",
+      "hex_missing_semicolon": "&#XDECE",
+      "value": 57038
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57039;",
+      "decimal_missing_semicolon": "&#57039",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDECF;",
+      "hex_missing_semicolon": "&#XDECF",
+      "value": 57039
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57040;",
+      "decimal_missing_semicolon": "&#57040",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED0;",
+      "hex_missing_semicolon": "&#XDED0",
+      "value": 57040
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57041;",
+      "decimal_missing_semicolon": "&#57041",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED1;",
+      "hex_missing_semicolon": "&#XDED1",
+      "value": 57041
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57042;",
+      "decimal_missing_semicolon": "&#57042",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED2;",
+      "hex_missing_semicolon": "&#XDED2",
+      "value": 57042
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57043;",
+      "decimal_missing_semicolon": "&#57043",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED3;",
+      "hex_missing_semicolon": "&#XDED3",
+      "value": 57043
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57044;",
+      "decimal_missing_semicolon": "&#57044",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED4;",
+      "hex_missing_semicolon": "&#XDED4",
+      "value": 57044
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57045;",
+      "decimal_missing_semicolon": "&#57045",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED5;",
+      "hex_missing_semicolon": "&#XDED5",
+      "value": 57045
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57046;",
+      "decimal_missing_semicolon": "&#57046",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED6;",
+      "hex_missing_semicolon": "&#XDED6",
+      "value": 57046
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57047;",
+      "decimal_missing_semicolon": "&#57047",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED7;",
+      "hex_missing_semicolon": "&#XDED7",
+      "value": 57047
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57048;",
+      "decimal_missing_semicolon": "&#57048",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED8;",
+      "hex_missing_semicolon": "&#XDED8",
+      "value": 57048
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57049;",
+      "decimal_missing_semicolon": "&#57049",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDED9;",
+      "hex_missing_semicolon": "&#XDED9",
+      "value": 57049
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57050;",
+      "decimal_missing_semicolon": "&#57050",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEDA;",
+      "hex_missing_semicolon": "&#XDEDA",
+      "value": 57050
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57051;",
+      "decimal_missing_semicolon": "&#57051",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEDB;",
+      "hex_missing_semicolon": "&#XDEDB",
+      "value": 57051
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57052;",
+      "decimal_missing_semicolon": "&#57052",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEDC;",
+      "hex_missing_semicolon": "&#XDEDC",
+      "value": 57052
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57053;",
+      "decimal_missing_semicolon": "&#57053",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEDD;",
+      "hex_missing_semicolon": "&#XDEDD",
+      "value": 57053
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57054;",
+      "decimal_missing_semicolon": "&#57054",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEDE;",
+      "hex_missing_semicolon": "&#XDEDE",
+      "value": 57054
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57055;",
+      "decimal_missing_semicolon": "&#57055",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEDF;",
+      "hex_missing_semicolon": "&#XDEDF",
+      "value": 57055
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57056;",
+      "decimal_missing_semicolon": "&#57056",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE0;",
+      "hex_missing_semicolon": "&#XDEE0",
+      "value": 57056
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57057;",
+      "decimal_missing_semicolon": "&#57057",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE1;",
+      "hex_missing_semicolon": "&#XDEE1",
+      "value": 57057
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57058;",
+      "decimal_missing_semicolon": "&#57058",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE2;",
+      "hex_missing_semicolon": "&#XDEE2",
+      "value": 57058
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57059;",
+      "decimal_missing_semicolon": "&#57059",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE3;",
+      "hex_missing_semicolon": "&#XDEE3",
+      "value": 57059
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57060;",
+      "decimal_missing_semicolon": "&#57060",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE4;",
+      "hex_missing_semicolon": "&#XDEE4",
+      "value": 57060
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57061;",
+      "decimal_missing_semicolon": "&#57061",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE5;",
+      "hex_missing_semicolon": "&#XDEE5",
+      "value": 57061
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57062;",
+      "decimal_missing_semicolon": "&#57062",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE6;",
+      "hex_missing_semicolon": "&#XDEE6",
+      "value": 57062
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57063;",
+      "decimal_missing_semicolon": "&#57063",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE7;",
+      "hex_missing_semicolon": "&#XDEE7",
+      "value": 57063
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57064;",
+      "decimal_missing_semicolon": "&#57064",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE8;",
+      "hex_missing_semicolon": "&#XDEE8",
+      "value": 57064
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57065;",
+      "decimal_missing_semicolon": "&#57065",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEE9;",
+      "hex_missing_semicolon": "&#XDEE9",
+      "value": 57065
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57066;",
+      "decimal_missing_semicolon": "&#57066",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEEA;",
+      "hex_missing_semicolon": "&#XDEEA",
+      "value": 57066
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57067;",
+      "decimal_missing_semicolon": "&#57067",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEEB;",
+      "hex_missing_semicolon": "&#XDEEB",
+      "value": 57067
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57068;",
+      "decimal_missing_semicolon": "&#57068",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEEC;",
+      "hex_missing_semicolon": "&#XDEEC",
+      "value": 57068
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57069;",
+      "decimal_missing_semicolon": "&#57069",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEED;",
+      "hex_missing_semicolon": "&#XDEED",
+      "value": 57069
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57070;",
+      "decimal_missing_semicolon": "&#57070",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEEE;",
+      "hex_missing_semicolon": "&#XDEEE",
+      "value": 57070
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57071;",
+      "decimal_missing_semicolon": "&#57071",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEEF;",
+      "hex_missing_semicolon": "&#XDEEF",
+      "value": 57071
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57072;",
+      "decimal_missing_semicolon": "&#57072",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF0;",
+      "hex_missing_semicolon": "&#XDEF0",
+      "value": 57072
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57073;",
+      "decimal_missing_semicolon": "&#57073",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF1;",
+      "hex_missing_semicolon": "&#XDEF1",
+      "value": 57073
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57074;",
+      "decimal_missing_semicolon": "&#57074",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF2;",
+      "hex_missing_semicolon": "&#XDEF2",
+      "value": 57074
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57075;",
+      "decimal_missing_semicolon": "&#57075",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF3;",
+      "hex_missing_semicolon": "&#XDEF3",
+      "value": 57075
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57076;",
+      "decimal_missing_semicolon": "&#57076",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF4;",
+      "hex_missing_semicolon": "&#XDEF4",
+      "value": 57076
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57077;",
+      "decimal_missing_semicolon": "&#57077",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF5;",
+      "hex_missing_semicolon": "&#XDEF5",
+      "value": 57077
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57078;",
+      "decimal_missing_semicolon": "&#57078",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF6;",
+      "hex_missing_semicolon": "&#XDEF6",
+      "value": 57078
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57079;",
+      "decimal_missing_semicolon": "&#57079",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF7;",
+      "hex_missing_semicolon": "&#XDEF7",
+      "value": 57079
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57080;",
+      "decimal_missing_semicolon": "&#57080",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF8;",
+      "hex_missing_semicolon": "&#XDEF8",
+      "value": 57080
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57081;",
+      "decimal_missing_semicolon": "&#57081",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEF9;",
+      "hex_missing_semicolon": "&#XDEF9",
+      "value": 57081
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57082;",
+      "decimal_missing_semicolon": "&#57082",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEFA;",
+      "hex_missing_semicolon": "&#XDEFA",
+      "value": 57082
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57083;",
+      "decimal_missing_semicolon": "&#57083",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEFB;",
+      "hex_missing_semicolon": "&#XDEFB",
+      "value": 57083
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57084;",
+      "decimal_missing_semicolon": "&#57084",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEFC;",
+      "hex_missing_semicolon": "&#XDEFC",
+      "value": 57084
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57085;",
+      "decimal_missing_semicolon": "&#57085",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEFD;",
+      "hex_missing_semicolon": "&#XDEFD",
+      "value": 57085
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57086;",
+      "decimal_missing_semicolon": "&#57086",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEFE;",
+      "hex_missing_semicolon": "&#XDEFE",
+      "value": 57086
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57087;",
+      "decimal_missing_semicolon": "&#57087",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDEFF;",
+      "hex_missing_semicolon": "&#XDEFF",
+      "value": 57087
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57088;",
+      "decimal_missing_semicolon": "&#57088",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF00;",
+      "hex_missing_semicolon": "&#XDF00",
+      "value": 57088
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57089;",
+      "decimal_missing_semicolon": "&#57089",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF01;",
+      "hex_missing_semicolon": "&#XDF01",
+      "value": 57089
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57090;",
+      "decimal_missing_semicolon": "&#57090",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF02;",
+      "hex_missing_semicolon": "&#XDF02",
+      "value": 57090
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57091;",
+      "decimal_missing_semicolon": "&#57091",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF03;",
+      "hex_missing_semicolon": "&#XDF03",
+      "value": 57091
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57092;",
+      "decimal_missing_semicolon": "&#57092",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF04;",
+      "hex_missing_semicolon": "&#XDF04",
+      "value": 57092
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57093;",
+      "decimal_missing_semicolon": "&#57093",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF05;",
+      "hex_missing_semicolon": "&#XDF05",
+      "value": 57093
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57094;",
+      "decimal_missing_semicolon": "&#57094",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF06;",
+      "hex_missing_semicolon": "&#XDF06",
+      "value": 57094
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57095;",
+      "decimal_missing_semicolon": "&#57095",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF07;",
+      "hex_missing_semicolon": "&#XDF07",
+      "value": 57095
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57096;",
+      "decimal_missing_semicolon": "&#57096",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF08;",
+      "hex_missing_semicolon": "&#XDF08",
+      "value": 57096
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57097;",
+      "decimal_missing_semicolon": "&#57097",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF09;",
+      "hex_missing_semicolon": "&#XDF09",
+      "value": 57097
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57098;",
+      "decimal_missing_semicolon": "&#57098",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF0A;",
+      "hex_missing_semicolon": "&#XDF0A",
+      "value": 57098
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57099;",
+      "decimal_missing_semicolon": "&#57099",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF0B;",
+      "hex_missing_semicolon": "&#XDF0B",
+      "value": 57099
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57100;",
+      "decimal_missing_semicolon": "&#57100",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF0C;",
+      "hex_missing_semicolon": "&#XDF0C",
+      "value": 57100
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57101;",
+      "decimal_missing_semicolon": "&#57101",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF0D;",
+      "hex_missing_semicolon": "&#XDF0D",
+      "value": 57101
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57102;",
+      "decimal_missing_semicolon": "&#57102",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF0E;",
+      "hex_missing_semicolon": "&#XDF0E",
+      "value": 57102
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57103;",
+      "decimal_missing_semicolon": "&#57103",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF0F;",
+      "hex_missing_semicolon": "&#XDF0F",
+      "value": 57103
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57104;",
+      "decimal_missing_semicolon": "&#57104",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF10;",
+      "hex_missing_semicolon": "&#XDF10",
+      "value": 57104
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57105;",
+      "decimal_missing_semicolon": "&#57105",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF11;",
+      "hex_missing_semicolon": "&#XDF11",
+      "value": 57105
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57106;",
+      "decimal_missing_semicolon": "&#57106",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF12;",
+      "hex_missing_semicolon": "&#XDF12",
+      "value": 57106
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57107;",
+      "decimal_missing_semicolon": "&#57107",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF13;",
+      "hex_missing_semicolon": "&#XDF13",
+      "value": 57107
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57108;",
+      "decimal_missing_semicolon": "&#57108",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF14;",
+      "hex_missing_semicolon": "&#XDF14",
+      "value": 57108
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57109;",
+      "decimal_missing_semicolon": "&#57109",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF15;",
+      "hex_missing_semicolon": "&#XDF15",
+      "value": 57109
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57110;",
+      "decimal_missing_semicolon": "&#57110",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF16;",
+      "hex_missing_semicolon": "&#XDF16",
+      "value": 57110
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57111;",
+      "decimal_missing_semicolon": "&#57111",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF17;",
+      "hex_missing_semicolon": "&#XDF17",
+      "value": 57111
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57112;",
+      "decimal_missing_semicolon": "&#57112",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF18;",
+      "hex_missing_semicolon": "&#XDF18",
+      "value": 57112
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57113;",
+      "decimal_missing_semicolon": "&#57113",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF19;",
+      "hex_missing_semicolon": "&#XDF19",
+      "value": 57113
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57114;",
+      "decimal_missing_semicolon": "&#57114",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF1A;",
+      "hex_missing_semicolon": "&#XDF1A",
+      "value": 57114
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57115;",
+      "decimal_missing_semicolon": "&#57115",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF1B;",
+      "hex_missing_semicolon": "&#XDF1B",
+      "value": 57115
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57116;",
+      "decimal_missing_semicolon": "&#57116",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF1C;",
+      "hex_missing_semicolon": "&#XDF1C",
+      "value": 57116
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57117;",
+      "decimal_missing_semicolon": "&#57117",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF1D;",
+      "hex_missing_semicolon": "&#XDF1D",
+      "value": 57117
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57118;",
+      "decimal_missing_semicolon": "&#57118",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF1E;",
+      "hex_missing_semicolon": "&#XDF1E",
+      "value": 57118
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57119;",
+      "decimal_missing_semicolon": "&#57119",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF1F;",
+      "hex_missing_semicolon": "&#XDF1F",
+      "value": 57119
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57120;",
+      "decimal_missing_semicolon": "&#57120",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF20;",
+      "hex_missing_semicolon": "&#XDF20",
+      "value": 57120
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57121;",
+      "decimal_missing_semicolon": "&#57121",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF21;",
+      "hex_missing_semicolon": "&#XDF21",
+      "value": 57121
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57122;",
+      "decimal_missing_semicolon": "&#57122",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF22;",
+      "hex_missing_semicolon": "&#XDF22",
+      "value": 57122
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57123;",
+      "decimal_missing_semicolon": "&#57123",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF23;",
+      "hex_missing_semicolon": "&#XDF23",
+      "value": 57123
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57124;",
+      "decimal_missing_semicolon": "&#57124",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF24;",
+      "hex_missing_semicolon": "&#XDF24",
+      "value": 57124
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57125;",
+      "decimal_missing_semicolon": "&#57125",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF25;",
+      "hex_missing_semicolon": "&#XDF25",
+      "value": 57125
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57126;",
+      "decimal_missing_semicolon": "&#57126",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF26;",
+      "hex_missing_semicolon": "&#XDF26",
+      "value": 57126
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57127;",
+      "decimal_missing_semicolon": "&#57127",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF27;",
+      "hex_missing_semicolon": "&#XDF27",
+      "value": 57127
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57128;",
+      "decimal_missing_semicolon": "&#57128",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF28;",
+      "hex_missing_semicolon": "&#XDF28",
+      "value": 57128
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57129;",
+      "decimal_missing_semicolon": "&#57129",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF29;",
+      "hex_missing_semicolon": "&#XDF29",
+      "value": 57129
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57130;",
+      "decimal_missing_semicolon": "&#57130",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF2A;",
+      "hex_missing_semicolon": "&#XDF2A",
+      "value": 57130
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57131;",
+      "decimal_missing_semicolon": "&#57131",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF2B;",
+      "hex_missing_semicolon": "&#XDF2B",
+      "value": 57131
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57132;",
+      "decimal_missing_semicolon": "&#57132",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF2C;",
+      "hex_missing_semicolon": "&#XDF2C",
+      "value": 57132
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57133;",
+      "decimal_missing_semicolon": "&#57133",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF2D;",
+      "hex_missing_semicolon": "&#XDF2D",
+      "value": 57133
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57134;",
+      "decimal_missing_semicolon": "&#57134",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF2E;",
+      "hex_missing_semicolon": "&#XDF2E",
+      "value": 57134
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57135;",
+      "decimal_missing_semicolon": "&#57135",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF2F;",
+      "hex_missing_semicolon": "&#XDF2F",
+      "value": 57135
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57136;",
+      "decimal_missing_semicolon": "&#57136",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF30;",
+      "hex_missing_semicolon": "&#XDF30",
+      "value": 57136
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57137;",
+      "decimal_missing_semicolon": "&#57137",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF31;",
+      "hex_missing_semicolon": "&#XDF31",
+      "value": 57137
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57138;",
+      "decimal_missing_semicolon": "&#57138",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF32;",
+      "hex_missing_semicolon": "&#XDF32",
+      "value": 57138
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57139;",
+      "decimal_missing_semicolon": "&#57139",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF33;",
+      "hex_missing_semicolon": "&#XDF33",
+      "value": 57139
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57140;",
+      "decimal_missing_semicolon": "&#57140",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF34;",
+      "hex_missing_semicolon": "&#XDF34",
+      "value": 57140
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57141;",
+      "decimal_missing_semicolon": "&#57141",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF35;",
+      "hex_missing_semicolon": "&#XDF35",
+      "value": 57141
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57142;",
+      "decimal_missing_semicolon": "&#57142",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF36;",
+      "hex_missing_semicolon": "&#XDF36",
+      "value": 57142
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57143;",
+      "decimal_missing_semicolon": "&#57143",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF37;",
+      "hex_missing_semicolon": "&#XDF37",
+      "value": 57143
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57144;",
+      "decimal_missing_semicolon": "&#57144",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF38;",
+      "hex_missing_semicolon": "&#XDF38",
+      "value": 57144
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57145;",
+      "decimal_missing_semicolon": "&#57145",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF39;",
+      "hex_missing_semicolon": "&#XDF39",
+      "value": 57145
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57146;",
+      "decimal_missing_semicolon": "&#57146",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF3A;",
+      "hex_missing_semicolon": "&#XDF3A",
+      "value": 57146
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57147;",
+      "decimal_missing_semicolon": "&#57147",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF3B;",
+      "hex_missing_semicolon": "&#XDF3B",
+      "value": 57147
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57148;",
+      "decimal_missing_semicolon": "&#57148",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF3C;",
+      "hex_missing_semicolon": "&#XDF3C",
+      "value": 57148
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57149;",
+      "decimal_missing_semicolon": "&#57149",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF3D;",
+      "hex_missing_semicolon": "&#XDF3D",
+      "value": 57149
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57150;",
+      "decimal_missing_semicolon": "&#57150",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF3E;",
+      "hex_missing_semicolon": "&#XDF3E",
+      "value": 57150
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57151;",
+      "decimal_missing_semicolon": "&#57151",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF3F;",
+      "hex_missing_semicolon": "&#XDF3F",
+      "value": 57151
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57152;",
+      "decimal_missing_semicolon": "&#57152",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF40;",
+      "hex_missing_semicolon": "&#XDF40",
+      "value": 57152
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57153;",
+      "decimal_missing_semicolon": "&#57153",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF41;",
+      "hex_missing_semicolon": "&#XDF41",
+      "value": 57153
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57154;",
+      "decimal_missing_semicolon": "&#57154",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF42;",
+      "hex_missing_semicolon": "&#XDF42",
+      "value": 57154
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57155;",
+      "decimal_missing_semicolon": "&#57155",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF43;",
+      "hex_missing_semicolon": "&#XDF43",
+      "value": 57155
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57156;",
+      "decimal_missing_semicolon": "&#57156",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF44;",
+      "hex_missing_semicolon": "&#XDF44",
+      "value": 57156
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57157;",
+      "decimal_missing_semicolon": "&#57157",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF45;",
+      "hex_missing_semicolon": "&#XDF45",
+      "value": 57157
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57158;",
+      "decimal_missing_semicolon": "&#57158",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF46;",
+      "hex_missing_semicolon": "&#XDF46",
+      "value": 57158
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57159;",
+      "decimal_missing_semicolon": "&#57159",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF47;",
+      "hex_missing_semicolon": "&#XDF47",
+      "value": 57159
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57160;",
+      "decimal_missing_semicolon": "&#57160",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF48;",
+      "hex_missing_semicolon": "&#XDF48",
+      "value": 57160
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57161;",
+      "decimal_missing_semicolon": "&#57161",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF49;",
+      "hex_missing_semicolon": "&#XDF49",
+      "value": 57161
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57162;",
+      "decimal_missing_semicolon": "&#57162",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF4A;",
+      "hex_missing_semicolon": "&#XDF4A",
+      "value": 57162
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57163;",
+      "decimal_missing_semicolon": "&#57163",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF4B;",
+      "hex_missing_semicolon": "&#XDF4B",
+      "value": 57163
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57164;",
+      "decimal_missing_semicolon": "&#57164",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF4C;",
+      "hex_missing_semicolon": "&#XDF4C",
+      "value": 57164
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57165;",
+      "decimal_missing_semicolon": "&#57165",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF4D;",
+      "hex_missing_semicolon": "&#XDF4D",
+      "value": 57165
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57166;",
+      "decimal_missing_semicolon": "&#57166",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF4E;",
+      "hex_missing_semicolon": "&#XDF4E",
+      "value": 57166
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57167;",
+      "decimal_missing_semicolon": "&#57167",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF4F;",
+      "hex_missing_semicolon": "&#XDF4F",
+      "value": 57167
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57168;",
+      "decimal_missing_semicolon": "&#57168",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF50;",
+      "hex_missing_semicolon": "&#XDF50",
+      "value": 57168
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57169;",
+      "decimal_missing_semicolon": "&#57169",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF51;",
+      "hex_missing_semicolon": "&#XDF51",
+      "value": 57169
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57170;",
+      "decimal_missing_semicolon": "&#57170",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF52;",
+      "hex_missing_semicolon": "&#XDF52",
+      "value": 57170
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57171;",
+      "decimal_missing_semicolon": "&#57171",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF53;",
+      "hex_missing_semicolon": "&#XDF53",
+      "value": 57171
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57172;",
+      "decimal_missing_semicolon": "&#57172",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF54;",
+      "hex_missing_semicolon": "&#XDF54",
+      "value": 57172
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57173;",
+      "decimal_missing_semicolon": "&#57173",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF55;",
+      "hex_missing_semicolon": "&#XDF55",
+      "value": 57173
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57174;",
+      "decimal_missing_semicolon": "&#57174",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF56;",
+      "hex_missing_semicolon": "&#XDF56",
+      "value": 57174
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57175;",
+      "decimal_missing_semicolon": "&#57175",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF57;",
+      "hex_missing_semicolon": "&#XDF57",
+      "value": 57175
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57176;",
+      "decimal_missing_semicolon": "&#57176",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF58;",
+      "hex_missing_semicolon": "&#XDF58",
+      "value": 57176
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57177;",
+      "decimal_missing_semicolon": "&#57177",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF59;",
+      "hex_missing_semicolon": "&#XDF59",
+      "value": 57177
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57178;",
+      "decimal_missing_semicolon": "&#57178",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF5A;",
+      "hex_missing_semicolon": "&#XDF5A",
+      "value": 57178
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57179;",
+      "decimal_missing_semicolon": "&#57179",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF5B;",
+      "hex_missing_semicolon": "&#XDF5B",
+      "value": 57179
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57180;",
+      "decimal_missing_semicolon": "&#57180",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF5C;",
+      "hex_missing_semicolon": "&#XDF5C",
+      "value": 57180
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57181;",
+      "decimal_missing_semicolon": "&#57181",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF5D;",
+      "hex_missing_semicolon": "&#XDF5D",
+      "value": 57181
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57182;",
+      "decimal_missing_semicolon": "&#57182",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF5E;",
+      "hex_missing_semicolon": "&#XDF5E",
+      "value": 57182
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57183;",
+      "decimal_missing_semicolon": "&#57183",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF5F;",
+      "hex_missing_semicolon": "&#XDF5F",
+      "value": 57183
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57184;",
+      "decimal_missing_semicolon": "&#57184",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF60;",
+      "hex_missing_semicolon": "&#XDF60",
+      "value": 57184
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57185;",
+      "decimal_missing_semicolon": "&#57185",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF61;",
+      "hex_missing_semicolon": "&#XDF61",
+      "value": 57185
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57186;",
+      "decimal_missing_semicolon": "&#57186",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF62;",
+      "hex_missing_semicolon": "&#XDF62",
+      "value": 57186
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57187;",
+      "decimal_missing_semicolon": "&#57187",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF63;",
+      "hex_missing_semicolon": "&#XDF63",
+      "value": 57187
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57188;",
+      "decimal_missing_semicolon": "&#57188",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF64;",
+      "hex_missing_semicolon": "&#XDF64",
+      "value": 57188
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57189;",
+      "decimal_missing_semicolon": "&#57189",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF65;",
+      "hex_missing_semicolon": "&#XDF65",
+      "value": 57189
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57190;",
+      "decimal_missing_semicolon": "&#57190",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF66;",
+      "hex_missing_semicolon": "&#XDF66",
+      "value": 57190
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57191;",
+      "decimal_missing_semicolon": "&#57191",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF67;",
+      "hex_missing_semicolon": "&#XDF67",
+      "value": 57191
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57192;",
+      "decimal_missing_semicolon": "&#57192",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF68;",
+      "hex_missing_semicolon": "&#XDF68",
+      "value": 57192
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57193;",
+      "decimal_missing_semicolon": "&#57193",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF69;",
+      "hex_missing_semicolon": "&#XDF69",
+      "value": 57193
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57194;",
+      "decimal_missing_semicolon": "&#57194",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF6A;",
+      "hex_missing_semicolon": "&#XDF6A",
+      "value": 57194
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57195;",
+      "decimal_missing_semicolon": "&#57195",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF6B;",
+      "hex_missing_semicolon": "&#XDF6B",
+      "value": 57195
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57196;",
+      "decimal_missing_semicolon": "&#57196",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF6C;",
+      "hex_missing_semicolon": "&#XDF6C",
+      "value": 57196
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57197;",
+      "decimal_missing_semicolon": "&#57197",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF6D;",
+      "hex_missing_semicolon": "&#XDF6D",
+      "value": 57197
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57198;",
+      "decimal_missing_semicolon": "&#57198",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF6E;",
+      "hex_missing_semicolon": "&#XDF6E",
+      "value": 57198
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57199;",
+      "decimal_missing_semicolon": "&#57199",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF6F;",
+      "hex_missing_semicolon": "&#XDF6F",
+      "value": 57199
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57200;",
+      "decimal_missing_semicolon": "&#57200",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF70;",
+      "hex_missing_semicolon": "&#XDF70",
+      "value": 57200
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57201;",
+      "decimal_missing_semicolon": "&#57201",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF71;",
+      "hex_missing_semicolon": "&#XDF71",
+      "value": 57201
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57202;",
+      "decimal_missing_semicolon": "&#57202",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF72;",
+      "hex_missing_semicolon": "&#XDF72",
+      "value": 57202
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57203;",
+      "decimal_missing_semicolon": "&#57203",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF73;",
+      "hex_missing_semicolon": "&#XDF73",
+      "value": 57203
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57204;",
+      "decimal_missing_semicolon": "&#57204",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF74;",
+      "hex_missing_semicolon": "&#XDF74",
+      "value": 57204
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57205;",
+      "decimal_missing_semicolon": "&#57205",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF75;",
+      "hex_missing_semicolon": "&#XDF75",
+      "value": 57205
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57206;",
+      "decimal_missing_semicolon": "&#57206",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF76;",
+      "hex_missing_semicolon": "&#XDF76",
+      "value": 57206
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57207;",
+      "decimal_missing_semicolon": "&#57207",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF77;",
+      "hex_missing_semicolon": "&#XDF77",
+      "value": 57207
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57208;",
+      "decimal_missing_semicolon": "&#57208",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF78;",
+      "hex_missing_semicolon": "&#XDF78",
+      "value": 57208
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57209;",
+      "decimal_missing_semicolon": "&#57209",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF79;",
+      "hex_missing_semicolon": "&#XDF79",
+      "value": 57209
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57210;",
+      "decimal_missing_semicolon": "&#57210",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF7A;",
+      "hex_missing_semicolon": "&#XDF7A",
+      "value": 57210
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57211;",
+      "decimal_missing_semicolon": "&#57211",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF7B;",
+      "hex_missing_semicolon": "&#XDF7B",
+      "value": 57211
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57212;",
+      "decimal_missing_semicolon": "&#57212",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF7C;",
+      "hex_missing_semicolon": "&#XDF7C",
+      "value": 57212
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57213;",
+      "decimal_missing_semicolon": "&#57213",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF7D;",
+      "hex_missing_semicolon": "&#XDF7D",
+      "value": 57213
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57214;",
+      "decimal_missing_semicolon": "&#57214",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF7E;",
+      "hex_missing_semicolon": "&#XDF7E",
+      "value": 57214
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57215;",
+      "decimal_missing_semicolon": "&#57215",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF7F;",
+      "hex_missing_semicolon": "&#XDF7F",
+      "value": 57215
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57216;",
+      "decimal_missing_semicolon": "&#57216",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF80;",
+      "hex_missing_semicolon": "&#XDF80",
+      "value": 57216
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57217;",
+      "decimal_missing_semicolon": "&#57217",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF81;",
+      "hex_missing_semicolon": "&#XDF81",
+      "value": 57217
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57218;",
+      "decimal_missing_semicolon": "&#57218",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF82;",
+      "hex_missing_semicolon": "&#XDF82",
+      "value": 57218
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57219;",
+      "decimal_missing_semicolon": "&#57219",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF83;",
+      "hex_missing_semicolon": "&#XDF83",
+      "value": 57219
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57220;",
+      "decimal_missing_semicolon": "&#57220",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF84;",
+      "hex_missing_semicolon": "&#XDF84",
+      "value": 57220
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57221;",
+      "decimal_missing_semicolon": "&#57221",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF85;",
+      "hex_missing_semicolon": "&#XDF85",
+      "value": 57221
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57222;",
+      "decimal_missing_semicolon": "&#57222",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF86;",
+      "hex_missing_semicolon": "&#XDF86",
+      "value": 57222
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57223;",
+      "decimal_missing_semicolon": "&#57223",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF87;",
+      "hex_missing_semicolon": "&#XDF87",
+      "value": 57223
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57224;",
+      "decimal_missing_semicolon": "&#57224",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF88;",
+      "hex_missing_semicolon": "&#XDF88",
+      "value": 57224
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57225;",
+      "decimal_missing_semicolon": "&#57225",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF89;",
+      "hex_missing_semicolon": "&#XDF89",
+      "value": 57225
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57226;",
+      "decimal_missing_semicolon": "&#57226",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF8A;",
+      "hex_missing_semicolon": "&#XDF8A",
+      "value": 57226
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57227;",
+      "decimal_missing_semicolon": "&#57227",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF8B;",
+      "hex_missing_semicolon": "&#XDF8B",
+      "value": 57227
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57228;",
+      "decimal_missing_semicolon": "&#57228",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF8C;",
+      "hex_missing_semicolon": "&#XDF8C",
+      "value": 57228
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57229;",
+      "decimal_missing_semicolon": "&#57229",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF8D;",
+      "hex_missing_semicolon": "&#XDF8D",
+      "value": 57229
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57230;",
+      "decimal_missing_semicolon": "&#57230",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF8E;",
+      "hex_missing_semicolon": "&#XDF8E",
+      "value": 57230
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57231;",
+      "decimal_missing_semicolon": "&#57231",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF8F;",
+      "hex_missing_semicolon": "&#XDF8F",
+      "value": 57231
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57232;",
+      "decimal_missing_semicolon": "&#57232",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF90;",
+      "hex_missing_semicolon": "&#XDF90",
+      "value": 57232
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57233;",
+      "decimal_missing_semicolon": "&#57233",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF91;",
+      "hex_missing_semicolon": "&#XDF91",
+      "value": 57233
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57234;",
+      "decimal_missing_semicolon": "&#57234",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF92;",
+      "hex_missing_semicolon": "&#XDF92",
+      "value": 57234
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57235;",
+      "decimal_missing_semicolon": "&#57235",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF93;",
+      "hex_missing_semicolon": "&#XDF93",
+      "value": 57235
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57236;",
+      "decimal_missing_semicolon": "&#57236",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF94;",
+      "hex_missing_semicolon": "&#XDF94",
+      "value": 57236
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57237;",
+      "decimal_missing_semicolon": "&#57237",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF95;",
+      "hex_missing_semicolon": "&#XDF95",
+      "value": 57237
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57238;",
+      "decimal_missing_semicolon": "&#57238",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF96;",
+      "hex_missing_semicolon": "&#XDF96",
+      "value": 57238
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57239;",
+      "decimal_missing_semicolon": "&#57239",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF97;",
+      "hex_missing_semicolon": "&#XDF97",
+      "value": 57239
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57240;",
+      "decimal_missing_semicolon": "&#57240",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF98;",
+      "hex_missing_semicolon": "&#XDF98",
+      "value": 57240
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57241;",
+      "decimal_missing_semicolon": "&#57241",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF99;",
+      "hex_missing_semicolon": "&#XDF99",
+      "value": 57241
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57242;",
+      "decimal_missing_semicolon": "&#57242",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF9A;",
+      "hex_missing_semicolon": "&#XDF9A",
+      "value": 57242
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57243;",
+      "decimal_missing_semicolon": "&#57243",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF9B;",
+      "hex_missing_semicolon": "&#XDF9B",
+      "value": 57243
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57244;",
+      "decimal_missing_semicolon": "&#57244",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF9C;",
+      "hex_missing_semicolon": "&#XDF9C",
+      "value": 57244
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57245;",
+      "decimal_missing_semicolon": "&#57245",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF9D;",
+      "hex_missing_semicolon": "&#XDF9D",
+      "value": 57245
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57246;",
+      "decimal_missing_semicolon": "&#57246",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF9E;",
+      "hex_missing_semicolon": "&#XDF9E",
+      "value": 57246
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57247;",
+      "decimal_missing_semicolon": "&#57247",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDF9F;",
+      "hex_missing_semicolon": "&#XDF9F",
+      "value": 57247
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57248;",
+      "decimal_missing_semicolon": "&#57248",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA0;",
+      "hex_missing_semicolon": "&#XDFA0",
+      "value": 57248
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57249;",
+      "decimal_missing_semicolon": "&#57249",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA1;",
+      "hex_missing_semicolon": "&#XDFA1",
+      "value": 57249
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57250;",
+      "decimal_missing_semicolon": "&#57250",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA2;",
+      "hex_missing_semicolon": "&#XDFA2",
+      "value": 57250
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57251;",
+      "decimal_missing_semicolon": "&#57251",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA3;",
+      "hex_missing_semicolon": "&#XDFA3",
+      "value": 57251
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57252;",
+      "decimal_missing_semicolon": "&#57252",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA4;",
+      "hex_missing_semicolon": "&#XDFA4",
+      "value": 57252
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57253;",
+      "decimal_missing_semicolon": "&#57253",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA5;",
+      "hex_missing_semicolon": "&#XDFA5",
+      "value": 57253
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57254;",
+      "decimal_missing_semicolon": "&#57254",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA6;",
+      "hex_missing_semicolon": "&#XDFA6",
+      "value": 57254
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57255;",
+      "decimal_missing_semicolon": "&#57255",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA7;",
+      "hex_missing_semicolon": "&#XDFA7",
+      "value": 57255
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57256;",
+      "decimal_missing_semicolon": "&#57256",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA8;",
+      "hex_missing_semicolon": "&#XDFA8",
+      "value": 57256
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57257;",
+      "decimal_missing_semicolon": "&#57257",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFA9;",
+      "hex_missing_semicolon": "&#XDFA9",
+      "value": 57257
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57258;",
+      "decimal_missing_semicolon": "&#57258",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFAA;",
+      "hex_missing_semicolon": "&#XDFAA",
+      "value": 57258
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57259;",
+      "decimal_missing_semicolon": "&#57259",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFAB;",
+      "hex_missing_semicolon": "&#XDFAB",
+      "value": 57259
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57260;",
+      "decimal_missing_semicolon": "&#57260",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFAC;",
+      "hex_missing_semicolon": "&#XDFAC",
+      "value": 57260
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57261;",
+      "decimal_missing_semicolon": "&#57261",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFAD;",
+      "hex_missing_semicolon": "&#XDFAD",
+      "value": 57261
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57262;",
+      "decimal_missing_semicolon": "&#57262",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFAE;",
+      "hex_missing_semicolon": "&#XDFAE",
+      "value": 57262
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57263;",
+      "decimal_missing_semicolon": "&#57263",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFAF;",
+      "hex_missing_semicolon": "&#XDFAF",
+      "value": 57263
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57264;",
+      "decimal_missing_semicolon": "&#57264",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB0;",
+      "hex_missing_semicolon": "&#XDFB0",
+      "value": 57264
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57265;",
+      "decimal_missing_semicolon": "&#57265",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB1;",
+      "hex_missing_semicolon": "&#XDFB1",
+      "value": 57265
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57266;",
+      "decimal_missing_semicolon": "&#57266",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB2;",
+      "hex_missing_semicolon": "&#XDFB2",
+      "value": 57266
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57267;",
+      "decimal_missing_semicolon": "&#57267",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB3;",
+      "hex_missing_semicolon": "&#XDFB3",
+      "value": 57267
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57268;",
+      "decimal_missing_semicolon": "&#57268",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB4;",
+      "hex_missing_semicolon": "&#XDFB4",
+      "value": 57268
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57269;",
+      "decimal_missing_semicolon": "&#57269",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB5;",
+      "hex_missing_semicolon": "&#XDFB5",
+      "value": 57269
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57270;",
+      "decimal_missing_semicolon": "&#57270",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB6;",
+      "hex_missing_semicolon": "&#XDFB6",
+      "value": 57270
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57271;",
+      "decimal_missing_semicolon": "&#57271",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB7;",
+      "hex_missing_semicolon": "&#XDFB7",
+      "value": 57271
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57272;",
+      "decimal_missing_semicolon": "&#57272",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB8;",
+      "hex_missing_semicolon": "&#XDFB8",
+      "value": 57272
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57273;",
+      "decimal_missing_semicolon": "&#57273",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFB9;",
+      "hex_missing_semicolon": "&#XDFB9",
+      "value": 57273
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57274;",
+      "decimal_missing_semicolon": "&#57274",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFBA;",
+      "hex_missing_semicolon": "&#XDFBA",
+      "value": 57274
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57275;",
+      "decimal_missing_semicolon": "&#57275",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFBB;",
+      "hex_missing_semicolon": "&#XDFBB",
+      "value": 57275
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57276;",
+      "decimal_missing_semicolon": "&#57276",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFBC;",
+      "hex_missing_semicolon": "&#XDFBC",
+      "value": 57276
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57277;",
+      "decimal_missing_semicolon": "&#57277",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFBD;",
+      "hex_missing_semicolon": "&#XDFBD",
+      "value": 57277
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57278;",
+      "decimal_missing_semicolon": "&#57278",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFBE;",
+      "hex_missing_semicolon": "&#XDFBE",
+      "value": 57278
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57279;",
+      "decimal_missing_semicolon": "&#57279",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFBF;",
+      "hex_missing_semicolon": "&#XDFBF",
+      "value": 57279
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57280;",
+      "decimal_missing_semicolon": "&#57280",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC0;",
+      "hex_missing_semicolon": "&#XDFC0",
+      "value": 57280
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57281;",
+      "decimal_missing_semicolon": "&#57281",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC1;",
+      "hex_missing_semicolon": "&#XDFC1",
+      "value": 57281
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57282;",
+      "decimal_missing_semicolon": "&#57282",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC2;",
+      "hex_missing_semicolon": "&#XDFC2",
+      "value": 57282
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57283;",
+      "decimal_missing_semicolon": "&#57283",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC3;",
+      "hex_missing_semicolon": "&#XDFC3",
+      "value": 57283
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57284;",
+      "decimal_missing_semicolon": "&#57284",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC4;",
+      "hex_missing_semicolon": "&#XDFC4",
+      "value": 57284
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57285;",
+      "decimal_missing_semicolon": "&#57285",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC5;",
+      "hex_missing_semicolon": "&#XDFC5",
+      "value": 57285
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57286;",
+      "decimal_missing_semicolon": "&#57286",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC6;",
+      "hex_missing_semicolon": "&#XDFC6",
+      "value": 57286
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57287;",
+      "decimal_missing_semicolon": "&#57287",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC7;",
+      "hex_missing_semicolon": "&#XDFC7",
+      "value": 57287
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57288;",
+      "decimal_missing_semicolon": "&#57288",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC8;",
+      "hex_missing_semicolon": "&#XDFC8",
+      "value": 57288
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57289;",
+      "decimal_missing_semicolon": "&#57289",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFC9;",
+      "hex_missing_semicolon": "&#XDFC9",
+      "value": 57289
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57290;",
+      "decimal_missing_semicolon": "&#57290",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFCA;",
+      "hex_missing_semicolon": "&#XDFCA",
+      "value": 57290
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57291;",
+      "decimal_missing_semicolon": "&#57291",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFCB;",
+      "hex_missing_semicolon": "&#XDFCB",
+      "value": 57291
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57292;",
+      "decimal_missing_semicolon": "&#57292",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFCC;",
+      "hex_missing_semicolon": "&#XDFCC",
+      "value": 57292
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57293;",
+      "decimal_missing_semicolon": "&#57293",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFCD;",
+      "hex_missing_semicolon": "&#XDFCD",
+      "value": 57293
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57294;",
+      "decimal_missing_semicolon": "&#57294",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFCE;",
+      "hex_missing_semicolon": "&#XDFCE",
+      "value": 57294
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57295;",
+      "decimal_missing_semicolon": "&#57295",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFCF;",
+      "hex_missing_semicolon": "&#XDFCF",
+      "value": 57295
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57296;",
+      "decimal_missing_semicolon": "&#57296",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD0;",
+      "hex_missing_semicolon": "&#XDFD0",
+      "value": 57296
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57297;",
+      "decimal_missing_semicolon": "&#57297",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD1;",
+      "hex_missing_semicolon": "&#XDFD1",
+      "value": 57297
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57298;",
+      "decimal_missing_semicolon": "&#57298",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD2;",
+      "hex_missing_semicolon": "&#XDFD2",
+      "value": 57298
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57299;",
+      "decimal_missing_semicolon": "&#57299",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD3;",
+      "hex_missing_semicolon": "&#XDFD3",
+      "value": 57299
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57300;",
+      "decimal_missing_semicolon": "&#57300",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD4;",
+      "hex_missing_semicolon": "&#XDFD4",
+      "value": 57300
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57301;",
+      "decimal_missing_semicolon": "&#57301",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD5;",
+      "hex_missing_semicolon": "&#XDFD5",
+      "value": 57301
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57302;",
+      "decimal_missing_semicolon": "&#57302",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD6;",
+      "hex_missing_semicolon": "&#XDFD6",
+      "value": 57302
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57303;",
+      "decimal_missing_semicolon": "&#57303",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD7;",
+      "hex_missing_semicolon": "&#XDFD7",
+      "value": 57303
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57304;",
+      "decimal_missing_semicolon": "&#57304",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD8;",
+      "hex_missing_semicolon": "&#XDFD8",
+      "value": 57304
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57305;",
+      "decimal_missing_semicolon": "&#57305",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFD9;",
+      "hex_missing_semicolon": "&#XDFD9",
+      "value": 57305
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57306;",
+      "decimal_missing_semicolon": "&#57306",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFDA;",
+      "hex_missing_semicolon": "&#XDFDA",
+      "value": 57306
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57307;",
+      "decimal_missing_semicolon": "&#57307",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFDB;",
+      "hex_missing_semicolon": "&#XDFDB",
+      "value": 57307
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57308;",
+      "decimal_missing_semicolon": "&#57308",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFDC;",
+      "hex_missing_semicolon": "&#XDFDC",
+      "value": 57308
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57309;",
+      "decimal_missing_semicolon": "&#57309",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFDD;",
+      "hex_missing_semicolon": "&#XDFDD",
+      "value": 57309
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57310;",
+      "decimal_missing_semicolon": "&#57310",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFDE;",
+      "hex_missing_semicolon": "&#XDFDE",
+      "value": 57310
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57311;",
+      "decimal_missing_semicolon": "&#57311",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFDF;",
+      "hex_missing_semicolon": "&#XDFDF",
+      "value": 57311
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57312;",
+      "decimal_missing_semicolon": "&#57312",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE0;",
+      "hex_missing_semicolon": "&#XDFE0",
+      "value": 57312
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57313;",
+      "decimal_missing_semicolon": "&#57313",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE1;",
+      "hex_missing_semicolon": "&#XDFE1",
+      "value": 57313
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57314;",
+      "decimal_missing_semicolon": "&#57314",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE2;",
+      "hex_missing_semicolon": "&#XDFE2",
+      "value": 57314
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57315;",
+      "decimal_missing_semicolon": "&#57315",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE3;",
+      "hex_missing_semicolon": "&#XDFE3",
+      "value": 57315
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57316;",
+      "decimal_missing_semicolon": "&#57316",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE4;",
+      "hex_missing_semicolon": "&#XDFE4",
+      "value": 57316
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57317;",
+      "decimal_missing_semicolon": "&#57317",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE5;",
+      "hex_missing_semicolon": "&#XDFE5",
+      "value": 57317
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57318;",
+      "decimal_missing_semicolon": "&#57318",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE6;",
+      "hex_missing_semicolon": "&#XDFE6",
+      "value": 57318
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57319;",
+      "decimal_missing_semicolon": "&#57319",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE7;",
+      "hex_missing_semicolon": "&#XDFE7",
+      "value": 57319
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57320;",
+      "decimal_missing_semicolon": "&#57320",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE8;",
+      "hex_missing_semicolon": "&#XDFE8",
+      "value": 57320
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57321;",
+      "decimal_missing_semicolon": "&#57321",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFE9;",
+      "hex_missing_semicolon": "&#XDFE9",
+      "value": 57321
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57322;",
+      "decimal_missing_semicolon": "&#57322",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFEA;",
+      "hex_missing_semicolon": "&#XDFEA",
+      "value": 57322
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57323;",
+      "decimal_missing_semicolon": "&#57323",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFEB;",
+      "hex_missing_semicolon": "&#XDFEB",
+      "value": 57323
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57324;",
+      "decimal_missing_semicolon": "&#57324",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFEC;",
+      "hex_missing_semicolon": "&#XDFEC",
+      "value": 57324
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57325;",
+      "decimal_missing_semicolon": "&#57325",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFED;",
+      "hex_missing_semicolon": "&#XDFED",
+      "value": 57325
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57326;",
+      "decimal_missing_semicolon": "&#57326",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFEE;",
+      "hex_missing_semicolon": "&#XDFEE",
+      "value": 57326
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57327;",
+      "decimal_missing_semicolon": "&#57327",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFEF;",
+      "hex_missing_semicolon": "&#XDFEF",
+      "value": 57327
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57328;",
+      "decimal_missing_semicolon": "&#57328",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF0;",
+      "hex_missing_semicolon": "&#XDFF0",
+      "value": 57328
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57329;",
+      "decimal_missing_semicolon": "&#57329",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF1;",
+      "hex_missing_semicolon": "&#XDFF1",
+      "value": 57329
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57330;",
+      "decimal_missing_semicolon": "&#57330",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF2;",
+      "hex_missing_semicolon": "&#XDFF2",
+      "value": 57330
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57331;",
+      "decimal_missing_semicolon": "&#57331",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF3;",
+      "hex_missing_semicolon": "&#XDFF3",
+      "value": 57331
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57332;",
+      "decimal_missing_semicolon": "&#57332",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF4;",
+      "hex_missing_semicolon": "&#XDFF4",
+      "value": 57332
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57333;",
+      "decimal_missing_semicolon": "&#57333",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF5;",
+      "hex_missing_semicolon": "&#XDFF5",
+      "value": 57333
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57334;",
+      "decimal_missing_semicolon": "&#57334",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF6;",
+      "hex_missing_semicolon": "&#XDFF6",
+      "value": 57334
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57335;",
+      "decimal_missing_semicolon": "&#57335",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF7;",
+      "hex_missing_semicolon": "&#XDFF7",
+      "value": 57335
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57336;",
+      "decimal_missing_semicolon": "&#57336",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF8;",
+      "hex_missing_semicolon": "&#XDFF8",
+      "value": 57336
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57337;",
+      "decimal_missing_semicolon": "&#57337",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFF9;",
+      "hex_missing_semicolon": "&#XDFF9",
+      "value": 57337
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57338;",
+      "decimal_missing_semicolon": "&#57338",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFFA;",
+      "hex_missing_semicolon": "&#XDFFA",
+      "value": 57338
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57339;",
+      "decimal_missing_semicolon": "&#57339",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFFB;",
+      "hex_missing_semicolon": "&#XDFFB",
+      "value": 57339
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57340;",
+      "decimal_missing_semicolon": "&#57340",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFFC;",
+      "hex_missing_semicolon": "&#XDFFC",
+      "value": 57340
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57341;",
+      "decimal_missing_semicolon": "&#57341",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFFD;",
+      "hex_missing_semicolon": "&#XDFFD",
+      "value": 57341
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57342;",
+      "decimal_missing_semicolon": "&#57342",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFFE;",
+      "hex_missing_semicolon": "&#XDFFE",
+      "value": 57342
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#57343;",
+      "decimal_missing_semicolon": "&#57343",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "hex": "&#xDFFF;",
+      "hex_missing_semicolon": "&#XDFFF",
+      "value": 57343
+    },
+    {
+      "characters": "",
+      "codepoints": [
+        57344
+      ],
+      "decimal": "&#57344;",
+      "decimal_missing_semicolon": "&#57344",
+      "diagnostics": [],
+      "hex": "&#xE000;",
+      "hex_missing_semicolon": "&#XE000",
+      "value": 57344
+    },
+    {
+      "characters": "",
+      "codepoints": [
+        57345
+      ],
+      "decimal": "&#57345;",
+      "decimal_missing_semicolon": "&#57345",
+      "diagnostics": [],
+      "hex": "&#xE001;",
+      "hex_missing_semicolon": "&#XE001",
+      "value": 57345
+    },
+    {
+      "characters": "﷏",
+      "codepoints": [
+        64975
+      ],
+      "decimal": "&#64975;",
+      "decimal_missing_semicolon": "&#64975",
+      "diagnostics": [],
+      "hex": "&#xFDCF;",
+      "hex_missing_semicolon": "&#XFDCF",
+      "value": 64975
+    },
+    {
+      "characters": "﷐",
+      "codepoints": [
+        64976
+      ],
+      "decimal": "&#64976;",
+      "decimal_missing_semicolon": "&#64976",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD0;",
+      "hex_missing_semicolon": "&#XFDD0",
+      "value": 64976
+    },
+    {
+      "characters": "﷑",
+      "codepoints": [
+        64977
+      ],
+      "decimal": "&#64977;",
+      "decimal_missing_semicolon": "&#64977",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD1;",
+      "hex_missing_semicolon": "&#XFDD1",
+      "value": 64977
+    },
+    {
+      "characters": "﷒",
+      "codepoints": [
+        64978
+      ],
+      "decimal": "&#64978;",
+      "decimal_missing_semicolon": "&#64978",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD2;",
+      "hex_missing_semicolon": "&#XFDD2",
+      "value": 64978
+    },
+    {
+      "characters": "﷓",
+      "codepoints": [
+        64979
+      ],
+      "decimal": "&#64979;",
+      "decimal_missing_semicolon": "&#64979",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD3;",
+      "hex_missing_semicolon": "&#XFDD3",
+      "value": 64979
+    },
+    {
+      "characters": "﷔",
+      "codepoints": [
+        64980
+      ],
+      "decimal": "&#64980;",
+      "decimal_missing_semicolon": "&#64980",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD4;",
+      "hex_missing_semicolon": "&#XFDD4",
+      "value": 64980
+    },
+    {
+      "characters": "﷕",
+      "codepoints": [
+        64981
+      ],
+      "decimal": "&#64981;",
+      "decimal_missing_semicolon": "&#64981",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD5;",
+      "hex_missing_semicolon": "&#XFDD5",
+      "value": 64981
+    },
+    {
+      "characters": "﷖",
+      "codepoints": [
+        64982
+      ],
+      "decimal": "&#64982;",
+      "decimal_missing_semicolon": "&#64982",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD6;",
+      "hex_missing_semicolon": "&#XFDD6",
+      "value": 64982
+    },
+    {
+      "characters": "﷗",
+      "codepoints": [
+        64983
+      ],
+      "decimal": "&#64983;",
+      "decimal_missing_semicolon": "&#64983",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD7;",
+      "hex_missing_semicolon": "&#XFDD7",
+      "value": 64983
+    },
+    {
+      "characters": "﷘",
+      "codepoints": [
+        64984
+      ],
+      "decimal": "&#64984;",
+      "decimal_missing_semicolon": "&#64984",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD8;",
+      "hex_missing_semicolon": "&#XFDD8",
+      "value": 64984
+    },
+    {
+      "characters": "﷙",
+      "codepoints": [
+        64985
+      ],
+      "decimal": "&#64985;",
+      "decimal_missing_semicolon": "&#64985",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDD9;",
+      "hex_missing_semicolon": "&#XFDD9",
+      "value": 64985
+    },
+    {
+      "characters": "﷚",
+      "codepoints": [
+        64986
+      ],
+      "decimal": "&#64986;",
+      "decimal_missing_semicolon": "&#64986",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDDA;",
+      "hex_missing_semicolon": "&#XFDDA",
+      "value": 64986
+    },
+    {
+      "characters": "﷛",
+      "codepoints": [
+        64987
+      ],
+      "decimal": "&#64987;",
+      "decimal_missing_semicolon": "&#64987",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDDB;",
+      "hex_missing_semicolon": "&#XFDDB",
+      "value": 64987
+    },
+    {
+      "characters": "﷜",
+      "codepoints": [
+        64988
+      ],
+      "decimal": "&#64988;",
+      "decimal_missing_semicolon": "&#64988",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDDC;",
+      "hex_missing_semicolon": "&#XFDDC",
+      "value": 64988
+    },
+    {
+      "characters": "﷝",
+      "codepoints": [
+        64989
+      ],
+      "decimal": "&#64989;",
+      "decimal_missing_semicolon": "&#64989",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDDD;",
+      "hex_missing_semicolon": "&#XFDDD",
+      "value": 64989
+    },
+    {
+      "characters": "﷞",
+      "codepoints": [
+        64990
+      ],
+      "decimal": "&#64990;",
+      "decimal_missing_semicolon": "&#64990",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDDE;",
+      "hex_missing_semicolon": "&#XFDDE",
+      "value": 64990
+    },
+    {
+      "characters": "﷟",
+      "codepoints": [
+        64991
+      ],
+      "decimal": "&#64991;",
+      "decimal_missing_semicolon": "&#64991",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDDF;",
+      "hex_missing_semicolon": "&#XFDDF",
+      "value": 64991
+    },
+    {
+      "characters": "﷠",
+      "codepoints": [
+        64992
+      ],
+      "decimal": "&#64992;",
+      "decimal_missing_semicolon": "&#64992",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE0;",
+      "hex_missing_semicolon": "&#XFDE0",
+      "value": 64992
+    },
+    {
+      "characters": "﷡",
+      "codepoints": [
+        64993
+      ],
+      "decimal": "&#64993;",
+      "decimal_missing_semicolon": "&#64993",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE1;",
+      "hex_missing_semicolon": "&#XFDE1",
+      "value": 64993
+    },
+    {
+      "characters": "﷢",
+      "codepoints": [
+        64994
+      ],
+      "decimal": "&#64994;",
+      "decimal_missing_semicolon": "&#64994",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE2;",
+      "hex_missing_semicolon": "&#XFDE2",
+      "value": 64994
+    },
+    {
+      "characters": "﷣",
+      "codepoints": [
+        64995
+      ],
+      "decimal": "&#64995;",
+      "decimal_missing_semicolon": "&#64995",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE3;",
+      "hex_missing_semicolon": "&#XFDE3",
+      "value": 64995
+    },
+    {
+      "characters": "﷤",
+      "codepoints": [
+        64996
+      ],
+      "decimal": "&#64996;",
+      "decimal_missing_semicolon": "&#64996",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE4;",
+      "hex_missing_semicolon": "&#XFDE4",
+      "value": 64996
+    },
+    {
+      "characters": "﷥",
+      "codepoints": [
+        64997
+      ],
+      "decimal": "&#64997;",
+      "decimal_missing_semicolon": "&#64997",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE5;",
+      "hex_missing_semicolon": "&#XFDE5",
+      "value": 64997
+    },
+    {
+      "characters": "﷦",
+      "codepoints": [
+        64998
+      ],
+      "decimal": "&#64998;",
+      "decimal_missing_semicolon": "&#64998",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE6;",
+      "hex_missing_semicolon": "&#XFDE6",
+      "value": 64998
+    },
+    {
+      "characters": "﷧",
+      "codepoints": [
+        64999
+      ],
+      "decimal": "&#64999;",
+      "decimal_missing_semicolon": "&#64999",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE7;",
+      "hex_missing_semicolon": "&#XFDE7",
+      "value": 64999
+    },
+    {
+      "characters": "﷨",
+      "codepoints": [
+        65000
+      ],
+      "decimal": "&#65000;",
+      "decimal_missing_semicolon": "&#65000",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE8;",
+      "hex_missing_semicolon": "&#XFDE8",
+      "value": 65000
+    },
+    {
+      "characters": "﷩",
+      "codepoints": [
+        65001
+      ],
+      "decimal": "&#65001;",
+      "decimal_missing_semicolon": "&#65001",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDE9;",
+      "hex_missing_semicolon": "&#XFDE9",
+      "value": 65001
+    },
+    {
+      "characters": "﷪",
+      "codepoints": [
+        65002
+      ],
+      "decimal": "&#65002;",
+      "decimal_missing_semicolon": "&#65002",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDEA;",
+      "hex_missing_semicolon": "&#XFDEA",
+      "value": 65002
+    },
+    {
+      "characters": "﷫",
+      "codepoints": [
+        65003
+      ],
+      "decimal": "&#65003;",
+      "decimal_missing_semicolon": "&#65003",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDEB;",
+      "hex_missing_semicolon": "&#XFDEB",
+      "value": 65003
+    },
+    {
+      "characters": "﷬",
+      "codepoints": [
+        65004
+      ],
+      "decimal": "&#65004;",
+      "decimal_missing_semicolon": "&#65004",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDEC;",
+      "hex_missing_semicolon": "&#XFDEC",
+      "value": 65004
+    },
+    {
+      "characters": "﷭",
+      "codepoints": [
+        65005
+      ],
+      "decimal": "&#65005;",
+      "decimal_missing_semicolon": "&#65005",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDED;",
+      "hex_missing_semicolon": "&#XFDED",
+      "value": 65005
+    },
+    {
+      "characters": "﷮",
+      "codepoints": [
+        65006
+      ],
+      "decimal": "&#65006;",
+      "decimal_missing_semicolon": "&#65006",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDEE;",
+      "hex_missing_semicolon": "&#XFDEE",
+      "value": 65006
+    },
+    {
+      "characters": "﷯",
+      "codepoints": [
+        65007
+      ],
+      "decimal": "&#65007;",
+      "decimal_missing_semicolon": "&#65007",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFDEF;",
+      "hex_missing_semicolon": "&#XFDEF",
+      "value": 65007
+    },
+    {
+      "characters": "ﷰ",
+      "codepoints": [
+        65008
+      ],
+      "decimal": "&#65008;",
+      "decimal_missing_semicolon": "&#65008",
+      "diagnostics": [],
+      "hex": "&#xFDF0;",
+      "hex_missing_semicolon": "&#XFDF0",
+      "value": 65008
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#65533;",
+      "decimal_missing_semicolon": "&#65533",
+      "diagnostics": [],
+      "hex": "&#xFFFD;",
+      "hex_missing_semicolon": "&#XFFFD",
+      "value": 65533
+    },
+    {
+      "characters": "￾",
+      "codepoints": [
+        65534
+      ],
+      "decimal": "&#65534;",
+      "decimal_missing_semicolon": "&#65534",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFFFE;",
+      "hex_missing_semicolon": "&#XFFFE",
+      "value": 65534
+    },
+    {
+      "characters": "￿",
+      "codepoints": [
+        65535
+      ],
+      "decimal": "&#65535;",
+      "decimal_missing_semicolon": "&#65535",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFFFF;",
+      "hex_missing_semicolon": "&#XFFFF",
+      "value": 65535
+    },
+    {
+      "characters": "𐀀",
+      "codepoints": [
+        65536
+      ],
+      "decimal": "&#65536;",
+      "decimal_missing_semicolon": "&#65536",
+      "diagnostics": [],
+      "hex": "&#x10000;",
+      "hex_missing_semicolon": "&#X10000",
+      "value": 65536
+    },
+    {
+      "characters": "😀",
+      "codepoints": [
+        128512
+      ],
+      "decimal": "&#128512;",
+      "decimal_missing_semicolon": "&#128512",
+      "diagnostics": [],
+      "hex": "&#x1F600;",
+      "hex_missing_semicolon": "&#X1F600",
+      "value": 128512
+    },
+    {
+      "characters": "🿽",
+      "codepoints": [
+        131069
+      ],
+      "decimal": "&#131069;",
+      "decimal_missing_semicolon": "&#131069",
+      "diagnostics": [],
+      "hex": "&#x1FFFD;",
+      "hex_missing_semicolon": "&#X1FFFD",
+      "value": 131069
+    },
+    {
+      "characters": "🿾",
+      "codepoints": [
+        131070
+      ],
+      "decimal": "&#131070;",
+      "decimal_missing_semicolon": "&#131070",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x1FFFE;",
+      "hex_missing_semicolon": "&#X1FFFE",
+      "value": 131070
+    },
+    {
+      "characters": "🿿",
+      "codepoints": [
+        131071
+      ],
+      "decimal": "&#131071;",
+      "decimal_missing_semicolon": "&#131071",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x1FFFF;",
+      "hex_missing_semicolon": "&#X1FFFF",
+      "value": 131071
+    },
+    {
+      "characters": "𯿽",
+      "codepoints": [
+        196605
+      ],
+      "decimal": "&#196605;",
+      "decimal_missing_semicolon": "&#196605",
+      "diagnostics": [],
+      "hex": "&#x2FFFD;",
+      "hex_missing_semicolon": "&#X2FFFD",
+      "value": 196605
+    },
+    {
+      "characters": "𯿾",
+      "codepoints": [
+        196606
+      ],
+      "decimal": "&#196606;",
+      "decimal_missing_semicolon": "&#196606",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x2FFFE;",
+      "hex_missing_semicolon": "&#X2FFFE",
+      "value": 196606
+    },
+    {
+      "characters": "𯿿",
+      "codepoints": [
+        196607
+      ],
+      "decimal": "&#196607;",
+      "decimal_missing_semicolon": "&#196607",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x2FFFF;",
+      "hex_missing_semicolon": "&#X2FFFF",
+      "value": 196607
+    },
+    {
+      "characters": "𿿽",
+      "codepoints": [
+        262141
+      ],
+      "decimal": "&#262141;",
+      "decimal_missing_semicolon": "&#262141",
+      "diagnostics": [],
+      "hex": "&#x3FFFD;",
+      "hex_missing_semicolon": "&#X3FFFD",
+      "value": 262141
+    },
+    {
+      "characters": "𿿾",
+      "codepoints": [
+        262142
+      ],
+      "decimal": "&#262142;",
+      "decimal_missing_semicolon": "&#262142",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x3FFFE;",
+      "hex_missing_semicolon": "&#X3FFFE",
+      "value": 262142
+    },
+    {
+      "characters": "𿿿",
+      "codepoints": [
+        262143
+      ],
+      "decimal": "&#262143;",
+      "decimal_missing_semicolon": "&#262143",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x3FFFF;",
+      "hex_missing_semicolon": "&#X3FFFF",
+      "value": 262143
+    },
+    {
+      "characters": "񏿽",
+      "codepoints": [
+        327677
+      ],
+      "decimal": "&#327677;",
+      "decimal_missing_semicolon": "&#327677",
+      "diagnostics": [],
+      "hex": "&#x4FFFD;",
+      "hex_missing_semicolon": "&#X4FFFD",
+      "value": 327677
+    },
+    {
+      "characters": "񏿾",
+      "codepoints": [
+        327678
+      ],
+      "decimal": "&#327678;",
+      "decimal_missing_semicolon": "&#327678",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x4FFFE;",
+      "hex_missing_semicolon": "&#X4FFFE",
+      "value": 327678
+    },
+    {
+      "characters": "񏿿",
+      "codepoints": [
+        327679
+      ],
+      "decimal": "&#327679;",
+      "decimal_missing_semicolon": "&#327679",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x4FFFF;",
+      "hex_missing_semicolon": "&#X4FFFF",
+      "value": 327679
+    },
+    {
+      "characters": "񟿽",
+      "codepoints": [
+        393213
+      ],
+      "decimal": "&#393213;",
+      "decimal_missing_semicolon": "&#393213",
+      "diagnostics": [],
+      "hex": "&#x5FFFD;",
+      "hex_missing_semicolon": "&#X5FFFD",
+      "value": 393213
+    },
+    {
+      "characters": "񟿾",
+      "codepoints": [
+        393214
+      ],
+      "decimal": "&#393214;",
+      "decimal_missing_semicolon": "&#393214",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x5FFFE;",
+      "hex_missing_semicolon": "&#X5FFFE",
+      "value": 393214
+    },
+    {
+      "characters": "񟿿",
+      "codepoints": [
+        393215
+      ],
+      "decimal": "&#393215;",
+      "decimal_missing_semicolon": "&#393215",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x5FFFF;",
+      "hex_missing_semicolon": "&#X5FFFF",
+      "value": 393215
+    },
+    {
+      "characters": "񯿽",
+      "codepoints": [
+        458749
+      ],
+      "decimal": "&#458749;",
+      "decimal_missing_semicolon": "&#458749",
+      "diagnostics": [],
+      "hex": "&#x6FFFD;",
+      "hex_missing_semicolon": "&#X6FFFD",
+      "value": 458749
+    },
+    {
+      "characters": "񯿾",
+      "codepoints": [
+        458750
+      ],
+      "decimal": "&#458750;",
+      "decimal_missing_semicolon": "&#458750",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x6FFFE;",
+      "hex_missing_semicolon": "&#X6FFFE",
+      "value": 458750
+    },
+    {
+      "characters": "񯿿",
+      "codepoints": [
+        458751
+      ],
+      "decimal": "&#458751;",
+      "decimal_missing_semicolon": "&#458751",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x6FFFF;",
+      "hex_missing_semicolon": "&#X6FFFF",
+      "value": 458751
+    },
+    {
+      "characters": "񿿽",
+      "codepoints": [
+        524285
+      ],
+      "decimal": "&#524285;",
+      "decimal_missing_semicolon": "&#524285",
+      "diagnostics": [],
+      "hex": "&#x7FFFD;",
+      "hex_missing_semicolon": "&#X7FFFD",
+      "value": 524285
+    },
+    {
+      "characters": "񿿾",
+      "codepoints": [
+        524286
+      ],
+      "decimal": "&#524286;",
+      "decimal_missing_semicolon": "&#524286",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x7FFFE;",
+      "hex_missing_semicolon": "&#X7FFFE",
+      "value": 524286
+    },
+    {
+      "characters": "񿿿",
+      "codepoints": [
+        524287
+      ],
+      "decimal": "&#524287;",
+      "decimal_missing_semicolon": "&#524287",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x7FFFF;",
+      "hex_missing_semicolon": "&#X7FFFF",
+      "value": 524287
+    },
+    {
+      "characters": "򏿽",
+      "codepoints": [
+        589821
+      ],
+      "decimal": "&#589821;",
+      "decimal_missing_semicolon": "&#589821",
+      "diagnostics": [],
+      "hex": "&#x8FFFD;",
+      "hex_missing_semicolon": "&#X8FFFD",
+      "value": 589821
+    },
+    {
+      "characters": "򏿾",
+      "codepoints": [
+        589822
+      ],
+      "decimal": "&#589822;",
+      "decimal_missing_semicolon": "&#589822",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x8FFFE;",
+      "hex_missing_semicolon": "&#X8FFFE",
+      "value": 589822
+    },
+    {
+      "characters": "򏿿",
+      "codepoints": [
+        589823
+      ],
+      "decimal": "&#589823;",
+      "decimal_missing_semicolon": "&#589823",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x8FFFF;",
+      "hex_missing_semicolon": "&#X8FFFF",
+      "value": 589823
+    },
+    {
+      "characters": "򟿽",
+      "codepoints": [
+        655357
+      ],
+      "decimal": "&#655357;",
+      "decimal_missing_semicolon": "&#655357",
+      "diagnostics": [],
+      "hex": "&#x9FFFD;",
+      "hex_missing_semicolon": "&#X9FFFD",
+      "value": 655357
+    },
+    {
+      "characters": "򟿾",
+      "codepoints": [
+        655358
+      ],
+      "decimal": "&#655358;",
+      "decimal_missing_semicolon": "&#655358",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x9FFFE;",
+      "hex_missing_semicolon": "&#X9FFFE",
+      "value": 655358
+    },
+    {
+      "characters": "򟿿",
+      "codepoints": [
+        655359
+      ],
+      "decimal": "&#655359;",
+      "decimal_missing_semicolon": "&#655359",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x9FFFF;",
+      "hex_missing_semicolon": "&#X9FFFF",
+      "value": 655359
+    },
+    {
+      "characters": "򯿽",
+      "codepoints": [
+        720893
+      ],
+      "decimal": "&#720893;",
+      "decimal_missing_semicolon": "&#720893",
+      "diagnostics": [],
+      "hex": "&#xAFFFD;",
+      "hex_missing_semicolon": "&#XAFFFD",
+      "value": 720893
+    },
+    {
+      "characters": "򯿾",
+      "codepoints": [
+        720894
+      ],
+      "decimal": "&#720894;",
+      "decimal_missing_semicolon": "&#720894",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xAFFFE;",
+      "hex_missing_semicolon": "&#XAFFFE",
+      "value": 720894
+    },
+    {
+      "characters": "򯿿",
+      "codepoints": [
+        720895
+      ],
+      "decimal": "&#720895;",
+      "decimal_missing_semicolon": "&#720895",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xAFFFF;",
+      "hex_missing_semicolon": "&#XAFFFF",
+      "value": 720895
+    },
+    {
+      "characters": "򿿽",
+      "codepoints": [
+        786429
+      ],
+      "decimal": "&#786429;",
+      "decimal_missing_semicolon": "&#786429",
+      "diagnostics": [],
+      "hex": "&#xBFFFD;",
+      "hex_missing_semicolon": "&#XBFFFD",
+      "value": 786429
+    },
+    {
+      "characters": "򿿾",
+      "codepoints": [
+        786430
+      ],
+      "decimal": "&#786430;",
+      "decimal_missing_semicolon": "&#786430",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xBFFFE;",
+      "hex_missing_semicolon": "&#XBFFFE",
+      "value": 786430
+    },
+    {
+      "characters": "򿿿",
+      "codepoints": [
+        786431
+      ],
+      "decimal": "&#786431;",
+      "decimal_missing_semicolon": "&#786431",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xBFFFF;",
+      "hex_missing_semicolon": "&#XBFFFF",
+      "value": 786431
+    },
+    {
+      "characters": "󏿽",
+      "codepoints": [
+        851965
+      ],
+      "decimal": "&#851965;",
+      "decimal_missing_semicolon": "&#851965",
+      "diagnostics": [],
+      "hex": "&#xCFFFD;",
+      "hex_missing_semicolon": "&#XCFFFD",
+      "value": 851965
+    },
+    {
+      "characters": "󏿾",
+      "codepoints": [
+        851966
+      ],
+      "decimal": "&#851966;",
+      "decimal_missing_semicolon": "&#851966",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xCFFFE;",
+      "hex_missing_semicolon": "&#XCFFFE",
+      "value": 851966
+    },
+    {
+      "characters": "󏿿",
+      "codepoints": [
+        851967
+      ],
+      "decimal": "&#851967;",
+      "decimal_missing_semicolon": "&#851967",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xCFFFF;",
+      "hex_missing_semicolon": "&#XCFFFF",
+      "value": 851967
+    },
+    {
+      "characters": "󟿽",
+      "codepoints": [
+        917501
+      ],
+      "decimal": "&#917501;",
+      "decimal_missing_semicolon": "&#917501",
+      "diagnostics": [],
+      "hex": "&#xDFFFD;",
+      "hex_missing_semicolon": "&#XDFFFD",
+      "value": 917501
+    },
+    {
+      "characters": "󟿾",
+      "codepoints": [
+        917502
+      ],
+      "decimal": "&#917502;",
+      "decimal_missing_semicolon": "&#917502",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xDFFFE;",
+      "hex_missing_semicolon": "&#XDFFFE",
+      "value": 917502
+    },
+    {
+      "characters": "󟿿",
+      "codepoints": [
+        917503
+      ],
+      "decimal": "&#917503;",
+      "decimal_missing_semicolon": "&#917503",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xDFFFF;",
+      "hex_missing_semicolon": "&#XDFFFF",
+      "value": 917503
+    },
+    {
+      "characters": "󯿽",
+      "codepoints": [
+        983037
+      ],
+      "decimal": "&#983037;",
+      "decimal_missing_semicolon": "&#983037",
+      "diagnostics": [],
+      "hex": "&#xEFFFD;",
+      "hex_missing_semicolon": "&#XEFFFD",
+      "value": 983037
+    },
+    {
+      "characters": "󯿾",
+      "codepoints": [
+        983038
+      ],
+      "decimal": "&#983038;",
+      "decimal_missing_semicolon": "&#983038",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xEFFFE;",
+      "hex_missing_semicolon": "&#XEFFFE",
+      "value": 983038
+    },
+    {
+      "characters": "󯿿",
+      "codepoints": [
+        983039
+      ],
+      "decimal": "&#983039;",
+      "decimal_missing_semicolon": "&#983039",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xEFFFF;",
+      "hex_missing_semicolon": "&#XEFFFF",
+      "value": 983039
+    },
+    {
+      "characters": "󿿽",
+      "codepoints": [
+        1048573
+      ],
+      "decimal": "&#1048573;",
+      "decimal_missing_semicolon": "&#1048573",
+      "diagnostics": [],
+      "hex": "&#xFFFFD;",
+      "hex_missing_semicolon": "&#XFFFFD",
+      "value": 1048573
+    },
+    {
+      "characters": "󿿾",
+      "codepoints": [
+        1048574
+      ],
+      "decimal": "&#1048574;",
+      "decimal_missing_semicolon": "&#1048574",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFFFFE;",
+      "hex_missing_semicolon": "&#XFFFFE",
+      "value": 1048574
+    },
+    {
+      "characters": "󿿿",
+      "codepoints": [
+        1048575
+      ],
+      "decimal": "&#1048575;",
+      "decimal_missing_semicolon": "&#1048575",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#xFFFFF;",
+      "hex_missing_semicolon": "&#XFFFFF",
+      "value": 1048575
+    },
+    {
+      "characters": "􏿽",
+      "codepoints": [
+        1114109
+      ],
+      "decimal": "&#1114109;",
+      "decimal_missing_semicolon": "&#1114109",
+      "diagnostics": [],
+      "hex": "&#x10FFFD;",
+      "hex_missing_semicolon": "&#X10FFFD",
+      "value": 1114109
+    },
+    {
+      "characters": "􏿾",
+      "codepoints": [
+        1114110
+      ],
+      "decimal": "&#1114110;",
+      "decimal_missing_semicolon": "&#1114110",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x10FFFE;",
+      "hex_missing_semicolon": "&#X10FFFE",
+      "value": 1114110
+    },
+    {
+      "characters": "􏿿",
+      "codepoints": [
+        1114111
+      ],
+      "decimal": "&#1114111;",
+      "decimal_missing_semicolon": "&#1114111",
+      "diagnostics": [
+        "noncharacter-character-reference"
+      ],
+      "hex": "&#x10FFFF;",
+      "hex_missing_semicolon": "&#X10FFFF",
+      "value": 1114111
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#1114112;",
+      "decimal_missing_semicolon": "&#1114112",
+      "diagnostics": [
+        "character-reference-outside-unicode-range"
+      ],
+      "hex": "&#x110000;",
+      "hex_missing_semicolon": "&#X110000",
+      "value": 1114112
+    },
+    {
+      "characters": "�",
+      "codepoints": [
+        65533
+      ],
+      "decimal": "&#4294967295;",
+      "decimal_missing_semicolon": "&#4294967295",
+      "diagnostics": [
+        "character-reference-outside-unicode-range"
+      ],
+      "hex": "&#xFFFFFFFF;",
+      "hex_missing_semicolon": "&#XFFFFFFFF",
+      "value": 4294967295
+    }
+  ],
+  "description": "Numeric character reference edge classes from the WHATWG HTML tokenization algorithm.",
+  "format": "whatwg-html-numeric-character-references/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_numeric_references_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_numeric_references_test.rs
@@ -1,0 +1,241 @@
+use coding_adventures_html_lexer::{
+    create_html_lexer, create_html_lexer_with_context, HtmlLexContext, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_NUMERIC_REFERENCES: &str = include_str!("fixtures/whatwg-numeric-references.json");
+const MISSING_SEMICOLON: &str = "missing-semicolon-after-character-reference";
+
+#[derive(Debug, Deserialize)]
+struct NumericSuite {
+    format: String,
+    cases: Vec<NumericCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NumericCase {
+    value: u32,
+    decimal: String,
+    hex: String,
+    decimal_missing_semicolon: String,
+    hex_missing_semicolon: String,
+    characters: String,
+    codepoints: Vec<u32>,
+    diagnostics: Vec<String>,
+}
+
+#[test]
+fn whatwg_numeric_character_references_decode_in_data_state() {
+    let suite = load_suite();
+    assert_eq!(suite.format, "whatwg-html-numeric-character-references/v1");
+    assert_eq!(suite.cases.len(), 2210);
+
+    for case in &suite.cases {
+        assert_characters_match_codepoints(case);
+        assert_numeric_reference_form_decodes_in_data(case, &case.decimal, false);
+        assert_numeric_reference_form_decodes_in_data(case, &case.hex, false);
+        assert_numeric_reference_form_decodes_in_data(case, &case.decimal_missing_semicolon, true);
+        assert_numeric_reference_form_decodes_in_data(case, &case.hex_missing_semicolon, true);
+    }
+}
+
+#[test]
+fn whatwg_numeric_character_references_decode_in_attributes() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert_numeric_reference_form_decodes_in_attribute(case, &case.decimal, false);
+        assert_numeric_reference_form_decodes_in_attribute(case, &case.hex, false);
+        assert_numeric_reference_form_decodes_in_attribute(
+            case,
+            &case.decimal_missing_semicolon,
+            true,
+        );
+        assert_numeric_reference_form_decodes_in_attribute(case, &case.hex_missing_semicolon, true);
+    }
+}
+
+#[test]
+fn whatwg_numeric_character_references_decode_in_rcdata() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert_numeric_reference_form_decodes_in_rcdata(case, &case.decimal, false);
+        assert_numeric_reference_form_decodes_in_rcdata(case, &case.hex, false);
+        assert_numeric_reference_form_decodes_in_rcdata(
+            case,
+            &case.decimal_missing_semicolon,
+            true,
+        );
+        assert_numeric_reference_form_decodes_in_rcdata(case, &case.hex_missing_semicolon, true);
+    }
+}
+
+#[test]
+fn digitless_numeric_references_stay_literal_while_reporting_absence_of_digits() {
+    for reference in ["&#;", "&#x;", "&#X;"] {
+        let (tokens, diagnostics) = lex_data(&format!("before {reference} after"));
+        assert_eq!(
+            tokens,
+            vec![Token::Text(format!("before {reference} after")), Token::Eof],
+            "data reference {reference}"
+        );
+        assert_eq!(
+            diagnostics,
+            vec!["absence-of-digits-in-numeric-character-reference"],
+            "data reference {reference}"
+        );
+
+        let (tokens, diagnostics) = lex_data(&format!("<p title='before {reference} after'>"));
+        assert_eq!(
+            single_title_attribute(&tokens),
+            format!("before {reference} after"),
+            "attribute reference {reference}"
+        );
+        assert_eq!(
+            diagnostics,
+            vec!["absence-of-digits-in-numeric-character-reference"],
+            "attribute reference {reference}"
+        );
+
+        let (tokens, diagnostics) = lex_title_rcdata(&format!("before {reference} after"));
+        assert_eq!(
+            tokens,
+            vec![Token::Text(format!("before {reference} after")), Token::Eof],
+            "RCDATA reference {reference}"
+        );
+        assert_eq!(
+            diagnostics,
+            vec!["absence-of-digits-in-numeric-character-reference"],
+            "RCDATA reference {reference}"
+        );
+    }
+}
+
+fn load_suite() -> NumericSuite {
+    serde_json::from_str(WHATWG_NUMERIC_REFERENCES)
+        .expect("WHATWG numeric reference fixture should parse")
+}
+
+fn assert_characters_match_codepoints(case: &NumericCase) {
+    let actual = case
+        .characters
+        .chars()
+        .map(|ch| ch as u32)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, case.codepoints, "value U+{:X}", case.value);
+}
+
+fn assert_numeric_reference_form_decodes_in_data(
+    case: &NumericCase,
+    reference: &str,
+    missing_semicolon: bool,
+) {
+    let source = format!("before {reference}/ after");
+    let expected = format!("before {}/ after", case.characters);
+    let (tokens, diagnostics) = lex_data(&source);
+
+    assert_eq!(
+        tokens,
+        vec![Token::Text(expected), Token::Eof],
+        "data value U+{:X} reference {reference}",
+        case.value
+    );
+    assert_diagnostics(case, missing_semicolon, diagnostics, reference);
+}
+
+fn assert_numeric_reference_form_decodes_in_attribute(
+    case: &NumericCase,
+    reference: &str,
+    missing_semicolon: bool,
+) {
+    let source = format!("<p title='before {reference}/ after'>");
+    let expected = format!("before {}/ after", case.characters);
+    let (tokens, diagnostics) = lex_data(&source);
+
+    assert_eq!(
+        single_title_attribute(&tokens),
+        expected,
+        "attribute value U+{:X} reference {reference}",
+        case.value
+    );
+    assert_diagnostics(case, missing_semicolon, diagnostics, reference);
+}
+
+fn assert_numeric_reference_form_decodes_in_rcdata(
+    case: &NumericCase,
+    reference: &str,
+    missing_semicolon: bool,
+) {
+    let source = format!("before {reference}/ after");
+    let expected = format!("before {}/ after", case.characters);
+    let (tokens, diagnostics) = lex_title_rcdata(&source);
+
+    assert_eq!(
+        tokens,
+        vec![Token::Text(expected), Token::Eof],
+        "RCDATA value U+{:X} reference {reference}",
+        case.value
+    );
+    assert_diagnostics(case, missing_semicolon, diagnostics, reference);
+}
+
+fn assert_diagnostics(
+    case: &NumericCase,
+    missing_semicolon: bool,
+    diagnostics: Vec<String>,
+    reference: &str,
+) {
+    let mut expected = case.diagnostics.clone();
+    if missing_semicolon {
+        expected.push(MISSING_SEMICOLON.to_string());
+    }
+
+    assert_eq!(
+        diagnostics, expected,
+        "value U+{:X} reference {reference}",
+        case.value
+    );
+}
+
+fn lex_data(source: &str) -> (Vec<Token>, Vec<String>) {
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    lexer.push(source).expect("push should succeed");
+    lexer.finish().expect("finish should succeed");
+    let diagnostics = lexer
+        .diagnostics()
+        .iter()
+        .map(|diagnostic| diagnostic.code.clone())
+        .collect::<Vec<_>>();
+    (lexer.drain_tokens(), diagnostics)
+}
+
+fn lex_title_rcdata(source: &str) -> (Vec<Token>, Vec<String>) {
+    let context = HtmlLexContext::for_element_text("title").expect("title should map to RCDATA");
+    let mut lexer = create_html_lexer_with_context(&context).expect("HTML lexer should build");
+    lexer.push(source).expect("push should succeed");
+    lexer.finish().expect("finish should succeed");
+    let diagnostics = lexer
+        .diagnostics()
+        .iter()
+        .map(|diagnostic| diagnostic.code.clone())
+        .collect::<Vec<_>>();
+    (lexer.drain_tokens(), diagnostics)
+}
+
+fn single_title_attribute(tokens: &[Token]) -> String {
+    match tokens {
+        [Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        }, Token::Eof] => {
+            assert_eq!(name, "p");
+            assert!(!self_closing);
+            assert_eq!(attributes.len(), 1);
+            assert_eq!(attributes[0].name, "title");
+            attributes[0].value.clone()
+        }
+        other => panic!("expected one start tag plus EOF, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG numeric character reference edge fixture with 2,210 cases
- exercise decimal and hexadecimal forms, with and without semicolons, across data, attribute, and RCDATA contexts
- cover null, controls, Windows-1252 remaps, surrogates, noncharacters, scalar boundaries, outside-range values, and digitless literal recovery
- document the regeneration/check workflow for the fixture

## Verification
- cargo test -p coding-adventures-html-lexer --test whatwg_numeric_references_test
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py --check