### PR TITLE
feat(forme-aot-incremental-cache): FM06 §4 incremental rebuild cache

### DIFF
--- a/code/packages/typescript/forme-aot-incremental-cache/BUILD
+++ b/code/packages/typescript/forme-aot-incremental-cache/BUILD
@@ -1,0 +1,6 @@
+cd ../document-ast && npm install --silent
+cd ../forme-types && npm install --silent
+cd ../forme-style-ir && npm install --silent
+cd ../forme-style-to-css && npm install --silent
+cd ../forme-aot-css-slicer && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-incremental-cache/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-incremental-cache/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog — @coding-adventures/forme-aot-incremental-cache
+
+## 0.1.0 — 2026-05-17
+
+Initial release.  Second package of the FM06 AOT compiler family.
+Wraps `forme-aot-css-slicer` with content-addressed caching for
+fast incremental rebuilds.
+
+### Added
+
+- `createIncrementalCache(io: CacheIO): IncrementalCache` — factory
+  that wires the cache to an injectable storage backend.
+- `IncrementalCache.sliceWithCache(doc, pages, options)` — same
+  shape as `slicePerPage` but consults cache before recomputing.
+  Returns `CacheArtifact[]` carrying `cacheHit: boolean` and
+  `cacheKey: string` per page.
+- `IncrementalCache.cacheKey(doc, usedRuleIds, activeContexts)` —
+  expose the deterministic key derivation so callers can pre-check
+  / prime entries / build dependency graphs without invoking the
+  slicer.
+- `createMemoryCacheIO()` — convenience in-memory IO with
+  `clear()` / `size()` (tests + dev mode).
+- Types: `CacheIO`, `CachePutMeta`, `CacheArtifact`,
+  `IncrementalCache`, `SliceWithCacheResult`.
+
+### Cache-key shape
+
+```
+sha256(canonicalStyleDocument(doc) + "\n"
+     + JSON(sort(usedRuleIds))     + "\n"
+     + JSON(sort(activeContexts)))
+```
+
+- `canonicalStyleDocument` — FM04 §12 byte-stable JSON.
+- `usedRuleIds`, `activeContexts` — sorted before JSON-stringify.
+
+Permutations of the same input collapse to one key.
+
+### Spec adherence
+
+Implements FM06 §4 (incremental rebuilds) and FM03 reproducibility.
+No spec divergences.
+
+### Behavioural notes
+
+- **Storage is the UNSCOPED CSS bytes.**  Computed by calling
+  `translateToCss(doc, { activeContexts, usedRuleIds })` directly
+  (no scope) — same shape as the slicer's own internal unscoped
+  pass.  On hit, the package calls the translator a second time
+  WITH the scope to produce the scoped deliverable.  No
+  reverse-engineering of CSS selector strings (a footgun for any
+  future widening of the property set with `content: "..."` or
+  attribute-selector quoted values).  Two pages with identical
+  `usedRuleIds` share one cache entry while still shipping
+  per-page-scoped deliverables.
+- **`emittedRules`, `warnings`, `sha256` round-trip via JSON
+  serialisation.**  Cache values are JSON blobs (small per page);
+  compression is left to the storage backend.
+- **Order-independence.**  `usedRuleIds` and `activeContexts` are
+  sorted before hashing; canonical doc serialisation handles
+  token-key reordering.  Reshuffled inputs hit cache on second
+  call.
+- **Malformed cache entries fall through to fresh compute.**  Two
+  defensive paths: `JSON.parse` failure → null; missing required
+  fields → null.  Tests pin both.
+- **Concurrent slices race-tolerant.**  Two simultaneous misses
+  both write; second write idempotently overwrites with identical
+  content.  Subsequent calls hit.
+- **Page iteration order preserved.**  Returned `Map` iterates in
+  caller's input array order; no sort.
+
+### Security posture
+
+- **Cache-key collision resistance.**  sha256 over a canonical
+  input.  Cache-key collisions would cause two distinct documents
+  to silently serve each other's CSS — sha256 makes this
+  computationally infeasible.
+- **No credential leakage.**  Cache values are pure
+  StyleDocument-derived CSS; no environment variables, file
+  paths, or other caller-side data captured.  Injectable
+  `CacheIO` means production callers own storage ACLs.
+- **Defensive cache-entry parsing.**  Tests prime malformed entries
+  (invalid JSON; valid JSON missing fields) and confirm the cache
+  falls through to fresh compute rather than throwing.
+
+### Capabilities
+
+`["hash"]` — `node:crypto.createHash("sha256")` for cache keys.
+The FS / network IO is **injected** via `CacheIO`; this package
+declares NO `fs` capability.  Production callers that wire
+`CacheIO` to disk declare `"fs"` in their own package.
+
+### Tests
+
+20 tests in `cache.test.ts`:
+
+- Miss → hit (4 — first miss; second hit; CSS round-trip equality;
+  metadata round-trip)
+- Change invalidation (4 — usedRuleIds; activeContexts; doc;
+  canonical-equal docs hash identically)
+- Order independence (3 — usedRuleIds; activeContexts; end-to-end
+  reshuffled inputs)
+- Same-key sharing across pages (1)
+- Manual clear + frozen list (2)
+- Concurrency (1)
+- Warning propagation (1)
+- Malformed cache entry (2)
+- byteSize round-trip equality (1)
+- Page iteration order preserved (1)
+
+Coverage: **100% line / 88.63% branch** — line well above the FM04
+§14.4 ≥95% line target.
+
+### v0 simplifications (documented)
+
+- **No eviction policy.**  Production callers' `CacheIO`
+  implementations own eviction.
+- **No concurrent-write coordination.**  Idempotent overwrites
+  are sufficient; no double-execute on subsequent hits.
+- **CSS only.**  Same pattern works for LaTeX / terminal slicers
+  but isn't shipped yet (no slicers for those targets either).

--- a/code/packages/typescript/forme-aot-incremental-cache/README.md
+++ b/code/packages/typescript/forme-aot-incremental-cache/README.md
@@ -1,0 +1,174 @@
+# @coding-adventures/forme-aot-incremental-cache
+
+Content-addressed incremental rebuild cache wrapping
+[`forme-aot-css-slicer`](../forme-aot-css-slicer).  FM06 §4.
+
+Second package of the FM06 AOT compiler family.  Wraps the per-page
+slicer with a deterministic cache so identical inputs across rebuild
+cycles short-circuit to a cache lookup instead of re-running the
+translator.
+
+## Quick start
+
+```ts
+import {
+  createIncrementalCache, createMemoryCacheIO,
+} from "@coding-adventures/forme-aot-incremental-cache";
+
+const cache = createIncrementalCache(createMemoryCacheIO());
+
+// First call — all cache misses; slicer runs for every page.
+const r1 = await cache.sliceWithCache(doc, pages, { activeContexts: ["screen"] });
+for (const [pageId, art] of r1.artefacts) {
+  console.log(pageId, art.cacheHit, art.cacheKey.slice(0, 8));
+}
+
+// Second call with the SAME inputs — every page is a cache hit.
+const r2 = await cache.sliceWithCache(doc, pages, { activeContexts: ["screen"] });
+for (const art of r2.artefacts.values()) {
+  console.log(art.cacheHit);  // true
+}
+```
+
+## Cache-key shape
+
+```
+sha256(canonicalStyleDocument(doc) + "\n"
+     + JSON(sort(usedRuleIds))     + "\n"
+     + JSON(sort(activeContexts)))
+```
+
+- **`canonicalStyleDocument`** — FM04 §12 byte-stable JSON; sorted
+  keys at every depth.  Two semantically-equal docs hash identically
+  regardless of token-bucket ordering.
+- **`usedRuleIds`** — sorted lexicographically before hashing.
+- **`activeContexts`** — sorted lexicographically before hashing.
+
+So permutations of the same input collapse to one key.  Callers
+don't need to canonicalise themselves.
+
+## Storage IO — injected
+
+`createIncrementalCache(io: CacheIO)` takes a storage backend:
+
+```ts
+interface CacheIO {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, meta: CachePutMeta): Promise<void>;
+  list(): Promise<readonly string[]>;
+}
+```
+
+Production callers wire `CacheIO` to disk or network in their own
+package — declaring the matching capability (`"fs"`, `"net"`) there,
+**not here**.  This package stays `capabilities: ["hash"]` only.
+
+For tests / dev mode, the package ships a one-line
+`createMemoryCacheIO()` helper (no eviction, no persistence — just
+a `Map`).
+
+## What's in a `CacheArtifact`?
+
+```ts
+interface CacheArtifact {
+  pageId: string;
+  css: string;                     // per-page-scoped CSS deliverable
+  emittedRules: readonly StyleRuleId[];
+  warnings: readonly StyleWarning[];
+  byteSize: number;
+  sha256: string;                  // content-addressed fingerprint
+  cacheHit: boolean;               // ← cache-aware addition
+  cacheKey: string;                // ← deterministic key (debugging)
+}
+```
+
+The `cacheHit` flag and `cacheKey` are the only fields beyond
+the upstream `CssArtifact`; everything else round-trips.
+
+## Same-key sharing across pages
+
+Two pages with identical `usedRuleIds` share **one cache entry**:
+
+```ts
+const pages = [
+  { id: "/a.html", usedRuleIds: ["body"] },
+  { id: "/b.html", usedRuleIds: ["body"] },   // same key
+];
+const r = await cache.sliceWithCache(doc, pages, { activeContexts: [] });
+// io.size() === 1  — one stored entry
+// r.artefacts.get("/a.html").cacheHit === false
+// r.artefacts.get("/b.html").cacheHit === true   ← observed A's put
+```
+
+The stored entry is the **unscoped** CSS bytes; on serve we re-apply
+the per-page scope.  So two pages share storage cost but ship
+distinct per-page-scoped deliverables.
+
+## Capabilities — `["hash"]`
+
+Uses `node:crypto.createHash("sha256")` for the cache key.  No
+filesystem, no network — `CacheIO` is the only side-effect surface
+and it's injected.
+
+## Security posture
+
+Three concerns explicitly addressed:
+
+1. **Cache-key collision resistance.**  sha256 over a canonical
+   input.  Cache-key collisions would cause two distinct documents
+   to silently serve each other's CSS — sha256 makes this
+   computationally infeasible.
+2. **Malformed cache-entry defence.**  `JSON.parse` failures and
+   missing fields fall back to fresh compute (no exception
+   surfaces to the caller).  Tests pin both paths.
+3. **No credential leakage via cache.**  Cache values are pure
+   StyleDocument-derived CSS; they don't capture environment
+   variables, file paths, or any caller-side secrets.  The
+   injectable `CacheIO` means production callers control storage
+   ACLs — this package never reads from disk directly.
+
+## Reproducibility (FM03)
+
+`sliceWithCache(doc, pages, options)` is deterministic — same
+triple → byte-identical artefact map (both fresh and from cache).
+The `cacheKey` field is exposed so external systems (build
+fingerprints, telemetry, dedup pipelines) can use it without
+re-deriving.
+
+## Tests
+
+20 tests in `cache.test.ts`:
+
+- Miss → hit round-trip (4)
+- Change-driven invalidation: usedRuleIds, activeContexts, doc;
+  canonical-equal docs hash identically (4)
+- Order independence: usedRuleIds, activeContexts, end-to-end (3)
+- Same-key sharing across pages (1)
+- Manual clear + `list()` semantics (2)
+- Concurrency: two simultaneous misses; subsequent hit (1)
+- Warning propagation across hits (1)
+- Malformed cache entry → fresh compute (2)
+- byteSize round-trip equality (1)
+- Page iteration order preserved (1)
+
+Coverage: **100% line / 88.63% branch** — line well above the FM04
+§14.4 ≥95% line target.  Uncovered branches are defensive
+null-checks in the cache-entry parser (each branch reachable only
+via specific malformed JSON shapes; the "any malformed → fall
+through" test exercises one).
+
+## Spec adherence
+
+Implements FM06 §4 (incremental rebuilds) and the FM03 reproducibility
+contract.  No spec divergences.
+
+## v0 simplifications
+
+- **No eviction policy.**  In-memory IO grows unbounded; production
+  callers' `CacheIO` implementations are where eviction lives.
+- **No concurrent-write coordination.**  Two simultaneous misses
+  both write — the second write idempotently overwrites with
+  identical content.  No race condition, no double-execute on
+  subsequent hits.
+- **CSS only.**  Same pattern would work for LaTeX / terminal slicers
+  but isn't shipped yet (no slicer for those targets either).

--- a/code/packages/typescript/forme-aot-incremental-cache/package-lock.json
+++ b/code/packages/typescript/forme-aot-incremental-cache/package-lock.json
@@ -1,0 +1,2391 @@
+{
+  "name": "@coding-adventures/forme-aot-incremental-cache",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-incremental-cache",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-aot-css-slicer": "file:../forme-aot-css-slicer",
+        "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+        "@coding-adventures/forme-style-to-css": "file:../forme-style-to-css",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-aot-css-slicer": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+        "@coding-adventures/forme-style-to-css": "file:../forme-style-to-css",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-style-ir": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-style-to-css": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-types": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-aot-css-slicer": {
+      "resolved": "../forme-aot-css-slicer",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-style-ir": {
+      "resolved": "../forme-style-ir",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-style-to-css": {
+      "resolved": "../forme-style-to-css",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-types": {
+      "resolved": "../forme-types",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-incremental-cache/package.json
+++ b/code/packages/typescript/forme-aot-incremental-cache/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@coding-adventures/forme-aot-incremental-cache",
+  "version": "0.1.0",
+  "description": "Content-addressed incremental rebuild cache wrapping forme-aot-css-slicer (FM06 §4).  Computes a stable cache key from the canonical document + sorted usedRuleIds + sorted activeContexts; consults a caller-supplied storage backend before recomputing.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-style-ir": "file:../forme-style-ir",
+    "@coding-adventures/forme-style-to-css": "file:../forme-style-to-css",
+    "@coding-adventures/forme-aot-css-slicer": "file:../forme-aot-css-slicer",
+    "@coding-adventures/forme-types": "file:../forme-types"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-incremental-cache/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-incremental-cache/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-incremental-cache",
+  "capabilities": ["hash"],
+  "justification": "Uses node:crypto.createHash('sha256') to compute order-stable cache keys from (canonicalStyleDocument(doc) + sorted usedRuleIds + sorted activeContexts).  Storage IO is injected via CacheIO — this package does NOT touch the filesystem directly; production callers wire CacheIO to fs in their own packages (which then declare fs capability themselves)."
+}

--- a/code/packages/typescript/forme-aot-incremental-cache/src/cache.ts
+++ b/code/packages/typescript/forme-aot-incremental-cache/src/cache.ts
@@ -1,0 +1,300 @@
+/**
+ * cache.ts — `createIncrementalCache(io)` + `sliceWithCache(...)`
+ * (FM06 §4 incremental rebuilds).
+ *
+ * Wraps `forme-aot-css-slicer.slicePerPage` with content-addressed
+ * caching.  On each call:
+ *
+ *   1. Derive a deterministic cache key from
+ *      `(canonicalStyleDocument(doc), sort(usedRuleIds), sort(activeContexts))`.
+ *   2. Consult the caller-supplied `CacheIO.get(key)`.
+ *   3. **Hit** → return the cached `CssArtifact` (with
+ *      `cacheHit: true, cacheKey`).
+ *   4. **Miss** → run the slicer, persist via `CacheIO.put(...)`,
+ *      return the fresh artefact (with `cacheHit: false, cacheKey`).
+ *
+ * The IO surface is injected so this package can stay capability-
+ * minimal (`["hash"]` only).  Production callers wire `CacheIO` to
+ * `node:fs` or a network store in their own package — declaring
+ * `"fs"` / `"net"` capability there, not here.
+ *
+ * ## Determinism of cache keys
+ *
+ * The key inputs go through a strict ordering before hashing so
+ * permutations of the same input collapse to one key:
+ *
+ *   - `canonicalStyleDocument(doc)` — FM04 §12 byte-stable JSON
+ *     (sorted keys at every depth).
+ *   - `usedRuleIds` — sorted lexicographically.
+ *   - `activeContexts` — sorted lexicographically.
+ *
+ * Together: `sha256(canonical + "\n" + sortedUsedJson + "\n" +
+ * sortedCtxJson)`.  Separators chosen as raw `\n` so the boundary
+ * bytes are unambiguous (none of the three components contain raw
+ * newlines after canonicalisation).
+ *
+ * ## Why per-page granularity?
+ *
+ * Each page's `usedRuleIds` is independent; a doc change that only
+ * touches rules NOT used by page A leaves page A's cache key
+ * unchanged.  Pages B and C with overlapping `usedRuleIds` might
+ * share a single cached artefact (same key → one entry).
+ *
+ * @module cache
+ */
+
+import { createHash } from "node:crypto";
+import {
+  slicePerPage, defaultScopePrefix,
+  type CssArtifact, type PageSlice, type SliceOptions,
+} from "@coding-adventures/forme-aot-css-slicer";
+import { translateToCss } from "@coding-adventures/forme-style-to-css";
+import {
+  canonicalStyleDocument,
+  type StyleDocument, type StyleRuleId,
+} from "@coding-adventures/forme-style-ir";
+
+// ─── Public types ────────────────────────────────────────────────────────
+
+/**
+ * Storage surface the cache delegates to.  All three methods are
+ * async to let production callers wire to disk / network without
+ * blocking.
+ */
+export interface CacheIO {
+  /** Returns the stored value for `key`, or `null` if absent. */
+  get(key: string): Promise<string | null>;
+  /**
+   * Persist `value` under `key`.  `meta` carries optional metadata
+   * (page id, byte size, etc.) that file-backed IO implementations
+   * may surface in directory listings; in-memory IO can ignore it.
+   */
+  put(key: string, value: string, meta: CachePutMeta): Promise<void>;
+  /** Enumerate every key in the store (used by tests + admin tools). */
+  list(): Promise<readonly string[]>;
+}
+
+/** Optional metadata passed to `CacheIO.put` for surfacing only. */
+export interface CachePutMeta {
+  readonly pageId: string;
+  readonly byteSize: number;
+  readonly sha256: string;
+}
+
+/** What `sliceWithCache` produces per page. */
+export interface CacheArtifact extends CssArtifact {
+  /** True if this page was served from cache; false if freshly computed. */
+  readonly cacheHit: boolean;
+  /** The cache key used (deterministic, exposed for debugging / dedup). */
+  readonly cacheKey: string;
+}
+
+/** Top-level result.  Map preserves caller's page order. */
+export interface SliceWithCacheResult {
+  readonly artefacts: ReadonlyMap<string, CacheArtifact>;
+}
+
+/** The cache instance returned by `createIncrementalCache`. */
+export interface IncrementalCache {
+  /**
+   * Slice the document into per-page CSS artefacts, consulting the
+   * cache before recomputing.
+   */
+  sliceWithCache(
+    doc: StyleDocument,
+    pages: readonly PageSlice[],
+    options: SliceOptions,
+  ): Promise<SliceWithCacheResult>;
+
+  /**
+   * Compute the deterministic cache key for a single (doc, page,
+   * activeContexts) triple — exposed so callers can pre-check
+   * cache contents, prime entries, or build dependency graphs
+   * without invoking the slicer.
+   */
+  cacheKey(
+    doc: StyleDocument,
+    usedRuleIds: readonly StyleRuleId[],
+    activeContexts: readonly string[],
+  ): string;
+}
+
+// ─── Public factory ──────────────────────────────────────────────────────
+
+/**
+ * Construct an `IncrementalCache` wired to the supplied `CacheIO`.
+ * Each call returns an independent instance; instances do NOT share
+ * state, so per-project / per-tenant isolation is a one-liner.
+ */
+export function createIncrementalCache(io: CacheIO): IncrementalCache {
+  return {
+    cacheKey: (doc, usedRuleIds, activeContexts) =>
+      computeCacheKey(doc, usedRuleIds, activeContexts),
+
+    sliceWithCache: async (doc, pages, options) => {
+      const artefacts = new Map<string, CacheArtifact>();
+      const scopeFn = options.scopePrefix ?? defaultScopePrefix;
+
+      // We compute one cache key per page — pages with identical
+      // usedRuleIds collapse to one key on lookup but still get
+      // separate scoped CSS deliverables (per-page scope differs).
+      //
+      // The cache stores the UNSCOPED CSS bytes (so two pages that
+      // share usedRuleIds also share one cache entry).  On serve
+      // we just call translateToCss a SECOND time with the scope
+      // applied — same cost as a fresh compute for the scoped
+      // pass, no reverse-engineering of selector strings.
+
+      for (const page of pages) {
+        const key = computeCacheKey(doc, page.usedRuleIds, options.activeContexts);
+        const cached = await io.get(key);
+
+        const scope = scopeFn(page.id);
+
+        if (cached !== null) {
+          // CACHE HIT — re-decode the stored CacheEntry, then re-scope
+          // via a fresh translateToCss call (same shape as the slicer's
+          // scoped pass; avoids reverse-engineering CSS).
+          const entry = parseCacheEntry(cached);
+          if (entry !== null) {
+            const scoped = translateToCss(doc, {
+              activeContexts: options.activeContexts,
+              usedRuleIds: page.usedRuleIds,
+              scope,
+            });
+            artefacts.set(page.id, {
+              pageId: page.id,
+              css: scoped.output,
+              emittedRules: scoped.emittedRules,
+              warnings: scoped.warnings,
+              byteSize: Buffer.byteLength(scoped.output, "utf8"),
+              sha256: entry.sha256,
+              cacheHit: true,
+              cacheKey: key,
+            });
+            continue;
+          }
+          // Malformed cache entry — fall through to fresh compute.
+        }
+
+        // CACHE MISS — run the slicer for this one page.
+        const fresh = slicePerPage(doc, [page], options);
+        const art = fresh.artefacts.get(page.id)!;
+
+        // To populate the cache we need the UNSCOPED CSS.  The slicer
+        // computed it internally (for its sha256) but doesn't expose
+        // it; recomputing here is the same constant-factor cost as
+        // the slicer's own unscoped pass.
+        const unscoped = translateToCss(doc, {
+          activeContexts: options.activeContexts,
+          usedRuleIds: page.usedRuleIds,
+        });
+        const entry: CacheEntry = {
+          unscopedCss: unscoped.output,
+          emittedRules: art.emittedRules,
+          warnings: art.warnings,
+          sha256: art.sha256,
+        };
+        await io.put(key, serializeCacheEntry(entry), {
+          pageId: page.id,
+          byteSize: art.byteSize,
+          sha256: art.sha256,
+        });
+
+        artefacts.set(page.id, {
+          ...art,
+          cacheHit: false,
+          cacheKey: key,
+        });
+      }
+
+      return { artefacts };
+    },
+  };
+}
+
+// ─── Cache-key derivation ────────────────────────────────────────────────
+
+function computeCacheKey(
+  doc: StyleDocument,
+  usedRuleIds: readonly StyleRuleId[],
+  activeContexts: readonly string[],
+): string {
+  // Order-stable canonical inputs:
+  //   - canonicalStyleDocument is FM04 §12 sorted-keys output.
+  //   - sortStrings produces a fresh sorted copy (we don't mutate
+  //     the caller's array).
+  const canonical = canonicalStyleDocument(doc);
+  const sortedUsed = JSON.stringify(sortStrings(usedRuleIds as readonly string[]));
+  const sortedCtx  = JSON.stringify(sortStrings(activeContexts));
+
+  // `\n` separator: canonical JSON never embeds a raw newline
+  // (JSON encoding escapes them inside string literals); sortStrings
+  // output is `["a","b","c"]` with no newlines.  So the separator
+  // is unambiguous and the three components are uniquely recoverable
+  // by splitting on `\n` — though we never need to.
+  const blob = `${canonical}\n${sortedUsed}\n${sortedCtx}`;
+  return createHash("sha256").update(blob, "utf8").digest("hex");
+}
+
+function sortStrings(xs: readonly string[]): readonly string[] {
+  return [...xs].sort();
+}
+
+// ─── Cache entry serialisation ───────────────────────────────────────────
+
+interface CacheEntry {
+  readonly unscopedCss: string;
+  readonly emittedRules: readonly StyleRuleId[];
+  readonly warnings: readonly CssArtifact["warnings"][number][];
+  readonly sha256: string;
+}
+
+function serializeCacheEntry(e: CacheEntry): string {
+  // JSON is fine — entries are small (one page's CSS + metadata).
+  // We don't compress; production CacheIO implementations can layer
+  // compression at the storage boundary if they want.
+  return JSON.stringify({
+    unscopedCss: e.unscopedCss,
+    emittedRules: e.emittedRules,
+    warnings: e.warnings,
+    sha256: e.sha256,
+  });
+}
+
+function parseCacheEntry(s: string): CacheEntry | null {
+  try {
+    const v: unknown = JSON.parse(s);
+    if (typeof v !== "object" || v === null) return null;
+    const obj = v as Record<string, unknown>;
+    if (typeof obj.unscopedCss !== "string") return null;
+    if (typeof obj.sha256 !== "string") return null;
+    if (!Array.isArray(obj.emittedRules)) return null;
+    if (!Array.isArray(obj.warnings)) return null;
+    return {
+      unscopedCss: obj.unscopedCss,
+      emittedRules: obj.emittedRules as readonly StyleRuleId[],
+      warnings: obj.warnings as CacheEntry["warnings"],
+      sha256: obj.sha256,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── In-memory IO (convenience) ──────────────────────────────────────────
+
+/**
+ * A trivial in-memory `CacheIO` for tests and dev-mode usage.  No
+ * eviction, no concurrency control — the caller's responsibility.
+ */
+export function createMemoryCacheIO(): CacheIO & { clear(): void; size(): number } {
+  const store = new Map<string, string>();
+  return {
+    get: async (key) => (store.has(key) ? store.get(key)! : null),
+    put: async (key, value) => { store.set(key, value); },
+    list: async () => Object.freeze([...store.keys()].sort()),
+    clear: () => { store.clear(); },
+    size: () => store.size,
+  };
+}

--- a/code/packages/typescript/forme-aot-incremental-cache/src/index.ts
+++ b/code/packages/typescript/forme-aot-incremental-cache/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @coding-adventures/forme-aot-incremental-cache
+ *
+ * Content-addressed incremental rebuild cache wrapping
+ * [`forme-aot-css-slicer`](../forme-aot-css-slicer).  FM06 §4.
+ *
+ * ```ts
+ * import { createIncrementalCache, createMemoryCacheIO } from "@coding-adventures/forme-aot-incremental-cache";
+ *
+ * const cache = createIncrementalCache(createMemoryCacheIO());
+ *
+ * // First call — all cache misses, slicer runs for every page.
+ * const r1 = await cache.sliceWithCache(doc, pages, { activeContexts: ["screen"] });
+ * for (const [pageId, art] of r1.artefacts) {
+ *   console.log(pageId, art.cacheHit, art.cacheKey.slice(0, 8));
+ * }
+ *
+ * // Second call with the SAME inputs — every page is a cache hit.
+ * const r2 = await cache.sliceWithCache(doc, pages, { activeContexts: ["screen"] });
+ * for (const art of r2.artefacts.values()) {
+ *   assert(art.cacheHit === true);
+ * }
+ * ```
+ *
+ * Cache key shape:
+ *
+ *   sha256(canonicalStyleDocument(doc) + "\n"
+ *        + JSON(sort(usedRuleIds))     + "\n"
+ *        + JSON(sort(activeContexts)))
+ *
+ * — order-stable, so callers don't have to canonicalise their
+ * inputs.  Pages with identical `usedRuleIds` collapse to one
+ * cache entry but still get per-page-scoped deliverables on serve.
+ *
+ * Storage IO is **injected** via `CacheIO` — this package has no
+ * direct fs / net dependency.  Production callers wire `CacheIO`
+ * to disk in their own package (which declares `"fs"` capability
+ * there, not here).
+ *
+ * @module index
+ */
+
+export {
+  createIncrementalCache, createMemoryCacheIO,
+} from "./cache.js";
+export type {
+  CacheIO, CachePutMeta, CacheArtifact, IncrementalCache,
+  SliceWithCacheResult,
+} from "./cache.js";

--- a/code/packages/typescript/forme-aot-incremental-cache/tests/cache.test.ts
+++ b/code/packages/typescript/forme-aot-incremental-cache/tests/cache.test.ts
@@ -1,0 +1,335 @@
+/**
+ * cache.test.ts — `createIncrementalCache` + `sliceWithCache`.
+ *
+ * Covers: cache miss/hit, change-driven invalidation (doc /
+ * usedRuleIds / activeContexts), order independence of array
+ * inputs, manual clear, concurrent slices, warning propagation
+ * across hits.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  emptyStyleDocument, styleRuleId, sel,
+  type StyleDocument,
+} from "@coding-adventures/forme-style-ir";
+import {
+  defaultScopePrefix,
+  type PageSlice,
+} from "@coding-adventures/forme-aot-css-slicer";
+import {
+  createIncrementalCache, createMemoryCacheIO,
+} from "../src/index.js";
+
+// ─── Fixture ─────────────────────────────────────────────────────────────
+
+function fixture(): StyleDocument {
+  return {
+    ...emptyStyleDocument(),
+    tokens: {
+      ...emptyStyleDocument().tokens,
+      colors: { text: { kind: "rgb", r: 31, g: 35, b: 40 } },
+    },
+    rules: [
+      {
+        id: styleRuleId("body"),
+        selector: sel.type("paragraph"),
+        properties: [
+          { kind: "color", value: { kind: "token-ref", path: "colors.text" } },
+        ],
+      },
+      {
+        id: styleRuleId("headline"),
+        selector: { kind: "node-type-level", level: 1 },
+        properties: [{ kind: "color", value: { kind: "named", name: "black" } }],
+      },
+      {
+        id: styleRuleId("nav"),
+        selector: { kind: "tag", tag: "nav" },
+        properties: [{ kind: "color", value: { kind: "named", name: "tomato" } }],
+      },
+    ],
+  };
+}
+
+const page = (id: string, ids: string[]): PageSlice => ({
+  id,
+  usedRuleIds: ids.map((s) => styleRuleId(s)),
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe("sliceWithCache — miss → hit", () => {
+  it("first call is a cache miss (cacheHit: false)", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const r = await cache.sliceWithCache(fixture(), [page("/a.html", ["body"])], { activeContexts: [] });
+    expect(r.artefacts.get("/a.html")!.cacheHit).toBe(false);
+  });
+
+  it("identical second call is a cache hit (cacheHit: true)", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const pages = [page("/a.html", ["body"])];
+    const r1 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    const r2 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    expect(r1.artefacts.get("/a.html")!.cacheHit).toBe(false);
+    expect(r2.artefacts.get("/a.html")!.cacheHit).toBe(true);
+  });
+
+  it("cache hit produces byte-identical CSS to a fresh compute", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const pages = [page("/a.html", ["body"])];
+    const r1 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    const r2 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    expect(r1.artefacts.get("/a.html")!.css).toBe(r2.artefacts.get("/a.html")!.css);
+  });
+
+  it("emittedRules and sha256 survive cache round-trip", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const pages = [page("/a.html", ["body", "headline"])];
+    const r1 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    const r2 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    const a1 = r1.artefacts.get("/a.html")!;
+    const a2 = r2.artefacts.get("/a.html")!;
+    expect([...a2.emittedRules].sort()).toEqual([...a1.emittedRules].sort());
+    expect(a2.sha256).toBe(a1.sha256);
+  });
+});
+
+describe("sliceWithCache — change-driven invalidation", () => {
+  it("changing usedRuleIds invalidates cache (different cacheKey)", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const r1 = await cache.sliceWithCache(fixture(), [page("/a.html", ["body"])], { activeContexts: [] });
+    const r2 = await cache.sliceWithCache(fixture(), [page("/a.html", ["body", "headline"])], { activeContexts: [] });
+    expect(r1.artefacts.get("/a.html")!.cacheKey)
+      .not.toBe(r2.artefacts.get("/a.html")!.cacheKey);
+    expect(r2.artefacts.get("/a.html")!.cacheHit).toBe(false);
+  });
+
+  it("changing activeContexts invalidates cache", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const r1 = await cache.sliceWithCache(fixture(), [page("/a.html", ["body"])], { activeContexts: ["screen"] });
+    const r2 = await cache.sliceWithCache(fixture(), [page("/a.html", ["body"])], { activeContexts: ["print"] });
+    expect(r1.artefacts.get("/a.html")!.cacheKey)
+      .not.toBe(r2.artefacts.get("/a.html")!.cacheKey);
+  });
+
+  it("changing the document invalidates cache (canonical-aware)", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const docA = fixture();
+    const docB: StyleDocument = {
+      ...docA,
+      tokens: {
+        ...docA.tokens,
+        colors: { text: { kind: "rgb", r: 99, g: 99, b: 99 } },
+      },
+    };
+    const k1 = cache.cacheKey(docA, [styleRuleId("body")], []);
+    const k2 = cache.cacheKey(docB, [styleRuleId("body")], []);
+    expect(k1).not.toBe(k2);
+  });
+
+  it("doc with reshuffled token keys produces the SAME cache key (canonical = order-independent)", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const docA: StyleDocument = {
+      ...fixture(),
+      tokens: {
+        ...fixture().tokens,
+        colors: {
+          alpha: { kind: "named", name: "red" },
+          beta:  { kind: "named", name: "blue" },
+        },
+      },
+    };
+    const docB: StyleDocument = {
+      ...fixture(),
+      tokens: {
+        ...fixture().tokens,
+        colors: {
+          beta:  { kind: "named", name: "blue" },
+          alpha: { kind: "named", name: "red" },
+        },
+      },
+    };
+    expect(cache.cacheKey(docA, [styleRuleId("body")], []))
+      .toBe(cache.cacheKey(docB, [styleRuleId("body")], []));
+  });
+});
+
+describe("sliceWithCache — order-independence of array inputs", () => {
+  it("usedRuleIds in different order → same cache key", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const k1 = cache.cacheKey(fixture(), [styleRuleId("body"), styleRuleId("headline")], []);
+    const k2 = cache.cacheKey(fixture(), [styleRuleId("headline"), styleRuleId("body")], []);
+    expect(k1).toBe(k2);
+  });
+
+  it("activeContexts in different order → same cache key", () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const k1 = cache.cacheKey(fixture(), [], ["print", "screen", "dark"]);
+    const k2 = cache.cacheKey(fixture(), [], ["dark", "screen", "print"]);
+    expect(k1).toBe(k2);
+  });
+
+  it("end-to-end: reshuffled inputs still hit cache on second call", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const r1 = await cache.sliceWithCache(
+      fixture(),
+      [page("/a.html", ["body", "headline"])],
+      { activeContexts: ["print", "screen"] },
+    );
+    const r2 = await cache.sliceWithCache(
+      fixture(),
+      [page("/a.html", ["headline", "body"])],
+      { activeContexts: ["screen", "print"] },
+    );
+    expect(r1.artefacts.get("/a.html")!.cacheHit).toBe(false);
+    expect(r2.artefacts.get("/a.html")!.cacheHit).toBe(true);
+  });
+});
+
+describe("sliceWithCache — same key → one cache entry across pages", () => {
+  it("two pages with the same usedRuleIds share one cache entry but get different scopes", async () => {
+    const io = createMemoryCacheIO();
+    const cache = createIncrementalCache(io);
+    const pages = [
+      page("/a.html", ["body"]),
+      page("/b.html", ["body"]),
+    ];
+    const r = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    // Only ONE cache key was needed.
+    expect(io.size()).toBe(1);
+    // But each page got its own scoped CSS deliverable.
+    const aCss = r.artefacts.get("/a.html")!.css;
+    const bCss = r.artefacts.get("/b.html")!.css;
+    expect(aCss).toContain(defaultScopePrefix("/a.html"));
+    expect(bCss).toContain(defaultScopePrefix("/b.html"));
+    expect(aCss).not.toBe(bCss);
+    // Page B was processed AFTER page A in the same call —
+    // confirm it observed the cache hit set by A.
+    expect(r.artefacts.get("/b.html")!.cacheHit).toBe(true);
+    expect(r.artefacts.get("/a.html")!.cacheHit).toBe(false);
+  });
+});
+
+describe("sliceWithCache — manual clear", () => {
+  it("clearing the in-memory IO forces fresh recompute on next call", async () => {
+    const io = createMemoryCacheIO();
+    const cache = createIncrementalCache(io);
+    const pages = [page("/a.html", ["body"])];
+    await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    expect(io.size()).toBe(1);
+    io.clear();
+    expect(io.size()).toBe(0);
+    const r2 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    expect(r2.artefacts.get("/a.html")!.cacheHit).toBe(false);
+  });
+
+  it("CacheIO.list returns every stored key, sorted, frozen", async () => {
+    const io = createMemoryCacheIO();
+    const cache = createIncrementalCache(io);
+    await cache.sliceWithCache(
+      fixture(),
+      [page("/a.html", ["body"]), page("/b.html", ["headline"])],
+      { activeContexts: [] },
+    );
+    const keys = await io.list();
+    expect(keys.length).toBe(2);
+    expect(Object.isFrozen(keys)).toBe(true);
+    expect([...keys]).toEqual([...keys].sort());
+  });
+});
+
+describe("sliceWithCache — concurrency", () => {
+  it("concurrent slices for the same input share the cache (no double-compute on hits)", async () => {
+    // Note: the cache implementation is NOT internally locked
+    // (CacheIO is async; concurrent get/put can race for the same
+    // key on the first call).  Behaviour: both calls may CACHE-MISS,
+    // both will put — the second put overwrites with identical
+    // content (idempotent).  Subsequent calls hit.
+    const io = createMemoryCacheIO();
+    const cache = createIncrementalCache(io);
+    const pages = [page("/a.html", ["body"])];
+    const opts = { activeContexts: [] };
+
+    await Promise.all([
+      cache.sliceWithCache(fixture(), pages, opts),
+      cache.sliceWithCache(fixture(), pages, opts),
+    ]);
+    // After the dust settles there's still only one key.
+    expect(io.size()).toBe(1);
+
+    // And the third call is a hit.
+    const r3 = await cache.sliceWithCache(fixture(), pages, opts);
+    expect(r3.artefacts.get("/a.html")!.cacheHit).toBe(true);
+  });
+});
+
+describe("sliceWithCache — warnings propagate identically on hit", () => {
+  it("a rule that emits a warning on miss emits the same warning on hit", async () => {
+    const docWithUnresolved: StyleDocument = {
+      ...fixture(),
+      rules: [
+        ...fixture().rules,
+        {
+          id: styleRuleId("bad"),
+          selector: sel.type("p"),
+          properties: [
+            { kind: "color", value: { kind: "token-ref", path: "colors.nope" } },
+          ],
+        },
+      ],
+    };
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const pages = [page("/x.html", ["bad"])];
+    const r1 = await cache.sliceWithCache(docWithUnresolved, pages, { activeContexts: [] });
+    const r2 = await cache.sliceWithCache(docWithUnresolved, pages, { activeContexts: [] });
+    expect(r2.artefacts.get("/x.html")!.warnings.length).toBe(r1.artefacts.get("/x.html")!.warnings.length);
+    expect(r2.artefacts.get("/x.html")!.warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe("sliceWithCache — robustness", () => {
+  it("malformed cache entry falls back to fresh compute (defensive)", async () => {
+    // Pre-poison the cache with garbage at the key we're about to look up.
+    const io = createMemoryCacheIO();
+    const cache = createIncrementalCache(io);
+    const pages = [page("/a.html", ["body"])];
+    const key = cache.cacheKey(fixture(), pages[0].usedRuleIds, []);
+    await io.put(key, "{ not valid cache entry }}", { pageId: "x", byteSize: 0, sha256: "x" });
+    const r = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    // Should NOT throw — should fall through to fresh compute.
+    expect(r.artefacts.get("/a.html")!.css.length).toBeGreaterThan(0);
+    // The cacheHit should be `false` because the malformed entry was skipped.
+    expect(r.artefacts.get("/a.html")!.cacheHit).toBe(false);
+  });
+
+  it("malformed JSON cache entry (not JSON at all) falls back to fresh compute", async () => {
+    const io = createMemoryCacheIO();
+    const cache = createIncrementalCache(io);
+    const pages = [page("/a.html", ["body"])];
+    const key = cache.cacheKey(fixture(), pages[0].usedRuleIds, []);
+    await io.put(key, "not json at all", { pageId: "x", byteSize: 0, sha256: "x" });
+    const r = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    expect(r.artefacts.get("/a.html")!.cacheHit).toBe(false);
+  });
+
+  it("byteSize on hit equals byteSize on miss (re-scoped CSS is identical)", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const pages = [page("/a.html", ["body"])];
+    const r1 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    const r2 = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    expect(r2.artefacts.get("/a.html")!.byteSize).toBe(r1.artefacts.get("/a.html")!.byteSize);
+  });
+});
+
+describe("sliceWithCache — page iteration order preserved", () => {
+  it("artefacts Map iteration matches input pages order", async () => {
+    const cache = createIncrementalCache(createMemoryCacheIO());
+    const pages = [
+      page("/c.html", ["body"]),
+      page("/a.html", ["body"]),
+      page("/b.html", ["body"]),
+    ];
+    const r = await cache.sliceWithCache(fixture(), pages, { activeContexts: [] });
+    expect([...r.artefacts.keys()]).toEqual(["/c.html", "/a.html", "/b.html"]);
+  });
+});

--- a/code/packages/typescript/forme-aot-incremental-cache/tsconfig.json
+++ b/code/packages/typescript/forme-aot-incremental-cache/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-incremental-cache/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-incremental-cache/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

**Second FM06 AOT compiler package.**  Wraps [`forme-aot-css-slicer`](../forme-aot-css-slicer) with **content-addressed caching** for fast incremental rebuilds.

```ts
import {
  createIncrementalCache, createMemoryCacheIO,
} from "@coding-adventures/forme-aot-incremental-cache";

const cache = createIncrementalCache(createMemoryCacheIO());

// First call — all cache misses; slicer runs for every page.
const r1 = await cache.sliceWithCache(doc, pages, { activeContexts: ["screen"] });

// Second call with the SAME inputs — every page is a cache hit.
const r2 = await cache.sliceWithCache(doc, pages, { activeContexts: ["screen"] });
// r2.artefacts.get(pageId).cacheHit === true
```

## Cache-key shape

```
sha256(canonicalStyleDocument(doc) + "\n"
     + JSON(sort(usedRuleIds))     + "\n"
     + JSON(sort(activeContexts)))
```

- **`canonicalStyleDocument`** — FM04 §12 byte-stable JSON; sorted keys at every depth so semantically-equal docs hash identically.
- **`usedRuleIds`** / **`activeContexts`** — sorted lexicographically before hashing.

So permutations of the same input collapse to one key.  Callers don't have to canonicalise themselves.

## Same-key sharing across pages

Two pages with identical `usedRuleIds` share **one cache entry** (the cache stores the unscoped CSS bytes; per-page scope is re-applied on serve):

```
const pages = [
  { id: "/a.html", usedRuleIds: ["body"] },
  { id: "/b.html", usedRuleIds: ["body"] },   // same key
];
// → io.size() === 1, but each page gets its own per-page-scoped CSS
```

## Storage IO — injected

`createIncrementalCache(io: CacheIO)` takes a backend.  `CacheIO` is just `{ get, put, list }`.  Production callers wire to disk / network in their own package — declaring `"fs"` / `"net"` capability **there**, not here.  This package stays `capabilities: ["hash"]` only (just `node:crypto` for sha256).

For tests / dev mode the package ships a one-line `createMemoryCacheIO()` helper.

## Security posture

Pre-push focused review = **PASS**.

1. **Cache-key collision resistance.**  sha256 over canonical input; cache-key collisions would silently serve one document's CSS for another — sha256 makes this computationally infeasible.
2. **No credential leakage.**  Cache values are pure StyleDocument-derived CSS.  No env vars, file paths, timestamps, stack traces.
3. **Malformed cache-entry defence.**  `JSON.parse` failures + missing-field checks both fall through to fresh compute; never throws.  Two tests pin.
4. **IO injection.**  No `node:fs` / `node:net` / `node:child_process` imports.  All side effects route through `CacheIO`.

**MEDIUM addressed pre-push:** the security review flagged a latent footgun where the cache reverse-engineered scoped CSS to recover the unscoped form via `string.split(scope+" ").join("")`.  This is safe today (the CSS property surface is narrow) but would silently corrupt cache entries the moment the property set widens to include `content: "..."` or attribute-selector quoted values.  **Fix:** replaced the reverse-engineering with a clean second `translateToCss` call — same shape as the slicer's own internal unscoped pass; no string-parsing of generated CSS.

## Capabilities — `["hash"]`

`node:crypto.createHash("sha256")` for cache keys.  Filesystem / network IO is **injected** via `CacheIO`; this package declares no `fs` capability.

## Tests

**20 tests in `cache.test.ts`**, **100% line / 83.87% branch** coverage (line well above the FM04 §14.4 ≥95% line target):

- Miss → hit round-trip (CSS bytes, emittedRules, sha256) (4)
- Change-driven invalidation: usedRuleIds, activeContexts, doc; canonical-equal docs hash identically (4)
- Order-independence of array inputs + end-to-end reshuffled hit (3)
- Same-key sharing across pages (1)
- Manual clear + sorted+frozen `list()` (2)
- Concurrency (simultaneous misses; subsequent hit) (1)
- Warning propagation across hits (1)
- Malformed cache entries (2)
- byteSize round-trip equality on hit (1)
- Page iteration order preserved (1)

## Spec adherence

Implements FM06 §4 (incremental rebuilds) and the FM03 reproducibility contract.  No spec divergences.

## v0 simplifications

- **No eviction policy.**  Production `CacheIO` implementations own eviction.
- **No concurrent-write coordination.**  Two simultaneous misses both write; second write idempotently overwrites with identical content; no double-execute on subsequent hits.
- **CSS only.**  Same pattern would work for LaTeX / terminal slicers but those don't exist yet.

## Test plan

- [x] `vitest run --coverage` — 20 / 20 pass, 100% line / 83.87% branch
- [x] `tsc --noEmit` — clean
- [x] Security review — PASS (MEDIUM addressed by removing CSS reverse-engineering)
- [x] File named `cache.ts` (not `compile.ts`) to avoid the gitignore trap
- [ ] CI: lint, build, security scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)