### PR TITLE
feat(board-vm): add UNO R4 storage metadata

### DIFF
--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -93,6 +93,15 @@ pub struct WatchdogInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StorageRegionInfo {
+    pub region: u8,
+    pub name: &'static str,
+    pub kind: &'static str,
+    pub bytes: u32,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DigitalPinInfo {
     pub pin: u8,
     pub label: &'static str,
@@ -150,6 +159,7 @@ pub struct BoardTargetInfo {
     pub can_buses: &'static [CanBusInfo],
     pub rtc: Option<RtcInfo>,
     pub watchdog: Option<WatchdogInfo>,
+    pub storage_regions: &'static [StorageRegionInfo],
     pub wireless: &'static [WirelessInterfaceInfo],
     pub capabilities: &'static [&'static str],
 }
@@ -327,6 +337,8 @@ pub const UNO_R4_CAN_BUSES: [CanBusInfo; 1] =
     map_uno_r4_can_buses(board_vm_uno_r4::UNO_R4_CAN_BUSES);
 pub const UNO_R4_RTC: RtcInfo = uno_r4_rtc(board_vm_uno_r4::UNO_R4_RTC);
 pub const UNO_R4_WATCHDOG: WatchdogInfo = uno_r4_watchdog(board_vm_uno_r4::UNO_R4_WATCHDOG);
+pub const UNO_R4_STORAGE_REGIONS: [StorageRegionInfo; 1] =
+    map_uno_r4_storage_regions(board_vm_uno_r4::UNO_R4_STORAGE_REGIONS);
 
 pub const ESP32_DIGITAL_PINS: [DigitalPinInfo; 30] =
     map_esp32_digital_pins(board_vm_esp32::ESP32_DEVKIT_V1_DIGITAL_PINS);
@@ -494,6 +506,31 @@ const fn uno_r4_watchdog(watchdog: board_vm_uno_r4::WatchdogDescriptor) -> Watch
     }
 }
 
+const fn map_uno_r4_storage_regions<const N: usize>(
+    source: [board_vm_uno_r4::StorageRegionDescriptor; N],
+) -> [StorageRegionInfo; N] {
+    let mut regions = [StorageRegionInfo {
+        region: 0,
+        name: "",
+        kind: "",
+        bytes: 0,
+        notes: "",
+    }; N];
+    let mut index = 0;
+    while index < N {
+        let region = source[index];
+        regions[index] = StorageRegionInfo {
+            region: region.region,
+            name: region.name,
+            kind: region.kind,
+            bytes: region.bytes,
+            notes: region.notes,
+        };
+        index += 1;
+    }
+    regions
+}
+
 const fn map_esp32_digital_pins<const N: usize>(
     source: [board_vm_esp32::DigitalPinDescriptor; N],
 ) -> [DigitalPinInfo; N] {
@@ -577,6 +614,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         can_buses: &UNO_R4_CAN_BUSES,
         rtc: Some(UNO_R4_RTC),
         watchdog: Some(UNO_R4_WATCHDOG),
+        storage_regions: &UNO_R4_STORAGE_REGIONS,
         wireless: &[],
         capabilities: &UNO_R4_MINIMA_CAPABILITIES,
     },
@@ -606,6 +644,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         can_buses: &UNO_R4_CAN_BUSES,
         rtc: Some(UNO_R4_RTC),
         watchdog: Some(UNO_R4_WATCHDOG),
+        storage_regions: &UNO_R4_STORAGE_REGIONS,
         wireless: &UNO_R4_WIFI_WIRELESS,
         capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
@@ -632,6 +671,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         can_buses: &[],
         rtc: None,
         watchdog: None,
+        storage_regions: &[],
         wireless: &ESP32_WIRELESS,
         capabilities: &ESP32_CAPABILITIES,
     },
@@ -661,6 +701,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         can_buses: &[],
         rtc: None,
         watchdog: None,
+        storage_regions: &[],
         wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
@@ -690,6 +731,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         can_buses: &[],
         rtc: None,
         watchdog: None,
+        storage_regions: &[],
         wireless: &PICO_W_WIRELESS,
         capabilities: &PICO_W_CAPABILITIES,
     },
@@ -866,6 +908,37 @@ mod tests {
         assert_eq!(find_target("esp32-devkit-v1").unwrap().watchdog, None);
         assert_eq!(find_target("raspberry-pi-pico").unwrap().watchdog, None);
         assert_eq!(find_target("raspberry-pi-pico-w").unwrap().watchdog, None);
+    }
+
+    #[test]
+    fn registry_exposes_storage_region_metadata() {
+        let minima = find_target("arduino-uno-r4-minima").unwrap();
+        assert_eq!(minima.storage_regions, &UNO_R4_STORAGE_REGIONS);
+        assert_eq!(minima.storage_regions.len(), 1);
+        assert_eq!(minima.storage_regions[0].region, 0);
+        assert_eq!(minima.storage_regions[0].name, "EEPROM emulation");
+        assert_eq!(minima.storage_regions[0].kind, "data flash");
+        assert_eq!(
+            minima.storage_regions[0].bytes,
+            board_vm_uno_r4::UNO_R4_DATA_FLASH_BYTES
+        );
+
+        let wifi = find_target("arduino-uno-r4-wifi").unwrap();
+        assert_eq!(wifi.storage_regions, minima.storage_regions);
+        assert!(wifi.storage_regions[0].notes.contains("program.store"));
+
+        assert!(find_target("esp32-devkit-v1")
+            .unwrap()
+            .storage_regions
+            .is_empty());
+        assert!(find_target("raspberry-pi-pico")
+            .unwrap()
+            .storage_regions
+            .is_empty());
+        assert!(find_target("raspberry-pi-pico-w")
+            .unwrap()
+            .storage_regions
+            .is_empty());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -68,6 +68,7 @@ pub struct TargetDescriptor {
     pub spi_buses: &'static [SpiBusDescriptor],
     pub uart_buses: &'static [UartBusDescriptor],
     pub can_buses: &'static [CanBusDescriptor],
+    pub storage_regions: &'static [StorageRegionDescriptor],
     pub rtc: Option<RtcDescriptor>,
     pub watchdog: Option<WatchdogDescriptor>,
 }
@@ -138,6 +139,15 @@ pub struct WatchdogDescriptor {
     pub instance: u8,
     pub name: &'static str,
     pub peripheral: &'static str,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StorageRegionDescriptor {
+    pub region: u8,
+    pub name: &'static str,
+    pub kind: &'static str,
+    pub bytes: u32,
     pub notes: &'static str,
 }
 
@@ -431,6 +441,16 @@ pub const UNO_R4_WATCHDOG: WatchdogDescriptor = WatchdogDescriptor {
     notes: "Renesas watchdog timer exposed through the UNO R4 core WDT library",
 };
 
+pub const UNO_R4_EEPROM_STORAGE: StorageRegionDescriptor = StorageRegionDescriptor {
+    region: 0,
+    name: "EEPROM emulation",
+    kind: "data flash",
+    bytes: UNO_R4_DATA_FLASH_BYTES,
+    notes: "Flash-backed EEPROM storage area exposed by the UNO R4 core; program.store and kv.store are not enabled yet",
+};
+
+pub const UNO_R4_STORAGE_REGIONS: [StorageRegionDescriptor; 1] = [UNO_R4_EEPROM_STORAGE];
+
 pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     board_id: "arduino-uno-r4-minima",
     display_name: "Arduino Uno R4 Minima",
@@ -459,6 +479,7 @@ pub const UNO_R4_MINIMA: TargetDescriptor = TargetDescriptor {
     spi_buses: &UNO_R4_SPI_BUSES,
     uart_buses: &UNO_R4_MINIMA_UART_BUSES,
     can_buses: &UNO_R4_CAN_BUSES,
+    storage_regions: &UNO_R4_STORAGE_REGIONS,
     rtc: Some(UNO_R4_RTC),
     watchdog: Some(UNO_R4_WATCHDOG),
 };
@@ -492,6 +513,7 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
     spi_buses: &UNO_R4_SPI_BUSES,
     uart_buses: &UNO_R4_WIFI_UART_BUSES,
     can_buses: &UNO_R4_CAN_BUSES,
+    storage_regions: &UNO_R4_STORAGE_REGIONS,
     rtc: Some(UNO_R4_RTC),
     watchdog: Some(UNO_R4_WATCHDOG),
 };
@@ -1353,6 +1375,20 @@ mod tests {
         assert_eq!(watchdog.name, "WDT");
         assert_eq!(watchdog.peripheral, "RA4M1 WDT");
         assert!(watchdog.notes.contains("watchdog timer"));
+    }
+
+    #[test]
+    fn knows_uno_r4_storage_regions() {
+        assert_eq!(UNO_R4_MINIMA.storage_regions, &UNO_R4_STORAGE_REGIONS);
+        assert_eq!(UNO_R4_WIFI.storage_regions, &UNO_R4_STORAGE_REGIONS);
+
+        let storage = UNO_R4_WIFI.storage_regions[0];
+        assert_eq!(storage.region, 0);
+        assert_eq!(storage.name, "EEPROM emulation");
+        assert_eq!(storage.kind, "data flash");
+        assert_eq!(storage.bytes, UNO_R4_DATA_FLASH_BYTES);
+        assert!(storage.notes.contains("program.store"));
+        assert!(storage.notes.contains("not enabled"));
     }
 
     #[test]

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -34,7 +34,7 @@ Source snapshot:
 | Hardware UART | SerialUSB plus UART pin pairs D22/D23, D1/D0, D24/D25 | descriptor metadata, handle open, and single-byte write/read implemented | `uart.open`, `uart.write`, `uart.read`, transport descriptors |
 | CAN | CAN0 TX D10, RX D13 | descriptor metadata implemented; bytecode capability pending | `can.open`, `can.write`, `can.read` |
 | RTC | one RTC instance in the core | descriptor metadata implemented; bytecode capability pending | `rtc.now`, `rtc.set`, alarms/events later |
-| EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | pending | `program.store` and possibly `kv.store` |
+| EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | descriptor metadata implemented; bytecode capability pending | `program.store` and possibly `kv.store` |
 | Watchdog | Renesas WDT library | descriptor metadata implemented; bytecode capability pending | `watchdog.configure`, `watchdog.kick` |
 | OPAMP | UNO R4 OPAMP library | pending | analog board-specific capability after ADC/DAC |
 | WiFi | WiFiS3 library through onboard network module | pending | network/transport capabilities, not direct Ruby bypass |
@@ -86,10 +86,12 @@ reject conflicting handles.
    metadata for the single UNO R4 `RA4M1 RTC` instance while `rtc.now` and
    `rtc.set` remain a later capability tranche. Watchdog now has descriptor
    metadata for the UNO R4 `RA4M1 WDT` instance while `watchdog.configure` and
-   `watchdog.kick` remain a later capability tranche. The next independent
-   tranche can move on to CAN byte I/O, RTC bytecode operations, watchdog
-   bytecode operations, EEPROM/store, or WiFi/network metadata and capability
-   slices.
+   `watchdog.kick` remain a later capability tranche. EEPROM/store now has
+   descriptor metadata for the 8 KiB flash-backed EEPROM/data-flash area while
+   `program.store` and `kv.store` remain later capability tranches. The next
+   independent tranche can move on to CAN byte I/O, RTC bytecode operations,
+   watchdog bytecode operations, EEPROM/store bytecode operations, or
+   WiFi/network metadata and capability slices.
 
 Every tranche should include the same layers: spec entry, IR capability id,
 runtime HAL method, UNO R4 target descriptor, firmware backend, host builder,


### PR DESCRIPTION
## Summary
- add UNO R4 storage-region descriptor metadata for the 8 KiB flash-backed EEPROM/data-flash area
- expose that storage metadata through the board-vm-targets registry for both UNO R4 variants
- update BVM07 to mark EEPROM/store metadata as present while keeping program.store and kv.store as pending bytecode tranches

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-storage-metadata cargo fmt -p board-vm-uno-r4 -p board-vm-targets
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-storage-metadata cargo test -p board-vm-uno-r4 -p board-vm-targets
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check