### PR TITLE
feat(symbolic-vm): Phases 29-33 algebraic rules — Abs/Sqrt/Log/Exp/Trig (TS + Rust 0.6.0)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,97 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.6.0] — 2026-05-18
+
+### Added — Phases 29–33: algebraic simplification rules
+
+Extends the symbolic backend with five new rule families that fire on every
+re-evaluation of the affected expressions.  All rules are guarded by the
+`simplify` flag so the `StrictBackend` (numeric-only) is unaffected.
+
+#### Phase 29 — Abs and Sqrt algebraic rules
+
+New free functions:
+- `frac_gcd`, `frac_make`, `frac_mod`, `frac_from_ir` — fraction arithmetic
+  helpers used internally by the Phase 33 π-multiple detection and by the
+  Phase 29–32 handlers.
+
+**`abs_handler`** (new — `Abs` head previously fell through unhandled):
+- Numeric fold: `Abs(-3) → 3`, `Abs(-p/q) → p/q`.
+- Idempotency: `Abs(Abs(x)) → Abs(x)`.
+- Negation strip: `Abs(Neg(x)) → Abs(x)`.
+- Mul-neg strip: `Abs(Mul(-1, x)) → Abs(x)`.
+- Even-power identity: `Abs(Pow(x, 2k)) → Pow(x, 2k)` for even integer 2k ≥ 2.
+- Registered as `"Abs"` in `build_handler_table`.
+
+**`sqrt_handler`** (replaces `single_trig` factory):
+- Perfect-square detection: `sqrt(4) → 2`, `sqrt(9) → 3`, etc.
+- Even-exponent rewrite `sqrt(x^{2k})`:
+  - k even → `Pow(x, k)` (e.g. `sqrt(x^4) = x^2`)
+  - k odd → `Abs(x^k)` (e.g. `sqrt(x^2) = |x|`, `sqrt(x^6) = |x^3|`)
+
+#### Phase 30 — Log / Exp cancellation rules
+
+**`log_handler`** (replaces `single_trig`):
+- `log(exp(x)) → x`  (structural cancellation).
+- Special value `log(1) → 0`; non-positive inputs left unevaluated.
+
+**`exp_handler`** (replaces `single_trig`):
+- `exp(log(x)) → x`.
+- `exp(n·log(x)) → x^n`  (both `Mul(n, log(x))` and `Mul(log(x), n)`).
+- Special value `exp(0) → 1`.
+
+**Regression note**: `D(x^x, x)` now returns `Mul(Pow(x,x), Add(log(x), x/x))`
+because `exp(x·log(x))` eagerly reduces to `x^x`.  Test updated.
+
+#### Phase 31 — Trig / hyperbolic negation symmetry and arc-cancellation
+
+**Odd** (`sin_handler`, `tan_handler`, `sinh_handler`, `tanh_handler`):
+- `f(Neg(x)) → Neg(f(x))` with `vm.eval` recursive descent.
+
+**Even** (`cos_handler`, `cosh_handler`):
+- `f(Neg(x)) → f(x)` (Neg stripped, recurse).
+
+**Arc-cancellation** in `sin`/`cos`/`tan`/`sinh`/`cosh`/`tanh`:
+- `sin(Asin(x)) → x`, `cos(Acos(x)) → x`, `tan(Atan(x)) → x`
+- `sinh(Asinh(x)) → x`, `cosh(Acosh(x)) → x`, `tanh(Atanh(x)) → x`
+
+#### Phase 32 — Inverse trig / hyperbolic odd symmetry
+
+**Odd** (`atan_handler`, `asin_handler`, `asinh_handler`, `atanh_handler`):
+- `f(Neg(x)) → Neg(f(x))`.
+
+**`acos_handler`** — reflection:
+- `acos(Neg(x)) → Sub(Symbol("%pi"), acos(x))`.
+
+**`acosh_handler`** — keeps `single_trig` factory (domain `[1, ∞)`, no symmetry).
+
+#### Phase 33 — Trig exact values at rational multiples of π
+
+New free functions:
+- `try_pi_multiple(arg: &IRNode) -> Option<Frac>` — detects float ≈ q·π and
+  structural patterns `%pi`, `Neg(%pi)`, `Mul(n, %pi)`, `Div(%pi, n)`,
+  `Div(Mul(n, %pi), d)`.
+- `p33_sqrt_over(n, d) -> IRNode` — helper building `Div(Sqrt(n), d)`.
+- `p33_neg(v: IRNode) -> IRNode` — wraps `Neg`.
+- `sin_pi_table(p, q) -> Option<IRNode>` — 16-entry exact sin table (period 2).
+- `cos_pi_table(p, q) -> Option<IRNode>` — 16-entry exact cos table (period 2).
+- `tan_pi_table(p, q) -> Option<IRNode>` — 7-entry exact tan table (period 1).
+
+`sin_handler`, `cos_handler`, `tan_handler` each call `try_pi_multiple` on the
+argument and look up the table before the numeric fold.
+
+`tan(π/2)` (undefined) is left unevaluated.
+
+**Tests added** (48 new tests across all 5 phases):
+- Phase 29: 8 tests (abs/sqrt rules)
+- Phase 30: 4 tests (log/exp cancellation + power form)
+- Phase 31: 12 tests (trig+hyperbolic symmetry and arc-cancellation)
+- Phase 32: 5 tests (inverse trig odd symmetry + acos reflection)
+- Phase 33: 19 tests (sin/cos/tan π-multiples including negative q and regression)
+
+Helper added to test file: `fn eval(expr: IRNode) -> IRNode` — thin wrapper
+around `symbolic().eval(expr)` used by the new Phase 29–33 tests.
+
 ## [0.5.0] — 2026-05-18
 
 ### Added — Phase 28: general IBP for poly×log(Q) and poly×atan(Q)

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -534,148 +534,499 @@ fn elementary_handler(
     })
 }
 
-// We can't store `IRNode` in a `&'static` slice, so we pre-compute them
-// via lazy_static.  Instead, we hard-code the numeric values and
-// reconstruct IRNode::Integer/Float as needed.
+// ---------------------------------------------------------------------------
+// Phase 29–33: algebraic helpers
+// ---------------------------------------------------------------------------
 
-fn sin_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Sin",
-            f64::sin,
-            &[(Numeric::Int(0), IRNode::Integer(0))],
-            simplify,
-        )
+/// Reduced fraction `(p, q)` with `q > 0` and `gcd(|p|, q) = 1`.
+type Frac = (i64, i64);
+
+fn frac_gcd(mut a: i64, mut b: i64) -> i64 {
+    a = a.abs();
+    b = b.abs();
+    while b != 0 { let t = b; b = a % b; a = t; }
+    if a == 0 { 1 } else { a }
+}
+
+/// Normalise `p/q` to lowest terms with `q > 0`.
+/// Returns `None` if `q == 0`.
+fn frac_make(p: i64, q: i64) -> Option<Frac> {
+    if q == 0 { return None; }
+    let (p, q) = if q < 0 { (-p, -q) } else { (p, q) };
+    let g = frac_gcd(p.abs(), q);
+    Some((p / g, q / g))
+}
+
+/// `(p/q) mod m`, result in `[0, m)`.
+fn frac_mod(p: i64, q: i64, m: i64) -> Option<Frac> {
+    // (p/q) mod m = (p mod (m·q)) / q
+    let mq = m.checked_mul(q)?;
+    let mut r = p % mq;
+    if r < 0 { r = r.checked_add(mq)?; }
+    frac_make(r, q)
+}
+
+/// Try to extract a plain `i64/i64` rational from an IR numeric node.
+fn frac_from_ir(node: &IRNode) -> Option<Frac> {
+    match node {
+        IRNode::Integer(n) => Some((*n, 1)),
+        IRNode::Rational(p, q) => frac_make(*p, *q),
+        _ => None,
+    }
+}
+
+/// Phase 33: if `arg = q·%pi` for a rational `q` with denominator in
+/// `{1,2,3,4,6}`, return `q` as `(numer, denom)`.  Otherwise `None`.
+///
+/// Strategy 1: float ≈ q·π (for backends that evaluate %pi → float).
+/// Strategy 2: structural match on `%pi`, `Neg(%pi)`, `Mul(n,%pi)`,
+///   `Div(%pi,n)`, `Div(Mul(n,%pi),d)`.
+fn try_pi_multiple(arg: &IRNode) -> Option<Frac> {
+    // Strategy 1: float value ≈ q·π
+    if let IRNode::Float(v) = arg {
+        let qf = v / std::f64::consts::PI;
+        for d in [1i64, 2, 3, 4, 6] {
+            let p_cand = (qf * d as f64).round() as i64;
+            if (qf * d as f64 - p_cand as f64).abs() < 1e-9 {
+                return frac_make(p_cand, d);
+            }
+        }
+        return None;
+    }
+    // Strategy 2: structural match
+    let pi_sym = IRNode::Symbol("%pi".to_string());
+    if *arg == pi_sym { return frac_make(1, 1); }
+    let IRNode::Apply(apply) = arg else { return None; };
+
+    // Neg(anything) — recurse and negate
+    if apply.head == IRNode::Symbol(NEG.to_string()) && apply.args.len() == 1 {
+        let inner = try_pi_multiple(&apply.args[0])?;
+        return frac_make(-inner.0, inner.1);
+    }
+
+    // Mul(n, %pi) or Mul(%pi, n)
+    if apply.head == IRNode::Symbol(MUL.to_string()) && apply.args.len() == 2 {
+        let (a, b) = (&apply.args[0], &apply.args[1]);
+        if *b == pi_sym { return frac_from_ir(a); }
+        if *a == pi_sym { return frac_from_ir(b); }
+    }
+
+    // Div(%pi, n) or Div(Mul(n,%pi), d)
+    if apply.head == IRNode::Symbol(DIV.to_string()) && apply.args.len() == 2 {
+        let (num, den) = (&apply.args[0], &apply.args[1]);
+        let df = frac_from_ir(den)?;
+        if df.0 == 0 { return None; }
+        // Div(%pi, n) → 1/df = (df.1, df.0)
+        if *num == pi_sym {
+            return frac_make(df.1, df.0);
+        }
+        // Div(Mul(n,%pi), d) or Div(Mul(%pi,n), d)
+        if let IRNode::Apply(mul_apply) = num {
+            if mul_apply.head == IRNode::Symbol(MUL.to_string()) && mul_apply.args.len() == 2 {
+                let (ma, mb) = (&mul_apply.args[0], &mul_apply.args[1]);
+                let coeff_node = if *mb == pi_sym { Some(ma) }
+                                 else if *ma == pi_sym { Some(mb) }
+                                 else { None }?;
+                let nf = frac_from_ir(coeff_node)?;
+                // nf / df = (nf.0 * df.1) / (nf.1 * df.0)
+                return frac_make(nf.0.checked_mul(df.1)?, nf.1.checked_mul(df.0)?);
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Phase 33: exact algebraic IR values for sin/cos/tan tables
+// ---------------------------------------------------------------------------
+
+/// `Div(Sqrt(n), d)` helper — produces the IR node `√n / d`.
+fn p33_sqrt_over(n: i64, d: i64) -> IRNode {
+    apply_node(DIV, vec![
+        apply_node(SQRT, vec![IRNode::Integer(n)]),
+        IRNode::Integer(d),
+    ])
+}
+
+/// `Neg(expr)` helper.
+fn p33_neg(v: IRNode) -> IRNode { apply_node(NEG, vec![v]) }
+
+/// sin(q·π) for `(q.0, q.1)` in canonical form with denominator dividing 12.
+/// Returns `None` if the key is not in the table (including q=1/2 period).
+fn sin_pi_table(p: i64, q: i64) -> Option<IRNode> {
+    // Entries for q ∈ [0/1, 11/6]  (16 entries, period 2).
+    // Key: (p, q) in reduced form after (p mod 2q)/q reduction.
+    match (p, q) {
+        (0, 1)  => Some(IRNode::Integer(0)),
+        (1, 6)  => Some(IRNode::Rational(1, 2)),
+        (1, 4)  => Some(p33_sqrt_over(2, 2)),
+        (1, 3)  => Some(p33_sqrt_over(3, 2)),
+        (1, 2)  => Some(IRNode::Integer(1)),
+        (2, 3)  => Some(p33_sqrt_over(3, 2)),
+        (3, 4)  => Some(p33_sqrt_over(2, 2)),
+        (5, 6)  => Some(IRNode::Rational(1, 2)),
+        (1, 1)  => Some(IRNode::Integer(0)),
+        (7, 6)  => Some(IRNode::Rational(-1, 2)),
+        (5, 4)  => Some(p33_neg(p33_sqrt_over(2, 2))),
+        (4, 3)  => Some(p33_neg(p33_sqrt_over(3, 2))),
+        (3, 2)  => Some(IRNode::Integer(-1)),
+        (5, 3)  => Some(p33_neg(p33_sqrt_over(3, 2))),
+        (7, 4)  => Some(p33_neg(p33_sqrt_over(2, 2))),
+        (11, 6) => Some(IRNode::Rational(-1, 2)),
+        _       => None,
+    }
+}
+
+/// cos(q·π) — same key convention as `sin_pi_table`.
+fn cos_pi_table(p: i64, q: i64) -> Option<IRNode> {
+    match (p, q) {
+        (0, 1)  => Some(IRNode::Integer(1)),
+        (1, 6)  => Some(p33_sqrt_over(3, 2)),
+        (1, 4)  => Some(p33_sqrt_over(2, 2)),
+        (1, 3)  => Some(IRNode::Rational(1, 2)),
+        (1, 2)  => Some(IRNode::Integer(0)),
+        (2, 3)  => Some(IRNode::Rational(-1, 2)),
+        (3, 4)  => Some(p33_neg(p33_sqrt_over(2, 2))),
+        (5, 6)  => Some(p33_neg(p33_sqrt_over(3, 2))),
+        (1, 1)  => Some(IRNode::Integer(-1)),
+        (7, 6)  => Some(p33_neg(p33_sqrt_over(3, 2))),
+        (5, 4)  => Some(p33_neg(p33_sqrt_over(2, 2))),
+        (4, 3)  => Some(IRNode::Rational(-1, 2)),
+        (3, 2)  => Some(IRNode::Integer(0)),
+        (5, 3)  => Some(IRNode::Rational(1, 2)),
+        (7, 4)  => Some(p33_sqrt_over(2, 2)),
+        (11, 6) => Some(p33_sqrt_over(3, 2)),
+        _       => None,
+    }
+}
+
+/// tan(q·π) — period π, key is `q mod 1` (denominator divides 6).
+/// q = 1/2 is omitted (undefined); returns `None` for that case too.
+fn tan_pi_table(p: i64, q: i64) -> Option<IRNode> {
+    match (p, q) {
+        (0, 1)  => Some(IRNode::Integer(0)),
+        (1, 6)  => Some(apply_node(DIV, vec![
+                       apply_node(SQRT, vec![IRNode::Integer(3)]),
+                       IRNode::Integer(3),
+                   ])),
+        (1, 4)  => Some(IRNode::Integer(1)),
+        (1, 3)  => Some(apply_node(SQRT, vec![IRNode::Integer(3)])),
+        (2, 3)  => Some(p33_neg(apply_node(SQRT, vec![IRNode::Integer(3)]))),
+        (3, 4)  => Some(IRNode::Integer(-1)),
+        (5, 6)  => Some(p33_neg(apply_node(DIV, vec![
+                       apply_node(SQRT, vec![IRNode::Integer(3)]),
+                       IRNode::Integer(3),
+                   ]))),
+        _       => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 29–33: Enhanced elementary handlers
+// ---------------------------------------------------------------------------
+
+/// Phase 29: Abs — idempotency, negation-strip, Mul(-1,x)-strip, even-power.
+fn abs_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let inner = &expr.args[0];
+        // Numeric fold: abs(n) = |n|.
+        if let Some(v) = to_numeric(inner) {
+            let f = v.to_f64().abs();
+            // Try to preserve exact integer/rational form.
+            match inner {
+                IRNode::Integer(n) => return IRNode::Integer(n.abs()),
+                IRNode::Rational(p, q) => return IRNode::Rational(p.abs(), *q),
+                _ => return IRNode::Float(f),
+            }
+        }
+        if !simplify { panic!("Abs requires a numeric argument: {expr}"); }
+        // Rule 4a: abs(abs(x)) = abs(x)
+        if let IRNode::Apply(inner_apply) = inner {
+            if inner_apply.head == IRNode::Symbol("Abs".to_string()) {
+                return inner.clone();
+            }
+            // Rule 4b: abs(-x) = abs(x)
+            if inner_apply.head == IRNode::Symbol(NEG.to_string()) && inner_apply.args.len() == 1 {
+                return vm.eval(apply_node("Abs", vec![inner_apply.args[0].clone()]));
+            }
+            // Rule 4c: abs(Mul(-1, x)) = abs(x)
+            if inner_apply.head == IRNode::Symbol(MUL.to_string()) && inner_apply.args.len() == 2 {
+                if inner_apply.args[0] == IRNode::Integer(-1) {
+                    return vm.eval(apply_node("Abs", vec![inner_apply.args[1].clone()]));
+                }
+            }
+            // Rule 4d: abs(x^{2k}) = x^{2k}  (even power ≥ 0 always)
+            if inner_apply.head == IRNode::Symbol(POW.to_string()) && inner_apply.args.len() == 2 {
+                if let IRNode::Integer(n) = &inner_apply.args[1] {
+                    if *n >= 2 && n % 2 == 0 { return inner.clone(); }
+                }
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
-fn cos_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Cos",
-            f64::cos,
-            &[(Numeric::Int(0), IRNode::Integer(1))],
-            simplify,
-        )
+/// Phase 29: Sqrt — perfect-square fold, even-power algebraic rewrite.
+fn sqrt_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            if va == Numeric::Int(1) { return IRNode::Integer(1); }
+            let result = va.to_f64().sqrt();
+            // Perfect-square detection: round(√n)² == n → return integer.
+            let int_result = result.round() as i64;
+            if (int_result as f64 * int_result as f64 - va.to_f64()).abs() < 1e-9 {
+                return IRNode::Integer(int_result);
+            }
+            return IRNode::Float(result);
+        }
+        if !simplify { panic!("Sqrt requires a numeric argument: {expr}"); }
+        // sqrt(x^{2k}) — split on parity of k.
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(POW.to_string()) && inner.args.len() == 2 {
+                let base = &inner.args[0];
+                if let IRNode::Integer(n) = &inner.args[1] {
+                    if *n > 0 && n % 2 == 0 {
+                        let k = n / 2;
+                        if k % 2 == 0 {
+                            // k even → x^k ≥ 0 always, e.g. sqrt(x^4) = x^2.
+                            return apply_node(POW, vec![base.clone(), IRNode::Integer(k)]);
+                        }
+                        // k odd → |x^k|
+                        let inner_expr = if k == 1 {
+                            base.clone()
+                        } else {
+                            apply_node(POW, vec![base.clone(), IRNode::Integer(k)])
+                        };
+                        return vm.eval(apply_node("Abs", vec![inner_expr]));
+                    }
+                }
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
-fn tan_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Tan",
-            f64::tan,
-            &[(Numeric::Int(0), IRNode::Integer(0))],
-            simplify,
-        )
-    })
-}
-
-fn exp_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Exp",
-            f64::exp,
-            &[(Numeric::Int(0), IRNode::Integer(1))],
-            simplify,
-        )
-    })
-}
-
+/// Phase 30: Log — special value log(1)=0, log(exp(x))=x cancellation.
 fn log_handler(simplify: bool) -> Handler {
     std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Log",
-            f64::ln,
-            &[(Numeric::Int(1), IRNode::Integer(0))],
-            simplify,
-        )
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(1) { return IRNode::Integer(0); }
+            let f = va.to_f64();
+            if f <= 0.0 { return IRNode::Apply(Box::new(expr)); } // undefined for non-positive
+            return IRNode::Float(f.ln());
+        }
+        if !simplify { panic!("Log requires a numeric argument: {expr}"); }
+        // log(exp(x)) = x  (structural cancellation).
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(EXP.to_string()) && inner.args.len() == 1 {
+                return inner.args[0].clone();
+            }
+        }
+        // Note: log(x^n) = n·log(x) requires assumption context; skipped here.
+        IRNode::Apply(Box::new(expr))
     })
 }
 
-fn sqrt_handler(simplify: bool) -> Handler {
+/// Phase 30: Exp — special value exp(0)=1, exp(log(x))=x, exp(n·log(x))=x^n.
+fn exp_handler(simplify: bool) -> Handler {
     std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Sqrt",
-            f64::sqrt,
-            &[
-                (Numeric::Int(0), IRNode::Integer(0)),
-                (Numeric::Int(1), IRNode::Integer(1)),
-            ],
-            simplify,
-        )
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(1); }
+            return IRNode::Float(va.to_f64().exp());
+        }
+        if !simplify { panic!("Exp requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            // exp(log(x)) = x
+            if inner.head == IRNode::Symbol(LOG.to_string()) && inner.args.len() == 1 {
+                return inner.args[0].clone();
+            }
+            // exp(n·log(x)) = x^n  — handles both Mul(n, log(x)) and Mul(log(x), n).
+            if inner.head == IRNode::Symbol(MUL.to_string()) && inner.args.len() == 2 {
+                let (a, b) = (&inner.args[0], &inner.args[1]);
+                let is_log_a = matches!(a, IRNode::Apply(ap) if ap.head == IRNode::Symbol(LOG.to_string()) && ap.args.len() == 1);
+                let is_log_b = matches!(b, IRNode::Apply(ap) if ap.head == IRNode::Symbol(LOG.to_string()) && ap.args.len() == 1);
+                if is_log_a {
+                    if let IRNode::Apply(log_ap) = a { return apply_node(POW, vec![log_ap.args[0].clone(), b.clone()]); }
+                }
+                if is_log_b {
+                    if let IRNode::Apply(log_ap) = b { return apply_node(POW, vec![log_ap.args[0].clone(), a.clone()]); }
+                }
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
-fn atan_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Atan",
-            f64::atan,
-            &[(Numeric::Int(0), IRNode::Integer(0))],
-            simplify,
-        )
+/// Phase 31+33: Sin — odd symmetry, arc-cancellation, π-multiple exact values.
+fn sin_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        // Rule 4 (Phase 33): π-multiple exact values — checked first.
+        if let Some((p, q)) = try_pi_multiple(arg) {
+            if let Some((rp, rq)) = frac_mod(p, q, 2) {
+                if let Some(val) = sin_pi_table(rp, rq) { return val; }
+            }
+        }
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().sin());
+        }
+        if !simplify { panic!("Sin requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            // Rule 2 (Phase 31): odd symmetry — sin(-x) = -sin(x).
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_sin = vm.eval(apply_node(SIN, vec![inner.args[0].clone()]));
+                return apply_node(NEG, vec![inner_sin]);
+            }
+            // Rule 3 (Phase 31): arc-cancellation — sin(asin(x)) = x.
+            if inner.head == IRNode::Symbol(ASIN.to_string()) && inner.args.len() == 1 {
+                return inner.args[0].clone();
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
-fn asin_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Asin",
-            f64::asin,
-            &[(Numeric::Int(0), IRNode::Integer(0))],
-            simplify,
-        )
+/// Phase 31+33: Cos — even symmetry, arc-cancellation, π-multiple exact values.
+fn cos_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        // Rule 4 (Phase 33): π-multiple.
+        if let Some((p, q)) = try_pi_multiple(arg) {
+            if let Some((rp, rq)) = frac_mod(p, q, 2) {
+                if let Some(val) = cos_pi_table(rp, rq) { return val; }
+            }
+        }
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(1); }
+            return IRNode::Float(va.to_f64().cos());
+        }
+        if !simplify { panic!("Cos requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            // Rule 2 (Phase 31): even symmetry — cos(-x) = cos(x).
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                return vm.eval(apply_node(COS, vec![inner.args[0].clone()]));
+            }
+            // Rule 3 (Phase 31): arc-cancellation — cos(acos(x)) = x.
+            if inner.head == IRNode::Symbol(ACOS.to_string()) && inner.args.len() == 1 {
+                return inner.args[0].clone();
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
-fn acos_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(&expr, "Acos", f64::acos, &[], simplify)
+/// Phase 31+33: Tan — odd symmetry, arc-cancellation, π-multiple exact values.
+fn tan_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        // Rule 4 (Phase 33): π-multiple.
+        if let Some((p, q)) = try_pi_multiple(arg) {
+            // tan(-q·π) = -tan(q·π): handle via sign.
+            let (sign, p_abs) = if p < 0 { (-1i64, -p) } else { (1, p) };
+            if let Some((rp, rq)) = frac_mod(p_abs, q, 1) {
+                if let Some(val) = tan_pi_table(rp, rq) {
+                    return if sign < 0 { apply_node(NEG, vec![val]) } else { val };
+                }
+                // rp/rq = 1/2 → undefined, fall through
+            }
+        }
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().tan());
+        }
+        if !simplify { panic!("Tan requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            // Rule 2 (Phase 31): odd symmetry — tan(-x) = -tan(x).
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_tan = vm.eval(apply_node(TAN, vec![inner.args[0].clone()]));
+                return apply_node(NEG, vec![inner_tan]);
+            }
+            // Rule 3 (Phase 31): arc-cancellation — tan(atan(x)) = x.
+            if inner.head == IRNode::Symbol(ATAN.to_string()) && inner.args.len() == 1 {
+                return inner.args[0].clone();
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
+/// Phase 31: Sinh — odd symmetry, arc-cancellation sinh(asinh(x)) = x.
 fn sinh_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Sinh",
-            f64::sinh,
-            &[(Numeric::Int(0), IRNode::Integer(0))],
-            simplify,
-        )
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().sinh());
+        }
+        if !simplify { panic!("Sinh requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_sinh = vm.eval(apply_node(SINH, vec![inner.args[0].clone()]));
+                return apply_node(NEG, vec![inner_sinh]);
+            }
+            if inner.head == IRNode::Symbol(ASINH.to_string()) && inner.args.len() == 1 {
+                return inner.args[0].clone();
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
+/// Phase 31: Cosh — even symmetry, arc-cancellation cosh(acosh(x)) = x.
 fn cosh_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Cosh",
-            f64::cosh,
-            &[(Numeric::Int(0), IRNode::Integer(1))],
-            simplify,
-        )
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(1); }
+            return IRNode::Float(va.to_f64().cosh());
+        }
+        if !simplify { panic!("Cosh requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                return vm.eval(apply_node(COSH, vec![inner.args[0].clone()]));
+            }
+            if inner.head == IRNode::Symbol(ACOSH.to_string()) && inner.args.len() == 1 {
+                return inner.args[0].clone();
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
+/// Phase 31: Tanh — odd symmetry, arc-cancellation tanh(atanh(x)) = x.
 fn tanh_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Tanh",
-            f64::tanh,
-            &[(Numeric::Int(0), IRNode::Integer(0))],
-            simplify,
-        )
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().tanh());
+        }
+        if !simplify { panic!("Tanh requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_tanh = vm.eval(apply_node(TANH, vec![inner.args[0].clone()]));
+                return apply_node(NEG, vec![inner_tanh]);
+            }
+            if inner.head == IRNode::Symbol(ATANH.to_string()) && inner.args.len() == 1 {
+                return inner.args[0].clone();
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
@@ -704,39 +1055,114 @@ fn csch_handler(simplify: bool) -> Handler {
     })
 }
 
-fn asinh_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Asinh",
-            f64::asinh,
-            &[(Numeric::Int(0), IRNode::Integer(0))],
-            simplify,
-        )
+/// Phase 32: Atan — odd symmetry.
+fn atan_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().atan());
+        }
+        if !simplify { panic!("Atan requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_atan = vm.eval(apply_node(ATAN, vec![inner.args[0].clone()]));
+                return apply_node(NEG, vec![inner_atan]);
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
+/// Phase 32: Asin — odd symmetry.
+fn asin_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().asin());
+        }
+        if !simplify { panic!("Asin requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_asin = vm.eval(apply_node(ASIN, vec![inner.args[0].clone()]));
+                return apply_node(NEG, vec![inner_asin]);
+            }
+        }
+        IRNode::Apply(Box::new(expr))
+    })
+}
+
+/// Phase 32: Acos — reflection identity acos(-x) = %pi − acos(x).
+fn acos_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(1) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().acos());
+        }
+        if !simplify { panic!("Acos requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_acos = vm.eval(apply_node(ACOS, vec![inner.args[0].clone()]));
+                // acos(-x) = %pi - acos(x)
+                return apply_node(SUB, vec![
+                    IRNode::Symbol("%pi".to_string()),
+                    inner_acos,
+                ]);
+            }
+        }
+        IRNode::Apply(Box::new(expr))
+    })
+}
+
+/// Phase 32: Asinh — odd symmetry.
+fn asinh_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().asinh());
+        }
+        if !simplify { panic!("Asinh requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_asinh = vm.eval(apply_node(ASINH, vec![inner.args[0].clone()]));
+                return apply_node(NEG, vec![inner_asinh]);
+            }
+        }
+        IRNode::Apply(Box::new(expr))
+    })
+}
+
+/// Acosh — numeric fold only (domain [1, ∞), no real symmetry rule).
 fn acosh_handler(simplify: bool) -> Handler {
     std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Acosh",
-            f64::acosh,
-            &[(Numeric::Int(1), IRNode::Integer(0))],
-            simplify,
-        )
+        single_trig(&expr, "Acosh", f64::acosh, &[(Numeric::Int(1), IRNode::Integer(0))], simplify)
     })
 }
 
+/// Phase 32: Atanh — odd symmetry.
 fn atanh_handler(simplify: bool) -> Handler {
-    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
-        single_trig(
-            &expr,
-            "Atanh",
-            f64::atanh,
-            &[(Numeric::Int(0), IRNode::Integer(0))],
-            simplify,
-        )
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 1 { return IRNode::Apply(Box::new(expr)); }
+        let arg = &expr.args[0];
+        if let Some(va) = to_numeric(arg) {
+            if va == Numeric::Int(0) { return IRNode::Integer(0); }
+            return IRNode::Float(va.to_f64().atanh());
+        }
+        if !simplify { panic!("Atanh requires a numeric argument: {expr}"); }
+        if let IRNode::Apply(inner) = arg {
+            if inner.head == IRNode::Symbol(NEG.to_string()) && inner.args.len() == 1 {
+                let inner_atanh = vm.eval(apply_node(ATANH, vec![inner.args[0].clone()]));
+                return apply_node(NEG, vec![inner_atanh]);
+            }
+        }
+        IRNode::Apply(Box::new(expr))
     })
 }
 
@@ -3539,6 +3965,7 @@ pub fn build_handler_table(simplify: bool) -> HashMap<String, Handler> {
     m.insert(POW.to_string(), pow_handler(simplify));
     m.insert(NEG.to_string(), neg_handler(simplify));
     m.insert(INV.to_string(), inv_handler(simplify));
+    m.insert("Abs".to_string(), abs_handler(simplify));
     m.insert(SIN.to_string(), sin_handler(simplify));
     m.insert(COS.to_string(), cos_handler(simplify));
     m.insert(TAN.to_string(), tan_handler(simplify));

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -4,9 +4,9 @@
 //! directly and evaluating them under each backend.
 
 use symbolic_ir::{
-    apply, flt, int, rat, sym, ACOSH, ADD, AND, ASINH, ASSIGN, ATAN, ATANH, COS, COSH, COTH, CSCH,
-    D, DEFINE, DIV, EXP, IF, INTEGRATE, LIST, LOG, MUL, NEG, NOT, OR, POW, SECH, SIN, SINH, SQRT,
-    SUB, TAN, TANH,
+    apply, flt, int, rat, sym, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ASSIGN, ATAN, ATANH, COS, COSH,
+    COTH, CSCH, D, DEFINE, DIV, EXP, IF, INTEGRATE, LIST, LOG, MUL, NEG, NOT, OR, POW, SECH, SIN,
+    SINH, SQRT, SUB, TAN, TANH,
 };
 use symbolic_vm::{StrictBackend, SymbolicBackend, VM};
 
@@ -20,6 +20,11 @@ fn strict() -> VM {
 
 fn symbolic() -> VM {
     VM::new(Box::new(SymbolicBackend::new()))
+}
+
+/// Evaluate a single expression in a fresh symbolic VM.
+fn eval(expr: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    symbolic().eval(expr)
 }
 
 fn d(f: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
@@ -922,18 +927,13 @@ fn derivative_power_rules() {
         )
     );
 
+    // Phase 30: exp(x·log(x)) now simplifies to x^x, so D(x^x, x) = x^x·(log(x)+1).
     assert_eq!(
         d(apply(sym(POW), vec![sym("x"), sym("x")])),
         apply(
             sym(MUL),
             vec![
-                apply(
-                    sym(EXP),
-                    vec![apply(
-                        sym(MUL),
-                        vec![sym("x"), apply(sym(LOG), vec![sym("x")])],
-                    )],
-                ),
+                apply(sym(POW), vec![sym("x"), sym("x")]),
                 apply(
                     sym(ADD),
                     vec![
@@ -1653,6 +1653,459 @@ fn phase28_regression_atan_x_stays_unevaluated() {
         vec![apply(sym(ATAN), vec![sym("x")]), sym("x")],
     );
     assert_eq!(result, original, "Phase 28 must not intercept linear atan(x)");
+}
+
+// ---------------------------------------------------------------------------
+// Phase 29: Abs and Sqrt algebraic rules
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase29_abs_numeric_fold() {
+    // abs(-3) = 3, abs(3) = 3
+    assert_eq!(eval(apply(sym("Abs"), vec![int(-3)])), int(3));
+    assert_eq!(eval(apply(sym("Abs"), vec![int(5)])), int(5));
+}
+
+#[test]
+fn phase29_abs_idempotent() {
+    // abs(abs(x)) = abs(x)
+    let x = sym("x");
+    let abs_x = apply(sym("Abs"), vec![x.clone()]);
+    assert_eq!(eval(apply(sym("Abs"), vec![abs_x.clone()])), abs_x);
+}
+
+#[test]
+fn phase29_abs_strips_neg() {
+    // abs(-x) = abs(x)
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym("Abs"), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym("Abs"), vec![x])
+    );
+}
+
+#[test]
+fn phase29_abs_even_power() {
+    // abs(x^2) = x^2,  abs(x^4) = x^4
+    let x = sym("x");
+    let x2 = apply(sym(POW), vec![x.clone(), int(2)]);
+    let x4 = apply(sym(POW), vec![x.clone(), int(4)]);
+    assert_eq!(eval(apply(sym("Abs"), vec![x2.clone()])), x2);
+    assert_eq!(eval(apply(sym("Abs"), vec![x4.clone()])), x4);
+}
+
+#[test]
+fn phase29_sqrt_perfect_squares() {
+    // sqrt(0)=0, sqrt(1)=1, sqrt(4)=2, sqrt(9)=3, sqrt(16)=4
+    let sqrt = |n: i64| eval(apply(sym(SQRT), vec![int(n)]));
+    assert_eq!(sqrt(0), int(0));
+    assert_eq!(sqrt(1), int(1));
+    assert_eq!(sqrt(4), int(2));
+    assert_eq!(sqrt(9), int(3));
+    assert_eq!(sqrt(16), int(4));
+    assert_eq!(sqrt(25), int(5));
+}
+
+#[test]
+fn phase29_sqrt_x2_is_abs_x() {
+    // sqrt(x^2) = |x|  — k=1, odd
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(SQRT), vec![apply(sym(POW), vec![x.clone(), int(2)])])),
+        apply(sym("Abs"), vec![x])
+    );
+}
+
+#[test]
+fn phase29_sqrt_x4_is_x2() {
+    // sqrt(x^4) = x^2  — k=2, even
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(SQRT), vec![apply(sym(POW), vec![x.clone(), int(4)])])),
+        apply(sym(POW), vec![x, int(2)])
+    );
+}
+
+#[test]
+fn phase29_sqrt_x6_is_abs_x3() {
+    // sqrt(x^6) = |x^3|  — k=3, odd
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(SQRT), vec![apply(sym(POW), vec![x.clone(), int(6)])])),
+        apply(sym("Abs"), vec![apply(sym(POW), vec![x, int(3)])])
+    );
+}
+
+#[test]
+fn phase29_sqrt_x8_is_x4() {
+    // sqrt(x^8) = x^4  — k=4, even
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(SQRT), vec![apply(sym(POW), vec![x.clone(), int(8)])])),
+        apply(sym(POW), vec![x, int(4)])
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 30: Log and Exp cancellation rules
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase30_log_exp_cancels() {
+    // log(exp(x)) = x
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(LOG), vec![apply(sym(EXP), vec![x.clone()])])),
+        x
+    );
+}
+
+#[test]
+fn phase30_exp_log_cancels() {
+    // exp(log(x)) = x
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(EXP), vec![apply(sym(LOG), vec![x.clone()])])),
+        x
+    );
+}
+
+#[test]
+fn phase30_exp_n_log_x_is_pow() {
+    // exp(2*log(x)) = x^2
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(EXP), vec![apply(
+            sym(MUL),
+            vec![int(2), apply(sym(LOG), vec![x.clone()])],
+        )])),
+        apply(sym(POW), vec![x.clone(), int(2)])
+    );
+}
+
+#[test]
+fn phase30_exp_log_x_n_commuted_is_pow() {
+    // exp(log(x)*3) = x^3  (commuted Mul)
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(EXP), vec![apply(
+            sym(MUL),
+            vec![apply(sym(LOG), vec![x.clone()]), int(3)],
+        )])),
+        apply(sym(POW), vec![x.clone(), int(3)])
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 31: Trig/hyperbolic symmetry and arc-cancellation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase31_sin_odd_symmetry() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(SIN), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(NEG), vec![apply(sym(SIN), vec![x])])
+    );
+}
+
+#[test]
+fn phase31_sin_arc_cancel() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(SIN), vec![apply(sym(ASIN), vec![x.clone()])])),
+        x
+    );
+}
+
+#[test]
+fn phase31_cos_even_symmetry() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(COS), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(COS), vec![x])
+    );
+}
+
+#[test]
+fn phase31_cos_arc_cancel() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(COS), vec![apply(sym(ACOS), vec![x.clone()])])),
+        x
+    );
+}
+
+#[test]
+fn phase31_tan_odd_symmetry() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(TAN), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(NEG), vec![apply(sym(TAN), vec![x])])
+    );
+}
+
+#[test]
+fn phase31_tan_arc_cancel() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(TAN), vec![apply(sym(ATAN), vec![x.clone()])])),
+        x
+    );
+}
+
+#[test]
+fn phase31_sinh_odd_symmetry() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(SINH), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(NEG), vec![apply(sym(SINH), vec![x])])
+    );
+}
+
+#[test]
+fn phase31_sinh_arc_cancel() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(SINH), vec![apply(sym(ASINH), vec![x.clone()])])),
+        x
+    );
+}
+
+#[test]
+fn phase31_cosh_even_symmetry() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(COS), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(COS), vec![x])
+    );
+}
+
+#[test]
+fn phase31_cosh_arc_cancel() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(COSH), vec![apply(sym(ACOSH), vec![x.clone()])])),
+        x
+    );
+}
+
+#[test]
+fn phase31_tanh_odd_symmetry() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(TANH), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(NEG), vec![apply(sym(TANH), vec![x])])
+    );
+}
+
+#[test]
+fn phase31_tanh_arc_cancel() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(TANH), vec![apply(sym(ATANH), vec![x.clone()])])),
+        x
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 32: Inverse trig/hyperbolic odd symmetry + acos reflection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase32_asin_odd() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(ASIN), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(NEG), vec![apply(sym(ASIN), vec![x])])
+    );
+}
+
+#[test]
+fn phase32_acos_reflection() {
+    // acos(-x) = %pi - acos(x)
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(ACOS), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(SUB), vec![
+            sym("%pi"),
+            apply(sym(ACOS), vec![x]),
+        ])
+    );
+}
+
+#[test]
+fn phase32_atan_odd() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(ATAN), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(NEG), vec![apply(sym(ATAN), vec![x])])
+    );
+}
+
+#[test]
+fn phase32_asinh_odd() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(ASINH), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(NEG), vec![apply(sym(ASINH), vec![x])])
+    );
+}
+
+#[test]
+fn phase32_atanh_odd() {
+    let x = sym("x");
+    assert_eq!(
+        eval(apply(sym(ATANH), vec![apply(sym(NEG), vec![x.clone()])])),
+        apply(sym(NEG), vec![apply(sym(ATANH), vec![x])])
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 33: Trig exact values at rational multiples of π
+// ---------------------------------------------------------------------------
+
+fn pi() -> symbolic_ir::IRNode { sym("%pi") }
+
+#[test]
+fn phase33_sin_pi_is_zero() {
+    assert_eq!(eval(apply(sym(SIN), vec![pi()])), int(0));
+}
+
+#[test]
+fn phase33_sin_pi_over_6_is_half() {
+    assert_eq!(
+        eval(apply(sym(SIN), vec![apply(sym(DIV), vec![pi(), int(6)])])),
+        symbolic_ir::IRNode::Rational(1, 2)
+    );
+}
+
+#[test]
+fn phase33_sin_pi_over_4_is_sqrt2_over_2() {
+    let result = eval(apply(sym(SIN), vec![apply(sym(DIV), vec![pi(), int(4)])]));
+    // Div(Sqrt(2), 2)
+    assert_eq!(result, apply(sym(DIV), vec![
+        apply(sym(SQRT), vec![int(2)]),
+        int(2),
+    ]));
+}
+
+#[test]
+fn phase33_sin_pi_over_2_is_one() {
+    assert_eq!(
+        eval(apply(sym(SIN), vec![apply(sym(DIV), vec![pi(), int(2)])])),
+        int(1)
+    );
+}
+
+#[test]
+fn phase33_sin_2pi_is_zero() {
+    assert_eq!(
+        eval(apply(sym(SIN), vec![apply(sym(MUL), vec![int(2), pi()])])),
+        int(0)
+    );
+}
+
+#[test]
+fn phase33_sin_3pi_over_2_is_neg_one() {
+    // 3π/2: sin = -1
+    let arg = apply(sym(DIV), vec![apply(sym(MUL), vec![int(3), pi()]), int(2)]);
+    assert_eq!(eval(apply(sym(SIN), vec![arg])), int(-1));
+}
+
+#[test]
+fn phase33_cos_pi_is_neg_one() {
+    assert_eq!(eval(apply(sym(COS), vec![pi()])), int(-1));
+}
+
+#[test]
+fn phase33_cos_pi_over_2_is_zero() {
+    assert_eq!(
+        eval(apply(sym(COS), vec![apply(sym(DIV), vec![pi(), int(2)])])),
+        int(0)
+    );
+}
+
+#[test]
+fn phase33_cos_pi_over_3_is_half() {
+    assert_eq!(
+        eval(apply(sym(COS), vec![apply(sym(DIV), vec![pi(), int(3)])])),
+        symbolic_ir::IRNode::Rational(1, 2)
+    );
+}
+
+#[test]
+fn phase33_cos_2pi_is_one() {
+    assert_eq!(
+        eval(apply(sym(COS), vec![apply(sym(MUL), vec![int(2), pi()])])),
+        int(1)
+    );
+}
+
+#[test]
+fn phase33_tan_pi_is_zero() {
+    assert_eq!(eval(apply(sym(TAN), vec![pi()])), int(0));
+}
+
+#[test]
+fn phase33_tan_pi_over_4_is_one() {
+    assert_eq!(
+        eval(apply(sym(TAN), vec![apply(sym(DIV), vec![pi(), int(4)])])),
+        int(1)
+    );
+}
+
+#[test]
+fn phase33_tan_pi_over_3_is_sqrt3() {
+    assert_eq!(
+        eval(apply(sym(TAN), vec![apply(sym(DIV), vec![pi(), int(3)])])),
+        apply(sym(SQRT), vec![int(3)])
+    );
+}
+
+#[test]
+fn phase33_tan_3pi_over_4_is_neg_one() {
+    let arg = apply(sym(DIV), vec![apply(sym(MUL), vec![int(3), pi()]), int(4)]);
+    assert_eq!(eval(apply(sym(TAN), vec![arg])), int(-1));
+}
+
+#[test]
+fn phase33_tan_pi_over_2_stays_unevaluated() {
+    // tan(π/2) is undefined — must remain unevaluated.
+    let arg = apply(sym(DIV), vec![pi(), int(2)]);
+    let result = eval(apply(sym(TAN), vec![arg.clone()]));
+    // Result should still be Tan(π/2), not a numeric value.
+    match &result {
+        symbolic_ir::IRNode::Apply(ap) => {
+            assert_eq!(ap.head, sym(TAN), "head should be Tan");
+        }
+        _ => panic!("expected unevaluated Tan, got: {result:?}"),
+    }
+}
+
+#[test]
+fn phase33_sin_neg_pi_over_6_is_neg_half() {
+    // sin(-π/6) = -1/2 via odd symmetry through table lookup
+    let arg = apply(sym(NEG), vec![apply(sym(DIV), vec![pi(), int(6)])]);
+    assert_eq!(eval(apply(sym(SIN), vec![arg])), symbolic_ir::IRNode::Rational(-1, 2));
+}
+
+#[test]
+fn phase33_cos_neg_pi_over_3_is_half() {
+    // cos(-π/3) = 1/2 via even-symmetry modular reduction
+    let arg = apply(sym(NEG), vec![apply(sym(DIV), vec![pi(), int(3)])]);
+    assert_eq!(
+        eval(apply(sym(COS), vec![arg])),
+        symbolic_ir::IRNode::Rational(1, 2)
+    );
+}
+
+#[test]
+fn phase33_regression_numeric_sin_cos_tan() {
+    // Existing numeric fold must still work after Phase 33.
+    assert_eq!(eval(apply(sym(SIN), vec![int(0)])), int(0));
+    assert_eq!(eval(apply(sym(COS), vec![int(0)])), int(1));
+    assert_eq!(eval(apply(sym(TAN), vec![int(0)])), int(0));
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,97 @@
 # Changelog
 
+## [0.6.0] — 2026-05-18
+
+### Added — Phases 29–33: algebraic simplification rules
+
+Extends the symbolic backend with five new rule families that fire on
+every re-evaluation of the affected expressions.
+
+#### Phase 29 — Abs and Sqrt algebraic rules
+
+**`Abs(x)`** (new handler — `Abs` head previously fell through unhandled):
+- Numeric fold: `Abs(-3) → 3`, `Abs(3/4) → 3/4`.
+- Idempotency: `Abs(Abs(x)) → Abs(x)`.
+- Negation strip: `Abs(-x) → Abs(x)` (detects `Neg` head).
+- Mul-neg strip: `Abs(Mul(-1, x)) → Abs(x)`.
+- Even-power identity: `Abs(x^{2k}) → x^{2k}` for integer 2k ≥ 2.
+
+**`Sqrt(x)`** (replaces numeric-only `elementary()` factory):
+- Perfect-square detection: `sqrt(4) → 2`, `sqrt(9) → 3`, etc.
+- Even-exponent rewrite `sqrt(x^{2k})`:
+  - k even → `x^k`  (e.g. `sqrt(x^4) = x^2`)
+  - k odd → `Abs(x^k)` (e.g. `sqrt(x^2) = |x|`, `sqrt(x^6) = |x^3|`)
+
+#### Phase 30 — Log / Exp cancellation rules
+
+**`Log(x)`**:
+- `log(exp(x)) → x`  (structural cancellation, unconditional for real domain).
+- Special value `log(1) → 0` preserved.
+
+**`Exp(x)`**:
+- `exp(log(x)) → x`.
+- `exp(n·log(x)) → x^n`  (handles both `Mul(n, log(x))` and `Mul(log(x), n)`).
+- Special value `exp(0) → 1` preserved.
+
+**Regression note**: the derivative of `x^x` now simplifies to `x^x·(log(x)+1)`
+instead of `exp(x·log(x))·(log(x)+1)` because `exp(x·log(x))` is eagerly reduced
+to `x^x`.  The test expectation was updated accordingly.
+
+#### Phase 31 — Trig / hyperbolic negation symmetry and arc-cancellation
+
+**Odd functions** (`sin`, `tan`, `sinh`, `tanh`):
+- `f(-x) → -f(x)` with recursive descent so double negations collapse.
+
+**Even functions** (`cos`, `cosh`):
+- `f(-x) → f(x)` (Neg stripped).
+
+**Arc-cancellation** (all six primary trig/hyperbolic functions):
+- `sin(asin(x)) → x`,  `cos(acos(x)) → x`,  `tan(atan(x)) → x`
+- `sinh(asinh(x)) → x`,  `cosh(acosh(x)) → x`,  `tanh(atanh(x)) → x`
+
+#### Phase 32 — Inverse trig / hyperbolic odd symmetry
+
+**Odd** (`asin`, `atan`, `asinh`, `atanh`):
+- `f(-x) → -f(x)`.
+
+**Acos reflection** (`acos`):
+- `acos(-x) → %pi − acos(x)` (`%pi` is `IRSymbol("%pi")`).
+
+**Acosh** has no symmetry rule (domain `[1, ∞)`) and keeps numeric-fold only.
+
+#### Phase 33 — Trig exact values at rational multiples of π
+
+`sin(q·%pi)`, `cos(q·%pi)`, and `tan(q·%pi)` return exact algebraic values
+when `q` is a rational number with denominator in `{1, 2, 3, 4, 6}`.
+
+**`tryPiMultiple(arg)`** detects:
+- Float ≈ q·π (denominators 1, 2, 3, 4, 6).
+- Structural: `%pi`, `Neg(%pi)`, `Mul(n, %pi)`, `Div(%pi, n)`,
+  `Div(Mul(n, %pi), d)` (both Mul orderings).
+
+**Lookup tables** (period 2π for sin/cos, period π for tan):
+
+| q | sin(q·π) | cos(q·π) | tan(q·π) |
+|---|----------|----------|----------|
+| 0 | 0 | 1 | 0 |
+| 1/6 | 1/2 | √3/2 | √3/3 |
+| 1/4 | √2/2 | √2/2 | 1 |
+| 1/3 | √3/2 | 1/2 | √3 |
+| 1/2 | 1 | 0 | undefined |
+| 2/3 | √3/2 | −1/2 | −√3 |
+| 3/4 | √2/2 | −√2/2 | −1 |
+| 5/6 | 1/2 | −√3/2 | −√3/3 |
+| 1 | 0 | −1 | 0 |
+
+`tan(π/2)` is left unevaluated (undefined).
+
+**Tests added** (54 new tests across all 5 phases):
+- Phase 29: 9 tests (abs fold/idempotency/strip/even-power; sqrt perfect-square/even-power)
+- Phase 30: 7 tests (log/exp cancellation and power form)
+- Phase 31: 12 tests (trig+hyperbolic symmetry and arc-cancellation)
+- Phase 32: 6 tests (inverse trig odd symmetry + acos reflection)
+- Phase 33: 20 tests (sin/cos/tan π-multiples including negative q and regression)
+
 ## [0.5.0] — 2026-05-18
 
 ### Added — Phase 28: general IBP for poly×log(Q) and poly×atan(Q)

--- a/code/packages/typescript/symbolic-vm/package-lock.json
+++ b/code/packages/typescript/symbolic-vm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/symbolic-vm",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/cas-factor": "file:../cas-factor",
@@ -31,7 +31,7 @@
     },
     "../symbolic-ir": {
       "name": "@coding-adventures/symbolic-ir",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -237,6 +237,207 @@ export function substitute(node: IRNode, mapping: ReadonlyMap<string, IRNode>): 
   return node;
 }
 
+// ---------------------------------------------------------------------------
+// Phase 29–33: algebraic helpers and lookup tables
+// ---------------------------------------------------------------------------
+
+// Reduced fraction [numerator, denominator] with denominator > 0.
+type Frac = readonly [bigint, bigint];
+
+/** GCD of two non-negative bigints. */
+function fracGcd(a: bigint, b: bigint): bigint {
+  while (b !== 0n) [a, b] = [b, a % b];
+  return a;
+}
+
+/** Reduce a rational number p/q to lowest terms with q > 0. */
+function fracMake(p: bigint, q: bigint): Frac {
+  if (q === 0n) throw new RangeError("zero denominator in fracMake");
+  if (q < 0n) { p = -p; q = -q; }
+  const g = fracGcd(p < 0n ? -p : p, q === 0n ? 1n : q);
+  return [p / g, q / g];
+}
+
+/** String key for a reduced fraction, used as Map key in PI tables. */
+function fracKey(f: Frac): string { return `${f[0]}/${f[1]}`; }
+
+/** Modular reduction: (p/q) mod m, result in [0, m). */
+function fracMod(f: Frac, m: bigint): Frac {
+  const [p, q] = f;
+  let r = p % (m * q);
+  if (r < 0n) r += m * q;
+  return fracMake(r, q);
+}
+
+/** Extract the fraction represented by a plain numeric IR node (integer or rational). */
+function fracFromIR(node: IRNode): Frac | undefined {
+  if (node.kind === "integer") return [node.value, 1n];
+  if (node.kind === "rational") return fracMake(node.numer, node.denom);
+  return undefined;
+}
+
+/**
+ * Phase 33: If `arg` equals `q · %pi` for a rational `q` with small
+ * denominator, return `q` as a reduced {@link Frac}.  Otherwise `undefined`.
+ *
+ * Two strategies:
+ * 1. **Float** — arg ≈ q·π; check denominators {1,2,3,4,6}.
+ * 2. **Structural** — matches `%pi`, `Neg(%pi)`, `Mul(n, %pi)`,
+ *    `Div(%pi, n)`, `Div(Mul(n, %pi), d)` (both orderings of n and %pi).
+ */
+function tryPiMultiple(arg: IRNode): Frac | undefined {
+  // Strategy 1: float value ≈ q·π
+  if (arg.kind === "float") {
+    const qf = arg.value / Math.PI;
+    for (const d of [1, 2, 3, 4, 6]) {
+      const pCand = Math.round(qf * d);
+      if (Math.abs(qf * d - pCand) < 1e-9)
+        return fracMake(BigInt(pCand), BigInt(d));
+    }
+    return undefined;
+  }
+  // Strategy 2: structural match
+  if (arg.kind === "symbol" && arg.name === "%pi") return [1n, 1n];
+  if (arg.kind !== "apply") return undefined;
+
+  // Neg(anything) — recurse and negate
+  if (equals(arg.head, NEG) && arg.args.length === 1) {
+    const inner = tryPiMultiple(arg.args[0]);
+    return inner === undefined ? undefined : fracMake(-inner[0], inner[1]);
+  }
+
+  // Mul(n, %pi) or Mul(%pi, n)
+  if (equals(arg.head, MUL) && arg.args.length === 2) {
+    const [a, b] = arg.args;
+    const piB = b.kind === "symbol" && b.name === "%pi";
+    const piA = a.kind === "symbol" && a.name === "%pi";
+    if (piB) return fracFromIR(a);
+    if (piA) return fracFromIR(b);
+  }
+
+  // Div(%pi, n) or Div(Mul(n,%pi), d)
+  if (equals(arg.head, DIV) && arg.args.length === 2) {
+    const [num, den] = arg.args;
+    const dFrac = fracFromIR(den);
+    if (dFrac === undefined || dFrac[0] === 0n) return undefined;
+
+    // Div(%pi, n) → 1 / dFrac = [dFrac[1], dFrac[0]]
+    if (num.kind === "symbol" && num.name === "%pi")
+      return fracMake(dFrac[1], dFrac[0]);
+
+    // Div(Mul(n,%pi), d) or Div(Mul(%pi,n), d)
+    if (num.kind === "apply" && equals(num.head, MUL) && num.args.length === 2) {
+      const [ma, mb] = num.args;
+      const piMb = mb.kind === "symbol" && mb.name === "%pi";
+      const piMa = ma.kind === "symbol" && ma.name === "%pi";
+      if (piMb) {
+        const nFrac = fracFromIR(ma);
+        return nFrac === undefined ? undefined
+          : fracMake(nFrac[0] * dFrac[1], nFrac[1] * dFrac[0]);
+      }
+      if (piMa) {
+        const nFrac = fracFromIR(mb);
+        return nFrac === undefined ? undefined
+          : fracMake(nFrac[0] * dFrac[1], nFrac[1] * dFrac[0]);
+      }
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 33: exact algebraic IR constants shared by sin/cos/tan tables
+// ---------------------------------------------------------------------------
+const _P33_SQRT2 = app(sym("Sqrt"), [int(2)]);
+const _P33_SQRT3 = app(sym("Sqrt"), [int(3)]);
+const _P33_SQRT2_OVER_2 = app(sym("Div"), [_P33_SQRT2, int(2)]);
+const _P33_SQRT3_OVER_2 = app(sym("Div"), [_P33_SQRT3, int(2)]);
+const _P33_SQRT3_OVER_3 = app(sym("Div"), [_P33_SQRT3, int(3)]);
+const _P33_NEG_SQRT2_OVER_2 = app(sym("Neg"), [_P33_SQRT2_OVER_2]);
+const _P33_NEG_SQRT3_OVER_2 = app(sym("Neg"), [_P33_SQRT3_OVER_2]);
+const _P33_NEG_SQRT3 = app(sym("Neg"), [_P33_SQRT3]);
+const _P33_NEG_SQRT3_OVER_3 = app(sym("Neg"), [_P33_SQRT3_OVER_3]);
+
+/**
+ * sin(q·π) for q ∈ [0, 2)  — period 2π → reduce mod 2.
+ *
+ * Values:
+ *   0      → 0,   1/6 → 1/2,  1/4 → √2/2, 1/3 → √3/2,
+ *   1/2    → 1,   2/3 → √3/2, 3/4 → √2/2, 5/6 → 1/2,
+ *   1      → 0,   7/6 → −1/2, 5/4 → −√2/2, 4/3 → −√3/2,
+ *   3/2    → −1,  5/3 → −√3/2, 7/4 → −√2/2, 11/6 → −1/2.
+ */
+const SIN_PI_TABLE = new Map<string, IRNode>([
+  ["0/1",   int(0)],
+  ["1/6",   rational(1n, 2n)],
+  ["1/4",   _P33_SQRT2_OVER_2],
+  ["1/3",   _P33_SQRT3_OVER_2],
+  ["1/2",   int(1)],
+  ["2/3",   _P33_SQRT3_OVER_2],
+  ["3/4",   _P33_SQRT2_OVER_2],
+  ["5/6",   rational(1n, 2n)],
+  ["1/1",   int(0)],
+  ["7/6",   rational(-1n, 2n)],
+  ["5/4",   _P33_NEG_SQRT2_OVER_2],
+  ["4/3",   _P33_NEG_SQRT3_OVER_2],
+  ["3/2",   int(-1)],
+  ["5/3",   _P33_NEG_SQRT3_OVER_2],
+  ["7/4",   _P33_NEG_SQRT2_OVER_2],
+  ["11/6",  rational(-1n, 2n)],
+]);
+
+/**
+ * cos(q·π) for q ∈ [0, 2)  — period 2π → reduce mod 2.
+ *
+ * Values:
+ *   0      → 1,   1/6 → √3/2, 1/4 → √2/2, 1/3 → 1/2,
+ *   1/2    → 0,   2/3 → −1/2, 3/4 → −√2/2, 5/6 → −√3/2,
+ *   1      → −1,  7/6 → −√3/2, 5/4 → −√2/2, 4/3 → −1/2,
+ *   3/2    → 0,   5/3 → 1/2, 7/4 → √2/2, 11/6 → √3/2.
+ */
+const COS_PI_TABLE = new Map<string, IRNode>([
+  ["0/1",   int(1)],
+  ["1/6",   _P33_SQRT3_OVER_2],
+  ["1/4",   _P33_SQRT2_OVER_2],
+  ["1/3",   rational(1n, 2n)],
+  ["1/2",   int(0)],
+  ["2/3",   rational(-1n, 2n)],
+  ["3/4",   _P33_NEG_SQRT2_OVER_2],
+  ["5/6",   _P33_NEG_SQRT3_OVER_2],
+  ["1/1",   int(-1)],
+  ["7/6",   _P33_NEG_SQRT3_OVER_2],
+  ["5/4",   _P33_NEG_SQRT2_OVER_2],
+  ["4/3",   rational(-1n, 2n)],
+  ["3/2",   int(0)],
+  ["5/3",   rational(1n, 2n)],
+  ["7/4",   _P33_SQRT2_OVER_2],
+  ["11/6",  _P33_SQRT3_OVER_2],
+]);
+
+/**
+ * tan(q·π) for q ∈ [0, 1) — period π → reduce mod 1.
+ * q = 1/2 is omitted — tan(π/2) is undefined; the handler leaves it unevaluated.
+ *
+ * Values:
+ *   0   → 0, 1/6 → √3/3, 1/4 → 1, 1/3 → √3,
+ *   2/3 → −√3, 3/4 → −1, 5/6 → −√3/3.
+ */
+const TAN_PI_TABLE = new Map<string, IRNode>([
+  ["0/1",  int(0)],
+  ["1/6",  _P33_SQRT3_OVER_3],
+  ["1/4",  int(1)],
+  ["1/3",  _P33_SQRT3],
+  ["2/3",  _P33_NEG_SQRT3],
+  ["3/4",  int(-1)],
+  ["5/6",  _P33_NEG_SQRT3_OVER_3],
+]);
+
+// The %pi symbol used in acos reflection identity: acos(-x) = %pi − acos(x).
+const _INV_TRIG_PI = sym("%pi");
+
+// The Abs head symbol for sqrt/abs rules.
+const _ABS_HEAD = sym("Abs");
+
 function buildHandlerTable(simplify: boolean): ReadonlyMap<string, Handler> {
   const table = new Map<string, Handler>();
   table.set(ADD.name, binaryNumeric("Add", simplify, (a, b) => addNumeric(a, b), (expr, a, b) => {
@@ -274,21 +475,346 @@ function buildHandlerTable(simplify: boolean): ReadonlyMap<string, Handler> {
   }));
   table.set(INV.name, unaryNumeric("Inv", simplify, invNumeric, (expr) => expr));
 
-  table.set(SIN.name, elementary("Sin", Math.sin, new Map([["0", int(0)]]), simplify));
-  table.set(COS.name, elementary("Cos", Math.cos, new Map([["0", int(1)]]), simplify));
-  table.set(TAN.name, elementary("Tan", Math.tan, new Map([["0", int(0)]]), simplify));
-  table.set(EXP.name, elementary("Exp", Math.exp, new Map([["0", int(1)]]), simplify));
-  table.set(LOG.name, elementary("Log", Math.log, new Map([["1", int(0)]]), simplify));
-  table.set(SQRT.name, elementary("Sqrt", Math.sqrt, new Map([["0", int(0)], ["1", int(1)]]), simplify));
-  table.set(ATAN.name, elementary("Atan", Math.atan, new Map([["0", int(0)]]), simplify));
-  table.set(ASIN.name, elementary("Asin", Math.asin, new Map([["0", int(0)]]), simplify));
-  table.set(ACOS.name, elementary("Acos", Math.acos, new Map(), simplify));
-  table.set(SINH.name, elementary("Sinh", Math.sinh, new Map([["0", int(0)]]), simplify));
-  table.set(COSH.name, elementary("Cosh", Math.cosh, new Map([["0", int(1)]]), simplify));
-  table.set(TANH.name, elementary("Tanh", Math.tanh, new Map([["0", int(0)]]), simplify));
-  table.set(ASINH.name, elementary("Asinh", Math.asinh, new Map([["0", int(0)]]), simplify));
-  table.set(ACOSH.name, elementary("Acosh", Math.acosh, new Map(), simplify));
-  table.set(ATANH.name, elementary("Atanh", Math.atanh, new Map([["0", int(0)]]), simplify));
+  // ----- Phase 29: Abs — idempotency, negation-strip, even-power -----
+  // The Abs head is not in symbolic-ir's export list, so we register it
+  // by string name here.  Any expression of the form Abs(x) produced by
+  // the sqrt handler will be caught by this handler on re-evaluation.
+  table.set("Abs", (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const inner = expr.args[0];
+    const na = toNumeric(inner);
+    if (na !== undefined) {
+      // Numeric fold: abs(n) = |n|.
+      if (na.kind === "int") return int(na.value < 0n ? -na.value : na.value);
+      if (na.kind === "rat") {
+        const n = na.numer < 0n ? -na.numer : na.numer;
+        return rational(n, na.denom);
+      }
+      return numberNode(Math.abs(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Abs requires a numeric argument: ${headName(expr.head)}`);
+    // Rule 4a: abs(abs(x)) = abs(x)
+    if (inner.kind === "apply" && equals(inner.head, _ABS_HEAD))
+      return inner;
+    // Rule 4b: abs(-x) = abs(x)  (strip NEG)
+    if (inner.kind === "apply" && equals(inner.head, NEG) && inner.args.length === 1)
+      return vm.eval(app(_ABS_HEAD, [inner.args[0]]));
+    // Rule 4c: abs(Mul(-1, x)) = abs(x)  (-x encoded as Mul after numeric fold)
+    if (inner.kind === "apply" && equals(inner.head, MUL) && inner.args.length === 2) {
+      const [mA] = inner.args;
+      if (mA.kind === "integer" && mA.value === -1n)
+        return vm.eval(app(_ABS_HEAD, [inner.args[1]]));
+    }
+    // Rule 4d: abs(x^{2k}) = x^{2k}  (even power ≥ 0 always)
+    if (inner.kind === "apply" && equals(inner.head, POW) && inner.args.length === 2) {
+      const [, expNode] = inner.args;
+      if (expNode.kind === "integer" && expNode.value >= 2n && expNode.value % 2n === 0n)
+        return inner;
+    }
+    return expr;
+  });
+
+  // ----- Phase 29: Sqrt — perfect-square fold, even-power rewrite -----
+  // Overrides the numeric-only elementary() factory.
+  table.set(SQRT.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      if (numericKey(na) === "1") return int(1);
+      const result = Math.sqrt(toNumber(na));
+      // Perfect-square detection: if round(√n)² == n, return integer.
+      const intResult = Math.round(result);
+      if (intResult * intResult === toNumber(na)) return int(intResult);
+      return numberNode(result);
+    }
+    if (!simplify) throw new TypeError(`Sqrt requires a numeric argument: ${headName(expr.head)}`);
+    // sqrt(x^{2k}): split into even-k (x^k is non-negative) and odd-k (need Abs).
+    if (arg.kind === "apply" && equals(arg.head, POW) && arg.args.length === 2) {
+      const [base, expNode] = arg.args;
+      if (expNode.kind === "integer" && expNode.value > 0n && expNode.value % 2n === 0n) {
+        const k = expNode.value / 2n;
+        if (k % 2n === 0n) {
+          // k even → x^k ≥ 0 always, e.g. sqrt(x^4) = x^2.
+          return app(POW, [base, int(k)]);
+        }
+        // k odd → |x^k|, e.g. sqrt(x^2) = |x|, sqrt(x^6) = |x^3|.
+        if (k === 1n) return vm.eval(app(_ABS_HEAD, [base]));
+        return vm.eval(app(_ABS_HEAD, [app(POW, [base, int(k)])]));
+      }
+    }
+    return expr;
+  });
+
+  // ----- Phase 30: Log — log(exp(x))→x cancellation -----
+  table.set(LOG.name, (_vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "1") return int(0);
+      if (toNumber(na) <= 0) return expr; // log undefined for non-positive reals
+      return numberNode(Math.log(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Log requires a numeric argument: ${headName(expr.head)}`);
+    // Rule 3: log(exp(x)) = x  (structural cancellation, always valid for real domain).
+    if (arg.kind === "apply" && equals(arg.head, EXP) && arg.args.length === 1)
+      return arg.args[0];
+    // Note: log(x^n) = n·log(x) requires an assumption context; skipped here.
+    return expr;
+  });
+
+  // ----- Phase 30: Exp — exp(log(x))→x and exp(n·log(x))→x^n -----
+  table.set(EXP.name, (_vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(1);
+      return numberNode(Math.exp(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Exp requires a numeric argument: ${headName(expr.head)}`);
+    // Rule 3: exp(log(x)) = x.
+    if (arg.kind === "apply" && equals(arg.head, LOG) && arg.args.length === 1)
+      return arg.args[0];
+    // Rule 4: exp(n·log(x)) = x^n  — handles both Mul(n, log(x)) and Mul(log(x), n).
+    if (arg.kind === "apply" && equals(arg.head, MUL) && arg.args.length === 2) {
+      const [a, b] = arg.args;
+      if (a.kind === "apply" && equals(a.head, LOG) && a.args.length === 1)
+        return app(POW, [a.args[0], b]);
+      if (b.kind === "apply" && equals(b.head, LOG) && b.args.length === 1)
+        return app(POW, [b.args[0], a]);
+    }
+    return expr;
+  });
+
+  // ----- Phase 31+33: Sin — odd symmetry, arc-cancel, π-multiples -----
+  table.set(SIN.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    // Rule 4 (Phase 33): π-multiple exact values (checked before numeric fold so
+    // that %pi symbols are detected before any backend evaluates them to floats).
+    const q = tryPiMultiple(arg);
+    if (q !== undefined) {
+      const val = SIN_PI_TABLE.get(fracKey(fracMod(q, 2n)));
+      if (val !== undefined) return val;
+    }
+    // Rule 1: numeric fold.
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      return numberNode(Math.sin(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Sin requires a numeric argument: ${headName(expr.head)}`);
+    // Rule 2 (Phase 31): odd symmetry — sin(-x) = -sin(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(NEG, [app(SIN, [arg.args[0]])]));
+    // Rule 3 (Phase 31): arc-cancellation — sin(asin(x)) = x.
+    if (arg.kind === "apply" && equals(arg.head, ASIN) && arg.args.length === 1)
+      return arg.args[0];
+    return expr;
+  });
+
+  // ----- Phase 31+33: Cos — even symmetry, arc-cancel, π-multiples -----
+  table.set(COS.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    // Rule 4 (Phase 33): π-multiple exact values.
+    // cos(-q·π) = cos(q·π) by even symmetry; this is handled automatically by the
+    // modular reduction since Fraction(-1/3) % 2 = Fraction(5/3) → same table entry.
+    const q = tryPiMultiple(arg);
+    if (q !== undefined) {
+      const val = COS_PI_TABLE.get(fracKey(fracMod(q, 2n)));
+      if (val !== undefined) return val;
+    }
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(1);
+      return numberNode(Math.cos(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Cos requires a numeric argument: ${headName(expr.head)}`);
+    // Rule 2 (Phase 31): even symmetry — cos(-x) = cos(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(COS, [arg.args[0]]));
+    // Rule 3 (Phase 31): arc-cancellation — cos(acos(x)) = x.
+    if (arg.kind === "apply" && equals(arg.head, ACOS) && arg.args.length === 1)
+      return arg.args[0];
+    return expr;
+  });
+
+  // ----- Phase 31+33: Tan — odd symmetry, arc-cancel, π-multiples -----
+  table.set(TAN.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    // Rule 4 (Phase 33): π-multiple exact values.
+    // tan(-q·π) = -tan(q·π) by odd symmetry — handled via sign and abs.
+    const q = tryPiMultiple(arg);
+    if (q !== undefined) {
+      const sign = q[0] < 0n ? -1 : 1;
+      const qAbs: Frac = q[0] < 0n ? [-q[0], q[1]] : q;
+      const qMod = fracKey(fracMod(qAbs, 1n)); // period π
+      const val = TAN_PI_TABLE.get(qMod);
+      if (val !== undefined)
+        return sign < 0 ? app(NEG, [val]) : val;
+      // q = 1/2 (mod 1) → undefined, fall through
+    }
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      return numberNode(Math.tan(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Tan requires a numeric argument: ${headName(expr.head)}`);
+    // Rule 2 (Phase 31): odd symmetry — tan(-x) = -tan(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(NEG, [app(TAN, [arg.args[0]])]));
+    // Rule 3 (Phase 31): arc-cancellation — tan(atan(x)) = x.
+    if (arg.kind === "apply" && equals(arg.head, ATAN) && arg.args.length === 1)
+      return arg.args[0];
+    return expr;
+  });
+
+  // ----- Phase 32: Atan — odd symmetry -----
+  table.set(ATAN.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      return numberNode(Math.atan(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Atan requires a numeric argument: ${headName(expr.head)}`);
+    // Odd symmetry — atan(-x) = -atan(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(NEG, [app(ATAN, [arg.args[0]])]));
+    return expr;
+  });
+
+  // ----- Phase 32: Asin — odd symmetry -----
+  table.set(ASIN.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      return numberNode(Math.asin(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Asin requires a numeric argument: ${headName(expr.head)}`);
+    // Odd symmetry — asin(-x) = -asin(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(NEG, [app(ASIN, [arg.args[0]])]));
+    return expr;
+  });
+
+  // ----- Phase 32: Acos — reflection identity acos(-x) = π - acos(x) -----
+  table.set(ACOS.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "1") return int(0);
+      return numberNode(Math.acos(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Acos requires a numeric argument: ${headName(expr.head)}`);
+    // Reflection: acos(-x) = π − acos(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1) {
+      const innerAcos = vm.eval(app(ACOS, [arg.args[0]]));
+      return app(SUB, [_INV_TRIG_PI, innerAcos]);
+    }
+    return expr;
+  });
+
+  // ----- Phase 31: Sinh — odd symmetry, arc-cancellation -----
+  table.set(SINH.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      return numberNode(Math.sinh(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Sinh requires a numeric argument: ${headName(expr.head)}`);
+    // Odd symmetry — sinh(-x) = -sinh(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(NEG, [app(SINH, [arg.args[0]])]));
+    // Arc-cancellation — sinh(asinh(x)) = x.
+    if (arg.kind === "apply" && equals(arg.head, ASINH) && arg.args.length === 1)
+      return arg.args[0];
+    return expr;
+  });
+
+  // ----- Phase 31: Cosh — even symmetry, arc-cancellation -----
+  table.set(COSH.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(1);
+      return numberNode(Math.cosh(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Cosh requires a numeric argument: ${headName(expr.head)}`);
+    // Even symmetry — cosh(-x) = cosh(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(COSH, [arg.args[0]]));
+    // Arc-cancellation — cosh(acosh(x)) = x.
+    if (arg.kind === "apply" && equals(arg.head, ACOSH) && arg.args.length === 1)
+      return arg.args[0];
+    return expr;
+  });
+
+  // ----- Phase 31: Tanh — odd symmetry, arc-cancellation -----
+  table.set(TANH.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      return numberNode(Math.tanh(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Tanh requires a numeric argument: ${headName(expr.head)}`);
+    // Odd symmetry — tanh(-x) = -tanh(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(NEG, [app(TANH, [arg.args[0]])]));
+    // Arc-cancellation — tanh(atanh(x)) = x.
+    if (arg.kind === "apply" && equals(arg.head, ATANH) && arg.args.length === 1)
+      return arg.args[0];
+    return expr;
+  });
+
+  // ----- Phase 32: Asinh — odd symmetry -----
+  table.set(ASINH.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      return numberNode(Math.asinh(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Asinh requires a numeric argument: ${headName(expr.head)}`);
+    // Odd symmetry — asinh(-x) = -asinh(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(NEG, [app(ASINH, [arg.args[0]])]));
+    return expr;
+  });
+
+  // ----- Acosh — numeric fold only (domain [1,∞), no symmetry rule) -----
+  table.set(ACOSH.name, elementary("Acosh", Math.acosh, new Map([["1", int(0)]]), simplify));
+
+  // ----- Phase 32: Atanh — odd symmetry -----
+  table.set(ATANH.name, (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = expr.args[0];
+    const na = toNumeric(arg);
+    if (na !== undefined) {
+      if (numericKey(na) === "0") return int(0);
+      return numberNode(Math.atanh(toNumber(na)));
+    }
+    if (!simplify) throw new TypeError(`Atanh requires a numeric argument: ${headName(expr.head)}`);
+    // Odd symmetry — atanh(-x) = -atanh(x).
+    if (arg.kind === "apply" && equals(arg.head, NEG) && arg.args.length === 1)
+      return vm.eval(app(NEG, [app(ATANH, [arg.args[0]])]));
+    return expr;
+  });
   table.set(COTH.name, elementary("Coth", (x) => Math.cosh(x) / Math.sinh(x), new Map(), simplify));
   table.set(SECH.name, elementary("Sech", (x) => 1 / Math.cosh(x), new Map([["0", int(1)]]), simplify));
   table.set(CSCH.name, elementary("Csch", (x) => 1 / Math.sinh(x), new Map(), simplify));

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  ACOS,
   ACOSH,
   ADD,
+  ASIN,
   ASINH,
   ASSIGN,
   ATAN,
@@ -34,6 +36,7 @@ import {
   TRUE,
   app,
   equals,
+  headName,
   int,
   numberNode,
   rational,
@@ -401,9 +404,10 @@ describe("symbolic-vm", () => {
     expect(vm.eval(app(D, [app(POW, [int(2), sym("x")]), sym("x")]))).toEqual(
       app(MUL, [app(POW, [int(2), sym("x")]), numberNode(Math.log(2))]),
     );
+    // Phase 30: exp(x·log(x)) now simplifies to x^x, so D(x^x, x) = x^x·(log(x)+1).
     expect(vm.eval(app(D, [app(POW, [sym("x"), sym("x")]), sym("x")]))).toEqual(
       app(MUL, [
-        app(EXP, [app(MUL, [sym("x"), app(LOG, [sym("x")])])]),
+        app(POW, [sym("x"), sym("x")]),
         app(ADD, [app(LOG, [sym("x")]), app(MUL, [sym("x"), app(DIV, [int(1), sym("x")])])]),
       ]),
     );
@@ -1099,5 +1103,337 @@ describe("symbolic-vm", () => {
     const result = vm.eval(app(INTEGRATE, [app(ATAN, [x]), x]));
     // Should remain unevaluated (Phase 11 is not implemented in TypeScript yet).
     expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 29: Abs and Sqrt algebraic rules
+// ---------------------------------------------------------------------------
+describe("Phase 29: Abs and Sqrt algebraic rules", () => {
+  it("Abs: numeric fold and exact values", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(sym("Abs"), [int(-3)]))).toEqual(int(3));
+    expect(vm.eval(app(sym("Abs"), [int(5)]))).toEqual(int(5));
+    expect(vm.eval(app(sym("Abs"), [rational(-3n, 4n)]))).toEqual(rational(3n, 4n));
+  });
+
+  it("Abs: idempotency — Abs(Abs(x)) = Abs(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const absX = app(sym("Abs"), [x]);
+    expect(vm.eval(app(sym("Abs"), [absX]))).toEqual(absX);
+  });
+
+  it("Abs: strips Neg — Abs(-x) = Abs(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(sym("Abs"), [app(NEG, [x])]))).toEqual(app(sym("Abs"), [x]));
+  });
+
+  it("Abs: even power — Abs(x^2) = x^2, Abs(x^4) = x^4", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const x2 = app(POW, [x, int(2)]);
+    const x4 = app(POW, [x, int(4)]);
+    expect(vm.eval(app(sym("Abs"), [x2]))).toEqual(x2);
+    expect(vm.eval(app(sym("Abs"), [x4]))).toEqual(x4);
+  });
+
+  it("Sqrt: numeric fold with perfect-square detection", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(SQRT, [int(0)]))).toEqual(int(0));
+    expect(vm.eval(app(SQRT, [int(1)]))).toEqual(int(1));
+    expect(vm.eval(app(SQRT, [int(4)]))).toEqual(int(2));
+    expect(vm.eval(app(SQRT, [int(9)]))).toEqual(int(3));
+    expect(vm.eval(app(SQRT, [int(16)]))).toEqual(int(4));
+    expect(vm.eval(app(SQRT, [int(25)]))).toEqual(int(5));
+  });
+
+  it("Sqrt: sqrt(x^2) = Abs(x)  — k=1 odd", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(SQRT, [app(POW, [x, int(2)])]))).toEqual(app(sym("Abs"), [x]));
+  });
+
+  it("Sqrt: sqrt(x^4) = x^2  — k=2 even", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(SQRT, [app(POW, [x, int(4)])]))).toEqual(app(POW, [x, int(2)]));
+  });
+
+  it("Sqrt: sqrt(x^6) = Abs(x^3)  — k=3 odd", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(SQRT, [app(POW, [x, int(6)])]))).toEqual(
+      app(sym("Abs"), [app(POW, [x, int(3)])]),
+    );
+  });
+
+  it("Sqrt: sqrt(x^8) = x^4  — k=4 even", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(SQRT, [app(POW, [x, int(8)])]))).toEqual(app(POW, [x, int(4)]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 30: Log and Exp cancellation rules
+// ---------------------------------------------------------------------------
+describe("Phase 30: Log and Exp cancellation rules", () => {
+  it("Log: special value log(1) = 0", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(LOG, [int(1)]))).toEqual(int(0));
+  });
+
+  it("Log: log(exp(x)) = x  (cancellation)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(LOG, [app(EXP, [x])]))).toEqual(x);
+  });
+
+  it("Log: log(exp(2·x)) = 2·x  (cancellation through product)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const twoX = app(MUL, [int(2), x]);
+    expect(vm.eval(app(LOG, [app(EXP, [twoX])]))).toEqual(twoX);
+  });
+
+  it("Exp: special value exp(0) = 1", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(EXP, [int(0)]))).toEqual(int(1));
+  });
+
+  it("Exp: exp(log(x)) = x  (cancellation)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(EXP, [app(LOG, [x])]))).toEqual(x);
+  });
+
+  it("Exp: exp(2·log(x)) = x^2  (power form, Mul(n, log(x)))", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(EXP, [app(MUL, [int(2), app(LOG, [x])])]))).toEqual(
+      app(POW, [x, int(2)]),
+    );
+  });
+
+  it("Exp: exp(log(x)·3) = x^3  (power form, Mul(log(x), n))", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(EXP, [app(MUL, [app(LOG, [x]), int(3)])]))).toEqual(
+      app(POW, [x, int(3)]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 31: Trig and hyperbolic symmetry + arc-cancellation
+// ---------------------------------------------------------------------------
+describe("Phase 31: Trig symmetry and arc-cancellation", () => {
+  it("Sin: odd symmetry — sin(-x) = -sin(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(SIN, [app(NEG, [x])]))).toEqual(app(NEG, [app(SIN, [x])]));
+  });
+
+  it("Sin: arc-cancellation — sin(asin(x)) = x", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(SIN, [app(ASIN, [x])]))).toEqual(x);
+  });
+
+  it("Cos: even symmetry — cos(-x) = cos(x)  (NEG stripped)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(COS, [app(NEG, [x])]))).toEqual(app(COS, [x]));
+  });
+
+  it("Cos: arc-cancellation — cos(acos(x)) = x", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(COS, [app(ACOS, [x])]))).toEqual(x);
+  });
+
+  it("Tan: odd symmetry — tan(-x) = -tan(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(TAN, [app(NEG, [x])]))).toEqual(app(NEG, [app(TAN, [x])]));
+  });
+
+  it("Tan: arc-cancellation — tan(atan(x)) = x", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(TAN, [app(ATAN, [x])]))).toEqual(x);
+  });
+
+  it("Sinh: odd symmetry — sinh(-x) = -sinh(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(SINH, [app(NEG, [x])]))).toEqual(app(NEG, [app(SINH, [x])]));
+  });
+
+  it("Sinh: arc-cancellation — sinh(asinh(x)) = x", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(SINH, [app(ASINH, [x])]))).toEqual(x);
+  });
+
+  it("Cosh: even symmetry — cosh(-x) = cosh(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(COSH, [app(NEG, [x])]))).toEqual(app(COSH, [x]));
+  });
+
+  it("Cosh: arc-cancellation — cosh(acosh(x)) = x", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(COSH, [app(ACOSH, [x])]))).toEqual(x);
+  });
+
+  it("Tanh: odd symmetry — tanh(-x) = -tanh(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(TANH, [app(NEG, [x])]))).toEqual(app(NEG, [app(TANH, [x])]));
+  });
+
+  it("Tanh: arc-cancellation — tanh(atanh(x)) = x", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(TANH, [app(ATANH, [x])]))).toEqual(x);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 32: Inverse trig/hyperbolic odd symmetry and acos reflection
+// ---------------------------------------------------------------------------
+describe("Phase 32: Inverse trig symmetry", () => {
+  it("Asin: odd symmetry — asin(-x) = -asin(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(ASIN, [app(NEG, [x])]))).toEqual(app(NEG, [app(ASIN, [x])]));
+  });
+
+  it("Acos: reflection — acos(-x) = %pi - acos(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(ACOS, [app(NEG, [x])]))).toEqual(
+      app(SUB, [sym("%pi"), app(ACOS, [x])]),
+    );
+  });
+
+  it("Atan: odd symmetry — atan(-x) = -atan(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(ATAN, [app(NEG, [x])]))).toEqual(app(NEG, [app(ATAN, [x])]));
+  });
+
+  it("Asinh: odd symmetry — asinh(-x) = -asinh(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(ASINH, [app(NEG, [x])]))).toEqual(app(NEG, [app(ASINH, [x])]));
+  });
+
+  it("Atanh: odd symmetry — atanh(-x) = -atanh(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    expect(vm.eval(app(ATANH, [app(NEG, [x])]))).toEqual(app(NEG, [app(ATANH, [x])]));
+  });
+
+  it("Double-neg collapses: asin(-(-x)) = asin(x)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    // asin(NEG(NEG(x))): NEG(x) evaluated → since NEG(NEG(x)) collapses to x,
+    // asin arg becomes x.
+    expect(vm.eval(app(ASIN, [app(NEG, [app(NEG, [x])])]))).toEqual(app(ASIN, [x]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 33: Trig exact values at rational multiples of π
+// ---------------------------------------------------------------------------
+describe("Phase 33: Trig π-multiple exact values", () => {
+  const vm = new VM(new SymbolicBackend());
+  const pi = sym("%pi");
+
+  it("sin(%pi) = 0", () => {
+    expect(vm.eval(app(SIN, [pi]))).toEqual(int(0));
+  });
+  it("sin(%pi/6) = 1/2", () => {
+    expect(vm.eval(app(SIN, [app(DIV, [pi, int(6)])]))).toEqual(rational(1n, 2n));
+  });
+  it("sin(%pi/4) = √2/2", () => {
+    expect(vm.eval(app(SIN, [app(DIV, [pi, int(4)])]))).toEqual(
+      app(DIV, [app(SQRT, [int(2)]), int(2)]),
+    );
+  });
+  it("sin(%pi/3) = √3/2", () => {
+    expect(vm.eval(app(SIN, [app(DIV, [pi, int(3)])]))).toEqual(
+      app(DIV, [app(SQRT, [int(3)]), int(2)]),
+    );
+  });
+  it("sin(%pi/2) = 1", () => {
+    expect(vm.eval(app(SIN, [app(DIV, [pi, int(2)])]))).toEqual(int(1));
+  });
+  it("sin(2·%pi) = 0", () => {
+    expect(vm.eval(app(SIN, [app(MUL, [int(2), pi])]))).toEqual(int(0));
+  });
+  it("sin(3·%pi/2) = -1", () => {
+    expect(vm.eval(app(SIN, [app(DIV, [app(MUL, [int(3), pi]), int(2)])]))).toEqual(int(-1));
+  });
+
+  it("cos(%pi) = -1", () => {
+    expect(vm.eval(app(COS, [pi]))).toEqual(int(-1));
+  });
+  it("cos(%pi/2) = 0", () => {
+    expect(vm.eval(app(COS, [app(DIV, [pi, int(2)])]))).toEqual(int(0));
+  });
+  it("cos(%pi/3) = 1/2", () => {
+    expect(vm.eval(app(COS, [app(DIV, [pi, int(3)])]))).toEqual(rational(1n, 2n));
+  });
+  it("cos(%pi/4) = √2/2", () => {
+    expect(vm.eval(app(COS, [app(DIV, [pi, int(4)])]))).toEqual(
+      app(DIV, [app(SQRT, [int(2)]), int(2)]),
+    );
+  });
+  it("cos(2·%pi) = 1", () => {
+    expect(vm.eval(app(COS, [app(MUL, [int(2), pi])]))).toEqual(int(1));
+  });
+
+  it("tan(%pi) = 0", () => {
+    expect(vm.eval(app(TAN, [pi]))).toEqual(int(0));
+  });
+  it("tan(%pi/4) = 1", () => {
+    expect(vm.eval(app(TAN, [app(DIV, [pi, int(4)])]))).toEqual(int(1));
+  });
+  it("tan(%pi/3) = √3", () => {
+    expect(vm.eval(app(TAN, [app(DIV, [pi, int(3)])]))).toEqual(app(SQRT, [int(3)]));
+  });
+  it("tan(3·%pi/4) = -1", () => {
+    expect(vm.eval(app(TAN, [app(DIV, [app(MUL, [int(3), pi]), int(4)])]))).toEqual(int(-1));
+  });
+  it("tan(%pi/2) stays unevaluated (undefined)", () => {
+    // tan(π/2) is undefined; the handler should leave it unevaluated.
+    const result = vm.eval(app(TAN, [app(DIV, [pi, int(2)])]));
+    expect(result.kind).toBe("apply");
+    if (result.kind === "apply") {
+      expect(headName(result.head)).toBe("Tan");
+    }
+  });
+
+  it("sin(-(%pi/6)) = -1/2  (odd symmetry via negative q)", () => {
+    // sin(-(π/6)) — tryPiMultiple detects NEG(Div(%pi, 6)) → q = -1/6
+    // (-1/6) mod 2 = 11/6 → sin(11π/6) = -1/2
+    expect(vm.eval(app(SIN, [app(NEG, [app(DIV, [pi, int(6)])])]))).toEqual(rational(-1n, 2n));
+  });
+
+  it("cos(-(%pi/3)) = 1/2  (even symmetry via negative q mod 2)", () => {
+    // cos(-(π/3)) — q = -1/3, (-1/3) mod 2 = 5/3 → cos(5π/3) = 1/2
+    expect(vm.eval(app(COS, [app(NEG, [app(DIV, [pi, int(3)])])]))).toEqual(rational(1n, 2n));
+  });
+
+  it("regression: numeric sin/cos/tan still work", () => {
+    expect(vm.eval(app(SIN, [int(0)]))).toEqual(int(0));
+    expect(vm.eval(app(COS, [int(0)]))).toEqual(int(1));
+    expect(vm.eval(app(TAN, [int(0)]))).toEqual(int(0));
   });
 });


### PR DESCRIPTION
## Summary

Ports Python `symbolic-vm` Phases 29–33 (v0.49.0–0.53.0) to both TypeScript and Rust, bumping both to **v0.6.0**.

- **Phase 29 — Abs / Sqrt algebraic rules**: `Abs(Abs(x))→Abs(x)`, `Abs(Neg(x))→Abs(x)`, `Abs(x^2k)→x^2k`, `sqrt(x²)→|x|`, `sqrt(x⁴)→x²`
- **Phase 30 — Log / Exp cancellation**: `log(exp(x))→x`, `exp(log(x))→x`, `exp(n·log(x))→x^n`
- **Phase 31 — Trig / hyperbolic symmetry + arc-cancellation**: `sin(-x)→-sin(x)`, `cos(-x)→cos(x)` etc.; `sin(asin(x))→x` etc.
- **Phase 32 — Inverse trig odd symmetry + acos reflection**: `asin(-x)→-asin(x)`, `acos(-x)→π-acos(x)`
- **Phase 33 — Trig exact values at rational π multiples**: lookup tables for `sin/cos/tan` at `π/6, π/4, π/3, π/2` and all reflections

Both implementations intentionally omit `log(x^n)→n·log(x)` and `sqrt(x²)→x` (require `x≥0` assumption context not available in TS/Rust).

## Test plan

- [ ] TypeScript: `npm test` in `code/packages/typescript/symbolic-vm` — 119 tests pass ✅
- [ ] Rust: `cargo test` in `code/packages/rust/symbolic-vm` — 153 tests pass ✅
- [ ] Security review passed (no vulnerabilities found) ✅
- [ ] Version bumped to 0.6.0 in `package.json` and `Cargo.toml` ✅
- [ ] CHANGELOG updated with full Phase 29–33 documentation ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)