### PR TITLE
spec + Phase 1: Ruby parser support for all versions from 1.0 to 3.3

### DIFF
--- a/code/specs/ruby-lexer-state-machine.md
+++ b/code/specs/ruby-lexer-state-machine.md
@@ -1,0 +1,327 @@
+# Ruby lexer state machine
+
+## Status
+
+Detail spec for the TOML-encoded state machine that drives the
+[ruby-parser](ruby-parser.md) pipeline.  Defines the EXPR_* lex
+states, the register vocabulary, the parser-feedback contract, and
+the per-state transitions for the ambiguous constructs.
+
+Same runtime as [html1.lexer.states.toml](../packages/rust/html-lexer/html1.lexer.states.toml)
+— the `state-machine-tokenizer/0.1` engine.  Ruby-specific machinery
+is in extra register types and a small set of new action verbs
+(catalogued below).
+
+## Reading guide
+
+- §1 enumerates the **lex states** (`EXPR_BEG`, `EXPR_END`, etc.)
+  that Ruby's lexer carries.
+- §2 enumerates the **registers** (text buffers, name tables,
+  heredoc queue).
+- §3 spells out the **parser-feedback contract** — what the lexer
+  asks the parser, what the parser tells the lexer.
+- §4 walks through the **ambiguity-resolution rules** for each of
+  the context-sensitive constructs.
+- §5 lists the **new action verbs** the state machine runtime must
+  learn (extensions to the HTML vocabulary).
+
+## §1. Lex states
+
+Mirrors MRI's `parse.y` enum.  The lex state controls how the lexer
+classifies the *next* token — most importantly, whether a `/` starts
+a regex or denotes division, and whether `+` / `-` / `*` are binary
+or unary.
+
+| State           | Mnemonic                          | `/` means    | Unary `+/-` allowed | Heredoc start `<<x` allowed |
+|-----------------|-----------------------------------|--------------|---------------------|------------------------------|
+| `EXPR_BEG`      | beginning of expression           | regex start  | yes                 | yes                          |
+| `EXPR_END`      | after a value-yielding token      | division     | no (binary)         | no (treat `<<` as shift)     |
+| `EXPR_ARG`      | after a method name, may take arg | regex start  | yes (unary)         | yes                          |
+| `EXPR_CMDARG`   | inside a command-style call arg   | regex start  | yes                 | yes                          |
+| `EXPR_ENDARG`   | after a paren-closed arg list     | division     | no                  | no                           |
+| `EXPR_MID`      | mid-expr (after binary op)        | regex start  | yes                 | no                           |
+| `EXPR_FNAME`    | after `def` / `.`                 | name-part    | no                  | no                           |
+| `EXPR_DOT`      | after `.` or `::`                 | name-part    | no                  | no                           |
+| `EXPR_CLASS`    | after `class` keyword             | name-part    | no                  | no                           |
+| `EXPR_LABEL`    | after `:` in a hash literal       | regex start  | yes                 | yes                          |
+| `EXPR_LABELED`  | after a labelled arg              | regex start  | yes                 | yes                          |
+| `EXPR_ENDFN`    | after a method-def signature      | division     | no                  | no                           |
+| `EXPR_VALUE`    | after `return` / `yield` etc.     | regex start  | yes                 | yes                          |
+
+State transitions happen on token emit; the table is encoded in the
+TOML as a per-token-class `next_state` field.  Several transitions
+also depend on parser state (see §3) — those use the action verb
+`set_state_via(parser_oracle_query)`.
+
+## §2. Registers
+
+Beyond the HTML lexer's `text_buffer`-style registers, Ruby needs:
+
+| Register             | Type                          | Use                                                  |
+|----------------------|-------------------------------|------------------------------------------------------|
+| `token_buffer`       | string                        | accumulating identifier / number / operator chars     |
+| `string_buffer`      | string                        | accumulating string-literal contents (escapes resolved) |
+| `string_delim`       | char                          | the opening delimiter of the current string literal   |
+| `interp_depth`       | uint                          | nesting depth of `#{...}` inside strings              |
+| `paren_stack`        | vec<char>                     | for `%w[...]` / `%q{...}` matched-delimiter tracking  |
+| `heredoc_queue`      | vec<HeredocSpec>              | terminators of heredocs whose bodies are pending      |
+| `heredoc_indent`     | int                           | for `<<~`, the smallest indentation seen              |
+| `current_lex_state`  | enum LexState (§1)            | the active expression-position state                  |
+| `cmdarg_stack`       | uint bitfield                 | for nested command-arg contexts                       |
+| `cond_stack`         | uint bitfield                 | for `cond` contexts (in `while`/`until` headers)      |
+| `paren_balance`      | int                           | gross `(`/`)` balance for error recovery              |
+| `version`            | const string                  | which ruby version's rules are active                  |
+
+`HeredocSpec` is `{ terminator: string, kind: enum (Plain, Indent, Squiggly), interpolating: bool, expanding: bool, body_buffer: string }`.
+
+## §3. Parser-feedback contract
+
+The lexer holds a reference to a `ParserOracle` and may call any of:
+
+```
+oracle.is_local(name)           -> bool       # disambiguates `f /x/`
+oracle.in_def()                 -> bool       # disambiguates some keyword behaviours
+oracle.in_block()               -> bool       # `next` / `break` / `return` differ
+oracle.in_lambda()              -> bool       # `return` is hard-return in lambdas
+oracle.in_class_body()          -> bool       # `def self.x` vs `def x` lex differently
+```
+
+The parser drives lexer state changes via:
+
+```
+lexer.set_lex_state(state)      # parser commits to EXPR_BEG, EXPR_FNAME, etc.
+lexer.push_heredoc(spec)        # parser saw `<<X`; lexer queues a body capture
+lexer.enter_string(delim, ...)  # parser entered a string-literal context
+lexer.exit_string()
+```
+
+The HTML lexer already exposes a one-way version of this
+(`apply_html_lex_context`).  Ruby's contract is bidirectional: the
+parser can both push state changes **and** answer queries during the
+parse.
+
+Implementation note: to avoid lifetime tangles, the oracle is a
+`&dyn ParserOracle` passed at construction.  The parser is the
+oracle (it implements the trait); during `parse_ruby` it holds a
+mutable handle to the lexer and a reference to itself via `Rc`
+indirection.  See [ruby-parser.md](ruby-parser.md) §"Public API".
+
+## §4. Ambiguity-resolution rules
+
+### `f /x/` — method call with regex vs division
+
+| `lex_state` at `/` | `is_local(f)` | Resolution             |
+|--------------------|---------------|------------------------|
+| `EXPR_END`         | (any)         | division              |
+| `EXPR_ENDARG`      | (any)         | division              |
+| `EXPR_ARG`         | true          | division              |
+| `EXPR_ARG`         | false         | regex (method call)   |
+| `EXPR_BEG`         | (any)         | regex                 |
+| `EXPR_MID`         | (any)         | regex                 |
+
+In words: `/` is **regex** when we're at an expression-start
+position and the preceding identifier could be a method.
+
+### `a + b` vs `a +b`
+
+After a name token in `EXPR_ARG`, when the next char is `+` or `-`:
+- If followed immediately by a digit / identifier with **no space
+  before**, treat as unary applied to a method-call argument
+  (`a(+b)`).
+- If followed by space-then-operand or by operand-then-space, treat
+  as binary (`a + b`).
+
+This mirrors MRI's exact heuristic: significant whitespace.
+
+### `do...end` vs `{...}` block-binding precedence
+
+Both are blocks.  Difference:
+- `{...}` binds **tightly** to the immediately preceding method call
+- `do...end` binds **loosely**, attaching to the leftmost outer call
+
+```ruby
+foo bar do end       # parsed as `foo(bar) { ... }` — do-block binds to foo
+foo bar { }          # parsed as `foo(bar { })` — brace-block binds to bar
+```
+
+The lexer just emits `do` or `{` tokens; the parser disambiguates.
+The parser uses a precedence shift rule keyed on the token kind.
+
+### Heredocs
+
+`<<X` (or `<<-X`, `<<~X`, `<<"X"`, `<<'X'`) declares a heredoc whose
+body extends to a line equal to `X` (with optional indentation
+stripping for `<<-` / `<<~`).
+
+Body capture is **deferred**: the lexer keeps lexing the current
+line as normal tokens, pushing the heredoc spec into
+`heredoc_queue`.  At the first newline, the lexer enters
+`heredoc_body` state, scans until the terminator line, then resumes
+the queue's next entry (if any) before returning to the normal
+state.
+
+Multiple heredocs on one line are legal and stack:
+
+```ruby
+x = <<A + <<B
+a body
+A
+b body
+B
+```
+
+The queue preserves FIFO order so `A`'s body comes before `B`'s.
+
+### String interpolation `#{...}`
+
+Inside a `"..."` or backtick or interpolating heredoc, the literal
+`#{` begins an embedded expression.
+
+- Lexer pushes the current string-literal context onto
+  `paren_stack` and re-enters `EXPR_BEG`.
+- A matching `}` (tracked by `interp_depth`) pops back into the
+  string-literal context.
+- Nested interpolation works recursively; `interp_depth` and
+  `paren_stack` handle it.
+
+The state machine encodes this as a *sub-machine entry* — same
+mechanism HTML uses for CDATA inside `<script>`.
+
+### Symbols vs ternary `?:`
+
+`:foo` is a symbol literal; `?` followed by anything else is the
+ternary.  The lex state at `:` decides:
+- In `EXPR_BEG` / `EXPR_MID` / `EXPR_VALUE` / `EXPR_ARG` (with
+  name-shaped follower): symbol.
+- In `EXPR_END` / `EXPR_ENDARG`: ternary operator.
+
+### `%w[...]`, `%q{...}`, `%r{...}` percent literals
+
+After `%`, the lexer reads:
+1. A type char (`w` / `i` / `q` / `Q` / `r` / `s` / `x`) — or none, meaning quoted string.
+2. An opening delimiter char (`(` / `[` / `{` / `<` / any non-alphanumeric).
+3. Body up to the matching closing delimiter, with nesting tracked
+   in `paren_stack`.
+
+These exist from Ruby 1.0; the type chars `i` (symbol array) and `I`
+(interpolating symbol array) were added in 2.0.  Version gating in
+the TOML uses an `available_in_version` predicate.
+
+### Numbered block parameters (`_1` .. `_9`)
+
+From Ruby 2.7.  A `NAME` token whose lexeme matches `_[1-9]` is
+re-classified as `NUMBERED_PARAM` only inside block bodies when the
+block had no explicit parameter list.  The lexer can't know this
+alone — the parser sets a `numbered_params_active` flag on the
+oracle when it enters such a block.
+
+### Endless method def (`def foo() = body`)
+
+From Ruby 3.0.  Pure parser-level disambiguation (the lexer doesn't
+need to know): after `def NAME ( params )`, the parser looks for `=`
+in the *grammar* and follows the expression-body production.  No
+new lexer state.
+
+## §5. New action verbs
+
+Beyond the HTML action vocabulary (`append_text`, `emit_token`, etc.):
+
+| Action                       | Effect                                                             |
+|------------------------------|--------------------------------------------------------------------|
+| `query_is_local(buffer)`     | sets transition condition based on `oracle.is_local(buffer)`        |
+| `push_heredoc(kind)`         | reads terminator from `string_buffer`, pushes onto `heredoc_queue`  |
+| `enter_heredoc_body`         | pops the head of `heredoc_queue`, switches to heredoc-body capture  |
+| `set_lex_state(state)`       | writes `current_lex_state` register                                  |
+| `push_paren(char)`           | appends to `paren_stack`                                            |
+| `pop_paren_or_fail`          | pops `paren_stack`, fails if mismatched                             |
+| `inc_interp_depth`           | for tracking `#{}` nesting                                          |
+| `dec_interp_depth`           | for `#{}` close                                                     |
+| `emit_with_state(kind,next)` | atomic emit + state-transition in one step                          |
+| `version_gate(ver)`          | guard transition behind `version >= ver`                            |
+
+The runtime extension is small (~10 verbs) and orthogonal to the
+HTML verbs — the same engine runs both.
+
+## TOML schema example (sketch)
+
+```toml
+format = "state-machine/v1"
+profile = "lexer/v1"
+name = "ruby-1.8-lexer"
+kind = "transducer"
+version = "0.1.0"
+runtime_min = "state-machine-tokenizer/0.2"   # new minor: adds Ruby verbs
+initial = "EXPR_BEG"
+includes = []
+
+[[tokens]]
+name = "NAME"
+fields = ["value", "lex_state"]
+
+[[tokens]]
+name = "REGEX"
+fields = ["pattern", "flags"]
+
+# ... ~50 token kinds total ...
+
+[[registers]]
+id = "current_lex_state"
+type = "enum"
+values = ["EXPR_BEG", "EXPR_END", "EXPR_ARG", ...]
+
+[[registers]]
+id = "heredoc_queue"
+type = "vec"
+element_type = "heredoc_spec"
+
+[[states]]
+id = "EXPR_BEG"
+
+[[states.transitions]]
+on_char = "/"
+goto = "regex_body"
+actions = ["set_state(EXPR_BEG)"]
+
+[[states]]
+id = "EXPR_ARG"
+
+# `f /x/` disambiguation
+[[states.transitions]]
+on_char = "/"
+guard = "query_is_local(token_buffer)"
+goto = "divison_after_name"   # treat as binary divide
+
+[[states.transitions]]
+on_char = "/"
+goto = "regex_body"            # otherwise regex
+```
+
+## Versioning the TOMLs
+
+Each era gets its own `ruby-<ver>.lexer.states.toml`.  Most rules
+are stable across versions; we use TOML inheritance:
+
+```toml
+extends = "ruby-1.8"
+overrides = ["states.EXPR_BEG.transitions[3]", ...]
+```
+
+Inheritance is resolved at compile time by `grammar-tools`, not at
+runtime.  Resulting per-version machines are byte-identical to a
+hand-written version-specific TOML — inheritance is just authoring
+convenience.
+
+## Cross-cutting concerns
+
+- **Source position tracking**: every token carries `line` /
+  `column` (1-based).  The runtime increments on `\n` and resets
+  column.  Same shape as HTML lexer output.
+- **Error recovery**: lexer never panics.  Malformed input emits a
+  `LexerError` token (with span and diagnostic message) and
+  continues from the next character.  The parser is responsible
+  for deciding whether to abort or skip ahead.
+- **Determinism**: the same input + version + oracle always
+  produces the same token stream.  Property tests verify this.
+- **Performance budget**: ~10 µs per KB of typical Ruby source on
+  a 2024 laptop.  This isn't a real number yet — to be tightened
+  after Phase 1 benchmarks.

--- a/code/specs/ruby-parser.md
+++ b/code/specs/ruby-parser.md
@@ -1,0 +1,295 @@
+# Ruby parser
+
+## Status
+
+Spec for a from-scratch Ruby lexer + parser that covers **every Ruby
+version from 1.0 (1996) through 3.3 (2023)**.  The current
+`ruby-lexer` / `ruby-parser` crates in this repo are placeholders —
+regex-based tokenizers that handle a Python-shaped subset and do not
+implement Ruby's real semantics.  This spec replaces them.
+
+Two companion specs hold the per-detail work:
+- [ruby-lexer-state-machine.md](ruby-lexer-state-machine.md) — the
+  TOML-encoded state machine, lex-state transitions, register
+  vocabulary, and parser-feedback contract.
+- [ruby-version-evolution.md](ruby-version-evolution.md) — the
+  per-version syntax delta tables (what landed in 1.6, 1.8, 1.9,
+  2.0, 2.7, 3.0, etc.).
+
+## Why this is harder than Python or JavaScript
+
+Ruby is **not context-free**.  Several constructs are syntactically
+identical until the lexer is told what surrounding context applies:
+
+| Source        | If `f` is a local           | If `f` is a method        |
+|---------------|-----------------------------|---------------------------|
+| `f /x/`       | `f / x / something`         | `f(/x/)`                  |
+| `f +1`        | `f + 1`                     | `f(+1)`                   |
+| `f *xs`       | `f * xs`                    | `f(*xs)`                  |
+| `f %w[a]`     | `f % w[a]`                  | `f(%w[a])`                |
+
+The lexer must know whether `f` is currently bound as a local
+variable, and locals are introduced by assignment — so this knowledge
+must come from the parser as parsing progresses.
+
+Heredocs further compound the problem: `x = <<EOF + "more"` puts the
+heredoc body on the *next line* but lexing continues on the current
+line, then splices in the body when newline is hit.
+
+String interpolation (`"a#{1 + foo("x")}b"`) recursively re-enters
+the full lexer (and parser) inside `#{...}`.
+
+## Approach
+
+Adopt the same pattern that the HTML lexer/parser already use in
+this repo: a **declarative state-machine lexer** (`html1.lexer.states.toml`)
+that the parser drives mid-stream via `apply_html_lex_context`.  The
+Ruby case extends that pattern with a *bidirectional* contract — the
+lexer also queries the parser for local-variable membership.
+
+```text
+ruby source
+   │
+   ▼  ruby_lexer::tokenize(source, version, parser_oracle)
+       ┌── parser_oracle: ────────────────────────────┐
+       │   is_local(name)            → bool           │
+       │   in_def?, in_block?, in_lambda? → bool      │
+       │   current_lex_state          → LexState      │
+       │   push_heredoc(terminator, kind)             │
+       └──────────────────────────────────────────────┘
+Tokens (with embedded lex-state annotations for debugging)
+   │
+   ▼  ruby_parser::parse(tokens, version)
+GrammarASTNode  (same CST shape as python-parser / javascript-parser)
+```
+
+Both crates load **versioned** state machines + grammars, mirroring
+the existing pattern from `python-parser` (versions `2.7`, `3.0`,
+…) and `javascript-parser` (`es5`, `es2015`, …).
+
+## Version coverage
+
+This spec commits to supporting **all Ruby versions from 1.0
+through 3.3** — including the very old ones.  Practical observation:
+not every minor release changed syntax.  We model **15 syntax-era
+versions**; intermediate point releases inherit the most recent era.
+
+| Era version | Released  | Headline syntax additions / breaks                     |
+|-------------|-----------|--------------------------------------------------------|
+| `1.0`       | 1996-12   | baseline: def/end, if/end, while/end, blocks, regex, heredocs, symbols |
+| `1.6`       | 2000-09   | minor lex-state refinement (`__END__`, `__FILE__`)     |
+| `1.8`       | 2003-08   | block-local `|x; y|`, multiple assignment refinements   |
+| `1.9.1`     | 2009-01   | hash shorthand `{a: 1}`, lambda `->()` , `__method__`, magic encoding comment, block-local `|x; y|` standardised |
+| `1.9.3`     | 2011-10   | (no new syntax — fork point for the 2.x line)          |
+| `2.0`       | 2013-02   | keyword arguments, `**` hash splat, `%i[]` symbol array, refinements |
+| `2.1`       | 2013-12   | required kwargs `key:`, rational `1r` / complex `1i`   |
+| `2.3`       | 2015-12   | safe navigation `&.`, `frozen_string_literal` pragma   |
+| `2.5`       | 2017-12   | `rescue` inside `do...end` without `begin`             |
+| `2.6`       | 2018-12   | endless ranges `(1..)`, `then`/`else` in `case`        |
+| `2.7`       | 2019-12   | numbered block params `_1`..`_9`, beginless ranges, `case/in` pattern matching (experimental) |
+| `3.0`       | 2020-12   | pattern matching stable, endless method def `def f = ...`, rightward `=>` assignment, one-line `expr in pat` |
+| `3.1`       | 2021-12   | hash shorthand `{x:}` (no value), anonymous block `&`  |
+| `3.2`       | 2022-12   | find pattern `[*, x, *]`, anonymous splat forwarding   |
+| `3.3`       | 2023-12   | (no new surface syntax — pinning the Prism era)        |
+
+Default version when caller passes `""` is `3.3`.  See
+[ruby-version-evolution.md](ruby-version-evolution.md) for the full
+delta tables and the inheritance rules between versions.
+
+## Package layout
+
+```
+code/packages/rust/
+  ruby-lexer/
+    Cargo.toml
+    src/
+      lib.rs                  # public API: create_ruby_lexer, tokenize_ruby
+      _machines.rs            # AUTO-GENERATED: compiled state machines, one per version
+      parser_oracle.rs        # trait + default impl for parser-feedback queries
+    grammars/
+      ruby-1.0.lexer.states.toml
+      ruby-1.8.lexer.states.toml
+      ruby-1.9.1.lexer.states.toml
+      ...
+      ruby-3.3.lexer.states.toml
+  ruby-parser/
+    Cargo.toml
+    src/
+      lib.rs                  # public API: parse_ruby
+      _grammar.rs             # AUTO-GENERATED: compiled parser grammars
+      local_scope.rs          # ParserOracle impl — tracks locals during parse
+      heredoc_queue.rs        # deferred-emit queue for heredoc bodies
+    grammars/
+      ruby-1.0.grammar
+      ruby-1.8.grammar
+      ...
+      ruby-3.3.grammar
+code/grammars/
+  ruby-1.0.lexer.states.toml      # canonical source-of-truth copies
+  ruby-1.0.grammar
+  ...
+```
+
+Mirrors the per-version grammar layout already used by
+[python-parser](../packages/rust/python-parser/) and
+[javascript-parser](../packages/rust/javascript-parser/).  TOML state
+files are compiled into Rust constants by `grammar-tools` at build
+time so production runs link a static machine — no runtime TOML
+parse.
+
+## Public API
+
+```rust
+// ruby-lexer
+pub fn create_ruby_lexer(source: &str, version: &str) -> Result<RubyLexer, String>;
+pub fn tokenize_ruby(source: &str, version: &str) -> Result<Vec<Token>, String>;
+
+/// The lexer's view of the parser.  Default impl (`NoLocals`)
+/// treats every name as a method, suitable for paren-required Ruby
+/// subsets and for round-trip tests of the lexer in isolation.
+pub trait ParserOracle {
+    fn is_local(&self, name: &str) -> bool { false }
+    fn in_def(&self) -> bool { false }
+    fn in_block(&self) -> bool { false }
+    fn in_lambda(&self) -> bool { false }
+}
+
+pub fn tokenize_ruby_with_oracle(
+    source: &str,
+    version: &str,
+    oracle: &dyn ParserOracle,
+) -> Result<Vec<Token>, String>;
+
+// ruby-parser
+pub fn parse_ruby(source: &str, version: &str) -> Result<GrammarASTNode, String>;
+```
+
+Parser internally constructs its own `LocalScopeOracle` that the
+lexer queries during the parse — call sites of `parse_ruby` don't
+have to wire anything up.
+
+## Tokens produced
+
+The lexer emits a stream where each token carries:
+- `kind`            — the Ruby token category (see [token list below](#token-categories))
+- `value`           — original lexeme (interpolation-resolved for strings)
+- `line` / `column` — 1-based source position
+- `lex_state`       — the EXPR_* state active when the token was emitted (debug aid; parser may also use it)
+
+### Token categories
+
+Operators: `+`, `-`, `*`, `/`, `%`, `**`, `==`, `!=`, `<`, `>`, `<=`,
+`>=`, `<=>`, `&&`, `||`, `!`, `&`, `|`, `^`, `~`, `<<`, `>>`, `..`,
+`...`, `=>`, `&.` (2.3+), `&` (anon, 3.1+).
+
+Punctuation: `(`, `)`, `[`, `]`, `{`, `}`, `,`, `;`, `:`, `::`, `.`,
+`?`, `@`.
+
+Keywords: `BEGIN`, `END`, `alias`, `and`, `begin`, `break`, `case`,
+`class`, `def`, `defined?`, `do`, `else`, `elsif`, `end`, `ensure`,
+`false`, `for`, `if`, `in`, `module`, `next`, `nil`, `not`, `or`,
+`redo`, `rescue`, `retry`, `return`, `self`, `super`, `then`, `true`,
+`undef`, `unless`, `until`, `when`, `while`, `yield`.  Newer eras
+add: `__ENCODING__` (1.9), `__method__` (1.9).
+
+Literals: `INT`, `FLOAT`, `RATIONAL` (2.1+), `IMAGINARY` (2.1+),
+`STRING` (with interpolation tokens), `SYMBOL`, `REGEX`, `HEREDOC`.
+
+Identifiers: `NAME` (local or method), `IVAR` (`@x`), `CVAR` (`@@x`),
+`GVAR` (`$x`), `CONST` (capitalised), `FID` (`foo!` / `foo?`).
+
+## Phasing
+
+We **don't** build all 15 era machines upfront.  Phases:
+
+**Phase 1 — paren-required Ruby 1.8 baseline**
+- Single state machine, no parser oracle calls (treat every name as
+  a method).  Disallows ambiguous forms: `f /x/`, `f *xs`, etc.
+- Covers `def`/`end`, `if`/`end`, `while`/`end`, blocks (`do...end`
+  and `{...}`), simple strings (no interpolation), regex `/.../`
+  only at start-of-expression context, symbols, classes, modules.
+- Goal: parse the existing `code/packages/ruby/` test corpus (most of
+  which uses parens).
+
+**Phase 2 — local-scope feedback**
+- Add `ParserOracle` and the parser's local-scope tracker.
+- Enable `f /x/` disambiguation, implicit-receiver method calls.
+- Still single-version (1.8 baseline).
+
+**Phase 3 — interpolation and heredocs**
+- Sub-lexer stack for `"a#{expr}b"`.
+- Heredoc deferred-emit queue.
+- Multi-line strings (`%q`, `%Q`, `%w`, `%i`, `%r`, etc.).
+
+**Phase 4 — version evolution**
+- Fork the 1.8 machine into 1.9.1 (hash shorthand, lambda `->`).
+- Add 2.0 (keyword args), 2.3 (`&.`), 2.7 (numbered params), 3.0
+  (endless def, pattern matching).
+- Older versions (1.0, 1.6) are forward-derived: start from 1.8 and
+  *remove* features that didn't exist yet.
+
+**Phase 5 — `ruby-to-semantic-ir` frontend**
+- Wire the parser into the existing narrow-waist Semantic IR (the
+  same pipeline as `python-to-semantic-ir` and
+  `javascript-to-semantic-ir`).  Demonstrates Ruby → SIR → Python
+  / JavaScript / TypeScript / Rust / Go.
+
+Each phase is its own PR with full tests before merging.
+
+## End-to-end success criteria
+
+A program of moderate complexity must round-trip:
+
+```ruby
+def factorial(n)
+  if n == 0
+    1
+  else
+    n * factorial(n - 1)
+  end
+end
+
+puts factorial(5)
+```
+
+- Tokenizes correctly (one `INT 5` not three `tok<?>`).
+- Parses without error.
+- Lowers via `ruby-to-semantic-ir` (Phase 5).
+- Re-emits as Python / JavaScript via existing backends, and runs.
+
+And the heredoc-heavy ambiguity test must also work:
+
+```ruby
+greeting = <<~END
+  hello
+END
+puts greeting.length / 2
+```
+
+- Heredoc body captured before `puts` is lexed.
+- `greeting.length / 2` parses as division (because `length` is
+  already known to be a method on `greeting`, not a local).
+
+## Tests
+
+Each lexer state machine ships with golden tests: a `.rb` input
+file paired with a `.tokens` expected-output file.  Per CLAUDE.md
+the per-package coverage target is ≥ 90%.
+
+Parser fuzzing: random valid Ruby strings drawn from a small
+generator, asserting parse-then-roundtrip-to-source equality.
+
+Differential testing against MRI's `ripper` library where Ruby is
+available at CI time (optional; not blocking on Windows).
+
+## Out of scope (this spec)
+
+- Code formatting / pretty-printing
+- Semantic analysis (use-before-def, type inference)
+- Refinements activation (the `using` directive is parsed but
+  refinement resolution is a separate IR pass)
+- `BEGIN { ... }` / `END { ... }` blocks — parsed but lowering is
+  deferred
+- Methods defined with non-ASCII identifiers — accepted syntactically,
+  no normalisation
+- `eval` / `instance_eval` strings — opaque, treated as `STRING`

--- a/code/specs/ruby-version-evolution.md
+++ b/code/specs/ruby-version-evolution.md
@@ -1,0 +1,291 @@
+# Ruby version evolution
+
+## Status
+
+Companion to [ruby-parser.md](ruby-parser.md).  Lists the syntax
+changes that landed in each Ruby release from 1.0 (1996) through
+3.3 (2023), with notes on whether the change is **lexer-visible**,
+**parser-only**, or **lib-only** (and therefore not our concern in
+this layer).
+
+We model 15 **era versions** — releases that actually changed surface
+syntax.  Intermediate point releases (2.0.0 vs 2.0.1, 2.4 vs 2.4.5)
+do not get their own grammar file; they inherit from the most
+recent era at or before their release.
+
+## Quick reference
+
+| Era    | Released  | Major adds / breaks                                                            |
+|--------|-----------|---------------------------------------------------------------------------------|
+| 1.0    | 1996-12   | Baseline                                                                        |
+| 1.6    | 2000-09   | `__END__`, `__FILE__`, `__LINE__`; reserved `BEGIN` / `END`                     |
+| 1.8    | 2003-08   | Block-local `|x|` made stricter; multiple assign refinements                    |
+| 1.9.1  | 2009-01   | `{a: 1}` hash, `->()` lambda, `#{}` in `:'..'` symbols, magic encoding         |
+| 1.9.3  | 2011-10   | (no surface; fork point — 2.0 forks here)                                       |
+| 2.0    | 2013-02   | Keyword args, `**`, `%i[]`, refinements (`using`)                               |
+| 2.1    | 2013-12   | Required kwargs `key:`, rational `1r` / complex `1i`                            |
+| 2.3    | 2015-12   | `&.`, `frozen_string_literal` magic comment                                     |
+| 2.5    | 2017-12   | `rescue` directly inside `do...end` (no `begin`)                                |
+| 2.6    | 2018-12   | Endless ranges `(1..)`, `then` in `case/when`                                   |
+| 2.7    | 2019-12   | Numbered block params `_1`..`_9`, beginless ranges `(..5)`, `case/in` pattern matching (experimental) |
+| 3.0    | 2020-12   | Pattern matching stable, endless method def `def f = ...`, rightward `=>` assignment, one-line `expr in pat` |
+| 3.1    | 2021-12   | Hash shorthand `{x:}` (no value), anonymous block `&`                            |
+| 3.2    | 2022-12   | Find pattern `[*, x, *]`, anonymous splat forwarding `*` / `**`                  |
+| 3.3    | 2023-12   | (no surface; Prism becomes default parser)                                       |
+
+## Detailed deltas
+
+### 1.0 — baseline (1996-12)
+
+Establishes the bulk of Ruby's syntax:
+- `def` / `end`, `class` / `end`, `module` / `end`
+- `if` / `elsif` / `else` / `end`, `unless`, `while`, `until`, `for`
+- `case` / `when` / `else` / `end`  (no `in` patterns yet)
+- `begin` / `rescue` / `ensure` / `end`
+- Blocks: `do ... end` and `{ ... }`
+- String literals: `"..."`, `'...'`, backticks, `%q{...}` / `%Q{...}` / `%w{...}` / `%r{...}` / `%s{...}` / `%x{...}`
+- Heredocs: `<<X`, `<<-X` (the `<<~` squiggly form is NOT in 1.0)
+- Symbols: `:foo`, `:"foo bar"`
+- Regex: `/.../` with flags `i`, `m`, `x`, `o`
+- Hash with hash-rocket: `{ :a => 1 }`
+- Range: `..`, `...`
+- Operators: `+ - * / % ** == != < > <= >= <=> && || ! & | ^ ~ << >> = += -= *= /= %= **= &= |= ^= <<= >>= &&= ||= => . :: ?:`
+- Globals (`$x`), instance vars (`@x`), class vars (`@@x`)
+- `nil`, `true`, `false`, `self`
+- `__FILE__`, `__LINE__` (already in 1.0)
+- All percent literals exist
+- All numeric literals: `0xFF`, `0o77`, `0b101`, `1_000`, `1.5e10`
+
+**Lexer-visible new behaviour vs nothing**: this *is* the baseline.
+
+### 1.6 — refinement of reserved words (2000-09)
+
+- `BEGIN { ... }` / `END { ... }` blocks accepted at top level
+- `__method__` NOT yet present
+- Minor lex-state cleanup in MRI; from our perspective: no
+  user-visible new tokens
+
+**Lexer-visible**: `BEGIN` / `END` reserved (already were keywords
+in 1.0, just less consistently).
+
+### 1.8 — pre-modern stable (2003-08)
+
+- Block parameters with semicolon-introduced locals: `do |x; y, z|`
+  (y and z are block-local, not captured)
+- Multiple assignment lhs/rhs splat refinements (`a, *b = [1, 2, 3]`)
+- `respond_to?` etc. become standard (lib, not syntax)
+
+**Lexer-visible**: block-local `;` inside `|...|` — needs a new
+tiny state for "after `;` inside block params".
+
+### 1.9.1 — the big break (2009-01)
+
+The most disruptive syntax change in Ruby's history:
+
+- **Hash shorthand**: `{a: 1, b: 2}` ≡ `{:a => 1, :b => 2}`
+- **Lambda literal**: `->(x, y) { x + y }`
+- **`__method__`** added (returns current method name as symbol)
+- **`__ENCODING__`** added (returns current source encoding)
+- **Magic encoding comment**: first or second line may say
+  `# coding: utf-8` (or `# encoding: utf-8`); changes how byte
+  sequences in string literals are interpreted
+- **Block-local variable syntax** standardised: `do |x; y, z|`
+  formally documented
+- **String literal encoding** drives byte interpretation; affects
+  `\u{XXXX}` escapes (1.9+ only)
+- **Strings are no longer enumerable as bytes** — affects parsing
+  of some constructs
+
+**Lexer-visible**: yes — the hash-shorthand requires `NAME :` to
+sometimes lex as a hash key (in `EXPR_LABEL` state), and lambda
+`->` is a new token.
+
+**Version gate**: if `version < 1.9.1`, reject `->`, `{a: 1}`
+shorthand, and `\u{...}` escapes.
+
+### 1.9.3 — fork point (2011-10)
+
+No new surface syntax.  We pin this as a fork point because the
+2.x series semantically starts here.
+
+### 2.0 — keyword arguments (2013-02)
+
+- **Keyword arguments**: `def foo(x:, y: 10)` defines two kwargs,
+  the first required, the second with default
+- **Double-splat**: `def foo(**rest)` collects all keyword args
+- **`%i[a b c]`** and **`%I[]`** for symbol arrays
+- **Refinements**: `module M; refine X do ... end; end`, `using M`
+  at module/file scope
+- **Module#prepend** (lib)
+- **`Module#using`** (parsed but resolution is later)
+
+**Lexer-visible**: `%i` / `%I` percent literals, `:` after a name
+in method-def args needs to lex as kwarg-marker (new state needed
+inside the parameter list).
+
+### 2.1 — kwargs and numeric types (2013-12)
+
+- **Required keyword args**: `def foo(x:)` (no default = required)
+- **Rational literal**: `2.5r`, `3r`
+- **Complex literal**: `2i`, `3.0i`
+- **`Module#def_method_missing`** (lib)
+- **`Binding#local_variable_set`** (lib)
+
+**Lexer-visible**: number suffixes `r` and `i` extend the numeric
+token grammar.
+
+### 2.3 — safe navigation (2015-12)
+
+- **Safe-navigation operator** `&.`: `obj&.foo` is `nil` if `obj` is
+  `nil`, else `obj.foo`
+- **`<<~`** (squiggly heredoc): strips common leading whitespace
+- **`frozen_string_literal: true`** magic comment freezes all
+  string literals in the file
+- **Hash#dig / Array#dig** (lib)
+
+**Lexer-visible**: `&.` is a new operator token, `<<~` is a new
+heredoc opener with `Squiggly` kind in the heredoc spec.
+
+### 2.5 — rescue in do/end (2017-12)
+
+- **Implicit `begin`** for `rescue` inside `do...end` or method
+  definitions: previously required wrapping in `begin...end`
+- **`yield_self`** (lib, now `then`)
+
+**Lexer-visible**: no new tokens.  Parser-only — `rescue` after a
+`do...end`-style block body now reduces to a different production.
+
+### 2.6 — endless ranges and `then` in case (2018-12)
+
+- **Endless range**: `(1..)` means "1 to infinity"
+- **Method composition** `>>` and `<<` are still binary operators
+  (lib feature, doesn't change syntax)
+- **`else` in `case` without `when`**: was always allowed, now formalised
+
+**Lexer-visible**: `(1..)` requires that `..` followed by `)` /
+`]` / newline / `,` is a *unary* range close, not "incomplete
+operator".
+
+### 2.7 — pattern matching arrives (2019-12)
+
+- **Numbered block parameters**: `[1, 2, 3].each { puts _1 }`
+- **Beginless range**: `(..5)` means "negative infinity to 5"
+- **Pattern matching** with `case / in`: `case x in [a, b] then ... end`
+- **`Comparable#clamp(range)`** (lib)
+- **Method reference operator** `.:` was experimental; **removed**
+  before final 2.7 (do not parse)
+
+**Lexer-visible**: `_1` through `_9` need oracle-driven
+reclassification (only valid inside un-explicit-parameter blocks);
+beginless ranges require the same `..` symmetry as 2.6's endless
+ranges.
+
+**Parser-only**: `case / in` introduces a new grammar production
+for patterns.
+
+### 3.0 — pattern matching stable, endless methods (2020-12)
+
+- **Pattern matching** stabilised (no more experimental warning)
+- **Endless method definition**: `def foo(x) = x * 2`
+- **Rightward assignment**: `42 => x` binds `x` to `42`
+- **One-line pattern matching**: `expr in pattern` returns boolean
+- **`Hash#except`** (lib)
+- **`String#scrub` defaults** (lib)
+
+**Lexer-visible**: `=>` already a token (hash rocket); rightward
+assignment is a parser-level reinterpretation in statement position.
+`def foo(x) = body` is parser-level — after `def NAME(args)`, the
+parser looks for `=` and switches productions.
+
+### 3.1 — hash shorthand without value (2021-12)
+
+- **Hash shorthand**: `{x:}` ≡ `{x: x}` — bare label means "use the
+  local of the same name"
+- **Anonymous block forwarding**: `def foo(&); bar(&); end`
+- **Pinning expressions in patterns**: `case x in ^(Foo.bar) then ... end`
+- **`Struct.new` with keyword init** (lib)
+
+**Lexer-visible**: bare-label hash entry needs the parser to know
+"after `{` or `,`, a `NAME :` not followed by an expression is a
+shorthand entry."  Parser-level disambiguation.
+
+### 3.2 — find patterns and anonymous splats (2022-12)
+
+- **Find pattern**: `case x in [*, 7, *] then ... end` — captures
+  middle.
+- **Anonymous splat forwarding**: `def foo(*); bar(*); end`
+- **Anonymous double-splat**: `def foo(**); bar(**); end`
+- **`Data.define`** for value classes (lib)
+
+**Lexer-visible**: no new tokens.  Parser productions for patterns
+are extended.
+
+### 3.3 — pin the Prism era (2023-12)
+
+- No surface syntax changes
+- **Prism** parser becomes the default in MRI (replacing parse.y)
+- Pinned as "what we emit by default"
+
+## Inheritance rules
+
+Each per-version TOML extends the immediately prior era:
+
+```
+ruby-1.0   (base)
+  └─ ruby-1.6
+       └─ ruby-1.8
+            └─ ruby-1.9.1
+                 ├─ ruby-1.9.3        (lib-only, identity inheritance)
+                 ├─ ruby-2.0
+                 │    └─ ruby-2.1
+                 │         └─ ruby-2.3
+                 │              └─ ruby-2.5
+                 │                   └─ ruby-2.6
+                 │                        └─ ruby-2.7
+                 │                             └─ ruby-3.0
+                 │                                  └─ ruby-3.1
+                 │                                       └─ ruby-3.2
+                 │                                            └─ ruby-3.3
+```
+
+A grammar file declares `extends = "ruby-X"` and supplies only the
+overrides for tokens / states / actions added in that era.
+`grammar-tools` resolves the inheritance graph at compile time and
+emits one *flat* per-version state machine (no inheritance
+indirection at runtime).
+
+## Old-version policy
+
+Versions 1.0 / 1.6 are forward-derived: the canonical TOML starts
+from 1.8 and **removes** features that don't exist yet (lambda
+`->`, hash shorthand, etc.).  This is more practical than writing
+1.0 from scratch — most of its syntax overlaps 1.8.
+
+When tests want to assert "this code is invalid in 1.0", they pass
+`version="1.0"` and expect the lexer/parser to reject the lambda /
+hash-shorthand / etc.  The TOML's `version_gate` action verb
+(§5 in [ruby-lexer-state-machine.md](ruby-lexer-state-machine.md))
+handles this declaratively.
+
+## Caveats
+
+- **YARV-specific syntax** like `__send__` is library-level, not
+  parser-level.
+- **`require`** and **`require_relative`** are method calls, not
+  syntax; the parser does not understand cross-file references.
+- **Heredoc `<<-` vs `<<~`**: `<<-` indents the terminator (1.0+);
+  `<<~` strips common leading whitespace from the body (2.3+).
+- **Hash methods `to_h`** (lib, not syntax).
+- **Bignum / Fixnum**: unified into `Integer` in 2.4; **not lex-
+  visible** (the lexer always emits `INT`, the type distinction is
+  runtime).
+
+## Out of scope
+
+- Method-visibility keywords (`private`, `public`, `protected`):
+  parsed as method calls, semantics applied later.
+- `prepend` (2.0+), `extend`: method calls, not syntax.
+- `String#tr_s`, `Array#zip`: library only.
+- DTrace / TracePoint hooks: not surface syntax.
+- The `it` implicit block param (3.4 preview): post-3.3, not
+  covered by this spec.


### PR DESCRIPTION
## Summary

Spec set **and** Phase 1 implementation for replacing the placeholder `ruby-lexer` / `ruby-parser` crates with a real, context-sensitive Ruby front end that supports **every Ruby version from 1.0 (1996) through 3.3 (2023)**.

## Commit 1 — specs

Three documents:
- **[ruby-parser.md](code/specs/ruby-parser.md)** — architecture overview: why Ruby isn't context-free, state-machine lexer + bidirectional parser-feedback contract, package layout, public API, 5-phase implementation plan.
- **[ruby-lexer-state-machine.md](code/specs/ruby-lexer-state-machine.md)** — the 13 `EXPR_*` lex states, register vocabulary, `ParserOracle` trait, ambiguity-resolution rules, new action verbs.
- **[ruby-version-evolution.md](code/specs/ruby-version-evolution.md)** — per-version syntax delta tables for 15 era versions (1.0, 1.6, 1.8, 1.9.1, 1.9.3, 2.0, 2.1, 2.3, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3) with era-inheritance graph.

## Commit 2 — Phase 1 implementation

The paren-required Ruby 1.8 baseline, driven by a hand-authored TOML state machine.

**Source of truth**: [`ruby-1.8.lexer.states.toml`](code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml) — declarative states, transitions, and portable action verbs.  Loaded via `include_str!`, parsed through `state_machine_markup_deserializer::from_states_toml`, executed via `state_machine::EffectfulStateMachine`.  Identical pattern to the existing [html1.lexer.states.toml](code/packages/rust/html-lexer/html1.lexer.states.toml).

**Phase 1 covers**:
- Identifiers (with `?` / `!` suffix), keywords lexer-classified
- Integers (with `_` separators)
- Strings (`"..."` and `'...'`, basic escape handling, **no interpolation**)
- Line comments
- All common operators (`+ - * / % == != < > <= >= = ! && || => ** ::`) with multi-character peek states
- Punctuation (`( ) [ ] { } , ; : . ?`)
- Newline-as-significant-token

**Deferred** (per [ruby-parser.md](code/specs/ruby-parser.md) §"Phasing"):
- Phase 2: parser-feedback for local-scope tracking, enables `f /x/` disambiguation
- Phase 3: heredocs, string interpolation, percent literals, regex
- Phase 4: version evolution (1.0, 1.6, 1.9.1, 2.0, 2.3, 2.7, 3.0, ...)
- Phase 5: `ruby-to-semantic-ir` frontend

**Shared-runtime extension**: two new generic lexer verbs added to `state-machine-markup-deserializer`'s allowed-action vocabulary (`clear_text` and `set_text(...)`).  Both are orthogonal to the HTML-specific verbs already in the list.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — 23 tests pass (factorial program, class/def nesting, all operator classes, determinism, ...)
- [x] `cargo test -p coding-adventures-ruby-parser` — 6 tests still pass against the new lexer (no parser changes needed)
- [x] `cargo test -p state-machine-markup-deserializer` — unchanged (verb additions purely additive)
- [x] `cargo test -p coding-adventures-html-lexer` — unchanged (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)