### PR TITLE
feat(symbolic-vm): Phase 34 Weierstrass — Rust port (0.7.0)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.7.0] — 2026-05-18
+
+### Added — Phase 34: Weierstrass substitution for ∫ 1/(a + b·sin/cos x) dx
+
+Ports Python `symbolic-vm` 0.59.0 Phase 34 to Rust.  The substitution
+`u = tan(x/2)` reduces `∫ 1/(a + b·sin x) dx` and `∫ 1/(a + b·cos x) dx`
+to rational functions of `u` whose closed form is an arctan whenever
+`a² > b²`.  Closed forms:
+
+    ∫ 1/(a + b·sin x) dx  =  (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
+    ∫ 1/(a + b·cos x) dx  =  (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
+
+For exact-rational `a, b` with `a² > b²` (and `a > 0` for the cos
+branch) the integrator now closes the form directly.  A numerator
+constant `c` simply scales the result.
+
+#### Deferred to a later phase
+
+- `a² < b²` — log form on `(a·tan(x/2)+b ± √(b²−a²))` (sign analysis).
+- `a² = b²` — degenerate, reduces to a rational in `tan(x/2)`.
+- `a ≤ 0` for the cos branch — `(a−b)/(a+b)` sign analysis.
+- Symbolic `a` or `b` — discriminant sign undecidable without an
+  assumption context (the Rust port has no assumption system).
+- Non-bare trig arguments (e.g. `sin(2x)`).
+
+#### Added (`src/handlers.rs`)
+
+- **`try_weierstrass_one_over_linear_trig(num, den, x)`** — Phase 34
+  entry point.  Matches `c / (a + b·sin/cos(x))` shapes with rational
+  c, a, b.  Returns the closed-form `IRNode` or `None`.
+- **`weierstrass_parse_a_plus_b_sincos(node, x)`** — structural matcher
+  returning `(a, b, trig_head_str)` for ADD/SUB with both operand
+  orderings.
+- **`weierstrass_parse_const_times_trig_x(node, x)`** — matches
+  `c·sin(x)`, `c·cos(x)`, `sin(x)`, `cos(x)`, and `Neg`-wrappings.
+- **`weierstrass_sqrt_fraction_ir(rc)`** — emits `Sqrt(p/q)` IR, folding
+  to a clean rational when both numerator and denominator are perfect
+  integer squares (reuses the existing `i128_sqrt` helper).
+- **`node_to_rc(node)`** — `IRNode` → `RatC` converter for Integer and
+  Rational literals.
+
+Wired into the `(DIV, [c, denom])` arm of `integrate` after the existing
+`1/x` case.  The Weierstrass path requires `!depends_on(c, x)` so it
+never fires for `x/(2+sin x)` style integrands.
+
+#### Tests (`tests/test_vm.rs`)
+
+14 new `#[test]` functions mirroring the Python and TS Phase 34 suites:
+
+- Closed-form structure: `∫ 1/(2 + sin x) dx` contains an `Atan` node.
+- Numeric-derivative verification at multiple sample points for both
+  sin and cos.
+- Perfect-square discriminant folds `Sqrt` away (a=5, b=3 → disc=16).
+- Numerator coefficient scales the closed form (`∫ 3/(2 + sin x) dx`).
+- Rational coefficients (a=3/2, b=1/2; disc=2).
+- Operand-order robustness (`∫ 1/(sin x + 2) dx` still closes).
+- Four fallthrough guarantees: a²<b², a²=b², non-bare arg, symbolic `a`.
+- Regression: `∫ sin(x) dx = −cos(x)` unchanged; `∫ 1/cos(x) dx` is
+  NOT misinterpreted as a Weierstrass case.
+
+New helpers in the test file: `phase34_subst`, `phase34_eval_at`,
+`phase34_numerical_derivative`, `is_unevaluated_integrate`.  The
+existing `eval_at` / `contains_head` helpers are kept intact (the
+Phase 34 numerical evaluator routes through the full `SymbolicBackend`
+to evaluate `Tan` / `Sqrt` / `Atan` correctly, while the existing
+`eval_at` is a manually-coded subset for Phases 26-28).
+
 ## [0.6.0] — 2026-05-18
 
 ### Added — Phases 29–33: algebraic simplification rules

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1422,6 +1422,185 @@ fn derivative_handler() -> Handler {
     })
 }
 
+// ---------------------------------------------------------------------------
+// Phase 34 — Weierstrass substitution for ∫ c/(a + b·sin(x)) dx and
+// ∫ c/(a + b·cos(x)) dx with rational a, b satisfying a² > b² (a > 0 for cos).
+// Mirrors Python symbolic-vm 0.59.0 and TypeScript symbolic-vm 0.7.0.
+//
+// Closed forms:
+//   ∫ 1/(a + b·sin x) dx = (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
+//   ∫ 1/(a + b·cos x) dx = (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
+//
+// Discriminant cases a² ≤ b² and a ≤ 0 for cos are deferred — they need
+// sign analysis the assumption-free port cannot perform symbolically.
+// ---------------------------------------------------------------------------
+
+/// Convert an IRNode to a `RatC` rational if it's an Integer or Rational
+/// literal.  Returns None for Float, Symbol, Apply.
+fn node_to_rc(node: &IRNode) -> Option<RatC> {
+    match node {
+        IRNode::Integer(n) => Some((*n as i128, 1)),
+        IRNode::Rational(n, d) => rc(*n as i128, *d as i128),
+        _ => None,
+    }
+}
+
+/// Build the IR for `√(rc)`, folding to a plain rational when both numerator
+/// and denominator are perfect integer squares.  Wraps in `Sqrt` otherwise.
+/// `rc` must be strictly positive — callers guard the discriminant first.
+fn weierstrass_sqrt_fraction_ir(rc_val: RatC) -> IRNode {
+    let (p, q) = rc_val;
+    if p <= 0 || q <= 0 {
+        // Defensive — produce a Sqrt of whatever rational we got.
+        return apply_node(
+            SQRT,
+            vec![rc_to_ir(rc_val).unwrap_or(IRNode::Float(rc_val.0 as f64 / rc_val.1 as f64))],
+        );
+    }
+    if let (Some(p_root), Some(q_root)) = (i128_sqrt(p), i128_sqrt(q)) {
+        if let Some(ir) = rc_to_ir((p_root, q_root)) {
+            return ir;
+        }
+    }
+    // Not a perfect-square pair — emit Sqrt(rational).
+    let inside = rc_to_ir(rc_val).unwrap_or(IRNode::Float(p as f64 / q as f64));
+    apply_node(SQRT, vec![inside])
+}
+
+/// Match `c·sin(x)`, `c·cos(x)`, `sin(x)`, `cos(x)`, or any `Neg`-wrapping.
+/// Returns `(c, trig_head_str)` where `trig_head_str` is `SIN` or `COS`.
+fn weierstrass_parse_const_times_trig_x(node: &IRNode, x: &str) -> Option<(RatC, &'static str)> {
+    let target = IRNode::Symbol(x.to_string());
+    if let IRNode::Apply(apply) = node {
+        // Bare sin(x) / cos(x) — coefficient is 1.
+        if apply.args.len() == 1 && apply.args[0] == target {
+            if apply.head == IRNode::Symbol(SIN.to_string()) {
+                return Some(((1, 1), SIN));
+            }
+            if apply.head == IRNode::Symbol(COS.to_string()) {
+                return Some(((1, 1), COS));
+            }
+        }
+        // Mul(c, sin/cos(x)) or Mul(sin/cos(x), c)
+        if apply.head == IRNode::Symbol(MUL.to_string()) && apply.args.len() == 2 {
+            let (a, b) = (&apply.args[0], &apply.args[1]);
+            for (const_side, trig_side) in [(a, b), (b, a)] {
+                if let Some(c) = node_to_rc(const_side) {
+                    if let IRNode::Apply(trig) = trig_side {
+                        if trig.args.len() == 1 && trig.args[0] == target {
+                            if trig.head == IRNode::Symbol(SIN.to_string()) {
+                                return Some((c, SIN));
+                            }
+                            if trig.head == IRNode::Symbol(COS.to_string()) {
+                                return Some((c, COS));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Neg(inner) — recurse one level and negate the coefficient.
+        if apply.head == IRNode::Symbol(NEG.to_string()) && apply.args.len() == 1 {
+            if let Some((c, head)) = weierstrass_parse_const_times_trig_x(&apply.args[0], x) {
+                return Some((rc_neg(c), head));
+            }
+        }
+    }
+    None
+}
+
+/// Parse `a + b·sin(x)` / `a + b·cos(x)` (any operand order, plus the
+/// SUB-headed variant) into `(a, b, trig_head_str)`.
+fn weierstrass_parse_a_plus_b_sincos(
+    node: &IRNode,
+    x: &str,
+) -> Option<(RatC, RatC, &'static str)> {
+    let IRNode::Apply(apply) = node else {
+        return None;
+    };
+    if apply.args.len() != 2 {
+        return None;
+    }
+    let (left, right) = (&apply.args[0], &apply.args[1]);
+    if apply.head == IRNode::Symbol(ADD.to_string()) {
+        for (const_side, trig_side) in [(left, right), (right, left)] {
+            if let Some(a_rc) = node_to_rc(const_side) {
+                if let Some((b_rc, head)) = weierstrass_parse_const_times_trig_x(trig_side, x) {
+                    return Some((a_rc, b_rc, head));
+                }
+            }
+        }
+        return None;
+    }
+    if apply.head == IRNode::Symbol(SUB.to_string()) {
+        // a − b·trig(x) = a + (−b)·trig(x)
+        if let Some(a_left) = node_to_rc(left) {
+            if let Some((b_rc, head)) = weierstrass_parse_const_times_trig_x(right, x) {
+                return Some((a_left, rc_neg(b_rc), head));
+            }
+        }
+        // b·trig(x) − a = −a + b·trig(x)
+        if let Some((b_left, head)) = weierstrass_parse_const_times_trig_x(left, x) {
+            if let Some(a_right) = node_to_rc(right) {
+                return Some((rc_neg(a_right), b_left, head));
+            }
+        }
+    }
+    None
+}
+
+/// Phase 34 entry point.  Returns the closed form when the integrand is
+/// `c / (a + b·sin/cos(x))` with rational c, a, b and a² > b² (a > 0 for cos),
+/// or `None` otherwise.
+fn try_weierstrass_one_over_linear_trig(
+    num: &IRNode,
+    den: &IRNode,
+    x: &str,
+) -> Option<IRNode> {
+    let c_rc = node_to_rc(num)?;
+    let (a_rc, b_rc, trig_head) = weierstrass_parse_a_plus_b_sincos(den, x)?;
+    // disc = a² − b²; must be strictly positive.
+    let a_sq = rc_mul(a_rc, a_rc)?;
+    let b_sq = rc_mul(b_rc, b_rc)?;
+    let disc = rc_sub(a_sq, b_sq)?;
+    if disc.0 <= 0 {
+        return None;
+    }
+    let sqrt_disc_ir = weierstrass_sqrt_fraction_ir(disc);
+    let tan_half = apply_node(
+        TAN,
+        vec![apply_node(
+            DIV,
+            vec![IRNode::Symbol(x.to_string()), IRNode::Integer(2)],
+        )],
+    );
+    let atan_arg = if trig_head == SIN {
+        // (a·tan(x/2) + b) / √disc
+        let a_ir = rc_to_ir(a_rc)?;
+        let b_ir = rc_to_ir(b_rc)?;
+        let top = apply_node(
+            ADD,
+            vec![apply_node(MUL, vec![a_ir, tan_half]), b_ir],
+        );
+        apply_node(DIV, vec![top, sqrt_disc_ir.clone()])
+    } else {
+        // cos branch — require a > 0 to avoid sign-flip.
+        if a_rc.0 <= 0 {
+            return None;
+        }
+        let ratio = rc_div(rc_sub(a_rc, b_rc)?, rc_add(a_rc, b_rc)?)?;
+        if ratio.0 <= 0 {
+            return None;
+        }
+        let sqrt_ratio_ir = weierstrass_sqrt_fraction_ir(ratio);
+        apply_node(MUL, vec![sqrt_ratio_ir, tan_half])
+    };
+    // Outer coefficient: 2c / √disc
+    let two_c = rc_mul(c_rc, (2, 1))?;
+    let coef_ir = apply_node(DIV, vec![rc_to_ir(two_c)?, sqrt_disc_ir]);
+    Some(apply_node(MUL, vec![coef_ir, apply_node(ATAN, vec![atan_arg])]))
+}
+
 fn integrate_handler() -> Handler {
     std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
         if expr.args.len() != 2 && expr.args.len() != 4 {
@@ -1499,6 +1678,12 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
         (MUL, [a, b]) if !depends_on(b, x) => apply_node(MUL, vec![b.clone(), integrate(a, x)]),
         (DIV, [c, denom]) if denom == &IRNode::Symbol(x.to_string()) && !depends_on(c, x) => {
             apply_node(MUL, vec![c.clone(), apply_node(LOG, vec![denom.clone()])])
+        }
+        // Phase 34: Weierstrass substitution for c / (a + b·sin/cos(x))
+        // when c, a, b are rational and a² > b² (and a > 0 for the cos case).
+        (DIV, [c, denom]) if !depends_on(c, x) => {
+            try_weierstrass_one_over_linear_trig(c, denom, x)
+                .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]))
         }
         (POW, [base, exponent]) if base == &IRNode::Symbol(x.to_string()) => {
             integrate_power_of_x(exponent, x)

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -2303,3 +2303,288 @@ fn strict_panics_on_symbolic_add() {
     // before Add even sees the arguments.
     strict().eval(apply(sym(ADD), vec![sym("x"), int(1)]));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 34: Weierstrass substitution for ∫ 1/(a + b·sin/cos x) dx
+// Mirrors the Python `test_phase34_weierstrass.py` and the TS
+// `phase34-weierstrass.test.ts` suites — numerical-derivative verification
+// and discriminant fallthrough checks.
+// ---------------------------------------------------------------------------
+
+/// Structural substitution: replace every occurrence of `var_name` in `node`
+/// with `value`.  Returns a fresh tree.
+fn phase34_subst(node: &symbolic_ir::IRNode, var_name: &str, value: &symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    if let symbolic_ir::IRNode::Symbol(name) = node {
+        if name == var_name {
+            return value.clone();
+        }
+    }
+    if let symbolic_ir::IRNode::Apply(apply) = node {
+        let new_args: Vec<symbolic_ir::IRNode> = apply
+            .args
+            .iter()
+            .map(|a| phase34_subst(a, var_name, value))
+            .collect();
+        return symbolic_ir::IRNode::Apply(Box::new(symbolic_ir::IRApply {
+            head: apply.head.clone(),
+            args: new_args,
+        }));
+    }
+    node.clone()
+}
+
+/// Evaluate `expr` after substituting x ← `x_val` through a fresh symbolic VM
+/// — so the full handler suite (including Tan, Sqrt, Atan) folds the tree.
+/// Returns NaN when the result is not numeric.
+fn phase34_eval_at(expr: &symbolic_ir::IRNode, x_val: f64) -> f64 {
+    let substituted = phase34_subst(expr, "x", &flt(x_val));
+    let folded = symbolic().eval(substituted);
+    match folded {
+        symbolic_ir::IRNode::Float(v) => v,
+        symbolic_ir::IRNode::Integer(n) => n as f64,
+        symbolic_ir::IRNode::Rational(n, d) => n as f64 / d as f64,
+        _ => f64::NAN,
+    }
+}
+
+/// Central-difference derivative of `expr` w.r.t. x at `x_val`.
+fn phase34_numerical_derivative(expr: &symbolic_ir::IRNode, x_val: f64) -> f64 {
+    let h = 1e-5;
+    (phase34_eval_at(expr, x_val + h) - phase34_eval_at(expr, x_val - h)) / (2.0 * h)
+}
+
+fn is_unevaluated_integrate(node: &symbolic_ir::IRNode) -> bool {
+    matches!(
+        node,
+        symbolic_ir::IRNode::Apply(apply)
+            if apply.head == symbolic_ir::IRNode::Symbol(INTEGRATE.to_string())
+    )
+}
+
+#[test]
+fn phase34_sin_two_plus_sin_closes_with_atan() {
+    // ∫ 1/(2 + sin x) dx — must close with an Atan in the body.
+    let integrand = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![int(2), apply(sym(SIN), vec![sym("x")])])],
+    );
+    let result = integrate(integrand);
+    assert!(
+        !is_unevaluated_integrate(&result),
+        "Phase 34 should close ∫ 1/(2+sin x) dx; got {result:?}"
+    );
+    assert!(
+        contains_head(&result, ATAN),
+        "Expected Atan in closed form; got {result:?}"
+    );
+}
+
+#[test]
+fn phase34_sin_two_plus_sin_derivative_matches() {
+    let integrand = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![int(2), apply(sym(SIN), vec![sym("x")])])],
+    );
+    let phi = integrate(integrand);
+    for &x_val in &[-2.5_f64, -1.0, -0.3, 0.0, 0.3, 1.0, 2.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (2.0 + x_val.sin());
+        assert!(
+            (got - expected).abs() < 1e-4,
+            "At x={x_val}: derivative={got}, expected={expected}"
+        );
+    }
+}
+
+#[test]
+fn phase34_sin_perfect_square_discriminant() {
+    // ∫ 1/(5 + 3·sin x) dx — disc=16 (perfect square) → Sqrt-free result.
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(
+                sym(ADD),
+                vec![int(5), apply(sym(MUL), vec![int(3), apply(sym(SIN), vec![sym("x")])])],
+            ),
+        ],
+    );
+    let phi = integrate(integrand);
+    assert!(
+        !contains_head(&phi, SQRT),
+        "Perfect-square disc should fold; got {phi:?}"
+    );
+    for &x_val in &[-1.0_f64, -0.2, 0.0, 0.7, 1.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (5.0 + 3.0 * x_val.sin());
+        assert!((got - expected).abs() < 1e-4);
+    }
+}
+
+#[test]
+fn phase34_sin_with_numerator_coefficient() {
+    // ∫ 3/(2 + sin x) dx — coefficient 3 must scale the closed form.
+    let integrand = apply(
+        sym(DIV),
+        vec![int(3), apply(sym(ADD), vec![int(2), apply(sym(SIN), vec![sym("x")])])],
+    );
+    let phi = integrate(integrand);
+    for &x_val in &[-1.0_f64, -0.2, 0.0, 0.7, 1.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 3.0 / (2.0 + x_val.sin());
+        assert!((got - expected).abs() < 1e-4);
+    }
+}
+
+#[test]
+fn phase34_sin_with_rational_coefficients() {
+    // ∫ 1/((3/2) + (1/2)·sin x) dx — rational a, b with disc = 2.
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(
+                sym(ADD),
+                vec![
+                    rat(3, 2),
+                    apply(sym(MUL), vec![rat(1, 2), apply(sym(SIN), vec![sym("x")])]),
+                ],
+            ),
+        ],
+    );
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi));
+    for &x_val in &[-1.5_f64, -0.4, 0.0, 0.4, 1.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (1.5 + 0.5 * x_val.sin());
+        assert!((got - expected).abs() < 1e-4);
+    }
+}
+
+#[test]
+fn phase34_cos_two_plus_cos_closes_and_matches() {
+    let integrand = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![int(2), apply(sym(COS), vec![sym("x")])])],
+    );
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi));
+    for &x_val in &[-1.5_f64, -0.4, 0.0, 0.4, 1.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (2.0 + x_val.cos());
+        assert!((got - expected).abs() < 1e-4);
+    }
+}
+
+#[test]
+fn phase34_cos_five_plus_three_cos_sqrt_free() {
+    // disc=16, ratio=(5-3)/(5+3)=1/4 — both perfect squares → no Sqrt.
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(
+                sym(ADD),
+                vec![int(5), apply(sym(MUL), vec![int(3), apply(sym(COS), vec![sym("x")])])],
+            ),
+        ],
+    );
+    let phi = integrate(integrand);
+    assert!(
+        !contains_head(&phi, SQRT),
+        "Expected Sqrt-free form; got {phi:?}"
+    );
+    for &x_val in &[-1.5_f64, -0.4, 0.0, 0.4, 1.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (5.0 + 3.0 * x_val.cos());
+        assert!((got - expected).abs() < 1e-4);
+    }
+}
+
+#[test]
+fn phase34_sin_operand_order_swapped() {
+    // ∫ 1/(sin x + 2) dx — constant on the right.  Must still close.
+    let integrand = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![apply(sym(SIN), vec![sym("x")]), int(2)])],
+    );
+    let result = integrate(integrand);
+    assert!(
+        !is_unevaluated_integrate(&result),
+        "Swapped form should still close; got {result:?}"
+    );
+}
+
+#[test]
+fn phase34_fallthrough_a_less_than_b() {
+    // ∫ 1/(1 + 2·sin x) dx — a²−b² = −3 < 0.  Log form deferred.
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(
+                sym(ADD),
+                vec![int(1), apply(sym(MUL), vec![int(2), apply(sym(SIN), vec![sym("x")])])],
+            ),
+        ],
+    );
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result));
+}
+
+#[test]
+fn phase34_fallthrough_a_equals_b() {
+    // ∫ 1/(1 + sin x) dx — a² = b² = 1.  Degenerate form deferred.
+    let integrand = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![int(1), apply(sym(SIN), vec![sym("x")])])],
+    );
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result));
+}
+
+#[test]
+fn phase34_fallthrough_non_bare_argument() {
+    // ∫ 1/(2 + sin(2x)) dx — argument isn't bare x.  Deferred.
+    let two_x = apply(sym(MUL), vec![int(2), sym("x")]);
+    let integrand = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![int(2), apply(sym(SIN), vec![two_x])])],
+    );
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result));
+}
+
+#[test]
+fn phase34_fallthrough_symbolic_coefficient() {
+    // ∫ 1/(a + sin x) dx — can't decide disc sign without assumptions.
+    let integrand = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![sym("a"), apply(sym(SIN), vec![sym("x")])])],
+    );
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result));
+}
+
+#[test]
+fn phase34_regression_pure_sin_unchanged() {
+    // ∫ sin(x) dx = −cos(x) must continue to work.
+    let result = integrate(apply(sym(SIN), vec![sym("x")]));
+    let cos_x = apply(sym(COS), vec![sym("x")]);
+    let neg_cos = apply(sym(NEG), vec![cos_x.clone()]);
+    let mul_neg = apply(sym(MUL), vec![int(-1), cos_x]);
+    assert!(result == neg_cos || result == mul_neg, "got {result:?}");
+}
+
+#[test]
+fn phase34_regression_one_over_cos_not_misinterpreted() {
+    // ∫ 1/cos(x) dx — denominator has no additive constant; Phase 34 must NOT
+    // fire and produce a spurious arctan of tan(x/2).
+    let integrand = apply(sym(DIV), vec![int(1), apply(sym(COS), vec![sym("x")])]);
+    let result = integrate(integrand);
+    if let symbolic_ir::IRNode::Apply(apply) = &result {
+        if apply.head == symbolic_ir::IRNode::Symbol(ATAN.to_string()) {
+            panic!("Phase 34 incorrectly fired on ∫ 1/cos(x) dx: {result:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports Phase 34 Weierstrass substitution from Python symbolic-vm 0.59.0
(PR #3472) and TypeScript symbolic-vm 0.7.0 (PR #3473) to Rust.

    ∫ 1/(a + b·sin x) dx → (2/√(a²−b²))·arctan((a·tan(x/2)+b)/√(a²−b²))
    ∫ 1/(a + b·cos x) dx → (2/√(a²−b²))·arctan(√((a−b)/(a+b))·tan(x/2))

Implementation (`src/handlers.rs`, ~185 lines) reuses the existing
RatC helpers (`rc`, `rc_add/sub/mul/div/neg`, `i128_sqrt`, `rc_to_ir`).
Wired into the `(DIV, [c, denom])` arm of `integrate` after the
existing `1/x` case.

Discriminant cases `a² ≤ b²` and `a ≤ 0` for cos are deferred
(sign analysis the assumption-free port cannot perform symbolically).

## Test plan

- [x] **14 new `#[test]` functions** in `tests/test_vm.rs` mirroring the
  Python and TS Phase 34 suites
- [x] Full Rust suite: **119 passed** (105 existing + 14 new)
- [x] `cargo build` clean (no warnings)
- [x] Security review: passed

## Version sequencing

Jumps `0.5.0 → 0.7.0` to leave `0.6.0` for the in-flight Phase 29-33
algebraic-rules port (PR #3468). Final order: 0.5.0 → 0.6.0 → 0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)