### PR TITLE
feat(mosstyle+grid-emitter): sub-part styles for Grid → demo gridlines

### DIFF
--- a/code/grammars/mosstyle.grammar
+++ b/code/grammars/mosstyle.grammar
@@ -51,9 +51,19 @@ style_def = KEYWORD NAME LBRACE { part_def } RBRACE ;
 # ============================================================================
 # Part block
 # ============================================================================
-# part part-name { part_item* }
+# part <part-path> { part_item* }
+#
+# `part-path` is one or more kebab-case NAMEs joined by `/`. Single-segment
+# paths address top-level parts the .mll file declares (`part sheet { ... }`);
+# multi-segment paths address sub-parts the primitive emits internally
+# (`part sheet/cell { ... }`, `part sheet/header-cell { ... }`). The .msl
+# compiler stores the entire path string as the part name; the emitter
+# matches sub-parts at the synthesised-element level when rendering.
+# See UI27 §3 for the full motivation and §5 for the Grid sub-part
+# vocabulary (cell, header-cell, header-row, data-row, etc.).
 
-part_def = KEYWORD NAME LBRACE { part_item } RBRACE ;
+part_def = KEYWORD part_path LBRACE { part_item } RBRACE ;
+part_path = NAME { SLASH NAME } ;
 
 # ============================================================================
 # Part items

--- a/code/grammars/mosstyle.tokens
+++ b/code/grammars/mosstyle.tokens
@@ -65,3 +65,12 @@ RPAREN    = ")"
 SEMICOLON = ";"
 COLON     = ":"
 COMMA     = ","
+# SLASH separates a part name from a sub-part name, e.g. `part sheet/cell`.
+# Per UI27 §3.1: a part block may declare sub-parts using a slash-separated
+# path. The slash means "the sub-part named on the right, of the parent
+# part on the left." Lets authors style the internal structure of
+# primitives (Grid cells, header cells, rows) that the emitter synthesises
+# below the top-level part. Note: the SLASH token must NOT collide with
+# the line-comment / block-comment skip rules — those use `//` and `/*`
+# and are recognised by the longer-match lexer ordering (skip rules first).
+SLASH     = "/"

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -685,22 +685,57 @@ fn emit_grid_jsx(
         None => None,
     };
 
-    // Table-level part style.
-    let part_style_str = node
+    // Table-level part style and sub-part styles. The author's .msl
+    // can target `part sheet` (the `<table>` itself) as well as
+    // sub-parts emitted internally — `sheet/cell`, `sheet/header-cell`,
+    // `sheet/header-row`, `sheet/data-row` — using UI27 §3.1 sub-part
+    // syntax. We look each up against `part_styles` (keyed by the
+    // slash-joined path) and inline-style the corresponding synthesised
+    // element. Authors get gridlines, header backgrounds, row stripes,
+    // etc., without the emitter hardcoding any of them.
+    let lookup_subpart = |suffix: &str| -> String {
+        node.part_name
+            .as_deref()
+            .map(|n| format!("{n}/{suffix}"))
+            .and_then(|key| part_styles.get(&key).map(String::clone))
+            .unwrap_or_default()
+    };
+    let table_style_str = node
         .part_name
         .as_deref()
         .and_then(|n| part_styles.get(n).map(String::as_str))
         .unwrap_or("");
-    let table_style_attr = if part_style_str.is_empty() {
+    let cell_subpart_style = lookup_subpart("cell");
+    let header_cell_subpart_style = lookup_subpart("header-cell");
+    let header_row_subpart_style = lookup_subpart("header-row");
+    let data_row_subpart_style = lookup_subpart("data-row");
+
+    let table_style_attr = if table_style_str.is_empty() {
         String::new()
     } else {
-        format!(" style={{{{ {part_style_str} }}}}")
+        format!(" style={{{{ {table_style_str} }}}}")
+    };
+    let header_row_style_attr = if header_row_subpart_style.is_empty() {
+        String::new()
+    } else {
+        format!(" style={{{{ {header_row_subpart_style} }}}}")
+    };
+    let data_row_style_attr = if data_row_subpart_style.is_empty() {
+        String::new()
+    } else {
+        format!(" style={{{{ {data_row_subpart_style} }}}}")
+    };
+    let header_cell_style_attr = if header_cell_subpart_style.is_empty() {
+        String::new()
+    } else {
+        format!(" style={{{{ {header_cell_subpart_style} }}}}")
     };
 
-    // Build the per-cell `style={{...}}` expression. If any of the
-    // selected/edit slot refs are present, emit a small CSS-in-JS spread
-    // that picks the highlight color at render time.
+    // Build the per-cell `style={{...}}` expression. Merges the
+    // `sheet/cell` sub-part (defaults — borders, padding) with the
+    // selected/editing highlight spreads (runtime — per cell).
     let cell_style_expr = build_grid_cell_style_expr(
+        &cell_subpart_style,
         selected_row_var.as_deref(),
         selected_col_var.as_deref(),
         edit_row_var.as_deref(),
@@ -720,13 +755,13 @@ fn emit_grid_jsx(
     writeln!(out, "{pad2}<thead>").unwrap();
     writeln!(
         out,
-        "{pad4}<tr>{{{headers_var}.map((h, c) => <th key={{c}}>{{h}}</th>)}}</tr>"
+        "{pad4}<tr{header_row_style_attr}>{{{headers_var}.map((h, c) => <th key={{c}}{header_cell_style_attr}>{{h}}</th>)}}</tr>"
     )
     .unwrap();
     writeln!(out, "{pad2}</thead>").unwrap();
     writeln!(out, "{pad2}<tbody>").unwrap();
     writeln!(out, "{pad4}{{{rows_var}.map((row, r) => (").unwrap();
-    writeln!(out, "{pad6}<tr key={{r}}>").unwrap();
+    writeln!(out, "{pad6}<tr key={{r}}{data_row_style_attr}>").unwrap();
     writeln!(out, "{pad8}{{row.map((cell, c) => (").unwrap();
     writeln!(
         out,
@@ -753,6 +788,7 @@ fn emit_grid_jsx(
 /// defaults: a real production component would inline the design-token
 /// values from mosstyle. That's a follow-up.
 fn build_grid_cell_style_expr(
+    cell_subpart_style: &str,
     selected_row: Option<&str>,
     selected_col: Option<&str>,
     edit_row: Option<&str>,
@@ -760,15 +796,20 @@ fn build_grid_cell_style_expr(
 ) -> String {
     let has_selected = selected_row.is_some() && selected_col.is_some();
     let has_editing = edit_row.is_some() && edit_col.is_some();
+    let has_subpart = !cell_subpart_style.is_empty();
 
-    if !has_selected && !has_editing {
+    if !has_selected && !has_editing && !has_subpart {
         return String::new();
     }
 
+    // Build the spread chain. The author's `part sheet/cell` style
+    // goes FIRST so subsequent state-dependent spreads can override
+    // any property (last-property-wins per React's style merging).
     let mut parts: Vec<String> = Vec::new();
-
+    if has_subpart {
+        parts.push(cell_subpart_style.to_string());
+    }
     if let (Some(sr), Some(sc)) = (selected_row, selected_col) {
-        // Selection highlight: `(r === sr && c === sc) ? selectedStyles : {}`.
         parts.push(format!(
             "...(r === {sr} && c === {sc} ? {{ background: \"#264f78\", color: \"#ffffff\", outline: \"1px solid #007acc\" }} : {{}})"
         ));
@@ -2379,6 +2420,171 @@ mod tests {
                 "<table style={{ fontFamily: \"monospace\", borderCollapse: \"collapse\" }}>"
             ),
             "expected styled <table>, got:\n{}",
+            result.output
+        );
+    }
+
+    /// Sub-part styles authored as `part sheet/cell { ... }` end up
+    /// inlined on every `<td>`, giving the Grid its gridlines without
+    /// the emitter hardcoding any border colours (UI27 §3 / §5).
+    /// Likewise `sheet/header-cell`, `sheet/header-row`, and
+    /// `sheet/data-row` light up `<th>`, `<thead><tr>`, and
+    /// `<tbody><tr>` respectively.
+    #[test]
+    fn grid_subpart_styles_appear_on_synthesised_cells_and_rows() {
+        let m = component(
+            "G",
+            vec![
+                slot("col-labels", SlotType::List(Box::new(ListInnerType::Text)), true),
+                slot("data-rows", SlotType::List(Box::new(ListInnerType::Text)), true),
+            ],
+            vec![],
+        );
+        // Build a StyleDef with multiple sub-parts under "sheet".
+        let s = StyleDef {
+            component_name: "G".to_string(),
+            parts: vec![
+                PartStyle {
+                    name: "sheet".to_string(),
+                    base: vec![StyleProp {
+                        name: "border-collapse".to_string(),
+                        value: "collapse".to_string(),
+                    }],
+                    states: Vec::new(),
+                },
+                PartStyle {
+                    name: "sheet/cell".to_string(),
+                    base: vec![
+                        StyleProp {
+                            name: "border-width".to_string(),
+                            value: "1px".to_string(),
+                        },
+                        StyleProp {
+                            name: "border-style".to_string(),
+                            value: "solid".to_string(),
+                        },
+                        StyleProp {
+                            name: "border-color".to_string(),
+                            value: "#3f3f46".to_string(),
+                        },
+                    ],
+                    states: Vec::new(),
+                },
+                PartStyle {
+                    name: "sheet/header-cell".to_string(),
+                    base: vec![StyleProp {
+                        name: "background".to_string(),
+                        value: "#2d2d30".to_string(),
+                    }],
+                    states: Vec::new(),
+                },
+                PartStyle {
+                    name: "sheet/header-row".to_string(),
+                    base: vec![StyleProp {
+                        name: "height".to_string(),
+                        value: "24px".to_string(),
+                    }],
+                    states: Vec::new(),
+                },
+                PartStyle {
+                    name: "sheet/data-row".to_string(),
+                    base: vec![StyleProp {
+                        name: "height".to_string(),
+                        value: "22px".to_string(),
+                    }],
+                    states: Vec::new(),
+                },
+            ],
+        };
+        let l = LayoutDef {
+            component_name: "G".to_string(),
+            root: LayoutNode {
+                tag: "Grid".to_string(),
+                part_name: Some("sheet".to_string()),
+                props: vec![
+                    slot_ref_prop("headers", "col-labels"),
+                    slot_ref_prop("rows", "data-rows"),
+                ],
+                children: Vec::new(),
+            },
+        };
+        let result = from_pipeline(&m, &l, &s).unwrap();
+        // <table> still carries the top-level sheet style.
+        assert!(
+            result.output.contains("<table style={{ borderCollapse: \"collapse\" }}>"),
+            "expected sheet style on <table>; got:\n{}",
+            result.output
+        );
+        // <td> carries the sheet/cell sub-part style.
+        assert!(
+            result.output.contains(
+                "<td key={c} style={{ borderWidth: \"1px\", borderStyle: \"solid\", borderColor: \"#3f3f46\" }}>"
+            ),
+            "expected sheet/cell inlined on <td>; got:\n{}",
+            result.output
+        );
+        // <th> carries the sheet/header-cell sub-part style.
+        assert!(
+            result.output.contains(
+                "<th key={c} style={{ background: \"#2d2d30\" }}>"
+            ),
+            "expected sheet/header-cell on <th>; got:\n{}",
+            result.output
+        );
+        // <thead><tr> carries the sheet/header-row sub-part style.
+        assert!(
+            result.output.contains("<tr style={{ height: \"24px\" }}>"),
+            "expected sheet/header-row on <tr>; got:\n{}",
+            result.output
+        );
+        // <tbody><tr> carries the sheet/data-row sub-part style.
+        assert!(
+            result.output.contains("<tr key={r} style={{ height: \"22px\" }}>"),
+            "expected sheet/data-row on <tr>; got:\n{}",
+            result.output
+        );
+    }
+
+    /// When only the sheet/cell sub-part is set (no selection / edit
+    /// slots), the per-cell style attribute carries just the sub-part
+    /// fragment — no leading comma or empty spread.
+    #[test]
+    fn grid_subpart_only_no_state_slots_still_inlines_cell_style() {
+        let m = component(
+            "G",
+            vec![
+                slot("col-labels", SlotType::List(Box::new(ListInnerType::Text)), true),
+                slot("data-rows", SlotType::List(Box::new(ListInnerType::Text)), true),
+            ],
+            vec![],
+        );
+        let s = StyleDef {
+            component_name: "G".to_string(),
+            parts: vec![PartStyle {
+                name: "sheet/cell".to_string(),
+                base: vec![StyleProp {
+                    name: "padding".to_string(),
+                    value: "4px".to_string(),
+                }],
+                states: Vec::new(),
+            }],
+        };
+        let l = LayoutDef {
+            component_name: "G".to_string(),
+            root: LayoutNode {
+                tag: "Grid".to_string(),
+                part_name: Some("sheet".to_string()),
+                props: vec![
+                    slot_ref_prop("headers", "col-labels"),
+                    slot_ref_prop("rows", "data-rows"),
+                ],
+                children: Vec::new(),
+            },
+        };
+        let result = from_pipeline(&m, &l, &s).unwrap();
+        assert!(
+            result.output.contains("<td key={c} style={{ padding: \"4px\" }}>"),
+            "expected just the sub-part fragment on <td>; got:\n{}",
             result.output
         );
     }

--- a/code/packages/rust/mosstyle-compiler/src/_grammar.rs
+++ b/code/packages/rust/mosstyle-compiler/src/_grammar.rs
@@ -115,6 +115,17 @@ pub fn token_grammar() -> TokenGrammar {
                 line_number: 67,
                 alias: None,
             },
+            // SLASH is the sub-part separator: `part sheet/cell`. Must
+            // come AFTER the LINE_COMMENT / BLOCK_COMMENT skip rules so
+            // `//` and `/*` are still recognised as comments — those
+            // are longer-pattern skips that the lexer tries first.
+            TokenDefinition {
+                name: r#"SLASH"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 76,
+                alias: None,
+            },
         ],
         keywords: vec![r#"style"#.to_string(), r#"part"#.to_string(), r#"state"#.to_string()],
         mode: None,
@@ -179,16 +190,31 @@ pub fn parser_grammar() -> ParserGrammar {
             ] },
             line_number: 49,
         },
+        // part_def = KEYWORD part_path LBRACE { part_item } RBRACE ;
+        // part_path replaces a bare NAME so the grammar can address
+        // sub-parts like `part sheet/cell` (UI27 §3.1).
         GrammarRule {
             name: r#"part_def"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"part_path"#.to_string() },
                 GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"part_item"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
             line_number: 56,
+        },
+        // part_path = NAME { SLASH NAME } ;
+        GrammarRule {
+            name: r#"part_path"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                ] }) },
+            ] },
+            line_number: 57,
         },
         GrammarRule {
             name: r#"part_item"#.to_string(),

--- a/code/packages/rust/mosstyle-compiler/src/lib.rs
+++ b/code/packages/rust/mosstyle-compiler/src/lib.rs
@@ -299,42 +299,46 @@ fn extract_parts(style_def: &GrammarASTNode) -> Result<Vec<PartStyle>, CompileEr
 }
 
 fn analyze_part(part_def: &GrammarASTNode) -> Result<PartStyle, CompileError> {
-    // part_def = KEYWORD("part") NAME LBRACE { part_item } RBRACE
-    let mut saw_keyword = false;
+    // part_def = KEYWORD("part") part_path LBRACE { part_item } RBRACE
+    //
+    // part_path = NAME { SLASH NAME }
+    //   Single-segment paths (sheet) address top-level parts; multi-
+    //   segment paths (sheet/cell) address sub-parts the primitive
+    //   emits internally. Per UI27 §3.1. The full slash-joined path
+    //   becomes the PartStyle.name and gets matched at emit time.
     let mut name: Option<String> = None;
     let mut base: Vec<StyleProp> = Vec::new();
     let mut states: Vec<StateStyle> = Vec::new();
 
     for child in &part_def.children {
         match child {
-            ASTNodeOrToken::Token(t) => {
-                if t.type_ == TokenType::Keyword && t.value == "part" {
-                    saw_keyword = true;
-                } else if saw_keyword && t.type_ == TokenType::Name && name.is_none() {
-                    name = Some(t.value.clone());
-                }
+            ASTNodeOrToken::Token(_) => {
+                // KEYWORD("part") and the structural punctuation tokens
+                // are consumed by the grammar without contributing to
+                // the analyzed result.
             }
-            ASTNodeOrToken::Node(n) => {
-                match n.rule_name.as_str() {
-                    "part_item" => {
-                        // part_item contains either state_block or property_decl.
-                        for item_child in &n.children {
-                            if let ASTNodeOrToken::Node(inner) = item_child {
-                                match inner.rule_name.as_str() {
-                                    "property_decl" => {
-                                        base.push(analyze_property(inner)?);
-                                    }
-                                    "state_block" => {
-                                        states.push(analyze_state(inner)?);
-                                    }
-                                    _ => {}
+            ASTNodeOrToken::Node(n) => match n.rule_name.as_str() {
+                "part_path" => {
+                    name = Some(analyze_part_path(n));
+                }
+                "part_item" => {
+                    // part_item contains either state_block or property_decl.
+                    for item_child in &n.children {
+                        if let ASTNodeOrToken::Node(inner) = item_child {
+                            match inner.rule_name.as_str() {
+                                "property_decl" => {
+                                    base.push(analyze_property(inner)?);
                                 }
+                                "state_block" => {
+                                    states.push(analyze_state(inner)?);
+                                }
+                                _ => {}
                             }
                         }
                     }
-                    _ => {}
                 }
-            }
+                _ => {}
+            },
         }
     }
 
@@ -346,6 +350,21 @@ fn analyze_part(part_def: &GrammarASTNode) -> Result<PartStyle, CompileError> {
         base,
         states,
     })
+}
+
+/// Join the NAME tokens of a `part_path` AST node with `/`. The
+/// SLASH tokens between them are dropped — they were structural
+/// separators, not semantic content.
+fn analyze_part_path(part_path: &GrammarASTNode) -> String {
+    let mut segments: Vec<String> = Vec::new();
+    for child in &part_path.children {
+        if let ASTNodeOrToken::Token(t) = child {
+            if t.type_ == TokenType::Name {
+                segments.push(t.value.clone());
+            }
+        }
+    }
+    segments.join("/")
 }
 
 fn analyze_state(state_block: &GrammarASTNode) -> Result<StateStyle, CompileError> {
@@ -473,7 +492,18 @@ pub fn validate(
 
     for part in &def.parts {
         // Validate part existence.
-        if has_part_map && !known_parts.contains(&part.name) {
+        //
+        // Sub-part paths (UI27 §3.1) contain a `/` separator —
+        // `sheet/cell` addresses the `cell` sub-part of the top-level
+        // `sheet` part. For validation we only require the top-level
+        // segment (before the first `/`) to exist in the .mll's
+        // part map. The sub-part name itself is validated by the
+        // primitive's known sub-part vocabulary at emit time (Grid
+        // exposes cell/header-cell/header-row/data-row/etc. per
+        // UI27 §5; the mosstyle compiler is intentionally agnostic
+        // here so it stays primitive-agnostic).
+        let lookup_name = part.name.split('/').next().unwrap_or(&part.name);
+        if has_part_map && !known_parts.contains(lookup_name) {
             errors.push(CompileError {
                 kind: ErrorKind::UnknownPart,
                 message: format!(
@@ -867,6 +897,88 @@ mod tests {
         assert!(result.is_err());
         let errs = result.unwrap_err();
         assert!(errs.iter().any(|e| e.kind == ErrorKind::UnknownPart));
+    }
+
+    // ── Sub-parts (UI27 §3) ──────────────────────────────────────────────────
+
+    /// Slash-separated `part sheet/cell` paths parse cleanly. The
+    /// PartStyle.name carries the entire `sheet/cell` string so the
+    /// emitter can match it at the synthesised-element level.
+    #[test]
+    fn test_parse_subpart_path() {
+        // NB: we deliberately use longhand `border-width / border-style /
+        // border-color` triplets instead of the CSS-shorthand
+        // `border: 1px solid #color` form. The current mosstyle grammar
+        // accepts only one style_value per property_decl; multi-value
+        // shorthand is a separate future grammar extension.
+        let src = r#"
+          style Grid {
+            part sheet {
+              background: #1e1e1e ;
+            }
+            part sheet/cell {
+              border-width: 1px ;
+              border-style: solid ;
+              border-color: #3f3f46 ;
+            }
+            part sheet/header-cell {
+              background: #2d2d30 ;
+              font-weight: bold ;
+            }
+          }
+        "#;
+        let result = compile(src, None).expect("sub-parts should compile");
+        let names: Vec<&str> = result.def.parts.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"sheet"));
+        assert!(names.contains(&"sheet/cell"));
+        assert!(names.contains(&"sheet/header-cell"));
+    }
+
+    /// Validator only checks the TOP-LEVEL segment of a sub-part path
+    /// against the .mll's part map. `sheet/cell` is OK if `sheet`
+    /// exists; the sub-part name `cell` is the primitive's concern.
+    #[test]
+    fn test_subpart_passes_when_top_level_part_exists() {
+        let part_map =
+            r#"{"component":"Grid","parts":[{"name":"sheet","primitive":"Grid"}]}"#;
+        let src = r#"
+          style Grid {
+            part sheet { background: #1e1e1e ; }
+            part sheet/cell { border-color: #3f3f46 ; }
+          }
+        "#;
+        let result = compile(src, Some(part_map));
+        assert!(result.is_ok(), "sub-part of an exported top-level part should validate");
+    }
+
+    /// Conversely, a sub-part whose top-level segment is NOT in the
+    /// part map still triggers UnknownPart.
+    #[test]
+    fn test_subpart_unknown_top_level_errors() {
+        let part_map =
+            r#"{"component":"Grid","parts":[{"name":"sheet","primitive":"Grid"}]}"#;
+        let src = r#"
+          style Grid {
+            part nonexistent/cell { border-color: #3f3f46 ; }
+          }
+        "#;
+        let result = compile(src, Some(part_map));
+        assert!(result.is_err());
+        let errs = result.unwrap_err();
+        assert!(errs.iter().any(|e| e.kind == ErrorKind::UnknownPart));
+    }
+
+    /// Triple-nested paths parse — `part sheet/header/cell` is a
+    /// hypothetical future case; the grammar permits arbitrary depth.
+    #[test]
+    fn test_deep_subpart_path() {
+        let src = r#"
+          style Grid {
+            part sheet/header/cell { background: #2d2d30 ; }
+          }
+        "#;
+        let result = compile(src, None).expect("deep sub-paths should compile");
+        assert_eq!(result.def.parts[0].name, "sheet/header/cell");
     }
 
     #[test]

--- a/demo/visicalc/mosaic/Grid.dark.msl
+++ b/demo/visicalc/mosaic/Grid.dark.msl
@@ -1,10 +1,18 @@
 // Grid.dark.msl — dark theme for the spreadsheet grid (UI26 §4.2).
 //
-// Note: state blocks (hover/selected/editing) are tracked by the
-// pipeline emitter as a known limitation — the inline conditional
-// `style={{ ... }}` expression in the Grid emitter handles
-// selected/editing highlights directly from the slot refs, so we
-// don't repeat the colors here.
+// Sub-part vocabulary (UI27 §5):
+//   sheet              — the outer <table>
+//   sheet/cell         — every body <td> (gridlines live here)
+//   sheet/header-cell  — every column-header <th>
+//   sheet/header-row   — the <tr> inside <thead>
+//   sheet/data-row     — every <tr> inside <tbody>
+//
+// State blocks (hover/selected/editing) are still handled by the
+// emitter's inline conditional `style={{ ... }}` spread — the Grid
+// component reads selected-row / selected-col / edit-row / edit-col
+// slots and merges per-cell highlight styles on top of `sheet/cell`.
+// Today those highlight colours are hardcoded in the emitter; a
+// follow-up will route them through the design tokens here.
 
 style Grid {
   part sheet {
@@ -14,5 +22,39 @@ style Grid {
     background:      #1e1e1e ;
     border-collapse: collapse ;
     width:           100% ;
+  }
+
+  // Body cells. The `border-*` triplet draws the gridlines that
+  // were missing in the first demo cut.
+  part sheet/cell {
+    border-width: 1px ;
+    border-style: solid ;
+    border-color: #3f3f46 ;
+    padding:      2px ;
+    height:       22px ;
+  }
+
+  // Column-header cells (the labels A, B, C, ... at the top).
+  part sheet/header-cell {
+    background:  #2d2d30 ;
+    color:       #9d9d9d ;
+    font-weight: normal ;
+    text-align:  center ;
+    border-width: 1px ;
+    border-style: solid ;
+    border-color: #3f3f46 ;
+  }
+
+  // The header row itself sets the row height; useful when the
+  // first column eventually gains row numbers.
+  part sheet/header-row {
+    height: 24px ;
+  }
+
+  // Body data rows share the cell height. Once row-stripe styling
+  // arrives (UI27 §5 `data-row:even`), alternating backgrounds will
+  // also live here.
+  part sheet/data-row {
+    height: 22px ;
   }
 }


### PR DESCRIPTION
## Summary

Adds gridlines to the VisiCalc demo. The first demo cut shipped without grid lines: mosstyle could target `part sheet` (the `<table>`) but had no way to reach into the `<td>`/`<th>`/`<tr>` elements the Grid emitter synthesises internally. UI27 §3 spells out the fix; this lands the minimal slice.

## What ships

### mosstyle grammar (sub-part syntax per UI27 §3.1)

- New **`SLASH = "/"`** token (defined after `LINE_COMMENT`/`BLOCK_COMMENT` skip rules so `//` and `/*` still win)
- **`part_def`** now reads `KEYWORD part_path LBRACE ... RBRACE`; **`part_path = NAME { SLASH NAME }`** — multi-segment paths like `part sheet/cell` parse cleanly. Single-segment paths still work.

### mosstyle-compiler

- `analyze_part` reads a `part_path` AST node and joins segments with `/` for `PartStyle.name`
- `validate()` only checks the TOP-LEVEL segment against the .mll's part map — the sub-part name is the primitive's vocabulary, not the compiler's concern (per UI27 §3.3, a future PR will add per-primitive vocabulary validation)

### mosaic-emit-react Grid emitter

`emit_grid_jsx` looks up four sub-parts and inlines them on the corresponding synthesised elements:

| Sub-part key | Lands on |
|---|---|
| `<sheet>/cell` | every body `<td>` |
| `<sheet>/header-cell` | every `<th>` |
| `<sheet>/header-row` | the `<thead><tr>` |
| `<sheet>/data-row` | every `<tbody><tr>` |

`build_grid_cell_style_expr` emits the sub-part fragment BEFORE the selection / editing spreads, so highlight overrides design-time defaults (React last-property-wins).

### Demo

`demo/visicalc/mosaic/Grid.dark.msl` now authors the gridlines:

```mosstyle
part sheet/cell {
  border-width: 1px ;
  border-style: solid ;
  border-color: #3f3f46 ;
  padding:      2px ;
  height:       22px ;
}
```

After regenerating `Grid.tsx`, every `<td>` emits `borderWidth: "1px", borderStyle: "solid", borderColor: "#3f3f46"`. **Gridlines appear.**

## Test plan

- [x] **mosstyle-compiler**: 21 unit tests (was 17, +4 sub-part tests including deep `sheet/header/cell`)
- [x] **mosaic-emit-react**: 72 lib tests (was 70, +2 sub-part tests covering full grid + cell-only)
- [x] `bash demo/visicalc/scripts/build.sh` succeeds; generated `Grid.tsx` carries the new sub-part styles (verified via grep — `borderWidth: "1px"`, `<th>` style, header/data row styles)
- [x] Generated `demo/visicalc/src/components/*.tsx` files remain gitignored
- [ ] CI green

## Not in this PR (queued)

- Multi-value CSS shorthand (`border: 1px solid #3f3f46` must currently be three longhand decls)
- Per-primitive sub-part vocabulary validation (UI27 §3.3)
- Slot-driven style overrides (UI27 §4 — typed `.mil` styling slots like `cell-border-color`)
- `data-row:even` row-stripe state suffix (UI27 §5)
- Routing the hardcoded selection/editing colours (`#264f78`, `#1f4f3f`) through design tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
