### PR TITLE
Add WHATWG markup declaration conformance sweep

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -60,6 +60,9 @@ documented in this file.
 - A generated WHATWG tokenizer text-mode delimiter fixture and Rust conformance
   test that pins RCDATA, RAWTEXT, script-data, escaped-script, and seeded
   end-tag continuation recovery.
+- A generated WHATWG tokenizer markup declaration fixture and Rust conformance
+  test that pins comment, bogus-comment, CDATA-looking declaration, DOCTYPE,
+  and seeded declaration continuation recovery.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -81,6 +81,9 @@ continuation states so parser-facing recovery stays pinned at stream end.
 The generated text-mode delimiter suite pins how RCDATA, RAWTEXT, script data,
 escaped script data, and seeded end-tag continuation states distinguish real
 matching end tags from literal apparent end tags.
+The generated markup declaration suite pins comment, bogus-comment, DOCTYPE,
+default HTML CDATA-looking bogus-comment recovery, explicit seeded CDATA
+continuation, and seeded declaration continuation behavior.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.
@@ -178,10 +181,10 @@ states, CDATA bracket/end states, and script less-than, end-tag-open,
 end-tag-name/whitespace/attributes/self-closing continuation states,
 escape-start, escaped end-tag-open/name/whitespace/attributes/self-closing
 continuations, and double-escape start/end states used by html5lib/WPT-style
-tokenizer fixtures. The markup declaration path also recognizes `<![CDATA[` and
-enters the CDATA section state so the generated lexer can exercise that
-tokenizer subflow end to end; a future parser can still decide when that opener
-is valid for foreign-content contexts.
+tokenizer fixtures. Default HTML data-state `<![CDATA[` reports
+`cdata-in-html-content` and recovers as a bogus comment; foreign-content CDATA
+is exercised through the explicit seeded CDATA context so a future parser can
+opt into that tokenizer subflow only after confirming the namespace context.
 The public Rust API now wraps those parser-controlled entry states in
 `HtmlTokenizerState` and `HtmlLexContext`, including an element-to-context map
 for `title`, `textarea`, raw-text elements, `script`, and `plaintext`. A
@@ -238,10 +241,13 @@ They use a documented JSON schema that Rust tests load with `include_str!`, so
 the test corpus is checked in and shared while production code still links only
 static Rust modules.
 
-Today the package carries two suites:
+Today the package carries these fixture suites:
 
 - `html-skeleton.json` for narrow bootstrap regression coverage
 - `html1.json` for the current Mosaic-era compatibility floor
+- generated WHATWG conformance slices for named references, numeric
+  references, input-stream preprocessing, chunk-boundary invariance, EOF
+  recovery, text-mode delimiters, and markup declarations
 
 The checked-in `whatwg-entities.json` fixture is generated from the HTML
 Standard's `entities.json` table and is exercised directly by Rust tests across
@@ -263,6 +269,16 @@ outside-range values. Regenerate or check it with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py \
+  --check
+```
+
+The checked-in `whatwg-markup-declarations.json` fixture exercises comment,
+bogus-comment, CDATA-looking declaration, DOCTYPE, and seeded declaration
+continuation recovery. Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -67,6 +67,9 @@ binary while production code continues to link only static Rust source.
 - `whatwg-text-mode-delimiters.json`: generated HTML tokenizer text-mode
   delimiter cases used by Rust tests to pin RCDATA, RAWTEXT, script-data,
   escaped-script, and seeded end-tag continuation recovery
+- `whatwg-markup-declarations.json`: generated HTML tokenizer markup
+  declaration cases used by Rust tests to pin comment, bogus-comment, CDATA,
+  DOCTYPE, and seeded declaration continuation recovery
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
@@ -90,6 +93,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_text_mode_delimiters_fixture.py`: importer that generates
   text-mode end-tag delimiter cases for the checked-in
   `whatwg-text-mode-delimiters.json` fixture
+- `generate_whatwg_markup_declarations_fixture.py`: importer that generates
+  markup declaration recovery cases for the checked-in
+  `whatwg-markup-declarations.json` fixture
 
 Regenerate or verify the WHATWG entity fixture with:
 
@@ -138,6 +144,14 @@ Regenerate or verify the WHATWG text-mode delimiter fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG markup declaration fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer markup-declaration fixture.
+
+Markup declaration tokenization fans out from `<!` into comments, DOCTYPE,
+CDATA, and bogus-comment recovery. This fixture pins that visible surface across
+ordinary data-state inputs plus seeded continuation states that parser and
+html5lib-style adapters can resume through the typed Rust context API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-markup-declarations.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer markup-declaration fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-markup-declarations/v1",
+        "description": (
+            "Markup declaration recovery for comments, bogus comments, CDATA, "
+            "DOCTYPE tokens, and seeded continuation states."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    cases.extend(comment_cases())
+    cases.extend(bogus_comment_cases())
+    cases.extend(cdata_cases())
+    cases.extend(doctype_cases())
+    cases.extend(seeded_comment_cases())
+    cases.extend(seeded_cdata_cases())
+    cases.extend(seeded_doctype_cases())
+    return cases
+
+
+def comment_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "comment-basic",
+            "description": "markup declaration recognizes an ordinary HTML comment",
+            "input": "a<!--note-->b",
+            "tokens": ["Text(data=a)", "Comment(data=note)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-empty-abrupt",
+            "description": "empty comment closes through the abrupt <!--> recovery path",
+            "input": "a<!-->b",
+            "tokens": ["Text(data=a)", "Comment(data=)", "Text(data=b)", "EOF"],
+            "diagnostics": ["abrupt-closing-of-empty-comment"],
+        },
+        {
+            "id": "comment-empty-start-dash",
+            "description": "three-dash empty comment closes without comment text",
+            "input": "a<!--->b",
+            "tokens": ["Text(data=a)", "Comment(data=)", "Text(data=b)", "EOF"],
+            "diagnostics": ["abrupt-closing-of-empty-comment"],
+        },
+        {
+            "id": "comment-nested-looking-opener",
+            "description": "nested-looking comment openers stay literal comment data",
+            "input": "a<!--x<!--y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x<!--y)", "Text(data=b)", "EOF"],
+            "diagnostics": ["nested-comment"],
+        },
+        {
+            "id": "comment-end-bang-close",
+            "description": "incorrect --!> comment close emits the comment and diagnostic",
+            "input": "a<!--x--!>b",
+            "tokens": ["Text(data=a)", "Comment(data=x)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-closed-comment"],
+        },
+        {
+            "id": "comment-end-bang-not-close",
+            "description": "non-closing --! text remains inside the comment",
+            "input": "a<!--x--!y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x--!y)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-null-replacement",
+            "description": "NULL inside comment data is replaced with U+FFFD",
+            "input": "a<!--x\u0000y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x�y)", "Text(data=b)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "comment-less-than-text",
+            "description": "less-than signs that do not nest remain comment text",
+            "input": "a<!--x<y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x<y)", "Text(data=b)", "EOF"],
+        },
+    ]
+
+
+def bogus_comment_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "processing-instruction-bogus-comment",
+            "description": "question-mark tag open recovers as a bogus comment",
+            "input": "a<?xml version='1.0'?>b",
+            "tokens": [
+                "Text(data=a)",
+                "Comment(data=?xml version='1.0'?)",
+                "Text(data=b)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-question-mark-instead-of-tag-name"],
+        },
+        {
+            "id": "malformed-declaration-bogus-comment",
+            "description": "unknown markup declarations recover as bogus comments",
+            "input": "a<!foo>b",
+            "tokens": ["Text(data=a)", "Comment(data=foo)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment"],
+        },
+        {
+            "id": "empty-malformed-declaration",
+            "description": "empty malformed declaration emits an empty bogus comment",
+            "input": "a<!>b",
+            "tokens": ["Text(data=a)", "Comment(data=)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment"],
+        },
+        {
+            "id": "one-dash-declaration",
+            "description": "one-dash markup declaration uses bogus-comment recovery",
+            "input": "a<!-x>b",
+            "tokens": ["Text(data=a)", "Comment(data=-x)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment"],
+        },
+        {
+            "id": "invalid-end-tag-open-bogus-comment",
+            "description": "malformed end-tag openers recover as bogus comments",
+            "input": "a</3>b",
+            "tokens": ["Text(data=a)", "Comment(data=3)", "Text(data=b)", "EOF"],
+            "diagnostics": ["invalid-first-character-of-tag-name"],
+        },
+        {
+            "id": "bogus-comment-null-replacement",
+            "description": "NULL inside bogus comments is replaced before emission",
+            "input": "a<!foo\u0000bar>b",
+            "tokens": ["Text(data=a)", "Comment(data=foo�bar)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment", "unexpected-null-character"],
+        },
+        {
+            "id": "malformed-cdata-bogus-comment",
+            "description": "partial CDATA openers recover as bogus comments",
+            "input": "a<![CDATAx]>b",
+            "tokens": ["Text(data=a)", "Comment(data=[CDATAx])", "Text(data=b)", "EOF"],
+        },
+    ]
+
+
+def cdata_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "cdata-section-from-markup-declaration",
+            "description": "default HTML data state recovers CDATA opener as a bogus comment",
+            "input": "a<![CDATA[x<y&z]]>b",
+            "tokens": [
+                "Text(data=a)",
+                "Comment(data=[CDATA[x<y&z]])",
+                "Text(data=b)",
+                "EOF",
+            ],
+            "diagnostics": ["cdata-in-html-content"],
+        },
+        {
+            "id": "cdata-section-bracket-not-end",
+            "description": "default HTML CDATA-looking declarations stay bogus comments",
+            "input": "a<![CDATA[x]y]]>b",
+            "tokens": [
+                "Text(data=a)",
+                "Comment(data=[CDATA[x]y]])",
+                "Text(data=b)",
+                "EOF",
+            ],
+            "diagnostics": ["cdata-in-html-content"],
+        },
+        {
+            "id": "cdata-section-null-replacement",
+            "description": "NULL inside default HTML CDATA-looking bogus comments is replaced",
+            "input": "a<![CDATA[x\u0000y]]>b",
+            "tokens": [
+                "Text(data=a)",
+                "Comment(data=[CDATA[x�y]])",
+                "Text(data=b)",
+                "EOF",
+            ],
+            "diagnostics": ["cdata-in-html-content", "unexpected-null-character"],
+        },
+    ]
+
+
+def doctype_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "doctype-simple",
+            "description": "simple DOCTYPE emits a non-quirks doctype token",
+            "input": "<!DOCTYPE html>",
+            "tokens": ["Doctype(name=html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-uppercase-keyword-and-name",
+            "description": "DOCTYPE keyword and name are ASCII-case-insensitive",
+            "input": "<!doctype HTML>",
+            "tokens": ["Doctype(name=html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-missing-name",
+            "description": "DOCTYPE without a name forces quirks mode",
+            "input": "<!DOCTYPE>",
+            "tokens": ["Doctype(name=null, force_quirks=true)", "EOF"],
+            "diagnostics": ["missing-doctype-name"],
+        },
+        {
+            "id": "doctype-missing-name-after-whitespace",
+            "description": "DOCTYPE with only whitespace before close forces quirks mode",
+            "input": "<!DOCTYPE >",
+            "tokens": ["Doctype(name=null, force_quirks=true)", "EOF"],
+            "diagnostics": ["missing-doctype-name"],
+        },
+        {
+            "id": "doctype-public-identifier",
+            "description": "PUBLIC identifier is preserved on the DOCTYPE token",
+            "input": '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=-//W3C//DTD HTML 4.01//EN, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-and-system-identifiers",
+            "description": "PUBLIC and system identifiers are preserved together",
+            "input": '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "about:legacy-compat">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=-//W3C//DTD HTML 4.01//EN, system_identifier=about:legacy-compat, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-system-identifier",
+            "description": "SYSTEM identifier is preserved on the DOCTYPE token",
+            "input": '<!DOCTYPE html SYSTEM "about:legacy-compat">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=about:legacy-compat, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-single-quoted-identifiers",
+            "description": "single-quoted PUBLIC and system identifiers are preserved",
+            "input": "<!DOCTYPE html PUBLIC '-//ID//' 'sys'>",
+            "tokens": [
+                "Doctype(name=html, public_identifier=-//ID//, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-null-in-name",
+            "description": "NULL in a DOCTYPE name is replaced with U+FFFD",
+            "input": "<!DOCTYPE ht\u0000ml>",
+            "tokens": ["Doctype(name=ht�ml, force_quirks=false)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "doctype-null-in-public-identifier",
+            "description": "NULL in a public identifier is replaced with U+FFFD",
+            "input": '<!DOCTYPE html PUBLIC "a\u0000b">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=a�b, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "doctype-missing-whitespace-before-public",
+            "description": "PUBLIC keyword without separating whitespace is diagnosed",
+            "input": "<!DOCTYPE htmlPUBLIC>",
+            "tokens": ["Doctype(name=htmlpublic, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-missing-public-identifier-quotes",
+            "description": "PUBLIC without quoted identifier forces quirks mode",
+            "input": "<!DOCTYPE html PUBLIC x>",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["missing-quote-before-doctype-public-identifier"],
+        },
+        {
+            "id": "doctype-missing-system-identifier-quotes",
+            "description": "SYSTEM without quoted identifier forces quirks mode",
+            "input": "<!DOCTYPE html SYSTEM x>",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["missing-quote-before-doctype-system-identifier"],
+        },
+        {
+            "id": "doctype-unexpected-trailing-junk",
+            "description": "trailing junk after a system identifier is diagnosed without forcing quirks",
+            "input": '<!DOCTYPE html SYSTEM "sys" junk>',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-character-after-doctype-system-identifier"],
+        },
+        {
+            "id": "doctype-malformed-keyword",
+            "description": "malformed DOCTYPE keyword recovers as a bogus comment",
+            "input": "<!DOCTYPX html>",
+            "tokens": ["Comment(data=DOCTYPX html)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment"],
+        },
+    ]
+
+
+def seeded_comment_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "seeded-comment-body-close",
+            "description": "seeded comment body appends data before closing",
+            "input": " tail-->after",
+            "initial_state": "Comment state",
+            "current_comment": "seed",
+            "tokens": ["Comment(data=seed tail)", "Text(data=after)", "EOF"],
+        },
+        {
+            "id": "seeded-comment-start-dash-close",
+            "description": "seeded comment start dash can close an empty comment",
+            "input": ">after",
+            "initial_state": "Comment start dash state",
+            "current_comment": "",
+            "tokens": ["Comment(data=)", "Text(data=after)", "EOF"],
+            "diagnostics": ["abrupt-closing-of-empty-comment"],
+        },
+        {
+            "id": "seeded-comment-end-dash-close",
+            "description": "seeded comment end dash preserves pending text before close",
+            "input": "->after",
+            "initial_state": "Comment end dash state",
+            "current_comment": "seed",
+            "tokens": ["Comment(data=seed)", "Text(data=after)", "EOF"],
+        },
+        {
+            "id": "seeded-comment-end-bang-close",
+            "description": "seeded comment end bang closes with incorrectly-closed diagnostic",
+            "input": ">after",
+            "initial_state": "Comment end bang state",
+            "current_comment": "seed",
+            "tokens": ["Comment(data=seed)", "Text(data=after)", "EOF"],
+            "diagnostics": ["incorrectly-closed-comment"],
+        },
+        {
+            "id": "seeded-bogus-comment-close",
+            "description": "seeded bogus comment closes on greater-than",
+            "input": " tail>after",
+            "initial_state": "Bogus comment state",
+            "current_comment": "seed",
+            "tokens": ["Comment(data=seed tail)", "Text(data=after)", "EOF"],
+        },
+    ]
+
+
+def seeded_cdata_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "seeded-cdata-section-close",
+            "description": "seeded CDATA section returns to data state at delimiter",
+            "input": "x]]>after",
+            "initial_state": "CDATA section state",
+            "tokens": ["Text(data=x)", "Text(data=after)", "EOF"],
+        },
+        {
+            "id": "seeded-cdata-bracket-not-close",
+            "description": "seeded CDATA bracket substate preserves non-closing bracket",
+            "input": "x]]>after",
+            "initial_state": "CDATA section bracket state",
+            "tokens": ["Text(data=]x)", "Text(data=after)", "EOF"],
+        },
+        {
+            "id": "seeded-cdata-end-close",
+            "description": "seeded CDATA end substate closes on greater-than",
+            "input": ">after",
+            "initial_state": "CDATA section end state",
+            "tokens": ["Text(data=after)", "EOF"],
+        },
+    ]
+
+
+def seeded_doctype_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "seeded-doctype-name-close",
+            "description": "seeded DOCTYPE name closes as a non-quirks token",
+            "input": ">after",
+            "initial_state": "DOCTYPE name state",
+            "current_doctype": {"name": "html"},
+            "tokens": [
+                "Doctype(name=html, force_quirks=false)",
+                "Text(data=after)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "seeded-doctype-name-null",
+            "description": "seeded DOCTYPE name state replaces NULL while appending",
+            "input": "\u0000>",
+            "initial_state": "DOCTYPE name state",
+            "current_doctype": {"name": "ht"},
+            "tokens": ["Doctype(name=ht�, force_quirks=false)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "seeded-public-identifier-close",
+            "description": "seeded public identifier appends text before closing",
+            "input": 'id">',
+            "initial_state": "DOCTYPE public identifier double quoted state",
+            "current_doctype": {"name": "html", "public_identifier": "pub-"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub-id, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "seeded-between-public-and-system",
+            "description": "seeded between identifiers reads a following system identifier",
+            "input": '"sys">after',
+            "initial_state": "Between DOCTYPE public and system identifiers state",
+            "current_doctype": {"name": "html", "public_identifier": "pub"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+                "Text(data=after)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "seeded-system-identifier-null",
+            "description": "seeded system identifier replaces NULL while appending",
+            "input": '\u0000">',
+            "initial_state": "DOCTYPE system identifier double quoted state",
+            "current_doctype": {"name": "html", "system_identifier": "sys"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys�, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "seeded-after-system-identifier-junk",
+            "description": "seeded after-system-identifier state diagnoses trailing junk",
+            "input": " junk>",
+            "initial_state": "After DOCTYPE system identifier state",
+            "current_doctype": {"name": "html", "system_identifier": "sys"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-character-after-doctype-system-identifier"],
+        },
+        {
+            "id": "seeded-bogus-doctype-close",
+            "description": "seeded bogus DOCTYPE closes while preserving force-quirks",
+            "input": " ignored>",
+            "initial_state": "Bogus DOCTYPE state",
+            "current_doctype": {"name": "html", "force_quirks": True},
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+        },
+    ]
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-markup-declarations.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-markup-declarations.json
@@ -1,0 +1,633 @@
+{
+  "cases": [
+    {
+      "description": "markup declaration recognizes an ordinary HTML comment",
+      "diagnostics": [],
+      "id": "comment-basic",
+      "input": "a<!--note-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=note)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "empty comment closes through the abrupt <!--> recovery path",
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
+      "id": "comment-empty-abrupt",
+      "input": "a<!-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "three-dash empty comment closes without comment text",
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
+      "id": "comment-empty-start-dash",
+      "input": "a<!--->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "nested-looking comment openers stay literal comment data",
+      "diagnostics": [
+        "nested-comment"
+      ],
+      "id": "comment-nested-looking-opener",
+      "input": "a<!--x<!--y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<!--y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "incorrect --!> comment close emits the comment and diagnostic",
+      "diagnostics": [
+        "incorrectly-closed-comment"
+      ],
+      "id": "comment-end-bang-close",
+      "input": "a<!--x--!>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "non-closing --! text remains inside the comment",
+      "diagnostics": [],
+      "id": "comment-end-bang-not-close",
+      "input": "a<!--x--!y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x--!y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside comment data is replaced with U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "comment-null-replacement",
+      "input": "a<!--x\u0000y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x�y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "less-than signs that do not nest remain comment text",
+      "diagnostics": [],
+      "id": "comment-less-than-text",
+      "input": "a<!--x<y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "question-mark tag open recovers as a bogus comment",
+      "diagnostics": [
+        "unexpected-question-mark-instead-of-tag-name"
+      ],
+      "id": "processing-instruction-bogus-comment",
+      "input": "a<?xml version='1.0'?>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=?xml version='1.0'?)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unknown markup declarations recover as bogus comments",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "malformed-declaration-bogus-comment",
+      "input": "a<!foo>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=foo)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "empty malformed declaration emits an empty bogus comment",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "empty-malformed-declaration",
+      "input": "a<!>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "one-dash markup declaration uses bogus-comment recovery",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "one-dash-declaration",
+      "input": "a<!-x>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=-x)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "malformed end-tag openers recover as bogus comments",
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ],
+      "id": "invalid-end-tag-open-bogus-comment",
+      "input": "a</3>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=3)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside bogus comments is replaced before emission",
+      "diagnostics": [
+        "incorrectly-opened-comment",
+        "unexpected-null-character"
+      ],
+      "id": "bogus-comment-null-replacement",
+      "input": "a<!foo\u0000bar>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=foo�bar)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "partial CDATA openers recover as bogus comments",
+      "diagnostics": [],
+      "id": "malformed-cdata-bogus-comment",
+      "input": "a<![CDATAx]>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=[CDATAx])",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "default HTML data state recovers CDATA opener as a bogus comment",
+      "diagnostics": [
+        "cdata-in-html-content"
+      ],
+      "id": "cdata-section-from-markup-declaration",
+      "input": "a<![CDATA[x<y&z]]>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=[CDATA[x<y&z]])",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "default HTML CDATA-looking declarations stay bogus comments",
+      "diagnostics": [
+        "cdata-in-html-content"
+      ],
+      "id": "cdata-section-bracket-not-end",
+      "input": "a<![CDATA[x]y]]>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=[CDATA[x]y]])",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside default HTML CDATA-looking bogus comments is replaced",
+      "diagnostics": [
+        "cdata-in-html-content",
+        "unexpected-null-character"
+      ],
+      "id": "cdata-section-null-replacement",
+      "input": "a<![CDATA[x\u0000y]]>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=[CDATA[x�y]])",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "simple DOCTYPE emits a non-quirks doctype token",
+      "diagnostics": [],
+      "id": "doctype-simple",
+      "input": "<!DOCTYPE html>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "DOCTYPE keyword and name are ASCII-case-insensitive",
+      "diagnostics": [],
+      "id": "doctype-uppercase-keyword-and-name",
+      "input": "<!doctype HTML>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "DOCTYPE without a name forces quirks mode",
+      "diagnostics": [
+        "missing-doctype-name"
+      ],
+      "id": "doctype-missing-name",
+      "input": "<!DOCTYPE>",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "DOCTYPE with only whitespace before close forces quirks mode",
+      "diagnostics": [
+        "missing-doctype-name"
+      ],
+      "id": "doctype-missing-name-after-whitespace",
+      "input": "<!DOCTYPE >",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PUBLIC identifier is preserved on the DOCTYPE token",
+      "diagnostics": [],
+      "id": "doctype-public-identifier",
+      "input": "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=-//W3C//DTD HTML 4.01//EN, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PUBLIC and system identifiers are preserved together",
+      "diagnostics": [],
+      "id": "doctype-public-and-system-identifiers",
+      "input": "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"about:legacy-compat\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=-//W3C//DTD HTML 4.01//EN, system_identifier=about:legacy-compat, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "SYSTEM identifier is preserved on the DOCTYPE token",
+      "diagnostics": [],
+      "id": "doctype-system-identifier",
+      "input": "<!DOCTYPE html SYSTEM \"about:legacy-compat\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=about:legacy-compat, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "single-quoted PUBLIC and system identifiers are preserved",
+      "diagnostics": [],
+      "id": "doctype-single-quoted-identifiers",
+      "input": "<!DOCTYPE html PUBLIC '-//ID//' 'sys'>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=-//ID//, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL in a DOCTYPE name is replaced with U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "doctype-null-in-name",
+      "input": "<!DOCTYPE ht\u0000ml>",
+      "tokens": [
+        "Doctype(name=ht�ml, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL in a public identifier is replaced with U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "doctype-null-in-public-identifier",
+      "input": "<!DOCTYPE html PUBLIC \"a\u0000b\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=a�b, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PUBLIC keyword without separating whitespace is diagnosed",
+      "diagnostics": [],
+      "id": "doctype-missing-whitespace-before-public",
+      "input": "<!DOCTYPE htmlPUBLIC>",
+      "tokens": [
+        "Doctype(name=htmlpublic, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PUBLIC without quoted identifier forces quirks mode",
+      "diagnostics": [
+        "missing-quote-before-doctype-public-identifier"
+      ],
+      "id": "doctype-missing-public-identifier-quotes",
+      "input": "<!DOCTYPE html PUBLIC x>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "SYSTEM without quoted identifier forces quirks mode",
+      "diagnostics": [
+        "missing-quote-before-doctype-system-identifier"
+      ],
+      "id": "doctype-missing-system-identifier-quotes",
+      "input": "<!DOCTYPE html SYSTEM x>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "trailing junk after a system identifier is diagnosed without forcing quirks",
+      "diagnostics": [
+        "unexpected-character-after-doctype-system-identifier"
+      ],
+      "id": "doctype-unexpected-trailing-junk",
+      "input": "<!DOCTYPE html SYSTEM \"sys\" junk>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "malformed DOCTYPE keyword recovers as a bogus comment",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "doctype-malformed-keyword",
+      "input": "<!DOCTYPX html>",
+      "tokens": [
+        "Comment(data=DOCTYPX html)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "seeded comment body appends data before closing",
+      "diagnostics": [],
+      "id": "seeded-comment-body-close",
+      "initial_state": "Comment state",
+      "input": " tail-->after",
+      "tokens": [
+        "Comment(data=seed tail)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "",
+      "description": "seeded comment start dash can close an empty comment",
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
+      "id": "seeded-comment-start-dash-close",
+      "initial_state": "Comment start dash state",
+      "input": ">after",
+      "tokens": [
+        "Comment(data=)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "seeded comment end dash preserves pending text before close",
+      "diagnostics": [],
+      "id": "seeded-comment-end-dash-close",
+      "initial_state": "Comment end dash state",
+      "input": "->after",
+      "tokens": [
+        "Comment(data=seed)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "seeded comment end bang closes with incorrectly-closed diagnostic",
+      "diagnostics": [
+        "incorrectly-closed-comment"
+      ],
+      "id": "seeded-comment-end-bang-close",
+      "initial_state": "Comment end bang state",
+      "input": ">after",
+      "tokens": [
+        "Comment(data=seed)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "seeded bogus comment closes on greater-than",
+      "diagnostics": [],
+      "id": "seeded-bogus-comment-close",
+      "initial_state": "Bogus comment state",
+      "input": " tail>after",
+      "tokens": [
+        "Comment(data=seed tail)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "seeded CDATA section returns to data state at delimiter",
+      "diagnostics": [],
+      "id": "seeded-cdata-section-close",
+      "initial_state": "CDATA section state",
+      "input": "x]]>after",
+      "tokens": [
+        "Text(data=x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "seeded CDATA bracket substate preserves non-closing bracket",
+      "diagnostics": [],
+      "id": "seeded-cdata-bracket-not-close",
+      "initial_state": "CDATA section bracket state",
+      "input": "x]]>after",
+      "tokens": [
+        "Text(data=]x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "seeded CDATA end substate closes on greater-than",
+      "diagnostics": [],
+      "id": "seeded-cdata-end-close",
+      "initial_state": "CDATA section end state",
+      "input": ">after",
+      "tokens": [
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html"
+      },
+      "description": "seeded DOCTYPE name closes as a non-quirks token",
+      "diagnostics": [],
+      "id": "seeded-doctype-name-close",
+      "initial_state": "DOCTYPE name state",
+      "input": ">after",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "ht"
+      },
+      "description": "seeded DOCTYPE name state replaces NULL while appending",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-doctype-name-null",
+      "initial_state": "DOCTYPE name state",
+      "input": "\u0000>",
+      "tokens": [
+        "Doctype(name=ht�, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html",
+        "public_identifier": "pub-"
+      },
+      "description": "seeded public identifier appends text before closing",
+      "diagnostics": [],
+      "id": "seeded-public-identifier-close",
+      "initial_state": "DOCTYPE public identifier double quoted state",
+      "input": "id\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub-id, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html",
+        "public_identifier": "pub"
+      },
+      "description": "seeded between identifiers reads a following system identifier",
+      "diagnostics": [],
+      "id": "seeded-between-public-and-system",
+      "initial_state": "Between DOCTYPE public and system identifiers state",
+      "input": "\"sys\">after",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html",
+        "system_identifier": "sys"
+      },
+      "description": "seeded system identifier replaces NULL while appending",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-system-identifier-null",
+      "initial_state": "DOCTYPE system identifier double quoted state",
+      "input": "\u0000\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys�, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html",
+        "system_identifier": "sys"
+      },
+      "description": "seeded after-system-identifier state diagnoses trailing junk",
+      "diagnostics": [
+        "unexpected-character-after-doctype-system-identifier"
+      ],
+      "id": "seeded-after-system-identifier-junk",
+      "initial_state": "After DOCTYPE system identifier state",
+      "input": " junk>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "force_quirks": true,
+        "name": "html"
+      },
+      "description": "seeded bogus DOCTYPE closes while preserving force-quirks",
+      "diagnostics": [],
+      "id": "seeded-bogus-doctype-close",
+      "initial_state": "Bogus DOCTYPE state",
+      "input": " ignored>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Markup declaration recovery for comments, bogus comments, CDATA, DOCTYPE tokens, and seeded continuation states.",
+  "format": "whatwg-html-tokenizer-markup-declarations/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
@@ -1,0 +1,235 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_MARKUP_DECLARATIONS: &str = include_str!("fixtures/whatwg-markup-declarations.json");
+
+#[derive(Debug, Deserialize)]
+struct MarkupDeclarationSuite {
+    format: String,
+    description: String,
+    cases: Vec<MarkupDeclarationCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarkupDeclarationCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    last_start_tag: Option<String>,
+    #[serde(default)]
+    current_end_tag: Option<String>,
+    #[serde(default)]
+    current_comment: Option<String>,
+    #[serde(default)]
+    current_doctype: Option<FixtureDoctypeSeed>,
+    #[serde(default)]
+    temporary_buffer: Option<String>,
+    #[serde(default)]
+    return_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureDoctypeSeed {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    public_identifier: Option<String>,
+    #[serde(default)]
+    system_identifier: Option<String>,
+    #[serde(default)]
+    force_quirks: bool,
+}
+
+#[test]
+fn whatwg_markup_declaration_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-tokenizer-markup-declarations/v1");
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 40);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "comment-nested-looking-opener"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "doctype-public-and-system-identifiers"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "seeded-bogus-doctype-close"));
+}
+
+#[test]
+fn whatwg_markup_declaration_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its markup declaration edge",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> MarkupDeclarationSuite {
+    serde_json::from_str(WHATWG_MARKUP_DECLARATIONS)
+        .expect("WHATWG markup-declaration fixture should parse")
+}
+
+fn configured_lexer(case: &MarkupDeclarationCase) -> HtmlLexer {
+    let state = case
+        .initial_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let mut context = HtmlLexContext::new(state);
+    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
+        context = context.with_last_start_tag(last_start_tag);
+    }
+    if let Some(current_end_tag) = case.current_end_tag.as_deref() {
+        context = context.with_current_end_tag(current_end_tag);
+    }
+    if let Some(current_comment) = case.current_comment.as_deref() {
+        context = context.with_current_comment(current_comment);
+    }
+    if let Some(current_doctype) = case.current_doctype.as_ref() {
+        context = context.with_current_doctype(DoctypeSeed {
+            name: current_doctype.name.clone(),
+            public_identifier: current_doctype.public_identifier.clone(),
+            system_identifier: current_doctype.system_identifier.clone(),
+            force_quirks: current_doctype.force_quirks,
+        });
+    }
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        context = context.with_temporary_buffer(temporary_buffer);
+    }
+    if let Some(return_state) = case
+        .return_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+    {
+        context = context.with_return_state(return_state);
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG markup-declaration fixture covering comments, bogus comments, default HTML CDATA-looking recovery, DOCTYPE tokens, and seeded declaration continuation states
- add a Rust conformance test that runs the 48-case fixture through the default HTML lexer and typed continuation contexts
- document the generator/check command and clarify default HTML CDATA-looking recovery vs explicit seeded foreign-content CDATA

## Verification
- cargo test -p coding-adventures-html-lexer --test whatwg_markup_declarations_test
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py --check
- git diff --check