### PR TITLE
feat(symbolic-vm): Phase 34 Weierstrass — ∫ 1/(a+b·sin/cos x) dx closed form

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog
 
+## 0.59.0 — 2026-05-18
+
+**Phase 34 integration — Weierstrass substitution for `∫ c/(a + b·sin(x)) dx`
+and `∫ c/(a + b·cos(x)) dx`.**
+
+The substitution `u = tan(x/2)` gives `sin(x) = 2u/(1+u²)`,
+`cos(x) = (1−u²)/(1+u²)`, `dx = 2/(1+u²) du` and reduces the two
+canonical denominator shapes to a rational function in `u`.  When
+the discriminant `a² − b² > 0` (denominator never zero on ℝ) the
+result is a clean arctan.
+
+Closed forms now produced:
+
+    ∫ 1/(a + b·sin x) dx  =  (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
+    ∫ 1/(a + b·cos x) dx  =  (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
+
+For numeric `a, b` with `a² > b²` and `a > 0` the integrator now closes
+the form directly; a numerator constant `c` simply scales the result.
+
+Deliberately deferred (return `None` and the caller emits an
+unevaluated `Integrate`):
+
+- `a² < b²` — log form on `(a·tan(x/2)+b ± √(b²−a²))`.
+- `a² = b²` — degenerate, reduces to `1/(a + b·tan(x/2))`.
+- `a ≤ 0` for the cos case — sign analysis of `(a−b)/(a+b)` needs more
+  care; the formula above assumes both `a+b > 0` and `a−b > 0`.
+- Symbolic `a` or `b` — discriminant sign undecidable without an
+  assumption context.
+- Non-bare trig arguments (e.g. `sin(2x)`) — composition with a future
+  linear-substitution phase will lift this.
+
+### Added
+
+- **`_try_weierstrass_one_over_linear_trig(integrand, x)`** — the entry
+  point.  Matches `Div(c, Add(a, ...))` where the `Add` resolves to
+  `a + b·sin(x)` or `a + b·cos(x)` and `a, b ∈ Q`.  Returns the closed
+  form in IR (an `arctan` wrapped around a `tan(x/2)` expression) or
+  `None`.  Wired into the `DIV` branch of `_integrate` after the
+  existing constant-denominator and `1/x` cases.
+
+- **`_parse_a_plus_b_sincos(node, x)`** — structural matcher returning
+  `(a, b, trig_head)` for the four canonical operand orderings of the
+  denominator.  Handles `Add` and `Sub` heads; unwraps a leading `Neg`
+  on the trig factor; falls back to `None` when the shape is not the
+  expected linear combination.
+
+- **`_parse_const_times_trig_x(node, x)`** — matches `c·sin(x)`,
+  `c·cos(x)`, `sin(x)`, `cos(x)`, and their `Neg`-wrapped variants.
+
+- **`_sqrt_fraction_ir(f)`** — emits `√(p/q)` IR, folding to a clean
+  rational when both `p` and `q` are perfect integer squares; otherwise
+  wraps the rational in `Sqrt(...)`.
+
+### Tests
+
+`tests/test_phase34_weierstrass.py` (14 cases):
+
+- ∫ 1/(2 + sin x) dx: closed form contains Atan, derivative matches
+  numerically across `x ∈ {−2.5, −1, −0.3, 0, 0.3, 1, 2.5}`.
+- ∫ 1/(5 + 3·sin x) dx: perfect-square discriminant (16) → no `Sqrt`
+  in the output; numeric derivative matches.
+- ∫ 3/(2 + sin x) dx: numerator coefficient scales the closed form.
+- ∫ 1/(3/2 + (1/2)·sin x) dx: rational `a, b` with `a² > b²`.
+- ∫ 1/(2 + cos x) dx and ∫ 1/(5 + 3·cos x) dx: both close; the
+  five-plus-three case has perfect-square ratio (1/4) and avoids `Sqrt`.
+- Operand-order robustness: ∫ 1/(sin x + 2) dx still closes.
+- Fallthrough: ∫ 1/(1 + 2·sin x) dx (a² < b²) stays unevaluated.
+- Fallthrough: ∫ 1/(1 + sin x) dx (a² = b²) stays unevaluated.
+- Fallthrough: ∫ 1/(2 + sin(2x)) dx (non-bare argument) stays unevaluated.
+- Fallthrough: ∫ 1/(a + sin x) dx with symbolic `a` stays unevaluated.
+- Regression: ∫ sin(x) dx = −cos(x) unchanged.
+- Regression: ∫ 1/cos(x) dx is **not** misinterpreted as a Weierstrass
+  case (denominator has no additive constant; Phase 34 must not fire).
+
 ## 0.58.0 — 2026-05-16
 
 **Phase 28 integration — general IBP for `∫ P(x)·log(Q(x)) dx` and

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.58.0"
+version = "0.59.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -805,6 +805,188 @@ def _rational_to_ir(
     return IRApply(DIV, (num_ir, den_ir))
 
 
+# ----------------------------------------------------------------------
+# Phase 34 — Weierstrass substitution for ∫ c/(a + b·sin(x)) dx and
+# ∫ c/(a + b·cos(x)) dx with numeric a, b satisfying a² > b².
+#
+# The substitution u = tan(x/2) gives sin(x) = 2u/(1+u²),
+# cos(x) = (1-u²)/(1+u²), dx = 2/(1+u²) du.  Applying it to the two
+# canonical integrands reduces both to a single rational function of u
+# that integrates to an arctan (when the resulting quadratic in u has
+# negative discriminant, i.e. a² > b²).  Direct closed forms:
+#
+#     ∫ 1/(a + b·sin x) dx  =  (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
+#     ∫ 1/(a + b·cos x) dx  =  (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
+#
+# Cases a² < b² (log form) and a² = b² (rational-in-tan form) are
+# intentionally deferred — they need a sign-determination on the
+# argument inside log, and are less common in practice.
+# ----------------------------------------------------------------------
+
+
+def _sqrt_fraction_ir(f: Fraction) -> IRNode:
+    """Express ``√f`` as IR, folding perfect rational squares.
+
+    For ``f = p/q`` with ``p, q > 0`` we return ``√p/√q`` simplified
+    when both numerator and denominator are perfect integer squares;
+    otherwise we emit ``Sqrt(Fraction)`` and let downstream simplification
+    handle it.  ``f`` must be strictly positive — callers guard the
+    discriminant first.
+    """
+    if f <= 0:
+        # Defensive — callers must guard.  Return raw Sqrt for safety.
+        return IRApply(SQRT, (_frac_ir(f),))
+    p = f.numerator
+    q = f.denominator
+    p_root = math.isqrt(p)
+    q_root = math.isqrt(q)
+    if p_root * p_root == p and q_root * q_root == q:
+        return _frac_ir(Fraction(p_root, q_root))
+    return IRApply(SQRT, (_frac_ir(f),))
+
+
+def _parse_const_times_trig_x(
+    node: IRNode, x: IRSymbol
+) -> tuple[Fraction, IRSymbol] | None:
+    """Match ``c·sin(x)`` / ``c·cos(x)`` / ``sin(x)`` / ``cos(x)`` and return
+    ``(c, head)``.
+
+    Accepts both argument orders within ``Mul`` and unwraps a leading
+    ``Neg``.  Argument inside trig must be the bare variable ``x``.
+    Returns ``None`` if the shape doesn't match.
+    """
+    if isinstance(node, IRApply) and node.head in (SIN, COS):
+        if len(node.args) == 1 and node.args[0] == x:
+            return Fraction(1), node.head
+    if isinstance(node, IRApply) and node.head == MUL and len(node.args) == 2:
+        left, right = node.args
+        for const_side, trig_side in ((left, right), (right, left)):
+            c = _node_to_frac(const_side)
+            if c is None:
+                continue
+            if (
+                isinstance(trig_side, IRApply)
+                and trig_side.head in (SIN, COS)
+                and len(trig_side.args) == 1
+                and trig_side.args[0] == x
+            ):
+                return c, trig_side.head
+    if isinstance(node, IRApply) and node.head == NEG and len(node.args) == 1:
+        inner = _parse_const_times_trig_x(node.args[0], x)
+        if inner is not None:
+            c, head = inner
+            return -c, head
+    return None
+
+
+def _parse_a_plus_b_sincos(
+    node: IRNode, x: IRSymbol
+) -> tuple[Fraction, Fraction, IRSymbol] | None:
+    """Parse ``a + b·sin(x)`` / ``a + b·cos(x)`` (any operand order) into
+    ``(a, b, head)`` with ``a, b ∈ Q``.
+
+    Accepts the SUB shape too (``a − b·sin(x)`` becomes ``(a, −b, sin)``).
+    Returns ``None`` if the shape isn't a binary linear combination of a
+    constant and a constant-multiple-of-trig-x.
+    """
+    if not isinstance(node, IRApply) or len(node.args) != 2:
+        return None
+    if node.head == ADD:
+        left, right = node.args
+    elif node.head == SUB:
+        # Treat ``a − b·trig(x)`` as ``a + (−b)·trig(x)``: parse the
+        # right side and negate.  Symmetric ``b·trig(x) − a`` is rarely
+        # the canonical form but we cover it via the swap branch below.
+        left, right_raw = node.args
+        # Wrap right_raw in Neg synthetically — but we can't mutate; we'll
+        # just try both arrangements directly.
+        a_left = _node_to_frac(left)
+        if a_left is not None:
+            trig_parse = _parse_const_times_trig_x(right_raw, x)
+            if trig_parse is not None:
+                b, head = trig_parse
+                return a_left, -b, head
+        # Try ``b·trig(x) − a`` = (−a) + b·trig(x)
+        b_trig_left = _parse_const_times_trig_x(left, x)
+        a_right = _node_to_frac(right_raw)
+        if b_trig_left is not None and a_right is not None:
+            b, head = b_trig_left
+            return -a_right, b, head
+        return None
+    else:
+        return None
+    # ADD path: try both orderings.
+    for const_side, trig_side in ((left, right), (right, left)):
+        a = _node_to_frac(const_side)
+        if a is None:
+            continue
+        trig_parse = _parse_const_times_trig_x(trig_side, x)
+        if trig_parse is None:
+            continue
+        b, head = trig_parse
+        return a, b, head
+    return None
+
+
+def _try_weierstrass_one_over_linear_trig(
+    integrand: IRNode, x: IRSymbol
+) -> IRNode | None:
+    """Phase 34: ``∫ c / (a + b·sin(x)) dx`` and ``∫ c / (a + b·cos(x)) dx``
+    via the Weierstrass substitution ``u = tan(x/2)``.
+
+    Both ``c`` (numerator) and the coefficients ``a, b`` must be numeric
+    (Integer or Rational); a closed form is only emitted when
+    ``a² > b²`` (denominator never zero on ℝ).  Returns ``None``
+    otherwise — log-form and linear-in-tan cases remain unevaluated.
+    """
+    if not isinstance(integrand, IRApply) or integrand.head != DIV:
+        return None
+    if len(integrand.args) != 2:
+        return None
+    num, den = integrand.args
+    if _depends_on(num, x):
+        return None
+    c = _node_to_frac(num)
+    if c is None:
+        return None
+    parsed = _parse_a_plus_b_sincos(den, x)
+    if parsed is None:
+        return None
+    a, b, trig_head = parsed
+    disc = a * a - b * b
+    if disc <= 0:
+        # a² ≤ b² → log form (a² < b²) or degenerate (a² = b²).
+        # Not implemented in this phase; leave unevaluated.
+        return None
+    sqrt_disc_ir = _sqrt_fraction_ir(disc)
+    tan_half = IRApply(TAN, (IRApply(DIV, (x, TWO)),))
+    if trig_head == SIN:
+        # arctan argument: (a·tan(x/2) + b) / √(a²−b²)
+        atan_arg_top = IRApply(
+            ADD,
+            (IRApply(MUL, (_frac_ir(a), tan_half)), _frac_ir(b)),
+        )
+        atan_arg = IRApply(DIV, (atan_arg_top, sqrt_disc_ir))
+    else:  # COS
+        # arctan argument: √((a−b)/(a+b)) · tan(x/2)
+        # Since a² > b², we have a+b ≠ 0; sign of (a−b)/(a+b) is positive
+        # iff a > 0 (and both numerator and denominator share the sign).
+        # When a < 0 the standard form needs adjustment; rather than chase
+        # branch issues, require a > 0 here and defer the a < 0 case.
+        if a <= 0:
+            return None
+        ratio = (a - b) / (a + b)
+        if ratio <= 0:
+            # Cannot happen when a² > b² and a > 0, but defensive.
+            return None
+        sqrt_ratio_ir = _sqrt_fraction_ir(ratio)
+        atan_arg = IRApply(MUL, (sqrt_ratio_ir, tan_half))
+    # Final result: (2c/√(a²−b²)) · arctan(...)
+    coef_frac = c * 2
+    coef_ir = IRApply(DIV, (_frac_ir(coef_frac), sqrt_disc_ir))
+    return IRApply(MUL, (coef_ir, IRApply(ATAN, (atan_arg,))))
+
+
 def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
     """Return an antiderivative of ``f`` w.r.t. ``x``, or ``None``.
 
@@ -976,6 +1158,11 @@ def _integrate(f: IRNode, x: IRSymbol) -> IRNode | None:
         # x-in-denominator shape Phase 1 handles directly.
         if b == x and not _depends_on(a, x):
             return IRApply(MUL, (a, IRApply(LOG, (x,))))
+        # Phase 34: Weierstrass substitution for c / (a + b·sin(x)) and
+        # c / (a + b·cos(x)) when a, b numeric and a² > b².
+        result = _try_weierstrass_one_over_linear_trig(f, x)
+        if result is not None:
+            return result
         return None
 
     # --- Power rule ---------------------------------------------------

--- a/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
@@ -1,0 +1,326 @@
+"""Tests for Phase 34: Weierstrass-substitution closed forms for
+``∫ c / (a + b·sin(x)) dx`` and ``∫ c / (a + b·cos(x)) dx``.
+
+The substitution ``u = tan(x/2)`` produces ``sin(x) = 2u/(1+u²)``,
+``cos(x) = (1−u²)/(1+u²)``, ``dx = 2/(1+u²) du`` and reduces the
+integrand to a rational function of ``u`` that integrates to an
+arctan whenever ``a² > b²`` (the denominator never crosses zero on ℝ).
+
+Closed forms emitted by Phase 34:
+
+    ∫ 1/(a + b·sin x) dx  =  (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
+    ∫ 1/(a + b·cos x) dx  =  (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
+
+Both formulas are validated below by **numerical differentiation**: we
+sample the integrand and the derivative of the returned closed form at
+several values of ``x`` on the open intervals where ``tan(x/2)`` is
+finite, and require the two to agree to a tight absolute tolerance.
+Structural assertions on the exact IR shape are deliberately avoided
+because the surrounding VM may re-canonicalise the arithmetic in
+ways orthogonal to correctness.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    ATAN,
+    COS,
+    DIV,
+    INTEGRATE,
+    MUL,
+    NEG,
+    SIN,
+    SQRT,
+    SUB,
+    TAN,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, SymbolicBackend
+
+X = IRSymbol("x")
+
+
+@pytest.fixture
+def vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+def _integrate(f: IRNode) -> IRNode:
+    return IRApply(INTEGRATE, (f, X))
+
+
+def _eval_at(vm: VM, expr: IRNode, x_val: float) -> float:
+    """Substitute ``x = x_val`` (as IRFloat) and evaluate to a float.
+
+    Returns ``math.nan`` if the evaluation cannot fold to a number —
+    callers should always assert real-number agreement and skip such
+    samples explicitly when needed.
+    """
+    substituted = _subst(expr, X, IRFloat(x_val))
+    folded = vm.eval(substituted)
+    if isinstance(folded, IRFloat):
+        return folded.value
+    if isinstance(folded, IRInteger):
+        return float(folded.value)
+    if isinstance(folded, IRRational):
+        return folded.numer / folded.denom
+    return math.nan
+
+
+def _subst(node: IRNode, var: IRSymbol, value: IRNode) -> IRNode:
+    """Tiny structural substitution — replaces every ``var`` occurrence."""
+    if node == var:
+        return value
+    if isinstance(node, IRApply):
+        return IRApply(node.head, tuple(_subst(a, var, value) for a in node.args))
+    return node
+
+
+# ---------------------------------------------------------------------------
+# ∫ 1/(a + b·sin(x)) dx — arctan form, a² > b²
+# ---------------------------------------------------------------------------
+
+
+def test_sin_two_plus_sin_returns_arctan_form(vm: VM) -> None:
+    """``∫ 1/(2 + sin(x)) dx`` must close as ``(2/√3)·arctan(...)``."""
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (X,))))))
+    result = vm.eval(_integrate(integrand))
+    # Must not stay as Integrate(...).
+    assert not (isinstance(result, IRApply) and result.head == INTEGRATE), (
+        f"Expected Phase 34 to close ∫ 1/(2+sin x) dx; got {result!r}"
+    )
+    # Should contain an Atan node somewhere.
+    assert _contains_head(result, ATAN), (
+        f"Expected an Atan in the closed form; got {result!r}"
+    )
+
+
+def test_sin_two_plus_sin_derivative_matches(vm: VM) -> None:
+    """Numerically: ``d/dx[Φ(x)]`` must equal ``1/(2 + sin(x))``."""
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (X,))))))
+    phi = vm.eval(_integrate(integrand))
+    # Sample on (−π, π) avoiding x = ±π where tan(x/2) blows up.
+    for x_val in (-2.5, -1.0, -0.3, 0.0, 0.3, 1.0, 2.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 + math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4), (
+            f"At x={x_val}: derivative={got!r}, expected={expected!r}"
+        )
+
+
+def test_sin_perfect_square_discriminant(vm: VM) -> None:
+    """``∫ 1/(5 + 3·sin(x)) dx``: ``a²−b² = 16`` is a perfect square — coefficient
+    folds to an integer/rational and the result is exact (no Sqrt node)."""
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(ADD, (IRInteger(5), IRApply(MUL, (IRInteger(3), IRApply(SIN, (X,)))))),
+        ),
+    )
+    result = vm.eval(_integrate(integrand))
+    assert not _contains_head(result, SQRT), (
+        f"a²−b²=16 should fold to 4 without leaving a Sqrt; got {result!r}"
+    )
+    # Verify numerically.
+    for x_val in (-1.0, -0.2, 0.0, 0.7, 1.5):
+        got = _numerical_derivative(vm, result, x_val)
+        expected = 1.0 / (5.0 + 3.0 * math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_sin_with_numerator_coefficient(vm: VM) -> None:
+    """``∫ 3/(2 + sin(x)) dx`` must scale the closed form by 3."""
+    integrand = IRApply(DIV, (IRInteger(3), IRApply(ADD, (IRInteger(2), IRApply(SIN, (X,))))))
+    phi = vm.eval(_integrate(integrand))
+    for x_val in (-1.0, -0.2, 0.0, 0.7, 1.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 3.0 / (2.0 + math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_sin_with_rational_coefficients(vm: VM) -> None:
+    """``∫ 1/(3/2 + (1/2)·sin(x)) dx`` — rational a, b with a² > b².
+
+    a = 3/2, b = 1/2 → disc = 9/4 − 1/4 = 2.
+    """
+    a = IRRational(3, 2)
+    b = IRRational(1, 2)
+    integrand = IRApply(
+        DIV,
+        (IRInteger(1), IRApply(ADD, (a, IRApply(MUL, (b, IRApply(SIN, (X,))))))),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-1.5, -0.4, 0.0, 0.4, 1.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.5 + 0.5 * math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# ∫ 1/(a + b·cos(x)) dx — arctan form, a² > b², a > 0
+# ---------------------------------------------------------------------------
+
+
+def test_cos_two_plus_cos_closes(vm: VM) -> None:
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(COS, (X,))))))
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-1.5, -0.4, 0.0, 0.4, 1.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 + math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_cos_five_plus_three_cos(vm: VM) -> None:
+    """``∫ 1/(5 + 3·cos(x)) dx``. disc=16 (perfect square), (a−b)/(a+b)=2/8=1/4
+    (also perfect-square ratio) — expect Sqrt-free output."""
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(ADD, (IRInteger(5), IRApply(MUL, (IRInteger(3), IRApply(COS, (X,)))))),
+        ),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not _contains_head(phi, SQRT), f"Expected Sqrt-free closed form; got {phi!r}"
+    for x_val in (-1.5, -0.4, 0.0, 0.4, 1.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (5.0 + 3.0 * math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Operand-order robustness
+# ---------------------------------------------------------------------------
+
+
+def test_sin_operand_order_swapped(vm: VM) -> None:
+    """``∫ 1/(sin(x) + 2) dx`` — constant on the right of Add. Same result."""
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (IRApply(SIN, (X,)), IRInteger(2)))))
+    phi = vm.eval(_integrate(integrand))
+    # The handler might canonicalise the Add and still close, OR the VM may
+    # re-sort args so the standard path fires.  Either way, the result must
+    # NOT stay as a raw Integrate.
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE), (
+        f"Operand-swapped form should still close; got {phi!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fallthroughs — must stay unevaluated (Phase 34 deliberately defers)
+# ---------------------------------------------------------------------------
+
+
+def test_fallthrough_a_less_than_b(vm: VM) -> None:
+    """``∫ 1/(1 + 2·sin(x)) dx`` — a²−b² = −3 < 0; log form not implemented."""
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(ADD, (IRInteger(1), IRApply(MUL, (IRInteger(2), IRApply(SIN, (X,)))))),
+        ),
+    )
+    result = vm.eval(_integrate(integrand))
+    assert isinstance(result, IRApply) and result.head == INTEGRATE, (
+        f"a²<b² log form is deferred; expected unevaluated, got {result!r}"
+    )
+
+
+def test_fallthrough_a_equals_b(vm: VM) -> None:
+    """``∫ 1/(1 + sin(x)) dx`` — a² = b²; linear-in-tan form not implemented."""
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (IRInteger(1), IRApply(SIN, (X,))))))
+    result = vm.eval(_integrate(integrand))
+    assert isinstance(result, IRApply) and result.head == INTEGRATE
+
+
+def test_fallthrough_non_bare_argument(vm: VM) -> None:
+    """``∫ 1/(2 + sin(2x)) dx`` — argument inside Sin is not bare x.
+
+    Phase 34 only handles the canonical bare-variable form.  A future
+    Phase could compose with substitution to handle linear arguments;
+    for now the integral remains unevaluated.
+    """
+    two_x = IRApply(MUL, (IRInteger(2), X))
+    integrand = IRApply(
+        DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (two_x,)))))
+    )
+    result = vm.eval(_integrate(integrand))
+    assert isinstance(result, IRApply) and result.head == INTEGRATE
+
+
+def test_fallthrough_symbolic_coefficients(vm: VM) -> None:
+    """Symbolic ``a`` or ``b`` — can't decide sign of disc, must defer."""
+    a_sym = IRSymbol("a")
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (a_sym, IRApply(SIN, (X,))))))
+    result = vm.eval(_integrate(integrand))
+    assert isinstance(result, IRApply) and result.head == INTEGRATE
+
+
+# ---------------------------------------------------------------------------
+# Regression — Phase 34 must not steal integrals it doesn't own
+# ---------------------------------------------------------------------------
+
+
+def test_regression_pure_sin_still_works(vm: VM) -> None:
+    """``∫ sin(x) dx = −cos(x)`` must continue to work after Phase 34 lands."""
+    result = vm.eval(_integrate(IRApply(SIN, (X,))))
+    # -cos(x) form — accept either Neg(Cos(x)) or Mul(-1, Cos(x)).
+    cos_x = IRApply(COS, (X,))
+    neg_cos = IRApply(NEG, (cos_x,))
+    mul_neg = IRApply(MUL, (IRInteger(-1), cos_x))
+    assert result in (neg_cos, mul_neg), f"Got {result!r}"
+
+
+def test_regression_one_over_cos_unchanged(vm: VM) -> None:
+    """``∫ 1/cos(x) dx`` (i.e. ∫ sec(x) dx) is NOT a Weierstrass case.
+
+    The denominator is bare ``cos(x)`` without an additive constant, so
+    ``_parse_a_plus_b_sincos`` returns None and Phase 34 does not engage.
+    The result therefore stays as ``Integrate(...)`` (∫sec x dx has no
+    elementary closed form in our pipeline yet).
+    """
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(COS, (X,))))
+    result = vm.eval(_integrate(integrand))
+    # Either unevaluated, or some elementary fold the VM applies — but
+    # specifically MUST NOT be a Phase 34 arctan-of-tan(x/2) artefact.
+    if isinstance(result, IRApply) and result.head == ATAN:
+        pytest.fail(f"Phase 34 incorrectly fired on ∫ 1/cos(x) dx: got {result!r}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _contains_head(node: IRNode, head: IRSymbol) -> bool:
+    if isinstance(node, IRApply):
+        if node.head == head:
+            return True
+        return any(_contains_head(a, head) for a in node.args)
+    return False
+
+
+def _numerical_derivative(vm: VM, expr: IRNode, x_val: float) -> float:
+    """Central-difference derivative of ``expr`` w.r.t. x at ``x_val``.
+
+    Uses a step of ``1e-5``.  Both ``expr(x_val + h)`` and
+    ``expr(x_val − h)`` are evaluated via ``vm.eval`` on float-substituted
+    copies, so the closed-form's structure doesn't matter — only the
+    numeric output of the function does.
+    """
+    h = 1e-5
+    fp = _eval_at(vm, expr, x_val + h)
+    fm = _eval_at(vm, expr, x_val - h)
+    return (fp - fm) / (2 * h)


### PR DESCRIPTION
## Summary

Adds the Weierstrass substitution `u = tan(x/2)` to the Python
`symbolic-vm` integrator, closing two new families of integrals:

    ∫ 1/(a + b·sin x) dx = (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
    ∫ 1/(a + b·cos x) dx = (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))

Numeric `a, b` with `a² > b²` are handled (and `a > 0` for the cos
branch). Numerator constants `c` scale the result.

Deliberately deferred (left unevaluated):
- `a² < b²` — log form on `(a·tan(x/2)+b ± √(b²−a²))`
- `a² = b²` — degenerate rational-in-tan
- `a ≤ 0` for the cos branch — sign analysis on `(a−b)/(a+b)`
- Non-bare trig arguments (e.g. `sin(2x)`)
- Symbolic `a` or `b` — discriminant sign undecidable without assumptions

## Test plan

- [x] **14 new tests** in `tests/test_phase34_weierstrass.py`:
  - Numeric derivative verification of closed forms at multiple sample
    points for both sin and cos cases
  - Perfect-square discriminant (`a=5, b=3` → disc=16) produces a
    Sqrt-free result
  - Rational `a, b` (`3/2 + (1/2)·sin x`) close correctly
  - Operand-order robustness (`sin(x) + 2` vs `2 + sin(x)`)
  - Four fallthrough guarantees (a²<b², a²=b², non-bare arg, symbolic coeffs)
  - Two regression tests: `∫ sin(x) dx = −cos(x)` and `∫ 1/cos(x) dx`
    unchanged (the latter must NOT be misinterpreted as Weierstrass)
- [x] **Full suite**: `1674 passed, 85 skipped, 81.30% coverage`
- [x] **Security review**: passed (no vulnerabilities)

## Files

- `src/symbolic_vm/integrate.py`: +187 lines (Phase 34 helpers + DIV hook)
- `tests/test_phase34_weierstrass.py`: new (326 lines, 14 tests)
- `pyproject.toml`: 0.58.0 → 0.59.0
- `CHANGELOG.md`: 0.59.0 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)