### PR TITLE
Add WHATWG EOF recovery conformance sweep

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -54,6 +54,9 @@ documented in this file.
   that proves tokens, diagnostics, and diagnostic positions are stable across
   every character split point for representative tokenizer contexts and seeded
   continuation states.
+- A generated WHATWG tokenizer EOF recovery fixture and Rust conformance test
+  that pins recovery for partial tags, attributes, comments, doctypes,
+  character references, text modes, and seeded continuation states.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -75,6 +75,9 @@ including chunk splits inside CRLF pairs.
 It also generates streaming chunk-boundary cases for the same tokenizer surface
 area, proving tokens, diagnostics, and diagnostic positions are independent of
 where an embedding splits the input stream.
+The generated EOF recovery suite covers partial tags, attributes, comments,
+bogus comments, doctypes, character references, text modes, and seeded
+continuation states so parser-facing recovery stays pinned at stream end.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -61,6 +61,9 @@ binary while production code continues to link only static Rust source.
 - `whatwg-chunk-boundaries.json`: generated HTML tokenizer streaming cases
   used by Rust tests to prove tokens, diagnostics, and positions stay stable
   across every character chunk split point
+- `whatwg-eof-recovery.json`: generated HTML tokenizer EOF recovery cases used
+  by Rust tests to pin unfinished tags, comments, doctypes, character
+  references, text modes, and seeded continuation states
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
@@ -79,6 +82,8 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_chunk_boundaries_fixture.py`: importer that generates
   streaming chunk-boundary invariance cases for the checked-in
   `whatwg-chunk-boundaries.json` fixture
+- `generate_whatwg_eof_recovery_fixture.py`: importer that generates EOF
+  recovery cases for the checked-in `whatwg-eof-recovery.json` fixture
 
 Regenerate or verify the WHATWG entity fixture with:
 
@@ -111,6 +116,14 @@ Regenerate or verify the WHATWG chunk-boundary fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_chunk_boundaries_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_chunk_boundaries_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG EOF recovery fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py \
   --check
 ```
 
@@ -252,6 +265,9 @@ currently supports:
   positions
 - generated chunk-boundary invariance coverage across data, Unicode text, tags,
   attributes, comments, doctypes, named/numeric character references, RCDATA,
+  RAWTEXT, script data, PLAINTEXT, CDATA, and seeded continuation states
+- generated EOF recovery coverage across partial tags, attributes, comments,
+  bogus comments, doctypes, named/numeric character references, RCDATA,
   RAWTEXT, script data, PLAINTEXT, CDATA, and seeded continuation states
 - EOF recovery for unfinished ordinary start and end tags, ensuring partial
   tokens are dropped before the parser sees them

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer EOF recovery fixture.
+
+The HTML tokenizer has many explicit EOF branches. This fixture keeps the
+observable recovery shape pinned across ordinary tags, attributes, comments,
+doctypes, character references, text modes, and seeded continuation states.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-eof-recovery.json")
+
+CASES = [
+    {
+        "id": "data-baseline",
+        "description": "ordinary data EOF flushes text",
+        "input": "alpha",
+        "tokens": ["Text(data=alpha)", "EOF"],
+    },
+    {
+        "id": "tag-open",
+        "description": "EOF after a tag opener emits literal less-than",
+        "input": "alpha<",
+        "tokens": ["Text(data=alpha<)", "EOF"],
+        "diagnostics": ["eof-in-tag-open-state"],
+    },
+    {
+        "id": "end-tag-open",
+        "description": "EOF after an end-tag opener emits literal markup",
+        "input": "alpha</",
+        "tokens": ["Text(data=alpha</)", "EOF"],
+        "diagnostics": ["eof-in-end-tag-open-state"],
+    },
+    {
+        "id": "start-tag-name",
+        "description": "EOF inside a start tag name drops the partial token",
+        "input": "<div",
+        "tokens": ["EOF"],
+        "diagnostics": ["eof-in-tag-name-state"],
+    },
+    {
+        "id": "start-tag-before-attribute",
+        "description": "EOF before an attribute drops the partial token",
+        "input": "<div ",
+        "tokens": ["EOF"],
+        "diagnostics": ["eof-in-tag"],
+    },
+    {
+        "id": "start-tag-attribute-name",
+        "description": "EOF inside an attribute name drops the partial token",
+        "input": "<div class",
+        "tokens": ["EOF"],
+        "diagnostics": ["eof-in-tag"],
+    },
+    {
+        "id": "start-tag-before-attribute-value",
+        "description": "EOF before an attribute value drops the partial token",
+        "input": "<div class=",
+        "tokens": ["EOF"],
+        "diagnostics": ["eof-in-tag"],
+    },
+    {
+        "id": "start-tag-double-quoted-attribute-value",
+        "description": "EOF inside a double quoted attribute value drops the partial token",
+        "input": '<div class="open',
+        "tokens": ["EOF"],
+        "diagnostics": ["eof-in-tag"],
+    },
+    {
+        "id": "start-tag-single-quoted-attribute-value",
+        "description": "EOF inside a single quoted attribute value drops the partial token",
+        "input": "<div class='open",
+        "tokens": ["EOF"],
+        "diagnostics": ["eof-in-tag"],
+    },
+    {
+        "id": "start-tag-unquoted-attribute-value",
+        "description": "EOF inside an unquoted attribute value drops the partial token",
+        "input": "<div class=open",
+        "tokens": ["EOF"],
+        "diagnostics": ["eof-in-tag"],
+    },
+    {
+        "id": "end-tag-name",
+        "description": "EOF inside an end tag name drops the partial token",
+        "input": "</section",
+        "tokens": ["EOF"],
+        "diagnostics": ["eof-in-end-tag-name-state"],
+    },
+    {
+        "id": "end-tag-with-attributes",
+        "description": "EOF inside end-tag attributes drops the partial token",
+        "input": "</section class=x",
+        "tokens": ["EOF"],
+        "diagnostics": ["end-tag-with-attributes", "eof-in-end-tag-name-state"],
+    },
+    {
+        "id": "attribute-named-reference",
+        "description": "EOF in an attribute named reference drops the partial tag",
+        "input": "<a href=&copy",
+        "tokens": ["EOF"],
+        "diagnostics": ["missing-semicolon-after-character-reference", "eof-in-tag"],
+    },
+    {
+        "id": "attribute-numeric-reference",
+        "description": "EOF in an attribute numeric reference drops the partial tag",
+        "input": "<a href=&#x41",
+        "tokens": ["EOF"],
+        "diagnostics": ["missing-semicolon-after-character-reference", "eof-in-tag"],
+    },
+    {
+        "id": "attribute-digitless-numeric-reference",
+        "description": "EOF in a digitless attribute numeric reference drops the partial tag",
+        "input": "<a href=&#x",
+        "tokens": ["EOF"],
+        "diagnostics": ["absence-of-digits-in-numeric-character-reference", "eof-in-tag"],
+    },
+    {
+        "id": "comment",
+        "description": "EOF inside a comment emits the comment token",
+        "input": "<!--open",
+        "tokens": ["Comment(data=open)", "EOF"],
+        "diagnostics": ["eof-in-comment"],
+    },
+    {
+        "id": "comment-start",
+        "description": "EOF after a comment opener emits an empty comment",
+        "input": "<!--",
+        "tokens": ["Comment(data=)", "EOF"],
+        "diagnostics": ["eof-in-comment"],
+    },
+    {
+        "id": "comment-start-dash",
+        "description": "EOF after a pending comment dash emits an empty comment",
+        "input": "<!---",
+        "tokens": ["Comment(data=)", "EOF"],
+        "diagnostics": ["eof-in-comment"],
+    },
+    {
+        "id": "comment-end-dash",
+        "description": "EOF after a trailing comment dash omits the delimiter dash",
+        "input": "<!--x-",
+        "tokens": ["Comment(data=x)", "EOF"],
+        "diagnostics": ["eof-in-comment"],
+    },
+    {
+        "id": "comment-end",
+        "description": "EOF after trailing comment end dashes omits delimiter dashes",
+        "input": "<!--x--",
+        "tokens": ["Comment(data=x)", "EOF"],
+        "diagnostics": ["eof-in-comment"],
+    },
+    {
+        "id": "bogus-comment",
+        "description": "EOF in bogus comment emits the comment without eof-in-comment",
+        "input": "<?xml",
+        "tokens": ["Comment(data=?xml)", "EOF"],
+        "diagnostics": ["unexpected-question-mark-instead-of-tag-name"],
+    },
+    {
+        "id": "markup-declaration-open",
+        "description": "EOF after markup declaration opener recovers as empty comment",
+        "input": "<!",
+        "tokens": ["Comment(data=)", "EOF"],
+        "diagnostics": ["incorrectly-opened-comment"],
+    },
+    {
+        "id": "doctype-keyword",
+        "description": "EOF inside the DOCTYPE keyword recovers as bogus comment",
+        "input": "<!DOCT",
+        "tokens": ["Comment(data=DOCT)", "EOF"],
+        "diagnostics": ["incorrectly-opened-comment"],
+    },
+    {
+        "id": "doctype-after-keyword",
+        "description": "EOF after DOCTYPE keyword emits a forced-quirks doctype",
+        "input": "<!DOCTYPE",
+        "tokens": ["Doctype(name=null, force_quirks=true)", "EOF"],
+        "diagnostics": ["eof-in-doctype"],
+    },
+    {
+        "id": "doctype-name",
+        "description": "EOF inside a DOCTYPE name emits a forced-quirks doctype",
+        "input": "<!DOCTYPE html",
+        "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+        "diagnostics": ["eof-in-doctype"],
+    },
+    {
+        "id": "doctype-public-identifier",
+        "description": "EOF inside a DOCTYPE public identifier emits a forced-quirks doctype",
+        "input": '<!DOCTYPE html PUBLIC "alpha',
+        "tokens": [
+            "Doctype(name=html, public_identifier=alpha, system_identifier=null, force_quirks=true)",
+            "EOF",
+        ],
+        "diagnostics": ["eof-in-doctype"],
+    },
+    {
+        "id": "doctype-system-identifier",
+        "description": "EOF inside a DOCTYPE system identifier emits a forced-quirks doctype",
+        "input": '<!DOCTYPE html SYSTEM "alpha',
+        "tokens": [
+            "Doctype(name=html, public_identifier=null, system_identifier=alpha, force_quirks=true)",
+            "EOF",
+        ],
+        "diagnostics": ["eof-in-doctype"],
+    },
+    {
+        "id": "data-named-reference",
+        "description": "EOF after a legacy named reference recovers in data",
+        "input": "alpha &copy",
+        "tokens": ["Text(data=alpha ©)", "EOF"],
+        "diagnostics": ["missing-semicolon-after-character-reference"],
+    },
+    {
+        "id": "data-unknown-reference",
+        "description": "EOF after an unknown named reference stays literal",
+        "input": "alpha &madeup",
+        "tokens": ["Text(data=alpha &madeup)", "EOF"],
+    },
+    {
+        "id": "data-digitless-numeric-reference",
+        "description": "EOF after a digitless numeric reference stays literal",
+        "input": "alpha &#x",
+        "tokens": ["Text(data=alpha &#x)", "EOF"],
+        "diagnostics": ["absence-of-digits-in-numeric-character-reference"],
+    },
+    {
+        "id": "rcdata-less-than-sign",
+        "description": "EOF after less-than in RCDATA emits literal less-than",
+        "input": "alpha<",
+        "initial_state": "RCDATA state",
+        "last_start_tag": "title",
+        "tokens": ["Text(data=alpha<)", "EOF"],
+    },
+    {
+        "id": "rcdata-end-tag-open",
+        "description": "EOF after RCDATA end-tag opener emits literal markup",
+        "input": "alpha</",
+        "initial_state": "RCDATA state",
+        "last_start_tag": "title",
+        "tokens": ["Text(data=alpha</)", "EOF"],
+    },
+    {
+        "id": "rawtext-end-tag-open",
+        "description": "EOF after RAWTEXT end-tag opener emits literal markup",
+        "input": "alpha</",
+        "initial_state": "RAWTEXT state",
+        "last_start_tag": "style",
+        "tokens": ["Text(data=alpha</)", "EOF"],
+    },
+    {
+        "id": "script-data-less-than-sign",
+        "description": "EOF after script less-than emits literal less-than",
+        "input": "alpha<",
+        "initial_state": "Script data state",
+        "last_start_tag": "script",
+        "tokens": ["Text(data=alpha<)", "EOF"],
+    },
+    {
+        "id": "script-data-escaped",
+        "description": "EOF inside script escaped text reports script comment-like EOF",
+        "input": "alpha",
+        "initial_state": "Script data escaped state",
+        "last_start_tag": "script",
+        "tokens": ["Text(data=alpha)", "EOF"],
+        "diagnostics": ["eof-in-script-html-comment-like-text"],
+    },
+    {
+        "id": "script-data-double-escaped",
+        "description": "EOF inside script double escaped text reports script comment-like EOF",
+        "input": "alpha",
+        "initial_state": "Script data double escaped state",
+        "last_start_tag": "script",
+        "tokens": ["Text(data=alpha)", "EOF"],
+        "diagnostics": ["eof-in-script-html-comment-like-text"],
+    },
+    {
+        "id": "plaintext",
+        "description": "EOF in PLAINTEXT flushes markup-looking text",
+        "input": "alpha <p>&copy;",
+        "initial_state": "PLAINTEXT state",
+        "tokens": ["Text(data=alpha <p>&copy;)", "EOF"],
+    },
+    {
+        "id": "cdata-section-bracket",
+        "description": "EOF with unclosed CDATA section brackets keeps brackets",
+        "input": "alpha]]",
+        "initial_state": "CDATA section state",
+        "tokens": ["Text(data=alpha]])", "EOF"],
+    },
+    {
+        "id": "seeded-comment",
+        "description": "EOF in a seeded comment emits seeded data",
+        "input": "tail",
+        "initial_state": "Comment state",
+        "current_comment": "seed:",
+        "tokens": ["Comment(data=seed:tail)", "EOF"],
+        "diagnostics": ["eof-in-comment"],
+    },
+    {
+        "id": "seeded-doctype-public-identifier",
+        "description": "EOF in a seeded DOCTYPE public identifier preserves seed",
+        "input": "tail",
+        "initial_state": "DOCTYPE public identifier double quoted state",
+        "current_doctype": {
+            "name": "html",
+            "public_identifier": "seed:",
+            "system_identifier": None,
+            "force_quirks": False,
+        },
+        "tokens": [
+            "Doctype(name=html, public_identifier=seed:tail, system_identifier=null, force_quirks=true)",
+            "EOF",
+        ],
+        "diagnostics": ["eof-in-doctype"],
+    },
+    {
+        "id": "seeded-character-reference-rcdata",
+        "description": "EOF in a seeded RCDATA named reference recovers through return state",
+        "input": "opy",
+        "initial_state": "Named character reference state",
+        "last_start_tag": "title",
+        "temporary_buffer": "&c",
+        "return_state": "RCDATA state",
+        "tokens": ["Text(data=©)", "EOF"],
+        "diagnostics": ["missing-semicolon-after-character-reference"],
+    },
+]
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer EOF recovery fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-eof-recovery/v1",
+        "description": (
+            "EOF recovery cases for HTML tokenizer states and parser-seeded "
+            "continuation contexts."
+        ),
+        "cases": [normalize_case(case) for case in CASES],
+    }
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-eof-recovery.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-eof-recovery.json
@@ -1,0 +1,501 @@
+{
+  "cases": [
+    {
+      "description": "ordinary data EOF flushes text",
+      "diagnostics": [],
+      "id": "data-baseline",
+      "input": "alpha",
+      "tokens": [
+        "Text(data=alpha)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after a tag opener emits literal less-than",
+      "diagnostics": [
+        "eof-in-tag-open-state"
+      ],
+      "id": "tag-open",
+      "input": "alpha<",
+      "tokens": [
+        "Text(data=alpha<)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after an end-tag opener emits literal markup",
+      "diagnostics": [
+        "eof-in-end-tag-open-state"
+      ],
+      "id": "end-tag-open",
+      "input": "alpha</",
+      "tokens": [
+        "Text(data=alpha</)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a start tag name drops the partial token",
+      "diagnostics": [
+        "eof-in-tag-name-state"
+      ],
+      "id": "start-tag-name",
+      "input": "<div",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF before an attribute drops the partial token",
+      "diagnostics": [
+        "eof-in-tag"
+      ],
+      "id": "start-tag-before-attribute",
+      "input": "<div ",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside an attribute name drops the partial token",
+      "diagnostics": [
+        "eof-in-tag"
+      ],
+      "id": "start-tag-attribute-name",
+      "input": "<div class",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF before an attribute value drops the partial token",
+      "diagnostics": [
+        "eof-in-tag"
+      ],
+      "id": "start-tag-before-attribute-value",
+      "input": "<div class=",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a double quoted attribute value drops the partial token",
+      "diagnostics": [
+        "eof-in-tag"
+      ],
+      "id": "start-tag-double-quoted-attribute-value",
+      "input": "<div class=\"open",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a single quoted attribute value drops the partial token",
+      "diagnostics": [
+        "eof-in-tag"
+      ],
+      "id": "start-tag-single-quoted-attribute-value",
+      "input": "<div class='open",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside an unquoted attribute value drops the partial token",
+      "diagnostics": [
+        "eof-in-tag"
+      ],
+      "id": "start-tag-unquoted-attribute-value",
+      "input": "<div class=open",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside an end tag name drops the partial token",
+      "diagnostics": [
+        "eof-in-end-tag-name-state"
+      ],
+      "id": "end-tag-name",
+      "input": "</section",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside end-tag attributes drops the partial token",
+      "diagnostics": [
+        "end-tag-with-attributes",
+        "eof-in-end-tag-name-state"
+      ],
+      "id": "end-tag-with-attributes",
+      "input": "</section class=x",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in an attribute named reference drops the partial tag",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "eof-in-tag"
+      ],
+      "id": "attribute-named-reference",
+      "input": "<a href=&copy",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in an attribute numeric reference drops the partial tag",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "eof-in-tag"
+      ],
+      "id": "attribute-numeric-reference",
+      "input": "<a href=&#x41",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in a digitless attribute numeric reference drops the partial tag",
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference",
+        "eof-in-tag"
+      ],
+      "id": "attribute-digitless-numeric-reference",
+      "input": "<a href=&#x",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a comment emits the comment token",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment",
+      "input": "<!--open",
+      "tokens": [
+        "Comment(data=open)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after a comment opener emits an empty comment",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-start",
+      "input": "<!--",
+      "tokens": [
+        "Comment(data=)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after a pending comment dash emits an empty comment",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-start-dash",
+      "input": "<!---",
+      "tokens": [
+        "Comment(data=)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after a trailing comment dash omits the delimiter dash",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-end-dash",
+      "input": "<!--x-",
+      "tokens": [
+        "Comment(data=x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after trailing comment end dashes omits delimiter dashes",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-end",
+      "input": "<!--x--",
+      "tokens": [
+        "Comment(data=x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in bogus comment emits the comment without eof-in-comment",
+      "diagnostics": [
+        "unexpected-question-mark-instead-of-tag-name"
+      ],
+      "id": "bogus-comment",
+      "input": "<?xml",
+      "tokens": [
+        "Comment(data=?xml)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after markup declaration opener recovers as empty comment",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "markup-declaration-open",
+      "input": "<!",
+      "tokens": [
+        "Comment(data=)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside the DOCTYPE keyword recovers as bogus comment",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "doctype-keyword",
+      "input": "<!DOCT",
+      "tokens": [
+        "Comment(data=DOCT)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after DOCTYPE keyword emits a forced-quirks doctype",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-after-keyword",
+      "input": "<!DOCTYPE",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a DOCTYPE name emits a forced-quirks doctype",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-name",
+      "input": "<!DOCTYPE html",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a DOCTYPE public identifier emits a forced-quirks doctype",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-public-identifier",
+      "input": "<!DOCTYPE html PUBLIC \"alpha",
+      "tokens": [
+        "Doctype(name=html, public_identifier=alpha, system_identifier=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a DOCTYPE system identifier emits a forced-quirks doctype",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-system-identifier",
+      "input": "<!DOCTYPE html SYSTEM \"alpha",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=alpha, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after a legacy named reference recovers in data",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "data-named-reference",
+      "input": "alpha &copy",
+      "tokens": [
+        "Text(data=alpha ©)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after an unknown named reference stays literal",
+      "diagnostics": [],
+      "id": "data-unknown-reference",
+      "input": "alpha &madeup",
+      "tokens": [
+        "Text(data=alpha &madeup)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after a digitless numeric reference stays literal",
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference"
+      ],
+      "id": "data-digitless-numeric-reference",
+      "input": "alpha &#x",
+      "tokens": [
+        "Text(data=alpha &#x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after less-than in RCDATA emits literal less-than",
+      "diagnostics": [],
+      "id": "rcdata-less-than-sign",
+      "initial_state": "RCDATA state",
+      "input": "alpha<",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha<)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after RCDATA end-tag opener emits literal markup",
+      "diagnostics": [],
+      "id": "rcdata-end-tag-open",
+      "initial_state": "RCDATA state",
+      "input": "alpha</",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha</)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after RAWTEXT end-tag opener emits literal markup",
+      "diagnostics": [],
+      "id": "rawtext-end-tag-open",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha</)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after script less-than emits literal less-than",
+      "diagnostics": [],
+      "id": "script-data-less-than-sign",
+      "initial_state": "Script data state",
+      "input": "alpha<",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha<)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside script escaped text reports script comment-like EOF",
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "id": "script-data-escaped",
+      "initial_state": "Script data escaped state",
+      "input": "alpha",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside script double escaped text reports script comment-like EOF",
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "id": "script-data-double-escaped",
+      "initial_state": "Script data double escaped state",
+      "input": "alpha",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in PLAINTEXT flushes markup-looking text",
+      "diagnostics": [],
+      "id": "plaintext",
+      "initial_state": "PLAINTEXT state",
+      "input": "alpha <p>&copy;",
+      "tokens": [
+        "Text(data=alpha <p>&copy;)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF with unclosed CDATA section brackets keeps brackets",
+      "diagnostics": [],
+      "id": "cdata-section-bracket",
+      "initial_state": "CDATA section state",
+      "input": "alpha]]",
+      "tokens": [
+        "Text(data=alpha]])",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed:",
+      "description": "EOF in a seeded comment emits seeded data",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "seeded-comment",
+      "initial_state": "Comment state",
+      "input": "tail",
+      "tokens": [
+        "Comment(data=seed:tail)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "force_quirks": false,
+        "name": "html",
+        "public_identifier": "seed:",
+        "system_identifier": null
+      },
+      "description": "EOF in a seeded DOCTYPE public identifier preserves seed",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "seeded-doctype-public-identifier",
+      "initial_state": "DOCTYPE public identifier double quoted state",
+      "input": "tail",
+      "tokens": [
+        "Doctype(name=html, public_identifier=seed:tail, system_identifier=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in a seeded RCDATA named reference recovers through return state",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "seeded-character-reference-rcdata",
+      "initial_state": "Named character reference state",
+      "input": "opy",
+      "last_start_tag": "title",
+      "return_state": "RCDATA state",
+      "temporary_buffer": "&c",
+      "tokens": [
+        "Text(data=©)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "EOF recovery cases for HTML tokenizer states and parser-seeded continuation contexts.",
+  "format": "whatwg-html-tokenizer-eof-recovery/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
@@ -1,0 +1,227 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_EOF_RECOVERY: &str = include_str!("fixtures/whatwg-eof-recovery.json");
+
+#[derive(Debug, Deserialize)]
+struct EofRecoverySuite {
+    format: String,
+    description: String,
+    cases: Vec<EofRecoveryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EofRecoveryCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    last_start_tag: Option<String>,
+    #[serde(default)]
+    current_end_tag: Option<String>,
+    #[serde(default)]
+    current_comment: Option<String>,
+    #[serde(default)]
+    current_doctype: Option<FixtureDoctypeSeed>,
+    #[serde(default)]
+    temporary_buffer: Option<String>,
+    #[serde(default)]
+    return_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureDoctypeSeed {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    public_identifier: Option<String>,
+    #[serde(default)]
+    system_identifier: Option<String>,
+    #[serde(default)]
+    force_quirks: bool,
+}
+
+#[test]
+fn whatwg_eof_recovery_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-tokenizer-eof-recovery/v1");
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 40);
+    assert!(suite.cases.iter().any(|case| case.id == "doctype-name"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "seeded-character-reference-rcdata"));
+}
+
+#[test]
+fn whatwg_eof_recovery_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its EOF edge",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> EofRecoverySuite {
+    serde_json::from_str(WHATWG_EOF_RECOVERY).expect("WHATWG EOF recovery fixture should parse")
+}
+
+fn configured_lexer(case: &EofRecoveryCase) -> HtmlLexer {
+    let state = case
+        .initial_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let mut context = HtmlLexContext::new(state);
+    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
+        context = context.with_last_start_tag(last_start_tag);
+    }
+    if let Some(current_end_tag) = case.current_end_tag.as_deref() {
+        context = context.with_current_end_tag(current_end_tag);
+    }
+    if let Some(current_comment) = case.current_comment.as_deref() {
+        context = context.with_current_comment(current_comment);
+    }
+    if let Some(current_doctype) = case.current_doctype.as_ref() {
+        context = context.with_current_doctype(DoctypeSeed {
+            name: current_doctype.name.clone(),
+            public_identifier: current_doctype.public_identifier.clone(),
+            system_identifier: current_doctype.system_identifier.clone(),
+            force_quirks: current_doctype.force_quirks,
+        });
+    }
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        context = context.with_temporary_buffer(temporary_buffer);
+    }
+    if let Some(return_state) = case
+        .return_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+    {
+        context = context.with_return_state(return_state);
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG tokenizer EOF recovery fixture covering partial tags, attributes, comments, bogus comments, doctypes, character references, text modes, and seeded continuation states
- add a Rust conformance harness that asserts exact token summaries and diagnostic codes for the generated EOF cases
- document the EOF fixture, generator, and regeneration/check workflow

## Verification
- cargo test -p coding-adventures-html-lexer --test whatwg_eof_recovery_test
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py --check
- git diff --check