### PR TITLE
feat(symbolic-vm): Phase 34 Weierstrass — TypeScript port (0.7.0)

### DIFF
--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## [0.7.0] — 2026-05-18
+
+### Added — Phase 34: Weierstrass substitution for ∫ 1/(a + b·sin/cos x) dx
+
+Ports the Python `symbolic-vm` 0.59.0 Phase 34 work to TypeScript.  The
+substitution `u = tan(x/2)` produces `sin(x) = 2u/(1+u²)`,
+`cos(x) = (1−u²)/(1+u²)`, `dx = 2/(1+u²) du` and reduces the two
+canonical denominator shapes to a rational function in `u` that
+integrates to an arctan whenever `a² > b²` (denominator never zero on
+ℝ).  Closed forms:
+
+    ∫ 1/(a + b·sin x) dx  =  (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
+    ∫ 1/(a + b·cos x) dx  =  (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
+
+For exact-rational `a, b` satisfying `a² > b²` (and `a > 0` for the cos
+branch) the integrator now closes the form directly.  A numerator
+constant `c` simply scales the result.
+
+#### Deferred to a later phase
+
+- `a² < b²` — log form on `(a·tan(x/2)+b ± √(b²−a²))` (sign analysis).
+- `a² = b²` — degenerate, reduces to a rational in `tan(x/2)`.
+- `a ≤ 0` for the cos case — `(a−b)/(a+b)` sign analysis.
+- Symbolic `a` or `b` — discriminant sign undecidable without an
+  assumption context (the TS port has no assumption system).
+- Non-bare trig arguments (e.g. `sin(2x)`) — composition with a future
+  linear-substitution phase will pick this up.
+
+#### Added
+
+- **`tryWeierstrassOneOverLinearTrig(integrand, x)`** — Phase 34 entry
+  point.  Matches `Div(c, Add(a, ...))` shapes where the `Add` resolves
+  to `a + b·sin(x)` or `a + b·cos(x)` and `c, a, b` are exact rationals.
+  Wired into the `DIV` branch of `integrateIndefinite` after the
+  existing constant-numerator and `1/x` cases.
+
+- **`weierstrassParseAPlusBSincos(node, x)`** — structural matcher
+  returning `{ a, b, trigHead }` for the four canonical operand
+  orderings (Add/Sub × constant-left/right).  Reuses the existing
+  `toNumeric` / `negNumeric` helpers.
+
+- **`weierstrassParseConstTimesTrigX(node, x)`** — matches `c·sin(x)`,
+  `c·cos(x)`, `sin(x)`, `cos(x)`, and their Neg-wrapped variants.
+
+- **`weierstrassSqrtFractionIR(f)`** — emits `Sqrt(p/q)` IR, folding to
+  a clean rational when both `p` and `q` are perfect integer squares
+  (uses the existing `bigIntIsqrt` helper).
+
+- **`isPositiveNumeric(v)`** — strict-positive predicate for Numeric.
+
+#### Tests
+
+`tests/phase34-weierstrass.test.ts` (14 cases mirroring Python's
+`test_phase34_weierstrass.py`):
+
+- Closed-form structure: ∫ 1/(2 + sin x) contains Atan in the body.
+- Numeric-derivative verification at 5–7 sample points across the
+  open interval where tan(x/2) is finite.
+- Perfect-square discriminant folds Sqrt away (a=5, b=3 → disc=16; cos
+  case has ratio 1/4 as well).
+- Numerator coefficient scales the closed form (∫ 3/(2 + sin x)).
+- Rational coefficients (a=3/2, b=1/2; disc=2).
+- Operand-order robustness (∫ 1/(sin x + 2) still closes).
+- Four fallthrough guarantees: a²<b², a²=b², non-bare argument,
+  symbolic `a`.
+- Regression: ∫ sin(x) dx = −cos(x) unchanged; ∫ 1/cos(x) dx is NOT
+  misinterpreted as a Weierstrass case.
+
 ## [0.6.0] — 2026-05-18
 
 ### Added — Phases 29–33: algebraic simplification rules

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1588,6 +1588,173 @@ function integrate(): Handler {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Phase 34 — Weierstrass substitution for ∫ c/(a + b·sin(x)) dx and
+// ∫ c/(a + b·cos(x)) dx with numeric a, b satisfying a² > b² (and a > 0
+// for the cos branch).  Mirrors the Python port at symbolic-vm 0.59.0.
+//
+// Closed forms:
+//   ∫ 1/(a + b·sin x) dx = (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
+//   ∫ 1/(a + b·cos x) dx = (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
+//
+// Numerator constants c scale the result.  Discriminant cases a² ≤ b² and
+// the a ≤ 0 cos branch are deliberately deferred — they need sign analysis
+// that the assumption-free TS port cannot perform symbolically.
+// ---------------------------------------------------------------------------
+
+/**
+ * Rational `p/q` with `q > 0` and `gcd(|p|, q) = 1`, stored as Numeric so we
+ * can reuse the existing arithmetic helpers (addNumeric / mulNumeric / ...).
+ */
+
+function weierstrassSqrtFractionIR(f: Numeric): IRNode {
+  // Defensive: only called with f > 0.  We fold p/q when both p and q are
+  // perfect integer squares; otherwise emit Sqrt(rational).
+  const rat = asRat(f);
+  const p = rat.numer;
+  const q = rat.denom;
+  if (p <= 0n || q <= 0n) {
+    return app(SQRT, [fromNumeric(f)]);
+  }
+  const pRoot = bigIntIsqrt(p);
+  const qRoot = bigIntIsqrt(q);
+  if (pRoot !== undefined && qRoot !== undefined) {
+    return fromNumeric(makeRat(pRoot, qRoot));
+  }
+  return app(SQRT, [fromNumeric(f)]);
+}
+
+/** Match `c·sin(x)`, `c·cos(x)`, `sin(x)`, `cos(x)`, or their Neg-wrappings.
+ *  Returns ``{ c, head }`` (head is SIN or COS) or undefined. */
+function weierstrassParseConstTimesTrigX(
+  node: IRNode,
+  x: IRNode
+): { readonly c: Numeric; readonly head: IRNode } | undefined {
+  if (node.kind === "apply" && (equals(node.head, SIN) || equals(node.head, COS))) {
+    if (node.args.length === 1 && equals(node.args[0], x)) {
+      return { c: { kind: "int", value: 1n }, head: node.head };
+    }
+  }
+  if (node.kind === "apply" && equals(node.head, MUL) && node.args.length === 2) {
+    const [left, right] = node.args;
+    for (const [constSide, trigSide] of [
+      [left, right],
+      [right, left],
+    ] as const) {
+      const c = toNumeric(constSide);
+      if (c === undefined || c.kind === "float") continue;
+      if (
+        trigSide.kind === "apply" &&
+        (equals(trigSide.head, SIN) || equals(trigSide.head, COS)) &&
+        trigSide.args.length === 1 &&
+        equals(trigSide.args[0], x)
+      ) {
+        return { c, head: trigSide.head };
+      }
+    }
+  }
+  if (node.kind === "apply" && equals(node.head, NEG) && node.args.length === 1) {
+    const inner = weierstrassParseConstTimesTrigX(node.args[0], x);
+    if (inner !== undefined) {
+      return { c: negNumeric(inner.c), head: inner.head };
+    }
+  }
+  return undefined;
+}
+
+/** Parse ``a + b·sin(x)`` or ``a + b·cos(x)`` (any operand ordering, plus the
+ *  SUB head variant).  Returns ``{ a, b, trigHead }`` or undefined. */
+function weierstrassParseAPlusBSincos(
+  node: IRNode,
+  x: IRNode
+): { readonly a: Numeric; readonly b: Numeric; readonly trigHead: IRNode } | undefined {
+  if (node.kind !== "apply" || node.args.length !== 2) return undefined;
+  if (equals(node.head, ADD)) {
+    const [left, right] = node.args;
+    for (const [constSide, trigSide] of [
+      [left, right],
+      [right, left],
+    ] as const) {
+      const a = toNumeric(constSide);
+      if (a === undefined || a.kind === "float") continue;
+      const trigParse = weierstrassParseConstTimesTrigX(trigSide, x);
+      if (trigParse === undefined) continue;
+      return { a, b: trigParse.c, trigHead: trigParse.head };
+    }
+    return undefined;
+  }
+  if (equals(node.head, SUB)) {
+    // `a − b·trig(x)` = `a + (−b)·trig(x)` and the symmetric reversal.
+    const [left, right] = node.args;
+    const aLeft = toNumeric(left);
+    if (aLeft !== undefined && aLeft.kind !== "float") {
+      const trigParse = weierstrassParseConstTimesTrigX(right, x);
+      if (trigParse !== undefined) {
+        return { a: aLeft, b: negNumeric(trigParse.c), trigHead: trigParse.head };
+      }
+    }
+    const bTrigLeft = weierstrassParseConstTimesTrigX(left, x);
+    const aRight = toNumeric(right);
+    if (bTrigLeft !== undefined && aRight !== undefined && aRight.kind !== "float") {
+      return {
+        a: negNumeric(aRight),
+        b: bTrigLeft.c,
+        trigHead: bTrigLeft.head,
+      };
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/** Phase 34 entry point. Returns the closed form, or undefined when the
+ *  shape doesn't match or the discriminant fails the a² > b² / a > 0 guards. */
+function tryWeierstrassOneOverLinearTrig(
+  integrand: IRNode,
+  x: IRNode
+): IRNode | undefined {
+  if (integrand.kind !== "apply" || !equals(integrand.head, DIV)) return undefined;
+  if (integrand.args.length !== 2) return undefined;
+  const [num, den] = integrand.args;
+  if (dependsOn(num, x)) return undefined;
+  const c = toNumeric(num);
+  if (c === undefined || c.kind === "float") return undefined;
+  const parsed = weierstrassParseAPlusBSincos(den, x);
+  if (parsed === undefined) return undefined;
+  const { a, b, trigHead } = parsed;
+  // disc = a² − b² (exact Numeric arithmetic — both a, b are Int/Rat).
+  const disc = subNumeric(mulNumeric(a, a), mulNumeric(b, b));
+  // disc must be strictly positive; reject zero (a² = b²) and negative.
+  if (!isPositiveNumeric(disc)) return undefined;
+  const sqrtDiscIR = weierstrassSqrtFractionIR(disc);
+  const tanHalf = app(TAN, [app(DIV, [x, int(2)])]);
+  let atanArg: IRNode;
+  if (equals(trigHead, SIN)) {
+    // (a·tan(x/2) + b) / √(a²−b²)
+    const top = app(ADD, [app(MUL, [fromNumeric(a), tanHalf]), fromNumeric(b)]);
+    atanArg = app(DIV, [top, sqrtDiscIR]);
+  } else {
+    // COS branch: requires a > 0 to avoid sign-flip; defers otherwise.
+    if (!isPositiveNumeric(a)) return undefined;
+    // ratio = (a − b) / (a + b)
+    const ratio = divNumeric(subNumeric(a, b), addNumeric(a, b));
+    if (!isPositiveNumeric(ratio)) return undefined;
+    const sqrtRatioIR = weierstrassSqrtFractionIR(ratio);
+    atanArg = app(MUL, [sqrtRatioIR, tanHalf]);
+  }
+  // Outer coefficient: 2c / √(a²−b²)
+  const coefFrac = mulNumeric(c, { kind: "int", value: 2n });
+  const coefIR = app(DIV, [fromNumeric(coefFrac), sqrtDiscIR]);
+  return app(MUL, [coefIR, app(ATAN, [atanArg])]);
+}
+
+/** True when ``v`` is an exact rational/integer strictly greater than zero. */
+function isPositiveNumeric(v: Numeric): boolean {
+  if (v.kind === "int") return v.value > 0n;
+  if (v.kind === "rat") return v.numer > 0n; // denominator is always positive
+  return v.value > 0;
+}
+
 function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
   if (!dependsOn(f, x)) {
     return app(MUL, [f, x]);
@@ -1653,6 +1820,10 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
     if (!dependsOn(numerator, x) && equals(denominator, x)) {
       return app(MUL, [numerator, app(LOG, [x])]);
     }
+    // Phase 34: Weierstrass substitution for c / (a + b·sin(x)) and
+    // c / (a + b·cos(x)) when a, b numeric and a² > b² (a > 0 for cos).
+    const weier = tryWeierstrassOneOverLinearTrig(f, x);
+    if (weier !== undefined) return weier;
     return undefined;
   }
   if (equals(f.head, POW)) {

--- a/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
@@ -1,0 +1,243 @@
+// Phase 34: Weierstrass-substitution closed forms for
+//   ∫ c / (a + b·sin(x)) dx   and   ∫ c / (a + b·cos(x)) dx
+//
+// Mirrors `tests/test_phase34_weierstrass.py` from the Python port.
+// Closed forms are validated via *numerical differentiation*: substitute
+// x ← x_val (IRFloat) into the closed form, evaluate via vm.eval, then
+// central-difference around several sample values and require agreement
+// with the original integrand to a tight tolerance.
+
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  ATAN,
+  COS,
+  DIV,
+  INTEGRATE,
+  IRNode,
+  MUL,
+  NEG,
+  SIN,
+  SQRT,
+  app,
+  equals,
+  int,
+  numberNode,
+  rational,
+  sym,
+} from "@coding-adventures/symbolic-ir";
+import { SymbolicBackend, VM } from "../src/index.js";
+
+const X = sym("x");
+
+function integrate(f: IRNode): IRNode {
+  return app(INTEGRATE, [f, X]);
+}
+
+function makeVM(): VM {
+  return new VM(new SymbolicBackend());
+}
+
+function subst(node: IRNode, varNode: IRNode, value: IRNode): IRNode {
+  if (equals(node, varNode)) return value;
+  if (node.kind === "apply") {
+    return app(node.head, node.args.map((a) => subst(a, varNode, value)));
+  }
+  return node;
+}
+
+/** Evaluate `expr` after substituting x ← x_val, returning the numeric value. */
+function evalAt(vm: VM, expr: IRNode, xVal: number): number {
+  const substituted = subst(expr, X, numberNode(xVal));
+  const folded = vm.eval(substituted);
+  if (folded.kind === "float") return folded.value;
+  if (folded.kind === "integer") return Number(folded.value);
+  if (folded.kind === "rational") return Number(folded.numer) / Number(folded.denom);
+  return Number.NaN;
+}
+
+/** Central-difference derivative of `expr` w.r.t. x at xVal. */
+function numericalDerivative(vm: VM, expr: IRNode, xVal: number): number {
+  const h = 1e-5;
+  return (evalAt(vm, expr, xVal + h) - evalAt(vm, expr, xVal - h)) / (2 * h);
+}
+
+function containsHead(node: IRNode, head: IRNode): boolean {
+  if (node.kind === "apply") {
+    if (equals(node.head, head)) return true;
+    return node.args.some((a) => containsHead(a, head));
+  }
+  return false;
+}
+
+function isUnevaluatedIntegrate(node: IRNode): boolean {
+  return node.kind === "apply" && equals(node.head, INTEGRATE);
+}
+
+// ---------------------------------------------------------------------------
+// ∫ 1/(a + b·sin(x)) dx — arctan form, a² > b²
+// ---------------------------------------------------------------------------
+
+describe("Phase 34: ∫ 1/(a + b·sin x) dx (Weierstrass arctan form)", () => {
+  it("∫ 1/(2 + sin x) dx closes with an Atan in the body", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [X])])]);
+    const result = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(result)).toBe(false);
+    expect(containsHead(result, ATAN)).toBe(true);
+  });
+
+  it("numerical derivative of the ∫ 1/(2 + sin x) closed form matches at multiple points", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [X])])]);
+    const phi = vm.eval(integrate(integrand));
+    for (const xVal of [-2.5, -1.0, -0.3, 0.0, 0.3, 1.0, 2.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (2 + Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("perfect-square discriminant (a=5, b=3 → disc=16) folds to Sqrt-free output", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(5), app(MUL, [int(3), app(SIN, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(containsHead(phi, SQRT)).toBe(false);
+    for (const xVal of [-1.0, -0.2, 0.0, 0.7, 1.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (5 + 3 * Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("numerator coefficient scales the closed form (∫ 3/(2 + sin x))", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(3), app(ADD, [int(2), app(SIN, [X])])]);
+    const phi = vm.eval(integrate(integrand));
+    for (const xVal of [-1.0, -0.2, 0.0, 0.7, 1.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 3 / (2 + Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("rational coefficients a=3/2, b=1/2 (disc=2)", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [
+      int(1),
+      app(ADD, [rational(3, 2), app(MUL, [rational(1, 2), app(SIN, [X])])]),
+    ]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-1.5, -0.4, 0.0, 0.4, 1.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (1.5 + 0.5 * Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ∫ 1/(a + b·cos(x)) dx — arctan form, a² > b², a > 0
+// ---------------------------------------------------------------------------
+
+describe("Phase 34: ∫ 1/(a + b·cos x) dx (Weierstrass arctan form)", () => {
+  it("∫ 1/(2 + cos x) dx closes; derivative matches", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(COS, [X])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-1.5, -0.4, 0.0, 0.4, 1.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (2 + Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("∫ 1/(5 + 3·cos x) dx: both disc and ratio are perfect squares → Sqrt-free", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(5), app(MUL, [int(3), app(COS, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(containsHead(phi, SQRT)).toBe(false);
+    for (const xVal of [-1.5, -0.4, 0.0, 0.4, 1.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (5 + 3 * Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Operand-order robustness
+// ---------------------------------------------------------------------------
+
+describe("Phase 34: operand-order robustness", () => {
+  it("∫ 1/(sin x + 2) dx — constant on the right — still closes", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [app(SIN, [X]), int(2)])]);
+    const result = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(result)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallthroughs — must stay unevaluated
+// ---------------------------------------------------------------------------
+
+describe("Phase 34: deferred discriminant cases", () => {
+  it("a² < b² (∫ 1/(1 + 2·sin x) dx) — log form deferred", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(1), app(MUL, [int(2), app(SIN, [X])])])]);
+    const result = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(result)).toBe(true);
+  });
+
+  it("a² = b² (∫ 1/(1 + sin x) dx) — degenerate form deferred", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(1), app(SIN, [X])])]);
+    const result = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(result)).toBe(true);
+  });
+
+  it("non-bare argument (∫ 1/(2 + sin 2x) dx) — Phase 34 doesn't compose with subs", () => {
+    const vm = makeVM();
+    const twoX = app(MUL, [int(2), X]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [twoX])])]);
+    const result = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(result)).toBe(true);
+  });
+
+  it("symbolic coefficient (∫ 1/(a + sin x) dx) — discriminant sign undecidable", () => {
+    const vm = makeVM();
+    const aSym = sym("a");
+    const integrand = app(DIV, [int(1), app(ADD, [aSym, app(SIN, [X])])]);
+    const result = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(result)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regressions — Phase 34 must not steal integrals it doesn't own
+// ---------------------------------------------------------------------------
+
+describe("Phase 34: regression — must not interfere with existing rules", () => {
+  it("∫ sin(x) dx = −cos(x) unchanged", () => {
+    const vm = makeVM();
+    const result = vm.eval(integrate(app(SIN, [X])));
+    const cosX = app(COS, [X]);
+    const negCos = app(NEG, [cosX]);
+    const mulNeg = app(MUL, [int(-1), cosX]);
+    expect(equals(result, negCos) || equals(result, mulNeg)).toBe(true);
+  });
+
+  it("∫ 1/cos(x) dx is NOT misinterpreted as Weierstrass (no additive constant)", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(COS, [X])]);
+    const result = vm.eval(integrate(integrand));
+    // Either unevaluated, or some elementary fold — but specifically MUST NOT be
+    // a top-level Atan (which would only come from Phase 34).
+    if (result.kind === "apply" && equals(result.head, ATAN)) {
+      throw new Error(`Phase 34 incorrectly fired on ∫ 1/cos(x) dx: got ${JSON.stringify(result)}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Phase 34 Weierstrass substitution from Python `symbolic-vm`
0.59.0 (PR #3472) to the TypeScript port. The substitution
`u = tan(x/2)` reduces:

    ∫ 1/(a + b·sin x) dx → (2/√(a²−b²))·arctan((a·tan(x/2)+b)/√(a²−b²))
    ∫ 1/(a + b·cos x) dx → (2/√(a²−b²))·arctan(√((a−b)/(a+b))·tan(x/2))

Implemented in `src/index.ts` (~170 lines: `tryWeierstrassOneOverLinearTrig`,
`weierstrassParseAPlusBSincos`, `weierstrassParseConstTimesTrigX`,
`weierstrassSqrtFractionIR`, `isPositiveNumeric`). Wired into the DIV
branch of `integrateIndefinite`.

Discriminant cases `a² ≤ b²` and the `a ≤ 0` cos branch are deferred
— the TS port has no assumption system to do the sign analysis.

## Test plan

- [x] **14 new tests** in `tests/phase34-weierstrass.test.ts` mirroring the
  Python Phase 34 suite, including numerical-derivative verification
- [x] Full TS suite: **79 passed (65 existing + 14 new)**
- [x] `npx tsc --noEmit` clean (no type errors)
- [x] Security review: passed (no vulnerabilities)

## Version sequencing

Version jumps `0.5.0 → 0.7.0` to leave `0.6.0` for the in-flight Phase
29-33 algebraic-rules port (PR #3468). When both PRs land the version
table reads cleanly: `0.5.0 → 0.6.0 → 0.7.0`. **This PR should land
after PR #3468 (Phase 29-33) and PR #3472 (Python Phase 34).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)