### PR TITLE
Add Board VM program store dispatch

### DIFF
--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -10,18 +10,19 @@ use board_vm_ir::{
 };
 use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
-    decode_run_request, decode_wire_frame, encode_caps_report, encode_error_payload, encode_frame,
-    encode_hello_ack, encode_program_begin, encode_program_chunk, encode_program_end,
-    encode_run_report_header, encode_value, encode_wire_frame, CapabilityDescriptor,
-    CapsReportHeader, ErrorPayload, Frame, HelloAck, MessageType, ProgramBegin, ProgramChunk,
-    ProgramEnd, ProtocolError, RunReportHeader, RunStatus as ProtocolRunStatus,
-    Value as ProtocolValue, CAP_FLAG_BYTECODE_CALLABLE, CAP_FLAG_PROTOCOL_FEATURE,
-    CAP_PROGRAM_RAM_EXEC, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE, NO_BYTECODE_OFFSET,
-    NO_PROGRAM_ID, RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
+    decode_run_request, decode_store_program, decode_wire_frame, encode_caps_report,
+    encode_error_payload, encode_frame, encode_hello_ack, encode_program_begin,
+    encode_program_chunk, encode_program_end, encode_run_report_header, encode_value,
+    encode_wire_frame, CapabilityDescriptor, CapsReportHeader, ErrorPayload, Frame, HelloAck,
+    MessageType, ProgramBegin, ProgramChunk, ProgramEnd, ProtocolError, RunReportHeader,
+    RunStatus as ProtocolRunStatus, Value as ProtocolValue, CAP_FLAG_BYTECODE_CALLABLE,
+    CAP_FLAG_PROTOCOL_FEATURE, CAP_PROGRAM_RAM_EXEC, CAP_PROGRAM_STORE, FLAG_IS_ERROR_RESPONSE,
+    FLAG_IS_RESPONSE, NO_BYTECODE_OFFSET, NO_PROGRAM_ID, RUN_FLAG_BACKGROUND_RUN,
+    RUN_FLAG_RESET_VM_BEFORE_RUN,
 };
 use board_vm_runtime::{
-    BoardHal, RunCursor, RunReport as RuntimeRunReport, RunStatus as RuntimeRunStatus, Runtime,
-    RuntimeError, Value as RuntimeValue,
+    BoardHal, HalError, RunCursor, RunReport as RuntimeRunReport, RunStatus as RuntimeRunStatus,
+    Runtime, RuntimeError, Value as RuntimeValue,
 };
 
 pub const DEFAULT_DEVICE_RUNTIME_ID: &str = "board-vm-device";
@@ -221,6 +222,12 @@ const PROGRAM_RAM_EXEC_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDes
     version: 1,
     flags: CAP_FLAG_PROTOCOL_FEATURE,
     name: "program.ram_exec",
+};
+const PROGRAM_STORE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_PROGRAM_STORE,
+    version: 1,
+    flags: CAP_FLAG_PROTOCOL_FEATURE,
+    name: "program.store",
 };
 
 pub const BLINK_MVP_CAPABILITIES: [CapabilityDescriptor<'static>; 7] = [
@@ -890,7 +897,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_AND_WATCHDOG_CAPABILIT
 ];
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_AND_STORAGE_CAPABILITIES:
-    [CapabilityDescriptor<'static>; 30] = [
+    [CapabilityDescriptor<'static>; 31] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -921,6 +928,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_AND_STORAGE_C
     STORAGE_WRITE_DESCRIPTOR,
     STORAGE_READ_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
+    PROGRAM_STORE_DESCRIPTOR,
 ];
 
 pub const BLINK_MVP_WITH_DAC_AND_LED_MATRIX_CAPABILITIES: [CapabilityDescriptor<'static>; 9] = [
@@ -1170,7 +1178,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_AND_LED_MATRI
 ];
 
 pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_AND_LED_MATRIX_CAPABILITIES:
-    [CapabilityDescriptor<'static>; 31] = [
+    [CapabilityDescriptor<'static>; 32] = [
     GPIO_OPEN_DESCRIPTOR,
     GPIO_WRITE_DESCRIPTOR,
     GPIO_READ_DESCRIPTOR,
@@ -1202,6 +1210,7 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_AND_L
     STORAGE_READ_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
+    PROGRAM_STORE_DESCRIPTOR,
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1455,6 +1464,9 @@ where
                 self.handle_program_chunk(request, payload_out, frame_out)
             }
             MessageType::PROGRAM_END => self.handle_program_end(request, payload_out, frame_out),
+            MessageType::STORE_PROGRAM => {
+                self.handle_store_program(request, payload_out, frame_out)
+            }
             MessageType::RUN => self.handle_run(request, payload_out, frame_out),
             MessageType::STOP => self.handle_stop(request, payload_out, frame_out),
             MessageType::BOOTLOADER_REBOOT => {
@@ -1592,6 +1604,37 @@ where
         self.program_id = end.program_id;
         self.upload.active = false;
         write_program_end_response(end, request.request_id, payload_out, frame_out)
+    }
+
+    fn handle_store_program(
+        &mut self,
+        request: Frame<'_>,
+        _payload_out: &mut [u8],
+        frame_out: &mut [u8],
+    ) -> Result<usize, BoardFault> {
+        if !self.descriptor.supports_store_program {
+            return Err(BoardFault::UnsupportedMessage);
+        }
+        let store = decode_store_program(request.payload)?;
+        if store.program_id != self.program_id || self.program_len == 0 {
+            return Err(BoardFault::InvalidProgram);
+        }
+
+        let program = &self.program[..self.program_len];
+        let module = parse_module(program).map_err(|_| BoardFault::InvalidBytecode)?;
+        validate(&module, self.runtime.hal().capabilities(), MAX_STACK as u8)
+            .map_err(|_| BoardFault::InvalidBytecode)?;
+        self.background = None;
+        self.runtime
+            .hal_mut()
+            .store_program(store.program_id, store.slot, store.boot_policy, program)
+            .map_err(BoardFault::Hal)?;
+        write_response(
+            MessageType::STORE_PROGRAM,
+            request.request_id,
+            &[],
+            frame_out,
+        )
     }
 
     fn handle_run(
@@ -1986,6 +2029,7 @@ enum BoardFault {
     PayloadTooLarge,
     InvalidProgram,
     InvalidBytecode,
+    Hal(HalError),
     Runtime(RuntimeError),
 }
 
@@ -2004,6 +2048,10 @@ impl BoardFault {
             Self::PayloadTooLarge => ERROR_PAYLOAD_TOO_LARGE,
             Self::InvalidProgram => ERROR_INVALID_PROGRAM,
             Self::InvalidBytecode => ERROR_INVALID_BYTECODE,
+            Self::Hal(
+                HalError::InvalidPin | HalError::UnsupportedMode | HalError::ResourceBusy,
+            ) => ERROR_INVALID_PROGRAM,
+            Self::Hal(HalError::BoardFault) => ERROR_BOARD_FAULT,
             Self::Runtime(error) => match error.kind {
                 board_vm_runtime::RuntimeErrorKind::InvalidBytecode
                 | board_vm_runtime::RuntimeErrorKind::ValidationFailed => ERROR_INVALID_BYTECODE,
@@ -2027,6 +2075,10 @@ impl BoardFault {
             Self::PayloadTooLarge => "payload too large",
             Self::InvalidProgram => "invalid program",
             Self::InvalidBytecode => "invalid bytecode",
+            Self::Hal(HalError::InvalidPin) => "invalid program",
+            Self::Hal(HalError::UnsupportedMode) => "unsupported mode",
+            Self::Hal(HalError::ResourceBusy) => "resource busy",
+            Self::Hal(HalError::BoardFault) => "board fault",
             Self::Runtime(error) => match error.kind {
                 board_vm_runtime::RuntimeErrorKind::InvalidBytecode
                 | board_vm_runtime::RuntimeErrorKind::ValidationFailed => "invalid bytecode",
@@ -2179,15 +2231,30 @@ mod tests {
     use board_vm_protocol::{
         decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
         decode_run_report_header, decode_wire_frame, encode_wire_frame, RunStatus, Value,
+        BOOT_RUN_AT_BOOT,
     };
     use board_vm_runtime::{GpioMode, HalError, Level};
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum Event {
-        GpioOpen { pin: u16, mode: GpioMode },
-        GpioWrite { token: u32, level: Level },
+        GpioOpen {
+            pin: u16,
+            mode: GpioMode,
+        },
+        GpioWrite {
+            token: u32,
+            level: Level,
+        },
         SleepMs(u16),
         BootloaderReboot,
+        StoreProgram {
+            program_id: u16,
+            slot: u8,
+            boot_policy: u8,
+            module_len: usize,
+            first_byte: u8,
+            last_byte: u8,
+        },
     }
 
     struct FakeHal {
@@ -2275,13 +2342,56 @@ mod tests {
                 Err(HalError::UnsupportedMode)
             }
         }
+
+        fn store_program(
+            &mut self,
+            program_id: u16,
+            slot: u8,
+            boot_policy: u8,
+            module: &[u8],
+        ) -> Result<(), HalError> {
+            self.push_event(Event::StoreProgram {
+                program_id,
+                slot,
+                boot_policy,
+                module_len: module.len(),
+                first_byte: module.first().copied().unwrap_or(0),
+                last_byte: module.last().copied().unwrap_or(0),
+            });
+            Ok(())
+        }
     }
 
     type Device = BoardVmDevice<'static, FakeHal, 256, 8, 8>;
 
+    const STORE_CAPABILITIES: [CapabilityDescriptor<'static>; 8] = [
+        GPIO_OPEN_DESCRIPTOR,
+        GPIO_WRITE_DESCRIPTOR,
+        GPIO_READ_DESCRIPTOR,
+        GPIO_CLOSE_DESCRIPTOR,
+        TIME_SLEEP_MS_DESCRIPTOR,
+        TIME_NOW_MS_DESCRIPTOR,
+        PROGRAM_RAM_EXEC_DESCRIPTOR,
+        PROGRAM_STORE_DESCRIPTOR,
+    ];
+
     fn new_device() -> Device {
         BoardVmDevice::new(
             DeviceDescriptor::blink_mvp("test-board", 0xB04D_1001),
+            FakeHal::new(CapabilitySet::blink_mvp()),
+        )
+    }
+
+    fn new_store_device() -> Device {
+        BoardVmDevice::new(
+            DeviceDescriptor {
+                board_id: "test-board",
+                runtime_id: DEFAULT_DEVICE_RUNTIME_ID,
+                board_nonce: 0xB04D_1001,
+                max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
+                supports_store_program: true,
+                capabilities: &STORE_CAPABILITIES,
+            },
             FakeHal::new(CapabilitySet::blink_mvp()),
         )
     }
@@ -2521,6 +2631,39 @@ mod tests {
     }
 
     #[test]
+    fn descriptor_reports_store_program_when_supported() {
+        let mut device = new_store_device();
+        let mut session = HostSession::new();
+        let mut request = [0u8; 128];
+        let mut device_payload = [0u8; 256];
+        let mut response = [0u8; 320];
+
+        let caps = session.caps_query_frame(&mut request).unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..caps.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        let (header, mut decoder) = decode_caps_report_header(frame.payload).unwrap();
+
+        assert!(header.supports_store_program);
+        assert_eq!(header.capability_count, STORE_CAPABILITIES.len() as u32);
+        let mut found_store = false;
+        for _ in 0..header.capability_count {
+            let capability = decoder.read_capability_descriptor().unwrap();
+            if capability.id == CAP_PROGRAM_STORE {
+                found_store = true;
+                assert_eq!(capability.name, "program.store");
+                assert_eq!(capability.flags, CAP_FLAG_PROTOCOL_FEATURE);
+            }
+        }
+        decoder.finish().unwrap();
+        assert!(found_store);
+    }
+
+    #[test]
     fn bootloader_reboot_request_is_acked_before_runtime_reset() {
         let mut device = BoardVmDevice::new(
             DeviceDescriptor::blink_mvp("test-board", 0xB04D_1001),
@@ -2705,6 +2848,111 @@ mod tests {
         assert_eq!(report.open_handles, 0);
         assert!(!device.is_background_running());
         assert_eq!(device.poll_background(100).unwrap(), None);
+    }
+
+    #[test]
+    fn store_program_persists_loaded_module_through_hal() {
+        let mut device = new_store_device();
+        let mut session = HostSession::new();
+        let mut module = [0u8; board_vm_host::BLINK_MODULE_LEN];
+        let module_len = write_blink_module(BlinkProgram::onboard_led(), &mut module).unwrap();
+        let module = &module[..module_len];
+        let mut host_payload = [0u8; 128];
+        let mut request = [0u8; 192];
+        let mut device_payload = [0u8; 256];
+        let mut response = [0u8; 320];
+
+        let begin = session
+            .program_begin_frame(DEFAULT_PROGRAM_ID, module, &mut host_payload, &mut request)
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..begin.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let chunk = session
+            .program_chunk_frame(
+                DEFAULT_PROGRAM_ID,
+                0,
+                module,
+                &mut host_payload,
+                &mut request,
+            )
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..chunk.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let end = session
+            .program_end_frame(DEFAULT_PROGRAM_ID, &mut host_payload, &mut request)
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..end.len],
+            &mut device_payload,
+            &mut response,
+        );
+
+        let store = session
+            .store_program_with_boot_policy_frame(
+                DEFAULT_PROGRAM_ID,
+                2,
+                BOOT_RUN_AT_BOOT,
+                &mut host_payload,
+                &mut request,
+            )
+            .unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..store.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+
+        assert_eq!(frame.flags, FLAG_IS_RESPONSE);
+        assert_eq!(frame.message_type, MessageType::STORE_PROGRAM);
+        assert_eq!(frame.request_id, store.request_id);
+        assert!(frame.payload.is_empty());
+        assert_eq!(
+            device.hal().events().last(),
+            Some(&Some(Event::StoreProgram {
+                program_id: DEFAULT_PROGRAM_ID,
+                slot: 2,
+                boot_policy: BOOT_RUN_AT_BOOT,
+                module_len,
+                first_byte: module[0],
+                last_byte: module[module.len() - 1],
+            }))
+        );
+    }
+
+    #[test]
+    fn store_program_reports_unsupported_when_descriptor_disables_it() {
+        let mut device = new_device();
+        let mut session = HostSession::new();
+        let mut request = [0u8; 64];
+        let mut device_payload = [0u8; 64];
+        let mut response = [0u8; 96];
+
+        let store = session
+            .store_program_frame(DEFAULT_PROGRAM_ID, 0, &mut device_payload, &mut request)
+            .unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..store.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        let error = decode_error_payload(frame.payload).unwrap();
+
+        assert_eq!(frame.message_type, MessageType::ERROR);
+        assert_eq!(error.code, ERROR_UNSUPPORTED_MESSAGE);
+        assert_eq!(error.message, "unsupported message");
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -3802,6 +3802,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"watchdog.kick".to_owned()));
         assert!(uno.capabilities.contains(&"storage.write".to_owned()));
         assert!(uno.capabilities.contains(&"storage.read".to_owned()));
+        assert!(uno.capabilities.contains(&"program.store".to_owned()));
         assert!(uno.capabilities.contains(&"network.ipv4".to_owned()));
         assert!(uno.capabilities.contains(&"network.tcp".to_owned()));
         assert!(uno.capabilities.contains(&"network.udp".to_owned()));

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -223,6 +223,16 @@ pub trait BoardHal {
         Err(HalError::UnsupportedMode)
     }
 
+    fn store_program(
+        &mut self,
+        _program_id: u16,
+        _slot: u8,
+        _boot_policy: u8,
+        _module: &[u8],
+    ) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn led_matrix_frame(&mut self, _frame: [u32; 3]) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -194,7 +194,7 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
     "program.ram_exec",
 ];
 
-pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 31] = [
+pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 32] = [
     "transport.serial",
     "gpio.open",
     "gpio.write",
@@ -226,9 +226,10 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 31] = [
     "storage.write",
     "storage.read",
     "program.ram_exec",
+    "program.store",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 38] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 39] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -267,6 +268,7 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 38] = [
     "storage.read",
     "led_matrix.frame",
     "program.ram_exec",
+    "program.store",
 ];
 
 pub const ESP32_CAPABILITIES: [&str; 12] = [
@@ -998,8 +1000,10 @@ mod tests {
         assert!(wifi.storage_regions[0].notes.contains("storage.read"));
         assert!(minima.capabilities.contains(&"storage.write"));
         assert!(minima.capabilities.contains(&"storage.read"));
+        assert!(minima.capabilities.contains(&"program.store"));
         assert!(wifi.capabilities.contains(&"storage.write"));
         assert!(wifi.capabilities.contains(&"storage.read"));
+        assert!(wifi.capabilities.contains(&"program.store"));
 
         assert!(find_target("esp32-devkit-v1")
             .unwrap()
@@ -1080,6 +1084,7 @@ mod tests {
         assert!(uno.capabilities.contains(&"can.read"));
         assert!(uno.capabilities.contains(&"storage.write"));
         assert!(uno.capabilities.contains(&"storage.read"));
+        assert!(uno.capabilities.contains(&"program.store"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -40,6 +40,12 @@ pub const UNO_R4_VM_RUNTIME_ID: &str = "board-vm-uno-r4";
 pub const UNO_R4_VM_MAX_PROGRAM_BYTES: usize = 4096;
 pub const UNO_R4_VM_MAX_STACK_VALUES: usize = 16;
 pub const UNO_R4_VM_MAX_HANDLES: usize = 8;
+pub const UNO_R4_PROGRAM_STORE_REGION: u16 = 0;
+pub const UNO_R4_PROGRAM_STORE_SLOT: u8 = 0;
+pub const UNO_R4_PROGRAM_STORE_MAGIC: [u8; 4] = *b"BVMS";
+pub const UNO_R4_PROGRAM_STORE_LAYOUT_VERSION: u8 = 1;
+pub const UNO_R4_PROGRAM_STORE_FORMAT_BVM_MODULE: u8 = 1;
+pub const UNO_R4_PROGRAM_STORE_HEADER_BYTES: usize = 20;
 
 pub type UnoR4Device<B> = BoardVmDevice<
     'static,
@@ -899,6 +905,57 @@ where
         self.backend.storage_read(region, offset, len)
     }
 
+    fn store_program(
+        &mut self,
+        program_id: u16,
+        slot: u8,
+        boot_policy: u8,
+        module: &[u8],
+    ) -> Result<(), HalError> {
+        if slot != UNO_R4_PROGRAM_STORE_SLOT {
+            return Err(HalError::InvalidPin);
+        }
+        let total_len = UNO_R4_PROGRAM_STORE_HEADER_BYTES
+            .checked_add(module.len())
+            .ok_or(HalError::InvalidPin)?;
+        if total_len > u16::MAX as usize {
+            return Err(HalError::InvalidPin);
+        }
+        let Some(descriptor) = self
+            .target
+            .storage_regions
+            .iter()
+            .find(|storage| storage.region == UNO_R4_PROGRAM_STORE_REGION as u8)
+        else {
+            return Err(HalError::InvalidPin);
+        };
+        if total_len > descriptor.bytes as usize {
+            return Err(HalError::InvalidPin);
+        }
+
+        let module_len = module.len() as u32;
+        let module_crc32 = crc32_ieee(module);
+        let mut header = [0u8; UNO_R4_PROGRAM_STORE_HEADER_BYTES];
+        header[0..4].copy_from_slice(&UNO_R4_PROGRAM_STORE_MAGIC);
+        header[4] = UNO_R4_PROGRAM_STORE_LAYOUT_VERSION;
+        header[5] = slot;
+        header[6] = boot_policy;
+        header[7] = UNO_R4_PROGRAM_STORE_FORMAT_BVM_MODULE;
+        header[8..10].copy_from_slice(&program_id.to_le_bytes());
+        header[12..16].copy_from_slice(&module_len.to_le_bytes());
+        header[16..20].copy_from_slice(&module_crc32.to_le_bytes());
+
+        self.storage_write(UNO_R4_PROGRAM_STORE_REGION, 0, &header)?;
+        let mut offset = UNO_R4_PROGRAM_STORE_HEADER_BYTES as u16;
+        for chunk in module.chunks(u8::MAX as usize) {
+            self.storage_write(UNO_R4_PROGRAM_STORE_REGION, offset, chunk)?;
+            offset = offset
+                .checked_add(chunk.len() as u16)
+                .ok_or(HalError::InvalidPin)?;
+        }
+        Ok(())
+    }
+
     fn spi_transfer(
         &mut self,
         token: u32,
@@ -1108,6 +1165,18 @@ fn normalize_storage_region(
     }
 }
 
+fn crc32_ieee(bytes: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFFu32;
+    for byte in bytes {
+        crc ^= *byte as u32;
+        for _ in 0..8 {
+            let mask = 0u32.wrapping_sub(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
 pub fn uno_r4_device_descriptor(
     target: &'static TargetDescriptor,
     board_nonce: u32,
@@ -1125,7 +1194,7 @@ fn uno_r4_device_descriptor_for_capabilities(
         runtime_id: UNO_R4_VM_RUNTIME_ID,
         board_nonce,
         max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
-        supports_store_program: false,
+        supports_store_program: capabilities.storage,
         capabilities: if target.supports_led_matrix
             && capabilities.pwm
             && capabilities.adc
@@ -1794,11 +1863,19 @@ mod tests {
         assert_eq!(descriptor.runtime_id, UNO_R4_VM_RUNTIME_ID);
         assert_eq!(descriptor.board_nonce, 0xA11C_E001);
         assert_eq!(descriptor.max_frame_payload, DEFAULT_MAX_FRAME_PAYLOAD);
+        assert!(descriptor.supports_store_program);
         assert_eq!(
             descriptor.capabilities.len(),
             BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_AND_LED_MATRIX_CAPABILITIES
                 .len()
         );
+        assert!(descriptor
+            .capabilities
+            .iter()
+            .any(
+                |capability| capability.id == board_vm_protocol::CAP_PROGRAM_STORE
+                    && capability.name == "program.store"
+            ));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -2208,6 +2285,65 @@ mod tests {
         );
         assert_eq!(
             board.storage_write(0, 0, &[0xaa; u8::MAX as usize + 1]),
+            Err(HalError::InvalidPin)
+        );
+    }
+
+    #[test]
+    fn store_program_writes_header_and_module_chunks_to_storage_region() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+        let mut module = vec![0xab; 300];
+        module[0] = b'B';
+        module[1] = b'V';
+        module[2] = b'M';
+        module[3] = b'1';
+
+        board.store_program(7, 0, 2, &module).unwrap();
+
+        let events = &board.backend().events;
+        assert_eq!(events.len(), 3);
+        let Event::StorageWrite(region, offset, header) = &events[0] else {
+            panic!("expected program-store header write");
+        };
+        assert_eq!((*region, *offset), (0, 0));
+        assert_eq!(&header[0..4], &UNO_R4_PROGRAM_STORE_MAGIC);
+        assert_eq!(header[4], UNO_R4_PROGRAM_STORE_LAYOUT_VERSION);
+        assert_eq!(header[5], 0);
+        assert_eq!(header[6], 2);
+        assert_eq!(header[7], UNO_R4_PROGRAM_STORE_FORMAT_BVM_MODULE);
+        assert_eq!(u16::from_le_bytes([header[8], header[9]]), 7);
+        assert_eq!(
+            u32::from_le_bytes([header[12], header[13], header[14], header[15]]),
+            module.len() as u32
+        );
+        assert_eq!(
+            u32::from_le_bytes([header[16], header[17], header[18], header[19]]),
+            crc32_ieee(&module)
+        );
+        assert_eq!(
+            events[1],
+            Event::StorageWrite(
+                0,
+                UNO_R4_PROGRAM_STORE_HEADER_BYTES as u16,
+                module[..255].to_vec()
+            )
+        );
+        assert_eq!(
+            events[2],
+            Event::StorageWrite(
+                0,
+                UNO_R4_PROGRAM_STORE_HEADER_BYTES as u16 + 255,
+                module[255..].to_vec()
+            )
+        );
+    }
+
+    #[test]
+    fn store_program_rejects_nonzero_slot_for_initial_uno_r4_layout() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        assert_eq!(
+            board.store_program(7, 1, 2, &[0x42]),
             Err(HalError::InvalidPin)
         );
     }

--- a/code/specs/BVM03-board-vm-rust-runtime.md
+++ b/code/specs/BVM03-board-vm-rust-runtime.md
@@ -126,6 +126,11 @@ pub trait ProgramStore {
 }
 ```
 
+The current no-heap Rust HAL exposes this first tranche as
+`BoardHal::store_program(program_id, slot, boot_policy, module)`. Board adapters
+may lower that protocol-level request into their existing bounded storage writes,
+while leaving language frontends as thin builders for the `STORE_PROGRAM` frame.
+
 `HandleToken` is private to the board adapter. The portable VM only sees compact
 `Handle` ids.
 
@@ -237,7 +242,7 @@ If `ProgramStore` is available:
 
 1. Host uploads a validated module.
 2. Host sends `STORE_PROGRAM(slot, boot_policy)`.
-3. Runtime writes bytes to nonvolatile storage.
+3. Runtime writes bytes and boot metadata to nonvolatile storage.
 4. On reset, runtime loads the slot and runs the module.
 
 ### Embedded Firmware

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -93,9 +93,13 @@ reject conflicting handles.
    bounded byte-buffer bytecode tranche for that region. WiFi/network now has
    Rust-owned descriptor metadata for the onboard WiFiS3 interface plus
    `network.ipv4`, `network.tcp`, and `network.udp` capability strings surfaced
-   through the language target APIs. `program.store`, higher-level KV storage,
-   and socket/control bytecode operations remain later capability tranches.
+   through the language target APIs. `program.store` now has a protocol
+   capability descriptor, `STORE_PROGRAM` device dispatch, runtime HAL hook, and
+   an initial UNO R4 storage-backed slot-0 layout that writes a compact header
+   plus module chunks through the same bounded storage substrate. Higher-level
+   KV storage and socket/control bytecode operations remain later capability
+   tranches.
 
-Every tranche should include the same layers: spec entry, IR capability id,
+Every tranche should include the same layers: spec entry, IR/protocol capability id,
 runtime HAL method, UNO R4 target descriptor, firmware backend, host builder,
 language SDK wrapper, and fake-backend tests.


### PR DESCRIPTION
## Summary
- add `program.store` protocol capability reporting and `STORE_PROGRAM` device dispatch
- add a runtime `BoardHal::store_program` hook and UNO R4 slot-0 storage-backed layout over existing bounded `storage.write`
- surface `program.store` in Rust-owned UNO R4 target metadata and update specs/tests

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-program-storage cargo fmt -p board-vm-ir -p board-vm-protocol -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core -p board-vm-uno-r4-firmware`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-program-storage cargo test -p board-vm-ir -p board-vm-protocol -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-program-storage cargo test -p board-vm-uno-r4-firmware`
- `bundle exec ruby -c lib/coding_adventures/board_vm/session.rb && bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb && bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD && git diff --check && git diff --cached --check`
