### PR TITLE
feat(twig-type-checker): LANG70 TW05-P Part 1 — generated symbol registration + 5 strict modules

### DIFF
--- a/code/packages/rust/twig-type-checker/CHANGELOG.md
+++ b/code/packages/rust/twig-type-checker/CHANGELOG.md
@@ -1,5 +1,82 @@
 # Changelog — twig-type-checker
 
+## [0.8.0] — 2026-05-17
+
+### Added (LANG70 — TW05-P Part 1: Generated Symbol Registration)
+
+- **`TypeEnv::register_record` extended** — in addition to registering the
+  record constructor (`TwigKind::Record(name)`), now also registers:
+  - `{to_lowercase(name)}?` → `TwigKind::Any`  (record predicate)
+  - `{to_lowercase(name)}-{field}` → `TwigKind::Any`  (field accessors, one
+    per declared field)
+
+  Example for `(record IirBuilder (name : any) (instrs : any) (reg-count : int) …)`:
+  - `iirbuilder?`, `iirbuilder-name`, `iirbuilder-instrs`, `iirbuilder-reg-count`,
+    `iirbuilder-label-count`
+
+  These naming conventions match `twig-ir-compiler` exactly (lines 343-348 of
+  `compiler.rs`): `prefix = RecordName.to_lowercase()`.
+
+- **`TypeEnv::register_union` extended** — in addition to registering variant
+  constructors (`TwigKind::Function { arity }`), now also registers:
+  - `{VariantName}?` → `TwigKind::Any`  (variant predicate, **original case**,
+    NOT lowercased — mirrors IR compiler line 355)
+  - `{to_lowercase(VariantName)}-{field}` → `TwigKind::Any`  (variant field
+    accessors, lowercased prefix — mirrors IR compiler lines 357-359)
+
+  Example for `(union Expr (IntLit (value : int) (span : any)) …)`:
+  - `IntLit?`, `intlit-value`, `intlit-span`
+
+  The asymmetry between record predicates (lowercased) and union variant
+  predicates (original case) is intentional — it mirrors the IR compiler's
+  own asymmetry.
+
+### Why `TwigKind::Any` for all generated symbols
+
+- The type checker does not verify accessor return types or enforce field-count
+  arity on generated functions; that is done by the IR compiler.
+- `Any` suppresses "unresolved variable" errors without introducing false
+  arity mismatches for generated accessor calls.
+
+### Tests added (6 — `mod tw05p1_tests`)
+
+| Test | What it verifies |
+|------|-----------------|
+| `record_predicate_resolves_in_strict` | `(record Point …) (define (f r) (point? r))` → ok |
+| `record_accessor_resolves_in_strict` | `(record Point …) (define (f r) (point-x r))` → ok |
+| `union_variant_predicate_resolves_in_strict` | `(union Color …) (define (f v) (Red? v))` → ok |
+| `union_variant_field_accessor_resolves_in_strict` | `(union Shape (Circle (radius : int))) …` → ok |
+| `diagnostic_tw_strict_mode_compiles` | Full `diagnostic.tw` snippet in strict mode → ok |
+| `iir_builder_tw_strict_mode_compiles` | Key `iir-builder.tw` functions in strict mode → ok |
+
+All 92 prior tests continue to pass (98 total).
+
+### Compiler modules converted to `(typed strict)`
+
+With generated symbols now registered, 5 additional compiler modules can run
+in strict mode:
+
+| Module | Reason safe after LANG70 |
+|--------|--------------------------|
+| `token.tw` | 0 `define` forms — trivially safe |
+| `ast.tw` | 0 `define` forms — trivially safe |
+| `iir-types.tw` | 0 `define` forms — trivially safe |
+| `diagnostic.tw` | Only calls own constructors (`Diagnostic`, `SevError`, …) |
+| `iir-builder.tw` | Calls own accessors (`iirbuilder-name`, …) — safe after this change |
+
+Combined with `span.tw` (LANG69), **6 of 11** compiler modules now use
+`(typed strict)`.  The remaining 5 modules (`lexer.tw`, `cst-parser.tw`,
+`parser.tw`, `emit.tw`, `main.tw`) call names from imported modules; converting
+them requires TW05-P Part 2 (LANG71, multi-module import propagation).
+
+### Backward compatibility
+
+No public API changes.  All registered names are additive; no existing lookups
+change.  The `TypeEnv`, `ScopeStack`, `TwigKind`, `type_check`, `check_program`,
+and `type_check_source` interfaces are unchanged.
+
+---
+
 ## [0.7.0] — 2026-05-17
 
 ### Added (LANG69 — TW05-O: Builtin Prelude + span.tw Strict Mode)

--- a/code/packages/rust/twig-type-checker/Cargo.toml
+++ b/code/packages/rust/twig-type-checker/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name        = "twig-type-checker"
-version     = "0.7.0"
+version     = "0.8.0"
 edition     = "2021"
-description = "Static type checker for Twig (TW05-B + TW05-C / LANG50 + LANG52 + LANG53 + LANG54 + LANG69).  Exposes two paths: type_check_source (GrammarASTNode + grammar-type-checker) for AOT/JIT annotation, and check_program (typed Program) for backward compatibility.  TW05-C adds RefinedInt narrowing and call-site refinement checking.  LANG54 refactors the refinement integration to use lang-refinement-protocol.  LANG69 pre-registers all Twig runtime builtins in TypeEnv::new()."
+description = "Static type checker for Twig (TW05-B + TW05-C / LANG50–LANG54 + LANG69 + LANG70).  LANG69 pre-registers all Twig runtime builtins in TypeEnv::new().  LANG70 (TW05-P Part 1) registers generated record/union symbols (predicates, field accessors) enabling strict mode for modules that call their own generated symbols."
 
 [dependencies]
 twig-parser               = { path = "../twig-parser" }

--- a/code/packages/rust/twig-type-checker/src/env.rs
+++ b/code/packages/rust/twig-type-checker/src/env.rs
@@ -191,47 +191,103 @@ impl TypeEnv {
         self.aliases.insert(name, expr);
     }
 
-    /// Register a record definition and expose its constructor in `globals`.
+    /// Register a record definition and expose its constructor, predicate, and
+    /// field accessors in `globals`.
     ///
-    /// For `(record Span (start : Nat) (end : Nat))`:
+    /// For `(record Span (start : int) (end : int))`:
     /// - `env.records["Span"] = ["start", "end"]`
-    /// - `env.globals["Span"] = TwigKind::Record("Span")`  ← the type itself
+    /// - `env.globals["Span"]       = TwigKind::Record("Span")`  ← constructor
+    /// - `env.globals["span?"]      = TwigKind::Any`              ← predicate
+    /// - `env.globals["span-start"] = TwigKind::Any`              ← accessor
+    /// - `env.globals["span-end"]   = TwigKind::Any`              ← accessor
     ///
-    /// The IR compiler also generates `span-start`, `span-end`, `span?`
-    /// builtins, but those carry `Any` in the type env for now (no declared
-    /// return types).
+    /// ## Naming convention (mirrors `twig-ir-compiler`)
+    ///
+    /// The IR compiler uses `RecordName.to_lowercase()` as the accessor prefix:
+    ///   - Predicate:  `{to_lowercase(name)}?`         (e.g. `span?`, `token?`)
+    ///   - Accessor i: `{to_lowercase(name)}-{field}`  (e.g. `span-start`)
+    ///
+    /// All generated symbols carry `TwigKind::Any` — the type checker does not
+    /// verify accessor return types; arity enforcement is done by the IR
+    /// compiler.  `Any` suppresses "unresolved variable" errors without
+    /// introducing false arity mismatches.
     pub fn register_record(&mut self, r: &twig_parser::RecordDef) {
         let field_names: Vec<String> = r.fields.iter().map(|f| f.name.clone()).collect();
         self.records.insert(r.name.clone(), field_names);
-        // The record name itself behaves as a type tag, not a callable — store
-        // as Record so type_expr_to_kind can map the name back.
+        // Constructor: stored as Record kind so type_expr_to_kind can map back.
         self.globals
             .insert(r.name.clone(), TwigKind::Record(r.name.clone()));
+
+        // ── Generated symbols (TW05-P Part 1 / LANG70) ──────────────────────
+        //
+        // The IR compiler emits these as `call_builtin` instructions, matching
+        // the naming conventions in twig-ir-compiler/src/compiler.rs lines
+        // 343-348.  Registering them here allows modules that call their own
+        // record accessors / predicates to pass in `(typed strict)` mode.
+        let prefix = r.name.to_lowercase();
+        // Predicate: <lower(RecordName)>?
+        self.globals
+            .insert(format!("{prefix}?"), TwigKind::Any);
+        // Field accessors: <lower(RecordName)>-<field_name>
+        for f in &r.fields {
+            self.globals
+                .insert(format!("{prefix}-{}", f.name), TwigKind::Any);
+        }
     }
 
-    /// Register a union definition and expose variant constructors in `globals`.
+    /// Register a union definition and expose variant constructors, variant
+    /// predicates, and variant field accessors in `globals`.
     ///
     /// For `(union Expr (IntLit (value : Int)) (NameRef (name : Symbol)))`:
     /// - `env.unions["Expr"] = ["IntLit", "NameRef"]`
-    /// - `env.globals["IntLit"] = Function { arity: 1 }`  ← constructor
-    /// - `env.globals["NameRef"] = Function { arity: 1 }` ← constructor
+    /// - `env.globals["Expr"]         = Union("Expr")`
+    /// - `env.globals["IntLit"]       = Function { arity: 1 }` ← constructor
+    /// - `env.globals["IntLit?"]      = Any`                   ← predicate
+    /// - `env.globals["intlit-value"] = Any`                   ← field accessor
+    /// - `env.globals["NameRef"]      = Function { arity: 1 }` ← constructor
+    /// - `env.globals["NameRef?"]     = Any`                   ← predicate
+    /// - `env.globals["nameref-name"] = Any`                   ← field accessor
     ///
-    /// The union type name itself is stored as `Union("Expr")` so that a
-    /// `VarRef` named `Expr` resolves correctly.
+    /// ## Naming convention (mirrors `twig-ir-compiler`)
+    ///
+    /// From twig-ir-compiler/src/compiler.rs lines 355-359:
+    ///   - Variant predicate:      `{VariantName}?`              (original case,
+    ///                             NOT lowercased — `TkInteger?` not `tkinteger?`)
+    ///   - Variant field accessor: `{to_lowercase(VariantName)}-{field_name}`
+    ///                             (e.g. `intlit-value`, `ifexpr-cond`)
+    ///
+    /// Note the asymmetry: record predicates use `to_lowercase(RecordName)` but
+    /// union variant predicates keep the **original** case of `VariantName`.
     pub fn register_union(&mut self, u: &twig_parser::UnionDef) {
         let variant_names: Vec<String> = u.variants.iter().map(|v| v.name.clone()).collect();
         self.unions.insert(u.name.clone(), variant_names);
-        // Store the union type name itself.
+        // Union type name itself.
         self.globals
             .insert(u.name.clone(), TwigKind::Union(u.name.clone()));
-        // Expose each variant constructor as a callable function.
+        // Expose each variant constructor + generated symbols.
         for v in &u.variants {
+            // Constructor: callable with arity = number of fields.
             self.globals.insert(
                 v.name.clone(),
                 TwigKind::Function {
                     arity: v.fields.len(),
                 },
             );
+            // ── Generated symbols (TW05-P Part 1 / LANG70) ─────────────────
+            //
+            // Variant predicate: <VariantName>?  (original case, not lowercased).
+            // Mirrors compiler.rs line 355: format!("{}?", variant.name)
+            self.globals
+                .insert(format!("{}?", v.name), TwigKind::Any);
+            // Variant field accessors: <lower(VariantName)>-<field_name>
+            // Mirrors compiler.rs lines 357-359:
+            //   let vprefix = variant.name.to_lowercase();
+            //   format!("{vprefix}-{}", f.name)
+            let vprefix = v.name.to_lowercase();
+            for f in &v.fields {
+                self.globals
+                    .insert(format!("{vprefix}-{}", f.name), TwigKind::Any);
+            }
         }
     }
 

--- a/code/packages/rust/twig-type-checker/src/lib.rs
+++ b/code/packages/rust/twig-type-checker/src/lib.rs
@@ -1152,3 +1152,170 @@ mod tw05o_tests {
             "unexpected type errors in span.tw strict check: {:?}", r.errors);
     }
 }
+
+// ---------------------------------------------------------------------------
+// TW05-P Part 1 tests — generated symbol registration (LANG70)
+// ---------------------------------------------------------------------------
+//
+// LANG70 extends `register_record` and `register_union` to also register
+// the symbols the IR compiler generates for each record/union declaration:
+//
+//   Record `Foo` with field `x`:
+//     - `foo?`   → the record predicate
+//     - `foo-x`  → the field accessor
+//
+//   Union variant `Bar` with field `y`:
+//     - `Bar?`   → the variant predicate   (original case, NOT lowercased)
+//     - `bar-y`  → the field accessor      (lowercased prefix)
+//
+// These tests verify that strict-mode modules which call their own generated
+// symbols no longer produce "unresolved variable" errors.
+
+#[cfg(test)]
+mod tw05p1_tests {
+    use super::*;
+
+    // Helper: strict-check an inline source snippet.
+    fn strict(src: &str) -> TypeCheckResult<TypedProgram> {
+        let program = parse(src).unwrap_or_else(|e| panic!("parse failed: {e}"));
+        check_program(&program, Some(TypedMode::Strict))
+    }
+
+    // ── Test 1: record predicate resolves ─────────────────────────────────
+    //
+    // `(record Point (x : int) (y : int))` generates `point?`.
+    // A strict-mode function calling `(point? v)` must not produce
+    // "unresolved variable `point?`".
+
+    #[test]
+    fn record_predicate_resolves_in_strict() {
+        let src = "(record Point (x : int) (y : int)) \
+                   (define (is-point? v) (point? v))";
+        let r = strict(src);
+        assert!(r.ok,
+            "record predicate `point?` should resolve in strict mode; \
+             errors: {:?}", r.errors);
+        assert!(r.errors.is_empty(),
+            "unexpected errors: {:?}", r.errors);
+    }
+
+    // ── Test 2: record field accessor resolves ────────────────────────────
+    //
+    // `(record Point (x : int) (y : int))` generates `point-x` and `point-y`.
+    // Strict-mode calls to those accessors must resolve.
+
+    #[test]
+    fn record_accessor_resolves_in_strict() {
+        let src = "(record Point (x : int) (y : int)) \
+                   (define (get-x p) (point-x p)) \
+                   (define (get-y p) (point-y p))";
+        let r = strict(src);
+        assert!(r.ok,
+            "record accessors `point-x`/`point-y` should resolve; \
+             errors: {:?}", r.errors);
+    }
+
+    // ── Test 3: union variant predicate resolves ──────────────────────────
+    //
+    // `(union Color (Red) (Green))` generates `Red?` and `Green?`.
+    // Note: variant predicates keep the ORIGINAL case (`Red?`, not `red?`).
+
+    #[test]
+    fn union_variant_predicate_resolves_in_strict() {
+        let src = "(union Color (Red) (Green) (Blue)) \
+                   (define (is-red? c) (Red? c)) \
+                   (define (is-green? c) (Green? c))";
+        let r = strict(src);
+        assert!(r.ok,
+            "union variant predicates `Red?`/`Green?` should resolve; \
+             errors: {:?}", r.errors);
+    }
+
+    // ── Test 4: union variant field accessor resolves ──────────────────────
+    //
+    // `(union Shape (Circle (radius : int)) (Rect (w : int) (h : int)))` generates:
+    //   `circle-radius`, `rect-w`, `rect-h`  (lowercased variant name prefix)
+
+    #[test]
+    fn union_variant_field_accessor_resolves_in_strict() {
+        let src = "(union Shape \
+                     (Circle (radius : int)) \
+                     (Rect (w : int) (h : int))) \
+                   (define (get-radius s) (circle-radius s)) \
+                   (define (get-width s) (rect-w s))";
+        let r = strict(src);
+        assert!(r.ok,
+            "union variant field accessors `circle-radius`/`rect-w` should resolve; \
+             errors: {:?}", r.errors);
+    }
+
+    // ── Test 5: diagnostic.tw content compiles in strict mode ─────────────
+    //
+    // diagnostic.tw has 3 define forms that call own union constructors only.
+    // No accessor calls.  Should pass trivially.
+
+    #[test]
+    fn diagnostic_tw_strict_mode_compiles() {
+        let src = "\
+            (module compiler/diagnostic (typed strict) \
+              (export Severity SevError SevWarning SevInfo \
+                      SevError? SevWarning? SevInfo? \
+                      Diagnostic diagnostic? diagnostic-severity \
+                      diagnostic-message diagnostic-span \
+                      make-error make-warning make-info)) \
+            (union Severity (SevError) (SevWarning) (SevInfo)) \
+            (record Diagnostic (severity : any) (message : any) (span : any)) \
+            (define (make-error message span) \
+              (Diagnostic (SevError) message span)) \
+            (define (make-warning message span) \
+              (Diagnostic (SevWarning) message span)) \
+            (define (make-info message span) \
+              (Diagnostic (SevInfo) message span))";
+        let r = strict(src);
+        assert!(r.ok,
+            "diagnostic.tw content should pass strict mode; \
+             errors: {:?}", r.errors);
+        assert!(r.errors.is_empty(),
+            "unexpected type errors: {:?}", r.errors);
+    }
+
+    // ── Test 6: iir-builder.tw content compiles in strict mode ────────────
+    //
+    // iir-builder.tw has 8 define forms that call own IirBuilder accessors
+    // (`iirbuilder-name`, `iirbuilder-reg-count`, etc.) and builtins.
+    // This confirms that accessor registration enables strict mode for
+    // a module that uses its own record's generated accessors.
+
+    #[test]
+    fn iir_builder_tw_strict_mode_compiles() {
+        // Minimal reproduction: IirBuilder record + 3 representative functions.
+        // Uses own accessors (iirbuilder-name, iirbuilder-instrs, etc.) and
+        // builtins (cons, reverse).
+        let src = "\
+            (module compiler/iir-builder (typed strict) \
+              (export IirBuilder iirbuilder? \
+                      iirbuilder-name iirbuilder-instrs \
+                      iirbuilder-reg-count iirbuilder-label-count \
+                      new-builder append-instr finalise-builder)) \
+            (record IirBuilder \
+              (name        : any) \
+              (instrs      : any) \
+              (reg-count   : int) \
+              (label-count : int)) \
+            (define (iirbuilder-with-instrs b new-instrs) \
+              (IirBuilder (iirbuilder-name b) new-instrs \
+                          (iirbuilder-reg-count b) (iirbuilder-label-count b))) \
+            (define (new-builder fn-name) \
+              (IirBuilder fn-name nil 0 0)) \
+            (define (append-instr b instr) \
+              (iirbuilder-with-instrs b (cons instr (iirbuilder-instrs b)))) \
+            (define (finalise-builder b) \
+              (reverse (iirbuilder-instrs b)))";
+        let r = strict(src);
+        assert!(r.ok,
+            "iir-builder.tw content should pass strict mode after accessor \
+             registration; errors: {:?}", r.errors);
+        assert!(r.errors.is_empty(),
+            "unexpected type errors in iir-builder strict check: {:?}", r.errors);
+    }
+}

--- a/code/specs/LANG70-tw05p1-generated-symbol-registration.md
+++ b/code/specs/LANG70-tw05p1-generated-symbol-registration.md
@@ -1,0 +1,224 @@
+# LANG70 — TW05-P Part 1: Generated Symbol Registration
+
+> **LANG69 (TW05-O) is merged.**  This spec covers TW05-P Part 1:
+> registering generated record accessors, record predicates, and union
+> variant predicates in `TypeEnv` during Pass 1 so that modules using their
+> own generated symbols can run in `(typed strict)` mode.
+
+---
+
+## Background
+
+### The generated-symbol gap
+
+After LANG69 (TW05-O), `TypeEnv::new()` pre-registers all Twig runtime
+builtins.  Pass 1 (`collect_forms`) also registers:
+
+- Record constructors: `Span`, `Token`, `IirBuilder` → `TwigKind::Record(name)`
+- Union type names: `TokenKind`, `Expr` → `TwigKind::Union(name)`
+- Union variant constructors: `TkInteger`, `IntLit` → `TwigKind::Function { arity }`
+
+**Not yet registered:**
+
+- Record predicates: `span?`, `token?`, `iirinstr?` — `{lowercase(name)}?`
+- Record field accessors: `span-start`, `token-kind`, `iirbuilder-reg-count` —
+  `{lowercase(name)}-{field}`
+- Union variant predicates: `TkInteger?`, `SevError?`, `IntLit?` — `{variant}?`
+- Union variant field accessors: `intlit-value`, `ifexpr-cond` —
+  `{lowercase(variant)}-{field}`
+
+These are emitted by `twig-ir-compiler` as `call_builtin` instructions, and
+their names follow exact conventions (see below).  Without registration the
+type checker reports "unresolved variable" for each generated-symbol call,
+blocking strict mode for any module that uses accessors or predicates.
+
+### Naming conventions (matching `twig-ir-compiler/src/compiler.rs`)
+
+From the IR compiler's `collect_forms` and `compile_record_def`:
+
+| Kind | Convention | Example |
+|------|-----------|---------|
+| Record constructor | `RecordName` (as-is) | `Token` |
+| Record predicate | `{to_lowercase(RecordName)}?` | `token?` |
+| Record field accessor | `{to_lowercase(RecordName)}-{field_name}` | `token-kind` |
+| Union type | `UnionName` (as-is) | `TokenKind` |
+| Union variant constructor | `VariantName` (as-is) | `TkInteger` |
+| Union variant predicate | `{VariantName}?` (NOT lowercased) | `TkInteger?` |
+| Union variant field accessor | `{to_lowercase(VariantName)}-{field_name}` | `intlit-value` |
+
+Note: record predicates use `to_lowercase(RecordName)`, but union variant
+predicates use the **original case** of `VariantName`.  This asymmetry
+matches the IR compiler's code at lines 348 and 355 of `compiler.rs`.
+
+### Which modules this unblocks
+
+After LANG70, the following modules can use `(typed strict)`:
+
+| Module | Reason strictly safe after LANG70 |
+|--------|----------------------------------|
+| `span.tw` | ✅ already strict (LANG69) |
+| `token.tw` | 0 `define` forms — trivially safe |
+| `ast.tw` | 0 `define` forms — trivially safe |
+| `iir-types.tw` | 0 `define` forms — trivially safe |
+| `diagnostic.tw` | Only calls own constructors (`Diagnostic`, `SevError`, …) |
+| `iir-builder.tw` | Calls own accessors (`iirbuilder-name`, `iirbuilder-reg-count`, …) — safe after accessor registration |
+
+Modules that remain `(typed lenient)` — they call names from **imported**
+modules (needs TW05-P Part 2 / LANG71):
+
+| Module | Unresolved imports |
+|--------|--------------------|
+| `lexer.tw` | `make-span`, `Token`, `TkLParen`, … from span/token |
+| `cst-parser.tw` | Token predicates, AST constructors from token/ast |
+| `parser.tw` | Token predicates, AST constructors from token/ast |
+| `emit.tw` | AST predicates, IirInstr from ast/iir-types/iir-builder |
+| `main.tw` | Everything from all modules |
+
+---
+
+## Changes
+
+### 1. `twig-type-checker/src/env.rs`
+
+#### `TypeEnv::register_record` — add accessor + predicate registration
+
+```rust
+pub fn register_record(&mut self, r: &twig_parser::RecordDef) {
+    let field_names: Vec<String> = r.fields.iter().map(|f| f.name.clone()).collect();
+    self.records.insert(r.name.clone(), field_names);
+    // Constructor: stored as Record kind (already present).
+    self.globals
+        .insert(r.name.clone(), TwigKind::Record(r.name.clone()));
+
+    // ── NEW: register generated symbols ─────────────────────────────────
+    // Naming mirrors twig-ir-compiler/src/compiler.rs lines 343-348.
+    let prefix = r.name.to_lowercase();
+    // Predicate: <lower(RecordName)>?
+    self.globals
+        .insert(format!("{prefix}?"), TwigKind::Any);
+    // Field accessors: <lower(RecordName)>-<field_name>
+    for f in &r.fields {
+        self.globals
+            .insert(format!("{prefix}-{}", f.name), TwigKind::Any);
+    }
+}
+```
+
+#### `TypeEnv::register_union` — add variant predicate + variant field accessor registration
+
+```rust
+pub fn register_union(&mut self, u: &twig_parser::UnionDef) {
+    let variant_names: Vec<String> = u.variants.iter().map(|v| v.name.clone()).collect();
+    self.unions.insert(u.name.clone(), variant_names);
+    self.globals
+        .insert(u.name.clone(), TwigKind::Union(u.name.clone()));
+    for v in &u.variants {
+        // Variant constructor (already present).
+        self.globals.insert(
+            v.name.clone(),
+            TwigKind::Function { arity: v.fields.len() },
+        );
+        // ── NEW: variant predicate: <VariantName>?  (original case, not lowercased)
+        // Mirrors twig-ir-compiler/src/compiler.rs line 355:
+        //   format!("{}?", variant.name)
+        self.globals
+            .insert(format!("{}?", v.name), TwigKind::Any);
+        // ── NEW: variant field accessors: <lower(VariantName)>-<field_name>
+        // Mirrors twig-ir-compiler/src/compiler.rs lines 357-359:
+        //   let vprefix = variant.name.to_lowercase();
+        //   format!("{vprefix}-{}", f.name)
+        let vprefix = v.name.to_lowercase();
+        for f in &v.fields {
+            self.globals
+                .insert(format!("{vprefix}-{}", f.name), TwigKind::Any);
+        }
+    }
+}
+```
+
+### 2. Convert 5 modules to `(typed strict)`
+
+Change the `(typed lenient)` declaration to `(typed strict)` in:
+- `code/twig/compiler/token.tw`
+- `code/twig/compiler/ast.tw`
+- `code/twig/compiler/iir-types.tw`
+- `code/twig/compiler/diagnostic.tw`
+- `code/twig/compiler/iir-builder.tw`
+
+### 3. Tests in `twig-type-checker/src/lib.rs`
+
+Add `mod tw05p1_tests` with the following tests:
+
+| Test | What it verifies |
+|------|-----------------|
+| `record_predicate_resolves_in_strict` | `(record R (x : int)) (define (f r) (r? r))` → ok |
+| `record_accessor_resolves_in_strict` | `(record R (x : int)) (define (f r) (r-x r))` → ok |
+| `union_variant_predicate_resolves_in_strict` | `(union U (A) (B)) (define (f v) (A? v))` → ok |
+| `union_variant_field_accessor_resolves_in_strict` | `(union U (A (x : int))) (define (f v) (a-x v))` → ok |
+| `diagnostic_tw_strict_mode_compiles` | Full `diagnostic.tw` snippet in strict mode → ok |
+| `iir_builder_tw_strict_mode_compiles` | Full `iir-builder.tw` snippet in strict mode → ok |
+
+### 4. Version bump
+
+- `twig-type-checker`: `0.7.0` → `0.8.0`
+- Update `CHANGELOG.md` for twig-type-checker
+
+---
+
+## Acceptance Criteria
+
+1. `cargo test -p twig-type-checker -- tw05p1` — all 6 tests pass.
+2. `cargo test -p twig-type-checker` — all 98 tests pass (92 prior + 6 new).
+3. `cargo test -p twig-module-driver` — all 79 tests still pass.
+4. `cargo build -p twig-type-checker` — clean build.
+
+---
+
+## What this does NOT change
+
+- Modules that call imported names (`lexer.tw`, `parser.tw`, `emit.tw`,
+  `cst-parser.tw`, `main.tw`) remain `(typed lenient)` — converting them
+  requires registering exported names from imported modules (TW05-P Part 2,
+  LANG71).
+- The `twig-module-driver` is unchanged — it does not yet propagate type
+  information from imported modules to the type checker of importing modules.
+- `TwigKind::Any` is used for all generated symbols (not `Function { arity }`)
+  because the type checker does not verify accessor return types or enforce
+  field-count arity on generated functions.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `code/specs/LANG70-tw05p1-generated-symbol-registration.md` | **new** |
+| `code/packages/rust/twig-type-checker/src/env.rs` | add accessor+predicate registration |
+| `code/packages/rust/twig-type-checker/src/lib.rs` | add `tw05p1_tests` (6 tests) |
+| `code/packages/rust/twig-type-checker/Cargo.toml` | version bump 0.7.0 → 0.8.0 |
+| `code/packages/rust/twig-type-checker/CHANGELOG.md` | prepend entry |
+| `code/twig/compiler/token.tw` | `(typed lenient)` → `(typed strict)` |
+| `code/twig/compiler/ast.tw` | `(typed lenient)` → `(typed strict)` |
+| `code/twig/compiler/iir-types.tw` | `(typed lenient)` → `(typed strict)` |
+| `code/twig/compiler/diagnostic.tw` | `(typed lenient)` → `(typed strict)` |
+| `code/twig/compiler/iir-builder.tw` | `(typed lenient)` → `(typed strict)` |
+
+---
+
+## Commit Sequence
+
+1. `docs(specs)` — `LANG70-tw05p1-generated-symbol-registration.md`
+2. `feat(twig-type-checker)` — register generated symbols in `register_record`
+   / `register_union` + tests
+3. `feat(twig)` — convert 5 modules to `(typed strict)`
+
+---
+
+## Verification
+
+```bash
+cargo test -p twig-type-checker -- tw05p1      # 6 new tests pass
+cargo test -p twig-type-checker                # all 98 tests pass
+cargo test -p twig-module-driver               # 79 tests pass
+cargo build -p twig-type-checker               # clean build
+```

--- a/code/twig/compiler/ast.tw
+++ b/code/twig/compiler/ast.tw
@@ -32,7 +32,7 @@
 ; resolve nested record/union types.  The runtime heap enforces structure.
 
 (module compiler/ast
-  (typed lenient)
+  (typed strict)
   (export Expr
           IntLit BoolLit StrLit SymLit NilLit VarRef
           IfExpr LetExpr DefExpr CallExpr BeginExpr LambdaExpr

--- a/code/twig/compiler/diagnostic.tw
+++ b/code/twig/compiler/diagnostic.tw
@@ -15,7 +15,7 @@
 ;     (SevError? (diagnostic-severity d)))   ; → #t
 
 (module compiler/diagnostic
-  (typed lenient)
+  (typed strict)
   (export Severity SevError SevWarning SevInfo
           SevError? SevWarning? SevInfo?
           Diagnostic diagnostic? diagnostic-severity diagnostic-message

--- a/code/twig/compiler/iir-builder.tw
+++ b/code/twig/compiler/iir-builder.tw
@@ -47,7 +47,7 @@
 ;     (length ins))   ; → 1
 
 (module compiler/iir-builder
-  (typed lenient)
+  (typed strict)
   (export IirBuilder iirbuilder? iirbuilder-name iirbuilder-instrs
           iirbuilder-reg-count iirbuilder-label-count
           new-builder alloc-slot alloc-label append-instr finalise-builder)

--- a/code/twig/compiler/iir-types.tw
+++ b/code/twig/compiler/iir-types.tw
@@ -42,7 +42,7 @@
 ; and to extract its op: `(iirinstr-op instr)`
 
 (module compiler/iir-types
-  (typed lenient)
+  (typed strict)
   (export TypeHint TInt TBool TStr TClosure TAny TVoid
           TInt? TBool? TStr? TClosure? TAny? TVoid?
           IirInstr iirinstr? iirinstr-op iirinstr-dest

--- a/code/twig/compiler/token.tw
+++ b/code/twig/compiler/token.tw
@@ -18,7 +18,7 @@
 ; TkEOF shifts from tag 8 to tag 9.
 
 (module compiler/token
-  (typed lenient)
+  (typed strict)
   (export TokenKind TkLParen TkRParen TkInteger TkIdentifier
           TkBoolean TkString TkDot TkQuote TkColon TkEOF
           TkLParen? TkRParen? TkInteger? TkIdentifier?


### PR DESCRIPTION
## Summary

- Extends `TypeEnv::register_record` and `TypeEnv::register_union` to also register the generated symbols the IR compiler emits for each record/union declaration: predicates (`span?`, `TkInteger?`), field accessors (`span-start`, `intlit-value`).
- Converts 5 more compiler modules from `(typed lenient)` to `(typed strict)`: `token.tw`, `ast.tw`, `iir-types.tw`, `diagnostic.tw`, `iir-builder.tw`.
- Combined with `span.tw` (LANG69), **6 of 11** compiler modules now use strict type checking.

## Test plan

- [x] `cargo test -p twig-type-checker -- tw05p1` — 6 new tests pass
- [x] `cargo test -p twig-type-checker` — all 98 tests pass (was 92)
- [x] `cargo test -p twig-module-driver` — all 79 tests still pass
- [x] Security review passed (no vulnerabilities found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)