### PR TITLE
Add WHATWG attribute edge conformance sweep

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -63,6 +63,10 @@ documented in this file.
 - A generated WHATWG tokenizer markup declaration fixture and Rust conformance
   test that pins comment, bogus-comment, CDATA-looking declaration, DOCTYPE,
   and seeded declaration continuation recovery.
+- A generated WHATWG tokenizer attribute-edge fixture and Rust conformance test
+  that pins quoted/unquoted values, duplicate attributes, missing-whitespace
+  recovery, NULL replacement, self-closing delimiters, unexpected solidus
+  recovery, and end-tag attribute diagnostics.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -84,6 +84,9 @@ matching end tags from literal apparent end tags.
 The generated markup declaration suite pins comment, bogus-comment, DOCTYPE,
 default HTML CDATA-looking bogus-comment recovery, explicit seeded CDATA
 continuation, and seeded declaration continuation behavior.
+The generated attribute-edge suite pins quoted/unquoted values, duplicate
+attributes, missing-whitespace recovery, NULL replacement, self-closing
+delimiters, unexpected solidus recovery, and end-tag attribute diagnostics.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -70,6 +70,10 @@ binary while production code continues to link only static Rust source.
 - `whatwg-markup-declarations.json`: generated HTML tokenizer markup
   declaration cases used by Rust tests to pin comment, bogus-comment, CDATA,
   DOCTYPE, and seeded declaration continuation recovery
+- `whatwg-attribute-edges.json`: generated HTML tokenizer attribute-edge cases
+  used by Rust tests to pin quoted/unquoted values, duplicate attributes,
+  missing whitespace recovery, NULL replacement, self-closing delimiters, and
+  end-tag attribute diagnostics
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
@@ -96,6 +100,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_markup_declarations_fixture.py`: importer that generates
   markup declaration recovery cases for the checked-in
   `whatwg-markup-declarations.json` fixture
+- `generate_whatwg_attribute_edges_fixture.py`: importer that generates
+  attribute-edge recovery cases for the checked-in
+  `whatwg-attribute-edges.json` fixture
 
 Regenerate or verify the WHATWG entity fixture with:
 
@@ -152,6 +159,14 @@ Regenerate or verify the WHATWG markup declaration fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG attribute-edge fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py \
   --check
 ```
 
@@ -300,6 +315,10 @@ currently supports:
 - generated text-mode delimiter coverage across RCDATA, RAWTEXT, script data,
   escaped script data, matching/mismatched apparent end tags, recoverable
   whitespace/attribute/solidus delimiters, and seeded end-tag continuations
+- generated attribute-edge coverage across quoted/unquoted values, duplicate
+  attributes, missing whitespace recovery, unexpected attribute characters,
+  NULL replacement, self-closing delimiters, unexpected solidus recovery, and
+  end-tag attributes
 - EOF recovery for unfinished ordinary start and end tags, ensuring partial
   tokens are dropped before the parser sees them
 - EOF recovery for unfinished attribute character references, including named

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer attribute-edge fixture.
+
+The HTML tokenizer attribute states are where small delimiter differences turn
+into visible parser-facing tokens and diagnostics. This fixture keeps those
+edges pinned across ordinary data-state lexing: quoted and unquoted values,
+duplicate names, missing whitespace, NULL replacement, self-closing syntax,
+unexpected solidus recovery, and recoverable end-tag attributes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-attribute-edges.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer attribute-edge fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-attribute-edges/v1",
+        "description": (
+            "Attribute tokenizer recovery for quoted and unquoted values, "
+            "duplicates, missing whitespace, NULLs, self-closing delimiters, "
+            "and recoverable end-tag attributes."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    cases.extend(attribute_value_cases())
+    cases.extend(attribute_diagnostic_cases())
+    cases.extend(solidus_and_self_closing_cases())
+    cases.extend(end_tag_attribute_cases())
+    return cases
+
+
+def attribute_value_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "mixed-quoted-and-unquoted-values",
+            "description": "double, single, unquoted, and boolean attributes emit in source order",
+            "input": "<a one=\"1\" two='2' three=3 four>",
+            "tokens": [
+                "StartTag(name=a, attributes=[one=1, two=2, three=3, four=], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "uppercase-tag-and-attribute-names",
+            "description": "HTML tag and attribute names are ASCII-lowercased",
+            "input": "<DIV CLASS=Hero DATA-ID=42>",
+            "tokens": [
+                "StartTag(name=div, attributes=[class=Hero, data-id=42], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "empty-quoted-values",
+            "description": "empty quoted attributes stay present with empty values",
+            "input": "<input disabled value=\"\" data-empty=''>",
+            "tokens": [
+                "StartTag(name=input, attributes=[disabled=, value=, data-empty=], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "attribute-values-keep-whitespace-inside-quotes",
+            "description": "quoted attribute values preserve internal ASCII whitespace",
+            "input": "<p title=\"one two\tthree\nfour\">",
+            "tokens": [
+                "StartTag(name=p, attributes=[title=one two\tthree\nfour], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "character-references-in-attributes",
+            "description": "attribute character references decode through the attribute return state",
+            "input": "<a title=\"A&amp;B\" data='&#x41;&#65;'>",
+            "tokens": [
+                "StartTag(name=a, attributes=[title=A&B, data=AA], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "ambiguous-ampersand-in-attribute",
+            "description": "semicolonless ambiguous ampersands stay literal in attributes",
+            "input": "<a href=\"?x=1&ampy=2\" title=Tom&ampJerry>",
+            "tokens": [
+                "StartTag(name=a, attributes=[href=?x=1&ampy=2, title=Tom&ampJerry], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "duplicate-attributes-drop-later-name",
+            "description": "duplicate attribute names keep the first value and report recovery",
+            "input": "<a href=one HREF=two title=ok>",
+            "tokens": [
+                "StartTag(name=a, attributes=[href=one, title=ok], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": ["duplicate-attribute"],
+        },
+    ]
+
+
+def attribute_diagnostic_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "unexpected-unquoted-characters",
+            "description": "unexpected unquoted value characters are preserved with diagnostics",
+            "input": "<a data=one=two sq=x'y lt=x<y tick=x`y dq=x\"y>",
+            "tokens": [
+                "StartTag(name=a, attributes=[data=one=two, sq=x'y, lt=x<y, tick=x`y, dq=x\"y], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": [
+                "unexpected-character-in-unquoted-attribute-value",
+                "unexpected-character-in-unquoted-attribute-value",
+                "unexpected-character-in-unquoted-attribute-value",
+                "unexpected-character-in-unquoted-attribute-value",
+                "unexpected-character-in-unquoted-attribute-value",
+            ],
+        },
+        {
+            "id": "first-unquoted-value-characters",
+            "description": "unexpected characters at the beginning of unquoted values are preserved",
+            "input": "<a lt=<x eq==x tick=`x ok=value>",
+            "tokens": [
+                "StartTag(name=a, attributes=[lt=<x, eq==x, tick=`x, ok=value], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": [
+                "unexpected-character-in-unquoted-attribute-value",
+                "unexpected-character-in-unquoted-attribute-value",
+                "unexpected-character-in-unquoted-attribute-value",
+            ],
+        },
+        {
+            "id": "unexpected-attribute-name-characters",
+            "description": "quote and less-than characters in attribute names report but stay literal",
+            "input": "<a \"pre=1 mid'dle=2 done <tail=3>",
+            "tokens": [
+                "StartTag(name=a, attributes=[\"pre=1, mid'dle=2, done=, <tail=3], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": [
+                "unexpected-character-in-attribute-name",
+                "unexpected-character-in-attribute-name",
+                "unexpected-character-in-attribute-name",
+            ],
+        },
+        {
+            "id": "missing-whitespace-after-quoted-value",
+            "description": "quoted attributes without separating whitespace reconsume into new attributes",
+            "input": "<a first=\"1\"second=2>",
+            "tokens": [
+                "StartTag(name=a, attributes=[first=1, second=2], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": ["missing-whitespace-between-attributes"],
+        },
+        {
+            "id": "equals-before-attribute-name-after-quoted-value",
+            "description": "missing whitespace before equals creates a recoverable equals-named attribute",
+            "input": "<a eq=\"x\"==y>",
+            "tokens": [
+                "StartTag(name=a, attributes=[eq=x, ==y], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": [
+                "missing-whitespace-between-attributes",
+                "unexpected-equals-before-attribute-name",
+            ],
+        },
+        {
+            "id": "nulls-in-attribute-values",
+            "description": "NULLs in quoted, unquoted, and bare attribute values become replacement characters",
+            "input": "<a title=\"x\u0000y\" data=x\u0000y bare=\u0000>",
+            "tokens": [
+                "StartTag(name=a, attributes=[title=x�y, data=x�y, bare=�], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": [
+                "unexpected-null-character",
+                "unexpected-null-character",
+                "unexpected-null-character",
+            ],
+        },
+        {
+            "id": "nulls-in-tag-and-attribute-names",
+            "description": "NULLs in tag and attribute names become replacement characters",
+            "input": "<x\u0000 \u0000=v a\u0000b=1 first \u0000second=2>",
+            "tokens": [
+                "StartTag(name=x�, attributes=[�=v, a�b=1, first=, �second=2], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": [
+                "unexpected-null-character",
+                "unexpected-null-character",
+                "unexpected-null-character",
+                "unexpected-null-character",
+            ],
+        },
+    ]
+
+
+def solidus_and_self_closing_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "self-closing-with-space",
+            "description": "a solidus after whitespace sets the self-closing flag",
+            "input": "<br />",
+            "tokens": ["StartTag(name=br, attributes=[], self_closing=true)", "EOF"],
+        },
+        {
+            "id": "self-closing-without-space",
+            "description": "a solidus immediately after the tag name sets the self-closing flag",
+            "input": "<br/>",
+            "tokens": ["StartTag(name=br, attributes=[], self_closing=true)", "EOF"],
+        },
+        {
+            "id": "double-solidus-before-close",
+            "description": "a second solidus before close is reported then preserves self-closing",
+            "input": "<br//>",
+            "tokens": ["StartTag(name=br, attributes=[], self_closing=true)", "EOF"],
+            "diagnostics": ["unexpected-solidus-in-tag"],
+        },
+        {
+            "id": "unexpected-solidus-before-attribute",
+            "description": "unexpected solidus before an attribute reconsumes in before-attribute-name",
+            "input": "<img/ src=one>",
+            "tokens": [
+                "StartTag(name=img, attributes=[src=one], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-solidus-in-tag"],
+        },
+        {
+            "id": "unexpected-solidus-before-null-attribute",
+            "description": "unexpected solidus before a NULL-starting attribute reports both recoveries",
+            "input": "<hr/\u0000=x>",
+            "tokens": [
+                "StartTag(name=hr, attributes=[�=x], self_closing=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-solidus-in-tag", "unexpected-null-character"],
+        },
+        {
+            "id": "solidus-in-unquoted-values",
+            "description": "solidus stays value text inside unquoted attribute values",
+            "input": "<a href=http://example.test/path data=a/b>",
+            "tokens": [
+                "StartTag(name=a, attributes=[href=http://example.test/path, data=a/b], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "trailing-solidus-inside-unquoted-value",
+            "description": "a trailing solidus before tag close belongs to the unquoted value",
+            "input": "<img src=cat/>",
+            "tokens": [
+                "StartTag(name=img, attributes=[src=cat/], self_closing=false)",
+                "EOF",
+            ],
+        },
+    ]
+
+
+def end_tag_attribute_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "end-tag-with-trailing-solidus",
+            "description": "end tags with trailing solidus emit the end tag and report recovery",
+            "input": "Before</p/>After",
+            "tokens": [
+                "Text(data=Before)",
+                "EndTag(name=p)",
+                "Text(data=After)",
+                "EOF",
+            ],
+            "diagnostics": ["end-tag-with-trailing-solidus"],
+        },
+        {
+            "id": "end-tag-with-whitespace-and-solidus",
+            "description": "end-tag whitespace before trailing solidus does not add an attribute diagnostic",
+            "input": "Before</p />After",
+            "tokens": [
+                "Text(data=Before)",
+                "EndTag(name=p)",
+                "Text(data=After)",
+                "EOF",
+            ],
+            "diagnostics": ["end-tag-with-trailing-solidus"],
+        },
+        {
+            "id": "end-tag-with-form-feed-and-solidus",
+            "description": "form feed is HTML whitespace before an end-tag trailing solidus",
+            "input": "Before</p\u000c/>After",
+            "tokens": [
+                "Text(data=Before)",
+                "EndTag(name=p)",
+                "Text(data=After)",
+                "EOF",
+            ],
+            "diagnostics": ["end-tag-with-trailing-solidus"],
+        },
+        {
+            "id": "end-tag-with-attributes",
+            "description": "end-tag attributes are ignored after reporting a single diagnostic",
+            "input": "Before</p class=x data-y>After",
+            "tokens": [
+                "Text(data=Before)",
+                "EndTag(name=p)",
+                "Text(data=After)",
+                "EOF",
+            ],
+            "diagnostics": ["end-tag-with-attributes"],
+        },
+        {
+            "id": "end-tag-with-attributes-and-trailing-solidus",
+            "description": "end-tag attributes followed by a solidus stay in attribute recovery",
+            "input": "Before</p class=x/>After",
+            "tokens": [
+                "Text(data=Before)",
+                "EndTag(name=p)",
+                "Text(data=After)",
+                "EOF",
+            ],
+            "diagnostics": ["end-tag-with-attributes"],
+        },
+    ]
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-attribute-edges.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-attribute-edges.json
@@ -1,0 +1,323 @@
+{
+  "cases": [
+    {
+      "description": "double, single, unquoted, and boolean attributes emit in source order",
+      "diagnostics": [],
+      "id": "mixed-quoted-and-unquoted-values",
+      "input": "<a one=\"1\" two='2' three=3 four>",
+      "tokens": [
+        "StartTag(name=a, attributes=[one=1, two=2, three=3, four=], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "HTML tag and attribute names are ASCII-lowercased",
+      "diagnostics": [],
+      "id": "uppercase-tag-and-attribute-names",
+      "input": "<DIV CLASS=Hero DATA-ID=42>",
+      "tokens": [
+        "StartTag(name=div, attributes=[class=Hero, data-id=42], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "empty quoted attributes stay present with empty values",
+      "diagnostics": [],
+      "id": "empty-quoted-values",
+      "input": "<input disabled value=\"\" data-empty=''>",
+      "tokens": [
+        "StartTag(name=input, attributes=[disabled=, value=, data-empty=], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "quoted attribute values preserve internal ASCII whitespace",
+      "diagnostics": [],
+      "id": "attribute-values-keep-whitespace-inside-quotes",
+      "input": "<p title=\"one two\tthree\nfour\">",
+      "tokens": [
+        "StartTag(name=p, attributes=[title=one two\tthree\nfour], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute character references decode through the attribute return state",
+      "diagnostics": [],
+      "id": "character-references-in-attributes",
+      "input": "<a title=\"A&amp;B\" data='&#x41;&#65;'>",
+      "tokens": [
+        "StartTag(name=a, attributes=[title=A&B, data=AA], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "semicolonless ambiguous ampersands stay literal in attributes",
+      "diagnostics": [],
+      "id": "ambiguous-ampersand-in-attribute",
+      "input": "<a href=\"?x=1&ampy=2\" title=Tom&ampJerry>",
+      "tokens": [
+        "StartTag(name=a, attributes=[href=?x=1&ampy=2, title=Tom&ampJerry], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "duplicate attribute names keep the first value and report recovery",
+      "diagnostics": [
+        "duplicate-attribute"
+      ],
+      "id": "duplicate-attributes-drop-later-name",
+      "input": "<a href=one HREF=two title=ok>",
+      "tokens": [
+        "StartTag(name=a, attributes=[href=one, title=ok], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unexpected unquoted value characters are preserved with diagnostics",
+      "diagnostics": [
+        "unexpected-character-in-unquoted-attribute-value",
+        "unexpected-character-in-unquoted-attribute-value",
+        "unexpected-character-in-unquoted-attribute-value",
+        "unexpected-character-in-unquoted-attribute-value",
+        "unexpected-character-in-unquoted-attribute-value"
+      ],
+      "id": "unexpected-unquoted-characters",
+      "input": "<a data=one=two sq=x'y lt=x<y tick=x`y dq=x\"y>",
+      "tokens": [
+        "StartTag(name=a, attributes=[data=one=two, sq=x'y, lt=x<y, tick=x`y, dq=x\"y], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unexpected characters at the beginning of unquoted values are preserved",
+      "diagnostics": [
+        "unexpected-character-in-unquoted-attribute-value",
+        "unexpected-character-in-unquoted-attribute-value",
+        "unexpected-character-in-unquoted-attribute-value"
+      ],
+      "id": "first-unquoted-value-characters",
+      "input": "<a lt=<x eq==x tick=`x ok=value>",
+      "tokens": [
+        "StartTag(name=a, attributes=[lt=<x, eq==x, tick=`x, ok=value], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "quote and less-than characters in attribute names report but stay literal",
+      "diagnostics": [
+        "unexpected-character-in-attribute-name",
+        "unexpected-character-in-attribute-name",
+        "unexpected-character-in-attribute-name"
+      ],
+      "id": "unexpected-attribute-name-characters",
+      "input": "<a \"pre=1 mid'dle=2 done <tail=3>",
+      "tokens": [
+        "StartTag(name=a, attributes=[\"pre=1, mid'dle=2, done=, <tail=3], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "quoted attributes without separating whitespace reconsume into new attributes",
+      "diagnostics": [
+        "missing-whitespace-between-attributes"
+      ],
+      "id": "missing-whitespace-after-quoted-value",
+      "input": "<a first=\"1\"second=2>",
+      "tokens": [
+        "StartTag(name=a, attributes=[first=1, second=2], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "missing whitespace before equals creates a recoverable equals-named attribute",
+      "diagnostics": [
+        "missing-whitespace-between-attributes",
+        "unexpected-equals-before-attribute-name"
+      ],
+      "id": "equals-before-attribute-name-after-quoted-value",
+      "input": "<a eq=\"x\"==y>",
+      "tokens": [
+        "StartTag(name=a, attributes=[eq=x, ==y], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULLs in quoted, unquoted, and bare attribute values become replacement characters",
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ],
+      "id": "nulls-in-attribute-values",
+      "input": "<a title=\"x\u0000y\" data=x\u0000y bare=\u0000>",
+      "tokens": [
+        "StartTag(name=a, attributes=[title=x�y, data=x�y, bare=�], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULLs in tag and attribute names become replacement characters",
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ],
+      "id": "nulls-in-tag-and-attribute-names",
+      "input": "<x\u0000 \u0000=v a\u0000b=1 first \u0000second=2>",
+      "tokens": [
+        "StartTag(name=x�, attributes=[�=v, a�b=1, first=, �second=2], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a solidus after whitespace sets the self-closing flag",
+      "diagnostics": [],
+      "id": "self-closing-with-space",
+      "input": "<br />",
+      "tokens": [
+        "StartTag(name=br, attributes=[], self_closing=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a solidus immediately after the tag name sets the self-closing flag",
+      "diagnostics": [],
+      "id": "self-closing-without-space",
+      "input": "<br/>",
+      "tokens": [
+        "StartTag(name=br, attributes=[], self_closing=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a second solidus before close is reported then preserves self-closing",
+      "diagnostics": [
+        "unexpected-solidus-in-tag"
+      ],
+      "id": "double-solidus-before-close",
+      "input": "<br//>",
+      "tokens": [
+        "StartTag(name=br, attributes=[], self_closing=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unexpected solidus before an attribute reconsumes in before-attribute-name",
+      "diagnostics": [
+        "unexpected-solidus-in-tag"
+      ],
+      "id": "unexpected-solidus-before-attribute",
+      "input": "<img/ src=one>",
+      "tokens": [
+        "StartTag(name=img, attributes=[src=one], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unexpected solidus before a NULL-starting attribute reports both recoveries",
+      "diagnostics": [
+        "unexpected-solidus-in-tag",
+        "unexpected-null-character"
+      ],
+      "id": "unexpected-solidus-before-null-attribute",
+      "input": "<hr/\u0000=x>",
+      "tokens": [
+        "StartTag(name=hr, attributes=[�=x], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "solidus stays value text inside unquoted attribute values",
+      "diagnostics": [],
+      "id": "solidus-in-unquoted-values",
+      "input": "<a href=http://example.test/path data=a/b>",
+      "tokens": [
+        "StartTag(name=a, attributes=[href=http://example.test/path, data=a/b], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a trailing solidus before tag close belongs to the unquoted value",
+      "diagnostics": [],
+      "id": "trailing-solidus-inside-unquoted-value",
+      "input": "<img src=cat/>",
+      "tokens": [
+        "StartTag(name=img, attributes=[src=cat/], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "end tags with trailing solidus emit the end tag and report recovery",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "end-tag-with-trailing-solidus",
+      "input": "Before</p/>After",
+      "tokens": [
+        "Text(data=Before)",
+        "EndTag(name=p)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "end-tag whitespace before trailing solidus does not add an attribute diagnostic",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "end-tag-with-whitespace-and-solidus",
+      "input": "Before</p />After",
+      "tokens": [
+        "Text(data=Before)",
+        "EndTag(name=p)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "form feed is HTML whitespace before an end-tag trailing solidus",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "end-tag-with-form-feed-and-solidus",
+      "input": "Before</p\f/>After",
+      "tokens": [
+        "Text(data=Before)",
+        "EndTag(name=p)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "end-tag attributes are ignored after reporting a single diagnostic",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "end-tag-with-attributes",
+      "input": "Before</p class=x data-y>After",
+      "tokens": [
+        "Text(data=Before)",
+        "EndTag(name=p)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "end-tag attributes followed by a solidus stay in attribute recovery",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "end-tag-with-attributes-and-trailing-solidus",
+      "input": "Before</p class=x/>After",
+      "tokens": [
+        "Text(data=Before)",
+        "EndTag(name=p)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Attribute tokenizer recovery for quoted and unquoted values, duplicates, missing whitespace, NULLs, self-closing delimiters, and recoverable end-tag attributes.",
+  "format": "whatwg-html-tokenizer-attribute-edges/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
@@ -1,0 +1,166 @@
+use coding_adventures_html_lexer::{create_html_lexer, Attribute, Token};
+use serde::Deserialize;
+
+const WHATWG_ATTRIBUTE_EDGES: &str = include_str!("fixtures/whatwg-attribute-edges.json");
+
+#[derive(Debug, Deserialize)]
+struct AttributeEdgeSuite {
+    format: String,
+    description: String,
+    cases: Vec<AttributeEdgeCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AttributeEdgeCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+}
+
+#[test]
+fn whatwg_attribute_edge_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-tokenizer-attribute-edges/v1");
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 25);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "duplicate-attributes-drop-later-name"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "unexpected-solidus-before-attribute"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "end-tag-with-attributes-and-trailing-solidus"));
+}
+
+#[test]
+fn whatwg_attribute_edge_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its attribute edge",
+            case.id
+        );
+        let mut lexer = create_html_lexer().expect("HTML lexer should build");
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> AttributeEdgeSuite {
+    serde_json::from_str(WHATWG_ATTRIBUTE_EDGES)
+        .expect("WHATWG attribute-edge fixture should parse")
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG attribute-edge fixture covering quoted/unquoted values, duplicate attributes, missing whitespace, NULL recovery, self-closing delimiters, unexpected solidus recovery, and end-tag attribute diagnostics
- add a Rust conformance test that runs the generated corpus through the default HTML lexer
- document the new fixture and generator in the lexer docs/changelog

## Verification
- cargo test -p coding-adventures-html-lexer --test whatwg_attribute_edges_test
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py --check
- git diff --check