### PR TITLE
feat(moslayout): STRING token + string-literal prop values

### DIFF
--- a/code/grammars/moslayout.grammar
+++ b/code/grammars/moslayout.grammar
@@ -87,7 +87,7 @@ part_name = LBRACKET NAME RBRACKET ;
 #
 # Every property is: name : value
 #
-# Values come in three forms:
+# Values come in four forms:
 #   1.  KEYWORD COLON NAME   — a slot or emit binding
 #          slot: column-headers
 #          emit: onNavigate
@@ -97,11 +97,15 @@ part_name = LBRACKET NAME RBRACKET ;
 #          center (align: center)
 #   3.  NUMBER               — a numeric value
 #          1.5  (grow: 1.5)
+#   4.  STRING               — a double-quoted string literal
+#          "Enter formula"   (placeholder: "Enter formula")
+#          "system-ui"       (font: "system-ui")
 #
 # LL(1) disambiguation:
 #   - If prop_value starts with KEYWORD → slot/emit binding
 #   - If prop_value starts with NAME    → keyword value
 #   - If prop_value starts with NUMBER  → numeric value
+#   - If prop_value starts with STRING  → string literal
 
 prop_list = prop { COMMA prop } ;
 
@@ -122,4 +126,5 @@ prop = NAME    COLON prop_value
 
 prop_value = KEYWORD COLON NAME
            | NAME
-           | NUMBER ;
+           | NUMBER
+           | STRING ;

--- a/code/grammars/moslayout.tokens
+++ b/code/grammars/moslayout.tokens
@@ -25,6 +25,16 @@ skip:
 # Literals
 # ============================================================================
 
+# Double-quoted string with `\`-escaped characters. Used for prop values
+# that need an exact string literal — most commonly `placeholder: "..."` on
+# Input and `aria-label: "..."` on accessible primitives. The escape rules
+# follow the `escapes: standard` directive at the top of this file.
+#
+# Listed BEFORE NAME so the lexer prefers STRING when the input starts with
+# a double quote (NAME would never match `"` anyway, but the explicit order
+# documents the intent).
+STRING = /"([^"\\\n]|\\.)*"/
+
 NUMBER = /[0-9]+(\.[0-9]+)?/
 
 # ============================================================================

--- a/code/packages/rust/mosaic-emit-react/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-react/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Input `placeholder` from string-literal prop values
+
+- The Input emitter consumes the new `LayoutPropValue::String` variant
+  (moslayout STRING token) and writes it through as a JSX
+  `placeholder="..."` attribute. The placeholder text is escaped for
+  JSX double-quoted attribute syntax (`\` and `"` get backslash-escaped).
+- The previous known-limitation note in the emitter doc-comment ("string
+  literals as prop values aren't yet supported by the grammar") is
+  removed; the limitation is resolved upstream in `moslayout-compiler`.
+- Two new tests cover the literal binding and the escape rules.
+
 ### Changed — Grid selection / editing colours come from `.msl`
 
 - The Grid primitive's per-cell selection (`r === selRow && c === selCol`)

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -493,11 +493,6 @@ fn emit_jsx_tree(
 ///
 /// ## Known limitations (tracked separately)
 ///
-/// - **placeholder** — moslayout's grammar does not yet support string
-///   literals as prop values, so `placeholder: "Enter formula"` cannot be
-///   expressed at the source level. The lowering omits the `placeholder`
-///   attr entirely. A follow-up grammar PR will add literal-string props,
-///   at which point we can wire `placeholder` through.
 /// - **payload-mapped emits** — only `onChange` gets a `value` payload here
 ///   (it's the canonical Input case). A general `connects: onX(p: text) -> emit onY(p: p)`
 ///   syntax in moslayout would let other emits carry payloads; that is
@@ -545,6 +540,16 @@ fn emit_input_jsx(
         if kw == "true" || kw == "false" {
             attrs.push_str(&format!(" readOnly={{{kw}}}"));
         }
+    }
+
+    // placeholder="text"  — string-literal moslayout prop (post-PR-H).
+    // Escaping: JSX double-quoted attributes require `\` and `"` escaped;
+    // newlines/tabs pass through as their literal characters.
+    if let Some(s) = find_string_prop(node, "placeholder") {
+        attrs.push_str(&format!(
+            " placeholder=\"{}\"",
+            escape_for_jsx_double_quoted(s)
+        ));
     }
 
     // maxLength={N}
@@ -971,6 +976,36 @@ fn find_number_prop(node: &LayoutNode, prop_name: &str) -> Option<f64> {
         }
         None
     })
+}
+
+/// Find a prop on `node` whose value is a `String` literal. Returns the
+/// unescaped inner text (no surrounding quotes), or `None`.
+fn find_string_prop<'a>(node: &'a LayoutNode, prop_name: &str) -> Option<&'a str> {
+    node.props.iter().find_map(|p| {
+        if p.name == prop_name {
+            if let LayoutPropValue::String(s) = &p.value {
+                return Some(s.as_str());
+            }
+        }
+        None
+    })
+}
+
+/// Escape a Rust `&str` for embedding inside a JSX double-quoted string
+/// attribute value. The only characters JSX requires escaped inside a
+/// `"..."` attribute are `"` (close the literal) and `\` (the escape
+/// character itself). Newlines / tabs are preserved as their literal
+/// characters because JSX double-quoted attributes accept them.
+fn escape_for_jsx_double_quoted(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"'  => out.push_str("\\\""),
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 /// Build the JSX event-handler attributes for a node.
@@ -2318,6 +2353,41 @@ mod tests {
         assert!(
             result.output.contains("maxLength={100}"),
             "expected maxLength={{100}}, got:\n{}",
+            result.output
+        );
+    }
+
+    /// String-literal prop values (moslayout STRING token) flow through to
+    /// the Input emitter as `placeholder="..."` — JSX double-quoted
+    /// attribute form so the value appears verbatim in the DOM.
+    #[test]
+    fn input_placeholder_string_literal_binds_to_placeholder_attr() {
+        let m = component("X", vec![], vec![]);
+        let l = input_layout(vec![LayoutProp {
+            name: "placeholder".to_string(),
+            value: LayoutPropValue::String("Enter formula".to_string()),
+        }]);
+        let result = from_pipeline(&m, &l, &empty_style("X")).unwrap();
+        assert!(
+            result.output.contains("placeholder=\"Enter formula\""),
+            "expected placeholder attr, got:\n{}",
+            result.output
+        );
+    }
+
+    /// Double quotes and backslashes inside the placeholder string get
+    /// escaped so the generated JSX attribute stays well-formed.
+    #[test]
+    fn input_placeholder_escapes_quotes_and_backslashes() {
+        let m = component("X", vec![], vec![]);
+        let l = input_layout(vec![LayoutProp {
+            name: "placeholder".to_string(),
+            value: LayoutPropValue::String(r#"say "hi" \ then more"#.to_string()),
+        }]);
+        let result = from_pipeline(&m, &l, &empty_style("X")).unwrap();
+        assert!(
+            result.output.contains(r#"placeholder="say \"hi\" \\ then more""#),
+            "expected escaped placeholder attr, got:\n{}",
             result.output
         );
     }

--- a/code/packages/rust/moslayout-compiler/CHANGELOG.md
+++ b/code/packages/rust/moslayout-compiler/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — moslayout-compiler
 
+## [Unreleased]
+
+### Added — STRING token + string-literal prop values
+
+- New `STRING` token in `moslayout.tokens`: a double-quoted string
+  literal with standard `\`-escapes (`\n`, `\t`, `\r`, `\"`, `\\`, `\0`).
+- `prop_value` grammar rule grows a fourth alternative for `STRING`,
+  alongside the existing slot/emit binding, keyword, and number forms.
+- New `LayoutPropValue::String(String)` enum variant on `LayoutProp`.
+  The lexer strips surrounding double quotes; the compiler resolves
+  standard escapes so downstream emitters receive the literal text
+  the author meant.
+- Three new unit tests cover the basic literal, escape resolution,
+  and the empty-string case.
+- Resolves limitation #3 in `demo/visicalc/README.md` —
+  `placeholder: "Enter formula"` is now expressible at the source level.
+
 ## [0.1.0] — 2026-05-11
 
 ### Added

--- a/code/packages/rust/moslayout-compiler/src/_grammar.rs
+++ b/code/packages/rust/moslayout-compiler/src/_grammar.rs
@@ -24,10 +24,18 @@ pub fn token_grammar() -> TokenGrammar {
     TokenGrammar {
         definitions: vec![
             TokenDefinition {
+                name: r#"STRING"#.to_string(),
+                pattern: r#""([^"\\
+]|\\.)*""#.to_string(),
+                is_regex: true,
+                line_number: 36,
+                alias: None,
+            },
+            TokenDefinition {
                 name: r#"NUMBER"#.to_string(),
                 pattern: r#"[0-9]+(\.[0-9]+)?"#.to_string(),
                 is_regex: true,
-                line_number: 28,
+                line_number: 38,
                 alias: None,
             },
             TokenDefinition {
@@ -221,8 +229,9 @@ pub fn parser_grammar() -> ParserGrammar {
                 ] },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 123,
+            line_number: 127,
         },
     ],
         version: 1,

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -180,6 +180,13 @@ pub enum LayoutPropValue {
     Keyword(String),
     /// A numeric value: `1.5`, `0`, `2`.
     Number(f64),
+    /// A double-quoted string literal: `"Enter formula"`, `"system-ui"`.
+    ///
+    /// Stored *unquoted and unescaped*: the lexer emits the source text
+    /// including the surrounding `"` characters, and `extract_prop_value`
+    /// strips them and resolves `\n`, `\t`, `\\`, `\"`, etc. so downstream
+    /// emitters can treat the value as the literal text the author meant.
+    String(String),
 }
 
 /// A named part exported by this layout (consumed by the mosstyle compiler).
@@ -786,12 +793,14 @@ fn extract_prop(prop_ast: &GrammarASTNode) -> Result<LayoutProp, CompileError> {
 
 /// Extract a `prop_value` from its AST node.
 ///
-/// Grammar: `prop_value = KEYWORD COLON NAME | NAME | NUMBER`
+/// Grammar: `prop_value = KEYWORD COLON NAME | NAME | NUMBER | STRING`
 ///
-/// The three alternatives are distinguished by the first child token's type:
+/// The four alternatives are distinguished by the first child token's type:
 /// - Keyword → slot/emit binding
 /// - Name    → keyword value
 /// - Number  → numeric value
+/// - String  → string literal (surrounding quotes are stripped and
+///             standard `\`-escapes are resolved by `unescape_string_literal`)
 fn extract_prop_value(pv_ast: &GrammarASTNode) -> Result<LayoutPropValue, CompileError> {
     let children = &pv_ast.children;
 
@@ -829,11 +838,61 @@ fn extract_prop_value(pv_ast: &GrammarASTNode) -> Result<LayoutPropValue, Compil
             })?;
             Ok(LayoutPropValue::Number(n))
         }
+        // STRING — quoted literal: "Enter formula", "system-ui", …
+        // The lexer emits the value with surrounding `"`s; strip and unescape.
+        [ASTNodeOrToken::Token(t)] if t.type_ == TokenType::String => {
+            Ok(LayoutPropValue::String(unescape_string_literal(&t.value)?))
+        }
         other => Err(CompileError {
             kind: ErrorKind::InternalError,
             message: format!("Unexpected prop_value shape: {:?}", other.len()),
         }),
     }
+}
+
+/// Resolve the standard `\`-escapes (`\n`, `\t`, `\\`, `\"`, `\r`, `\0`)
+/// in a STRING token's value. The lexer has already stripped the
+/// surrounding double quotes for us, so this function operates on the
+/// inner text only. Any other `\x` sequence is preserved literally — the
+/// grammar's STRING regex already rejects unescaped newlines and
+/// unmatched quotes, so this function only needs to handle the
+/// well-formed cases.
+fn unescape_string_literal(raw: &str) -> Result<String, CompileError> {
+    // Defensive: if a future lexer change starts shipping quotes, strip them.
+    let inner: &str = raw
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(raw);
+
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('n')  => out.push('\n'),
+                Some('t')  => out.push('\t'),
+                Some('r')  => out.push('\r'),
+                Some('0')  => out.push('\0'),
+                Some('\\') => out.push('\\'),
+                Some('"')  => out.push('"'),
+                Some(other) => {
+                    // Preserve unknown escapes verbatim (e.g. `\u` follow-up
+                    // could land later as a separate feature).
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => {
+                    return Err(CompileError {
+                        kind: ErrorKind::InternalError,
+                        message: format!("Trailing backslash in string literal {:?}", raw),
+                    });
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    Ok(out)
 }
 
 // ===========================================================================
@@ -1036,6 +1095,60 @@ mod tests {
         assert_eq!(root.props.len(), 1);
         assert_eq!(root.props[0].name, "grow");
         assert_eq!(root.props[0].value, LayoutPropValue::Number(2.0));
+    }
+
+    /// String-literal prop value: `placeholder: "Enter formula"`. The
+    /// surrounding double quotes are stripped at compile time so downstream
+    /// emitters see the literal text the author meant.
+    #[test]
+    fn test_string_literal_prop() {
+        let src = r#"
+          layout Bar {
+            Input [ field ] ( placeholder: "Enter formula" ) { }
+          }
+        "#;
+        let def = parse_and_analyze(src);
+        let root = &def.root;
+        assert_eq!(root.tag, "Input");
+        assert_eq!(root.props.len(), 1);
+        assert_eq!(root.props[0].name, "placeholder");
+        assert_eq!(
+            root.props[0].value,
+            LayoutPropValue::String("Enter formula".to_string())
+        );
+    }
+
+    /// Standard `\`-escapes inside a string literal are resolved at compile
+    /// time: `\n`, `\t`, `\"`, `\\`. Unknown escapes are preserved verbatim.
+    #[test]
+    fn test_string_literal_escapes() {
+        let src = r#"
+          layout Bar {
+            Input [ field ] ( placeholder: "line\none\ttwo\"three" ) { }
+          }
+        "#;
+        let def = parse_and_analyze(src);
+        let root = &def.root;
+        assert_eq!(
+            root.props[0].value,
+            LayoutPropValue::String("line\none\ttwo\"three".to_string())
+        );
+    }
+
+    /// Empty string is a valid literal — useful for clearing a previous
+    /// placeholder when composing styles, or for sentinel values.
+    #[test]
+    fn test_empty_string_literal_prop() {
+        let src = r#"
+          layout Bar {
+            Input [ field ] ( placeholder: "" ) { }
+          }
+        "#;
+        let def = parse_and_analyze(src);
+        assert_eq!(
+            def.root.props[0].value,
+            LayoutPropValue::String(String::new())
+        );
     }
 
     #[test]

--- a/demo/visicalc/README.md
+++ b/demo/visicalc/README.md
@@ -111,11 +111,11 @@ contributor can pick them up:
    shapes directly from the generated component files instead of
    redeclaring them in `state.ts`.
 
-3. **No `placeholder: "..."` on the FormulaBar Input.** Per UI25, the
-   moslayout grammar does not yet accept string-literal prop values, so
-   `placeholder: "Enter formula"` cannot be expressed at the source
-   level. The Input renders without a placeholder. Follow-up: add
-   string-literal prop support to the moslayout grammar.
+3. ~~**No `placeholder: "..."` on the FormulaBar Input.**~~ *Resolved.*
+   moslayout's grammar now accepts double-quoted string literals as prop
+   values, and the React Input emitter wires `placeholder` straight
+   through to the generated `<input placeholder="...">`. The FormulaBar
+   `.mll` carries `placeholder: "Enter formula"` directly.
 
 4. **No formula evaluation.** Cells store and display raw strings.
    `editCommit` is where a real formula engine would plug in; see

--- a/demo/visicalc/mosaic/FormulaBar.desktop.mll
+++ b/demo/visicalc/mosaic/FormulaBar.desktop.mll
@@ -10,11 +10,12 @@ layout FormulaBar {
   Row [bar] {
     Text [address-label] (content: slot: cell-address)
     Input [formula-field] (
-      value:      slot: formula,
-      read-only:  slot: read-only,
-      onChange:   emit: onFormulaChange,
-      onCommit:   emit: onCommit,
-      onCancel:   emit: onCancel
+      value:       slot: formula,
+      read-only:   slot: read-only,
+      placeholder: "Enter formula",
+      onChange:    emit: onFormulaChange,
+      onCommit:    emit: onCommit,
+      onCancel:    emit: onCancel
     )
   }
 }


### PR DESCRIPTION
## Summary

Adds a fourth alternative to the moslayout `prop_value` rule: a double-quoted string literal with the standard `\`-escape set (`\n`, `\t`, `\r`, `\"`, `\`, `\0`). End result: `placeholder: \"Enter formula\"` is now expressible in `.mll` source.

### Grammar layer
- `moslayout.tokens`: new `STRING` regex `/\"([^\"\\\n]|\\.)*\"/`.
- `moslayout.grammar`: `prop_value` grows the STRING alternative.
- `moslayout-compiler/src/_grammar.rs`: static grammar mirrors the source (hand-edited per existing convention).

### Compiler layer
- New `LayoutPropValue::String(String)` variant.
- `extract_prop_value` recognises STRING tokens and calls `unescape_string_literal` to resolve backslash escapes.
- 3 new unit tests: basic literal, escape resolution, empty-string case.

### Emitter layer (React/Input)
- Input emitter consumes the new variant for `placeholder` and writes a JSX `placeholder=\"...\"` attribute.
- Helper `escape_for_jsx_double_quoted` escapes `\` and `\"` inside the attribute value; newlines/tabs pass through.
- 2 new tests covering the basic attribute and the escape rules.
- The previous \"string literals not yet supported\" doc-comment limitation is removed.

### Demo
- `demo/visicalc/mosaic/FormulaBar.desktop.mll` declares `placeholder: \"Enter formula\"` directly.

Resolves known limitation #3 in `demo/visicalc/README.md`.

## Test plan
- [x] `cargo test -p moslayout-compiler --lib` — 22 tests pass (was 19; +3 for new STRING cases)
- [x] `cargo test -p mosaic-emit-react --lib` — 80 tests pass (was 78; +2 for new placeholder cases)
- [ ] CI green
- [ ] After regenerating `bash demo/visicalc/scripts/build.sh`, the FormulaBar's `<input>` shows the placeholder

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)