### PR TITLE
Add Board VM TCP socket bytecode

### DIFF
--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -4,7 +4,8 @@ use board_vm_ir::{
     parse_module, validate, CAP_ADC_READ, CAP_CAN_OPEN, CAP_CAN_READ, CAP_CAN_WRITE,
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
     CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
-    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_SPI_TRANSFER,
+    CAP_LED_MATRIX_FRAME, CAP_NETWORK_TCP_CLOSE, CAP_NETWORK_TCP_OPEN, CAP_NETWORK_TCP_READ,
+    CAP_NETWORK_TCP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_SPI_TRANSFER,
     CAP_STORAGE_READ, CAP_STORAGE_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, CAP_UART_OPEN,
     CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE, CAP_WATCHDOG_KICK,
 };
@@ -210,6 +211,30 @@ const STORAGE_READ_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescrip
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "storage.read",
+};
+const NETWORK_TCP_OPEN_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_NETWORK_TCP_OPEN,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "network.tcp.open",
+};
+const NETWORK_TCP_WRITE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_NETWORK_TCP_WRITE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "network.tcp.write",
+};
+const NETWORK_TCP_READ_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_NETWORK_TCP_READ,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "network.tcp.read",
+};
+const NETWORK_TCP_CLOSE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_NETWORK_TCP_CLOSE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "network.tcp.close",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -1208,6 +1233,46 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_AND_L
     WATCHDOG_KICK_DESCRIPTOR,
     STORAGE_WRITE_DESCRIPTOR,
     STORAGE_READ_DESCRIPTOR,
+    LED_MATRIX_FRAME_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+    PROGRAM_STORE_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_AND_LED_MATRIX_CAPABILITIES:
+    [CapabilityDescriptor<'static>; 36] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    PWM_WRITE_DESCRIPTOR,
+    ADC_READ_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    I2C_OPEN_DESCRIPTOR,
+    I2C_WRITE_U8_DESCRIPTOR,
+    I2C_READ_U8_DESCRIPTOR,
+    I2C_WRITE_DESCRIPTOR,
+    I2C_READ_DESCRIPTOR,
+    I2C_TRANSFER_DESCRIPTOR,
+    SPI_OPEN_DESCRIPTOR,
+    SPI_TRANSFER_DESCRIPTOR,
+    UART_OPEN_DESCRIPTOR,
+    UART_WRITE_DESCRIPTOR,
+    UART_READ_DESCRIPTOR,
+    CAN_OPEN_DESCRIPTOR,
+    CAN_WRITE_DESCRIPTOR,
+    CAN_READ_DESCRIPTOR,
+    RTC_NOW_DESCRIPTOR,
+    RTC_SET_DESCRIPTOR,
+    WATCHDOG_CONFIGURE_DESCRIPTOR,
+    WATCHDOG_KICK_DESCRIPTOR,
+    STORAGE_WRITE_DESCRIPTOR,
+    STORAGE_READ_DESCRIPTOR,
+    NETWORK_TCP_OPEN_DESCRIPTOR,
+    NETWORK_TCP_WRITE_DESCRIPTOR,
+    NETWORK_TCP_READ_DESCRIPTOR,
+    NETWORK_TCP_CLOSE_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
     PROGRAM_STORE_DESCRIPTOR,
@@ -2375,6 +2440,20 @@ mod tests {
         PROGRAM_STORE_DESCRIPTOR,
     ];
 
+    const NETWORK_TCP_CAPABILITIES: [CapabilityDescriptor<'static>; 11] = [
+        GPIO_OPEN_DESCRIPTOR,
+        GPIO_WRITE_DESCRIPTOR,
+        GPIO_READ_DESCRIPTOR,
+        GPIO_CLOSE_DESCRIPTOR,
+        TIME_SLEEP_MS_DESCRIPTOR,
+        TIME_NOW_MS_DESCRIPTOR,
+        NETWORK_TCP_OPEN_DESCRIPTOR,
+        NETWORK_TCP_WRITE_DESCRIPTOR,
+        NETWORK_TCP_READ_DESCRIPTOR,
+        NETWORK_TCP_CLOSE_DESCRIPTOR,
+        PROGRAM_RAM_EXEC_DESCRIPTOR,
+    ];
+
     fn new_device() -> Device {
         BoardVmDevice::new(
             DeviceDescriptor::blink_mvp("test-board", 0xB04D_1001),
@@ -2661,6 +2740,69 @@ mod tests {
         }
         decoder.finish().unwrap();
         assert!(found_store);
+    }
+
+    #[test]
+    fn descriptor_reports_network_tcp_bytecode_capabilities() {
+        let mut device = BoardVmDevice::new(
+            DeviceDescriptor {
+                board_id: "test-board",
+                runtime_id: DEFAULT_DEVICE_RUNTIME_ID,
+                board_nonce: 0xB04D_1001,
+                max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
+                supports_store_program: false,
+                capabilities: &NETWORK_TCP_CAPABILITIES,
+            },
+            FakeHal::new(CapabilitySet::blink_mvp().with_network_tcp()),
+        );
+        let mut session = HostSession::new();
+        let mut request = [0u8; 128];
+        let mut device_payload = [0u8; 256];
+        let mut response = [0u8; 320];
+
+        let caps = session.caps_query_frame(&mut request).unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..caps.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        let (header, mut decoder) = decode_caps_report_header(frame.payload).unwrap();
+
+        assert_eq!(
+            header.capability_count,
+            NETWORK_TCP_CAPABILITIES.len() as u32
+        );
+        let mut found = [false; 4];
+        for _ in 0..header.capability_count {
+            let capability = decoder.read_capability_descriptor().unwrap();
+            match capability.id {
+                CAP_NETWORK_TCP_OPEN => {
+                    found[0] = true;
+                    assert_eq!(capability.name, "network.tcp.open");
+                    assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
+                }
+                CAP_NETWORK_TCP_WRITE => {
+                    found[1] = true;
+                    assert_eq!(capability.name, "network.tcp.write");
+                    assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
+                }
+                CAP_NETWORK_TCP_READ => {
+                    found[2] = true;
+                    assert_eq!(capability.name, "network.tcp.read");
+                    assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
+                }
+                CAP_NETWORK_TCP_CLOSE => {
+                    found[3] = true;
+                    assert_eq!(capability.name, "network.tcp.close");
+                    assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
+                }
+                _ => {}
+            }
+        }
+        decoder.finish().unwrap();
+        assert_eq!(found, [true; 4]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -2,11 +2,12 @@ use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_ADC_READ, CAP_CAN_OPEN,
     CAP_CAN_READ, CAP_CAN_WRITE, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ,
     CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE,
-    CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN,
-    CAP_SPI_TRANSFER, CAP_STORAGE_READ, CAP_STORAGE_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
-    CAP_UART_OPEN, CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE, CAP_WATCHDOG_KICK,
-    FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MAX_BYTE_BUFFER_LEN,
-    MODULE_MAGIC, MODULE_VERSION,
+    CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_NETWORK_TCP_CLOSE, CAP_NETWORK_TCP_OPEN,
+    CAP_NETWORK_TCP_READ, CAP_NETWORK_TCP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET,
+    CAP_SPI_OPEN, CAP_SPI_TRANSFER, CAP_STORAGE_READ, CAP_STORAGE_WRITE, CAP_TIME_NOW_MS,
+    CAP_TIME_SLEEP_MS, CAP_UART_OPEN, CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE,
+    CAP_WATCHDOG_KICK, FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+    MAX_BYTE_BUFFER_LEN, MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -89,6 +90,14 @@ pub const STORAGE_WRITE_MAX_MODULE_LEN: usize =
     8 + 1 + STORAGE_WRITE_CODE_LEN + 1 + MAX_BYTE_BUFFER_LEN;
 pub const STORAGE_READ_CODE_LEN: usize = 10;
 pub const STORAGE_READ_MODULE_LEN: usize = 20;
+pub const NETWORK_TCP_OPEN_CODE_LEN: usize = 14;
+pub const NETWORK_TCP_OPEN_MODULE_LEN: usize = 24;
+pub const NETWORK_TCP_WRITE_CODE_LEN: usize = 5;
+pub const NETWORK_TCP_WRITE_MODULE_LEN: usize = 15;
+pub const NETWORK_TCP_READ_CODE_LEN: usize = 4;
+pub const NETWORK_TCP_READ_MODULE_LEN: usize = 14;
+pub const NETWORK_TCP_CLOSE_CODE_LEN: usize = 2;
+pub const NETWORK_TCP_CLOSE_MODULE_LEN: usize = 12;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -310,6 +319,30 @@ pub struct StorageReadProgram {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkTcpOpenProgram {
+    pub interface: u8,
+    pub remote_ipv4: u32,
+    pub remote_port: u16,
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkTcpWriteProgram {
+    pub byte: u8,
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkTcpReadProgram {
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkTcpCloseProgram {
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct I2cWriteU8Program {
     pub address: u16,
     pub byte: u8,
@@ -487,6 +520,47 @@ impl StorageReadProgram {
             len,
             max_stack: 3,
         }
+    }
+}
+
+impl NetworkTcpOpenProgram {
+    pub const fn new(interface: u8, remote_ipv4: u32, remote_port: u16) -> Self {
+        Self {
+            interface,
+            remote_ipv4,
+            remote_port,
+            max_stack: 4,
+        }
+    }
+}
+
+impl NetworkTcpWriteProgram {
+    pub const fn new(byte: u8) -> Self {
+        Self { byte, max_stack: 3 }
+    }
+}
+
+impl NetworkTcpReadProgram {
+    pub const fn new() -> Self {
+        Self { max_stack: 2 }
+    }
+}
+
+impl Default for NetworkTcpReadProgram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NetworkTcpCloseProgram {
+    pub const fn new() -> Self {
+        Self { max_stack: 1 }
+    }
+}
+
+impl Default for NetworkTcpCloseProgram {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -2055,6 +2129,173 @@ pub fn write_storage_read_module(
     Ok(offset)
 }
 
+pub fn write_network_tcp_open_code(
+    program: NetworkTcpOpenProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_TCP_OPEN_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.interface)?;
+    write_push_u32(out, &mut offset, program.remote_ipv4)?;
+    write_push_u16(out, &mut offset, program.remote_port)?;
+    write_call_u8(out, &mut offset, CAP_NETWORK_TCP_OPEN)?;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_network_tcp_open_module(
+    program: NetworkTcpOpenProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_TCP_OPEN_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; NETWORK_TCP_OPEN_CODE_LEN];
+    let code_len = write_network_tcp_open_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(0, program.max_stack, &code[..code_len]),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_network_tcp(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
+pub fn write_network_tcp_write_code(
+    program: NetworkTcpWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_TCP_WRITE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.byte)?;
+    write_call_u8(out, &mut offset, CAP_NETWORK_TCP_WRITE)?;
+    Ok(offset)
+}
+
+pub fn write_network_tcp_write_module(
+    program: NetworkTcpWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_TCP_WRITE_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; NETWORK_TCP_WRITE_CODE_LEN];
+    let code_len = write_network_tcp_write_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_network_tcp(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
+pub fn write_network_tcp_read_code(
+    _program: NetworkTcpReadProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_TCP_READ_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_call_u8(out, &mut offset, CAP_NETWORK_TCP_READ)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_network_tcp_read_module(
+    program: NetworkTcpReadProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_TCP_READ_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; NETWORK_TCP_READ_CODE_LEN];
+    let code_len = write_network_tcp_read_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_network_tcp(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
+pub fn write_network_tcp_close_code(
+    _program: NetworkTcpCloseProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_TCP_CLOSE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_call_u8(out, &mut offset, CAP_NETWORK_TCP_CLOSE)?;
+    Ok(offset)
+}
+
+pub fn write_network_tcp_close_module(
+    program: NetworkTcpCloseProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_TCP_CLOSE_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; NETWORK_TCP_CLOSE_CODE_LEN];
+    let code_len = write_network_tcp_close_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_network_tcp(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn spi_transfer_module_len(write_len: usize) -> Result<usize, HostError> {
     if write_len > MAX_BYTE_BUFFER_LEN {
         return Err(HostError::ProgramTooLarge);
@@ -2588,8 +2829,9 @@ mod tests {
         collect_required_capabilities, parse_module, validate, CapabilitySet, ModuleError,
         CAP_ADC_READ, CAP_CAN_OPEN, CAP_CAN_READ, CAP_CAN_WRITE, CAP_DAC_WRITE_U12, CAP_I2C_OPEN,
         CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
-        CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_UART_READ,
-        CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE, CAP_WATCHDOG_KICK,
+        CAP_LED_MATRIX_FRAME, CAP_NETWORK_TCP_CLOSE, CAP_NETWORK_TCP_OPEN, CAP_NETWORK_TCP_READ,
+        CAP_NETWORK_TCP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN,
+        CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE, CAP_WATCHDOG_KICK,
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
@@ -2667,6 +2909,19 @@ mod tests {
     ];
     const CAN_READ_MODULE_HEX: [u8; CAN_READ_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x02, 0x00, 0x04, 0x20, 0x40, 0x33, 0x50, 0x00,
+    ];
+    const NETWORK_TCP_OPEN_MODULE_HEX: [u8; NETWORK_TCP_OPEN_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x04, 0x00, 0x0E, 0x12, 0x00, 0x14, 0x2A, 0x01, 0xA8,
+        0xC0, 0x13, 0x90, 0x1F, 0x40, 0x3A, 0x20, 0x50, 0x00,
+    ];
+    const NETWORK_TCP_WRITE_A5_MODULE_HEX: [u8; NETWORK_TCP_WRITE_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x03, 0x00, 0x05, 0x20, 0x12, 0xA5, 0x40, 0x3B, 0x00,
+    ];
+    const NETWORK_TCP_READ_MODULE_HEX: [u8; NETWORK_TCP_READ_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x02, 0x00, 0x04, 0x20, 0x40, 0x3C, 0x50, 0x00,
+    ];
+    const NETWORK_TCP_CLOSE_MODULE_HEX: [u8; NETWORK_TCP_CLOSE_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x01, 0x00, 0x02, 0x40, 0x3D, 0x00,
     ];
     const RTC_NOW_MODULE_HEX: [u8; RTC_NOW_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x03, 0x40, 0x34, 0x50, 0x00,
@@ -3003,6 +3258,60 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_CAN_READ]);
+    }
+
+    #[test]
+    fn builds_network_tcp_open_module() {
+        let mut module = [0u8; NETWORK_TCP_OPEN_MODULE_LEN];
+        let len = write_network_tcp_open_module(
+            NetworkTcpOpenProgram::new(0, 0xc0a8_012a, 8080),
+            &mut module,
+        )
+        .unwrap();
+        assert_eq!(len, NETWORK_TCP_OPEN_MODULE_LEN);
+        assert_eq!(module, NETWORK_TCP_OPEN_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_network_tcp(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_NETWORK_TCP_OPEN]);
+    }
+
+    #[test]
+    fn builds_network_tcp_byte_io_and_close_modules() {
+        let mut write = [0u8; NETWORK_TCP_WRITE_MODULE_LEN];
+        let write_len =
+            write_network_tcp_write_module(NetworkTcpWriteProgram::new(0xa5), &mut write).unwrap();
+        assert_eq!(write_len, NETWORK_TCP_WRITE_MODULE_LEN);
+        assert_eq!(write, NETWORK_TCP_WRITE_A5_MODULE_HEX);
+        let parsed = parse_module(&write).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_network_tcp(), 3).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_NETWORK_TCP_WRITE]);
+
+        let mut read = [0u8; NETWORK_TCP_READ_MODULE_LEN];
+        let read_len =
+            write_network_tcp_read_module(NetworkTcpReadProgram::new(), &mut read).unwrap();
+        assert_eq!(read_len, NETWORK_TCP_READ_MODULE_LEN);
+        assert_eq!(read, NETWORK_TCP_READ_MODULE_HEX);
+        let parsed = parse_module(&read).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_network_tcp(), 2).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_NETWORK_TCP_READ]);
+
+        let mut close = [0u8; NETWORK_TCP_CLOSE_MODULE_LEN];
+        let close_len =
+            write_network_tcp_close_module(NetworkTcpCloseProgram::new(), &mut close).unwrap();
+        assert_eq!(close_len, NETWORK_TCP_CLOSE_MODULE_LEN);
+        assert_eq!(close, NETWORK_TCP_CLOSE_MODULE_HEX);
+        let parsed = parse_module(&close).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_network_tcp(), 1).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_NETWORK_TCP_CLOSE]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -41,6 +41,10 @@ pub const CAP_WATCHDOG_CONFIGURE: u16 = 0x36;
 pub const CAP_WATCHDOG_KICK: u16 = 0x37;
 pub const CAP_STORAGE_WRITE: u16 = 0x38;
 pub const CAP_STORAGE_READ: u16 = 0x39;
+pub const CAP_NETWORK_TCP_OPEN: u16 = 0x3A;
+pub const CAP_NETWORK_TCP_WRITE: u16 = 0x3B;
+pub const CAP_NETWORK_TCP_READ: u16 = 0x3C;
+pub const CAP_NETWORK_TCP_CLOSE: u16 = 0x3D;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
 const CAP_GPIO_WRITE_U8: u8 = CAP_GPIO_WRITE as u8;
@@ -72,6 +76,10 @@ const CAP_WATCHDOG_CONFIGURE_U8: u8 = CAP_WATCHDOG_CONFIGURE as u8;
 const CAP_WATCHDOG_KICK_U8: u8 = CAP_WATCHDOG_KICK as u8;
 const CAP_STORAGE_WRITE_U8: u8 = CAP_STORAGE_WRITE as u8;
 const CAP_STORAGE_READ_U8: u8 = CAP_STORAGE_READ as u8;
+const CAP_NETWORK_TCP_OPEN_U8: u8 = CAP_NETWORK_TCP_OPEN as u8;
+const CAP_NETWORK_TCP_WRITE_U8: u8 = CAP_NETWORK_TCP_WRITE as u8;
+const CAP_NETWORK_TCP_READ_U8: u8 = CAP_NETWORK_TCP_READ as u8;
+const CAP_NETWORK_TCP_CLOSE_U8: u8 = CAP_NETWORK_TCP_CLOSE as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Op {
@@ -157,6 +165,7 @@ pub struct CapabilitySet {
     pub rtc: bool,
     pub watchdog: bool,
     pub storage: bool,
+    pub network_tcp: bool,
 }
 
 impl CapabilitySet {
@@ -175,6 +184,7 @@ impl CapabilitySet {
             rtc: false,
             watchdog: false,
             storage: false,
+            network_tcp: false,
         }
     }
 
@@ -193,6 +203,7 @@ impl CapabilitySet {
             rtc: false,
             watchdog: false,
             storage: false,
+            network_tcp: false,
         }
     }
 
@@ -249,6 +260,13 @@ impl CapabilitySet {
         }
     }
 
+    pub const fn with_network_tcp(self) -> Self {
+        Self {
+            network_tcp: true,
+            ..self
+        }
+    }
+
     pub const fn supports(self, capability_id: u16) -> bool {
         match capability_id {
             CAP_GPIO_OPEN | CAP_GPIO_WRITE | CAP_GPIO_READ | CAP_GPIO_CLOSE => self.gpio_digital,
@@ -265,6 +283,10 @@ impl CapabilitySet {
             CAP_RTC_NOW | CAP_RTC_SET => self.rtc,
             CAP_WATCHDOG_CONFIGURE | CAP_WATCHDOG_KICK => self.watchdog,
             CAP_STORAGE_WRITE | CAP_STORAGE_READ => self.storage,
+            CAP_NETWORK_TCP_OPEN
+            | CAP_NETWORK_TCP_WRITE
+            | CAP_NETWORK_TCP_READ
+            | CAP_NETWORK_TCP_CLOSE => self.network_tcp,
             _ => false,
         }
     }
@@ -550,6 +572,10 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_WATCHDOG_KICK_U8) | Op::CallU16(CAP_WATCHDOG_KICK) => (0, 0),
         Op::CallU8(CAP_STORAGE_WRITE_U8) | Op::CallU16(CAP_STORAGE_WRITE) => (3, 0),
         Op::CallU8(CAP_STORAGE_READ_U8) | Op::CallU16(CAP_STORAGE_READ) => (3, 1),
+        Op::CallU8(CAP_NETWORK_TCP_OPEN_U8) | Op::CallU16(CAP_NETWORK_TCP_OPEN) => (3, 1),
+        Op::CallU8(CAP_NETWORK_TCP_WRITE_U8) | Op::CallU16(CAP_NETWORK_TCP_WRITE) => (2, 0),
+        Op::CallU8(CAP_NETWORK_TCP_READ_U8) | Op::CallU16(CAP_NETWORK_TCP_READ) => (1, 1),
+        Op::CallU8(CAP_NETWORK_TCP_CLOSE_U8) | Op::CallU16(CAP_NETWORK_TCP_CLOSE) => (1, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
     }

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -3806,6 +3806,10 @@ mod tests {
         assert!(uno.capabilities.contains(&"network.ipv4".to_owned()));
         assert!(uno.capabilities.contains(&"network.tcp".to_owned()));
         assert!(uno.capabilities.contains(&"network.udp".to_owned()));
+        assert!(uno.capabilities.contains(&"network.tcp.open".to_owned()));
+        assert!(uno.capabilities.contains(&"network.tcp.write".to_owned()));
+        assert!(uno.capabilities.contains(&"network.tcp.read".to_owned()));
+        assert!(uno.capabilities.contains(&"network.tcp.close".to_owned()));
         assert_eq!(uno.network_interfaces.len(), 1);
         let uno_network = &uno.network_interfaces[0];
         assert_eq!(uno_network.interface, 0);

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -4,7 +4,8 @@ use board_vm_ir::{
     decode_next, validate, CapabilitySet, Module, Op, CAP_ADC_READ, CAP_CAN_OPEN, CAP_CAN_READ,
     CAP_CAN_WRITE, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE,
     CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
-    CAP_LED_MATRIX_FRAME, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_SPI_TRANSFER,
+    CAP_LED_MATRIX_FRAME, CAP_NETWORK_TCP_CLOSE, CAP_NETWORK_TCP_OPEN, CAP_NETWORK_TCP_READ,
+    CAP_NETWORK_TCP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_SPI_TRANSFER,
     CAP_STORAGE_READ, CAP_STORAGE_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, CAP_UART_OPEN,
     CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE, CAP_WATCHDOG_KICK, MAX_BYTE_BUFFER_LEN,
 };
@@ -223,6 +224,27 @@ pub trait BoardHal {
         Err(HalError::UnsupportedMode)
     }
 
+    fn network_tcp_open(
+        &mut self,
+        _interface: u16,
+        _remote_ipv4: u32,
+        _remote_port: u16,
+    ) -> Result<u32, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn network_tcp_write(&mut self, _token: u32, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn network_tcp_read(&mut self, _token: u32) -> Result<u8, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn network_tcp_close(&mut self, _token: u32) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn store_program(
         &mut self,
         _program_id: u16,
@@ -315,6 +337,7 @@ enum HandleKind {
     Spi,
     Uart,
     Can,
+    NetworkTcp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -871,6 +894,54 @@ where
                         })?;
                 self.push(Value::Bytes(bytes), ip)
             }
+            CAP_NETWORK_TCP_OPEN => {
+                let remote_port = self.pop_u16(ip)?;
+                let remote_ipv4 = self.pop_u32(ip)?;
+                let interface = self.pop_u16(ip)?;
+                let token = self
+                    .hal
+                    .network_tcp_open(interface, remote_ipv4, remote_port)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                let handle = self.alloc_handle(HandleKind::NetworkTcp, token, ip)?;
+                self.push(Value::Handle(handle), ip)
+            }
+            CAP_NETWORK_TCP_WRITE => {
+                let byte = self.pop_u8(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::NetworkTcp, ip)?;
+                self.hal
+                    .network_tcp_write(token, byte)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })
+            }
+            CAP_NETWORK_TCP_READ => {
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::NetworkTcp, ip)?;
+                let byte = self
+                    .hal
+                    .network_tcp_read(token)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                self.push(Value::U8(byte), ip)
+            }
+            CAP_NETWORK_TCP_CLOSE => {
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::NetworkTcp, ip)?;
+                self.hal
+                    .network_tcp_close(token)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                self.close_handle(handle, ip)
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -1144,6 +1215,10 @@ mod tests {
         WatchdogKick,
         StorageWrite(u16, u16, ByteBuffer),
         StorageRead(u16, u16, u8),
+        NetworkTcpOpen(u16, u32, u16),
+        NetworkTcpWrite(u32, u8),
+        NetworkTcpRead(u32),
+        NetworkTcpClose(u32),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -1176,6 +1251,7 @@ mod tests {
                 .with_rtc()
                 .with_watchdog()
                 .with_storage()
+                .with_network_tcp()
                 .with_led_matrix()
         }
 
@@ -1373,6 +1449,32 @@ mod tests {
                 *byte = pattern[index % pattern.len()];
             }
             ByteBuffer::from_slice(&bytes).map_err(|_| HalError::UnsupportedMode)
+        }
+
+        fn network_tcp_open(
+            &mut self,
+            interface: u16,
+            remote_ipv4: u32,
+            remote_port: u16,
+        ) -> Result<u32, HalError> {
+            self.events
+                .push(Event::NetworkTcpOpen(interface, remote_ipv4, remote_port));
+            Ok(0x5_2002)
+        }
+
+        fn network_tcp_write(&mut self, token: u32, byte: u8) -> Result<(), HalError> {
+            self.events.push(Event::NetworkTcpWrite(token, byte));
+            Ok(())
+        }
+
+        fn network_tcp_read(&mut self, token: u32) -> Result<u8, HalError> {
+            self.events.push(Event::NetworkTcpRead(token));
+            Ok(0x42)
+        }
+
+        fn network_tcp_close(&mut self, token: u32) -> Result<(), HalError> {
+            self.events.push(Event::NetworkTcpClose(token));
+            Ok(())
         }
 
         fn led_matrix_frame(&mut self, frame: [u32; 3]) -> Result<(), HalError> {
@@ -1803,6 +1905,50 @@ mod tests {
             Value::Bytes(ByteBuffer::from_slice(&[0xde, 0xad]).unwrap())
         );
         assert_eq!(runtime.hal().events, vec![Event::StorageRead(0, 0x0010, 2)]);
+    }
+
+    #[test]
+    fn network_tcp_dispatches_socket_open_byte_io_and_close() {
+        let mut runtime: Runtime<FakeHal, 4, 1> = Runtime::new(FakeHal::new());
+        let code = [
+            0x12,
+            0x00,
+            0x14,
+            0x2a,
+            0x01,
+            0xa8,
+            0xc0,
+            0x13,
+            0x90,
+            0x1f,
+            0x40,
+            CAP_NETWORK_TCP_OPEN as u8,
+            0x20,
+            0x12,
+            0x41,
+            0x40,
+            CAP_NETWORK_TCP_WRITE as u8,
+            0x20,
+            0x40,
+            CAP_NETWORK_TCP_READ as u8,
+            0x21,
+            0x40,
+            CAP_NETWORK_TCP_CLOSE as u8,
+        ];
+
+        let report = runtime.run_code(&code, 20).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.open_handles, 0);
+        assert_eq!(
+            runtime.hal().events,
+            vec![
+                Event::NetworkTcpOpen(0, 0xc0a8_012a, 8080),
+                Event::NetworkTcpWrite(0x5_2002, 0x41),
+                Event::NetworkTcpRead(0x5_2002),
+                Event::NetworkTcpClose(0x5_2002),
+            ]
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -229,7 +229,7 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 32] = [
     "program.store",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 39] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 43] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -237,6 +237,10 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 39] = [
     "network.ipv4",
     "network.tcp",
     "network.udp",
+    "network.tcp.open",
+    "network.tcp.write",
+    "network.tcp.read",
+    "network.tcp.close",
     "gpio.open",
     "gpio.write",
     "gpio.read",
@@ -1122,6 +1126,10 @@ mod tests {
         assert!(uno_r4_wifi.capabilities.contains(&"network.ipv4"));
         assert!(uno_r4_wifi.capabilities.contains(&"network.tcp"));
         assert!(uno_r4_wifi.capabilities.contains(&"network.udp"));
+        assert!(uno_r4_wifi.capabilities.contains(&"network.tcp.open"));
+        assert!(uno_r4_wifi.capabilities.contains(&"network.tcp.write"));
+        assert!(uno_r4_wifi.capabilities.contains(&"network.tcp.read"));
+        assert!(uno_r4_wifi.capabilities.contains(&"network.tcp.close"));
         assert_eq!(
             uno_r4_wifi.network_interfaces,
             &UNO_R4_WIFI_NETWORK_INTERFACES

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -23,6 +23,7 @@ use board_vm_device::{
     BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_AND_LED_MATRIX_CAPABILITIES,
     BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_AND_STORAGE_CAPABILITIES,
     BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_AND_LED_MATRIX_CAPABILITIES,
     BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_RTC_AND_LED_MATRIX_CAPABILITIES,
     BLINK_MVP_WITH_PWM_AND_ADC_CAPABILITIES, BLINK_MVP_WITH_PWM_AND_DAC_CAPABILITIES,
     BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_PWM_CAPABILITIES,
@@ -531,7 +532,8 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
         .with_can()
         .with_rtc()
         .with_watchdog()
-        .with_storage(),
+        .with_storage()
+        .with_network_tcp(),
     digital_pins: &UNO_R4_DIGITAL_PINS,
     i2c_buses: &UNO_R4_WIFI_I2C_BUSES,
     spi_buses: &UNO_R4_SPI_BUSES,
@@ -586,6 +588,10 @@ pub trait UnoR4Backend {
     }
 
     fn supports_storage(&self) -> bool {
+        false
+    }
+
+    fn supports_network_tcp(&self) -> bool {
         false
     }
 
@@ -663,6 +669,27 @@ pub trait UnoR4Backend {
         _offset: u16,
         _len: u8,
     ) -> Result<ByteBuffer, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn open_network_tcp(
+        &mut self,
+        _interface: u8,
+        _remote_ipv4: u32,
+        _remote_port: u16,
+    ) -> Result<u32, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn write_network_tcp(&mut self, _socket: u8, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn read_network_tcp(&mut self, _socket: u8) -> Result<u8, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn close_network_tcp(&mut self, _socket: u8) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -766,6 +793,8 @@ where
         capabilities.rtc = self.backend.supports_rtc();
         capabilities.watchdog = self.backend.supports_watchdog();
         capabilities.storage = self.backend.supports_storage();
+        capabilities.network_tcp =
+            self.target.supports_wifi_module && self.backend.supports_network_tcp();
         capabilities
     }
 }
@@ -903,6 +932,35 @@ where
     fn storage_read(&mut self, region: u16, offset: u16, len: u8) -> Result<ByteBuffer, HalError> {
         let region = normalize_storage_region(self.target, region, offset, len)?;
         self.backend.storage_read(region, offset, len)
+    }
+
+    fn network_tcp_open(
+        &mut self,
+        interface: u16,
+        remote_ipv4: u32,
+        remote_port: u16,
+    ) -> Result<u32, HalError> {
+        if !self.target.supports_wifi_module {
+            return Err(HalError::UnsupportedMode);
+        }
+        let interface = normalize_network_interface(interface)?;
+        self.backend
+            .open_network_tcp(interface, remote_ipv4, remote_port)
+    }
+
+    fn network_tcp_write(&mut self, token: u32, byte: u8) -> Result<(), HalError> {
+        let socket = normalize_network_socket(token)?;
+        self.backend.write_network_tcp(socket, byte)
+    }
+
+    fn network_tcp_read(&mut self, token: u32) -> Result<u8, HalError> {
+        let socket = normalize_network_socket(token)?;
+        self.backend.read_network_tcp(socket)
+    }
+
+    fn network_tcp_close(&mut self, token: u32) -> Result<(), HalError> {
+        let socket = normalize_network_socket(token)?;
+        self.backend.close_network_tcp(socket)
     }
 
     fn store_program(
@@ -1165,6 +1223,18 @@ fn normalize_storage_region(
     }
 }
 
+fn normalize_network_interface(interface: u16) -> Result<u8, HalError> {
+    if interface == 0 {
+        Ok(0)
+    } else {
+        Err(HalError::InvalidPin)
+    }
+}
+
+fn normalize_network_socket(token: u32) -> Result<u8, HalError> {
+    u8::try_from(token & 0xff).map_err(|_| HalError::InvalidPin)
+}
+
 fn crc32_ieee(bytes: &[u8]) -> u32 {
     let mut crc = 0xFFFF_FFFFu32;
     for byte in bytes {
@@ -1195,7 +1265,22 @@ fn uno_r4_device_descriptor_for_capabilities(
         board_nonce,
         max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
         supports_store_program: capabilities.storage,
-        capabilities: if target.supports_led_matrix
+        capabilities: if target.supports_wifi_module
+            && target.supports_led_matrix
+            && capabilities.pwm
+            && capabilities.adc
+            && capabilities.dac
+            && capabilities.i2c
+            && capabilities.spi
+            && capabilities.uart
+            && capabilities.can
+            && capabilities.rtc
+            && capabilities.watchdog
+            && capabilities.storage
+            && capabilities.network_tcp
+        {
+            &BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_led_matrix
             && capabilities.pwm
             && capabilities.adc
             && capabilities.dac
@@ -1454,6 +1539,10 @@ mod tests {
         WatchdogKick,
         StorageWrite(u8, u16, Vec<u8>),
         StorageRead(u8, u16, u8),
+        NetworkTcpOpen(u8, u32, u16),
+        NetworkTcpWrite(u8, u8),
+        NetworkTcpRead(u8),
+        NetworkTcpClose(u8),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -1534,6 +1623,10 @@ mod tests {
         }
 
         fn supports_storage(&self) -> bool {
+            true
+        }
+
+        fn supports_network_tcp(&self) -> bool {
             true
         }
 
@@ -1635,6 +1728,32 @@ mod tests {
                 *byte = pattern[index % pattern.len()];
             }
             ByteBuffer::from_slice(&bytes).map_err(|_| HalError::UnsupportedMode)
+        }
+
+        fn open_network_tcp(
+            &mut self,
+            interface: u8,
+            remote_ipv4: u32,
+            remote_port: u16,
+        ) -> Result<u32, HalError> {
+            self.events
+                .push(Event::NetworkTcpOpen(interface, remote_ipv4, remote_port));
+            Ok(0x5_2002)
+        }
+
+        fn write_network_tcp(&mut self, socket: u8, byte: u8) -> Result<(), HalError> {
+            self.events.push(Event::NetworkTcpWrite(socket, byte));
+            Ok(())
+        }
+
+        fn read_network_tcp(&mut self, socket: u8) -> Result<u8, HalError> {
+            self.events.push(Event::NetworkTcpRead(socket));
+            Ok(0x42)
+        }
+
+        fn close_network_tcp(&mut self, socket: u8) -> Result<(), HalError> {
+            self.events.push(Event::NetworkTcpClose(socket));
+            Ok(())
         }
 
         fn transfer_spi(
@@ -1866,7 +1985,7 @@ mod tests {
         assert!(descriptor.supports_store_program);
         assert_eq!(
             descriptor.capabilities.len(),
-            BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_AND_LED_MATRIX_CAPABILITIES
+            BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_AND_LED_MATRIX_CAPABILITIES
                 .len()
         );
         assert!(descriptor
@@ -1876,6 +1995,10 @@ mod tests {
                 |capability| capability.id == board_vm_protocol::CAP_PROGRAM_STORE
                     && capability.name == "program.store"
             ));
+        assert!(descriptor.capabilities.iter().any(|capability| {
+            capability.id == board_vm_ir::CAP_NETWORK_TCP_OPEN
+                && capability.name == "network.tcp.open"
+        }));
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -1929,6 +2052,21 @@ mod tests {
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_STORAGE_READ));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_TCP_OPEN));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_TCP_WRITE));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_TCP_READ));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_TCP_CLOSE));
+        assert!(!UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_TCP_OPEN));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -2268,6 +2406,42 @@ mod tests {
         assert_eq!(
             board.backend().events,
             vec![Event::StorageRead(0, 0x0010, 2)]
+        );
+    }
+
+    #[test]
+    fn network_tcp_runs_through_wifi_backend() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        let token = board.network_tcp_open(0, 0xc0a8_012a, 8080).unwrap();
+        board.network_tcp_write(token, 0x41).unwrap();
+        let byte = board.network_tcp_read(token).unwrap();
+        board.network_tcp_close(token).unwrap();
+
+        assert_eq!(byte, 0x42);
+        assert_eq!(
+            board.backend().events,
+            vec![
+                Event::NetworkTcpOpen(0, 0xc0a8_012a, 8080),
+                Event::NetworkTcpWrite(2, 0x41),
+                Event::NetworkTcpRead(2),
+                Event::NetworkTcpClose(2),
+            ]
+        );
+    }
+
+    #[test]
+    fn network_tcp_rejects_non_wifi_target_or_unknown_interface() {
+        let mut minima = UnoR4Board::minima(FakeBackend::new());
+        assert_eq!(
+            minima.network_tcp_open(0, 0xc0a8_012a, 8080),
+            Err(HalError::UnsupportedMode)
+        );
+
+        let mut wifi = UnoR4Board::wifi(FakeBackend::new());
+        assert_eq!(
+            wifi.network_tcp_open(1, 0xc0a8_012a, 8080),
+            Err(HalError::InvalidPin)
         );
     }
 

--- a/code/specs/BVM03-board-vm-rust-runtime.md
+++ b/code/specs/BVM03-board-vm-rust-runtime.md
@@ -131,6 +131,14 @@ The current no-heap Rust HAL exposes this first tranche as
 may lower that protocol-level request into their existing bounded storage writes,
 while leaving language frontends as thin builders for the `STORE_PROGRAM` frame.
 
+The first network tranche keeps the same no-heap shape: `network.tcp.open`
+accepts an interface id, an IPv4 address encoded as a `u32`, and a remote port,
+then returns a portable socket handle. `network.tcp.write`, `network.tcp.read`,
+and `network.tcp.close` operate on that handle and delegate to narrow
+`BoardHal::network_tcp_*` hooks. Host SDKs build bytecode for these calls; board
+ports decide when a concrete backend can actually drive a WiFi or Ethernet
+module.
+
 `HandleToken` is private to the board adapter. The portable VM only sees compact
 `Handle` ids.
 
@@ -142,6 +150,7 @@ The interpreter dispatches `CALL_U8` and `CALL_U16` through a capability table.
 CALL_U8 0x01 -> gpio.open
 CALL_U8 0x02 -> gpio.write
 CALL_U8 0x10 -> time.sleep_ms
+CALL_U8 0x3a -> network.tcp.open
 ```
 
 Each handler:

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -37,7 +37,7 @@ Source snapshot:
 | EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | descriptor metadata and bounded bytecode read/write implemented | `storage.write`, `storage.read`; stored program / KV layers later |
 | Watchdog | Renesas WDT library | descriptor metadata and direct bytecode operations implemented | `watchdog.configure`, `watchdog.kick` |
 | OPAMP | UNO R4 OPAMP library | pending | analog board-specific capability after ADC/DAC |
-| WiFi | WiFiS3 library through onboard network module | descriptor metadata and network capability strings implemented | `transport.wifi`, `network.ipv4`, `network.tcp`, `network.udp`; socket/control bytecode later |
+| WiFi | WiFiS3 library through onboard network module | descriptor metadata, network capability strings, and first TCP socket bytecode tranche implemented | `transport.wifi`, `network.ipv4`, `network.tcp`, `network.udp`, `network.tcp.open`, `network.tcp.write`, `network.tcp.read`, `network.tcp.close`; UDP and WiFi association control later |
 | USB/HID | TinyUSB device support | pending | transport/device descriptors first; HID later |
 | OTA/SDU | OTAUpdate and SDU libraries | pending | firmware-management capability, separate from bytecode VM |
 
@@ -93,12 +93,15 @@ reject conflicting handles.
    bounded byte-buffer bytecode tranche for that region. WiFi/network now has
    Rust-owned descriptor metadata for the onboard WiFiS3 interface plus
    `network.ipv4`, `network.tcp`, and `network.udp` capability strings surfaced
-   through the language target APIs. `program.store` now has a protocol
-   capability descriptor, `STORE_PROGRAM` device dispatch, runtime HAL hook, and
-   an initial UNO R4 storage-backed slot-0 layout that writes a compact header
-   plus module chunks through the same bounded storage substrate. Higher-level
-   KV storage and socket/control bytecode operations remain later capability
-   tranches.
+   through the language target APIs. `network.tcp.open`, `network.tcp.write`,
+   `network.tcp.read`, and `network.tcp.close` now establish the first socket
+   bytecode tranche with runtime handle-table ownership, host builders, device
+   capability descriptors, and UNO R4 WiFi backend hooks. `program.store` now
+   has a protocol capability descriptor, `STORE_PROGRAM` device dispatch,
+   runtime HAL hook, and an initial UNO R4 storage-backed slot-0 layout that
+   writes a compact header plus module chunks through the same bounded storage
+   substrate. Higher-level KV storage, WiFi association control, DNS, and UDP
+   bytecode operations remain later capability tranches.
 
 Every tranche should include the same layers: spec entry, IR/protocol capability id,
 runtime HAL method, UNO R4 target descriptor, firmware backend, host builder,


### PR DESCRIPTION
## Summary
- add `network.tcp.open/write/read/close` bytecode capability IDs, stack validation, runtime dispatch, and no-heap HAL hooks
- surface TCP socket bytecode descriptors through Board VM device caps and UNO R4 WiFi capability selection
- add host module builders, Rust-owned target metadata strings, and spec updates for the first network socket tranche

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-network-bytecode cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-device -p board-vm-uno-r4 -p board-vm-host -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-network-bytecode cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-network-bytecode cargo test -p board-vm-uno-r4-firmware`
- `bundle exec ruby -c lib/coding_adventures/board_vm/session.rb`
- `bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb`
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`