### PR TITLE
Add WHATWG DOCTYPE boundary fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -70,6 +70,10 @@ documented in this file.
 - A generated WHATWG tokenizer tag-open recovery fixture and Rust conformance
   test that pins ordinary tags, ASCII casing, tag whitespace, invalid openers,
   NULL replacement in tag names, and EOF partial-token drops.
+- A generated WHATWG tokenizer DOCTYPE boundary fixture and Rust conformance
+  test that pins name whitespace, PUBLIC/SYSTEM identifier recovery,
+  force-quirks transitions, EOF, NULL replacement, and seeded continuation
+  contexts.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -90,6 +90,10 @@ delimiters, unexpected solidus recovery, and end-tag attribute diagnostics.
 The generated tag-open recovery suite pins ordinary tags, ASCII casing, tag
 whitespace, invalid openers, NULL replacement in tag names, and EOF
 partial-token drops.
+The generated DOCTYPE boundary suite pins the focused states after
+`<!DOCTYPE` dispatch: name whitespace, PUBLIC/SYSTEM identifier recovery,
+force-quirks transitions, EOF, NULL replacement, and seeded continuation
+contexts.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -77,6 +77,10 @@ binary while production code continues to link only static Rust source.
 - `whatwg-tag-open-recovery.json`: generated HTML tokenizer tag-open recovery
   cases used by Rust tests to pin ordinary tags, ASCII casing, tag whitespace,
   invalid openers, NULL replacement in tag names, and EOF partial-token drops
+- `whatwg-doctype-boundaries.json`: generated HTML tokenizer DOCTYPE boundary
+  cases used by Rust tests to pin keyword/name whitespace, PUBLIC/SYSTEM
+  identifier recovery, force-quirks transitions, EOF, NULL replacement, and
+  seeded continuation contexts
 - `html5lib-smoke.json`: generated normalized Venture fixture corpus derived from
   the raw html5lib-style smoke file
 - `upstream-html5lib-smoke.test`: raw html5lib-style tokenizer cases used to
@@ -109,6 +113,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_tag_open_recovery_fixture.py`: importer that generates
   tag-open recovery cases for the checked-in
   `whatwg-tag-open-recovery.json` fixture
+- `generate_whatwg_doctype_boundaries_fixture.py`: importer that generates
+  focused DOCTYPE boundary cases for the checked-in
+  `whatwg-doctype-boundaries.json` fixture
 
 Regenerate or verify the WHATWG entity fixture with:
 
@@ -181,6 +188,14 @@ Regenerate or verify the WHATWG tag-open recovery fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG DOCTYPE boundary fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer DOCTYPE boundary fixture.
+
+The broader markup-declaration fixture proves that `<!DOCTYPE` dispatch works.
+This focused suite pins the boundary states after that dispatch: keyword/name
+whitespace, PUBLIC/SYSTEM identifier selection, quoted identifier recovery,
+NULL replacement, force-quirks handling, and seeded continuation contexts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-doctype-boundaries.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer DOCTYPE boundary fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-doctype-boundaries/v1",
+        "description": (
+            "DOCTYPE keyword, name, PUBLIC/SYSTEM identifier, force-quirks, "
+            "NULL replacement, EOF, and seeded continuation boundary recovery."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    cases.extend(name_boundary_cases())
+    cases.extend(public_identifier_cases())
+    cases.extend(system_identifier_cases())
+    cases.extend(eof_and_bogus_cases())
+    cases.extend(seeded_boundary_cases())
+    return cases
+
+
+def name_boundary_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "doctype-name-tab",
+            "description": "tab after DOCTYPE keyword begins the name",
+            "input": "<!DOCTYPE\thtml>",
+            "tokens": ["Doctype(name=html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-name-line-feed",
+            "description": "line feed after DOCTYPE keyword begins the name",
+            "input": "<!DOCTYPE\nhtml>",
+            "tokens": ["Doctype(name=html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-name-form-feed",
+            "description": "form feed after DOCTYPE keyword begins the name",
+            "input": "<!DOCTYPE\u000chtml>",
+            "tokens": ["Doctype(name=html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-name-leading-whitespace-run",
+            "description": "multiple HTML whitespace characters before the name are skipped",
+            "input": "<!DOCTYPE \t\n\u000cHTML>",
+            "tokens": ["Doctype(name=html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-name-uppercase-mixed",
+            "description": "DOCTYPE names are ASCII-lowercased while reading the name",
+            "input": "<!DOCTYPE HtMl>",
+            "tokens": ["Doctype(name=html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-name-null-replacement",
+            "description": "NULL inside a DOCTYPE name becomes U+FFFD",
+            "input": "<!DOCTYPE h\u0000tml>",
+            "tokens": ["Doctype(name=h�tml, force_quirks=false)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "doctype-missing-name-before-comment",
+            "description": "hyphen text after DOCTYPE keyword is accepted as the name",
+            "input": "<!DOCTYPE --html>",
+            "tokens": ["Doctype(name=--html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-name-missing-whitespace-before-public",
+            "description": "PUBLIC text without whitespace remains part of the name",
+            "input": "<!DOCTYPE htmlPUBLIC>",
+            "tokens": ["Doctype(name=htmlpublic, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-name-missing-whitespace-before-system",
+            "description": "SYSTEM text without whitespace remains part of the name",
+            "input": "<!DOCTYPE htmlSYSTEM>",
+            "tokens": ["Doctype(name=htmlsystem, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "doctype-name-public-prefix-not-keyword",
+            "description": "non-keyword text after a name emits the current name",
+            "input": "<!DOCTYPE html PUBLIK>",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["invalid-character-sequence-after-doctype-name"],
+        },
+    ]
+
+
+def public_identifier_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "doctype-public-tab-before-keyword",
+            "description": "tab separates the name from a PUBLIC keyword",
+            "input": '<!DOCTYPE html\tPUBLIC "pub">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-line-feed-before-keyword",
+            "description": "line feed separates the name from a PUBLIC keyword",
+            "input": '<!DOCTYPE html\nPUBLIC "pub">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-form-feed-before-keyword",
+            "description": "form feed separates the name from a PUBLIC keyword",
+            "input": '<!DOCTYPE html\u000cPUBLIC "pub">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-lowercase-keyword",
+            "description": "PUBLIC keyword matching is ASCII-case-insensitive",
+            "input": '<!DOCTYPE html public "pub">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-tab-before-identifier",
+            "description": "tab after PUBLIC keyword can precede the identifier quote",
+            "input": '<!DOCTYPE html PUBLIC\t"pub">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-line-feed-before-identifier",
+            "description": "line feed after PUBLIC keyword can precede the identifier quote",
+            "input": '<!DOCTYPE html PUBLIC\n"pub">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-single-quoted-identifier",
+            "description": "single-quoted PUBLIC identifiers are preserved",
+            "input": "<!DOCTYPE html PUBLIC 'pub'>",
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-empty-identifier",
+            "description": "empty PUBLIC identifiers stay empty and do not force quirks",
+            "input": '<!DOCTYPE html PUBLIC "">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-null-in-identifier",
+            "description": "NULL inside a PUBLIC identifier becomes U+FFFD",
+            "input": '<!DOCTYPE html PUBLIC "a\u0000b">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=a�b, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "doctype-public-missing-whitespace-before-identifier",
+            "description": "a quote immediately after PUBLIC is recovered as the identifier",
+            "input": '<!DOCTYPE html PUBLIC"pub">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["missing-whitespace-after-doctype-public-keyword"],
+        },
+        {
+            "id": "doctype-public-missing-quote",
+            "description": "PUBLIC without an identifier quote forces quirks mode",
+            "input": "<!DOCTYPE html PUBLIC pub>",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["missing-quote-before-doctype-public-identifier"],
+        },
+        {
+            "id": "doctype-public-abrupt-close",
+            "description": "PUBLIC keyword closed before an identifier forces quirks mode",
+            "input": "<!DOCTYPE html PUBLIC>",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["missing-doctype-public-identifier"],
+        },
+        {
+            "id": "doctype-public-system-with-space",
+            "description": "a system identifier after PUBLIC is read after whitespace",
+            "input": '<!DOCTYPE html PUBLIC "pub" "sys">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-system-with-tab",
+            "description": "tab separates PUBLIC and system identifiers",
+            "input": '<!DOCTYPE html PUBLIC "pub"\t"sys">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-public-system-missing-whitespace",
+            "description": "a system quote immediately after PUBLIC identifier is recovered",
+            "input": '<!DOCTYPE html PUBLIC "pub""sys">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["missing-whitespace-between-doctype-public-and-system-identifiers"],
+        },
+        {
+            "id": "doctype-public-trailing-junk",
+            "description": "text after a PUBLIC identifier is recovered as a missing system quote",
+            "input": '<!DOCTYPE html PUBLIC "pub" junk>',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=true)",
+                "EOF",
+            ],
+            "diagnostics": ["missing-quote-before-doctype-system-identifier"],
+        },
+    ]
+
+
+def system_identifier_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "doctype-system-tab-before-keyword",
+            "description": "tab separates the name from a SYSTEM keyword",
+            "input": '<!DOCTYPE html\tSYSTEM "sys">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-system-lowercase-keyword",
+            "description": "SYSTEM keyword matching is ASCII-case-insensitive",
+            "input": '<!DOCTYPE html system "sys">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-system-form-feed-before-identifier",
+            "description": "form feed after SYSTEM keyword can precede the identifier quote",
+            "input": '<!DOCTYPE html SYSTEM\u000c"sys">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-system-single-quoted-identifier",
+            "description": "single-quoted SYSTEM identifiers are preserved",
+            "input": "<!DOCTYPE html SYSTEM 'sys'>",
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-system-empty-identifier",
+            "description": "empty SYSTEM identifiers stay empty and do not force quirks",
+            "input": '<!DOCTYPE html SYSTEM "">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "doctype-system-null-in-identifier",
+            "description": "NULL inside a SYSTEM identifier becomes U+FFFD",
+            "input": '<!DOCTYPE html SYSTEM "s\u0000s">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=s�s, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "doctype-system-missing-whitespace-before-identifier",
+            "description": "a quote immediately after SYSTEM is recovered as the identifier",
+            "input": '<!DOCTYPE html SYSTEM"sys">',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["missing-whitespace-after-doctype-system-keyword"],
+        },
+        {
+            "id": "doctype-system-missing-quote",
+            "description": "SYSTEM without an identifier quote forces quirks mode",
+            "input": "<!DOCTYPE html SYSTEM sys>",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["missing-quote-before-doctype-system-identifier"],
+        },
+        {
+            "id": "doctype-system-abrupt-close",
+            "description": "SYSTEM keyword closed before an identifier forces quirks mode",
+            "input": "<!DOCTYPE html SYSTEM>",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["missing-doctype-system-identifier"],
+        },
+        {
+            "id": "doctype-system-trailing-junk",
+            "description": "unexpected text after a SYSTEM identifier is diagnosed",
+            "input": '<!DOCTYPE html SYSTEM "sys" junk>',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-character-after-doctype-system-identifier"],
+        },
+    ]
+
+
+def eof_and_bogus_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "doctype-eof-after-keyword",
+            "description": "EOF immediately after DOCTYPE keyword emits force-quirks",
+            "input": "<!DOCTYPE",
+            "tokens": ["Doctype(name=null, force_quirks=true)", "EOF"],
+            "diagnostics": ["eof-in-doctype"],
+        },
+        {
+            "id": "doctype-eof-after-name",
+            "description": "EOF inside a DOCTYPE name emits force-quirks",
+            "input": "<!DOCTYPE html",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["eof-in-doctype"],
+        },
+        {
+            "id": "doctype-eof-after-public-keyword",
+            "description": "EOF after PUBLIC keyword emits force-quirks",
+            "input": "<!DOCTYPE html PUBLIC",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["eof-in-doctype"],
+        },
+        {
+            "id": "doctype-eof-in-public-identifier",
+            "description": "EOF inside a PUBLIC identifier emits force-quirks",
+            "input": '<!DOCTYPE html PUBLIC "pub',
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=true)",
+                "EOF",
+            ],
+            "diagnostics": ["eof-in-doctype"],
+        },
+        {
+            "id": "doctype-eof-after-system-keyword",
+            "description": "EOF after SYSTEM keyword emits force-quirks",
+            "input": "<!DOCTYPE html SYSTEM",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["eof-in-doctype"],
+        },
+        {
+            "id": "doctype-eof-in-system-identifier",
+            "description": "EOF inside a SYSTEM identifier emits force-quirks",
+            "input": '<!DOCTYPE html SYSTEM "sys',
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=true)",
+                "EOF",
+            ],
+            "diagnostics": ["eof-in-doctype"],
+        },
+        {
+            "id": "doctype-bogus-null-discard",
+            "description": "bogus DOCTYPE recovery discards NULL after reporting it",
+            "input": "<!DOCTYPE html PUBLIC pub\u0000rest>",
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": [
+                "missing-quote-before-doctype-public-identifier",
+                "unexpected-null-character",
+            ],
+        },
+    ]
+
+
+def seeded_boundary_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "seeded-after-keyword-whitespace-to-name",
+            "description": "seeded after-keyword state skips whitespace before the name",
+            "input": "\thtml>",
+            "initial_state": "Before DOCTYPE name state",
+            "current_doctype": {},
+            "tokens": ["Doctype(name=html, force_quirks=false)", "EOF"],
+        },
+        {
+            "id": "seeded-name-to-public-keyword",
+            "description": "seeded after-name state recognizes a following PUBLIC keyword",
+            "input": ' PUBLIC "pub">',
+            "initial_state": "After DOCTYPE name state",
+            "current_doctype": {"name": "html"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "seeded-name-to-system-keyword",
+            "description": "seeded after-name state recognizes a following SYSTEM keyword",
+            "input": ' SYSTEM "sys">',
+            "initial_state": "After DOCTYPE name state",
+            "current_doctype": {"name": "html"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "seeded-after-public-keyword-missing-whitespace",
+            "description": "seeded after-PUBLIC state recovers a quote without whitespace",
+            "input": '"pub">',
+            "initial_state": "After DOCTYPE public keyword state",
+            "current_doctype": {"name": "html"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["missing-whitespace-after-doctype-public-keyword"],
+        },
+        {
+            "id": "seeded-public-identifier-single-quoted-null",
+            "description": "seeded single-quoted PUBLIC identifiers replace NULL",
+            "input": "\u0000id'>",
+            "initial_state": "DOCTYPE public identifier single quoted state",
+            "current_doctype": {"name": "html", "public_identifier": "pub-"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub-�id, system_identifier=null, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "seeded-between-identifiers-space-to-system",
+            "description": "seeded between-identifiers state skips whitespace before system quote",
+            "input": ' \t"sys">',
+            "initial_state": "Between DOCTYPE public and system identifiers state",
+            "current_doctype": {"name": "html", "public_identifier": "pub"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+        },
+        {
+            "id": "seeded-after-system-keyword-missing-whitespace",
+            "description": "seeded after-SYSTEM state recovers a quote without whitespace",
+            "input": '"sys">',
+            "initial_state": "After DOCTYPE system keyword state",
+            "current_doctype": {"name": "html"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["missing-whitespace-after-doctype-system-keyword"],
+        },
+        {
+            "id": "seeded-system-identifier-single-quoted-null",
+            "description": "seeded single-quoted SYSTEM identifiers replace NULL",
+            "input": "\u0000id'>",
+            "initial_state": "DOCTYPE system identifier single quoted state",
+            "current_doctype": {"name": "html", "system_identifier": "sys-"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=null, system_identifier=sys-�id, force_quirks=false)",
+                "EOF",
+            ],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "seeded-after-public-identifier-trailing-junk",
+            "description": "seeded after-PUBLIC-identifier state recovers text as a missing system quote",
+            "input": " junk>",
+            "initial_state": "After DOCTYPE public identifier state",
+            "current_doctype": {"name": "html", "public_identifier": "pub"},
+            "tokens": [
+                "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=true)",
+                "EOF",
+            ],
+            "diagnostics": ["missing-quote-before-doctype-system-identifier"],
+        },
+        {
+            "id": "seeded-bogus-doctype-null-discard",
+            "description": "seeded bogus DOCTYPE recovery discards NULL after reporting it",
+            "input": "\u0000ignored>",
+            "initial_state": "Bogus DOCTYPE state",
+            "current_doctype": {"name": "html", "force_quirks": True},
+            "tokens": ["Doctype(name=html, force_quirks=true)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+    ]
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-doctype-boundaries.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-doctype-boundaries.json
@@ -1,0 +1,632 @@
+{
+  "cases": [
+    {
+      "description": "tab after DOCTYPE keyword begins the name",
+      "diagnostics": [],
+      "id": "doctype-name-tab",
+      "input": "<!DOCTYPE\thtml>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "line feed after DOCTYPE keyword begins the name",
+      "diagnostics": [],
+      "id": "doctype-name-line-feed",
+      "input": "<!DOCTYPE\nhtml>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "form feed after DOCTYPE keyword begins the name",
+      "diagnostics": [],
+      "id": "doctype-name-form-feed",
+      "input": "<!DOCTYPE\fhtml>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "multiple HTML whitespace characters before the name are skipped",
+      "diagnostics": [],
+      "id": "doctype-name-leading-whitespace-run",
+      "input": "<!DOCTYPE \t\n\fHTML>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "DOCTYPE names are ASCII-lowercased while reading the name",
+      "diagnostics": [],
+      "id": "doctype-name-uppercase-mixed",
+      "input": "<!DOCTYPE HtMl>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside a DOCTYPE name becomes U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "doctype-name-null-replacement",
+      "input": "<!DOCTYPE h\u0000tml>",
+      "tokens": [
+        "Doctype(name=h�tml, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "hyphen text after DOCTYPE keyword is accepted as the name",
+      "diagnostics": [],
+      "id": "doctype-missing-name-before-comment",
+      "input": "<!DOCTYPE --html>",
+      "tokens": [
+        "Doctype(name=--html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PUBLIC text without whitespace remains part of the name",
+      "diagnostics": [],
+      "id": "doctype-name-missing-whitespace-before-public",
+      "input": "<!DOCTYPE htmlPUBLIC>",
+      "tokens": [
+        "Doctype(name=htmlpublic, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "SYSTEM text without whitespace remains part of the name",
+      "diagnostics": [],
+      "id": "doctype-name-missing-whitespace-before-system",
+      "input": "<!DOCTYPE htmlSYSTEM>",
+      "tokens": [
+        "Doctype(name=htmlsystem, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "non-keyword text after a name emits the current name",
+      "diagnostics": [
+        "invalid-character-sequence-after-doctype-name"
+      ],
+      "id": "doctype-name-public-prefix-not-keyword",
+      "input": "<!DOCTYPE html PUBLIK>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "tab separates the name from a PUBLIC keyword",
+      "diagnostics": [],
+      "id": "doctype-public-tab-before-keyword",
+      "input": "<!DOCTYPE html\tPUBLIC \"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "line feed separates the name from a PUBLIC keyword",
+      "diagnostics": [],
+      "id": "doctype-public-line-feed-before-keyword",
+      "input": "<!DOCTYPE html\nPUBLIC \"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "form feed separates the name from a PUBLIC keyword",
+      "diagnostics": [],
+      "id": "doctype-public-form-feed-before-keyword",
+      "input": "<!DOCTYPE html\fPUBLIC \"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PUBLIC keyword matching is ASCII-case-insensitive",
+      "diagnostics": [],
+      "id": "doctype-public-lowercase-keyword",
+      "input": "<!DOCTYPE html public \"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "tab after PUBLIC keyword can precede the identifier quote",
+      "diagnostics": [],
+      "id": "doctype-public-tab-before-identifier",
+      "input": "<!DOCTYPE html PUBLIC\t\"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "line feed after PUBLIC keyword can precede the identifier quote",
+      "diagnostics": [],
+      "id": "doctype-public-line-feed-before-identifier",
+      "input": "<!DOCTYPE html PUBLIC\n\"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "single-quoted PUBLIC identifiers are preserved",
+      "diagnostics": [],
+      "id": "doctype-public-single-quoted-identifier",
+      "input": "<!DOCTYPE html PUBLIC 'pub'>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "empty PUBLIC identifiers stay empty and do not force quirks",
+      "diagnostics": [],
+      "id": "doctype-public-empty-identifier",
+      "input": "<!DOCTYPE html PUBLIC \"\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside a PUBLIC identifier becomes U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "doctype-public-null-in-identifier",
+      "input": "<!DOCTYPE html PUBLIC \"a\u0000b\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=a�b, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a quote immediately after PUBLIC is recovered as the identifier",
+      "diagnostics": [
+        "missing-whitespace-after-doctype-public-keyword"
+      ],
+      "id": "doctype-public-missing-whitespace-before-identifier",
+      "input": "<!DOCTYPE html PUBLIC\"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PUBLIC without an identifier quote forces quirks mode",
+      "diagnostics": [
+        "missing-quote-before-doctype-public-identifier"
+      ],
+      "id": "doctype-public-missing-quote",
+      "input": "<!DOCTYPE html PUBLIC pub>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PUBLIC keyword closed before an identifier forces quirks mode",
+      "diagnostics": [
+        "missing-doctype-public-identifier"
+      ],
+      "id": "doctype-public-abrupt-close",
+      "input": "<!DOCTYPE html PUBLIC>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a system identifier after PUBLIC is read after whitespace",
+      "diagnostics": [],
+      "id": "doctype-public-system-with-space",
+      "input": "<!DOCTYPE html PUBLIC \"pub\" \"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "tab separates PUBLIC and system identifiers",
+      "diagnostics": [],
+      "id": "doctype-public-system-with-tab",
+      "input": "<!DOCTYPE html PUBLIC \"pub\"\t\"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a system quote immediately after PUBLIC identifier is recovered",
+      "diagnostics": [
+        "missing-whitespace-between-doctype-public-and-system-identifiers"
+      ],
+      "id": "doctype-public-system-missing-whitespace",
+      "input": "<!DOCTYPE html PUBLIC \"pub\"\"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "text after a PUBLIC identifier is recovered as a missing system quote",
+      "diagnostics": [
+        "missing-quote-before-doctype-system-identifier"
+      ],
+      "id": "doctype-public-trailing-junk",
+      "input": "<!DOCTYPE html PUBLIC \"pub\" junk>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "tab separates the name from a SYSTEM keyword",
+      "diagnostics": [],
+      "id": "doctype-system-tab-before-keyword",
+      "input": "<!DOCTYPE html\tSYSTEM \"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "SYSTEM keyword matching is ASCII-case-insensitive",
+      "diagnostics": [],
+      "id": "doctype-system-lowercase-keyword",
+      "input": "<!DOCTYPE html system \"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "form feed after SYSTEM keyword can precede the identifier quote",
+      "diagnostics": [],
+      "id": "doctype-system-form-feed-before-identifier",
+      "input": "<!DOCTYPE html SYSTEM\f\"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "single-quoted SYSTEM identifiers are preserved",
+      "diagnostics": [],
+      "id": "doctype-system-single-quoted-identifier",
+      "input": "<!DOCTYPE html SYSTEM 'sys'>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "empty SYSTEM identifiers stay empty and do not force quirks",
+      "diagnostics": [],
+      "id": "doctype-system-empty-identifier",
+      "input": "<!DOCTYPE html SYSTEM \"\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside a SYSTEM identifier becomes U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "doctype-system-null-in-identifier",
+      "input": "<!DOCTYPE html SYSTEM \"s\u0000s\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=s�s, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a quote immediately after SYSTEM is recovered as the identifier",
+      "diagnostics": [
+        "missing-whitespace-after-doctype-system-keyword"
+      ],
+      "id": "doctype-system-missing-whitespace-before-identifier",
+      "input": "<!DOCTYPE html SYSTEM\"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "SYSTEM without an identifier quote forces quirks mode",
+      "diagnostics": [
+        "missing-quote-before-doctype-system-identifier"
+      ],
+      "id": "doctype-system-missing-quote",
+      "input": "<!DOCTYPE html SYSTEM sys>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "SYSTEM keyword closed before an identifier forces quirks mode",
+      "diagnostics": [
+        "missing-doctype-system-identifier"
+      ],
+      "id": "doctype-system-abrupt-close",
+      "input": "<!DOCTYPE html SYSTEM>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unexpected text after a SYSTEM identifier is diagnosed",
+      "diagnostics": [
+        "unexpected-character-after-doctype-system-identifier"
+      ],
+      "id": "doctype-system-trailing-junk",
+      "input": "<!DOCTYPE html SYSTEM \"sys\" junk>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF immediately after DOCTYPE keyword emits force-quirks",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-eof-after-keyword",
+      "input": "<!DOCTYPE",
+      "tokens": [
+        "Doctype(name=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a DOCTYPE name emits force-quirks",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-eof-after-name",
+      "input": "<!DOCTYPE html",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after PUBLIC keyword emits force-quirks",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-eof-after-public-keyword",
+      "input": "<!DOCTYPE html PUBLIC",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a PUBLIC identifier emits force-quirks",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-eof-in-public-identifier",
+      "input": "<!DOCTYPE html PUBLIC \"pub",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after SYSTEM keyword emits force-quirks",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-eof-after-system-keyword",
+      "input": "<!DOCTYPE html SYSTEM",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF inside a SYSTEM identifier emits force-quirks",
+      "diagnostics": [
+        "eof-in-doctype"
+      ],
+      "id": "doctype-eof-in-system-identifier",
+      "input": "<!DOCTYPE html SYSTEM \"sys",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "bogus DOCTYPE recovery discards NULL after reporting it",
+      "diagnostics": [
+        "missing-quote-before-doctype-public-identifier",
+        "unexpected-null-character"
+      ],
+      "id": "doctype-bogus-null-discard",
+      "input": "<!DOCTYPE html PUBLIC pub\u0000rest>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {},
+      "description": "seeded after-keyword state skips whitespace before the name",
+      "diagnostics": [],
+      "id": "seeded-after-keyword-whitespace-to-name",
+      "initial_state": "Before DOCTYPE name state",
+      "input": "\thtml>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html"
+      },
+      "description": "seeded after-name state recognizes a following PUBLIC keyword",
+      "diagnostics": [],
+      "id": "seeded-name-to-public-keyword",
+      "initial_state": "After DOCTYPE name state",
+      "input": " PUBLIC \"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html"
+      },
+      "description": "seeded after-name state recognizes a following SYSTEM keyword",
+      "diagnostics": [],
+      "id": "seeded-name-to-system-keyword",
+      "initial_state": "After DOCTYPE name state",
+      "input": " SYSTEM \"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html"
+      },
+      "description": "seeded after-PUBLIC state recovers a quote without whitespace",
+      "diagnostics": [
+        "missing-whitespace-after-doctype-public-keyword"
+      ],
+      "id": "seeded-after-public-keyword-missing-whitespace",
+      "initial_state": "After DOCTYPE public keyword state",
+      "input": "\"pub\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html",
+        "public_identifier": "pub-"
+      },
+      "description": "seeded single-quoted PUBLIC identifiers replace NULL",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-public-identifier-single-quoted-null",
+      "initial_state": "DOCTYPE public identifier single quoted state",
+      "input": "\u0000id'>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub-�id, system_identifier=null, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html",
+        "public_identifier": "pub"
+      },
+      "description": "seeded between-identifiers state skips whitespace before system quote",
+      "diagnostics": [],
+      "id": "seeded-between-identifiers-space-to-system",
+      "initial_state": "Between DOCTYPE public and system identifiers state",
+      "input": " \t\"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html"
+      },
+      "description": "seeded after-SYSTEM state recovers a quote without whitespace",
+      "diagnostics": [
+        "missing-whitespace-after-doctype-system-keyword"
+      ],
+      "id": "seeded-after-system-keyword-missing-whitespace",
+      "initial_state": "After DOCTYPE system keyword state",
+      "input": "\"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html",
+        "system_identifier": "sys-"
+      },
+      "description": "seeded single-quoted SYSTEM identifiers replace NULL",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-system-identifier-single-quoted-null",
+      "initial_state": "DOCTYPE system identifier single quoted state",
+      "input": "\u0000id'>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=null, system_identifier=sys-�id, force_quirks=false)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "name": "html",
+        "public_identifier": "pub"
+      },
+      "description": "seeded after-PUBLIC-identifier state recovers text as a missing system quote",
+      "diagnostics": [
+        "missing-quote-before-doctype-system-identifier"
+      ],
+      "id": "seeded-after-public-identifier-trailing-junk",
+      "initial_state": "After DOCTYPE public identifier state",
+      "input": " junk>",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=null, force_quirks=true)",
+        "EOF"
+      ]
+    },
+    {
+      "current_doctype": {
+        "force_quirks": true,
+        "name": "html"
+      },
+      "description": "seeded bogus DOCTYPE recovery discards NULL after reporting it",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-bogus-doctype-null-discard",
+      "initial_state": "Bogus DOCTYPE state",
+      "input": "\u0000ignored>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "DOCTYPE keyword, name, PUBLIC/SYSTEM identifier, force-quirks, NULL replacement, EOF, and seeded continuation boundary recovery.",
+  "format": "whatwg-html-tokenizer-doctype-boundaries/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
@@ -1,0 +1,206 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_DOCTYPE_BOUNDARIES: &str = include_str!("fixtures/whatwg-doctype-boundaries.json");
+
+#[derive(Debug, Deserialize)]
+struct DoctypeBoundarySuite {
+    format: String,
+    description: String,
+    cases: Vec<DoctypeBoundaryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DoctypeBoundaryCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    current_doctype: Option<FixtureDoctypeSeed>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureDoctypeSeed {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    public_identifier: Option<String>,
+    #[serde(default)]
+    system_identifier: Option<String>,
+    #[serde(default)]
+    force_quirks: bool,
+}
+
+#[test]
+fn whatwg_doctype_boundaries_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-tokenizer-doctype-boundaries/v1");
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 40);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "doctype-public-system-missing-whitespace"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "doctype-bogus-null-discard"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "seeded-after-system-keyword-missing-whitespace"));
+}
+
+#[test]
+fn whatwg_doctype_boundaries_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its DOCTYPE boundary",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> DoctypeBoundarySuite {
+    serde_json::from_str(WHATWG_DOCTYPE_BOUNDARIES)
+        .expect("WHATWG DOCTYPE boundary fixture should parse")
+}
+
+fn configured_lexer(case: &DoctypeBoundaryCase) -> HtmlLexer {
+    let state = case
+        .initial_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let mut context = HtmlLexContext::new(state);
+    if let Some(current_doctype) = case.current_doctype.as_ref() {
+        context = context.with_current_doctype(DoctypeSeed {
+            name: current_doctype.name.clone(),
+            public_identifier: current_doctype.public_identifier.clone(),
+            system_identifier: current_doctype.system_identifier.clone(),
+            force_quirks: current_doctype.force_quirks,
+        });
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add generated WHATWG DOCTYPE boundary fixture covering name whitespace, PUBLIC/SYSTEM identifier recovery, force-quirks, EOF, NULL replacement, and seeded continuations
- add Rust conformance test for the generated fixture
- document the new fixture generator in the lexer README, fixture README, and changelog

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- git diff --cached --check