### PR TITLE
fix(sql-pipeline): SQLite-compatible NULL ordering in ORDER BY

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.37.0] - 2026-05-17
+
+### Fixed
+
+- **SQLite-compatible NULL ordering** (`sql-codegen 1.28.0`, `sql-vm 1.26.0`) —
+  `ORDER BY x` previously placed NULL rows at the end of the result; SQLite
+  places them at the start (treating NULL as smaller than any non-NULL value).
+  `ORDER BY x DESC` now correctly puts NULLs at the *end* (previously, due to
+  a separate VM bug, they ended up at the start).
+
+  10 new oracle tests in `test_tier3_null_ordering.py` lock the byte-for-byte
+  match against the real `sqlite3` module across ASC, DESC, multi-key sorts,
+  TEXT columns, and LIMIT interactions.
+
 ## [1.36.0] - 2026-05-16
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.36.0"
+version = "1.37.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier20_orderby_hidden_col.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier20_orderby_hidden_col.py
@@ -195,21 +195,17 @@ def test_order_by_star_visible_column():
 
 
 def test_order_by_null_handling_hidden():
-    """NULL rows in hidden sort column must not crash; NULLs sort last (our semantics).
+    """NULL rows in hidden sort column sort first for ASC (SQLite-compatible).
 
-    Note: SQLite places NULLs *first* for ASC ORDER BY (treating NULL as smaller
-    than any other value), whereas this VM places NULLs *last*.  This is a known
-    pre-existing behavioural difference in the plain ORDER BY path as well.  We
-    verify here that the hidden-column injection does not crash and applies the
-    VM's own NULL ordering rule consistently.
+    SQLite treats NULL as smaller than any non-NULL value.  Therefore an ASC
+    ORDER BY puts NULL rows at the top of the result.  We oracle-compare
+    against the real sqlite3 module to lock the behaviour in.
     """
-    mini, _ = _setup(
+    mini, ref = _setup(
         "CREATE TABLE t (x INTEGER, y INTEGER)",
         [(None, 1), (2, 2), (1, 3)],
     )
-    rows = mini.execute("SELECT y FROM t ORDER BY x").fetchall()
-    # Our VM puts NULLs last: x=1→y=3, x=2→y=2, x=NULL→y=1
-    assert rows == [(3,), (2,), (1,)], f"unexpected: {rows}"
+    _check(mini, ref, "SELECT y FROM t ORDER BY x")
 
 
 def test_order_by_hidden_column_single_row():

--- a/code/packages/python/mini-sqlite/tests/test_tier3_null_ordering.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_null_ordering.py
@@ -1,0 +1,115 @@
+"""
+SQLite-compatible NULL ordering in ORDER BY.
+
+SQLite treats NULL as the *smallest* value when sorting.  Therefore:
+
+  • ASC  → NULL rows appear first
+  • DESC → NULL rows appear last
+
+This is the SQL:2003 default for systems that use NULL-as-smallest semantics
+(PostgreSQL uses the opposite default but allows NULLS FIRST/LAST overrides).
+
+Truth table:
+
++-------------------+----------------------+
+| ORDER BY x        | NULL position        |
++===================+======================+
+| ASC (default)     | first                |
+| DESC              | last                 |
+| ASC NULLS LAST    | last  (explicit)     |
+| DESC NULLS FIRST  | first (explicit)     |
++-------------------+----------------------+
+
+Every test in this file oracle-compares against the real ``sqlite3`` module.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _setup(rows):
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    schema = "CREATE TABLE t (id INTEGER, val INTEGER)"
+    mini.execute(schema)
+    ref.execute(schema)
+    mini.executemany("INSERT INTO t VALUES (?, ?)", rows)
+    ref.executemany("INSERT INTO t VALUES (?, ?)", rows)
+    return mini, ref
+
+
+def _check(mini, ref, sql):
+    got = mini.execute(sql).fetchall()
+    exp = ref.execute(sql).fetchall()
+    assert got == exp, f"SQL: {sql!r}\n  got {got}\n  exp {exp}"
+
+
+def test_asc_nulls_appear_first():
+    """ASC default: NULL rows lead the result."""
+    mini, ref = _setup([(1, 10), (2, None), (3, 30), (4, None), (5, 20)])
+    _check(mini, ref, "SELECT id FROM t ORDER BY val")
+
+
+def test_desc_nulls_appear_last():
+    """DESC default: NULL rows trail the result."""
+    mini, ref = _setup([(1, 10), (2, None), (3, 30), (4, None), (5, 20)])
+    _check(mini, ref, "SELECT id FROM t ORDER BY val DESC")
+
+
+def test_asc_multiple_nulls():
+    """Multiple NULLs in ASC sort stay grouped at the front."""
+    mini, ref = _setup([(1, None), (2, 5), (3, None), (4, 1), (5, None)])
+    _check(mini, ref, "SELECT id FROM t ORDER BY val")
+
+
+def test_desc_multiple_nulls():
+    """Multiple NULLs in DESC sort stay grouped at the back."""
+    mini, ref = _setup([(1, None), (2, 5), (3, None), (4, 1), (5, None)])
+    _check(mini, ref, "SELECT id FROM t ORDER BY val DESC")
+
+
+def test_asc_all_nulls():
+    """ASC sort when every row is NULL: order should be by insertion (stable)."""
+    mini, ref = _setup([(1, None), (2, None), (3, None)])
+    _check(mini, ref, "SELECT id FROM t ORDER BY val")
+
+
+def test_asc_no_nulls():
+    """ASC sort with no NULLs is unchanged by the new rule."""
+    mini, ref = _setup([(1, 30), (2, 10), (3, 20)])
+    _check(mini, ref, "SELECT id, val FROM t ORDER BY val")
+
+
+def test_asc_nulls_with_limit():
+    """NULLs go first in ASC; LIMIT may pull out only NULL rows."""
+    mini, ref = _setup([(1, 100), (2, None), (3, 50), (4, None)])
+    _check(mini, ref, "SELECT id FROM t ORDER BY val LIMIT 2")
+
+
+def test_desc_nulls_with_limit():
+    """LIMIT after DESC sort: top-N excludes the NULLs at the end."""
+    mini, ref = _setup([(1, 100), (2, None), (3, 50), (4, None)])
+    _check(mini, ref, "SELECT id FROM t ORDER BY val DESC LIMIT 2")
+
+
+def test_multi_key_with_nulls():
+    """Multi-key ORDER BY: NULL ordering rule applies per key."""
+    mini, ref = _setup([(1, None), (2, 5), (3, None), (4, 5), (5, None)])
+    _check(mini, ref, "SELECT id FROM t ORDER BY val ASC, id DESC")
+
+
+def test_order_by_text_column_with_nulls():
+    """NULL ordering also applies to TEXT columns."""
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    mini.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+    ref.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+    rows = [(1, "carol"), (2, None), (3, "alice"), (4, None), (5, "bob")]
+    mini.executemany("INSERT INTO t VALUES (?, ?)", rows)
+    ref.executemany("INSERT INTO t VALUES (?, ?)", rows)
+    got = mini.execute("SELECT id FROM t ORDER BY name").fetchall()
+    exp = ref.execute("SELECT id FROM t ORDER BY name").fetchall()
+    assert got == exp, f"got {got}\n  exp {exp}"

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.28.0] - 2026-05-17
+
+### Fixed
+
+- **SQLite-compatible NULL ordering in ORDER BY** — the codegen's
+  `_compile_sort_key` previously defaulted every sort key to `NullsOrder.LAST`,
+  regardless of direction.  SQLite (and the SQL:2003 default) treats NULL as
+  smaller than every non-NULL value, so an ASC sort puts NULLs *first* and a
+  DESC sort puts them *last*.  The new logic:
+
+  | `nulls_first` | direction | resolved `NullsOrder` |
+  |---------------|-----------|------------------------|
+  | `True`        | any       | `FIRST`               |
+  | `False`       | any       | `LAST`                |
+  | `None`        | ASC       | `FIRST` ← new default |
+  | `None`        | DESC      | `LAST`  ← new default |
+
+  This matches the real `sqlite3` module byte-for-byte and removes a known
+  divergence that was previously documented as "this VM places NULLs last".
+
 ## [1.27.0] - 2026-05-15
 
 ### Added

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.27.0"
+version = "1.28.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -1784,7 +1784,18 @@ def _to_sort_key(k: object, agg_alias_map: dict[tuple, str] | None = None) -> So
 
     assert isinstance(k, PlanSortKey)
     direction = Direction.DESC if k.descending else Direction.ASC
-    nulls = NullsOrder.FIRST if k.nulls_first else NullsOrder.LAST
+    # SQLite-compatible NULL ordering:
+    #   • Explicit  NULLS FIRST / NULLS LAST  → honour the request.
+    #   • Default (nulls_first is None)        → NULLs are treated as smaller
+    #     than any non-NULL value.  Therefore an ASC sort puts NULLs FIRST,
+    #     and a DESC sort puts NULLs LAST.  This matches SQLite's behaviour
+    #     and the SQL:2003 default of NULLS LAST for DESC, NULLS FIRST for ASC.
+    if k.nulls_first is True:
+        nulls = NullsOrder.FIRST
+    elif k.nulls_first is False:
+        nulls = NullsOrder.LAST
+    else:
+        nulls = NullsOrder.LAST if k.descending else NullsOrder.FIRST
 
     # Positional sort key (ORDER BY N): use column_idx for direct index lookup.
     if k.positional_index is not None:

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.26.0 — 2026-05-17
+
+### Fixed
+
+- **NULL ordering bug in `_do_sort`** — the DESC branch of the sort comparator
+  negated the NULL-placement rank (`-rank`), which inadvertently coupled NULL
+  position to sort direction.  As a result `ORDER BY x DESC` with `NULLS LAST`
+  put NULLs at the *start* of the result, not the end.
+
+  NULL placement is now independent of direction: the rank (0/1/2 for
+  FIRST/non-null/LAST) is kept positive in both ASC and DESC branches.  Only
+  the value comparison is inverted (via the existing `_Rev` wrapper) for DESC.
+
+  Truth table after the fix:
+
+  | direction | nulls   | output                              |
+  |-----------|---------|-------------------------------------|
+  | ASC       | FIRST   | NULLs first, non-null ascending     |
+  | ASC       | LAST    | non-null ascending, NULLs last      |
+  | DESC      | FIRST   | NULLs first, non-null descending    |
+  | DESC      | LAST    | non-null descending, NULLs last     |
+
+  Combined with sql-codegen 1.28.0 (which now resolves the default to FIRST
+  for ASC and LAST for DESC), this makes mini-sqlite byte-compatible with the
+  real `sqlite3` module for NULL ordering.
+
 ## 1.25.0 — 2026-05-15
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.25.0"
+version = "1.26.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -1425,15 +1425,23 @@ def _do_sort(ins: SortResult, st: _VmState) -> None:
             idx = k.column_idx if k.column_idx is not None else columns.index(k.column)
             v = row[idx]
             is_null = v is None
-            # NULLs first/last encoded as 0 / 2 around non-null = 1.
+            # NULL placement is *independent* of direction.  We encode it as a
+            # rank prefix where 0=first / 2=last, with non-null=1 in the middle.
+            # The rank is NOT negated for DESC sorts — only the value comparison
+            # is inverted (via _Rev).  This keeps NULL placement consistent:
+            #   ASC  NULLS FIRST: NULLs at start, non-null ascending
+            #   ASC  NULLS LAST : non-null ascending, NULLs at end
+            #   DESC NULLS FIRST: NULLs at start, non-null descending
+            #   DESC NULLS LAST : non-null descending, NULLs at end  ← SQLite default
             rank = (
                 (0 if is_null else 1)
                 if k.nulls is NullsOrder.FIRST
                 else (2 if is_null else 1)
             )
             if k.direction is Direction.DESC:
-                # Invert: larger values sort first. Trick: use _Reversed wrappers.
-                out.append((-rank, _Rev(v)))
+                # _Rev wraps the value so larger values sort first.  Rank is
+                # kept positive so NULL placement obeys k.nulls, not direction.
+                out.append((rank, _Rev(v)))
             else:
                 out.append((rank, _NoneLast(v)))
         return tuple(out)

--- a/code/packages/python/sql-vm/tests/test_select.py
+++ b/code/packages/python/sql-vm/tests/test_select.py
@@ -94,7 +94,8 @@ def test_sort_asc_desc(employees: InMemoryBackend) -> None:
     assert [r[0] for r in result.rows] == ["Eve", "Dave", "Carol", "Bob", "Alice"]
 
 
-def test_sort_nulls_last(employees: InMemoryBackend) -> None:
+def test_sort_nulls_first_asc(employees: InMemoryBackend) -> None:
+    """ASC sort places NULLs FIRST by SQLite-compatible default."""
     employees.insert(
         "employees",
         {"id": 6, "name": None, "dept": "x", "salary": 1, "active": True},
@@ -104,7 +105,25 @@ def test_sort_nulls_last(employees: InMemoryBackend) -> None:
             input=Scan(table="employees", alias="e"),
             items=(ProjectionItem(expr=Column("e", "name"), alias="name"),),
         ),
-        keys=(SortKey(expr=Column("e", "name")),),  # ASC default → NULLs last
+        keys=(SortKey(expr=Column("e", "name")),),  # ASC default → NULLs first (SQLite)
+    )
+    result = execute(compile(plan), employees)
+    first = result.rows[0][0]
+    assert first is None
+
+
+def test_sort_nulls_last_explicit(employees: InMemoryBackend) -> None:
+    """Explicit NULLS LAST in ASC still puts NULLs at the end (overrides default)."""
+    employees.insert(
+        "employees",
+        {"id": 6, "name": None, "dept": "x", "salary": 1, "active": True},
+    )
+    plan = Sort(
+        input=Project(
+            input=Scan(table="employees", alias="e"),
+            items=(ProjectionItem(expr=Column("e", "name"), alias="name"),),
+        ),
+        keys=(SortKey(expr=Column("e", "name"), nulls_first=False),),  # explicit NULLS LAST
     )
     result = execute(compile(plan), employees)
     last = result.rows[-1][0]
@@ -191,7 +210,11 @@ def test_sort_null_null_desc(employees: InMemoryBackend) -> None:
 
 
 def test_sort_nulls_both_none_asc(employees: InMemoryBackend) -> None:
-    """Two NULL rows in ASC sort exercise _NoneLast.__lt__(None, None) paths."""
+    """Two NULL rows in ASC sort exercise the comparator's None-vs-None path.
+
+    With SQLite-compatible defaults NULLs go FIRST in ASC; both NULL rows
+    should land at the beginning of the result.
+    """
     employees.insert("employees", {"id": 6, "name": None, "dept": "x", "salary": 1, "active": True})
     employees.insert("employees", {"id": 7, "name": None, "dept": "y", "salary": 2, "active": True})
     plan = Sort(
@@ -199,13 +222,13 @@ def test_sort_nulls_both_none_asc(employees: InMemoryBackend) -> None:
             input=Scan(table="employees", alias="e"),
             items=(ProjectionItem(expr=Column("e", "name"), alias="name"),),
         ),
-        keys=(SortKey(expr=Column("e", "name")),),  # ASC, NULLs last
+        keys=(SortKey(expr=Column("e", "name")),),  # ASC default → NULLs first
     )
     result = execute(compile(plan), employees)
     names = [r[0] for r in result.rows]
-    # The two NULLs should appear at the end.
-    assert names[-1] is None
-    assert names[-2] is None
+    # The two NULLs should appear at the beginning.
+    assert names[0] is None
+    assert names[1] is None
 
 
 def test_sort_positional_column_idx(employees: InMemoryBackend) -> None:


### PR DESCRIPTION
## Summary

Two coordinated bug fixes that align mini-sqlite's `ORDER BY` NULL placement with real SQLite.

- **sql-codegen 1.27.0 → 1.28.0**: default `nulls_first` resolution now depends on direction (FIRST for ASC, LAST for DESC). Explicit `NULLS FIRST`/`NULLS LAST` still honoured.
- **sql-vm 1.25.0 → 1.26.0**: removed a `-rank` negation bug in `_do_sort` that inadvertently coupled NULL placement to sort direction. NULL position now obeys `k.nulls` regardless of ASC/DESC.
- **mini-sqlite 1.36.0 → 1.37.0**: new oracle test file with 10 byte-for-byte comparisons against the real `sqlite3` module.

## Truth table (after fix)

| `ORDER BY x` | NULL position |
|--------------|---------------|
| ASC (default) | first |
| DESC | last |
| ASC NULLS LAST | last (explicit) |
| DESC NULLS FIRST | first (explicit) |

## Test plan

- [ ] 1,256 mini-sqlite tests pass (10 new oracle tests for NULL ordering)
- [ ] 628 sql-vm tests pass
- [ ] 82 sql-codegen tests pass
- [ ] SQLLogicTest select1.test still 1031/1031 (100%)
- [ ] ruff clean on all changed packages
- [ ] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)