### PR TITLE
feat(mosmodel): nested list types — list<list<T>> for Grid viewport-rows

### DIFF
--- a/code/grammars/mosmodel.grammar
+++ b/code/grammars/mosmodel.grammar
@@ -61,10 +61,13 @@ slot_type = scalar_type
 # The six scalar type keywords
 scalar_type = KEYWORD ;
 
-# list<T> where T is a scalar or named component type
+# list<T> where T is a scalar, a nested list (list<list<text>>), or a
+# named component type. Nested lists are needed by table-like layouts:
+# the Grid primitive in UI26 uses `list<list<text>>` for its viewport
+# rows (each row is itself a list of cell strings).
 list_type = KEYWORD LANGLE inner_type RANGLE ;
 
-inner_type = scalar_type | NAME ;
+inner_type = list_type | scalar_type | NAME ;
 
 # Allowed inline defaults: string, number, or bool literal
 slot_default = STRING | NUMBER | KEYWORD ;

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -1084,13 +1084,9 @@ fn list_inner_to_ts(t: &ListInnerType) -> String {
         ListInnerType::Color => "string".to_string(),
         ListInnerType::Node => "React.ReactNode".to_string(),
         ListInnerType::Component(name) => format!("React.ReactNode /* {name} */"),
+        // Nested list — `list<list<text>>` lowers to `Array<Array<string>>`.
+        ListInnerType::List(inner) => format!("Array<{}>", list_inner_to_ts(inner)),
     }
-    // NB: `mosmodel-compiler::ListInnerType` does not currently model nested
-    // lists (`list<list<text>>`), even though UI13 §1 allows them in the
-    // mosmodel grammar. That discrepancy is tracked separately as a
-    // mosmodel-compiler bug; lowering `list<list<text>>` (needed for the
-    // Grid component's `viewport-rows` slot) will work once the inner enum
-    // gains a `List(Box<ListInnerType>)` variant.
 }
 
 /// Map a mosmodel emit-payload type to a TypeScript type string.

--- a/code/packages/rust/mosmodel-compiler/src/_grammar.rs
+++ b/code/packages/rust/mosmodel-compiler/src/_grammar.rs
@@ -264,10 +264,17 @@ pub fn parser_grammar() -> ParserGrammar {
             ]},
             line_number: 60,
         },
-        // inner_type = scalar_type | NAME ;
+        // inner_type = list_type | scalar_type | NAME ;
+        // list_type comes first because both `list_type` and
+        // `scalar_type` start with a KEYWORD; in a first-match
+        // alternation a bare `scalar_type` would greedily accept the
+        // `list` keyword and then fail at the inner `<`. Putting
+        // `list_type` first lets nested lists like `list<list<text>>`
+        // (Grid primitive's viewport-rows slot, UI26 §2.1) parse.
         GrammarRule {
             name: r#"inner_type"#.to_string(),
             body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"list_type"#.to_string() },
                 GrammarElement::RuleReference { name: r#"scalar_type"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ]},

--- a/code/packages/rust/mosmodel-compiler/src/lib.rs
+++ b/code/packages/rust/mosmodel-compiler/src/lib.rs
@@ -158,6 +158,12 @@ pub enum SlotType {
 }
 
 /// The inner type of a `list<T>` slot.
+///
+/// Nested lists are supported via the `List` variant — `list<list<text>>`
+/// parses as `List(Box::new(ListInnerType::List(Box::new(ListInnerType::Text))))`.
+/// The Grid primitive's `viewport-rows` slot (UI26 §2.1) is the
+/// motivating use case: each row is itself a list of cell strings, so
+/// the natural type is `list<list<text>>`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ListInnerType {
@@ -168,6 +174,9 @@ pub enum ListInnerType {
     Color,
     Node,
     Component(String),
+    /// Nested list — `list<list<T>>` and deeper. The boxed inner is
+    /// itself a `ListInnerType`, so arbitrary nesting depths parse.
+    List(Box<ListInnerType>),
 }
 
 /// Valid types for an emit payload parameter.
@@ -542,11 +551,30 @@ fn parse_scalar_slot_type(node: &GrammarASTNode) -> Result<SlotType, CompileErro
 }
 
 fn parse_list_inner_type(node: &GrammarASTNode) -> Result<ListInnerType, CompileError> {
-    // inner_type = scalar_type | NAME
+    // inner_type = scalar_type | list_type | NAME
+    //
+    // The `list_type` arm enables nested lists: `list<list<text>>`
+    // recurses through here once with `node.rule_name == "list_type"`,
+    // yielding `ListInnerType::List(Box::new(<inner>))`.
     for child in &node.children {
         match child {
             ASTNodeOrToken::Node(n) if n.rule_name == "scalar_type" => {
                 return parse_scalar_list_inner(n);
+            }
+            ASTNodeOrToken::Node(n) if n.rule_name == "list_type" => {
+                // list_type = KEYWORD("list") LANGLE inner_type RANGLE
+                // Find the nested inner_type child and recurse.
+                for inner_child in &n.children {
+                    if let ASTNodeOrToken::Node(ic) = inner_child {
+                        if ic.rule_name == "inner_type" {
+                            return Ok(ListInnerType::List(Box::new(parse_list_inner_type(ic)?)));
+                        }
+                    }
+                }
+                return Err(CompileError {
+                    kind: ErrorKind::UnknownType,
+                    message: "nested list_type missing inner_type".to_string(),
+                });
             }
             ASTNodeOrToken::Token(t) if is_name_token(t) => {
                 return Ok(ListInnerType::Component(t.value.clone()));
@@ -951,15 +979,17 @@ fn slot_type_to_rust(ty: &SlotType) -> String {
     }
 }
 
-fn list_inner_to_rust(inner: &ListInnerType) -> &'static str {
+fn list_inner_to_rust(inner: &ListInnerType) -> String {
     match inner {
-        ListInnerType::Text => "String",
-        ListInnerType::Number => "f64",
-        ListInnerType::Bool => "bool",
-        ListInnerType::Image => "ImageHandle",
-        ListInnerType::Color => "[f32; 4]",
-        ListInnerType::Node => "Box<dyn AnyNode>",
-        ListInnerType::Component(_) => "Box<dyn AnyNode>",
+        ListInnerType::Text => "String".to_string(),
+        ListInnerType::Number => "f64".to_string(),
+        ListInnerType::Bool => "bool".to_string(),
+        ListInnerType::Image => "ImageHandle".to_string(),
+        ListInnerType::Color => "[f32; 4]".to_string(),
+        ListInnerType::Node => "Box<dyn AnyNode>".to_string(),
+        ListInnerType::Component(_) => "Box<dyn AnyNode>".to_string(),
+        // Nested list — `list<list<text>>` becomes `Vec<Vec<String>>`.
+        ListInnerType::List(deeper) => format!("Vec<{}>", list_inner_to_rust(deeper)),
     }
 }
 
@@ -1265,6 +1295,51 @@ mod tests {
             .unwrap();
         assert_eq!(headers.r#type, SlotType::List(Box::new(ListInnerType::Text)));
         assert!(headers.required);
+    }
+
+    /// Nested list types (`list<list<text>>`) parse as
+    /// `List(List(Text))`. Motivating use case: the Grid primitive's
+    /// `viewport-rows` slot in UI26 §2.1.
+    #[test]
+    fn slot_nested_list_type() {
+        let src = r#"
+component Grid {
+  slot viewport-rows : list<list<text>> ;
+}
+"#;
+        let out = compile(src).expect("nested list should compile");
+        let rows = out
+            .component
+            .slots
+            .iter()
+            .find(|s| s.name == "viewport-rows")
+            .unwrap();
+        assert_eq!(
+            rows.r#type,
+            SlotType::List(Box::new(ListInnerType::List(Box::new(ListInnerType::Text))))
+        );
+    }
+
+    /// Triply-nested `list<list<list<number>>>` also parses (rare in
+    /// practice, but the grammar permits arbitrary nesting).
+    #[test]
+    fn slot_triply_nested_list_type() {
+        let src = r#"
+component Cube {
+  slot cube : list<list<list<number>>> ;
+}
+"#;
+        let out = compile(src).expect("triply-nested list should compile");
+        let cube = out
+            .component
+            .slots
+            .iter()
+            .find(|s| s.name == "cube")
+            .unwrap();
+        let expected = SlotType::List(Box::new(ListInnerType::List(Box::new(
+            ListInnerType::List(Box::new(ListInnerType::Number)),
+        ))));
+        assert_eq!(cube.r#type, expected);
     }
 
     /// `viewport-offset` slot defaults to 0.

--- a/demo/visicalc/mosaic/Grid.mil
+++ b/demo/visicalc/mosaic/Grid.mil
@@ -7,7 +7,14 @@
 component Grid {
   // Display data (host computes from cells + viewport offset).
   slot column-headers : list<text> ;
-  slot viewport-rows  : list<text> ;
+  // viewport-rows is `list<list<text>>` — each row is itself a list
+  // of cell strings. Generated TS prop type is
+  // `Array<Array<string>>`, which matches the App's
+  // `buildViewportRows(...)` return shape. The nested form needs
+  // `mosmodel-compiler::ListInnerType::List`; before that variant
+  // existed, this slot had to spell `list<text>` and the App used
+  // `@ts-expect-error` to paper over the mismatch.
+  slot viewport-rows  : list<list<text>> ;
 
   // Selection (host owns, pushes in).
   slot selected-row : number ;

--- a/demo/visicalc/src/app/App.tsx
+++ b/demo/visicalc/src/app/App.tsx
@@ -5,16 +5,13 @@
 // components themselves know nothing about spreadsheets — they just
 // render the props they receive and fire events.
 //
-// ## Known limitation: viewport-rows nested-list typing
-//
-// The UI26 spec calls for `slot viewport-rows : list<list<text>>` so the
-// Grid receives an `Array<Array<string>>`. The current mosmodel-compiler
-// `ListInnerType` enum only models flat lists (no recursive `List`
-// variant), so the generated Grid.tsx prop type is `Array<string>`
-// instead of the spec's `Array<Array<string>>`. We use `// @ts-expect-error`
-// below to acknowledge the mismatch — the architecture is correct, but
-// the demo will not render row cells correctly until mosmodel grows
-// nested-list support. See README for the follow-up note.
+// `viewport-rows` is typed `list<list<text>>` in Grid.mil, which the
+// mosmodel-compiler now lowers to `Array<Array<string>>` in the
+// generated TS prop. Each row is a list of cell strings — the natural
+// shape of a spreadsheet viewport slice. Before mosmodel-compiler's
+// `ListInnerType::List` variant existed, the .mil had to spell
+// `list<text>` and this file carried a `@ts-expect-error` to mask the
+// resulting `Array<string>` vs `Array<Array<string>>` mismatch.
 
 import { useReducer, useMemo, useEffect, useCallback } from "react";
 import { Grid } from "../components/Grid";
@@ -117,10 +114,6 @@ export function App() {
       />
       <Grid
         columnHeaders={state.columnHeaders}
-        // @ts-expect-error UI26 §11: Grid component expects Array<Array<string>>
-        // per spec, but mosmodel-compiler can only represent `list<text>` (flat)
-        // until ListInnerType gains a recursive `List` variant. Documented in
-        // README. The demo still compiles and renders the FormulaBar correctly.
         viewportRows={viewportRows}
         selectedRow={state.selectedRow - state.viewportOffset}
         selectedCol={state.selectedCol}


### PR DESCRIPTION
## Summary

Unblocks the VisiCalc demo's Grid cell rendering. The Grid's `viewport-rows` slot needs `list<list<text>>` so each row is a list of cell strings; until now mosmodel-compiler couldn't parse nested lists, so the `.mil` had to spell `list<text>` and the App carried a `@ts-expect-error` for the `Array<string>` vs `Array<Array<string>>` mismatch.

## What ships

- **mosmodel grammar** — `inner_type` now accepts `list_type` as the first alternative (must come before `scalar_type` because both start with a KEYWORD; first-match would otherwise greedy-eat the `list` keyword)
- **mosmodel-compiler** — `ListInnerType` enum gains a `List(Box<ListInnerType>)` variant; `parse_list_inner_type` recurses when the AST shows an inner `list_type`; `list_inner_to_rust` returns `String` so it can format `Vec<Vec<...>>` at runtime
- **mosaic-emit-react** — `list_inner_to_ts` recurses to spell `Array<Array<string>>`; the "tracked-as-bug" comment is gone
- **demo/visicalc** — `Grid.mil` typed `list<list<text>>`; App.tsx loses the `@ts-expect-error` and the Known-Limitation doc-block

## Test plan

- [x] 2 new mosmodel-compiler tests: `slot_nested_list_type` and `slot_triply_nested_list_type` (arbitrary depth)
- [x] All 36 existing mosmodel-compiler tests pass
- [x] All 70 mosaic-emit-react tests pass
- [x] `bash demo/visicalc/scripts/build.sh` succeeds end-to-end
- [x] Generated `Grid.tsx` declares `viewportRows: Array<Array<string>>` (was `Array<string>`)
- [x] Generated files remain gitignored (`demo/visicalc/.gitignore`)
- [ ] CI green

## Follow-up

PR-B will tackle the missing gridlines — adds mosstyle sub-part syntax (`part sheet/cell`) and wires the Grid React emitter to inline per-sub-part styles on `<td>`/`<th>`/`<tr>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
