### PR TITLE
spec: Win32 + XAML backends for Mosaic + decoupled event loop

### DIFF
--- a/code/specs/mosaic-emit-win32.md
+++ b/code/specs/mosaic-emit-win32.md
@@ -1,0 +1,550 @@
+# mosaic-emit-win32 — Pure Win32 + Paint VM backend for Mosaic
+
+**Status:** Specification (draft)
+**Layer:** UI / backend emitter (rendering)
+**Depends on:**
+  UI22 (mosaic-emit-paint — the Paint VM emit path),
+  UI23 (mosaic-pipeline),
+  UI24 (mosaic-emit-dispatch),
+  P2D00 / P2D01 (PaintInstructions, PaintVM),
+  P2D06 (Direct2D native backend — `paint-vm-direct2d`),
+  `win32-event-loop.md` (decoupled message pump)
+**Sibling backend:** `mosaic-emit-xaml.md` (WinUI 3, C# output). The two share
+only the UI24 dispatch contract.
+**Produces:** Rust source files (`.rs`) implementing a `Component` struct, a
+`render(scene, …)` function that emits Paint VM instructions, and the
+Win32 input wiring that translates `win32-event-loop::Event`s into UI24
+`{Component}Event` variants.
+
+---
+
+## 1. Purpose
+
+Take a Mosaic three-file pipeline triple and generate a Rust crate (or set
+of modules) that, when built and linked into a Win32 application, renders
+the component using:
+
+- **Win32 alone** for window creation (no XAML, no WinUI, no .NET runtime).
+- **Direct2D + DirectWrite** for drawing, via the existing **Paint VM**
+  (`paint-vm` + `paint-vm-direct2d`). The Mosaic emitter never calls
+  Direct2D directly; it produces Paint VM scenes and lets the runtime
+  dispatch table draw them. This is the same separation as
+  UI22 (`mosaic-emit-paint`) — UI22 emits Paint VM scenes for use by *any*
+  Paint VM backend, including web canvas. UI29 (this spec) is the Win32
+  *executable host* that wraps UI22's output in a real `HWND` + message
+  loop.
+- The standalone **`win32-event-loop`** crate for the message pump. The
+  emitted code does not own the message loop; it registers a handler with
+  the loop the host already runs.
+
+The user-facing promise: a Mosaic component compiled with `--backend
+win32` produces a single Rust crate that depends on `paint-vm-direct2d`
+and `win32-event-loop`. The host application drops that crate into its
+`Cargo.toml`, creates an `HWND`, hands it to the generated `Grid::mount(…)`
+function, and is done.
+
+Compared with `mosaic-emit-xaml`:
+
+|                          | mosaic-emit-xaml          | mosaic-emit-win32              |
+|--------------------------|----------------------------|--------------------------------|
+| Output language          | C# + XAML                 | Rust                           |
+| Rendering                | WinUI control tree        | Direct2D via Paint VM scene    |
+| Runtime dependency       | Windows App SDK 1.5+      | `paint-vm-direct2d` crate only |
+| Host integration         | XAML `Resources` + DPs    | `HWND` + closure handler       |
+| Final binary             | `.exe` + `.dll`s, MSIX    | single `.exe`, no extra DLLs   |
+| DPI / theming surface    | XAML-native               | Hand-rolled (see §8)           |
+
+## 2. Output shape
+
+For a component `Grid` declared in `Grid.mil` / `Grid.desktop.mll` /
+`Grid.dark.msl`, the backend writes a Rust module:
+
+```
+grid/
+  mod.rs          — public `Grid` struct + `mount`/`render`/`dispatch` API
+  scene.rs        — the moslayout tree → Paint VM scene builder
+  events.rs       — the `GridEvent` discriminated enum (UI24)
+  style.rs        — mosstyle properties as Rust constants / functions
+  hit.rs          — hit-testing (which cell/element is under (x, y)?), used
+                    by the input wiring to translate Win32 mouse events
+                    into UI24 events
+```
+
+The crate is named `mosaic_generated_<component>` by default; the
+`--crate-name` flag overrides it. With `--single-file` (default off) all
+five modules collapse into one `{Component}.rs` for embedding directly
+into an existing crate without a sub-module.
+
+When invoked with `--emit-host` (default off), the backend additionally
+writes:
+
+```
+src/main.rs       — host that registers the WNDCLASS, calls
+                    `Grid::mount(hwnd, dispatch_callback)`, runs the
+                    win32-event-loop, and exits
+Cargo.toml        — depends on `paint-vm-direct2d`, `win32-event-loop`,
+                    and the generated component crate
+```
+
+This is enough to `cargo build --release` and get a working `.exe`. The
+VisiCalc plumbing (§10) uses `--emit-host`; library consumers turn it off.
+
+## 3. Mapping table — moslayout primitives → Paint VM scene
+
+Every moslayout primitive lowers to a sub-tree of Paint VM instructions
+(`PaintRect`, `PaintGlyphRun`, `PaintGroup`, `PaintClip`, …). The Paint VM
+docs (P2D00) define the instruction set; this table is the moslayout view.
+
+| moslayout primitive | Paint VM lowering                                                 |
+|---------------------|-------------------------------------------------------------------|
+| `Box`               | `PaintGroup { bounds = part_bounds, ops = [ PaintRect(background), …children… ] }` |
+| `Row` / `Column`    | `PaintGroup` with children laid out via a layout pass (§5).       |
+| `Stack`             | `PaintGroup` — children stacked in source order, all at the same origin. |
+| `Grid`              | `PaintGroup` containing header `PaintGlyphRun`s, then a nested `PaintGroup` per row, each holding cell `PaintRect` + `PaintGlyphRun`. See §4. |
+| `Text`              | `PaintGlyphRun` resolved at render time from the bound `text` slot via DirectWrite. |
+| `Image`             | `PaintImage` (file path or in-memory bytes from the slot). |
+| `Input`             | `PaintGroup { bounds, ops = [ PaintRect(background, border), PaintGlyphRun(buffer_text) ] }`. Caret + selection are tracked in the component struct and added to the scene as additional `PaintRect`s during render. See §5. |
+| `Scroll`            | `PaintClip` to the viewport bounds; child sub-tree is translated by the scroll offset before being added. |
+| `Spacer`            | (no-op — affects layout only). |
+| `Divider`           | A single `PaintRect` of the divider thickness in the long axis.   |
+| `Icon`              | `PaintGlyphRun` against the Segoe Fluent Icons font.              |
+
+The emitter does NOT call into Direct2D directly. It builds a
+`paint_instructions::Scene` and lets the `paint-vm-direct2d` runtime walk
+it. The emitter is therefore renderer-agnostic — the same generated code
+can later run against a Skia or Cairo backend by swapping the runtime
+crate.
+
+## 4. Grid primitive
+
+The Grid primitive carries the most complexity. The emitter produces:
+
+```rust
+impl Grid {
+    pub fn build_scene(&self) -> paint_instructions::Scene {
+        let mut scene = Scene::new();
+        let sheet_bounds = self.layout.sheet_bounds();
+
+        // Part style: background, font, padding (from mosstyle).
+        scene.push(PaintRect {
+            bounds: sheet_bounds,
+            fill:   style::SHEET_BACKGROUND,
+            stroke: None,
+        });
+
+        // Headers: one PaintGlyphRun per column.
+        for (c, header) in self.column_headers.iter().enumerate() {
+            scene.push(PaintGlyphRun {
+                bounds:    self.layout.header_bounds(c),
+                text:      header.clone(),
+                font:      style::HEADER_FONT,
+                fill:      style::HEADER_COLOR,
+                alignment: Alignment::Center,
+            });
+        }
+
+        // Cells: PaintRect for background + PaintGlyphRun for text. Selection
+        // and editing highlights are inlined into the cell's fill colour at
+        // build-scene time (mirroring the React backend's inline style spread).
+        for (r, row) in self.viewport_rows.iter().enumerate() {
+            for (c, cell) in row.iter().enumerate() {
+                let fill = if (r as i32) == self.selected_row && (c as i32) == self.selected_col {
+                    style::SELECTED_BACKGROUND
+                } else if (r as i32) == self.edit_row && (c as i32) == self.edit_col {
+                    style::EDITING_BACKGROUND
+                } else {
+                    style::CELL_BACKGROUND
+                };
+                let bounds = self.layout.cell_bounds(r, c);
+                scene.push(PaintRect { bounds, fill, stroke: Some(style::CELL_BORDER) });
+                scene.push(PaintGlyphRun {
+                    bounds, text: cell.clone(),
+                    font: style::CELL_FONT, fill: style::CELL_COLOR,
+                    alignment: Alignment::LeftCenter,
+                });
+            }
+        }
+        scene
+    }
+}
+```
+
+`self.layout` is a small layout cache produced by `scene.rs`'s layout pass
+(see §5). `style::*` constants are emitted into `style.rs` from the
+mosstyle `.msl` source.
+
+### 4.1 column-widths
+
+When the moslayout binds `column-widths: slot: column-widths`, the
+emitter inserts a `column_widths: Vec<f32>` field on the component struct
+and the layout pass consumes it to compute `cell_bounds(r, c)`. When the
+prop is absent, the layout pass falls back to equal-width columns sized
+to `sheet_bounds.width() / col_count`.
+
+### 4.2 Hit testing → onNavigate
+
+The generated `hit.rs` module produces a function:
+
+```rust
+pub fn hit_test(&self, x: i32, y: i32) -> Option<GridHit> {
+    // returns Cell { row, col } or HeaderCell { col } or None
+}
+```
+
+The Win32 input wiring (§7) calls this on every `Event::MouseDown { Left, .. }`
+and dispatches the corresponding `GridEvent::Navigate { row, col }` when
+the cell hit succeeds. Header cells produce nothing today (UI26 reserves
+header click for column sorting, which is out of scope).
+
+## 5. Layout pass
+
+moslayout's vertical / horizontal / grid containers each get a small
+layout function generated alongside the scene builder. The functions are
+deterministic and only depend on the bound slot values + the sheet
+bounds; they compute child bounds in pixels and stash them in a
+`LayoutCache`. Re-running the layout when a slot value changes is cheap
+and runs on the main thread before `build_scene()`.
+
+The layout vocabulary is intentionally small:
+
+- `Box`: child fills the box minus padding.
+- `Row` / `Column`: lay out children along the main axis. Each child
+  contributes either a fixed size (from style `width` / `height`) or
+  `flex: <weight>` consumed from a future moslayout grammar extension. The
+  first cut treats every non-fixed-size child as `flex: 1`.
+- `Stack`: every child gets the parent's full bounds.
+- `Grid`: see §4.
+
+The layout pass is *not* a full constraint solver — it is a single
+top-down walk that runs in `O(n)` over the moslayout tree. This is enough
+for VisiCalc (one Grid + one FormulaBar) and explicitly punts on the
+hard cases (resizable splits, percentage-of-parent, intrinsic sizing).
+
+## 6. Event dispatch (UI24)
+
+For a component with `n` emits, the emitter writes the discriminated enum
+to `events.rs`:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum GridEvent {
+    Navigate   { row: i32, col: i32 },
+    EditCommit { value: String },
+    // ...
+}
+```
+
+…and the component struct exposes a single dispatch field:
+
+```rust
+pub struct Grid {
+    // slot fields...
+    dispatch: Box<dyn Fn(GridEvent) + 'static>,
+}
+
+impl Grid {
+    pub fn mount(
+        hwnd: HWND,
+        dispatch: impl Fn(GridEvent) + 'static,
+    ) -> (Self, win32_event_loop::Registration) {
+        let component = Grid { /* slots = defaults */, dispatch: Box::new(dispatch) };
+        let registration = win32_event_loop::EventLoop::current().register(
+            hwnd,
+            // input wiring — see §7
+            component.handler(),
+        );
+        (component, registration)
+    }
+}
+```
+
+The empty-emit case still emits the enum (`pub enum FooEvent {}` —
+matching the `export type FooEvent = never` shape from UI24 §3.1) so
+downstream `match` arms compile uniformly.
+
+## 7. Input wiring — `win32-event-loop::Event` → UI24
+
+The generated `mod.rs` includes a `handler()` method that constructs a
+`win32_event_loop::EventHandler` whose `handle()` body is a `match` over
+the loop's typed events:
+
+```rust
+impl Grid {
+    fn handler(&self) -> impl win32_event_loop::EventHandler {
+        let dispatch = self.dispatch.clone(); // Arc'd internally
+        win32_event_loop::closure_handler(move |event| {
+            match event {
+                Event::Paint { hwnd, rect } => {
+                    let scene = self.build_scene();
+                    paint_vm_direct2d::render(&scene, hwnd, rect);
+                    Action::Consumed
+                }
+                Event::Resize { hwnd: _, client } => {
+                    self.set_bounds(client);
+                    Action::Consumed
+                }
+                Event::MouseDown { x, y, button: MouseButton::Left, .. } => {
+                    if let Some(GridHit::Cell { row, col }) = self.hit_test(x, y) {
+                        dispatch(GridEvent::Navigate { row, col });
+                    }
+                    Action::Consumed
+                }
+                Event::Char { codepoint, .. } => {
+                    // Forwarded to host as future GridEvent::TypeChar — out of
+                    // scope for v1, falls through to Default.
+                    Action::Default
+                }
+                _ => Action::Default,
+            }
+        })
+    }
+}
+```
+
+Three things to notice:
+
+1. The handler **never calls `GetMessage` or `DispatchMessage`** — that is
+   the event loop's job. The handler is a pure function from `Event` to
+   `Action`.
+2. The handler **never calls Direct2D APIs directly** — it builds a
+   `Scene` and lets `paint_vm_direct2d::render` walk it. The Paint VM is
+   the only renderer surface the generated code knows about.
+3. The `Action::Default` return values matter — they preserve normal
+   Win32 behaviour for everything the component didn't model.
+   Keyboard accelerators, Alt+F4, system shortcuts, etc. keep working.
+
+### 7.1 Input primitive — caret + selection
+
+The `Input` primitive is the only one with rich keyboard handling. UI25
+specifies four emits and §5 of this spec maps them. The Win32 wiring is:
+
+| Event                                | Maps to                                |
+|--------------------------------------|----------------------------------------|
+| `Char { codepoint, .. }`             | append to buffer; dispatch `Change(value)` |
+| `KeyDown { vk: Backspace, .. }`      | pop from buffer; dispatch `Change(value)` |
+| `KeyDown { vk: Enter, .. }`          | dispatch `Commit`                      |
+| `KeyDown { vk: Escape, .. }`         | dispatch `Cancel`                      |
+| `KeyDown { vk: Left/Right/Home/End, .. }` | move caret; trigger repaint        |
+| `MouseDown { Left, x, y, .. }`       | caret-by-hit-test; trigger repaint     |
+
+The caret is rendered as a single thin `PaintRect` blinking via a
+`SetTimer`-driven `WM_TIMER` invalidate. Selection is a `PaintRect` with
+a translucent fill behind the affected glyph run.
+
+## 8. Style application — mosstyle → `style.rs`
+
+The `.msl` source's part blocks are compiled to a `style.rs` of typed
+constants:
+
+```rust
+// style.rs — auto-generated from Grid.dark.msl
+use paint_instructions::{Color, Font, Stroke};
+
+pub const SHEET_BACKGROUND: Color  = Color::from_rgb(0x1e, 0x1e, 0x1e);
+pub const SHEET_FONT_FAMILY: &str  = "Consolas";
+pub const SHEET_FONT_SIZE:   f32   = 12.0;
+pub const CELL_BORDER:       Stroke = Stroke { color: Color::from_rgb(0xe0, 0xe0, 0xe0), width: 1.0 };
+pub const SELECTED_BACKGROUND: Color = Color::from_rgb(0x26, 0x4f, 0x78);
+pub const EDITING_BACKGROUND:  Color = Color::from_rgb(0x1f, 0x4f, 0x3f);
+// ...
+```
+
+State blocks (`state hover { … }`) become per-state functions:
+
+```rust
+pub fn cell_background(state: CellState) -> Color {
+    match state {
+        CellState::Hover    => Color::from_rgb(0x2a, 0x2d, 0x2e),
+        CellState::Selected => SELECTED_BACKGROUND,
+        CellState::Editing  => EDITING_BACKGROUND,
+        CellState::Idle     => SHEET_BACKGROUND,
+    }
+}
+```
+
+Sub-parts (UI27 §3 — `sheet/cell`, `sheet/header-cell`) get their own
+constant groups (`SHEET_CELL_*`, `SHEET_HEADER_CELL_*`).
+
+The .msl property → Rust constant mapping is the same fixed table as the
+XAML backend (§8 of `mosaic-emit-xaml.md`), but with `Color` / `Font` /
+`Stroke` types from `paint_instructions` instead of XAML setters.
+
+### 8.1 DPI awareness
+
+Generated layout code treats logical and physical pixels as **the same**
+in v1. A follow-up will pipe `Event::Resize`'s DPI through the layout
+pass (the loop reports DPI via a future event; for now the host calls
+`SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)`
+and the layout works in physical pixels).
+
+## 9. Public API
+
+```rust
+// code/packages/rust/mosaic-emit-win32/src/lib.rs
+
+pub struct Win32Renderer { /* options */ }
+
+pub struct Win32EmitResult {
+    pub modules: Vec<EmittedModule>,        // mod.rs, scene.rs, events.rs, style.rs, hit.rs
+    pub host:    Option<HostFiles>,         // Some(...) when emit_host=true
+    pub component_name: String,
+}
+
+pub struct EmittedModule {
+    pub filename: String,                   // "mod.rs", "scene.rs", ...
+    pub source:   String,
+}
+
+pub struct HostFiles {
+    pub main_rs:    String,
+    pub cargo_toml: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Win32EmitError {
+    #[error("component name mismatch: mil/mll/msl disagree ({0:?})")]
+    ComponentNameMismatch(Vec<String>),
+    #[error("unsupported primitive: {0}")]
+    UnsupportedPrimitive(String),
+    #[error("slot type {0:?} has no Win32 mapping")]
+    UnmappableSlotType(String),
+    #[error("style property {0:?} has no Paint VM mapping")]
+    UnmappableStyleProperty(String),
+}
+
+pub fn from_pipeline(
+    model:  &mosmodel_compiler::MosmodelComponent,
+    layout: &moslayout_compiler::LayoutDef,
+    style:  &mosstyle_compiler::StyleDef,
+    options: &EmitOptions,
+) -> Result<Win32EmitResult, Win32EmitError>;
+```
+
+Mirrors the React and XAML emitters; one type swap, same call shape.
+
+## 10. VisiCalc plumbing — proof that this all hangs together
+
+```
+demo/visicalc/
+  windows/win32/
+    Cargo.toml                  — generated (when --emit-host)
+    src/
+      main.rs                   — generated host: registers WNDCLASS, creates
+                                   HWND, mounts Grid + FormulaBar, runs the
+                                   win32-event-loop
+      generated/
+        grid/                   — Grid component crate (mod.rs, scene.rs, ...)
+        formula_bar/            — FormulaBar component crate
+      state.rs                  — hand-written; mirrors src/app/state.ts. The
+                                   reducer is a `fn step(state: AppState,
+                                   event: AppEvent) -> AppState` shaped
+                                   identically to the React reducer.
+  windows/build.ps1             — calls `mosaic-compile --backend win32` for
+                                   each component, then `cargo build --release`
+```
+
+The end-to-end story: `cargo build --release` in
+`demo/visicalc/windows/win32/` produces a single ~3-5 MB `.exe` with no
+runtime dependencies (it statically links `paint-vm-direct2d`,
+`win32-event-loop`, and the generated component crates). Double-clicking
+it opens a window that renders the same VisiCalc grid as the React demo,
+fed by the same `.mil`/`.mll`/`.msl` sources.
+
+The host file `state.rs` is approximately 150 lines of pure Rust mirroring
+`src/app/state.ts` — same fields, same reducer cases, same A1 helpers.
+The shared invariant from UI26 (host owns state, components are dumb
+renderers) carries through unchanged.
+
+## 11. CLI integration
+
+`mosaic-compile --backend win32` accepts the standard pipeline flags
+(`--interface`, `--layout`, `--style`, `-o`) plus:
+
+| Flag                   | Default | Effect                                          |
+|------------------------|---------|-------------------------------------------------|
+| `--emit-host`          | `false` | Also write `src/main.rs` + `Cargo.toml`.        |
+| `--crate-name <name>`  | `mosaic_generated_<component>` | Override the generated crate name.  |
+| `--single-file`        | `false` | Concatenate mod.rs/scene.rs/events.rs/style.rs/hit.rs into one file. |
+| `--paint-vm-rev <hash>`| pinned  | Pin a specific `paint-vm` git revision in the emitted `Cargo.toml` when `--emit-host` is on. |
+
+The `mosaic-compile` match in `code/packages/rust/mosaic-compile/src/main.rs`
+adds a new `"win32"` arm that constructs a
+`mosaic_emit_win32::Win32Renderer { … }` and writes the file set.
+
+## 12. Test plan
+
+1. **Unit tests** (cross-platform — emitter is pure code generation):
+   - Each row of §3 → assert the emitted `scene.rs` contains the
+     expected `Scene::push(...)` call.
+   - Each row of §8 → assert the emitted `style.rs` contains the
+     expected constant.
+   - UI24 dispatch cases (empty, one, three emits).
+   - Component-name mismatch / unsupported primitive errors.
+2. **Compile-the-output tests** (cross-platform via `cargo check`):
+   for each `demo/visicalc/mosaic/*` triple, run the emitter, drop the
+   output into a temp crate, and assert `cargo check` succeeds. This
+   catches emitter bugs that produce un-compilable Rust.
+3. **Windows-only smoke tests** (`#[cfg(target_os = "windows")]`):
+   on the windows-latest CI matrix:
+   - `cargo build --release` the VisiCalc Win32 demo.
+   - Launch the resulting `.exe` with a `--smoketest` flag that
+     immediately calls `request_quit` after the first paint;
+     exit-code 0 means the WNDCLASS registered, the HWND was created,
+     `Grid::mount` succeeded, and the first scene rendered without
+     panic.
+
+Target coverage: ≥90% for the emitter, exit-code-0 from the smoke test.
+
+## 13. Why a separate event-loop crate
+
+The `win32-event-loop.md` spec explains the rationale at length. The
+short version: the existing `window-win32` crate bakes together window
+creation, paint dispatch, and message pumping. Mosaic Win32's generated
+code wants only the third concern, decoupled enough that:
+
+- One event loop can host multiple Mosaic components in the same window
+  (different sub-HWNDs, or one HWND with internal routing).
+- A future MFC-style host can mix Mosaic components with hand-written
+  Win32 controls.
+- Tests can pump synthetic messages without owning any real window.
+
+The Mosaic Win32 emitter therefore *uses* but does not *own* the loop —
+the host application constructs the loop, registers the component's
+handler, and runs the loop on its own schedule.
+
+## 14. Why Paint VM rather than direct Direct2D calls
+
+Three reasons:
+
+1. **Renderer agnosticism.** The generated code only knows about
+   `paint_instructions::Scene`. Swapping `paint-vm-direct2d` for
+   `paint-vm-skia` or `paint-vm-cairo` later is one Cargo dependency
+   change; no emitter change is required.
+2. **Diff-based repaint.** The Paint VM exposes a `patch(old, new, ctx)`
+   API (P2D01) that diffs two scenes and replays only the changed
+   instructions. The Mosaic emitter does not need to know about this —
+   the host calls `vm.patch(prev_scene, new_scene, &mut d2d_ctx)` on
+   every Win32 `Event::Paint` and gets retained-mode performance for
+   free.
+3. **Testability.** Pure-Rust unit tests can build a `Scene` and assert
+   on its instruction list without touching Win32 or Direct2D.
+
+## 15. Out of scope (tracked as follow-ups)
+
+- **Compose mode.** Multiple top-level Mosaic components composed into
+  one window (today the spec assumes one component per HWND). A follow-up
+  defines a `Compose` primitive in moslayout and an `--emit-compose-root`
+  flag.
+- **Animations.** Same status as the XAML backend — the IR does not yet
+  model motion, so neither backend can generate animations.
+- **High-DPI per-monitor changes.** v1 reads DPI once at mount; tracking
+  DPI changes mid-flight (e.g. window moved between monitors) needs a
+  `Event::DpiChanged` variant on the event-loop crate.
+- **Theme switching.** Like the XAML backend, multi-theme requires two
+  `.msl` sources and a runtime selector; the demo only ships dark today.
+- **Accessibility (UIA).** Exposing Mosaic-rendered components to screen
+  readers is a separate spec; Direct2D-painted controls are otherwise
+  invisible to UIA without explicit work.
+- **Keyboard focus traversal.** v1 assumes one focusable element per
+  component (the Input). Multi-input focus rings, Tab order, etc. follow
+  in a focused-input PR.

--- a/code/specs/mosaic-emit-xaml.md
+++ b/code/specs/mosaic-emit-xaml.md
@@ -1,0 +1,440 @@
+# mosaic-emit-xaml — WinUI 3 / XAML backend for Mosaic
+
+**Status:** Specification (draft)
+**Layer:** UI / backend emitter
+**Depends on:** UI23 (mosaic-pipeline), UI24 (mosaic-emit-dispatch), the three
+IR compilers (mosmodel, moslayout, mosstyle), UI25 (Input), UI27 (Grid v2)
+**Sibling backends:** UI20 (React/TSX), `mosaic-emit-win32.md` (pure Win32 +
+Paint VM, Rust output)
+**Produces:** WinUI 3 C# source files (`.xaml` + `.xaml.cs` + project glue)
+
+---
+
+## 1. Purpose
+
+This spec defines a Mosaic backend that lowers a three-file pipeline triple
+(`.mil` + `.mll` + `.msl`) to a WinUI 3 component:
+
+```
+Grid.mil       \
+Grid.desktop.mll → mosaic-compile --backend xaml → Grid.xaml + Grid.xaml.cs
+Grid.dark.msl  /
+```
+
+WinUI 3 was chosen as the entry point for the XAML family (over WPF and
+UWP) because:
+
+1. It is the actively developed Microsoft Windows UI framework (Windows App
+   SDK 1.x line) — WPF is in maintenance, UWP is steered toward WinUI 3.
+2. Its XAML parser and control set are the closest to a "modern" XAML that
+   future WPF / Uno / Avalonia backends can fork from.
+3. The Mosaic moslayout vocabulary (Box / Row / Column / Grid / Input /
+   Text / Image / Spacer / Scroll / Divider / Stack / Icon) has direct
+   one-to-one XAML control mappings — no novel JSX-style trickery is
+   required.
+
+The companion `mosaic-emit-win32.md` spec covers the other extreme: pure
+Win32 + Direct2D via the Paint VM, no XAML, Rust output. The two share
+nothing except the UI24 event-dispatch contract.
+
+## 2. Output shape
+
+For a component named `Grid` declared by `Grid.mil` / `Grid.desktop.mll` /
+`Grid.dark.msl`, the backend writes:
+
+```
+Grid.xaml         — XAML markup; root is the moslayout root primitive lowered to a Panel
+Grid.xaml.cs      — code-behind: dependency properties for each slot, a
+                    `Dispatch` event for the discriminated event union,
+                    InitializeComponent boilerplate, and any inline event
+                    handlers UI24 dispatch wiring requires
+Grid.Event.cs     — the discriminated event union (record types + interface)
+                    — equivalent of the TS `export type GridEvent = ...`
+                    from UI24 §3.1
+```
+
+Additionally, when invoked with `--emit-project` (default off), the backend
+writes a minimal WinUI 3 `.csproj` and `App.xaml` / `App.xaml.cs` that hosts
+the generated component as the top-level window. With `--emit-project off`
+the backend only writes the per-component triple above and the caller is
+expected to integrate them into an existing WinUI 3 project. The VisiCalc
+plumbing (§9) uses `--emit-project` on; library consumers turn it off.
+
+## 3. Mapping table — moslayout primitives → XAML
+
+| moslayout primitive | XAML control                          | Notes |
+|---------------------|---------------------------------------|-------|
+| `Box`               | `<Border>`                            | Holds part-styled background, border, padding. |
+| `Row`               | `<StackPanel Orientation="Horizontal">` | Children flow left→right. |
+| `Column`            | `<StackPanel Orientation="Vertical">`   | Children flow top→bottom. |
+| `Stack`             | `<Grid>` (single cell, all children)   | Z-stack via children's `Grid.ZIndex`. |
+| `Grid`              | `<Grid>` with `RowDefinitions` / `ColumnDefinitions` and `<DataTemplate>`-based content for `headers` + `rows`. | See §4. |
+| `Text`              | `<TextBlock>`                          | `Text="{Binding ...}"` to a slot. |
+| `Image`             | `<Image Source="..."/>`                | |
+| `Input`             | `<TextBox>` (or `<MultilineTextBox>` analogue) | See §5; `multiline: true` → AcceptsReturn=True + TextWrapping=Wrap. |
+| `Scroll`            | `<ScrollViewer>`                       | |
+| `Spacer`            | `<Rectangle/>`                         | With `Width` / `Height` set from the moslayout prop. |
+| `Divider`           | `<Border BorderThickness=".."/>`       | Direction picked from props. |
+| `Icon`              | `<FontIcon Glyph="..."/>`              | Segoe Fluent Icons font. |
+
+Every emitted control gets `x:Name="{kebab→PascalCase part name}"` so the
+code-behind can refer to it without re-querying the visual tree.
+
+## 4. Grid primitive (UI27 §3 + §2.1 in this spec)
+
+XAML has no built-in spreadsheet control, so Grid lowers to a virtualised
+`<ItemsRepeater>` (or `<ListView>` with `ItemContainerStyle` for header
+rows) wrapped in a `<Grid>` that holds the header row, the data rows
+viewport, and (optionally) a `<colgroup>`-equivalent built from
+`<Grid.ColumnDefinitions>` driven by the `column-widths` slot.
+
+Concretely:
+
+```xml
+<Grid x:Name="Sheet" Background="{x:Bind PartBackground}">
+  <Grid.RowDefinitions>
+    <RowDefinition Height="Auto"/>   <!-- header row -->
+    <RowDefinition Height="*"/>      <!-- data rows scroll-viewer -->
+  </Grid.RowDefinitions>
+  <Grid.ColumnDefinitions/>          <!-- generated at runtime from column-widths -->
+
+  <ItemsRepeater Grid.Row="0" ItemsSource="{x:Bind ColumnHeaders}">
+    <ItemsRepeater.Layout>
+      <StackLayout Orientation="Horizontal"/>
+    </ItemsRepeater.Layout>
+    <ItemsRepeater.ItemTemplate>
+      <DataTemplate x:DataType="x:String">
+        <Border Style="{StaticResource HeaderCellStyle}">
+          <TextBlock Text="{x:Bind}"/>
+        </Border>
+      </DataTemplate>
+    </ItemsRepeater.ItemTemplate>
+  </ItemsRepeater>
+
+  <ScrollViewer Grid.Row="1">
+    <ItemsRepeater ItemsSource="{x:Bind ViewportRows}">
+      <ItemsRepeater.ItemTemplate>
+        <DataTemplate x:DataType="local:RowVm">
+          <ItemsRepeater ItemsSource="{x:Bind Cells}">
+            <ItemsRepeater.Layout>
+              <StackLayout Orientation="Horizontal"/>
+            </ItemsRepeater.Layout>
+            <ItemsRepeater.ItemTemplate>
+              <DataTemplate x:DataType="local:CellVm">
+                <Border Style="{StaticResource DataCellStyle}" Tapped="Cell_Tapped">
+                  <TextBlock Text="{x:Bind Value}"/>
+                </Border>
+              </DataTemplate>
+            </ItemsRepeater.ItemTemplate>
+          </ItemsRepeater>
+        </DataTemplate>
+      </ItemsRepeater.ItemTemplate>
+    </ItemsRepeater>
+  </ScrollViewer>
+</Grid>
+```
+
+The code-behind generates `RowVm` and `CellVm` POCOs whose properties match
+the `list<list<text>>` shape coming in via the `viewport-rows` slot.
+Per-cell selection / editing highlights are realised by `CellVm` toggling
+visual states (`VisualStateManager.GoToState`) rather than inline style
+spreads.
+
+### 4.1 column-widths
+
+When the moslayout's Grid binds `column-widths: slot: column-widths`, the
+code-behind appends one `<ColumnDefinition Width="{w}"/>` per element to
+`Sheet.ColumnDefinitions` and walks the per-row `ItemsRepeater` setting
+`Grid.Column=i, Width=widths[i]` on each cell `Border`. The slot stays
+`list<number>` (interpreted as DIPs — the WinUI default unit).
+
+### 4.2 onNavigate
+
+The `<Border>` template's `Tapped` handler is generated as:
+
+```csharp
+private void Cell_Tapped(object sender, TappedRoutedEventArgs e)
+{
+    var cell = (CellVm)((FrameworkElement)sender).DataContext;
+    Dispatch?.Invoke(this, new GridEvent.Navigate(cell.Row, cell.Col));
+}
+```
+
+Where `Dispatch` is the routed-event delegate defined in §6.
+
+## 5. Input primitive (UI25)
+
+`Input` lowers to `<TextBox>` with two-way binding to the bound `value`
+slot. UI25 specifies four emits — `onChange`, `onCommit`, `onCancel`,
+`onFocus` — which the backend maps as:
+
+| Emit         | XAML hookup                                          |
+|--------------|------------------------------------------------------|
+| `onChange`   | `TextChanged` handler dispatching a `Change(value)`. |
+| `onCommit`   | `KeyDown` handler with `e.Key == Enter`.             |
+| `onCancel`   | `KeyDown` handler with `e.Key == Escape`.            |
+| `onFocus`    | `GotFocus`.                                          |
+
+`multiline: true` props produce `AcceptsReturn=True`, `TextWrapping=Wrap`,
+and an explicit `Height="*"` row in the parent Grid.
+
+When the moslayout grammar adds string-literal prop values (today's known
+limitation #3 in `demo/visicalc/README.md`), `placeholder: "Enter formula"`
+will compile to `PlaceholderText="Enter formula"`. Until then, the
+emitter ignores the prop (matching the React backend's behaviour).
+
+## 6. Event dispatch contract (UI24)
+
+For a component with `n ≥ 0` emits, the emitter writes
+`{Component}.Event.cs`:
+
+```csharp
+namespace Mosaic.Generated;
+
+public abstract record GridEvent
+{
+    public sealed record Navigate(int Row, int Col) : GridEvent;
+    public sealed record EditCommit(string Value)   : GridEvent;
+    // ...
+}
+```
+
+And in `Grid.xaml.cs`:
+
+```csharp
+public sealed partial class Grid : UserControl
+{
+    /// <summary>Fires once for every emit declared in the .mil interface.</summary>
+    public event EventHandler<GridEvent>? Dispatch;
+
+    // One DependencyProperty per slot — see §7.
+}
+```
+
+Hosts wire it up identically to the React `dispatch` prop:
+
+```csharp
+grid.Dispatch += (sender, e) => state.HandleEvent(e);
+```
+
+The empty-emit case still emits the abstract record with zero concrete
+variants (matching the `export type Foo = never` shape from UI24 §3.1) so
+host code can pattern-match exhaustively without special-casing.
+
+## 7. Slot lowering — mosmodel → DependencyProperty
+
+Every slot in `.mil` becomes a public WinUI `DependencyProperty` with the
+following type translation:
+
+| mosmodel slot type   | C# property type                  |
+|----------------------|------------------------------------|
+| `text`               | `string`                          |
+| `number`             | `double`                          |
+| `bool`               | `bool`                            |
+| `color`              | `Windows.UI.Color`                |
+| `image`              | `Microsoft.UI.Xaml.Media.Imaging.ImageSource` |
+| `node`               | `Microsoft.UI.Xaml.UIElement`     |
+| `list<T>`            | `IReadOnlyList<T-mapped>`         |
+| `list<list<T>>`      | `IReadOnlyList<IReadOnlyList<T-mapped>>` (UI27 §2.1) |
+
+DependencyProperty registration is hand-rolled per slot to keep changes
+observable from XAML bindings; the property name is kebab→PascalCase
+(`column-widths` → `ColumnWidths`). The `Required: true` flag in the .mil
+becomes a `[Required]` attribute on the property; bindings still
+compile, but a runtime warning is logged on first render when the
+property is its default.
+
+## 8. Style application (UI23 §5)
+
+The mosstyle `.msl` source's `part` blocks are lowered into a
+`<ResourceDictionary>` emitted into `Grid.xaml`'s top-level `<UserControl.Resources>`:
+
+```xml
+<UserControl.Resources>
+  <Style x:Key="SheetStyle" TargetType="Border">
+    <Setter Property="Background" Value="#1e1e1e"/>
+    <Setter Property="FontFamily" Value="Consolas"/>
+    <Setter Property="FontSize"   Value="12"/>
+  </Style>
+  <!-- sub-parts (UI27 §3) get their own keys: SheetCellStyle, SheetHeaderCellStyle, ... -->
+</UserControl.Resources>
+```
+
+CSS property names are translated to XAML setter names by a fixed table —
+no design-time inference. The table covers the UI26 demo property surface:
+
+| .msl property              | XAML setter                                   |
+|----------------------------|-----------------------------------------------|
+| `background`               | `Background`                                  |
+| `color`                    | `Foreground`                                  |
+| `font-family`              | `FontFamily`                                  |
+| `font-size`                | `FontSize`                                    |
+| `font-weight`              | `FontWeight`                                  |
+| `padding`                  | `Padding`                                     |
+| `border-width`             | `BorderThickness`                             |
+| `border-color`             | `BorderBrush`                                 |
+| `border` (shorthand UI27)  | `BorderThickness` + `BorderBrush` (split)     |
+| `border-collapse`          | (ignored — XAML grids do not have collapse)   |
+| `width` / `height`         | `Width` / `Height`                            |
+
+State blocks (`state hover { … }`, `state pressed { … }`, etc.) compile to
+`<VisualState>` entries inside a `<VisualStateGroup>` named after the
+state's parent part:
+
+```xml
+<VisualStateManager.VisualStateGroups>
+  <VisualStateGroup x:Name="SheetCellStates">
+    <VisualState x:Name="Hover">
+      <VisualState.Setters>
+        <Setter Target="Cell.Background" Value="#2a2d2e"/>
+      </VisualState.Setters>
+    </VisualState>
+  </VisualStateGroup>
+</VisualStateManager.VisualStateGroups>
+```
+
+(See "state semantics" in UI27 §5.)
+
+## 9. VisiCalc plumbing — proof that this all hangs together
+
+Once both this backend and `mosaic-emit-win32` land, the VisiCalc demo
+re-uses its `.mil` / `.mll` / `.msl` sources unchanged and produces:
+
+```
+demo/visicalc/
+  windows/xaml/
+    VisiCalc.csproj           — generated WinUI 3 project (when --emit-project)
+    App.xaml, App.xaml.cs     — generated host shell
+    Grid.xaml, Grid.xaml.cs, Grid.Event.cs
+    FormulaBar.xaml, FormulaBar.xaml.cs, FormulaBar.Event.cs
+    State.cs                  — hand-written host equivalent of src/app/state.ts
+                                 (reducer over the union of GridEvent +
+                                 FormulaBarEvent + host events, mirrors
+                                 the React reducer shape per UI26 §7.3)
+    MainWindow.xaml(.cs)      — generated; instantiates Grid + FormulaBar and
+                                 wires Dispatch to State.HandleEvent
+  windows/build.ps1           — calls `mosaic-compile --backend xaml` for each
+                                 component, then `dotnet build VisiCalc.csproj`
+```
+
+`demo/visicalc/windows/xaml/README.md` documents how to install Windows App
+SDK and run the resulting `.exe`. The C# host code is small (~150 lines —
+mirroring `src/app/state.ts`) and lives next to the React host code so the
+two stay in lockstep.
+
+## 10. CLI integration
+
+`mosaic-compile --backend xaml` accepts the same `--interface`,
+`--layout`, `--style`, and `-o` flags as the React backend, plus:
+
+| Flag                    | Default | Effect                                                |
+|-------------------------|---------|-------------------------------------------------------|
+| `--emit-project`        | `false` | Also write `.csproj` + `App.xaml(.cs)` + `MainWindow.xaml(.cs)`. |
+| `--namespace <ns>`      | `Mosaic.Generated` | Top-level C# namespace for emitted types. |
+| `--windows-app-sdk <v>` | `1.5`   | Pins the `<PackageReference Include="Microsoft.WindowsAppSDK" Version="..."/>` for `--emit-project`. |
+
+Inside `code/packages/rust/mosaic-compile/src/main.rs`, the `--backend`
+match grows a new `"xaml"` arm that constructs a
+`mosaic_emit_xaml::XamlRenderer { … }`, validates the moslayout / mosstyle
+pair through the shared `mosaic-analyzer`, and writes the file set.
+
+## 11. Public API
+
+```rust
+// code/packages/rust/mosaic-emit-xaml/src/lib.rs
+
+pub struct XamlRenderer { /* options */ }
+
+pub struct XamlEmitResult {
+    pub xaml:         String,       // {Component}.xaml
+    pub code_behind:  String,       // {Component}.xaml.cs
+    pub events:       String,       // {Component}.Event.cs
+    pub project:      Option<ProjectFiles>, // Some(...) when emit_project=true
+    pub component_name: String,
+}
+
+pub struct ProjectFiles {
+    pub csproj:           String,
+    pub app_xaml:         String,
+    pub app_xaml_cs:      String,
+    pub main_window_xaml: String,
+    pub main_window_cs:   String,
+    pub package_manifest: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum XamlEmitError {
+    #[error("component name mismatch: mil/mll/msl disagree ({0:?})")]
+    ComponentNameMismatch(Vec<String>),
+    #[error("unsupported primitive: {0}")]
+    UnsupportedPrimitive(String),
+    #[error("slot type {0:?} has no XAML mapping")]
+    UnmappableSlotType(String),
+    #[error("style property {0:?} has no XAML setter mapping")]
+    UnmappableStyleProperty(String),
+}
+
+pub fn from_pipeline(
+    model:  &mosmodel_compiler::MosmodelComponent,
+    layout: &moslayout_compiler::LayoutDef,
+    style:  &mosstyle_compiler::StyleDef,
+    options: &EmitOptions,
+) -> Result<XamlEmitResult, XamlEmitError>;
+```
+
+Mirrors `mosaic_emit_react::pipeline::from_pipeline` so callers can swap
+backends with one type change.
+
+## 12. Test plan
+
+The crate is tested at three levels:
+
+1. **Unit tests** (don't require Windows): for each row of §3, build a
+   tiny `LayoutDef` and assert the XAML output contains the expected
+   control name and attribute set. Empty-emit, one-emit, three-emit
+   cases for §6. Each row of §8's setter table.
+2. **Integration tests** (don't require Windows): compile each of the
+   `demo/visicalc/mosaic/*.mil/.mll/.msl` triples through `from_pipeline`
+   and assert the XAML round-trips through a reference XAML parser
+   (the lightweight one in `code/packages/rust/xaml-lexer/` if it exists,
+   else just check well-formedness via `quick_xml`).
+3. **Windows-only smoke tests** (`#[cfg(target_os = "windows")]`): the CI
+   matrix's windows-latest job runs `dotnet build` on the
+   `--emit-project` output for each VisiCalc component, asserting a
+   successful build.
+
+Target coverage: ≥90% for the pure emitter, smoke tests for the
+Windows-only build.
+
+## 13. Out of scope (tracked as follow-ups)
+
+- **WPF backend.** WPF can fork most of this spec — same `Grid`,
+  `StackPanel`, `Border`, dependency-property model — but uses
+  `System.Windows.Controls` not `Microsoft.UI.Xaml.Controls` and runs on
+  .NET Framework 4.x or .NET 6+. Future spec: `mosaic-emit-wpf.md`.
+- **Avalonia / Uno backend.** Same XAML-flavoured surface; a thin
+  fork of this spec switches the namespace and a few control names.
+- **Animation / transition lowering.** The UI24+ spec does not yet model
+  motion; the XAML backend will pick up `<Storyboard>` mapping when the
+  IR catches up.
+- **Localization.** `x:Uid` resource binding is not generated; emitted
+  strings come from slot bindings only.
+- **Themes beyond dark.** The UI26 demo only ships `.dark.msl`; multi-theme
+  switching via `ResourceDictionary.ThemeDictionaries` is a follow-up
+  once the demo gains a light theme.
+
+## 14. Why WinUI 3 first, not WPF
+
+WPF has the larger installed base but is in maintenance. The Mosaic
+backend table is going to grow — WPF, Avalonia, Uno, MAUI — and they all
+share 80%+ of the XAML vocabulary. Picking WinUI 3 as the first cut
+locks in the *most modern* XAML dialect; downward forks to WPF (smaller
+control set, different DependencyProperty registration syntax) are
+easier than upward forks from WPF (which doesn't have
+`ItemsRepeater`, `VisualStateManager` setters of the same shape, or the
+`x:Bind` markup extension this spec leans on heavily).
+
+The trade-off: WinUI 3 requires the Windows App SDK runtime on the user's
+machine. For the VisiCalc plumbing, this is acceptable — the same demo
+also has a no-runtime path via `mosaic-emit-win32` + Direct2D for users
+who want a single self-contained `.exe`.

--- a/code/specs/win32-event-loop.md
+++ b/code/specs/win32-event-loop.md
@@ -1,0 +1,372 @@
+# win32-event-loop — decoupled Win32 message pump
+
+**Status:** Specification (draft)
+**Layer:** Platform plumbing (sits below any Win32-targeting renderer)
+**Depends on:** the `windows` crate (Win32 bindings)
+**Consumed by:** `mosaic-emit-win32` (UI), future Win32-targeted spreadsheet hosts, any
+crate that needs a Win32 message pump without owning window creation
+
+---
+
+## 1. Purpose
+
+The classic Win32 application is built around `GetMessage` / `TranslateMessage` /
+`DispatchMessage`. Today the only Mosaic-adjacent crate that runs this pump is
+[`window-win32`](../packages/rust/window-win32/), which couples four concerns into
+one type:
+
+1. Registering a `WNDCLASS`
+2. Creating an `HWND`
+3. Running the message loop
+4. Routing `WM_PAINT` to a single fixed paint callback
+
+That coupling is fine for a one-window helper but fights any application that
+wants to:
+
+- Run multiple top-level windows on one thread (the standard Win32 model — every
+  HWND on a thread shares a single message queue).
+- Drive its own paint pipeline (e.g. a `paint-vm-direct2d` callback per HWND, or
+  a per-component `render(Scene)` function the Mosaic Win32 emitter generates).
+- Mix Mosaic-emitted components with non-Mosaic Win32 controls (a host that
+  embeds, say, a `mosaic-emit-win32`-generated Grid alongside a hand-written
+  ribbon).
+- Pump events from a non-blocking context (a unit test, a Tokio runtime, a
+  game-loop-style frame scheduler that wants to interleave Win32 events with
+  other work).
+
+This spec carves the *event loop itself* into a small, single-purpose crate
+that knows nothing about Mosaic, Direct2D, or how individual windows are
+created. The Win32 Mosaic backend (UI: `mosaic-emit-win32`) is the first
+consumer; future Windows runtimes plug in the same way.
+
+## 2. Non-goals
+
+- **Window creation.** This crate never calls `CreateWindowExW` or registers a
+  `WNDCLASS`. Callers create windows themselves (directly via the `windows`
+  crate, or indirectly via `window-win32`) and then *register* the resulting
+  `HWND` with this crate so it knows where to route messages.
+- **Rendering.** This crate does not paint. It exposes a `Paint` event that
+  carries the bounds to invalidate; the consumer is expected to call its own
+  drawing code (e.g. `paint_vm_direct2d::render(scene, hwnd, rect)`).
+- **Cross-platform abstraction.** That belongs in `window-core` /
+  `window-win32`. This crate is *pure Win32* — it imports `GetMessageW`,
+  `DispatchMessageW`, and the standard message constants directly.
+- **Threading model overhauls.** Win32 message queues are per-thread; this
+  crate respects that. One `EventLoop` per thread is the only supported model.
+  Cross-thread coordination is out of scope (consumers wanting it can post
+  thread messages with `PostThreadMessage` themselves).
+
+## 3. Architecture
+
+```
++----------------------+      +----------------------+
+|  Mosaic Win32        |      |  Hand-written Win32  |
+|  emitter output      |      |  host code           |
+|  (mosaic-emit-win32) |      |  (anything else)     |
++----------+-----------+      +-----------+----------+
+           |                              |
+           |   register(hwnd, handler)    |
+           +--------------+---------------+
+                          |
+                          v
+                +---------+----------+
+                |   win32-event-loop |
+                |  (this crate)      |
+                |                    |
+                |  - HWND → handler  |
+                |    table           |
+                |  - GetMessage pump |
+                |  - typed Event     |
+                |    enum            |
+                +---------+----------+
+                          |
+                          | GetMessageW/DispatchMessageW
+                          v
+                +---------+----------+
+                |    User32/Win32    |
+                +--------------------+
+```
+
+The crate is structurally trivial — a `WNDPROC`, a global thread-local HWND→
+handler table, a message-translation function, and a blocking `run()` /
+non-blocking `pump_once()` pair. It is deliberately small (target: under
+1500 LOC including tests).
+
+## 4. Public API
+
+```rust
+//! win32-event-loop — single-threaded Win32 message pump.
+
+use windows::Win32::Foundation::HWND;
+
+/// A single typed event delivered to a registered HWND's handler.
+///
+/// The variants are a minimal common subset every Win32 consumer cares about;
+/// the raw message is also exposed for consumers that need to look at
+/// vendor-specific or device-specific WMs (WM_DEVICECHANGE, custom WM_USER+N,
+/// etc.).
+#[derive(Debug, Clone)]
+pub enum Event {
+    /// Window was asked to repaint a region. The handler must perform the
+    /// paint synchronously; the loop calls BeginPaint/EndPaint around the
+    /// dispatch so the consumer only sees the invalidate rect.
+    Paint { hwnd: HWND, rect: Rect },
+
+    /// Window resized. `client` is the new client-area size in physical pixels.
+    Resize { hwnd: HWND, client: Size },
+
+    /// A character was typed (translated WM_CHAR — Unicode codepoint after IME).
+    Char { hwnd: HWND, codepoint: u32, modifiers: Modifiers },
+
+    /// A key was pressed (raw virtual-key code, not yet translated).
+    KeyDown { hwnd: HWND, vk: VirtualKey, modifiers: Modifiers, repeat: bool },
+    KeyUp   { hwnd: HWND, vk: VirtualKey, modifiers: Modifiers },
+
+    /// Mouse button events. `button` is Left/Middle/Right/X1/X2.
+    MouseDown { hwnd: HWND, button: MouseButton, x: i32, y: i32, modifiers: Modifiers },
+    MouseUp   { hwnd: HWND, button: MouseButton, x: i32, y: i32, modifiers: Modifiers },
+    MouseMove { hwnd: HWND, x: i32, y: i32, modifiers: Modifiers },
+    MouseWheel { hwnd: HWND, x: i32, y: i32, delta: i32, modifiers: Modifiers },
+
+    /// Window close was requested (the X button, Alt+F4, system menu).
+    /// Returning Action::Default still closes the window; return
+    /// Action::Consumed to veto.
+    CloseRequested { hwnd: HWND },
+
+    /// Focus gained / lost.
+    FocusIn  { hwnd: HWND },
+    FocusOut { hwnd: HWND },
+
+    /// Escape hatch: an unrecognised message. The handler may return
+    /// Action::Default to let DefWindowProc handle it, or Action::Consumed
+    /// to return zero without calling DefWindowProc.
+    Raw { hwnd: HWND, message: u32, wparam: usize, lparam: isize },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Rect { pub left: i32, pub top: i32, pub right: i32, pub bottom: i32 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct Size { pub width: u32, pub height: u32 }
+
+/// Modifier-key bitset captured at the moment the event was dispatched.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Modifiers {
+    pub shift: bool,
+    pub ctrl:  bool,
+    pub alt:   bool,
+    pub win:   bool,
+}
+
+/// Subset of the virtual-key namespace this loop translates. Variants beyond
+/// the named ones fall through as `Raw`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtualKey {
+    Enter, Escape, Tab, Backspace, Delete,
+    Left, Right, Up, Down,
+    Home, End, PageUp, PageDown,
+    F(u8),                       // F1..F24
+    Char(u8),                    // A..Z, 0..9 (uppercase ASCII)
+    Other(u32),                  // raw VK code for anything else
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseButton { Left, Middle, Right, X1, X2 }
+
+/// What the handler did with the event.
+///
+/// - `Consumed` — the handler fully handled the message; the loop returns
+///   zero and does NOT call `DefWindowProc`.
+/// - `Default`  — the handler did nothing or wants the OS default behaviour;
+///   the loop calls `DefWindowProc`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action { Consumed, Default }
+
+/// Object-safe handler trait. Consumers either implement this directly or
+/// use the `closure_handler` adapter for simple lambdas.
+pub trait EventHandler: 'static {
+    fn handle(&mut self, event: Event) -> Action;
+}
+
+/// Adapt a `FnMut(Event) -> Action` into an `EventHandler`.
+pub fn closure_handler<F: FnMut(Event) -> Action + 'static>(f: F) -> impl EventHandler;
+
+/// The thread-local event loop. Construct once per thread; passing it across
+/// threads is a compile error (`!Send`).
+pub struct EventLoop { /* private */ }
+
+impl EventLoop {
+    /// Get the current thread's event loop, creating it if needed. Returns
+    /// the same loop on every call within one thread.
+    pub fn current() -> &'static EventLoop;
+
+    /// Register a handler for messages destined to `hwnd`.
+    ///
+    /// Panics if `hwnd` is already registered on this loop. Returns a
+    /// `Registration` whose `Drop` impl unregisters automatically.
+    pub fn register(&self, hwnd: HWND, handler: impl EventHandler) -> Registration;
+
+    /// Block forever, draining the message queue, until `PostQuitMessage`
+    /// is called (e.g. via `request_quit` or a handler that decides it's done).
+    /// Returns the WPARAM passed to WM_QUIT (conventionally 0 on clean exit).
+    pub fn run(&self) -> i32;
+
+    /// Drain at most `max` messages, returning the number actually processed.
+    /// Useful for integrating with non-Win32 schedulers — call this every
+    /// frame instead of `run()`. Returns 0 when the queue is empty AND
+    /// nothing was waiting.
+    pub fn pump_once(&self, max: usize) -> usize;
+
+    /// Post WM_QUIT(0) to this thread, causing any `run()` in flight to
+    /// return after the current message finishes dispatching.
+    pub fn request_quit(&self);
+}
+
+/// RAII handle. Dropping unregisters the HWND from the loop's routing table.
+/// The HWND itself is NOT destroyed — that remains the caller's job.
+pub struct Registration { /* private */ }
+```
+
+## 5. Internal design notes
+
+### 5.1 Routing table
+
+A `Mutex<HashMap<HWND, Box<dyn EventHandler>>>` lives behind a `OnceCell` keyed
+per thread. The crate's `extern "system"` window procedure is shared by all
+WNDCLASSes that opt into routing (callers pass it when they register their
+class); on each message it:
+
+1. Looks up `hwnd` in the table.
+2. If found, translates the message into an `Event` and calls `handle()`.
+3. If the handler returns `Action::Consumed`, returns 0; otherwise calls
+   `DefWindowProcW`.
+4. If no handler is registered, just calls `DefWindowProcW`.
+
+### 5.2 The shared WNDPROC
+
+The crate exposes the `extern "system" fn wndproc(...)` symbol so consumers
+can pass it to `WNDCLASS::lpfnWndProc` when registering their classes.
+Callers that want to use their own WNDPROC must instead implement message
+forwarding themselves; see §6.
+
+### 5.3 Message translation
+
+The crate handles a fixed list of `WM_*` constants and translates them into
+`Event`. Everything else falls through as `Event::Raw`. Translation rules:
+
+| Win32 message            | Translates to                          | Notes |
+|--------------------------|----------------------------------------|-------|
+| `WM_PAINT`               | `Event::Paint`                         | Wrapped in `BeginPaint`/`EndPaint`; rect = `PAINTSTRUCT::rcPaint`. |
+| `WM_SIZE`                | `Event::Resize`                        | `client = LOWORD(lParam) × HIWORD(lParam)`. |
+| `WM_CHAR`                | `Event::Char`                          | After `TranslateMessage`. |
+| `WM_KEYDOWN`/`WM_SYSKEYDOWN` | `Event::KeyDown`                   | `repeat = bit 30 of lParam`. |
+| `WM_KEYUP`/`WM_SYSKEYUP` | `Event::KeyUp`                         | |
+| `WM_LBUTTONDOWN`/...     | `Event::MouseDown`                     | Button derived from message id. |
+| `WM_LBUTTONUP`/...       | `Event::MouseUp`                       | |
+| `WM_MOUSEMOVE`           | `Event::MouseMove`                     | |
+| `WM_MOUSEWHEEL`          | `Event::MouseWheel`                    | `delta = HIWORD(wParam) as i16 as i32`. |
+| `WM_CLOSE`               | `Event::CloseRequested`                | `Action::Consumed` vetoes; `Action::Default` lets DefWindowProc destroy. |
+| `WM_SETFOCUS`            | `Event::FocusIn`                       | |
+| `WM_KILLFOCUS`           | `Event::FocusOut`                      | |
+| `WM_DESTROY`             | (internal) auto-unregisters the HWND.  | Then forwards `PostQuitMessage(0)` if it was the last registered window. |
+| anything else            | `Event::Raw`                           | |
+
+### 5.4 Thread-safety
+
+`EventLoop` is `!Send + !Sync`. The routing table lives in a thread-local
+`OnceLock`; cross-thread access is a compile error. Cross-thread messaging
+between two `EventLoop` instances is done via `PostThreadMessageW` — the
+crate exposes no helper for that today (out of scope).
+
+## 6. Interop with `window-win32`
+
+`window-win32` today both creates HWNDs and runs its own message loop. This
+crate is designed to coexist:
+
+- Callers that want the `window-win32` HWND creation but the loop here:
+  construct a `Win32Window` with a paint callback that *does nothing*, then
+  `EventLoop::current().register(window.hwnd(), ...)`, then `loop.run()`
+  instead of `window.run()`. The shared WNDPROC is opt-in: if `window-win32`
+  registered its own class, the messages do not flow through this loop's
+  routing table.
+
+- A follow-up PR can refactor `window-win32` to use this crate internally and
+  expose only window creation. That is *not* in scope for this spec — it's a
+  migration that needs its own review.
+
+## 7. Errors and panics
+
+The crate avoids returning `Result` from the high-traffic path
+(`pump_once`/`run`). Panics signal programmer errors only:
+
+- Calling `register(hwnd, _)` twice with the same HWND.
+- Calling `register` from a thread different from the one that owns the HWND
+  (verified via `GetWindowThreadProcessId`).
+- Calling `run`/`pump_once` from inside a handler (re-entrancy).
+
+Recoverable conditions return a `LoopError`:
+
+```rust
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum LoopError {
+    #[error("GetMessage returned -1 (Win32 error {0:#x})")]
+    GetMessageFailed(u32),
+}
+```
+
+`run` returns `Result<i32, LoopError>`; `pump_once` returns
+`Result<usize, LoopError>`. (The signatures above in §4 are simplified; the
+real API returns Result.)
+
+## 8. Test plan
+
+The crate is hard to unit-test in a vacuum because it depends on the real
+Win32 message queue. Test approach:
+
+1. **Pure-translation tests** (run on any OS via `#[cfg(test)]` shims):
+   parameterise the translation table — `fn translate(message: u32, wparam,
+   lparam) -> Option<Event>` — and unit-test every row of §5.3 without
+   touching Win32. ≥30 tests.
+2. **Windows-only integration tests** (`#[cfg(all(test, target_os = "windows"))]`):
+   - Create a hidden message-only HWND (`HWND_MESSAGE`), register a handler,
+     `PostMessage` a synthetic `WM_CHAR`, then `pump_once`. Assert handler saw
+     the right `Event::Char`.
+   - Two HWNDs, one handler each, two `PostMessage`s — each handler sees
+     only its own message.
+   - Handler returns `Action::Consumed` — verify `DefWindowProc` is NOT
+     called (use a custom WM_USER message that has observable side effects
+     in DefWindowProc).
+   - `Registration::drop` removes the HWND from the routing table — verify
+     by dropping and posting another message, then asserting the handler was
+     not invoked.
+   - `request_quit` makes `run` return.
+
+3. **Crash-safety tests**: a handler that panics must not corrupt the
+   routing table; the panic propagates out of `run`/`pump_once` and the HWND
+   stays registered for the next pump call.
+
+Target coverage: 95%+ for the pure-translation paths, 80%+ for the
+Windows-only integration paths.
+
+## 9. Crate boilerplate
+
+- Cargo.toml — depends on `windows = { version = "0.58", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_Graphics_Gdi"] }`, `thiserror`, and dev-dep `serial_test` (event-loop integration tests are inherently serial per thread).
+- README.md — usage example: create HWND with `windows` crate, register a closure handler, call `run()`.
+- CHANGELOG.md — initial 0.1.0 entry on landing.
+- BUILD — standard Rust BUILD pattern with the workspace deps.
+- The crate is **Windows-only at the implementation level** but compiles to
+  a no-op stub on other targets so dependents can be `cargo build`ed
+  cross-platform (matches the `#[cfg(target_os = "windows")]` pattern in
+  `window-win32`).
+
+## 10. Out of scope (tracked as follow-ups)
+
+- Touch / pen input (`WM_POINTER*`). Add later as new `Event::Touch` variants.
+- IME composition events (`WM_IME_*`). Today `WM_CHAR` after `TranslateMessage`
+  is enough for plain text input; full IME composition needs its own design.
+- High-DPI / per-monitor DPI awareness. Captured in a follow-up — the loop
+  reports physical pixels and leaves DPI handling to consumers.
+- A `tokio`/`async` adapter. The synchronous `pump_once(max)` is the building
+  block; an async wrapper can live in a separate crate without depending on
+  this one.


### PR DESCRIPTION
## Summary

Three new specs that map out a path from VisiCalc's existing `.mil`/`.mll`/`.msl` sources to two native Windows runtimes — one via WinUI 3 (C#), the other via pure Win32 + Direct2D (Rust). Both share only the UI24 event-dispatch contract; otherwise they are independent.

### `code/specs/win32-event-loop.md`

Standalone crate spec for a decoupled Win32 message pump. Owns `GetMessage`/`DispatchMessage` and an `HWND` → handler routing table. Knows nothing about Mosaic, Paint VM, or window creation — callers create their own `HWND`s (via `windows` crate or `window-win32`) and register them. Exposes a typed `Event` enum (`Paint`, `Resize`, `Char`, `KeyDown/Up`, `MouseDown/Up/Move/Wheel`, `CloseRequested`, `FocusIn/Out`, `Raw`) plus blocking `run()` and non-blocking `pump_once(max)`.

### `code/specs/mosaic-emit-xaml.md`

WinUI 3 backend producing C# + XAML. Maps moslayout primitives to native XAML controls (`Border`/`StackPanel`/`Grid`/`ItemsRepeater`/`TextBox`/...), mosstyle properties to XAML `Setter`s, mosmodel slots to `DependencyProperty`s, and UI24 event-dispatch to a single routed `Dispatch` event. Includes a VisiCalc plumbing section showing how the existing demo compiles through unchanged.

### `code/specs/mosaic-emit-win32.md`

Pure Win32 + Direct2D backend producing Rust. Lowers moslayout to a `paint_instructions::Scene` consumed by `paint-vm-direct2d` at runtime; never touches Direct2D APIs directly. Input wiring routes `win32-event-loop::Event` into UI24 `{Component}Event` variants via hit-testing. Output is a single self-contained `.exe` with no .NET runtime dependency.

## Why split this way

Per the design conversation: WinUI 3 first for the XAML family (most modern dialect; WPF/Avalonia/Uno can fork from it), Rust+Direct2D for the pure-Win32 path so we stay inside the existing Rust toolchain and Paint VM line, and an explicit standalone event-loop crate so neither backend hard-couples to a window-creation strategy.

## Test plan

- [x] All three specs are internally consistent (cross-references between them resolve)
- [x] Each opens with a `# Title` (no frontmatter), follows the unprefixed-filename convention from the recent plan file, and matches the style of UI24/UI25/UI26
- [x] Each domain stays in its own spec — no \"formula\" or \"spreadsheet-specific\" assumptions baked into the backend specs
- [ ] Reviewer feedback on whether to start implementation with the event loop, the XAML backend, or the Win32 backend first

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)