### PR TITLE
Add WHATWG input stream preprocessing sweep

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -47,6 +47,9 @@ documented in this file.
 - A generated WHATWG numeric character reference edge fixture and Rust
   conformance test that exercises decimal, hexadecimal, semicolon, and
   missing-semicolon forms across data, attribute, and RCDATA contexts.
+- A generated WHATWG input-stream preprocessing fixture and Rust conformance
+  test that exercises CRLF and bare-CR normalization across tokenizer contexts,
+  every chunk split point, and diagnostic line/column positions.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -68,6 +68,10 @@ character references.
 The Rust HTML wrapper also enables input-stream newline preprocessing, so CRLF
 pairs and bare carriage returns are tokenized as LF while source offsets still
 advance across the original bytes.
+The conformance suite now generates input-stream preprocessing cases across
+data, tags, attributes, comments, doctypes, character references, RCDATA,
+RAWTEXT, script data, PLAINTEXT, CDATA, and seeded continuation states,
+including chunk splits inside CRLF pairs.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -55,6 +55,9 @@ binary while production code continues to link only static Rust source.
   reference edge table used by Rust tests to exercise decimal, hexadecimal,
   semicolon, and missing-semicolon forms across data, attribute, and RCDATA
   contexts
+- `whatwg-input-stream.json`: generated HTML Standard input-stream
+  preprocessing cases used by Rust tests to exercise CRLF and bare-CR
+  normalization across tokenizer contexts and chunk boundaries
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
@@ -67,6 +70,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_numeric_references_fixture.py`: importer that generates the
   finite numeric character reference edge table for the checked-in
   `whatwg-numeric-references.json` fixture
+- `generate_whatwg_input_stream_fixture.py`: importer that generates finite
+  CRLF/bare-CR preprocessing cases for the checked-in
+  `whatwg-input-stream.json` fixture
 
 Regenerate or verify the WHATWG entity fixture with:
 
@@ -83,6 +89,14 @@ Regenerate or verify the WHATWG numeric-reference fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG input-stream preprocessing fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py \
   --check
 ```
 
@@ -217,6 +231,11 @@ currently supports:
 - form-feed handling as an HTML ASCII-whitespace delimiter for script double
   escape and semicolonless legacy named character references
 - CRLF and bare-CR input-stream newline preprocessing before tokenization
+- generated CRLF and bare-CR input-stream preprocessing coverage across data,
+  markup, attributes, comments, doctypes, character references, RCDATA,
+  RAWTEXT, script data, PLAINTEXT, CDATA, seeded comment continuations, seeded
+  DOCTYPE continuations, all chunk split points, and diagnostic line/column
+  positions
 - EOF recovery for unfinished ordinary start and end tags, ensuring partial
   tokens are dropped before the parser sees them
 - EOF recovery for unfinished attribute character references, including named

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG input-stream preprocessing fixture.
+
+The HTML input stream normalizes CRLF and bare CR to LF before tokenization.
+This fixture keeps that invariant explicit across tokenizer contexts where a
+newline can appear in text, markup, attributes, comments, doctypes, raw text,
+RCDATA, script data, and seeded continuation states.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-input-stream.json")
+
+NEWLINE_FORMS = {
+    "lf": "\n",
+    "cr": "\r",
+    "crlf": "\r\n",
+    "mixed": "\r\n\r\n\r",
+}
+
+TEMPLATES = [
+    {
+        "id": "data-text",
+        "description": "data state text",
+        "input": "alpha{nl}beta",
+        "normalized": "alpha{normalized}beta",
+    },
+    {
+        "id": "tag-name-boundary",
+        "description": "tag name whitespace boundary",
+        "input": "<p{nl}class=x>alpha</p>",
+        "normalized": "<p{normalized}class=x>alpha</p>",
+    },
+    {
+        "id": "before-attribute-name",
+        "description": "before attribute name state",
+        "input": "<p class=x{nl}title=y>alpha</p>",
+        "normalized": "<p class=x{normalized}title=y>alpha</p>",
+    },
+    {
+        "id": "double-quoted-attribute",
+        "description": "double quoted attribute value",
+        "input": "<p title=\"alpha{nl}beta\">x</p>",
+        "normalized": "<p title=\"alpha{normalized}beta\">x</p>",
+    },
+    {
+        "id": "single-quoted-attribute",
+        "description": "single quoted attribute value",
+        "input": "<p title='alpha{nl}beta'>x</p>",
+        "normalized": "<p title='alpha{normalized}beta'>x</p>",
+    },
+    {
+        "id": "unquoted-attribute",
+        "description": "unquoted attribute whitespace boundary",
+        "input": "<p title=alpha{nl}beta=gamma>x</p>",
+        "normalized": "<p title=alpha{normalized}beta=gamma>x</p>",
+    },
+    {
+        "id": "comment-data",
+        "description": "comment data",
+        "input": "<!--alpha{nl}beta-->",
+        "normalized": "<!--alpha{normalized}beta-->",
+    },
+    {
+        "id": "bogus-comment-data",
+        "description": "bogus comment data",
+        "input": "<?alpha{nl}beta>",
+        "normalized": "<?alpha{normalized}beta>",
+    },
+    {
+        "id": "doctype-before-name",
+        "description": "DOCTYPE whitespace before name",
+        "input": "<!DOCTYPE{nl}html>",
+        "normalized": "<!DOCTYPE{normalized}html>",
+    },
+    {
+        "id": "doctype-public-identifier",
+        "description": "DOCTYPE public identifier",
+        "input": '<!DOCTYPE html PUBLIC "alpha{nl}beta" "system">',
+        "normalized": '<!DOCTYPE html PUBLIC "alpha{normalized}beta" "system">',
+    },
+    {
+        "id": "doctype-system-identifier",
+        "description": "DOCTYPE system identifier",
+        "input": '<!DOCTYPE html SYSTEM "alpha{nl}beta">',
+        "normalized": '<!DOCTYPE html SYSTEM "alpha{normalized}beta">',
+    },
+    {
+        "id": "named-reference-recovery",
+        "description": "named character reference recovery before newline",
+        "input": "alpha&not{nl}beta",
+        "normalized": "alpha&not{normalized}beta",
+    },
+    {
+        "id": "numeric-reference-recovery",
+        "description": "numeric character reference missing semicolon before newline",
+        "input": "alpha&#65{nl}beta",
+        "normalized": "alpha&#65{normalized}beta",
+    },
+    {
+        "id": "rcdata-text",
+        "description": "RCDATA text",
+        "input": "alpha{nl}beta</title>",
+        "normalized": "alpha{normalized}beta</title>",
+        "initial_state": "RCDATA state",
+        "last_start_tag": "title",
+    },
+    {
+        "id": "rcdata-end-tag-name",
+        "description": "RCDATA end tag name recovery",
+        "input": "</tit{nl}le>",
+        "normalized": "</tit{normalized}le>",
+        "initial_state": "RCDATA state",
+        "last_start_tag": "title",
+    },
+    {
+        "id": "rawtext-text",
+        "description": "RAWTEXT text",
+        "input": "alpha{nl}beta</style>",
+        "normalized": "alpha{normalized}beta</style>",
+        "initial_state": "RAWTEXT state",
+        "last_start_tag": "style",
+    },
+    {
+        "id": "rawtext-end-tag-name",
+        "description": "RAWTEXT end tag name recovery",
+        "input": "</sty{nl}le>",
+        "normalized": "</sty{normalized}le>",
+        "initial_state": "RAWTEXT state",
+        "last_start_tag": "style",
+    },
+    {
+        "id": "script-data-text",
+        "description": "script data text",
+        "input": "alpha{nl}beta</script>",
+        "normalized": "alpha{normalized}beta</script>",
+        "initial_state": "Script data state",
+        "last_start_tag": "script",
+    },
+    {
+        "id": "script-data-escaped",
+        "description": "script data escaped text",
+        "input": "alpha{nl}beta--></script>",
+        "normalized": "alpha{normalized}beta--></script>",
+        "initial_state": "Script data escaped state",
+        "last_start_tag": "script",
+    },
+    {
+        "id": "plaintext-text",
+        "description": "PLAINTEXT text",
+        "input": "alpha{nl}<beta>",
+        "normalized": "alpha{normalized}<beta>",
+        "initial_state": "PLAINTEXT state",
+    },
+    {
+        "id": "cdata-section",
+        "description": "CDATA section text",
+        "input": "alpha{nl}beta]]>",
+        "normalized": "alpha{normalized}beta]]>",
+        "initial_state": "CDATA section state",
+    },
+    {
+        "id": "seeded-comment-state",
+        "description": "seeded comment continuation",
+        "input": "alpha{nl}beta-->",
+        "normalized": "alpha{normalized}beta-->",
+        "initial_state": "Comment state",
+        "current_comment": "seed:",
+    },
+    {
+        "id": "seeded-doctype-public-identifier",
+        "description": "seeded DOCTYPE public identifier continuation",
+        "input": 'alpha{nl}beta">',
+        "normalized": 'alpha{normalized}beta">',
+        "initial_state": "DOCTYPE public identifier double quoted state",
+        "current_doctype": {
+            "name": "html",
+            "public_identifier": "",
+            "system_identifier": None,
+            "force_quirks": False,
+        },
+    },
+]
+
+POSITION_TEMPLATES = [
+    {
+        "id": "data-null-after-newline",
+        "description": "unexpected NULL after preprocessed newline in data",
+        "input": "alpha{nl}\u0000",
+        "initial_state": "Data state",
+        "diagnostic": "unexpected-null-character",
+    },
+    {
+        "id": "attribute-null-after-newline",
+        "description": "unexpected NULL after preprocessed newline in attribute value",
+        "input": "<p title='alpha{nl}\u0000'>",
+        "initial_state": "Data state",
+        "diagnostic": "unexpected-null-character",
+    },
+    {
+        "id": "comment-null-after-newline",
+        "description": "unexpected NULL after preprocessed newline in comment",
+        "input": "<!--alpha{nl}\u0000-->",
+        "initial_state": "Data state",
+        "diagnostic": "unexpected-null-character",
+    },
+    {
+        "id": "rcdata-null-after-newline",
+        "description": "unexpected NULL after preprocessed newline in RCDATA",
+        "input": "alpha{nl}\u0000</title>",
+        "initial_state": "RCDATA state",
+        "last_start_tag": "title",
+        "diagnostic": "unexpected-null-character",
+    },
+]
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG input-stream preprocessing fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-input-stream-preprocessing/v1",
+        "description": (
+            "CRLF and bare CR preprocessing equivalence cases for HTML "
+            "tokenization contexts."
+        ),
+        "newline_forms": [
+            {"id": form_id, "source": source, "normalized": normalize_newlines(source)}
+            for form_id, source in NEWLINE_FORMS.items()
+        ],
+        "cases": [
+            materialize_case(template, form_id, source)
+            for template in TEMPLATES
+            for form_id, source in NEWLINE_FORMS.items()
+        ],
+        "position_cases": [
+            materialize_position_case(template, form_id, source)
+            for template in POSITION_TEMPLATES
+            for form_id, source in NEWLINE_FORMS.items()
+        ],
+    }
+
+
+def materialize_case(
+    template: dict[str, object], newline_id: str, newline_source: str
+) -> dict[str, object]:
+    normalized_newline = normalize_newlines(newline_source)
+    case = {
+        "id": f"{template['id']}-{newline_id}",
+        "description": f"{template['description']} with {newline_id}",
+        "input": str(template["input"]).format(nl=newline_source),
+        "normalized": str(template["normalized"]).format(normalized=normalized_newline),
+    }
+    copy_context(template, case)
+    return case
+
+
+def materialize_position_case(
+    template: dict[str, object], newline_id: str, newline_source: str
+) -> dict[str, object]:
+    before_newline = str(template["input"]).split("{nl}", 1)[0]
+    case = {
+        "id": f"{template['id']}-{newline_id}",
+        "description": f"{template['description']} with {newline_id}",
+        "input": str(template["input"]).format(nl=newline_source),
+        "diagnostic": template["diagnostic"],
+        "expected_line": before_newline.count("\n") + normalize_newlines(newline_source).count("\n") + 1,
+        "expected_column": 1,
+    }
+    copy_context(template, case)
+    return case
+
+
+def copy_context(source: dict[str, object], target: dict[str, object]) -> None:
+    for key in [
+        "initial_state",
+        "last_start_tag",
+        "current_comment",
+        "current_doctype",
+    ]:
+        if key in source:
+            target[key] = source[key]
+
+
+def normalize_newlines(value: str) -> str:
+    return value.replace("\r\n", "\n").replace("\r", "\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-input-stream.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-input-stream.json
@@ -1,0 +1,822 @@
+{
+  "cases": [
+    {
+      "description": "data state text with lf",
+      "id": "data-text-lf",
+      "input": "alpha\nbeta",
+      "normalized": "alpha\nbeta"
+    },
+    {
+      "description": "data state text with cr",
+      "id": "data-text-cr",
+      "input": "alpha\rbeta",
+      "normalized": "alpha\nbeta"
+    },
+    {
+      "description": "data state text with crlf",
+      "id": "data-text-crlf",
+      "input": "alpha\r\nbeta",
+      "normalized": "alpha\nbeta"
+    },
+    {
+      "description": "data state text with mixed",
+      "id": "data-text-mixed",
+      "input": "alpha\r\n\r\n\rbeta",
+      "normalized": "alpha\n\n\nbeta"
+    },
+    {
+      "description": "tag name whitespace boundary with lf",
+      "id": "tag-name-boundary-lf",
+      "input": "<p\nclass=x>alpha</p>",
+      "normalized": "<p\nclass=x>alpha</p>"
+    },
+    {
+      "description": "tag name whitespace boundary with cr",
+      "id": "tag-name-boundary-cr",
+      "input": "<p\rclass=x>alpha</p>",
+      "normalized": "<p\nclass=x>alpha</p>"
+    },
+    {
+      "description": "tag name whitespace boundary with crlf",
+      "id": "tag-name-boundary-crlf",
+      "input": "<p\r\nclass=x>alpha</p>",
+      "normalized": "<p\nclass=x>alpha</p>"
+    },
+    {
+      "description": "tag name whitespace boundary with mixed",
+      "id": "tag-name-boundary-mixed",
+      "input": "<p\r\n\r\n\rclass=x>alpha</p>",
+      "normalized": "<p\n\n\nclass=x>alpha</p>"
+    },
+    {
+      "description": "before attribute name state with lf",
+      "id": "before-attribute-name-lf",
+      "input": "<p class=x\ntitle=y>alpha</p>",
+      "normalized": "<p class=x\ntitle=y>alpha</p>"
+    },
+    {
+      "description": "before attribute name state with cr",
+      "id": "before-attribute-name-cr",
+      "input": "<p class=x\rtitle=y>alpha</p>",
+      "normalized": "<p class=x\ntitle=y>alpha</p>"
+    },
+    {
+      "description": "before attribute name state with crlf",
+      "id": "before-attribute-name-crlf",
+      "input": "<p class=x\r\ntitle=y>alpha</p>",
+      "normalized": "<p class=x\ntitle=y>alpha</p>"
+    },
+    {
+      "description": "before attribute name state with mixed",
+      "id": "before-attribute-name-mixed",
+      "input": "<p class=x\r\n\r\n\rtitle=y>alpha</p>",
+      "normalized": "<p class=x\n\n\ntitle=y>alpha</p>"
+    },
+    {
+      "description": "double quoted attribute value with lf",
+      "id": "double-quoted-attribute-lf",
+      "input": "<p title=\"alpha\nbeta\">x</p>",
+      "normalized": "<p title=\"alpha\nbeta\">x</p>"
+    },
+    {
+      "description": "double quoted attribute value with cr",
+      "id": "double-quoted-attribute-cr",
+      "input": "<p title=\"alpha\rbeta\">x</p>",
+      "normalized": "<p title=\"alpha\nbeta\">x</p>"
+    },
+    {
+      "description": "double quoted attribute value with crlf",
+      "id": "double-quoted-attribute-crlf",
+      "input": "<p title=\"alpha\r\nbeta\">x</p>",
+      "normalized": "<p title=\"alpha\nbeta\">x</p>"
+    },
+    {
+      "description": "double quoted attribute value with mixed",
+      "id": "double-quoted-attribute-mixed",
+      "input": "<p title=\"alpha\r\n\r\n\rbeta\">x</p>",
+      "normalized": "<p title=\"alpha\n\n\nbeta\">x</p>"
+    },
+    {
+      "description": "single quoted attribute value with lf",
+      "id": "single-quoted-attribute-lf",
+      "input": "<p title='alpha\nbeta'>x</p>",
+      "normalized": "<p title='alpha\nbeta'>x</p>"
+    },
+    {
+      "description": "single quoted attribute value with cr",
+      "id": "single-quoted-attribute-cr",
+      "input": "<p title='alpha\rbeta'>x</p>",
+      "normalized": "<p title='alpha\nbeta'>x</p>"
+    },
+    {
+      "description": "single quoted attribute value with crlf",
+      "id": "single-quoted-attribute-crlf",
+      "input": "<p title='alpha\r\nbeta'>x</p>",
+      "normalized": "<p title='alpha\nbeta'>x</p>"
+    },
+    {
+      "description": "single quoted attribute value with mixed",
+      "id": "single-quoted-attribute-mixed",
+      "input": "<p title='alpha\r\n\r\n\rbeta'>x</p>",
+      "normalized": "<p title='alpha\n\n\nbeta'>x</p>"
+    },
+    {
+      "description": "unquoted attribute whitespace boundary with lf",
+      "id": "unquoted-attribute-lf",
+      "input": "<p title=alpha\nbeta=gamma>x</p>",
+      "normalized": "<p title=alpha\nbeta=gamma>x</p>"
+    },
+    {
+      "description": "unquoted attribute whitespace boundary with cr",
+      "id": "unquoted-attribute-cr",
+      "input": "<p title=alpha\rbeta=gamma>x</p>",
+      "normalized": "<p title=alpha\nbeta=gamma>x</p>"
+    },
+    {
+      "description": "unquoted attribute whitespace boundary with crlf",
+      "id": "unquoted-attribute-crlf",
+      "input": "<p title=alpha\r\nbeta=gamma>x</p>",
+      "normalized": "<p title=alpha\nbeta=gamma>x</p>"
+    },
+    {
+      "description": "unquoted attribute whitespace boundary with mixed",
+      "id": "unquoted-attribute-mixed",
+      "input": "<p title=alpha\r\n\r\n\rbeta=gamma>x</p>",
+      "normalized": "<p title=alpha\n\n\nbeta=gamma>x</p>"
+    },
+    {
+      "description": "comment data with lf",
+      "id": "comment-data-lf",
+      "input": "<!--alpha\nbeta-->",
+      "normalized": "<!--alpha\nbeta-->"
+    },
+    {
+      "description": "comment data with cr",
+      "id": "comment-data-cr",
+      "input": "<!--alpha\rbeta-->",
+      "normalized": "<!--alpha\nbeta-->"
+    },
+    {
+      "description": "comment data with crlf",
+      "id": "comment-data-crlf",
+      "input": "<!--alpha\r\nbeta-->",
+      "normalized": "<!--alpha\nbeta-->"
+    },
+    {
+      "description": "comment data with mixed",
+      "id": "comment-data-mixed",
+      "input": "<!--alpha\r\n\r\n\rbeta-->",
+      "normalized": "<!--alpha\n\n\nbeta-->"
+    },
+    {
+      "description": "bogus comment data with lf",
+      "id": "bogus-comment-data-lf",
+      "input": "<?alpha\nbeta>",
+      "normalized": "<?alpha\nbeta>"
+    },
+    {
+      "description": "bogus comment data with cr",
+      "id": "bogus-comment-data-cr",
+      "input": "<?alpha\rbeta>",
+      "normalized": "<?alpha\nbeta>"
+    },
+    {
+      "description": "bogus comment data with crlf",
+      "id": "bogus-comment-data-crlf",
+      "input": "<?alpha\r\nbeta>",
+      "normalized": "<?alpha\nbeta>"
+    },
+    {
+      "description": "bogus comment data with mixed",
+      "id": "bogus-comment-data-mixed",
+      "input": "<?alpha\r\n\r\n\rbeta>",
+      "normalized": "<?alpha\n\n\nbeta>"
+    },
+    {
+      "description": "DOCTYPE whitespace before name with lf",
+      "id": "doctype-before-name-lf",
+      "input": "<!DOCTYPE\nhtml>",
+      "normalized": "<!DOCTYPE\nhtml>"
+    },
+    {
+      "description": "DOCTYPE whitespace before name with cr",
+      "id": "doctype-before-name-cr",
+      "input": "<!DOCTYPE\rhtml>",
+      "normalized": "<!DOCTYPE\nhtml>"
+    },
+    {
+      "description": "DOCTYPE whitespace before name with crlf",
+      "id": "doctype-before-name-crlf",
+      "input": "<!DOCTYPE\r\nhtml>",
+      "normalized": "<!DOCTYPE\nhtml>"
+    },
+    {
+      "description": "DOCTYPE whitespace before name with mixed",
+      "id": "doctype-before-name-mixed",
+      "input": "<!DOCTYPE\r\n\r\n\rhtml>",
+      "normalized": "<!DOCTYPE\n\n\nhtml>"
+    },
+    {
+      "description": "DOCTYPE public identifier with lf",
+      "id": "doctype-public-identifier-lf",
+      "input": "<!DOCTYPE html PUBLIC \"alpha\nbeta\" \"system\">",
+      "normalized": "<!DOCTYPE html PUBLIC \"alpha\nbeta\" \"system\">"
+    },
+    {
+      "description": "DOCTYPE public identifier with cr",
+      "id": "doctype-public-identifier-cr",
+      "input": "<!DOCTYPE html PUBLIC \"alpha\rbeta\" \"system\">",
+      "normalized": "<!DOCTYPE html PUBLIC \"alpha\nbeta\" \"system\">"
+    },
+    {
+      "description": "DOCTYPE public identifier with crlf",
+      "id": "doctype-public-identifier-crlf",
+      "input": "<!DOCTYPE html PUBLIC \"alpha\r\nbeta\" \"system\">",
+      "normalized": "<!DOCTYPE html PUBLIC \"alpha\nbeta\" \"system\">"
+    },
+    {
+      "description": "DOCTYPE public identifier with mixed",
+      "id": "doctype-public-identifier-mixed",
+      "input": "<!DOCTYPE html PUBLIC \"alpha\r\n\r\n\rbeta\" \"system\">",
+      "normalized": "<!DOCTYPE html PUBLIC \"alpha\n\n\nbeta\" \"system\">"
+    },
+    {
+      "description": "DOCTYPE system identifier with lf",
+      "id": "doctype-system-identifier-lf",
+      "input": "<!DOCTYPE html SYSTEM \"alpha\nbeta\">",
+      "normalized": "<!DOCTYPE html SYSTEM \"alpha\nbeta\">"
+    },
+    {
+      "description": "DOCTYPE system identifier with cr",
+      "id": "doctype-system-identifier-cr",
+      "input": "<!DOCTYPE html SYSTEM \"alpha\rbeta\">",
+      "normalized": "<!DOCTYPE html SYSTEM \"alpha\nbeta\">"
+    },
+    {
+      "description": "DOCTYPE system identifier with crlf",
+      "id": "doctype-system-identifier-crlf",
+      "input": "<!DOCTYPE html SYSTEM \"alpha\r\nbeta\">",
+      "normalized": "<!DOCTYPE html SYSTEM \"alpha\nbeta\">"
+    },
+    {
+      "description": "DOCTYPE system identifier with mixed",
+      "id": "doctype-system-identifier-mixed",
+      "input": "<!DOCTYPE html SYSTEM \"alpha\r\n\r\n\rbeta\">",
+      "normalized": "<!DOCTYPE html SYSTEM \"alpha\n\n\nbeta\">"
+    },
+    {
+      "description": "named character reference recovery before newline with lf",
+      "id": "named-reference-recovery-lf",
+      "input": "alpha&not\nbeta",
+      "normalized": "alpha&not\nbeta"
+    },
+    {
+      "description": "named character reference recovery before newline with cr",
+      "id": "named-reference-recovery-cr",
+      "input": "alpha&not\rbeta",
+      "normalized": "alpha&not\nbeta"
+    },
+    {
+      "description": "named character reference recovery before newline with crlf",
+      "id": "named-reference-recovery-crlf",
+      "input": "alpha&not\r\nbeta",
+      "normalized": "alpha&not\nbeta"
+    },
+    {
+      "description": "named character reference recovery before newline with mixed",
+      "id": "named-reference-recovery-mixed",
+      "input": "alpha&not\r\n\r\n\rbeta",
+      "normalized": "alpha&not\n\n\nbeta"
+    },
+    {
+      "description": "numeric character reference missing semicolon before newline with lf",
+      "id": "numeric-reference-recovery-lf",
+      "input": "alpha&#65\nbeta",
+      "normalized": "alpha&#65\nbeta"
+    },
+    {
+      "description": "numeric character reference missing semicolon before newline with cr",
+      "id": "numeric-reference-recovery-cr",
+      "input": "alpha&#65\rbeta",
+      "normalized": "alpha&#65\nbeta"
+    },
+    {
+      "description": "numeric character reference missing semicolon before newline with crlf",
+      "id": "numeric-reference-recovery-crlf",
+      "input": "alpha&#65\r\nbeta",
+      "normalized": "alpha&#65\nbeta"
+    },
+    {
+      "description": "numeric character reference missing semicolon before newline with mixed",
+      "id": "numeric-reference-recovery-mixed",
+      "input": "alpha&#65\r\n\r\n\rbeta",
+      "normalized": "alpha&#65\n\n\nbeta"
+    },
+    {
+      "description": "RCDATA text with lf",
+      "id": "rcdata-text-lf",
+      "initial_state": "RCDATA state",
+      "input": "alpha\nbeta</title>",
+      "last_start_tag": "title",
+      "normalized": "alpha\nbeta</title>"
+    },
+    {
+      "description": "RCDATA text with cr",
+      "id": "rcdata-text-cr",
+      "initial_state": "RCDATA state",
+      "input": "alpha\rbeta</title>",
+      "last_start_tag": "title",
+      "normalized": "alpha\nbeta</title>"
+    },
+    {
+      "description": "RCDATA text with crlf",
+      "id": "rcdata-text-crlf",
+      "initial_state": "RCDATA state",
+      "input": "alpha\r\nbeta</title>",
+      "last_start_tag": "title",
+      "normalized": "alpha\nbeta</title>"
+    },
+    {
+      "description": "RCDATA text with mixed",
+      "id": "rcdata-text-mixed",
+      "initial_state": "RCDATA state",
+      "input": "alpha\r\n\r\n\rbeta</title>",
+      "last_start_tag": "title",
+      "normalized": "alpha\n\n\nbeta</title>"
+    },
+    {
+      "description": "RCDATA end tag name recovery with lf",
+      "id": "rcdata-end-tag-name-lf",
+      "initial_state": "RCDATA state",
+      "input": "</tit\nle>",
+      "last_start_tag": "title",
+      "normalized": "</tit\nle>"
+    },
+    {
+      "description": "RCDATA end tag name recovery with cr",
+      "id": "rcdata-end-tag-name-cr",
+      "initial_state": "RCDATA state",
+      "input": "</tit\rle>",
+      "last_start_tag": "title",
+      "normalized": "</tit\nle>"
+    },
+    {
+      "description": "RCDATA end tag name recovery with crlf",
+      "id": "rcdata-end-tag-name-crlf",
+      "initial_state": "RCDATA state",
+      "input": "</tit\r\nle>",
+      "last_start_tag": "title",
+      "normalized": "</tit\nle>"
+    },
+    {
+      "description": "RCDATA end tag name recovery with mixed",
+      "id": "rcdata-end-tag-name-mixed",
+      "initial_state": "RCDATA state",
+      "input": "</tit\r\n\r\n\rle>",
+      "last_start_tag": "title",
+      "normalized": "</tit\n\n\nle>"
+    },
+    {
+      "description": "RAWTEXT text with lf",
+      "id": "rawtext-text-lf",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha\nbeta</style>",
+      "last_start_tag": "style",
+      "normalized": "alpha\nbeta</style>"
+    },
+    {
+      "description": "RAWTEXT text with cr",
+      "id": "rawtext-text-cr",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha\rbeta</style>",
+      "last_start_tag": "style",
+      "normalized": "alpha\nbeta</style>"
+    },
+    {
+      "description": "RAWTEXT text with crlf",
+      "id": "rawtext-text-crlf",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha\r\nbeta</style>",
+      "last_start_tag": "style",
+      "normalized": "alpha\nbeta</style>"
+    },
+    {
+      "description": "RAWTEXT text with mixed",
+      "id": "rawtext-text-mixed",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha\r\n\r\n\rbeta</style>",
+      "last_start_tag": "style",
+      "normalized": "alpha\n\n\nbeta</style>"
+    },
+    {
+      "description": "RAWTEXT end tag name recovery with lf",
+      "id": "rawtext-end-tag-name-lf",
+      "initial_state": "RAWTEXT state",
+      "input": "</sty\nle>",
+      "last_start_tag": "style",
+      "normalized": "</sty\nle>"
+    },
+    {
+      "description": "RAWTEXT end tag name recovery with cr",
+      "id": "rawtext-end-tag-name-cr",
+      "initial_state": "RAWTEXT state",
+      "input": "</sty\rle>",
+      "last_start_tag": "style",
+      "normalized": "</sty\nle>"
+    },
+    {
+      "description": "RAWTEXT end tag name recovery with crlf",
+      "id": "rawtext-end-tag-name-crlf",
+      "initial_state": "RAWTEXT state",
+      "input": "</sty\r\nle>",
+      "last_start_tag": "style",
+      "normalized": "</sty\nle>"
+    },
+    {
+      "description": "RAWTEXT end tag name recovery with mixed",
+      "id": "rawtext-end-tag-name-mixed",
+      "initial_state": "RAWTEXT state",
+      "input": "</sty\r\n\r\n\rle>",
+      "last_start_tag": "style",
+      "normalized": "</sty\n\n\nle>"
+    },
+    {
+      "description": "script data text with lf",
+      "id": "script-data-text-lf",
+      "initial_state": "Script data state",
+      "input": "alpha\nbeta</script>",
+      "last_start_tag": "script",
+      "normalized": "alpha\nbeta</script>"
+    },
+    {
+      "description": "script data text with cr",
+      "id": "script-data-text-cr",
+      "initial_state": "Script data state",
+      "input": "alpha\rbeta</script>",
+      "last_start_tag": "script",
+      "normalized": "alpha\nbeta</script>"
+    },
+    {
+      "description": "script data text with crlf",
+      "id": "script-data-text-crlf",
+      "initial_state": "Script data state",
+      "input": "alpha\r\nbeta</script>",
+      "last_start_tag": "script",
+      "normalized": "alpha\nbeta</script>"
+    },
+    {
+      "description": "script data text with mixed",
+      "id": "script-data-text-mixed",
+      "initial_state": "Script data state",
+      "input": "alpha\r\n\r\n\rbeta</script>",
+      "last_start_tag": "script",
+      "normalized": "alpha\n\n\nbeta</script>"
+    },
+    {
+      "description": "script data escaped text with lf",
+      "id": "script-data-escaped-lf",
+      "initial_state": "Script data escaped state",
+      "input": "alpha\nbeta--></script>",
+      "last_start_tag": "script",
+      "normalized": "alpha\nbeta--></script>"
+    },
+    {
+      "description": "script data escaped text with cr",
+      "id": "script-data-escaped-cr",
+      "initial_state": "Script data escaped state",
+      "input": "alpha\rbeta--></script>",
+      "last_start_tag": "script",
+      "normalized": "alpha\nbeta--></script>"
+    },
+    {
+      "description": "script data escaped text with crlf",
+      "id": "script-data-escaped-crlf",
+      "initial_state": "Script data escaped state",
+      "input": "alpha\r\nbeta--></script>",
+      "last_start_tag": "script",
+      "normalized": "alpha\nbeta--></script>"
+    },
+    {
+      "description": "script data escaped text with mixed",
+      "id": "script-data-escaped-mixed",
+      "initial_state": "Script data escaped state",
+      "input": "alpha\r\n\r\n\rbeta--></script>",
+      "last_start_tag": "script",
+      "normalized": "alpha\n\n\nbeta--></script>"
+    },
+    {
+      "description": "PLAINTEXT text with lf",
+      "id": "plaintext-text-lf",
+      "initial_state": "PLAINTEXT state",
+      "input": "alpha\n<beta>",
+      "normalized": "alpha\n<beta>"
+    },
+    {
+      "description": "PLAINTEXT text with cr",
+      "id": "plaintext-text-cr",
+      "initial_state": "PLAINTEXT state",
+      "input": "alpha\r<beta>",
+      "normalized": "alpha\n<beta>"
+    },
+    {
+      "description": "PLAINTEXT text with crlf",
+      "id": "plaintext-text-crlf",
+      "initial_state": "PLAINTEXT state",
+      "input": "alpha\r\n<beta>",
+      "normalized": "alpha\n<beta>"
+    },
+    {
+      "description": "PLAINTEXT text with mixed",
+      "id": "plaintext-text-mixed",
+      "initial_state": "PLAINTEXT state",
+      "input": "alpha\r\n\r\n\r<beta>",
+      "normalized": "alpha\n\n\n<beta>"
+    },
+    {
+      "description": "CDATA section text with lf",
+      "id": "cdata-section-lf",
+      "initial_state": "CDATA section state",
+      "input": "alpha\nbeta]]>",
+      "normalized": "alpha\nbeta]]>"
+    },
+    {
+      "description": "CDATA section text with cr",
+      "id": "cdata-section-cr",
+      "initial_state": "CDATA section state",
+      "input": "alpha\rbeta]]>",
+      "normalized": "alpha\nbeta]]>"
+    },
+    {
+      "description": "CDATA section text with crlf",
+      "id": "cdata-section-crlf",
+      "initial_state": "CDATA section state",
+      "input": "alpha\r\nbeta]]>",
+      "normalized": "alpha\nbeta]]>"
+    },
+    {
+      "description": "CDATA section text with mixed",
+      "id": "cdata-section-mixed",
+      "initial_state": "CDATA section state",
+      "input": "alpha\r\n\r\n\rbeta]]>",
+      "normalized": "alpha\n\n\nbeta]]>"
+    },
+    {
+      "current_comment": "seed:",
+      "description": "seeded comment continuation with lf",
+      "id": "seeded-comment-state-lf",
+      "initial_state": "Comment state",
+      "input": "alpha\nbeta-->",
+      "normalized": "alpha\nbeta-->"
+    },
+    {
+      "current_comment": "seed:",
+      "description": "seeded comment continuation with cr",
+      "id": "seeded-comment-state-cr",
+      "initial_state": "Comment state",
+      "input": "alpha\rbeta-->",
+      "normalized": "alpha\nbeta-->"
+    },
+    {
+      "current_comment": "seed:",
+      "description": "seeded comment continuation with crlf",
+      "id": "seeded-comment-state-crlf",
+      "initial_state": "Comment state",
+      "input": "alpha\r\nbeta-->",
+      "normalized": "alpha\nbeta-->"
+    },
+    {
+      "current_comment": "seed:",
+      "description": "seeded comment continuation with mixed",
+      "id": "seeded-comment-state-mixed",
+      "initial_state": "Comment state",
+      "input": "alpha\r\n\r\n\rbeta-->",
+      "normalized": "alpha\n\n\nbeta-->"
+    },
+    {
+      "current_doctype": {
+        "force_quirks": false,
+        "name": "html",
+        "public_identifier": "",
+        "system_identifier": null
+      },
+      "description": "seeded DOCTYPE public identifier continuation with lf",
+      "id": "seeded-doctype-public-identifier-lf",
+      "initial_state": "DOCTYPE public identifier double quoted state",
+      "input": "alpha\nbeta\">",
+      "normalized": "alpha\nbeta\">"
+    },
+    {
+      "current_doctype": {
+        "force_quirks": false,
+        "name": "html",
+        "public_identifier": "",
+        "system_identifier": null
+      },
+      "description": "seeded DOCTYPE public identifier continuation with cr",
+      "id": "seeded-doctype-public-identifier-cr",
+      "initial_state": "DOCTYPE public identifier double quoted state",
+      "input": "alpha\rbeta\">",
+      "normalized": "alpha\nbeta\">"
+    },
+    {
+      "current_doctype": {
+        "force_quirks": false,
+        "name": "html",
+        "public_identifier": "",
+        "system_identifier": null
+      },
+      "description": "seeded DOCTYPE public identifier continuation with crlf",
+      "id": "seeded-doctype-public-identifier-crlf",
+      "initial_state": "DOCTYPE public identifier double quoted state",
+      "input": "alpha\r\nbeta\">",
+      "normalized": "alpha\nbeta\">"
+    },
+    {
+      "current_doctype": {
+        "force_quirks": false,
+        "name": "html",
+        "public_identifier": "",
+        "system_identifier": null
+      },
+      "description": "seeded DOCTYPE public identifier continuation with mixed",
+      "id": "seeded-doctype-public-identifier-mixed",
+      "initial_state": "DOCTYPE public identifier double quoted state",
+      "input": "alpha\r\n\r\n\rbeta\">",
+      "normalized": "alpha\n\n\nbeta\">"
+    }
+  ],
+  "description": "CRLF and bare CR preprocessing equivalence cases for HTML tokenization contexts.",
+  "format": "whatwg-html-input-stream-preprocessing/v1",
+  "newline_forms": [
+    {
+      "id": "lf",
+      "normalized": "\n",
+      "source": "\n"
+    },
+    {
+      "id": "cr",
+      "normalized": "\n",
+      "source": "\r"
+    },
+    {
+      "id": "crlf",
+      "normalized": "\n",
+      "source": "\r\n"
+    },
+    {
+      "id": "mixed",
+      "normalized": "\n\n\n",
+      "source": "\r\n\r\n\r"
+    }
+  ],
+  "position_cases": [
+    {
+      "description": "unexpected NULL after preprocessed newline in data with lf",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "data-null-after-newline-lf",
+      "initial_state": "Data state",
+      "input": "alpha\n\u0000"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in data with cr",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "data-null-after-newline-cr",
+      "initial_state": "Data state",
+      "input": "alpha\r\u0000"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in data with crlf",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "data-null-after-newline-crlf",
+      "initial_state": "Data state",
+      "input": "alpha\r\n\u0000"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in data with mixed",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 4,
+      "id": "data-null-after-newline-mixed",
+      "initial_state": "Data state",
+      "input": "alpha\r\n\r\n\r\u0000"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in attribute value with lf",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "attribute-null-after-newline-lf",
+      "initial_state": "Data state",
+      "input": "<p title='alpha\n\u0000'>"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in attribute value with cr",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "attribute-null-after-newline-cr",
+      "initial_state": "Data state",
+      "input": "<p title='alpha\r\u0000'>"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in attribute value with crlf",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "attribute-null-after-newline-crlf",
+      "initial_state": "Data state",
+      "input": "<p title='alpha\r\n\u0000'>"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in attribute value with mixed",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 4,
+      "id": "attribute-null-after-newline-mixed",
+      "initial_state": "Data state",
+      "input": "<p title='alpha\r\n\r\n\r\u0000'>"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in comment with lf",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "comment-null-after-newline-lf",
+      "initial_state": "Data state",
+      "input": "<!--alpha\n\u0000-->"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in comment with cr",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "comment-null-after-newline-cr",
+      "initial_state": "Data state",
+      "input": "<!--alpha\r\u0000-->"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in comment with crlf",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "comment-null-after-newline-crlf",
+      "initial_state": "Data state",
+      "input": "<!--alpha\r\n\u0000-->"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in comment with mixed",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 4,
+      "id": "comment-null-after-newline-mixed",
+      "initial_state": "Data state",
+      "input": "<!--alpha\r\n\r\n\r\u0000-->"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in RCDATA with lf",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "rcdata-null-after-newline-lf",
+      "initial_state": "RCDATA state",
+      "input": "alpha\n\u0000</title>",
+      "last_start_tag": "title"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in RCDATA with cr",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "rcdata-null-after-newline-cr",
+      "initial_state": "RCDATA state",
+      "input": "alpha\r\u0000</title>",
+      "last_start_tag": "title"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in RCDATA with crlf",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 2,
+      "id": "rcdata-null-after-newline-crlf",
+      "initial_state": "RCDATA state",
+      "input": "alpha\r\n\u0000</title>",
+      "last_start_tag": "title"
+    },
+    {
+      "description": "unexpected NULL after preprocessed newline in RCDATA with mixed",
+      "diagnostic": "unexpected-null-character",
+      "expected_column": 1,
+      "expected_line": 4,
+      "id": "rcdata-null-after-newline-mixed",
+      "initial_state": "RCDATA state",
+      "input": "alpha\r\n\r\n\r\u0000</title>",
+      "last_start_tag": "title"
+    }
+  ]
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_input_stream_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_input_stream_test.rs
@@ -1,0 +1,216 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, SourcePosition, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_INPUT_STREAM: &str = include_str!("fixtures/whatwg-input-stream.json");
+
+#[derive(Debug, Deserialize)]
+struct InputStreamSuite {
+    format: String,
+    newline_forms: Vec<NewlineForm>,
+    cases: Vec<InputStreamCase>,
+    position_cases: Vec<PositionCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NewlineForm {
+    id: String,
+    source: String,
+    normalized: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct InputStreamCase {
+    id: String,
+    input: String,
+    normalized: String,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    last_start_tag: Option<String>,
+    #[serde(default)]
+    current_comment: Option<String>,
+    #[serde(default)]
+    current_doctype: Option<FixtureDoctypeSeed>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PositionCase {
+    id: String,
+    input: String,
+    diagnostic: String,
+    expected_line: usize,
+    expected_column: usize,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    last_start_tag: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureDoctypeSeed {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    public_identifier: Option<String>,
+    #[serde(default)]
+    system_identifier: Option<String>,
+    #[serde(default)]
+    force_quirks: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Lexed {
+    tokens: Vec<Token>,
+    diagnostics: Vec<String>,
+}
+
+#[test]
+fn whatwg_input_stream_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(
+        suite.format,
+        "whatwg-html-input-stream-preprocessing/v1"
+    );
+    assert_eq!(suite.newline_forms.len(), 4);
+    assert_eq!(suite.cases.len(), 92);
+    assert_eq!(suite.position_cases.len(), 16);
+    assert!(suite.newline_forms.iter().any(|form| {
+        form.id == "crlf" && form.source == "\r\n" && form.normalized == "\n"
+    }));
+    assert!(suite.newline_forms.iter().any(|form| {
+        form.id == "mixed" && form.source == "\r\n\r\n\r" && form.normalized == "\n\n\n"
+    }));
+}
+
+#[test]
+fn whatwg_input_stream_cr_and_crlf_match_preprocessed_lf_stream() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        let expected = lex_case(case, &case.normalized);
+
+        for chunks in chunkings(&case.input) {
+            let actual = lex_case_chunks(case, &chunks);
+            assert_eq!(
+                actual, expected,
+                "case `{}` chunks {:?} should match preprocessed stream {:?}",
+                case.id, chunks, case.normalized
+            );
+        }
+    }
+}
+
+#[test]
+fn whatwg_input_stream_newline_positions_are_stable_across_chunks() {
+    let suite = load_suite();
+
+    for case in &suite.position_cases {
+        for chunks in chunkings(&case.input) {
+            let position = diagnostic_position(case, &chunks);
+            assert_eq!(
+                (position.line, position.column),
+                (case.expected_line, case.expected_column),
+                "case `{}` chunks {:?} should report {:?} at normalized line/column",
+                case.id, chunks, case.diagnostic
+            );
+        }
+    }
+}
+
+fn load_suite() -> InputStreamSuite {
+    serde_json::from_str(WHATWG_INPUT_STREAM).expect("WHATWG input stream fixture should parse")
+}
+
+fn lex_case(case: &InputStreamCase, source: &str) -> Lexed {
+    lex_case_chunks(case, &[source])
+}
+
+fn lex_case_chunks(case: &InputStreamCase, chunks: &[&str]) -> Lexed {
+    let mut lexer = configured_lexer(
+        case.initial_state.as_deref(),
+        case.last_start_tag.as_deref(),
+        case.current_comment.as_deref(),
+        case.current_doctype.as_ref(),
+    );
+    for chunk in chunks {
+        lexer.push(chunk).expect("push should succeed");
+    }
+    lexer.finish().expect("finish should succeed");
+    Lexed {
+        tokens: lexer.drain_tokens(),
+        diagnostics: lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect(),
+    }
+}
+
+fn diagnostic_position(case: &PositionCase, chunks: &[&str]) -> SourcePosition {
+    let mut lexer = configured_lexer(
+        case.initial_state.as_deref(),
+        case.last_start_tag.as_deref(),
+        None,
+        None,
+    );
+    for chunk in chunks {
+        lexer.push(chunk).expect("push should succeed");
+    }
+    lexer.finish().expect("finish should succeed");
+    lexer
+        .diagnostics()
+        .iter()
+        .find(|diagnostic| diagnostic.code == case.diagnostic)
+        .unwrap_or_else(|| panic!("case `{}` did not report {}", case.id, case.diagnostic))
+        .position
+}
+
+fn configured_lexer(
+    initial_state: Option<&str>,
+    last_start_tag: Option<&str>,
+    current_comment: Option<&str>,
+    current_doctype: Option<&FixtureDoctypeSeed>,
+) -> HtmlLexer {
+    let state = initial_state
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let mut context = HtmlLexContext::new(state);
+    if let Some(last_start_tag) = last_start_tag {
+        context = context.with_last_start_tag(last_start_tag);
+    }
+    if let Some(current_comment) = current_comment {
+        context = context.with_current_comment(current_comment);
+    }
+    if let Some(current_doctype) = current_doctype {
+        context = context.with_current_doctype(DoctypeSeed {
+            name: current_doctype.name.clone(),
+            public_identifier: current_doctype.public_identifier.clone(),
+            system_identifier: current_doctype.system_identifier.clone(),
+            force_quirks: current_doctype.force_quirks,
+        });
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn chunkings(source: &str) -> Vec<Vec<&str>> {
+    let mut boundaries = source
+        .char_indices()
+        .map(|(index, _)| index)
+        .chain(std::iter::once(source.len()))
+        .collect::<Vec<_>>();
+    boundaries.sort_unstable();
+    boundaries.dedup();
+
+    let mut chunkings = vec![vec![source]];
+    for boundary in boundaries {
+        chunkings.push(vec![&source[..boundary], &source[boundary..]]);
+    }
+    chunkings
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG input-stream preprocessing fixture for CRLF and bare-CR normalization
- exercise data, markup, attributes, comments, doctypes, character references, RCDATA, RAWTEXT, script, PLAINTEXT, CDATA, and seeded continuation contexts
- verify every chunk split point plus diagnostic line/column positions, and document fixture regeneration

## Verification
- cargo test -p coding-adventures-html-lexer --test whatwg_input_stream_test
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py --check
- git diff --check