### PR TITLE
Add WHATWG comment boundary fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -63,6 +63,9 @@ documented in this file.
 - A generated WHATWG tokenizer markup declaration fixture and Rust conformance
   test that pins comment, bogus-comment, CDATA-looking declaration, DOCTYPE,
   and seeded declaration continuation recovery.
+- A generated WHATWG tokenizer comment boundary fixture and Rust conformance
+  test that pins nested-comment recovery, pending dash and end-bang handling,
+  bogus comments, EOF, NULL replacement, and seeded comment continuations.
 - A generated WHATWG tokenizer attribute-edge fixture and Rust conformance test
   that pins quoted/unquoted values, duplicate attributes, missing-whitespace
   recovery, NULL replacement, self-closing delimiters, unexpected solidus

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -84,6 +84,10 @@ matching end tags from literal apparent end tags.
 The generated markup declaration suite pins comment, bogus-comment, DOCTYPE,
 default HTML CDATA-looking bogus-comment recovery, explicit seeded CDATA
 continuation, and seeded declaration continuation behavior.
+The generated comment boundary suite then drills into the states after comment
+dispatch: less-than/bang nested-comment recovery, pending dash and end-bang
+handling, bogus comments, EOF, NULL replacement, and seeded continuation
+contexts.
 The generated attribute-edge suite pins quoted/unquoted values, duplicate
 attributes, missing-whitespace recovery, NULL replacement, self-closing
 delimiters, unexpected solidus recovery, and end-tag attribute diagnostics.
@@ -289,6 +293,16 @@ continuation recovery. Regenerate or check it with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py \
+  --check
+```
+
+The checked-in `whatwg-comment-boundaries.json` fixture exercises the focused
+comment and bogus-comment continuation states after markup declaration
+dispatch. Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -70,6 +70,10 @@ binary while production code continues to link only static Rust source.
 - `whatwg-markup-declarations.json`: generated HTML tokenizer markup
   declaration cases used by Rust tests to pin comment, bogus-comment, CDATA,
   DOCTYPE, and seeded declaration continuation recovery
+- `whatwg-comment-boundaries.json`: generated HTML tokenizer comment boundary
+  cases used by Rust tests to pin nested-comment recovery, pending dash and
+  end-bang handling, bogus comments, EOF, NULL replacement, and seeded comment
+  continuations
 - `whatwg-attribute-edges.json`: generated HTML tokenizer attribute-edge cases
   used by Rust tests to pin quoted/unquoted values, duplicate attributes,
   missing whitespace recovery, NULL replacement, self-closing delimiters, and
@@ -107,6 +111,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_markup_declarations_fixture.py`: importer that generates
   markup declaration recovery cases for the checked-in
   `whatwg-markup-declarations.json` fixture
+- `generate_whatwg_comment_boundaries_fixture.py`: importer that generates
+  focused comment and bogus-comment boundary cases for the checked-in
+  `whatwg-comment-boundaries.json` fixture
 - `generate_whatwg_attribute_edges_fixture.py`: importer that generates
   attribute-edge recovery cases for the checked-in
   `whatwg-attribute-edges.json` fixture
@@ -172,6 +179,14 @@ Regenerate or verify the WHATWG markup declaration fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG comment boundary fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer comment boundary fixture.
+
+The broader markup-declaration fixture proves that `<!--` and malformed `<!`
+dispatch into comment recovery. This focused suite pins the states after that
+dispatch: ordinary comments, less-than/bang nested-comment recovery, end-dash
+and end-bang handling, bogus comments, NULL replacement, EOF recovery, and
+seeded parser continuation contexts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-comment-boundaries.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    fixture = build_fixture()
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        existing = output.read_text()
+        if existing != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer comment boundary fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-comment-boundaries/v1",
+        "description": (
+            "Comment, bogus-comment, nested-comment, EOF, NULL replacement, "
+            "end-bang, and seeded continuation boundary recovery."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    cases.extend(comment_data_cases())
+    cases.extend(comment_eof_cases())
+    cases.extend(bogus_comment_cases())
+    cases.extend(seeded_comment_cases())
+    cases.extend(seeded_bogus_comment_cases())
+    return cases
+
+
+def comment_data_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "comment-basic-close",
+            "description": "ordinary comments emit their data between opener and close",
+            "input": "a<!--note-->b",
+            "tokens": ["Text(data=a)", "Comment(data=note)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-empty-abrupt",
+            "description": "empty comments may close abruptly from comment start state",
+            "input": "a<!-->b",
+            "tokens": ["Text(data=a)", "Comment(data=)", "Text(data=b)", "EOF"],
+            "diagnostics": ["abrupt-closing-of-empty-comment"],
+        },
+        {
+            "id": "comment-empty-start-dash",
+            "description": "comment start dash state closes abruptly on greater-than",
+            "input": "a<!--->b",
+            "tokens": ["Text(data=a)", "Comment(data=)", "Text(data=b)", "EOF"],
+            "diagnostics": ["abrupt-closing-of-empty-comment"],
+        },
+        {
+            "id": "comment-double-dash-empty",
+            "description": "the shortest non-abrupt comment close emits empty data",
+            "input": "a<!---->b",
+            "tokens": ["Text(data=a)", "Comment(data=)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-null-body",
+            "description": "NULL inside comment data is replaced with U+FFFD",
+            "input": "a<!--x\u0000y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x�y)", "Text(data=b)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "comment-null-after-start",
+            "description": "NULL immediately after the opener is replaced in comment start state",
+            "input": "a<!--\u0000-->b",
+            "tokens": ["Text(data=a)", "Comment(data=�)", "Text(data=b)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "comment-null-after-start-dash",
+            "description": "NULL after one pending dash preserves the dash before replacement",
+            "input": "a<!---\u0000-->b",
+            "tokens": ["Text(data=a)", "Comment(data=-�)", "Text(data=b)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "comment-less-than-text",
+            "description": "less-than signs that do not introduce nested comments stay literal",
+            "input": "a<!--x<y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x<y)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-less-than-repeat",
+            "description": "repeated less-than signs remain in the comment text",
+            "input": "a<!--x<<y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x<<y)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-less-than-bang-text",
+            "description": "less-than bang without following dashes stays literal",
+            "input": "a<!--x<!y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x<!y)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-less-than-bang-dash-text",
+            "description": "less-than bang dash without a second dash stays literal",
+            "input": "a<!--x<!-y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x<!-y)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-nested-looking-opener",
+            "description": "nested-looking comment openers stay literal and report nested-comment",
+            "input": "a<!--x<!--y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x<!--y)", "Text(data=b)", "EOF"],
+            "diagnostics": ["nested-comment"],
+        },
+        {
+            "id": "comment-end-dash-nonclose",
+            "description": "a single dash before ordinary data is preserved",
+            "input": "a<!--x-y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x-y)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-end-double-dash-nonclose",
+            "description": "double dash followed by data remains part of the comment",
+            "input": "a<!--x--y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x--y)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-end-dash-null",
+            "description": "NULL after an end dash preserves the pending dash before replacement",
+            "input": "a<!--x-\u0000-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x-�)", "Text(data=b)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "comment-end-double-dash-null",
+            "description": "NULL after double dash preserves both pending dashes before replacement",
+            "input": "a<!--x--\u0000-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x--�)", "Text(data=b)", "EOF"],
+            "diagnostics": ["unexpected-null-character"],
+        },
+        {
+            "id": "comment-end-bang-close",
+            "description": "incorrect --!> comment close emits the comment and diagnostic",
+            "input": "a<!--x--!>b",
+            "tokens": ["Text(data=a)", "Comment(data=x)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-closed-comment"],
+        },
+        {
+            "id": "comment-end-bang-not-close",
+            "description": "non-closing --! text remains inside the comment",
+            "input": "a<!--x--!y-->b",
+            "tokens": ["Text(data=a)", "Comment(data=x--!y)", "Text(data=b)", "EOF"],
+        },
+        {
+            "id": "comment-end-bang-dash-close",
+            "description": "dash after --! re-enters end-dash handling and keeps greater-than literal",
+            "input": "a<!--x--!->b",
+            "tokens": ["Text(data=a)", "Comment(data=x--!->b)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+    ]
+
+
+def comment_eof_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "comment-eof-body",
+            "description": "EOF in comment body emits the current comment with eof-in-comment",
+            "input": "a<!--open",
+            "tokens": ["Text(data=a)", "Comment(data=open)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-start",
+            "description": "EOF in comment start state emits an empty comment",
+            "input": "a<!--",
+            "tokens": ["Text(data=a)", "Comment(data=)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-start-dash",
+            "description": "EOF after one initial dash emits an empty comment",
+            "input": "a<!---",
+            "tokens": ["Text(data=a)", "Comment(data=)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-less-than",
+            "description": "EOF after a less-than sign preserves it in the comment",
+            "input": "a<!--x<",
+            "tokens": ["Text(data=a)", "Comment(data=x<)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-less-than-bang",
+            "description": "EOF after less-than bang preserves both characters",
+            "input": "a<!--x<!",
+            "tokens": ["Text(data=a)", "Comment(data=x<!)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-less-than-bang-dash",
+            "description": "EOF in less-than bang dash state emits without appending the pending dash",
+            "input": "a<!--x<!-",
+            "tokens": ["Text(data=a)", "Comment(data=x<!)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-less-than-bang-dash-dash",
+            "description": "EOF after nested opener punctuation follows end-state EOF recovery",
+            "input": "a<!--x<!--",
+            "tokens": ["Text(data=a)", "Comment(data=x<!)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-end-dash",
+            "description": "EOF after one end dash emits the current comment",
+            "input": "a<!--x-",
+            "tokens": ["Text(data=a)", "Comment(data=x)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-end",
+            "description": "EOF after double dash emits the current comment",
+            "input": "a<!--x--",
+            "tokens": ["Text(data=a)", "Comment(data=x)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+        {
+            "id": "comment-eof-end-bang",
+            "description": "EOF after --! appends that pending sequence before emission",
+            "input": "a<!--x--!",
+            "tokens": ["Text(data=a)", "Comment(data=x--!)", "EOF"],
+            "diagnostics": ["eof-in-comment"],
+        },
+    ]
+
+
+def bogus_comment_cases() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "processing-instruction-bogus-comment",
+            "description": "question-mark tag open recovers as a bogus comment",
+            "input": "a<?xml?>b",
+            "tokens": ["Text(data=a)", "Comment(data=?xml?)", "Text(data=b)", "EOF"],
+            "diagnostics": ["unexpected-question-mark-instead-of-tag-name"],
+        },
+        {
+            "id": "processing-instruction-bogus-comment-eof",
+            "description": "EOF in a question-mark bogus comment emits without eof-in-comment",
+            "input": "a<?xml",
+            "tokens": ["Text(data=a)", "Comment(data=?xml)", "EOF"],
+            "diagnostics": ["unexpected-question-mark-instead-of-tag-name"],
+        },
+        {
+            "id": "malformed-declaration-bogus-comment",
+            "description": "unknown markup declarations recover as bogus comments",
+            "input": "a<!foo>b",
+            "tokens": ["Text(data=a)", "Comment(data=foo)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment"],
+        },
+        {
+            "id": "empty-malformed-declaration",
+            "description": "empty malformed declaration emits an empty bogus comment",
+            "input": "a<!>b",
+            "tokens": ["Text(data=a)", "Comment(data=)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment"],
+        },
+        {
+            "id": "one-dash-declaration",
+            "description": "one-dash markup declaration uses bogus-comment recovery",
+            "input": "a<!-x>b",
+            "tokens": ["Text(data=a)", "Comment(data=-x)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment"],
+        },
+        {
+            "id": "bogus-comment-null",
+            "description": "NULL inside bogus comments is replaced before emission",
+            "input": "a<!foo\u0000bar>b",
+            "tokens": ["Text(data=a)", "Comment(data=foo�bar)", "Text(data=b)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment", "unexpected-null-character"],
+        },
+        {
+            "id": "bogus-comment-eof",
+            "description": "EOF in bogus comment emits the current comment without eof-in-comment",
+            "input": "a<!foo",
+            "tokens": ["Text(data=a)", "Comment(data=foo)", "EOF"],
+            "diagnostics": ["incorrectly-opened-comment"],
+        },
+        {
+            "id": "invalid-end-tag-open-bogus-comment",
+            "description": "malformed end-tag openers recover as bogus comments",
+            "input": "a</3>b",
+            "tokens": ["Text(data=a)", "Comment(data=3)", "Text(data=b)", "EOF"],
+            "diagnostics": ["invalid-first-character-of-tag-name"],
+        },
+    ]
+
+
+def seeded_comment_cases() -> list[dict[str, object]]:
+    return [
+        seeded(
+            "seeded-comment-start-abrupt-close",
+            "comment start state closes abruptly on greater-than",
+            "Comment start state",
+            "",
+            ">after",
+            ["Comment(data=)", "Text(data=after)", "EOF"],
+            ["abrupt-closing-of-empty-comment"],
+        ),
+        seeded(
+            "seeded-comment-start-null",
+            "comment start state replaces NULL before continuing",
+            "Comment start state",
+            "seed",
+            "\u0000-->after",
+            ["Comment(data=seed�)", "Text(data=after)", "EOF"],
+            ["unexpected-null-character"],
+        ),
+        seeded(
+            "seeded-comment-start-dash-abrupt-close",
+            "comment start dash state closes abruptly on greater-than",
+            "Comment start dash state",
+            "",
+            ">after",
+            ["Comment(data=)", "Text(data=after)", "EOF"],
+            ["abrupt-closing-of-empty-comment"],
+        ),
+        seeded(
+            "seeded-comment-start-dash-null",
+            "comment start dash state appends the pending dash before NULL replacement",
+            "Comment start dash state",
+            "seed",
+            "\u0000-->after",
+            ["Comment(data=seed-�)", "Text(data=after)", "EOF"],
+            ["unexpected-null-character"],
+        ),
+        seeded(
+            "seeded-comment-body-close",
+            "comment body continuation appends text before the close",
+            "Comment state",
+            "seed",
+            " tail-->after",
+            ["Comment(data=seed tail)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-body-null",
+            "comment body continuation replaces NULL before closing",
+            "Comment state",
+            "seed",
+            "\u0000-->after",
+            ["Comment(data=seed�)", "Text(data=after)", "EOF"],
+            ["unexpected-null-character"],
+        ),
+        seeded(
+            "seeded-comment-less-than-text",
+            "less-than continuation preserves the already-appended less-than sign",
+            "Comment less-than sign state",
+            "seed<",
+            "x-->after",
+            ["Comment(data=seed<x)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-less-than-repeat",
+            "less-than continuation can remain in the less-than state",
+            "Comment less-than sign state",
+            "seed<",
+            "<x-->after",
+            ["Comment(data=seed<<x)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-less-than-bang-text",
+            "less-than bang continuation falls back to comment body on text",
+            "Comment less-than sign bang state",
+            "seed<!",
+            "x-->after",
+            ["Comment(data=seed<!x)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-less-than-bang-dash-text",
+            "less-than bang dash continuation appends the pending dash via end-dash state",
+            "Comment less-than sign bang dash state",
+            "seed<!",
+            "x-->after",
+            ["Comment(data=seed<!-x)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-less-than-bang-dash-dash-nested",
+            "less-than bang dash dash reports nested-comment before end-state recovery",
+            "Comment less-than sign bang dash dash state",
+            "seed<!",
+            "x-->after",
+            ["Comment(data=seed<!--x)", "Text(data=after)", "EOF"],
+            ["nested-comment"],
+        ),
+        seeded(
+            "seeded-comment-end-dash-text",
+            "end dash continuation preserves the pending dash before text",
+            "Comment end dash state",
+            "seed",
+            "x-->after",
+            ["Comment(data=seed-x)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-end-dash-null",
+            "end dash continuation preserves dash before NULL replacement",
+            "Comment end dash state",
+            "seed",
+            "\u0000-->after",
+            ["Comment(data=seed-�)", "Text(data=after)", "EOF"],
+            ["unexpected-null-character"],
+        ),
+        seeded(
+            "seeded-comment-end-close",
+            "comment end continuation emits on greater-than",
+            "Comment end state",
+            "seed",
+            ">after",
+            ["Comment(data=seed)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-end-text",
+            "comment end continuation appends pending double dash before text",
+            "Comment end state",
+            "seed",
+            "x-->after",
+            ["Comment(data=seed--x)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-end-null",
+            "comment end continuation appends double dash before NULL replacement",
+            "Comment end state",
+            "seed",
+            "\u0000-->after",
+            ["Comment(data=seed--�)", "Text(data=after)", "EOF"],
+            ["unexpected-null-character"],
+        ),
+        seeded(
+            "seeded-comment-end-bang-close",
+            "comment end bang continuation emits with incorrectly-closed-comment",
+            "Comment end bang state",
+            "seed",
+            ">after",
+            ["Comment(data=seed)", "Text(data=after)", "EOF"],
+            ["incorrectly-closed-comment"],
+        ),
+        seeded(
+            "seeded-comment-end-bang-text",
+            "comment end bang continuation appends --! before text",
+            "Comment end bang state",
+            "seed",
+            "x-->after",
+            ["Comment(data=seed--!x)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-comment-end-bang-eof",
+            "comment end bang continuation appends --! before EOF emission",
+            "Comment end bang state",
+            "seed",
+            "",
+            ["Comment(data=seed--!)", "EOF"],
+            ["eof-in-comment"],
+        ),
+    ]
+
+
+def seeded_bogus_comment_cases() -> list[dict[str, object]]:
+    return [
+        seeded(
+            "seeded-bogus-comment-close",
+            "bogus comment continuation emits on greater-than",
+            "Bogus comment state",
+            "seed",
+            " tail>after",
+            ["Comment(data=seed tail)", "Text(data=after)", "EOF"],
+        ),
+        seeded(
+            "seeded-bogus-comment-null",
+            "bogus comment continuation replaces NULL before emission",
+            "Bogus comment state",
+            "seed",
+            "\u0000>after",
+            ["Comment(data=seed�)", "Text(data=after)", "EOF"],
+            ["unexpected-null-character"],
+        ),
+        seeded(
+            "seeded-bogus-comment-eof",
+            "bogus comment continuation emits on EOF without eof-in-comment",
+            "Bogus comment state",
+            "seed",
+            " tail",
+            ["Comment(data=seed tail)", "EOF"],
+        ),
+    ]
+
+
+def seeded(
+    case_id: str,
+    description: str,
+    state: str,
+    current_comment: str,
+    input_text: str,
+    tokens: list[str],
+    diagnostics: list[str] | None = None,
+) -> dict[str, object]:
+    case: dict[str, object] = {
+        "id": case_id,
+        "description": description,
+        "initial_state": state,
+        "current_comment": current_comment,
+        "input": input_text,
+        "tokens": tokens,
+    }
+    if diagnostics:
+        case["diagnostics"] = diagnostics
+    return case
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-comment-boundaries.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-comment-boundaries.json
@@ -1,0 +1,800 @@
+{
+  "cases": [
+    {
+      "description": "ordinary comments emit their data between opener and close",
+      "diagnostics": [],
+      "id": "comment-basic-close",
+      "input": "a<!--note-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=note)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "empty comments may close abruptly from comment start state",
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
+      "id": "comment-empty-abrupt",
+      "input": "a<!-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "comment start dash state closes abruptly on greater-than",
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
+      "id": "comment-empty-start-dash",
+      "input": "a<!--->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "the shortest non-abrupt comment close emits empty data",
+      "diagnostics": [],
+      "id": "comment-double-dash-empty",
+      "input": "a<!---->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside comment data is replaced with U+FFFD",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "comment-null-body",
+      "input": "a<!--x\u0000y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x�y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL immediately after the opener is replaced in comment start state",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "comment-null-after-start",
+      "input": "a<!--\u0000-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=�)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL after one pending dash preserves the dash before replacement",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "comment-null-after-start-dash",
+      "input": "a<!---\u0000-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=-�)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "less-than signs that do not introduce nested comments stay literal",
+      "diagnostics": [],
+      "id": "comment-less-than-text",
+      "input": "a<!--x<y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "repeated less-than signs remain in the comment text",
+      "diagnostics": [],
+      "id": "comment-less-than-repeat",
+      "input": "a<!--x<<y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<<y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "less-than bang without following dashes stays literal",
+      "diagnostics": [],
+      "id": "comment-less-than-bang-text",
+      "input": "a<!--x<!y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<!y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "less-than bang dash without a second dash stays literal",
+      "diagnostics": [],
+      "id": "comment-less-than-bang-dash-text",
+      "input": "a<!--x<!-y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<!-y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "nested-looking comment openers stay literal and report nested-comment",
+      "diagnostics": [
+        "nested-comment"
+      ],
+      "id": "comment-nested-looking-opener",
+      "input": "a<!--x<!--y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<!--y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "a single dash before ordinary data is preserved",
+      "diagnostics": [],
+      "id": "comment-end-dash-nonclose",
+      "input": "a<!--x-y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x-y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "double dash followed by data remains part of the comment",
+      "diagnostics": [],
+      "id": "comment-end-double-dash-nonclose",
+      "input": "a<!--x--y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x--y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL after an end dash preserves the pending dash before replacement",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "comment-end-dash-null",
+      "input": "a<!--x-\u0000-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x-�)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL after double dash preserves both pending dashes before replacement",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "comment-end-double-dash-null",
+      "input": "a<!--x--\u0000-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x--�)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "incorrect --!> comment close emits the comment and diagnostic",
+      "diagnostics": [
+        "incorrectly-closed-comment"
+      ],
+      "id": "comment-end-bang-close",
+      "input": "a<!--x--!>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "non-closing --! text remains inside the comment",
+      "diagnostics": [],
+      "id": "comment-end-bang-not-close",
+      "input": "a<!--x--!y-->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x--!y)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "dash after --! re-enters end-dash handling and keeps greater-than literal",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-end-bang-dash-close",
+      "input": "a<!--x--!->b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x--!->b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in comment body emits the current comment with eof-in-comment",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-body",
+      "input": "a<!--open",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=open)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in comment start state emits an empty comment",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-start",
+      "input": "a<!--",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after one initial dash emits an empty comment",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-start-dash",
+      "input": "a<!---",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after a less-than sign preserves it in the comment",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-less-than",
+      "input": "a<!--x<",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after less-than bang preserves both characters",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-less-than-bang",
+      "input": "a<!--x<!",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in less-than bang dash state emits without appending the pending dash",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-less-than-bang-dash",
+      "input": "a<!--x<!-",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after nested opener punctuation follows end-state EOF recovery",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-less-than-bang-dash-dash",
+      "input": "a<!--x<!--",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x<!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after one end dash emits the current comment",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-end-dash",
+      "input": "a<!--x-",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after double dash emits the current comment",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-end",
+      "input": "a<!--x--",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF after --! appends that pending sequence before emission",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "comment-eof-end-bang",
+      "input": "a<!--x--!",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=x--!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "question-mark tag open recovers as a bogus comment",
+      "diagnostics": [
+        "unexpected-question-mark-instead-of-tag-name"
+      ],
+      "id": "processing-instruction-bogus-comment",
+      "input": "a<?xml?>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=?xml?)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in a question-mark bogus comment emits without eof-in-comment",
+      "diagnostics": [
+        "unexpected-question-mark-instead-of-tag-name"
+      ],
+      "id": "processing-instruction-bogus-comment-eof",
+      "input": "a<?xml",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=?xml)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unknown markup declarations recover as bogus comments",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "malformed-declaration-bogus-comment",
+      "input": "a<!foo>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=foo)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "empty malformed declaration emits an empty bogus comment",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "empty-malformed-declaration",
+      "input": "a<!>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "one-dash markup declaration uses bogus-comment recovery",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "one-dash-declaration",
+      "input": "a<!-x>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=-x)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "NULL inside bogus comments is replaced before emission",
+      "diagnostics": [
+        "incorrectly-opened-comment",
+        "unexpected-null-character"
+      ],
+      "id": "bogus-comment-null",
+      "input": "a<!foo\u0000bar>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=foo�bar)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "EOF in bogus comment emits the current comment without eof-in-comment",
+      "diagnostics": [
+        "incorrectly-opened-comment"
+      ],
+      "id": "bogus-comment-eof",
+      "input": "a<!foo",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=foo)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "malformed end-tag openers recover as bogus comments",
+      "diagnostics": [
+        "invalid-first-character-of-tag-name"
+      ],
+      "id": "invalid-end-tag-open-bogus-comment",
+      "input": "a</3>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=3)",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "",
+      "description": "comment start state closes abruptly on greater-than",
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
+      "id": "seeded-comment-start-abrupt-close",
+      "initial_state": "Comment start state",
+      "input": ">after",
+      "tokens": [
+        "Comment(data=)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment start state replaces NULL before continuing",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-comment-start-null",
+      "initial_state": "Comment start state",
+      "input": "\u0000-->after",
+      "tokens": [
+        "Comment(data=seed�)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "",
+      "description": "comment start dash state closes abruptly on greater-than",
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
+      "id": "seeded-comment-start-dash-abrupt-close",
+      "initial_state": "Comment start dash state",
+      "input": ">after",
+      "tokens": [
+        "Comment(data=)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment start dash state appends the pending dash before NULL replacement",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-comment-start-dash-null",
+      "initial_state": "Comment start dash state",
+      "input": "\u0000-->after",
+      "tokens": [
+        "Comment(data=seed-�)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment body continuation appends text before the close",
+      "diagnostics": [],
+      "id": "seeded-comment-body-close",
+      "initial_state": "Comment state",
+      "input": " tail-->after",
+      "tokens": [
+        "Comment(data=seed tail)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment body continuation replaces NULL before closing",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-comment-body-null",
+      "initial_state": "Comment state",
+      "input": "\u0000-->after",
+      "tokens": [
+        "Comment(data=seed�)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed<",
+      "description": "less-than continuation preserves the already-appended less-than sign",
+      "diagnostics": [],
+      "id": "seeded-comment-less-than-text",
+      "initial_state": "Comment less-than sign state",
+      "input": "x-->after",
+      "tokens": [
+        "Comment(data=seed<x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed<",
+      "description": "less-than continuation can remain in the less-than state",
+      "diagnostics": [],
+      "id": "seeded-comment-less-than-repeat",
+      "initial_state": "Comment less-than sign state",
+      "input": "<x-->after",
+      "tokens": [
+        "Comment(data=seed<<x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed<!",
+      "description": "less-than bang continuation falls back to comment body on text",
+      "diagnostics": [],
+      "id": "seeded-comment-less-than-bang-text",
+      "initial_state": "Comment less-than sign bang state",
+      "input": "x-->after",
+      "tokens": [
+        "Comment(data=seed<!x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed<!",
+      "description": "less-than bang dash continuation appends the pending dash via end-dash state",
+      "diagnostics": [],
+      "id": "seeded-comment-less-than-bang-dash-text",
+      "initial_state": "Comment less-than sign bang dash state",
+      "input": "x-->after",
+      "tokens": [
+        "Comment(data=seed<!-x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed<!",
+      "description": "less-than bang dash dash reports nested-comment before end-state recovery",
+      "diagnostics": [
+        "nested-comment"
+      ],
+      "id": "seeded-comment-less-than-bang-dash-dash-nested",
+      "initial_state": "Comment less-than sign bang dash dash state",
+      "input": "x-->after",
+      "tokens": [
+        "Comment(data=seed<!--x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "end dash continuation preserves the pending dash before text",
+      "diagnostics": [],
+      "id": "seeded-comment-end-dash-text",
+      "initial_state": "Comment end dash state",
+      "input": "x-->after",
+      "tokens": [
+        "Comment(data=seed-x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "end dash continuation preserves dash before NULL replacement",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-comment-end-dash-null",
+      "initial_state": "Comment end dash state",
+      "input": "\u0000-->after",
+      "tokens": [
+        "Comment(data=seed-�)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment end continuation emits on greater-than",
+      "diagnostics": [],
+      "id": "seeded-comment-end-close",
+      "initial_state": "Comment end state",
+      "input": ">after",
+      "tokens": [
+        "Comment(data=seed)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment end continuation appends pending double dash before text",
+      "diagnostics": [],
+      "id": "seeded-comment-end-text",
+      "initial_state": "Comment end state",
+      "input": "x-->after",
+      "tokens": [
+        "Comment(data=seed--x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment end continuation appends double dash before NULL replacement",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-comment-end-null",
+      "initial_state": "Comment end state",
+      "input": "\u0000-->after",
+      "tokens": [
+        "Comment(data=seed--�)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment end bang continuation emits with incorrectly-closed-comment",
+      "diagnostics": [
+        "incorrectly-closed-comment"
+      ],
+      "id": "seeded-comment-end-bang-close",
+      "initial_state": "Comment end bang state",
+      "input": ">after",
+      "tokens": [
+        "Comment(data=seed)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment end bang continuation appends --! before text",
+      "diagnostics": [],
+      "id": "seeded-comment-end-bang-text",
+      "initial_state": "Comment end bang state",
+      "input": "x-->after",
+      "tokens": [
+        "Comment(data=seed--!x)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "comment end bang continuation appends --! before EOF emission",
+      "diagnostics": [
+        "eof-in-comment"
+      ],
+      "id": "seeded-comment-end-bang-eof",
+      "initial_state": "Comment end bang state",
+      "input": "",
+      "tokens": [
+        "Comment(data=seed--!)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "bogus comment continuation emits on greater-than",
+      "diagnostics": [],
+      "id": "seeded-bogus-comment-close",
+      "initial_state": "Bogus comment state",
+      "input": " tail>after",
+      "tokens": [
+        "Comment(data=seed tail)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "bogus comment continuation replaces NULL before emission",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-bogus-comment-null",
+      "initial_state": "Bogus comment state",
+      "input": "\u0000>after",
+      "tokens": [
+        "Comment(data=seed�)",
+        "Text(data=after)",
+        "EOF"
+      ]
+    },
+    {
+      "current_comment": "seed",
+      "description": "bogus comment continuation emits on EOF without eof-in-comment",
+      "diagnostics": [],
+      "id": "seeded-bogus-comment-eof",
+      "initial_state": "Bogus comment state",
+      "input": " tail",
+      "tokens": [
+        "Comment(data=seed tail)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Comment, bogus-comment, nested-comment, EOF, NULL replacement, end-bang, and seeded continuation boundary recovery.",
+  "format": "whatwg-html-tokenizer-comment-boundaries/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
@@ -1,0 +1,189 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_COMMENT_BOUNDARIES: &str = include_str!("fixtures/whatwg-comment-boundaries.json");
+
+#[derive(Debug, Deserialize)]
+struct CommentBoundarySuite {
+    format: String,
+    description: String,
+    cases: Vec<CommentBoundaryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommentBoundaryCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    current_comment: Option<String>,
+}
+
+#[test]
+fn whatwg_comment_boundaries_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-tokenizer-comment-boundaries/v1");
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 45);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "comment-nested-looking-opener"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "comment-eof-end-bang"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "seeded-bogus-comment-eof"));
+}
+
+#[test]
+fn whatwg_comment_boundaries_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its comment boundary",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> CommentBoundarySuite {
+    serde_json::from_str(WHATWG_COMMENT_BOUNDARIES)
+        .expect("WHATWG comment boundary fixture should parse")
+}
+
+fn configured_lexer(case: &CommentBoundaryCase) -> HtmlLexer {
+    let state = case
+        .initial_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let mut context = HtmlLexContext::new(state);
+    if let Some(current_comment) = case.current_comment.as_deref() {
+        context = context.with_current_comment(current_comment);
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG tokenizer comment-boundary fixture covering ordinary comments, nested-comment recovery, EOF, NULL replacement, end-bang/end-dash paths, bogus comments, and seeded continuations
- add a Rust conformance test for the fixture through the default lexer
- document the new generator and fixture in html-lexer docs/changelog

## Validation
- rustfmt --check code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- git diff --check