### PR TITLE
Add WHATWG tree insertion audit fixture

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -8,6 +8,9 @@ documented in this file.
 ### Added
 - Initial HTML parser crate that consumes `coding-adventures-html-lexer` tokens
   and builds a `dom-core` document.
+- Generated WHATWG tree-insertion audit fixture over the html5lib
+  adoption-agency, table/foster-parenting, template, foreign-content fragment,
+  and HTML fragment-shell families, with a dedicated parser regression test.
 - Stack-of-open-elements tree construction seed with void element handling,
   adjacent text merging, simple implied end tags, and unmatched end-tag
   diagnostics.

--- a/code/packages/rust/html-parser/Cargo.toml
+++ b/code/packages/rust/html-parser/Cargo.toml
@@ -7,3 +7,7 @@ description = "Incremental HTML parser that builds a DOM tree for Venture"
 [dependencies]
 coding-adventures-html-lexer = { path = "../html-lexer" }
 dom-core = { path = "../dom-core" }
+
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -80,6 +80,16 @@ The audit fails if an upstream tree-construction case is missing, if an
 upstream tokenizer case is missing from the raw mirrored tokenizer corpus, or
 if the normalized tokenizer corpus records skipped cases.
 
+For sharper parser regression reporting, the generated
+`tests/fixtures/whatwg-tree-insertion-audit.json` fixture indexes the
+adoption-agency, table/foster-parenting, template, foreign-content fragment,
+and HTML fragment-shell cases inside the tree-construction smoke corpus:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py \
+  --check
+```
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -21,3 +21,15 @@ HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
 The command exits nonzero if any upstream tree-construction or tokenizer source
 case is missing, or if the normalized tokenizer fixture still has skipped
 runtime gaps.
+
+`whatwg-tree-insertion-audit.json` is a generated index over the high-signal
+tree-construction families inside `html5lib-tree-construction-smoke.dat`:
+adoption-agency formatting recovery, table insertion and foster parenting,
+template insertion, foreign-content fragments, and HTML fragment shells.
+Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py \
+  --check
+```

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG tree-insertion audit fixture.
+
+The parser already carries a large html5lib tree-construction smoke corpus. This
+fixture indexes the high-signal insertion-mode families inside that corpus so CI
+can report parser regressions against adoption-agency, table/foster-parenting,
+template, foreign-content fragment, and fragment-shell recovery separately from
+the catch-all smoke test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-tree-insertion-audit.json"
+
+CASE_FAMILIES = (
+    {
+        "prefix": "adoption",
+        "axis": "adoption-agency",
+        "reason": "misnested formatting elements and adoption-agency recovery",
+    },
+    {
+        "prefix": "tables01.dat",
+        "axis": "table-insertion",
+        "reason": "table insertion modes, implied rows/cells, and foster parenting",
+    },
+    {
+        "prefix": "template.dat",
+        "axis": "template-insertion",
+        "reason": "template contents and template-context insertion modes",
+    },
+    {
+        "prefix": "foreign-fragment.dat",
+        "axis": "foreign-fragment",
+        "reason": "foreign-content fragment contexts and HTML integration recovery",
+    },
+    {
+        "prefix": "tests_innerHTML_1.dat",
+        "axis": "html-fragment",
+        "reason": "innerHTML fragment shell recovery across HTML contexts",
+    },
+)
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    sources = parse_sources(input_path)
+    fixture = build_fixture(sources)
+    text = json.dumps(fixture, indent=2, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output_path.read_text()
+        if existing != text:
+            raise SystemExit(f"{output_path} is stale; regenerate it")
+        return 0
+
+    output_path.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG tree-insertion audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_sources(path: Path) -> list[str]:
+    sources: list[str] = []
+    for line in path.read_text().splitlines():
+        if line.startswith("#source "):
+            sources.append(line.removeprefix("#source ").strip())
+    if not sources:
+        raise SystemExit(f"{path} does not contain any #source markers")
+    return sources
+
+
+def build_fixture(sources: list[str]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for source in sources:
+        family = family_for_source(source)
+        if family is None:
+            continue
+        if source in seen:
+            raise SystemExit(f"duplicate selected source: {source}")
+        seen.add(source)
+        selected.append(
+            {
+                "id": stable_case_id(source),
+                "source": source,
+                "axis": family["axis"],
+                "reason": family["reason"],
+            }
+        )
+
+    if not selected:
+        raise SystemExit("no tree-insertion audit cases matched the configured families")
+
+    counts_by_axis = {
+        family["axis"]: sum(1 for case in selected if case["axis"] == family["axis"])
+        for family in CASE_FAMILIES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-tree-insertion-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction "
+            "families that stress insertion-mode recovery."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def family_for_source(source: str) -> dict[str, str] | None:
+    for family in CASE_FAMILIES:
+        prefix = family["prefix"]
+        if prefix.endswith(".dat"):
+            if source.startswith(f"{prefix}:"):
+                return family
+        elif source.startswith(prefix):
+            return family
+    return None
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-tree-insertion-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-tree-insertion-audit.json
@@ -1,0 +1,1809 @@
+{
+  "case_count": 299,
+  "cases": [
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-1",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:1"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-2",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:2"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-3",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:3"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-4",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:4"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-5",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:5"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-6",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:6"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-7",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:7"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-8",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:8"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-9",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:9"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-10",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:10"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-11",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:11"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-12",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:12"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-13",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:13"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-14",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:14"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-15",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:15"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-16",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:16"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-17",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:17"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption02-dat-18",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption02.dat:18"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption02-dat-19",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption02.dat:19"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-436",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:436"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-437",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:437"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-438",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:438"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-439",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:439"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-440",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:440"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-441",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:441"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-442",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:442"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-443",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:443"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-444",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:444"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-445",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:445"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-446",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:446"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-447",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:447"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-448",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:448"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-449",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:449"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-450",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:450"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-451",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:451"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-452",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:452"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-453",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:453"
+    },
+    {
+      "axis": "table-insertion",
+      "id": "tables01-dat-454",
+      "reason": "table insertion modes, implied rows/cells, and foster parenting",
+      "source": "tables01.dat:454"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-455",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:455"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-456",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:456"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-457",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:457"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-458",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:458"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-459",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:459"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-460",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:460"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-461",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:461"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-462",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:462"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-463",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:463"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-464",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:464"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-465",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:465"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-466",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:466"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-467",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:467"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-468",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:468"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-469",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:469"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-470",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:470"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-471",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:471"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-472",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:472"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-473",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:473"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-474",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:474"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-475",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:475"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-476",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:476"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-477",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:477"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-478",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:478"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-479",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:479"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-480",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:480"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-481",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:481"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-482",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:482"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-483",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:483"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-484",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:484"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-485",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:485"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-486",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:486"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-487",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:487"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-488",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:488"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-489",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:489"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-490",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:490"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-491",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:491"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-492",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:492"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-493",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:493"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-494",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:494"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-495",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:495"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-496",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:496"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-497",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:497"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-498",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:498"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-499",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:499"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-500",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:500"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-501",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:501"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-502",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:502"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-503",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:503"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-504",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:504"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-505",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:505"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-506",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:506"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-507",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:507"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-508",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:508"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-509",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:509"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-510",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:510"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-511",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:511"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-512",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:512"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-513",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:513"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-514",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:514"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-515",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:515"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-516",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:516"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-517",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:517"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-518",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:518"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-519",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:519"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-520",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:520"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-521",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:521"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-522",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:522"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-523",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:523"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-524",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:524"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-525",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:525"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-526",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:526"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-527",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:527"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-528",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:528"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-529",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:529"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-530",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:530"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-531",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:531"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-532",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:532"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-533",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:533"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-534",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:534"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-535",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:535"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-536",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:536"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-537",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:537"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-538",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:538"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-539",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:539"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-540",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:540"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-541",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:541"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-542",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:542"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-543",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:543"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-544",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:544"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-545",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:545"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-546",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:546"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-547",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:547"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-548",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:548"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-549",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:549"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-550",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:550"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-551",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:551"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-552",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:552"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-553",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:553"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-554",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:554"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-555",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:555"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-556",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:556"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-557",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:557"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-558",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:558"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-559",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:559"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-560",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:560"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-561",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:561"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-562",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:562"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-563",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:563"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-564",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:564"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-565",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:565"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-1",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:1"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-2",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:2"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-3",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:3"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-4",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:4"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-5",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:5"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-6",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:6"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-7",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:7"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-8",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:8"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-9",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:9"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-10",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:10"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-11",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:11"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-12",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:12"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-13",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:13"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-14",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:14"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-15",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:15"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-16",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:16"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-17",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:17"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-18",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:18"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-19",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:19"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-20",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:20"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-21",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:21"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-22",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:22"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-23",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:23"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-24",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:24"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-25",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:25"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-26",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:26"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-27",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:27"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-28",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:28"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-29",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:29"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-30",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:30"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-31",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:31"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-32",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:32"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-33",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:33"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-34",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:34"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-35",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:35"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-36",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:36"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-37",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:37"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-38",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:38"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-39",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:39"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-40",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:40"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-41",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:41"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-42",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:42"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-43",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:43"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-44",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:44"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-45",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:45"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-46",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:46"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-48",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:48"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-50",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:50"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-51",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:51"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-52",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:52"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-53",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:53"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-54",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:54"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-55",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:55"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-56",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:56"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-57",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:57"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-58",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:58"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-59",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:59"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-60",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:60"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-61",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:61"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-62",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:62"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-63",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:63"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-64",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:64"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-65",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:65"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-66",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:66"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-67",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:67"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-68",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:68"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-69",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:69"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-70",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:70"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-71",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:71"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-72",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:72"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-73",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:73"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-75",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:75"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-77",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:77"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-78",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:78"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-79",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:79"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-80",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:80"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-81",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:81"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-47",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:47"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-49",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:49"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-74",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:74"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption01-dat-18",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption01.dat:18"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-1",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:1"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-2",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:2"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-3",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:3"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-4",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:4"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-5",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:5"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-6",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:6"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-7",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:7"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-8",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:8"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-9",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:9"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-10",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:10"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-11",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:11"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-12",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:12"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-13",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:13"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-14",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:14"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-15",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:15"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-16",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:16"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-17",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:17"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-18",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:18"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-19",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:19"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-20",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:20"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-21",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:21"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-22",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:22"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-23",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:23"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-24",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:24"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-25",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:25"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-26",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:26"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-27",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:27"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-28",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:28"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-29",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:29"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-30",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:30"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-31",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:31"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-32",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:32"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-33",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:33"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-34",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:34"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-35",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:35"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-36",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:36"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-37",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:37"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-38",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:38"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-39",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:39"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-40",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:40"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-41",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:41"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-42",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:42"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-43",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:43"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-44",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:44"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-45",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:45"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-46",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:46"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-47",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:47"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-48",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:48"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-49",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:49"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-50",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:50"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-51",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:51"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-52",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:52"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-53",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:53"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-54",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:54"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-55",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:55"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-56",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:56"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-57",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:57"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-58",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:58"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-59",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:59"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-60",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:60"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-61",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:61"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-62",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:62"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-63",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:63"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-64",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:64"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-65",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:65"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "foreign-fragment-dat-66",
+      "reason": "foreign-content fragment contexts and HTML integration recovery",
+      "source": "foreign-fragment.dat:66"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-112",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:112"
+    },
+    {
+      "axis": "template-insertion",
+      "id": "template-dat-109",
+      "reason": "template contents and template-context insertion modes",
+      "source": "template.dat:109"
+    },
+    {
+      "axis": "html-fragment",
+      "id": "tests-innerhtml-1-dat-76",
+      "reason": "innerHTML fragment shell recovery across HTML contexts",
+      "source": "tests_innerHTML_1.dat:76"
+    }
+  ],
+  "counts_by_axis": {
+    "adoption-agency": 20,
+    "foreign-fragment": 66,
+    "html-fragment": 81,
+    "table-insertion": 19,
+    "template-insertion": 113
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction families that stress insertion-mode recovery.",
+  "format": "whatwg-html-tree-insertion-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_tree_insertion_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_tree_insertion_audit_test.rs
@@ -1,0 +1,329 @@
+use coding_adventures_html_lexer::HtmlScriptingMode;
+use coding_adventures_html_parser::{
+    parse_html_fragment_for_context_with_options, parse_html_with_options, HtmlParseOptions,
+};
+use dom_core::{Document, DocumentType, Element, Node};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_TREE_INSERTION_AUDIT: &str = include_str!("fixtures/whatwg-tree-insertion-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct TreeInsertionSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<TreeInsertionCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TreeInsertionCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug)]
+struct TreeConstructionCase {
+    source: String,
+    data: String,
+    scripting: HtmlScriptingMode,
+    fragment_context: Option<String>,
+    document: Vec<String>,
+}
+
+#[test]
+fn whatwg_tree_insertion_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-tree-insertion-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 250);
+    assert_axis_count(&suite, "adoption-agency", 19);
+    assert_axis_count(&suite, "table-insertion", 15);
+    assert_axis_count(&suite, "template-insertion", 100);
+    assert_axis_count(&suite, "foreign-fragment", 60);
+    assert_axis_count(&suite, "html-fragment", 75);
+}
+
+#[test]
+fn whatwg_tree_insertion_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let options = HtmlParseOptions {
+            scripting: source_case.scripting,
+            ..HtmlParseOptions::default()
+        };
+        let actual = if let Some(fragment_context) = &source_case.fragment_context {
+            let nodes = parse_html_fragment_for_context_with_options(
+                &source_case.data,
+                fragment_context,
+                options,
+            )
+            .unwrap_or_else(|error| {
+                panic!(
+                    "case `{}` ({}) fragment parse failed: {error:?}",
+                    case.id, case.axis
+                )
+            });
+            dump_nodes(&nodes)
+        } else {
+            let document =
+                parse_html_with_options(&source_case.data, options).unwrap_or_else(|error| {
+                    panic!("case `{}` ({}) parse failed: {error:?}", case.id, case.axis)
+                });
+            dump_document(&document)
+        };
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> TreeInsertionSuite {
+    serde_json::from_str(WHATWG_TREE_INSERTION_AUDIT)
+        .expect("WHATWG tree insertion audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &TreeInsertionSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}
+
+fn parse_tree_construction_cases(raw: &str) -> Vec<TreeConstructionCase> {
+    let mut cases = Vec::new();
+    let mut lines = raw.lines().peekable();
+
+    let mut source = String::new();
+
+    while let Some(line) = lines.next() {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("#source ") {
+            source = rest.to_string();
+            continue;
+        }
+        assert_eq!(line, "#data");
+
+        let mut data = Vec::new();
+        for line in lines.by_ref() {
+            if line == "#errors" {
+                break;
+            }
+            data.push(line);
+        }
+
+        let mut scripting = HtmlScriptingMode::Enabled;
+        let mut fragment_context = None;
+        while let Some(line) = lines.next() {
+            if line == "#document" {
+                break;
+            }
+            if line == "#document-fragment" {
+                fragment_context = Some(
+                    lines
+                        .next()
+                        .expect("document-fragment marker should name a context element")
+                        .to_string(),
+                );
+                continue;
+            }
+            if line == "#script-off" {
+                scripting = HtmlScriptingMode::Disabled;
+            } else if line == "#script-on" {
+                scripting = HtmlScriptingMode::Enabled;
+            }
+        }
+
+        let mut document = Vec::new();
+        while let Some(line) = lines.peek() {
+            if *line == "#data" || line.starts_with("#source ") {
+                break;
+            }
+            document.push(lines.next().expect("peeked line should exist").to_string());
+        }
+        while document.last().is_some_and(|line| line.is_empty()) {
+            document.pop();
+        }
+
+        cases.push(TreeConstructionCase {
+            source: std::mem::take(&mut source),
+            data: data.join("\n"),
+            scripting,
+            fragment_context,
+            document,
+        });
+    }
+
+    cases
+}
+
+fn dump_document(document: &Document) -> Vec<String> {
+    dump_nodes(&document.children)
+}
+
+fn dump_nodes(nodes: &[Node]) -> Vec<String> {
+    let mut lines = Vec::new();
+    for node in nodes {
+        dump_node(node, 0, &mut lines);
+    }
+    lines
+}
+
+fn dump_node(node: &Node, depth: usize, lines: &mut Vec<String>) {
+    match node {
+        Node::DocumentType(doctype) => dump_doctype(doctype, depth, lines),
+        Node::Element(element) => dump_element(element, depth, lines),
+        Node::Text(text) => dump_text(&text.data, depth, lines),
+        Node::Comment(comment) => dump_comment(&comment.data, depth, lines),
+    }
+}
+
+fn dump_comment(comment: &str, depth: usize, lines: &mut Vec<String>) {
+    let parts = comment.split('\n').collect::<Vec<_>>();
+    if parts.len() == 1 {
+        lines.push(format!("{}<!-- {} -->", prefix(depth), comment));
+        return;
+    }
+
+    let last_index = parts.len() - 1;
+    for (index, part) in parts.iter().enumerate() {
+        match index {
+            0 => lines.push(format!("{}<!-- {}", prefix(depth), part)),
+            index if index == last_index => lines.push(format!("{part} -->")),
+            _ => lines.push((*part).to_string()),
+        }
+    }
+}
+
+fn dump_text(text: &str, depth: usize, lines: &mut Vec<String>) {
+    let parts = text.split('\n').collect::<Vec<_>>();
+    if parts.len() == 1 {
+        lines.push(format!("{}\"{}\"", prefix(depth), text));
+        return;
+    }
+
+    let last_index = parts.len() - 1;
+    for (index, part) in parts.iter().enumerate() {
+        match index {
+            0 => lines.push(format!("{}\"{}", prefix(depth), part)),
+            index if index == last_index => lines.push(format!("{part}\"")),
+            _ => lines.push((*part).to_string()),
+        }
+    }
+}
+
+fn dump_doctype(doctype: &DocumentType, depth: usize, lines: &mut Vec<String>) {
+    let name = doctype.name.as_deref().unwrap_or("");
+    match (
+        doctype.public_identifier.as_deref(),
+        doctype.system_identifier.as_deref(),
+    ) {
+        (Some(public), Some(system)) => {
+            lines.push(format!(
+                "{}<!DOCTYPE {} \"{}\" \"{}\">",
+                prefix(depth),
+                name,
+                public,
+                system
+            ));
+        }
+        (Some(public), None) => {
+            lines.push(format!(
+                "{}<!DOCTYPE {} \"{}\" \"\">",
+                prefix(depth),
+                name,
+                public
+            ));
+        }
+        (None, Some(system)) => {
+            lines.push(format!(
+                "{}<!DOCTYPE {} \"\" \"{}\">",
+                prefix(depth),
+                name,
+                system
+            ));
+        }
+        (None, None) => lines.push(format!("{}<!DOCTYPE {}>", prefix(depth), name)),
+    }
+}
+
+fn dump_element(element: &Element, depth: usize, lines: &mut Vec<String>) {
+    if let Some(namespace) = &element.namespace {
+        lines.push(format!("{}<{} {}>", prefix(depth), namespace, element.name));
+    } else {
+        lines.push(format!("{}<{}>", prefix(depth), element.name));
+    }
+
+    let mut attributes = element.attributes.iter().collect::<Vec<_>>();
+    attributes.sort_by(|left, right| left.name.cmp(&right.name));
+    for attribute in attributes {
+        if element.namespace.is_some() {
+            if let Some(local_name) = attribute.name.strip_prefix("xlink ") {
+                lines.push(format!(
+                    "{}xlink {}=\"{}\"",
+                    prefix(depth + 1),
+                    local_name,
+                    attribute.value
+                ));
+                continue;
+            }
+            if let Some(local_name) = attribute.name.strip_prefix("xml ") {
+                lines.push(format!(
+                    "{}xml {}=\"{}\"",
+                    prefix(depth + 1),
+                    local_name,
+                    attribute.value
+                ));
+                continue;
+            }
+        }
+        lines.push(format!(
+            "{}{}=\"{}\"",
+            prefix(depth + 1),
+            attribute.name,
+            attribute.value
+        ));
+    }
+
+    if element.name == "template" && element.namespace.is_none() {
+        lines.push(format!("{}content", prefix(depth + 1)));
+        for child in &element.children {
+            dump_node(child, depth + 2, lines);
+        }
+    } else {
+        for child in &element.children {
+            dump_node(child, depth + 1, lines);
+        }
+    }
+}
+
+fn prefix(depth: usize) -> String {
+    format!("| {}", "  ".repeat(depth))
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG tree-insertion audit fixture indexing high-signal html5lib parser families
- cover adoption-agency, table/foster-parenting, template, foreign-content fragment, and HTML fragment-shell cases with a dedicated parser regression test
- document the generator and --check workflow for the parser fixture

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- git diff --check