### PR TITLE
Add WHATWG text-mode delimiter conformance sweep

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -57,6 +57,9 @@ documented in this file.
 - A generated WHATWG tokenizer EOF recovery fixture and Rust conformance test
   that pins recovery for partial tags, attributes, comments, doctypes,
   character references, text modes, and seeded continuation states.
+- A generated WHATWG tokenizer text-mode delimiter fixture and Rust conformance
+  test that pins RCDATA, RAWTEXT, script-data, escaped-script, and seeded
+  end-tag continuation recovery.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -78,6 +78,9 @@ where an embedding splits the input stream.
 The generated EOF recovery suite covers partial tags, attributes, comments,
 bogus comments, doctypes, character references, text modes, and seeded
 continuation states so parser-facing recovery stays pinned at stream end.
+The generated text-mode delimiter suite pins how RCDATA, RAWTEXT, script data,
+escaped script data, and seeded end-tag continuation states distinguish real
+matching end tags from literal apparent end tags.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -64,6 +64,9 @@ binary while production code continues to link only static Rust source.
 - `whatwg-eof-recovery.json`: generated HTML tokenizer EOF recovery cases used
   by Rust tests to pin unfinished tags, comments, doctypes, character
   references, text modes, and seeded continuation states
+- `whatwg-text-mode-delimiters.json`: generated HTML tokenizer text-mode
+  delimiter cases used by Rust tests to pin RCDATA, RAWTEXT, script-data,
+  escaped-script, and seeded end-tag continuation recovery
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
@@ -84,6 +87,9 @@ binary while production code continues to link only static Rust source.
   `whatwg-chunk-boundaries.json` fixture
 - `generate_whatwg_eof_recovery_fixture.py`: importer that generates EOF
   recovery cases for the checked-in `whatwg-eof-recovery.json` fixture
+- `generate_whatwg_text_mode_delimiters_fixture.py`: importer that generates
+  text-mode end-tag delimiter cases for the checked-in
+  `whatwg-text-mode-delimiters.json` fixture
 
 Regenerate or verify the WHATWG entity fixture with:
 
@@ -124,6 +130,14 @@ Regenerate or verify the WHATWG EOF recovery fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG text-mode delimiter fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py \
   --check
 ```
 
@@ -269,6 +283,9 @@ currently supports:
 - generated EOF recovery coverage across partial tags, attributes, comments,
   bogus comments, doctypes, named/numeric character references, RCDATA,
   RAWTEXT, script data, PLAINTEXT, CDATA, and seeded continuation states
+- generated text-mode delimiter coverage across RCDATA, RAWTEXT, script data,
+  escaped script data, matching/mismatched apparent end tags, recoverable
+  whitespace/attribute/solidus delimiters, and seeded end-tag continuations
 - EOF recovery for unfinished ordinary start and end tags, ensuring partial
   tokens are dropped before the parser sees them
 - EOF recovery for unfinished attribute character references, including named

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer text-mode delimiter fixture.
+
+RCDATA, RAWTEXT, and script-data tokenization all use parser-provided
+last-start-tag context to decide whether an apparent end tag is a real delimiter
+or literal text. This fixture pins the observable delimiter matrix across
+matching tags, mismatches, whitespace, attributes, self-closing recovery, and
+seeded end-tag continuation states.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-text-mode-delimiters.json")
+
+TEXT_MODE_CONTEXTS = [
+    {
+        "mode": "rcdata",
+        "initial_state": "RCDATA state",
+        "last_start_tag": "title",
+        "entity_prefix": "Tom &amp; ",
+        "entity_text": "Tom & ",
+        "mismatch_tag": "style",
+    },
+    {
+        "mode": "rawtext",
+        "initial_state": "RAWTEXT state",
+        "last_start_tag": "style",
+        "entity_prefix": "Tom &amp; ",
+        "entity_text": "Tom &amp; ",
+        "mismatch_tag": "title",
+    },
+    {
+        "mode": "script-data",
+        "initial_state": "Script data state",
+        "last_start_tag": "script",
+        "entity_prefix": "Tom &amp; ",
+        "entity_text": "Tom &amp; ",
+        "mismatch_tag": "style",
+    },
+    {
+        "mode": "script-data-escaped",
+        "initial_state": "Script data escaped state",
+        "last_start_tag": "script",
+        "entity_prefix": "Tom &amp; ",
+        "entity_text": "Tom &amp; ",
+        "mismatch_tag": "style",
+        "script_like_eof": True,
+    },
+]
+
+SEEDED_END_TAG_STATES = [
+    {
+        "id": "rcdata-name",
+        "initial_state": "RCDATA end tag name state",
+        "last_start_tag": "title",
+        "current_end_tag": "title",
+        "temporary_buffer": "title",
+    },
+    {
+        "id": "rawtext-name",
+        "initial_state": "RAWTEXT end tag name state",
+        "last_start_tag": "style",
+        "current_end_tag": "style",
+        "temporary_buffer": "style",
+    },
+    {
+        "id": "script-name",
+        "initial_state": "Script data end tag name state",
+        "last_start_tag": "script",
+        "current_end_tag": "script",
+        "temporary_buffer": "script",
+    },
+    {
+        "id": "script-escaped-name",
+        "initial_state": "Script data escaped end tag name state",
+        "last_start_tag": "script",
+        "current_end_tag": "script",
+        "temporary_buffer": "script",
+        "script_like_eof": True,
+    },
+]
+
+RECOVERY_STATES = [
+    {
+        "id": "rcdata-whitespace",
+        "initial_state": "RCDATA end tag whitespace state",
+        "last_start_tag": "title",
+        "current_end_tag": "title",
+        "temporary_buffer": "title ",
+        "diagnostic": "unexpected-whitespace-after-end-tag-name",
+    },
+    {
+        "id": "rawtext-attributes",
+        "initial_state": "RAWTEXT end tag attributes state",
+        "last_start_tag": "style",
+        "current_end_tag": "style",
+        "temporary_buffer": "style class=x",
+        "diagnostic": "end-tag-with-attributes",
+    },
+    {
+        "id": "script-self-closing",
+        "initial_state": "Script data self-closing end tag state",
+        "last_start_tag": "script",
+        "current_end_tag": "script",
+        "temporary_buffer": "script",
+        "diagnostic": "end-tag-with-trailing-solidus",
+    },
+    {
+        "id": "script-escaped-attributes",
+        "initial_state": "Script data escaped end tag attributes state",
+        "last_start_tag": "script",
+        "current_end_tag": "script",
+        "temporary_buffer": "script class=x",
+        "diagnostic": "end-tag-with-attributes",
+        "script_like_eof": True,
+    },
+]
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer text-mode delimiter fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-text-mode-delimiters/v1",
+        "description": (
+            "Text-mode end-tag delimiter recovery for parser-controlled "
+            "RCDATA, RAWTEXT, script data, and seeded continuation states."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    for context in TEXT_MODE_CONTEXTS:
+        cases.extend(text_mode_cases(context))
+    cases.extend(seeded_end_tag_cases())
+    cases.extend(script_escape_cases())
+    return cases
+
+
+def text_mode_cases(context: dict[str, object]) -> list[dict[str, object]]:
+    mode = str(context["mode"])
+    state = str(context["initial_state"])
+    tag = str(context["last_start_tag"])
+    mismatch = str(context["mismatch_tag"])
+    entity_prefix = str(context["entity_prefix"])
+    entity_text = str(context["entity_text"])
+    script_like_eof = bool(context.get("script_like_eof", False))
+
+    base = {
+        "initial_state": state,
+        "last_start_tag": tag,
+    }
+    cases = [
+        {
+            **base,
+            "id": f"{mode}-matching-end-tag",
+            "description": f"{state} recognizes its matching end tag delimiter",
+            "input": f"{entity_prefix}</{tag}>after",
+            "tokens": [
+                f"Text(data={entity_text})",
+                f"EndTag(name={tag})",
+                "Text(data=after)",
+                "EOF",
+            ],
+        },
+        {
+            **base,
+            "id": f"{mode}-uppercase-matching-end-tag",
+            "description": f"{state} matches end tag names ASCII-case-insensitively",
+            "input": f"alpha</{tag.upper()}>after",
+            "tokens": [
+                "Text(data=alpha)",
+                f"EndTag(name={tag})",
+                "Text(data=after)",
+                "EOF",
+            ],
+        },
+        {
+            **base,
+            "id": f"{mode}-mismatched-end-tag",
+            "description": f"{state} keeps mismatched apparent end tags literal",
+            "input": f"alpha</{mismatch}>tail</{tag}>",
+            "tokens": [
+                f"Text(data=alpha</{mismatch}>tail)",
+                f"EndTag(name={tag})",
+                "EOF",
+            ],
+        },
+        {
+            **base,
+            "id": f"{mode}-longer-prefix-mismatch",
+            "description": f"{state} requires a delimiter after the matching tag name",
+            "input": f"alpha</{tag}x>tail</{tag}>",
+            "tokens": [
+                f"Text(data=alpha</{tag}x>tail)",
+                f"EndTag(name={tag})",
+                "EOF",
+            ],
+        },
+        {
+            **base,
+            "id": f"{mode}-whitespace-after-end-tag-name",
+            "description": f"{state} accepts whitespace after a matching end tag name with a diagnostic",
+            "input": f"alpha</{tag} >tail",
+            "tokens": ["Text(data=alpha)", f"EndTag(name={tag})", "Text(data=tail)", "EOF"],
+            "diagnostics": ["unexpected-whitespace-after-end-tag-name"],
+        },
+        {
+            **base,
+            "id": f"{mode}-form-feed-after-end-tag-name",
+            "description": f"{state} treats form feed as whitespace after a matching end tag name",
+            "input": f"alpha</{tag}\f>tail",
+            "tokens": ["Text(data=alpha)", f"EndTag(name={tag})", "Text(data=tail)", "EOF"],
+            "diagnostics": ["unexpected-whitespace-after-end-tag-name"],
+        },
+        {
+            **base,
+            "id": f"{mode}-end-tag-with-attributes",
+            "description": f"{state} emits matching end tags with recoverable attributes",
+            "input": f"alpha</{tag} class=x>tail",
+            "tokens": ["Text(data=alpha)", f"EndTag(name={tag})", "Text(data=tail)", "EOF"],
+            "diagnostics": ["end-tag-with-attributes"],
+        },
+        {
+            **base,
+            "id": f"{mode}-self-closing-end-tag",
+            "description": f"{state} emits matching self-closing-looking end tags with a diagnostic",
+            "input": f"alpha</{tag}/>tail",
+            "tokens": ["Text(data=alpha)", f"EndTag(name={tag})", "Text(data=tail)", "EOF"],
+            "diagnostics": ["end-tag-with-trailing-solidus"],
+        },
+        {
+            **base,
+            "id": f"{mode}-eof-after-end-tag-open",
+            "description": f"{state} keeps a dangling end-tag opener literal at EOF",
+            "input": "alpha</",
+            "tokens": ["Text(data=alpha</)", "EOF"],
+        },
+    ]
+    return cases
+
+
+def seeded_end_tag_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    for context in SEEDED_END_TAG_STATES:
+        tag = str(context["last_start_tag"])
+        script_like_eof = bool(context.get("script_like_eof", False))
+        base = {
+            "initial_state": context["initial_state"],
+            "last_start_tag": context["last_start_tag"],
+            "current_end_tag": context["current_end_tag"],
+            "temporary_buffer": context["temporary_buffer"],
+        }
+        cases.extend(
+            [
+                {
+                    **base,
+                    "id": f"seeded-{context['id']}-delimiter",
+                    "description": f"{context['initial_state']} emits the seeded matching end tag",
+                    "input": ">after",
+                    "tokens": [f"EndTag(name={tag})", "Text(data=after)", "EOF"],
+                },
+                {
+                    **base,
+                    "id": f"seeded-{context['id']}-eof",
+                    "description": f"{context['initial_state']} keeps seeded text literal at EOF",
+                    "input": "",
+                    "tokens": [f"Text(data=</{context['temporary_buffer']})", "EOF"],
+                },
+            ]
+        )
+    for context in RECOVERY_STATES:
+        tag = str(context["last_start_tag"])
+        cases.append(
+            {
+                "id": f"seeded-{context['id']}-delimiter",
+                "description": f"{context['initial_state']} emits seeded matching end tag with recovery diagnostic",
+                "input": ">after",
+                "initial_state": context["initial_state"],
+                "last_start_tag": context["last_start_tag"],
+                "current_end_tag": context["current_end_tag"],
+                "temporary_buffer": context["temporary_buffer"],
+                "tokens": [f"EndTag(name={tag})", "Text(data=after)", "EOF"],
+                "diagnostics": [context["diagnostic"]],
+            }
+        )
+    cases.extend(
+        [
+            {
+                "id": "seeded-rcdata-name-mismatch",
+                "description": "seeded RCDATA end-tag name mismatch remains literal before a later delimiter",
+                "input": ">text</title>",
+                "initial_state": "RCDATA end tag name state",
+                "last_start_tag": "title",
+                "current_end_tag": "style",
+                "temporary_buffer": "style",
+                "tokens": ["Text(data=</style>text)", "EndTag(name=title)", "EOF"],
+            },
+            {
+                "id": "seeded-script-escaped-self-closing-mismatch",
+                "description": "seeded script escaped self-closing mismatch remains literal before a later delimiter",
+                "input": ">tail</script>",
+                "initial_state": "Script data escaped self-closing end tag state",
+                "last_start_tag": "script",
+                "current_end_tag": "style",
+                "temporary_buffer": "style",
+                "tokens": ["Text(data=</style/>tail)", "EndTag(name=script)", "EOF"],
+            },
+        ]
+    )
+    return cases
+
+
+def script_escape_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "script-data-comment-like-escape",
+            "description": "script data keeps comment-like escape text before the matching end tag",
+            "input": "alpha<!-- hidden --></script>after",
+            "initial_state": "Script data state",
+            "last_start_tag": "script",
+            "tokens": [
+                "Text(data=alpha<!-- hidden -->)",
+                "EndTag(name=script)",
+                "Text(data=after)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "script-escaped-double-escape-start",
+            "description": "script escaped double-escape start keeps inner script delimiters literal",
+            "input": "alpha<script>inside</script>after</script>",
+            "initial_state": "Script data escaped state",
+            "last_start_tag": "script",
+            "tokens": [
+                "Text(data=alpha<script>inside</script>after)",
+                "EndTag(name=script)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "script-double-escaped-less-than-slash",
+            "description": "script double escaped less-than state exits on slash-prefixed script text",
+            "input": "/script>inside</script>after</script>",
+            "initial_state": "Script data double escaped less-than sign state",
+            "last_start_tag": "script",
+            "tokens": [
+                "Text(data=/script>inside)",
+                "EndTag(name=script)",
+                "Text(data=after)",
+                "EndTag(name=script)",
+                "EOF",
+            ],
+        },
+    ]
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-text-mode-delimiters.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-text-mode-delimiters.json
@@ -1,0 +1,782 @@
+{
+  "cases": [
+    {
+      "description": "RCDATA state recognizes its matching end tag delimiter",
+      "diagnostics": [],
+      "id": "rcdata-matching-end-tag",
+      "initial_state": "RCDATA state",
+      "input": "Tom &amp; </title>after",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=Tom & )",
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state matches end tag names ASCII-case-insensitively",
+      "diagnostics": [],
+      "id": "rcdata-uppercase-matching-end-tag",
+      "initial_state": "RCDATA state",
+      "input": "alpha</TITLE>after",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state keeps mismatched apparent end tags literal",
+      "diagnostics": [],
+      "id": "rcdata-mismatched-end-tag",
+      "initial_state": "RCDATA state",
+      "input": "alpha</style>tail</title>",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha</style>tail)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state requires a delimiter after the matching tag name",
+      "diagnostics": [],
+      "id": "rcdata-longer-prefix-mismatch",
+      "initial_state": "RCDATA state",
+      "input": "alpha</titlex>tail</title>",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha</titlex>tail)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state accepts whitespace after a matching end tag name with a diagnostic",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "rcdata-whitespace-after-end-tag-name",
+      "initial_state": "RCDATA state",
+      "input": "alpha</title >tail",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state treats form feed as whitespace after a matching end tag name",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "rcdata-form-feed-after-end-tag-name",
+      "initial_state": "RCDATA state",
+      "input": "alpha</title\f>tail",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state emits matching end tags with recoverable attributes",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "rcdata-end-tag-with-attributes",
+      "initial_state": "RCDATA state",
+      "input": "alpha</title class=x>tail",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state emits matching self-closing-looking end tags with a diagnostic",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "rcdata-self-closing-end-tag",
+      "initial_state": "RCDATA state",
+      "input": "alpha</title/>tail",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state keeps a dangling end-tag opener literal at EOF",
+      "diagnostics": [],
+      "id": "rcdata-eof-after-end-tag-open",
+      "initial_state": "RCDATA state",
+      "input": "alpha</",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=alpha</)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state recognizes its matching end tag delimiter",
+      "diagnostics": [],
+      "id": "rawtext-matching-end-tag",
+      "initial_state": "RAWTEXT state",
+      "input": "Tom &amp; </style>after",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=Tom &amp; )",
+        "EndTag(name=style)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state matches end tag names ASCII-case-insensitively",
+      "diagnostics": [],
+      "id": "rawtext-uppercase-matching-end-tag",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</STYLE>after",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=style)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state keeps mismatched apparent end tags literal",
+      "diagnostics": [],
+      "id": "rawtext-mismatched-end-tag",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</title>tail</style>",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha</title>tail)",
+        "EndTag(name=style)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state requires a delimiter after the matching tag name",
+      "diagnostics": [],
+      "id": "rawtext-longer-prefix-mismatch",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</stylex>tail</style>",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha</stylex>tail)",
+        "EndTag(name=style)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state accepts whitespace after a matching end tag name with a diagnostic",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "rawtext-whitespace-after-end-tag-name",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</style >tail",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state treats form feed as whitespace after a matching end tag name",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "rawtext-form-feed-after-end-tag-name",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</style\f>tail",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state emits matching end tags with recoverable attributes",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "rawtext-end-tag-with-attributes",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</style class=x>tail",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state emits matching self-closing-looking end tags with a diagnostic",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "rawtext-self-closing-end-tag",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</style/>tail",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state keeps a dangling end-tag opener literal at EOF",
+      "diagnostics": [],
+      "id": "rawtext-eof-after-end-tag-open",
+      "initial_state": "RAWTEXT state",
+      "input": "alpha</",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=alpha</)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state recognizes its matching end tag delimiter",
+      "diagnostics": [],
+      "id": "script-data-matching-end-tag",
+      "initial_state": "Script data state",
+      "input": "Tom &amp; </script>after",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=Tom &amp; )",
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state matches end tag names ASCII-case-insensitively",
+      "diagnostics": [],
+      "id": "script-data-uppercase-matching-end-tag",
+      "initial_state": "Script data state",
+      "input": "alpha</SCRIPT>after",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state keeps mismatched apparent end tags literal",
+      "diagnostics": [],
+      "id": "script-data-mismatched-end-tag",
+      "initial_state": "Script data state",
+      "input": "alpha</style>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha</style>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state requires a delimiter after the matching tag name",
+      "diagnostics": [],
+      "id": "script-data-longer-prefix-mismatch",
+      "initial_state": "Script data state",
+      "input": "alpha</scriptx>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha</scriptx>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state accepts whitespace after a matching end tag name with a diagnostic",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "script-data-whitespace-after-end-tag-name",
+      "initial_state": "Script data state",
+      "input": "alpha</script >tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state treats form feed as whitespace after a matching end tag name",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "script-data-form-feed-after-end-tag-name",
+      "initial_state": "Script data state",
+      "input": "alpha</script\f>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state emits matching end tags with recoverable attributes",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "script-data-end-tag-with-attributes",
+      "initial_state": "Script data state",
+      "input": "alpha</script class=x>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state emits matching self-closing-looking end tags with a diagnostic",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "script-data-self-closing-end-tag",
+      "initial_state": "Script data state",
+      "input": "alpha</script/>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state keeps a dangling end-tag opener literal at EOF",
+      "diagnostics": [],
+      "id": "script-data-eof-after-end-tag-open",
+      "initial_state": "Script data state",
+      "input": "alpha</",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha</)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state recognizes its matching end tag delimiter",
+      "diagnostics": [],
+      "id": "script-data-escaped-matching-end-tag",
+      "initial_state": "Script data escaped state",
+      "input": "Tom &amp; </script>after",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=Tom &amp; )",
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state matches end tag names ASCII-case-insensitively",
+      "diagnostics": [],
+      "id": "script-data-escaped-uppercase-matching-end-tag",
+      "initial_state": "Script data escaped state",
+      "input": "alpha</SCRIPT>after",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state keeps mismatched apparent end tags literal",
+      "diagnostics": [],
+      "id": "script-data-escaped-mismatched-end-tag",
+      "initial_state": "Script data escaped state",
+      "input": "alpha</style>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha</style>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state requires a delimiter after the matching tag name",
+      "diagnostics": [],
+      "id": "script-data-escaped-longer-prefix-mismatch",
+      "initial_state": "Script data escaped state",
+      "input": "alpha</scriptx>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha</scriptx>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state accepts whitespace after a matching end tag name with a diagnostic",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "script-data-escaped-whitespace-after-end-tag-name",
+      "initial_state": "Script data escaped state",
+      "input": "alpha</script >tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state treats form feed as whitespace after a matching end tag name",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "script-data-escaped-form-feed-after-end-tag-name",
+      "initial_state": "Script data escaped state",
+      "input": "alpha</script\f>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state emits matching end tags with recoverable attributes",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "script-data-escaped-end-tag-with-attributes",
+      "initial_state": "Script data escaped state",
+      "input": "alpha</script class=x>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state emits matching self-closing-looking end tags with a diagnostic",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "script-data-escaped-self-closing-end-tag",
+      "initial_state": "Script data escaped state",
+      "input": "alpha</script/>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state keeps a dangling end-tag opener literal at EOF",
+      "diagnostics": [],
+      "id": "script-data-escaped-eof-after-end-tag-open",
+      "initial_state": "Script data escaped state",
+      "input": "alpha</",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha</)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "title",
+      "description": "RCDATA end tag name state emits the seeded matching end tag",
+      "diagnostics": [],
+      "id": "seeded-rcdata-name-delimiter",
+      "initial_state": "RCDATA end tag name state",
+      "input": ">after",
+      "last_start_tag": "title",
+      "temporary_buffer": "title",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "title",
+      "description": "RCDATA end tag name state keeps seeded text literal at EOF",
+      "diagnostics": [],
+      "id": "seeded-rcdata-name-eof",
+      "initial_state": "RCDATA end tag name state",
+      "input": "",
+      "last_start_tag": "title",
+      "temporary_buffer": "title",
+      "tokens": [
+        "Text(data=</title)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "style",
+      "description": "RAWTEXT end tag name state emits the seeded matching end tag",
+      "diagnostics": [],
+      "id": "seeded-rawtext-name-delimiter",
+      "initial_state": "RAWTEXT end tag name state",
+      "input": ">after",
+      "last_start_tag": "style",
+      "temporary_buffer": "style",
+      "tokens": [
+        "EndTag(name=style)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "style",
+      "description": "RAWTEXT end tag name state keeps seeded text literal at EOF",
+      "diagnostics": [],
+      "id": "seeded-rawtext-name-eof",
+      "initial_state": "RAWTEXT end tag name state",
+      "input": "",
+      "last_start_tag": "style",
+      "temporary_buffer": "style",
+      "tokens": [
+        "Text(data=</style)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "script",
+      "description": "Script data end tag name state emits the seeded matching end tag",
+      "diagnostics": [],
+      "id": "seeded-script-name-delimiter",
+      "initial_state": "Script data end tag name state",
+      "input": ">after",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "script",
+      "description": "Script data end tag name state keeps seeded text literal at EOF",
+      "diagnostics": [],
+      "id": "seeded-script-name-eof",
+      "initial_state": "Script data end tag name state",
+      "input": "",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "Text(data=</script)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "script",
+      "description": "Script data escaped end tag name state emits the seeded matching end tag",
+      "diagnostics": [],
+      "id": "seeded-script-escaped-name-delimiter",
+      "initial_state": "Script data escaped end tag name state",
+      "input": ">after",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "script",
+      "description": "Script data escaped end tag name state keeps seeded text literal at EOF",
+      "diagnostics": [],
+      "id": "seeded-script-escaped-name-eof",
+      "initial_state": "Script data escaped end tag name state",
+      "input": "",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "Text(data=</script)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "title",
+      "description": "RCDATA end tag whitespace state emits seeded matching end tag with recovery diagnostic",
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "id": "seeded-rcdata-whitespace-delimiter",
+      "initial_state": "RCDATA end tag whitespace state",
+      "input": ">after",
+      "last_start_tag": "title",
+      "temporary_buffer": "title ",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "style",
+      "description": "RAWTEXT end tag attributes state emits seeded matching end tag with recovery diagnostic",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "seeded-rawtext-attributes-delimiter",
+      "initial_state": "RAWTEXT end tag attributes state",
+      "input": ">after",
+      "last_start_tag": "style",
+      "temporary_buffer": "style class=x",
+      "tokens": [
+        "EndTag(name=style)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "script",
+      "description": "Script data self-closing end tag state emits seeded matching end tag with recovery diagnostic",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "seeded-script-self-closing-delimiter",
+      "initial_state": "Script data self-closing end tag state",
+      "input": ">after",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "script",
+      "description": "Script data escaped end tag attributes state emits seeded matching end tag with recovery diagnostic",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "seeded-script-escaped-attributes-delimiter",
+      "initial_state": "Script data escaped end tag attributes state",
+      "input": ">after",
+      "last_start_tag": "script",
+      "temporary_buffer": "script class=x",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "style",
+      "description": "seeded RCDATA end-tag name mismatch remains literal before a later delimiter",
+      "diagnostics": [],
+      "id": "seeded-rcdata-name-mismatch",
+      "initial_state": "RCDATA end tag name state",
+      "input": ">text</title>",
+      "last_start_tag": "title",
+      "temporary_buffer": "style",
+      "tokens": [
+        "Text(data=</style>text)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "style",
+      "description": "seeded script escaped self-closing mismatch remains literal before a later delimiter",
+      "diagnostics": [],
+      "id": "seeded-script-escaped-self-closing-mismatch",
+      "initial_state": "Script data escaped self-closing end tag state",
+      "input": ">tail</script>",
+      "last_start_tag": "script",
+      "temporary_buffer": "style",
+      "tokens": [
+        "Text(data=</style/>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "script data keeps comment-like escape text before the matching end tag",
+      "diagnostics": [],
+      "id": "script-data-comment-like-escape",
+      "initial_state": "Script data state",
+      "input": "alpha<!-- hidden --></script>after",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha<!-- hidden -->)",
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "script escaped double-escape start keeps inner script delimiters literal",
+      "diagnostics": [],
+      "id": "script-escaped-double-escape-start",
+      "initial_state": "Script data escaped state",
+      "input": "alpha<script>inside</script>after</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=alpha<script>inside</script>after)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "script double escaped less-than state exits on slash-prefixed script text",
+      "diagnostics": [],
+      "id": "script-double-escaped-less-than-slash",
+      "initial_state": "Script data double escaped less-than sign state",
+      "input": "/script>inside</script>after</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=/script>inside)",
+        "EndTag(name=script)",
+        "Text(data=after)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Text-mode end-tag delimiter recovery for parser-controlled RCDATA, RAWTEXT, script data, and seeded continuation states.",
+  "format": "whatwg-html-tokenizer-text-mode-delimiters/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
@@ -1,0 +1,235 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_TEXT_MODE_DELIMITERS: &str =
+    include_str!("fixtures/whatwg-text-mode-delimiters.json");
+
+#[derive(Debug, Deserialize)]
+struct TextModeDelimiterSuite {
+    format: String,
+    description: String,
+    cases: Vec<TextModeDelimiterCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TextModeDelimiterCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    last_start_tag: Option<String>,
+    #[serde(default)]
+    current_end_tag: Option<String>,
+    #[serde(default)]
+    current_comment: Option<String>,
+    #[serde(default)]
+    current_doctype: Option<FixtureDoctypeSeed>,
+    #[serde(default)]
+    temporary_buffer: Option<String>,
+    #[serde(default)]
+    return_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureDoctypeSeed {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    public_identifier: Option<String>,
+    #[serde(default)]
+    system_identifier: Option<String>,
+    #[serde(default)]
+    force_quirks: bool,
+}
+
+#[test]
+fn whatwg_text_mode_delimiter_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(
+        suite.format,
+        "whatwg-html-tokenizer-text-mode-delimiters/v1"
+    );
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 50);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "rcdata-matching-end-tag"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "script-escaped-double-escape-start"));
+}
+
+#[test]
+fn whatwg_text_mode_delimiter_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its delimiter edge",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> TextModeDelimiterSuite {
+    serde_json::from_str(WHATWG_TEXT_MODE_DELIMITERS)
+        .expect("WHATWG text-mode delimiter fixture should parse")
+}
+
+fn configured_lexer(case: &TextModeDelimiterCase) -> HtmlLexer {
+    let state = case
+        .initial_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let mut context = HtmlLexContext::new(state);
+    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
+        context = context.with_last_start_tag(last_start_tag);
+    }
+    if let Some(current_end_tag) = case.current_end_tag.as_deref() {
+        context = context.with_current_end_tag(current_end_tag);
+    }
+    if let Some(current_comment) = case.current_comment.as_deref() {
+        context = context.with_current_comment(current_comment);
+    }
+    if let Some(current_doctype) = case.current_doctype.as_ref() {
+        context = context.with_current_doctype(DoctypeSeed {
+            name: current_doctype.name.clone(),
+            public_identifier: current_doctype.public_identifier.clone(),
+            system_identifier: current_doctype.system_identifier.clone(),
+            force_quirks: current_doctype.force_quirks,
+        });
+    }
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        context = context.with_temporary_buffer(temporary_buffer);
+    }
+    if let Some(return_state) = case
+        .return_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+    {
+        context = context.with_return_state(return_state);
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG tokenizer text-mode delimiter fixture covering RCDATA, RAWTEXT, script data, escaped script data, and seeded end-tag continuations
- assert exact token summaries and diagnostics for matching/mismatched end tags, case-insensitive matching, whitespace/form-feed delimiters, attributes, trailing solidus recovery, EOF literals, and script double-escape edges
- document the fixture, generator, and regeneration/check workflow

## Verification
- cargo test -p coding-adventures-html-lexer --test whatwg_text_mode_delimiters_test
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- git diff --check