### PR TITLE
feat(twigc): LANG73 TW05-R — twigc CLI driver

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -615,6 +615,7 @@ members = [
     "twig-to-jvm",
     "twig-to-cil",
     "twig-demo",
+    "twigc",
     "twig-lsp-bridge",
     "twig-dap",
     "conduit",

--- a/code/packages/rust/twigc/BUILD
+++ b/code/packages/rust/twigc/BUILD
@@ -1,0 +1,1 @@
+cargo build --release && cargo test -- --nocapture

--- a/code/packages/rust/twigc/CHANGELOG.md
+++ b/code/packages/rust/twigc/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog — twigc
+
+## [0.1.0] — 2026-05-17
+
+### Added (LANG73 — TW05-R twigc CLI driver)
+
+Initial release.  Wraps the Twig multi-file compilation pipeline in a
+user-facing CLI binary and a testable library.
+
+#### CLI (`twigc` binary)
+
+- `twigc <file.tw>` — compile and run; prints the integer result of `main()`.
+- `twigc --check <file.tw>` — type-check only; exit 0 on success, 1 on
+  `TypeErrors` from a `(typed strict)` module.
+- `twigc --emit=iir <file.tw>` — compile to IIR and print a human-readable
+  function listing to stdout.
+- `twigc --search-path=<DIR>` — add DIR to the module search path (repeatable).
+- `-h`/`--help` and `-V`/`--version` flags.
+
+#### Library (`twigc` crate)
+
+- `twigc_check(path, search_paths) -> Result<(), TwigcError>`
+- `twigc_emit_iir(path, search_paths) -> Result<String, TwigcError>`
+- `twigc_run(path, search_paths) -> Result<i64, TwigcError>`
+- `TwigcError` enum: `Driver(ModuleDriverError)` and `Vm { message }`.
+
+#### Tests (`twigc_tests`, 6 tests)
+
+| Test | Verifies |
+|------|---------|
+| `check_clean_strict_program_ok` | Clean strict module → `Ok(())` |
+| `check_strict_program_with_type_error_fails` | Bad varref in strict → `Err(TypeErrors)` |
+| `check_lenient_bad_varref_passes` | Bad varref in lenient → not TypeErrors |
+| `emit_iir_produces_fn_listing` | IIR listing contains `fn main:` |
+| `run_arithmetic_returns_value` | `(+ 21 21)` → 42 |
+| `run_compiler_tree_main_returns_2` | Full 11-module compiler tree, `(main)` → 2 (span.tw fn count) |

--- a/code/packages/rust/twigc/Cargo.toml
+++ b/code/packages/rust/twigc/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "twigc"
+version = "0.1.0"
+edition = "2021"
+description = "TW05-R — twigc: command-line compiler driver for Twig. Wraps twig-module-driver (multi-file module resolution + Phase 3.5 type-check) and twig-vm (interpreter execution)."
+
+[[bin]]
+name = "twigc"
+path = "src/main.rs"
+
+[lib]
+name = "twigc"
+path = "src/lib.rs"
+
+[dependencies]
+# Multi-file module resolution, phase 3.5 type-check, IIR compilation
+twig-module-driver = { path = "../twig-module-driver" }
+
+# Interpreter execution backend
+twig-vm            = { path = "../twig-vm" }
+
+# IIR types for the --emit=iir formatter
+interpreter-ir     = { path = "../interpreter-ir" }
+
+[dev-dependencies]
+# No extra dev deps — tests use std + the lib above

--- a/code/packages/rust/twigc/README.md
+++ b/code/packages/rust/twigc/README.md
@@ -1,0 +1,106 @@
+# twigc — Twig Compiler CLI
+
+`twigc` is the command-line compiler driver for the Twig programming language
+(TW05-R / LANG73).  It wraps the full multi-file compilation pipeline — module
+resolution, Phase 3.5 type-checking, IIR compilation, and interpreter execution
+— in a single binary.
+
+## Usage
+
+```bash
+twigc [OPTIONS] <file.tw>
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--check` | Type-check only.  Exit 0 on success, 1 on type errors in `(typed strict)` modules. |
+| `--emit=iir` | Compile to IIR and print a human-readable listing to stdout. |
+| `--search-path=<DIR>` | Add DIR to the module search path (repeatable). |
+| `-h`, `--help` | Print help. |
+| `-V`, `--version` | Print version. |
+
+Default (no flags): compile and run via `twig-vm`; print the integer return
+value of `main()` to stdout.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Type error in a `(typed strict)` module |
+| 2 | Compilation error (parse error, missing import, …) |
+| 3 | Runtime trap from the interpreter |
+| 4 | Usage error (bad flags, missing file) |
+
+## Examples
+
+```bash
+# Type-check only — useful in CI:
+twigc --check src/main.tw
+
+# Dump IIR for debugging:
+twigc --emit=iir src/main.tw
+
+# Compile and run:
+twigc src/main.tw
+
+# Multi-module program with an explicit search path:
+twigc --search-path=lib src/main.tw
+```
+
+## How it works
+
+```
+<file.tw>
+   │
+   ▼  twig-module-driver::compile_module_tree
+Phase 1: recursive import discovery
+Phase 2: cycle detection
+Phase 3: extern name collection
+Phase 3.5: topological type-check  ← LANG72 / TW05-Q
+Phase 4: per-module IIR compilation
+Phase 5: IIR linking
+   │
+   ▼  twig-vm::run  (default mode only)
+IIRModule → interpreter → i64 result
+```
+
+`--check` stops after Phase 5 (compilation only).
+`--emit=iir` runs Phase 1–5 and formats the resulting `IIRModule`.
+Default mode runs all phases plus the interpreter.
+
+## Library API
+
+The `twigc` crate also exposes a library:
+
+```rust
+use twigc::{twigc_check, twigc_emit_iir, twigc_run};
+use std::path::Path;
+
+// Type-check only
+twigc_check(Path::new("main.tw"), &[]).unwrap();
+
+// Emit IIR text
+let iir = twigc_emit_iir(Path::new("main.tw"), &[]).unwrap();
+
+// Compile and run
+let result = twigc_run(Path::new("main.tw"), &[]).unwrap();
+println!("→ {result}");
+```
+
+## In the stack
+
+```
+twigc (this crate)
+├── twig-module-driver  — multi-file resolution + type-check
+│   ├── twig-parser     — lexer, parser, AST
+│   ├── twig-ir-compiler — IIR code generation
+│   └── twig-type-checker — static type checking
+└── twig-vm             — interpreter execution
+```
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).

--- a/code/packages/rust/twigc/src/lib.rs
+++ b/code/packages/rust/twigc/src/lib.rs
@@ -1,0 +1,399 @@
+//! # twigc — Twig compiler driver library (TW05-R / LANG73)
+//!
+//! This crate provides three thin, testable functions that wrap
+//! [`twig_module_driver::compile_module_tree`] and [`twig_vm`]:
+//!
+//! | Function | Description |
+//! |----------|-------------|
+//! | [`twigc_check`]    | Type-check only; return `Ok(())` or `Err(TwigcError)`. |
+//! | [`twigc_emit_iir`] | Compile to IIR and return a human-readable listing. |
+//! | [`twigc_run`]      | Compile and run via twig-vm; return the `i64` result. |
+//!
+//! ## Error model
+//!
+//! All three functions return `Result<_, TwigcError>`.  [`TwigcError`] wraps
+//! [`twig_module_driver::ModuleDriverError`] (covers parse errors, import
+//! resolution failures, type errors) and adds a `Vm` variant for runtime
+//! traps.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use twigc::twigc_run;
+//! use std::path::Path;
+//!
+//! let result = twigc_run(Path::new("main.tw"), &[]).unwrap();
+//! println!("→ {result}");
+//! ```
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use interpreter_ir::IIRModule;
+use twig_module_driver::{compile_module_tree, ModuleDriverError};
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// All errors that `twigc` operations can produce.
+///
+/// Each variant carries a human-readable message so callers can display it
+/// directly without inspecting the underlying library types.
+#[derive(Debug)]
+pub enum TwigcError {
+    /// The module driver failed (parse, import resolution, or type errors).
+    ///
+    /// The `ModuleDriverError` inside covers all phases up to IIR compilation.
+    Driver(ModuleDriverError),
+
+    /// The compiled module trapped at runtime.
+    ///
+    /// `message` is the stringified `twig_vm::TwigFileError`.
+    Vm { message: String },
+}
+
+impl fmt::Display for TwigcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TwigcError::Driver(e) => write!(f, "{e}"),
+            TwigcError::Vm { message } => write!(f, "runtime error: {message}"),
+        }
+    }
+}
+
+impl From<ModuleDriverError> for TwigcError {
+    fn from(e: ModuleDriverError) -> Self {
+        TwigcError::Driver(e)
+    }
+}
+
+// ── Core helpers ──────────────────────────────────────────────────────────────
+
+/// Convert `&[PathBuf]` to `Vec<&Path>` for the module-driver / twig-vm APIs.
+fn as_path_refs(v: &[PathBuf]) -> Vec<&Path> {
+    v.iter().map(PathBuf::as_path).collect()
+}
+
+/// Compile `path` (multi-file) and return the linked `IIRModule`.
+///
+/// This is the shared kernel used by all three public functions.
+/// It calls `compile_module_tree` which runs:
+///   - Phase 1: recursive import discovery
+///   - Phase 2: cycle detection
+///   - Phase 3: extern name collection
+///   - Phase 3.5: topological type-check (LANG72)
+///   - Phase 4: IIR compilation per module
+///   - Phase 5: IIR linking
+fn compile(path: &Path, search_paths: &[PathBuf]) -> Result<IIRModule, TwigcError> {
+    let refs = as_path_refs(search_paths);
+    compile_module_tree(path, &refs).map_err(TwigcError::Driver)
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Type-check a Twig program without running it.
+///
+/// Runs the full compilation pipeline through Phase 3.5 (type-check) and
+/// Phase 4 (IIR compilation), but does **not** execute the resulting module.
+///
+/// Returns `Ok(())` if the program compiles successfully.  Returns
+/// `Err(TwigcError::Driver(TypeErrors { … }))` if a `(typed strict)` module
+/// has type errors.
+///
+/// # Example
+///
+/// ```no_run
+/// use twigc::twigc_check;
+/// use std::path::Path;
+///
+/// twigc_check(Path::new("main.tw"), &[]).unwrap();
+/// ```
+pub fn twigc_check(path: &Path, search_paths: &[PathBuf]) -> Result<(), TwigcError> {
+    compile(path, search_paths)?;
+    Ok(())
+}
+
+/// Compile a Twig program and return a human-readable IIR listing.
+///
+/// Each function in the linked module is formatted as:
+///
+/// ```text
+/// fn <name>:
+///   <index>  <op>  <dest?>  <srcs…>
+/// ```
+///
+/// This is the `--emit=iir` mode: it lets you inspect what the compiler
+/// produces without running the program.
+///
+/// # Example
+///
+/// ```no_run
+/// use twigc::twigc_emit_iir;
+/// use std::path::Path;
+///
+/// let iir_text = twigc_emit_iir(Path::new("main.tw"), &[]).unwrap();
+/// println!("{iir_text}");
+/// ```
+pub fn twigc_emit_iir(path: &Path, search_paths: &[PathBuf]) -> Result<String, TwigcError> {
+    let module = compile(path, search_paths)?;
+    let mut out = String::new();
+
+    // A module contains all functions from all linked source files.
+    // We emit them in definition order, which matches the link order.
+    for func in &module.functions {
+        out.push_str(&format!("fn {}:\n", func.name));
+        for (i, instr) in func.instructions.iter().enumerate() {
+            // Format: <index>  <op>  [dest]  [srcs…]
+            let dest_str = instr
+                .dest
+                .as_deref()
+                .unwrap_or("-");
+            let srcs_str: Vec<String> = instr
+                .srcs
+                .iter()
+                .map(|op| format!("{op:?}"))
+                .collect();
+            out.push_str(&format!(
+                "  {i:>4}  {op:<16}  {dest:<12}  {srcs}\n",
+                op = instr.op,
+                dest = dest_str,
+                srcs = srcs_str.join("  "),
+            ));
+        }
+        out.push('\n');
+    }
+
+    Ok(out)
+}
+
+/// Compile and run a Twig program via the interpreter, returning the integer
+/// result of `main()`.
+///
+/// The return value is extracted from the `LispyValue` returned by the VM.
+/// If `main()` returns a non-integer value (e.g. `#t` or a cons cell), the
+/// function returns `Ok(0)` as a safe default.
+///
+/// # Example
+///
+/// ```no_run
+/// use twigc::twigc_run;
+/// use std::path::Path;
+///
+/// let result = twigc_run(Path::new("main.tw"), &[]).unwrap();
+/// assert_eq!(result, 42);
+/// ```
+pub fn twigc_run(path: &Path, search_paths: &[PathBuf]) -> Result<i64, TwigcError> {
+    let refs = as_path_refs(search_paths);
+    let value = twig_vm::run_module_tree(path, &refs).map_err(|e| TwigcError::Vm {
+        message: format!("{e:?}"),
+    })?;
+    // Extract the integer value; non-integer results (booleans, cons cells,
+    // strings) are mapped to 0 — callers who need exact values should use
+    // `compile_module_tree` + `twig_vm::run` directly.
+    Ok(value.as_int().unwrap_or(0))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+//
+// All tests write temporary `.tw` files to a unique temp directory so they
+// are hermetic and can run in parallel.
+
+#[cfg(test)]
+mod twigc_tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    // ── helper ───────────────────────────────────────────────────────────────
+
+    fn make_tempdir(tag: &str) -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "twigc_{tag}_{}_{}",
+            std::process::id(),
+            nonce
+        ));
+        fs::create_dir(&dir).unwrap_or_else(|e| {
+            panic!("make_tempdir: could not create {}: {e}", dir.display())
+        });
+        dir
+    }
+
+    fn compiler_src_dir() -> PathBuf {
+        // Navigate: twigc/ → rust/ → packages/ → code/ → twig/compiler/
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent().unwrap()  // rust/
+            .parent().unwrap()  // packages/
+            .parent().unwrap()  // code/
+            .join("twig/compiler")
+            .canonicalize()
+            .expect("code/twig/compiler/ must exist")
+    }
+
+    fn copy_tw(twig_src: &Path, dest_dir: &Path, name: &str) {
+        let src = twig_src.join(format!("{name}.tw"));
+        let dest = dest_dir.join("compiler");
+        fs::create_dir_all(&dest).unwrap();
+        fs::copy(&src, dest.join(format!("{name}.tw")))
+            .unwrap_or_else(|e| panic!("copy {name}.tw: {e}"));
+    }
+
+    fn copy_all_tw_modules(twig_src: &Path, dest_dir: &Path) {
+        for name in &[
+            "span", "token", "diagnostic", "ast", "iir-types",
+            "iir-builder", "lexer", "cst-parser", "parser", "emit", "main",
+        ] {
+            copy_tw(twig_src, dest_dir, name);
+        }
+    }
+
+    // ── Test 1 ───────────────────────────────────────────────────────────────
+    //
+    // `twigc_check` on a clean `(typed strict)` program should return `Ok(())`.
+
+    #[test]
+    fn check_clean_strict_program_ok() {
+        let dir = make_tempdir("check_clean");
+        let src = r#"
+(module twigc/test1
+  (typed strict)
+  (export main))
+
+(define (main) (+ 21 21))
+"#;
+        let root = dir.join("main.tw");
+        fs::write(&root, src).unwrap();
+        let result = twigc_check(&root, &[]);
+        assert!(result.is_ok(), "clean strict program should type-check: {result:?}");
+    }
+
+    // ── Test 2 ───────────────────────────────────────────────────────────────
+    //
+    // `twigc_check` on a `(typed strict)` program that calls an undefined
+    // function should return `Err(Driver(TypeErrors { … }))`.
+
+    #[test]
+    fn check_strict_program_with_type_error_fails() {
+        let dir = make_tempdir("check_fail");
+        let src = r#"
+(module twigc/test2
+  (typed strict)
+  (export main))
+
+(define (main) (no-such-function 99))
+"#;
+        let root = dir.join("main.tw");
+        fs::write(&root, src).unwrap();
+        let result = twigc_check(&root, &[]);
+        match result {
+            Err(TwigcError::Driver(ModuleDriverError::TypeErrors { .. })) => {
+                // correct
+            }
+            Ok(()) => panic!("expected TypeErrors but got Ok"),
+            Err(e) => panic!("expected TypeErrors but got: {e}"),
+        }
+    }
+
+    // ── Test 3 ───────────────────────────────────────────────────────────────
+    //
+    // `twigc_check` on a `(typed lenient)` program with an undefined function
+    // should NOT return TypeErrors (lenient mode never fails Phase 3.5).
+
+    #[test]
+    fn check_lenient_bad_varref_passes() {
+        let dir = make_tempdir("check_lenient");
+        let src = r#"
+(module twigc/test3
+  (typed lenient)
+  (export main))
+
+(define (main) (no-such-function 99))
+"#;
+        let root = dir.join("main.tw");
+        fs::write(&root, src).unwrap();
+        let result = twigc_check(&root, &[]);
+        match result {
+            Err(TwigcError::Driver(ModuleDriverError::TypeErrors { .. })) => {
+                panic!("lenient mode must never produce TypeErrors from Phase 3.5");
+            }
+            _ => {} // Ok or any non-TypeErrors Err is acceptable
+        }
+    }
+
+    // ── Test 4 ───────────────────────────────────────────────────────────────
+    //
+    // `twigc_emit_iir` on a simple program should produce a string that
+    // contains the function name.
+
+    #[test]
+    fn emit_iir_produces_fn_listing() {
+        let dir = make_tempdir("emit_iir");
+        let src = r#"(define (main) (+ 21 21))"#;
+        let root = dir.join("main.tw");
+        fs::write(&root, src).unwrap();
+        let listing = twigc_emit_iir(&root, &[]).unwrap();
+        assert!(
+            listing.contains("fn main:"),
+            "IIR listing should contain 'fn main:'; got:\n{listing}"
+        );
+        assert!(
+            listing.contains("add") || listing.contains("const"),
+            "IIR listing should contain arithmetic opcodes; got:\n{listing}"
+        );
+    }
+
+    // ── Test 5 ───────────────────────────────────────────────────────────────
+    //
+    // `twigc_run` on `(define (main) (+ 21 21))` should return `Ok(42)`.
+
+    #[test]
+    fn run_arithmetic_returns_value() {
+        let dir = make_tempdir("run_arith");
+        let src = r#"(define (main) (+ 21 21))"#;
+        let root = dir.join("main.tw");
+        fs::write(&root, src).unwrap();
+        let result = twigc_run(&root, &[]).unwrap();
+        assert_eq!(result, 42, "expected 42 but got {result}");
+    }
+
+    // ── Test 6 ───────────────────────────────────────────────────────────────
+    //
+    // `twigc_run` on the full 11-module compiler tree runs `(main)` which
+    // compiles a stripped in-memory version of `span.tw` and returns 2
+    // (the number of function definitions in span.tw: make-span + dummy-span).
+    //
+    // This verifies that the multi-module driver, type-checker (Phase 3.5),
+    // and interpreter all wire together correctly end-to-end through twigc.
+    //
+    // Note: `(self-compile-all dir)` returns 179 but requires a `dir` argument
+    // and uses `host/read_file` — that is tested separately in twig-module-driver
+    // tw05n_tests.  `(main)` uses an in-memory source string and is safe to call
+    // without extra arguments.
+
+    #[test]
+    fn run_compiler_tree_main_returns_2() {
+        let twig_src = compiler_src_dir();
+        let dir = make_tempdir("run_compiler");
+        copy_all_tw_modules(&twig_src, &dir);
+
+        // Spawn with a 32 MiB stack to accommodate deep recursive-descent
+        // parsing and type-checking over ~500 lines of typed Twig in debug mode.
+        let result = std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                let root = dir.join("compiler").join("main.tw");
+                twigc_run(&root, &[dir.clone()]).unwrap()
+            })
+            .expect("failed to spawn thread")
+            .join()
+            .expect("thread panicked");
+
+        assert_eq!(
+            result, 2,
+            "twigc_run on compiler tree: (main) should return 2 (span.tw fn count); got {result}"
+        );
+    }
+}

--- a/code/packages/rust/twigc/src/main.rs
+++ b/code/packages/rust/twigc/src/main.rs
@@ -1,0 +1,215 @@
+//! # twigc — Twig compiler CLI (TW05-R / LANG73)
+//!
+//! ```text
+//! USAGE:
+//!   twigc [OPTIONS] <file.tw>
+//!
+//! OPTIONS:
+//!   --check              Type-check only.  Exit 0 on success, 1 on type errors.
+//!   --emit=iir           Compile to IIR and print a human-readable summary.
+//!   --search-path=<DIR>  Add DIR to the module search path (repeatable).
+//!   -h, --help           Print this help.
+//!   -V, --version        Print version.
+//!
+//! DEFAULT (no flags):
+//!   Compile and run via twig-vm; print the integer return value to stdout.
+//! ```
+//!
+//! ## Exit codes
+//!
+//! | Code | Meaning |
+//! |------|---------|
+//! | 0    | Success (check passed / IIR printed / run returned) |
+//! | 1    | Type error in a `(typed strict)` module |
+//! | 2    | Any other compilation error (parse error, missing import, …) |
+//! | 3    | Runtime trap from twig-vm |
+//! | 4    | Usage error (bad flags, missing file argument) |
+//!
+//! ## Examples
+//!
+//! ```text
+//! # Type-check only:
+//! twigc --check src/main.tw
+//!
+//! # Dump IIR:
+//! twigc --emit=iir src/main.tw
+//!
+//! # Compile and run:
+//! twigc src/main.tw
+//!
+//! # Multi-module with explicit search path:
+//! twigc --search-path=stdlib src/main.tw
+//! ```
+
+use std::path::PathBuf;
+use std::process;
+
+use twigc::{twigc_check, twigc_emit_iir, twigc_run, TwigcError};
+use twig_module_driver::ModuleDriverError;
+
+// ── Version constant ──────────────────────────────────────────────────────────
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// ── Usage string ──────────────────────────────────────────────────────────────
+
+const USAGE: &str = "\
+USAGE:
+  twigc [OPTIONS] <file.tw>
+
+OPTIONS:
+  --check              Type-check only.  Exit 0 on success, 1 on type errors.
+  --emit=iir           Compile to IIR and print a human-readable listing.
+  --search-path=<DIR>  Add DIR to the module search path (repeatable).
+  -h, --help           Print this help.
+  -V, --version        Print version.
+
+DEFAULT (no flags):
+  Compile and run via twig-vm; print the integer return value to stdout.
+
+EXIT CODES:
+  0  Success
+  1  Type error in a (typed strict) module
+  2  Compilation error (parse, import, …)
+  3  Runtime trap
+  4  Usage error
+";
+
+// ── CLI parsing ───────────────────────────────────────────────────────────────
+
+/// The mode of operation selected by the user.
+#[derive(Debug, PartialEq)]
+enum Mode {
+    /// `--check` — type-check only, no execution.
+    Check,
+    /// `--emit=iir` — dump IIR listing to stdout.
+    EmitIir,
+    /// Default — compile and run, print integer result.
+    Run,
+}
+
+/// Parsed command-line arguments.
+struct Args {
+    mode: Mode,
+    file: PathBuf,
+    search_paths: Vec<PathBuf>,
+}
+
+/// Parse `std::env::args().collect()`.
+///
+/// Prints usage to stderr and calls `process::exit(4)` on any parse error.
+fn parse_args(raw: Vec<String>) -> Args {
+    let mut mode = Mode::Run;
+    let mut file: Option<PathBuf> = None;
+    let mut search_paths: Vec<PathBuf> = Vec::new();
+
+    let mut i = 1usize; // skip argv[0]
+    while i < raw.len() {
+        let arg = &raw[i];
+        match arg.as_str() {
+            "-h" | "--help" => {
+                print!("{USAGE}");
+                process::exit(0);
+            }
+            "-V" | "--version" => {
+                println!("twigc {VERSION}");
+                process::exit(0);
+            }
+            "--check" => {
+                mode = Mode::Check;
+            }
+            "--emit=iir" => {
+                mode = Mode::EmitIir;
+            }
+            s if s.starts_with("--search-path=") => {
+                let dir = s.trim_start_matches("--search-path=");
+                search_paths.push(PathBuf::from(dir));
+            }
+            s if s.starts_with('-') => {
+                eprintln!("twigc: unknown option: {s}");
+                eprintln!("{USAGE}");
+                process::exit(4);
+            }
+            _ => {
+                if file.is_some() {
+                    eprintln!("twigc: unexpected positional argument: {arg}");
+                    eprintln!("{USAGE}");
+                    process::exit(4);
+                }
+                file = Some(PathBuf::from(arg));
+            }
+        }
+        i += 1;
+    }
+
+    let file = match file {
+        Some(f) => f,
+        None => {
+            eprintln!("twigc: missing required argument: <file.tw>");
+            eprintln!("{USAGE}");
+            process::exit(4);
+        }
+    };
+
+    Args { mode, file, search_paths }
+}
+
+// ── Error reporting ───────────────────────────────────────────────────────────
+
+/// Print a `TwigcError` to stderr and return the appropriate exit code.
+fn handle_error(e: &TwigcError) -> i32 {
+    match e {
+        TwigcError::Driver(ModuleDriverError::TypeErrors { path, errors }) => {
+            eprintln!("twigc: type error(s) in {}:", path.display());
+            for err in errors.iter().take(5) {
+                eprintln!("  {}:{}: {}", err.line, err.column, err.message);
+            }
+            if errors.len() > 5 {
+                eprintln!("  … and {} more", errors.len() - 5);
+            }
+            1
+        }
+        TwigcError::Driver(e) => {
+            eprintln!("twigc: compilation error: {e}");
+            2
+        }
+        TwigcError::Vm { message } => {
+            eprintln!("twigc: runtime error: {message}");
+            3
+        }
+    }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let args = parse_args(std::env::args().collect());
+
+    let exit_code = match args.mode {
+        Mode::Check => match twigc_check(&args.file, &args.search_paths) {
+            Ok(()) => {
+                // Silent success — exit 0.  Mirrors how `rustc --check-cfg` behaves.
+                0
+            }
+            Err(ref e) => handle_error(e),
+        },
+
+        Mode::EmitIir => match twigc_emit_iir(&args.file, &args.search_paths) {
+            Ok(listing) => {
+                print!("{listing}");
+                0
+            }
+            Err(ref e) => handle_error(e),
+        },
+
+        Mode::Run => match twigc_run(&args.file, &args.search_paths) {
+            Ok(value) => {
+                println!("{value}");
+                0
+            }
+            Err(ref e) => handle_error(e),
+        },
+    };
+
+    process::exit(exit_code);
+}

--- a/code/specs/LANG73-tw05r-twigc-cli.md
+++ b/code/specs/LANG73-tw05r-twigc-cli.md
@@ -1,0 +1,113 @@
+# LANG73 — TW05-R: `twigc` CLI Driver
+
+## Motivation
+
+After LANG72 (TW05-Q), the full Twig compilation pipeline —
+multi-file module resolution, Phase 3.5 type-checking, and IIR
+compilation — lives entirely inside `compile_module_tree` in
+`twig-module-driver`.  However, there is no user-facing CLI tool;
+the pipeline is only accessible through Rust integration tests.
+
+TW05-R closes this gap by creating `twigc`: a command-line compiler
+driver that exposes `compile_module_tree` + `twig-vm` to end users.
+This completes the "Artifact and CLI shape" section of the TW05 spec.
+
+## Solution
+
+New crate `code/packages/rust/twigc/` added to the main Rust
+workspace.
+
+### CLI surface
+
+```
+twigc [OPTIONS] <file.tw>
+
+Options:
+  --check            Type-check only.  Exit 0 on success, 1 on type errors.
+  --emit=iir         Compile to IIR and print a human-readable summary to
+                     stdout.  Exit 0 on success.
+  --search-path=DIR  Add DIR to the module search path (may be repeated).
+  -h, --help         Print help.
+  -V, --version      Print version.
+
+Default (no flags):  compile and run via twig-vm; print the integer return
+value of main() to stdout.
+```
+
+### Behaviour
+
+**`--check`** mode:
+1. Call `compile_module_tree(path, search_paths)`.
+2. If it returns `Err(TypeErrors { … })` print the first error to
+   stderr and exit 1.
+3. If it returns any other `Err` print the error to stderr and exit 2.
+4. On `Ok(_)` exit 0 (type check passed).
+
+**`--emit=iir`** mode:
+1. Call `compile_module_tree(path, search_paths)`.
+2. On error: same stderr + exit-code policy as `--check`.
+3. On `Ok(module)`: iterate `module.functions` and for each function
+   print:
+   ```
+   fn <name>:
+     <index>  <op>  <dest>  <srcs…>
+   ```
+   Exit 0.
+
+**Default (run)** mode:
+1. Compile via `compile_module_tree`.
+2. Run the resulting `IIRModule` via `twig_vm::TwigVM::new().run_module`.
+3. Print the integer return value of `main()` to stdout.
+4. Exit 0 on success, non-zero on error.
+
+### Library API (`src/lib.rs`)
+
+```rust
+pub fn twigc_check(path: &Path, search_paths: &[PathBuf]) -> Result<(), TwigcError>;
+pub fn twigc_emit_iir(path: &Path, search_paths: &[PathBuf]) -> Result<String, TwigcError>;
+pub fn twigc_run(path: &Path, search_paths: &[PathBuf]) -> Result<i64, TwigcError>;
+```
+
+`TwigcError` wraps `ModuleDriverError` and adds a `Vm` variant for
+runtime errors.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `code/specs/LANG73-tw05r-twigc-cli.md` | **new** (this file) |
+| `code/packages/rust/twigc/Cargo.toml` | **new** |
+| `code/packages/rust/twigc/src/main.rs` | **new** |
+| `code/packages/rust/twigc/src/lib.rs` | **new** |
+| `code/packages/rust/twigc/BUILD` | **new** |
+| `code/packages/rust/twigc/README.md` | **new** |
+| `code/packages/rust/twigc/CHANGELOG.md` | **new** |
+| `code/packages/rust/Cargo.toml` | Add `"twigc"` to `members` |
+
+## Tests (`twigc_tests`, 6 tests)
+
+| Test | Verifies |
+|------|---------|
+| `check_clean_strict_program_ok` | `twigc_check` on a valid strict module → `Ok(())` |
+| `check_strict_program_with_type_error_fails` | `twigc_check` on bad varref → `Err(TypeErrors)` |
+| `check_lenient_bad_varref_passes` | `twigc_check` on lenient bad varref → `Ok(())` |
+| `emit_iir_produces_fn_listing` | `twigc_emit_iir` → string contains `fn main:` |
+| `run_arithmetic_returns_value` | `twigc_run` on `(define (main) (+ 21 21))` → `Ok(42)` |
+| `run_compiler_tree_returns_179` | `twigc_run` on `code/twig/compiler/main.tw` → `Ok(179)` |
+
+## Version
+
+`twigc`: 0.1.0 (new package)
+
+## Commit sequence
+
+1. `docs(specs)` — `LANG73-tw05r-twigc-cli.md`
+2. `feat(twigc)` — new CLI driver package, 6 tests, bump workspace
+
+## Verification
+
+```bash
+cargo test -p twigc --lib            # 6 new tests pass
+cargo build -p twigc --release       # binary compiles
+cargo build --workspace              # clean workspace build
+```

--- a/code/specs/LANG73-tw05r-twigc-cli.md
+++ b/code/specs/LANG73-tw05r-twigc-cli.md
@@ -93,7 +93,7 @@ runtime errors.
 | `check_lenient_bad_varref_passes` | `twigc_check` on lenient bad varref → `Ok(())` |
 | `emit_iir_produces_fn_listing` | `twigc_emit_iir` → string contains `fn main:` |
 | `run_arithmetic_returns_value` | `twigc_run` on `(define (main) (+ 21 21))` → `Ok(42)` |
-| `run_compiler_tree_returns_179` | `twigc_run` on `code/twig/compiler/main.tw` → `Ok(179)` |
+| `run_compiler_tree_main_returns_2` | `twigc_run` on `code/twig/compiler/main.tw` → `Ok(2)` (`(main)` returns the span.tw fn count) |
 
 ## Version
 


### PR DESCRIPTION
## Summary

- Adds new `twigc` crate: command-line compiler driver for Twig (TW05-R / LANG73)
- Wraps the full multi-file compilation pipeline (`twig-module-driver` Phase 1–5 + `twig-vm`) in a user-facing binary and testable library
- Adds `"twigc"` to workspace members in `code/packages/rust/Cargo.toml`

## Changes

### New crate: `code/packages/rust/twigc/`

**CLI (`twigc` binary):**
- `twigc <file.tw>` — compile and run; print `i64` result of `main()`
- `twigc --check <file.tw>` — type-check only; exit 0/1/2
- `twigc --emit=iir <file.tw>` — print IIR listing to stdout
- `twigc --search-path=<DIR>` — add DIR to search path (repeatable)
- `-h`/`--help`, `-V`/`--version`

**Exit codes:** 0 success, 1 TypeErrors, 2 compile error, 3 runtime trap, 4 usage error

**Library API (`src/lib.rs`):**
```rust
twigc_check(path, search_paths)    -> Result<(), TwigcError>
twigc_emit_iir(path, search_paths) -> Result<String, TwigcError>
twigc_run(path, search_paths)      -> Result<i64, TwigcError>
```

**Tests (6):**
| Test | Verifies |
|------|---------|
| `check_clean_strict_program_ok` | Clean strict module → `Ok(())` |
| `check_strict_program_with_type_error_fails` | Bad varref in strict → `Err(TypeErrors)` |
| `check_lenient_bad_varref_passes` | Bad varref in lenient → not TypeErrors |
| `emit_iir_produces_fn_listing` | IIR listing contains `fn main:` |
| `run_arithmetic_returns_value` | `(+ 21 21)` → 42 |
| `run_compiler_tree_main_returns_2` | Full 11-module compiler tree, `(main)` → 2 |

Test 6 spawns a 32 MiB thread to handle deep recursive-descent parsing + Phase 3.5 type-checking over the full ~500-line Twig compiler source without stack overflow.

## Test plan

- [ ] `cargo test -p twigc --lib` — 6 tests pass
- [ ] `cargo build -p twigc --release` — binary compiles
- [ ] `cargo build --workspace` — clean workspace build

🤖 Generated with [Claude Code](https://claude.com/claude-code)