### PR TITLE
Add WHATWG tag-open recovery conformance sweep

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -67,6 +67,9 @@ documented in this file.
   that pins quoted/unquoted values, duplicate attributes, missing-whitespace
   recovery, NULL replacement, self-closing delimiters, unexpected solidus
   recovery, and end-tag attribute diagnostics.
+- A generated WHATWG tokenizer tag-open recovery fixture and Rust conformance
+  test that pins ordinary tags, ASCII casing, tag whitespace, invalid openers,
+  NULL replacement in tag names, and EOF partial-token drops.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -87,6 +87,9 @@ continuation, and seeded declaration continuation behavior.
 The generated attribute-edge suite pins quoted/unquoted values, duplicate
 attributes, missing-whitespace recovery, NULL replacement, self-closing
 delimiters, unexpected solidus recovery, and end-tag attribute diagnostics.
+The generated tag-open recovery suite pins ordinary tags, ASCII casing, tag
+whitespace, invalid openers, NULL replacement in tag names, and EOF
+partial-token drops.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -74,6 +74,9 @@ binary while production code continues to link only static Rust source.
   used by Rust tests to pin quoted/unquoted values, duplicate attributes,
   missing whitespace recovery, NULL replacement, self-closing delimiters, and
   end-tag attribute diagnostics
+- `whatwg-tag-open-recovery.json`: generated HTML tokenizer tag-open recovery
+  cases used by Rust tests to pin ordinary tags, ASCII casing, tag whitespace,
+  invalid openers, NULL replacement in tag names, and EOF partial-token drops
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
@@ -103,6 +106,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_attribute_edges_fixture.py`: importer that generates
   attribute-edge recovery cases for the checked-in
   `whatwg-attribute-edges.json` fixture
+- `generate_whatwg_tag_open_recovery_fixture.py`: importer that generates
+  tag-open recovery cases for the checked-in
+  `whatwg-tag-open-recovery.json` fixture
 
 Regenerate or verify the WHATWG entity fixture with:
 
@@ -167,6 +173,14 @@ Regenerate or verify the WHATWG attribute-edge fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG tag-open recovery fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py \
   --check
 ```
 
@@ -319,6 +333,9 @@ currently supports:
   attributes, missing whitespace recovery, unexpected attribute characters,
   NULL replacement, self-closing delimiters, unexpected solidus recovery, and
   end-tag attributes
+- generated tag-open recovery coverage across ordinary tags, ASCII casing,
+  HTML whitespace delimiters, invalid tag openers, NULL replacement in tag
+  names, and EOF partial-token drops
 - EOF recovery for unfinished ordinary start and end tags, ensuring partial
   tokens are dropped before the parser sees them
 - EOF recovery for unfinished attribute character references, including named

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer tag-open recovery fixture.
+
+Tag-open and tag-name states decide whether `<` starts markup, remains text, or
+falls into bogus-comment recovery. This fixture pins the visible lexer contract
+for ordinary start/end tags, ASCII casing, tag whitespace, invalid openers,
+NULL replacement in tag names, and EOF recovery for partial tag tokens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-tag-open-recovery.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer tag-open recovery fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-tag-open-recovery/v1",
+        "description": (
+            "Tag-open and tag-name recovery for ordinary tags, ASCII casing, "
+            "HTML whitespace delimiters, invalid openers, NULL replacement, "
+            "and EOF partial-token drops."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    cases.extend(ordinary_tag_cases())
+    cases.extend(tag_name_recovery_cases())
+    cases.extend(invalid_tag_open_cases())
+    cases.extend(eof_recovery_cases())
+    return cases
+
+
+def ordinary_tag_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "basic-start-text-end",
+            "description": "ordinary start and end tags bracket text",
+            "input": "<p>Hello</p>",
+            "tokens": [
+                "StartTag(name=p, attributes=[], self_closing=false)",
+                "Text(data=Hello)",
+                "EndTag(name=p)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "uppercase-start-and-end-tags",
+            "description": "tag names are ASCII-lowercased in start and end tags",
+            "input": "<DIV>Hi</DIV>",
+            "tokens": [
+                "StartTag(name=div, attributes=[], self_closing=false)",
+                "Text(data=Hi)",
+                "EndTag(name=div)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "mixed-case-tag-name",
+            "description": "mixed-case tag names preserve non-ASCII text while lowering ASCII",
+            "input": "<My-Tag>ok</My-Tag>",
+            "tokens": [
+                "StartTag(name=my-tag, attributes=[], self_closing=false)",
+                "Text(data=ok)",
+                "EndTag(name=my-tag)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "start-tag-tab-whitespace",
+            "description": "tab after a tag name enters attribute parsing",
+            "input": "<p\tclass=x>",
+            "tokens": [
+                "StartTag(name=p, attributes=[class=x], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "start-tag-newline-whitespace",
+            "description": "line feed after a tag name enters attribute parsing",
+            "input": "<p\nclass=x>",
+            "tokens": [
+                "StartTag(name=p, attributes=[class=x], self_closing=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "start-tag-form-feed-whitespace",
+            "description": "form feed is HTML whitespace after a tag name",
+            "input": "<p\u000cclass=x\u000c/>",
+            "tokens": [
+                "StartTag(name=p, attributes=[class=x], self_closing=true)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "end-tag-form-feed-before-close",
+            "description": "form feed is HTML whitespace after an end-tag name",
+            "input": "</p\u000c>",
+            "tokens": ["EndTag(name=p)", "EOF"],
+        },
+        {
+            "id": "self-closing-start-tag",
+            "description": "solidus after tag name marks a self-closing start tag",
+            "input": "<br/>",
+            "tokens": ["StartTag(name=br, attributes=[], self_closing=true)", "EOF"],
+        },
+    ]
+
+
+def tag_name_recovery_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "null-in-start-tag-name",
+            "description": "NULL inside a start-tag name becomes U+FFFD",
+            "input": "<x\u0000>",
+            "tokens": ["StartTag(name=x�, attributes=[], self_closing=false)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "null-in-end-tag-name",
+            "description": "NULL inside an end-tag name becomes U+FFFD",
+            "input": "</x\u0000>",
+            "tokens": ["EndTag(name=x�)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "nulls-in-matching-tag-pair",
+            "description": "matching start and end tag names both replace NULLs",
+            "input": "<x\u0000>body</x\u0000>",
+            "tokens": [
+                "StartTag(name=x�, attributes=[], self_closing=false)",
+                "Text(data=body)",
+                "EndTag(name=x�)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-null-character", "unexpected-null-character"],
+        },
+    ]
+
+
+def invalid_tag_open_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "less-than-space-stays-text",
+            "description": "less-than followed by space is text plus a diagnostic",
+            "input": "Before < after",
+            "tokens": ["Text(data=Before )", "Text(data=< after)", "EOF"],
+            "diagnostics": ["invalid-first-character-of-tag-name"],
+        },
+        {
+            "id": "less-than-equals-stays-text",
+            "description": "less-than followed by equals is not a tag opener",
+            "input": "a<=b",
+            "tokens": ["Text(data=a)", "Text(data=<=b)", "EOF"],
+            "diagnostics": ["invalid-first-character-of-tag-name"],
+        },
+        {
+            "id": "less-than-digit-stays-text",
+            "description": "less-than followed by a digit is text recovery",
+            "input": "a<3b",
+            "tokens": ["Text(data=a)", "Text(data=<3b)", "EOF"],
+            "diagnostics": ["invalid-first-character-of-tag-name"],
+        },
+        {
+            "id": "less-than-null-reconsumes-as-text",
+            "description": "NULL after less-than reports invalid tag open then data NULL recovery",
+            "input": "Before <\u0000 after",
+            "tokens": ["Text(data=Before )", "Text(data=<� after)", "EOF"],
+            "diagnostics": [
+                "invalid-first-character-of-tag-name",
+                "unexpected-null-character",
+            ],
+        },
+        {
+            "id": "invalid-end-tag-digit-bogus-comment",
+            "description": "end-tag open followed by a digit recovers as a bogus comment",
+            "input": "Before</3>After",
+            "tokens": [
+                "Text(data=Before)",
+                "Comment(data=3)",
+                "Text(data=After)",
+                "EOF",
+            ],
+            "diagnostics": ["invalid-first-character-of-tag-name"],
+        },
+        {
+            "id": "invalid-end-tag-space-bogus-comment",
+            "description": "end-tag open followed by whitespace recovers as a bogus comment",
+            "input": "Before</ nope>After",
+            "tokens": [
+                "Text(data=Before)",
+                "Comment(data= nope)",
+                "Text(data=After)",
+                "EOF",
+            ],
+            "diagnostics": ["invalid-first-character-of-tag-name"],
+        },
+    ]
+
+
+def eof_recovery_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "eof-after-less-than",
+            "description": "EOF after a lone less-than preserves text recovery",
+            "input": "Before<",
+            "tokens": ["Text(data=Before)", "Text(data=<)", "EOF"],
+            "diagnostics": ["eof-in-tag-open-state"],
+        },
+        {
+            "id": "eof-after-end-tag-open",
+            "description": "EOF after an end-tag opener preserves literal text recovery",
+            "input": "Before</",
+            "tokens": ["Text(data=Before)", "Text(data=</)", "EOF"],
+            "diagnostics": ["eof-in-end-tag-open-state"],
+        },
+        {
+            "id": "eof-in-start-tag-name",
+            "description": "EOF in a start-tag name drops the partial start tag",
+            "input": "<div",
+            "tokens": ["EOF"],
+            "diagnostics": ["eof-in-tag-name-state"],
+        },
+        {
+            "id": "eof-in-start-tag-attribute",
+            "description": "EOF in start-tag attributes drops the partial start tag",
+            "input": "<div class=\"open",
+            "tokens": ["EOF"],
+            "diagnostics": ["eof-in-tag"],
+        },
+        {
+            "id": "eof-in-end-tag-name",
+            "description": "EOF in an end-tag name drops the partial end tag",
+            "input": "</section",
+            "tokens": ["EOF"],
+            "diagnostics": ["eof-in-end-tag-name-state"],
+        },
+        {
+            "id": "eof-in-end-tag-attributes",
+            "description": "EOF in end-tag attributes drops the partial end tag",
+            "input": "</section class=x",
+            "tokens": ["EOF"],
+            "diagnostics": ["end-tag-with-attributes", "eof-in-end-tag-name-state"],
+        },
+    ]
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-tag-open-recovery.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-tag-open-recovery.json
@@ -1,0 +1,283 @@
+{
+  "cases": [
+    {
+      "description": "ordinary start and end tags bracket text",
+      "diagnostics": [],
+      "id": "basic-start-text-end",
+      "input": "<p>Hello</p>",
+      "tokens": [
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=Hello)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "tag names are ASCII-lowercased in start and end tags",
+      "diagnostics": [],
+      "id": "uppercase-start-and-end-tags",
+      "input": "<DIV>Hi</DIV>",
+      "tokens": [
+        "StartTag(name=div, attributes=[], self_closing=false)",
+        "Text(data=Hi)",
+        "EndTag(name=div)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "mixed-case tag names preserve non-ASCII text while lowering ASCII",
+      "diagnostics": [],
+      "id": "mixed-case-tag-name",
+      "input": "<My-Tag>ok</My-Tag>",
+      "tokens": [
+        "StartTag(name=my-tag, attributes=[], self_closing=false)",
+        "Text(data=ok)",
+        "EndTag(name=my-tag)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "tab after a tag name enters attribute parsing",
+      "diagnostics": [],
+      "id": "start-tag-tab-whitespace",
+      "input": "<p\tclass=x>",
+      "tokens": [
+        "StartTag(name=p, attributes=[class=x], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "line feed after a tag name enters attribute parsing",
+      "diagnostics": [],
+      "id": "start-tag-newline-whitespace",
+      "input": "<p\nclass=x>",
+      "tokens": [
+        "StartTag(name=p, attributes=[class=x], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "form feed is HTML whitespace after a tag name",
+      "diagnostics": [],
+      "id": "start-tag-form-feed-whitespace",
+      "input": "<p\fclass=x\f/>",
+      "tokens": [
+        "StartTag(name=p, attributes=[class=x], self_closing=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "form feed is HTML whitespace after an end-tag name",
+      "diagnostics": [],
+      "id": "end-tag-form-feed-before-close",
+      "input": "</p\f>",
+      "tokens": [
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "solidus after tag name marks a self-closing start tag",
+      "diagnostics": [],
+      "id": "self-closing-start-tag",
+      "input": "<br/>",
+      "tokens": [
+        "StartTag(name=br, attributes=[], self_closing=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside a start-tag name becomes U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "null-in-start-tag-name",
+      "input": "<x\u0000>",
+      "tokens": [
+        "StartTag(name=x�, attributes=[], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside an end-tag name becomes U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "null-in-end-tag-name",
+      "input": "</x\u0000>",
+      "tokens": [
+        "EndTag(name=x�)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "matching start and end tag names both replace NULLs",
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ],
+      "id": "nulls-in-matching-tag-pair",
+      "input": "<x\u0000>body</x\u0000>",
+      "tokens": [
+        "StartTag(name=x�, attributes=[], self_closing=false)",
+        "Text(data=body)",
+        "EndTag(name=x�)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "less-than followed by space is text plus a diagnostic",
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ],
+      "id": "less-than-space-stays-text",
+      "input": "Before < after",
+      "tokens": [
+        "Text(data=Before )",
+        "Text(data=< after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "less-than followed by equals is not a tag opener",
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ],
+      "id": "less-than-equals-stays-text",
+      "input": "a<=b",
+      "tokens": [
+        "Text(data=a)",
+        "Text(data=<=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "less-than followed by a digit is text recovery",
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ],
+      "id": "less-than-digit-stays-text",
+      "input": "a<3b",
+      "tokens": [
+        "Text(data=a)",
+        "Text(data=<3b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL after less-than reports invalid tag open then data NULL recovery",
+      "diagnostics": [
+        "invalid-first-character-of-tag-name",
+        "unexpected-null-character"
+      ],
+      "id": "less-than-null-reconsumes-as-text",
+      "input": "Before <\u0000 after",
+      "tokens": [
+        "Text(data=Before )",
+        "Text(data=<� after)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "end-tag open followed by a digit recovers as a bogus comment",
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ],
+      "id": "invalid-end-tag-digit-bogus-comment",
+      "input": "Before</3>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data=3)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "end-tag open followed by whitespace recovers as a bogus comment",
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ],
+      "id": "invalid-end-tag-space-bogus-comment",
+      "input": "Before</ nope>After",
+      "tokens": [
+        "Text(data=Before)",
+        "Comment(data= nope)",
+        "Text(data=After)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after a lone less-than preserves text recovery",
+      "diagnostics": [
+        "eof-in-tag-open-state"
+      ],
+      "id": "eof-after-less-than",
+      "input": "Before<",
+      "tokens": [
+        "Text(data=Before)",
+        "Text(data=<)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after an end-tag opener preserves literal text recovery",
+      "diagnostics": [
+        "eof-in-end-tag-open-state"
+      ],
+      "id": "eof-after-end-tag-open",
+      "input": "Before</",
+      "tokens": [
+        "Text(data=Before)",
+        "Text(data=</)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in a start-tag name drops the partial start tag",
+      "diagnostics": [
+        "eof-in-tag-name-state"
+      ],
+      "id": "eof-in-start-tag-name",
+      "input": "<div",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in start-tag attributes drops the partial start tag",
+      "diagnostics": [
+        "eof-in-tag"
+      ],
+      "id": "eof-in-start-tag-attribute",
+      "input": "<div class=\"open",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in an end-tag name drops the partial end tag",
+      "diagnostics": [
+        "eof-in-end-tag-name-state"
+      ],
+      "id": "eof-in-end-tag-name",
+      "input": "</section",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in end-tag attributes drops the partial end tag",
+      "diagnostics": [
+        "end-tag-with-attributes",
+        "eof-in-end-tag-name-state"
+      ],
+      "id": "eof-in-end-tag-attributes",
+      "input": "</section class=x",
+      "tokens": [
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Tag-open and tag-name recovery for ordinary tags, ASCII casing, HTML whitespace delimiters, invalid openers, NULL replacement, and EOF partial-token drops.",
+  "format": "whatwg-html-tokenizer-tag-open-recovery/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
@@ -1,0 +1,166 @@
+use coding_adventures_html_lexer::{create_html_lexer, Attribute, Token};
+use serde::Deserialize;
+
+const WHATWG_TAG_OPEN_RECOVERY: &str = include_str!("fixtures/whatwg-tag-open-recovery.json");
+
+#[derive(Debug, Deserialize)]
+struct TagOpenRecoverySuite {
+    format: String,
+    description: String,
+    cases: Vec<TagOpenRecoveryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TagOpenRecoveryCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+}
+
+#[test]
+fn whatwg_tag_open_recovery_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-tokenizer-tag-open-recovery/v1");
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 20);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "less-than-null-reconsumes-as-text"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "invalid-end-tag-digit-bogus-comment"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "eof-in-end-tag-attributes"));
+}
+
+#[test]
+fn whatwg_tag_open_recovery_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its tag-open edge",
+            case.id
+        );
+        let mut lexer = create_html_lexer().expect("HTML lexer should build");
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> TagOpenRecoverySuite {
+    serde_json::from_str(WHATWG_TAG_OPEN_RECOVERY)
+        .expect("WHATWG tag-open recovery fixture should parse")
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG tag-open recovery fixture covering ordinary tags, casing, tag whitespace, invalid openers, NULL replacement in tag names, and EOF partial-token drops
- add a Rust conformance test that runs the generated corpus through the default HTML lexer
- document the new fixture and generator in the lexer docs/changelog

## Verification
- cargo test -p coding-adventures-html-lexer --test whatwg_tag_open_recovery_test
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- git diff --check