### PR TITLE
feat(mosaic-emit-react): Grid column-widths slot ref

### DIFF
--- a/code/packages/rust/mosaic-emit-react/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-react/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Grid `column-widths` slot ref
+
+- The Grid primitive now reads an optional `column-widths` slot-ref prop
+  (UI26 §2.1). When bound, the emitter writes a `<colgroup>` between the
+  opening `<table>` and the `<thead>`, mapping each width to a
+  `<col style={{ width: "${w}px" }} />`. Both `<th>` and `<td>` in the
+  same column inherit the width through the standard HTML table model.
+- When the prop is absent (existing demos), no `<colgroup>` is emitted,
+  preserving the previous flex-default behaviour.
+- Two new tests cover both branches.
+- The VisiCalc demo (`demo/visicalc/mosaic/Grid.mil` and
+  `Grid.desktop.mll`) was updated to declare and bind the slot, and
+  `App.tsx` now passes `state.columnWidths` through. Resolves known
+  limitation #5 in `demo/visicalc/README.md`.
+
 ### Changed — event-union types are now exported
 
 - `emit_event_union` now writes `export type {Component}Event = ...`

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -677,6 +677,17 @@ fn emit_grid_jsx(
     validate_slot_or_field_name(&headers_var).map_err(PipelineEmitError::UnsafeSlotName)?;
     validate_slot_or_field_name(&rows_var).map_err(PipelineEmitError::UnsafeSlotName)?;
 
+    // Optional column-widths slot ref — when bound, emit a `<colgroup>` so
+    // each column carries an explicit pixel width. The slot is expected to
+    // be `Array<number>` (in mosmodel: `slot column-widths : list<number>`)
+    // and is iterated alongside `headers` / cells.
+    let column_widths_var = find_slot_ref_prop(node, "column-widths")
+        .map(to_camel_case_first_lower)
+        .filter(|s| !s.is_empty());
+    if let Some(v) = column_widths_var.as_deref() {
+        validate_slot_or_field_name(v).map_err(PipelineEmitError::UnsafeSlotName)?;
+    }
+
     // Optional state slot refs — render selection / editing highlights when present.
     let selected_row_var = find_slot_ref_prop(node, "selected-row")
         .map(to_camel_case_first_lower)
@@ -775,6 +786,19 @@ fn emit_grid_jsx(
 
     let mut out = String::new();
     writeln!(out, "{pad}<table{table_style_attr}>").unwrap();
+    // Emit a `<colgroup>` when column-widths is bound. Each `<col>` carries an
+    // inline `style={{ width: "${w}px" }}` so both `<thead>` `<th>` and
+    // `<tbody>` `<td>` pick up the column width without needing per-cell
+    // styling.
+    if let Some(widths_var) = column_widths_var.as_deref() {
+        writeln!(out, "{pad2}<colgroup>").unwrap();
+        writeln!(
+            out,
+            "{pad4}{{{widths_var}.map((w, c) => <col key={{c}} style={{{{ width: `${{w}}px` }}}} />)}}"
+        )
+        .unwrap();
+        writeln!(out, "{pad2}</colgroup>").unwrap();
+    }
     writeln!(out, "{pad2}<thead>").unwrap();
     writeln!(
         out,
@@ -2565,6 +2589,77 @@ mod tests {
                 "<table style={{ fontFamily: \"monospace\", borderCollapse: \"collapse\" }}>"
             ),
             "expected styled <table>, got:\n{}",
+            result.output
+        );
+    }
+
+    /// UI26 §2.1 — `column-widths : list<number>`.
+    ///
+    /// When the Grid layout binds `column-widths: slot: column-widths`, the
+    /// emitter writes a `<colgroup>` between the opening `<table>` and the
+    /// `<thead>`, mapping each width to a `<col style={{ width: "${w}px" }} />`.
+    /// This makes both `<th>` and `<td>` in the same column inherit the
+    /// width without per-cell styling.
+    #[test]
+    fn grid_column_widths_emits_colgroup_with_pixel_widths() {
+        let m = component(
+            "G",
+            vec![
+                slot("col-labels", SlotType::List(Box::new(ListInnerType::Text)), true),
+                slot("data-rows", SlotType::List(Box::new(ListInnerType::Text)), true),
+                slot("col-widths", SlotType::List(Box::new(ListInnerType::Number)), true),
+            ],
+            vec![],
+        );
+        let l = grid_layout(
+            "G",
+            vec![
+                slot_ref_prop("headers", "col-labels"),
+                slot_ref_prop("rows", "data-rows"),
+                slot_ref_prop("column-widths", "col-widths"),
+            ],
+        );
+        let result = from_pipeline(&m, &l, &empty_style("G")).unwrap();
+        let out = &result.output;
+        assert!(
+            out.contains("<colgroup>"),
+            "expected <colgroup>, got:\n{out}"
+        );
+        assert!(
+            out.contains("colWidths.map((w, c) => <col key={c} style={{ width: `${w}px` }} />)"),
+            "expected col mapper, got:\n{out}"
+        );
+        assert!(out.contains("</colgroup>"), "expected </colgroup>");
+        // colgroup must precede thead.
+        let cg = out.find("<colgroup>").unwrap();
+        let th = out.find("<thead>").unwrap();
+        assert!(cg < th, "expected <colgroup> before <thead>, got:\n{out}");
+    }
+
+    /// When `column-widths` is *not* bound the emitter must remain
+    /// backwards-compatible: no `<colgroup>` element appears and columns
+    /// are flex-default. This guards against accidental always-on emission.
+    #[test]
+    fn grid_without_column_widths_emits_no_colgroup() {
+        let m = component(
+            "G",
+            vec![
+                slot("col-labels", SlotType::List(Box::new(ListInnerType::Text)), true),
+                slot("data-rows", SlotType::List(Box::new(ListInnerType::Text)), true),
+            ],
+            vec![],
+        );
+        let l = grid_layout(
+            "G",
+            vec![
+                slot_ref_prop("headers", "col-labels"),
+                slot_ref_prop("rows", "data-rows"),
+            ],
+        );
+        let result = from_pipeline(&m, &l, &empty_style("G")).unwrap();
+        assert!(
+            !result.output.contains("<colgroup>"),
+            "expected no <colgroup>, got:\n{}",
             result.output
         );
     }

--- a/demo/visicalc/README.md
+++ b/demo/visicalc/README.md
@@ -121,9 +121,11 @@ contributor can pick them up:
    `editCommit` is where a real formula engine would plug in; see
    UI26 §11 and the separate formula-engine track for details.
 
-5. **No column-widths binding.** UI26 §2.1 also lists a `column-widths`
-   slot; the Grid emitter doesn't yet read it. Columns are flex-default.
-   Follow-up: pass `column-widths` through the Grid emitter.
+5. ~~**No column-widths binding.**~~ *Resolved.* The Grid emitter now
+   reads the optional `column-widths` slot ref (UI26 §2.1) and emits a
+   `<colgroup>` mapping each width to a `<col style={{ width: "${w}px" }} />`.
+   The VisiCalc host passes `state.columnWidths` through, so both
+   header and body cells share a stable per-column width.
 
 6. **No viewport virtualisation.** The host passes the full viewport
    slice; the Grid renders every row it sees. Row-windowing is the

--- a/demo/visicalc/mosaic/Grid.desktop.mll
+++ b/demo/visicalc/mosaic/Grid.desktop.mll
@@ -6,12 +6,13 @@
 
 layout Grid {
   Grid [sheet] (
-    headers:      slot: column-headers,
-    rows:         slot: viewport-rows,
-    selected-row: slot: selected-row,
-    selected-col: slot: selected-col,
-    edit-row:     slot: edit-row,
-    edit-col:     slot: edit-col,
-    onNavigate:   emit: onNavigate
+    headers:       slot: column-headers,
+    rows:          slot: viewport-rows,
+    column-widths: slot: column-widths,
+    selected-row:  slot: selected-row,
+    selected-col:  slot: selected-col,
+    edit-row:      slot: edit-row,
+    edit-col:      slot: edit-col,
+    onNavigate:    emit: onNavigate
   )
 }

--- a/demo/visicalc/mosaic/Grid.mil
+++ b/demo/visicalc/mosaic/Grid.mil
@@ -16,6 +16,11 @@ component Grid {
   // `@ts-expect-error` to paper over the mismatch.
   slot viewport-rows  : list<list<text>> ;
 
+  // Per-column pixel widths. The Grid emitter writes a `<colgroup>`
+  // when this slot is bound, so each column has a stable width
+  // regardless of its content. UI26 §2.1.
+  slot column-widths  : list<number> ;
+
   // Selection (host owns, pushes in).
   slot selected-row : number ;
   slot selected-col : number ;

--- a/demo/visicalc/src/app/App.tsx
+++ b/demo/visicalc/src/app/App.tsx
@@ -115,6 +115,7 @@ export function App() {
       <Grid
         columnHeaders={state.columnHeaders}
         viewportRows={viewportRows}
+        columnWidths={state.columnWidths}
         selectedRow={state.selectedRow - state.viewportOffset}
         selectedCol={state.selectedCol}
         editRow={state.editRow - state.viewportOffset}


### PR DESCRIPTION
## Summary

- The Grid primitive now reads an optional `column-widths` slot-ref prop (UI26 §2.1). When bound, the emitter writes a `<colgroup>` between the opening `<table>` and the `<thead>`, mapping each width to a `<col style={{ width: \"\${w}px\" }} />`. Both `<th>` and `<td>` in the same column inherit the width through the standard HTML table model.
- When the prop is absent, no `<colgroup>` is emitted (existing demos remain flex-default).
- The VisiCalc demo declares `slot column-widths : list<number>`, binds it through the layout, and passes `state.columnWidths` from the host App.

Resolves known limitation #5 in `demo/visicalc/README.md`.

## Stacked on #3457

This branch is based on `claude/emit-export-event-union` (PR #3457). It will rebase onto main cleanly once #3457 merges; reviewers can also review on its own merits since the diff is independent.

## Test plan

- [x] `cargo test -p mosaic-emit-react --lib` — 74 tests pass (was 72; +2 for the new column-widths cases: `grid_column_widths_emits_colgroup_with_pixel_widths`, `grid_without_column_widths_emits_no_colgroup`)
- [ ] CI green
- [ ] After regenerating with `bash demo/visicalc/scripts/build.sh`, the demo Grid renders with stable per-column widths

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)