### PR TITLE
feat(symbolic-vm): Phase 35 — degenerate a²=b² Weierstrass cases (Python 0.60.0)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.60.0 — 2026-05-18
+
+**Phase 35 integration — degenerate `a² = b²` Weierstrass cases.**
+
+Closes the four degenerate-discriminant branches that Phase 34 left as
+unevaluated:
+
+    ∫ 1/(a + a·sin x) dx  =  -2 / (a · (tan(x/2) + 1))
+    ∫ 1/(a − a·sin x) dx  =   2 / (a · (1 − tan(x/2)))
+    ∫ 1/(a + a·cos x) dx  =   tan(x/2) / a
+    ∫ 1/(a − a·cos x) dx  =  -1 / (a · tan(x/2))     (= -cot(x/2)/a)
+
+Each formula is exact (no `Sqrt` factor, no `Atan` wrapper) because the
+post-substitution quadratic in `u = tan(x/2)` factors as `a(u ± 1)²` for
+sin and reduces to `2a` (constant) or `2a·u²` for cos.  A numerator
+constant `c` scales every output.
+
+### Added
+
+- **`_try_weierstrass_degenerate(c, a, b, trig_head, x)`** — Phase 35
+  helper.  Called from `_try_weierstrass_one_over_linear_trig` when
+  `disc == 0` (the existing function previously returned `None` in this
+  case).  Matches the four sign combinations on `(b == a, b == -a) ×
+  (SIN, COS)` and emits the corresponding closed form.  Returns `None`
+  for the pathological `a = 0` sub-case (which only fires when
+  `b = 0` too — a zero denominator, not integrable).
+
+- Updated the existing `_try_weierstrass_one_over_linear_trig`
+  dispatcher to call `_try_weierstrass_degenerate` for `disc == 0` and
+  to return `None` (defer) for `disc < 0` (log form, still open).
+
+### Tests
+
+`tests/test_phase34_weierstrass.py` (5 new tests + 1 promoted from
+fallthrough to closed form):
+
+- `test_phase35_a_equals_b_now_closes` — ∫ 1/(1 + sin x) dx now closes;
+  numerical derivative matches.  (Previously a fallthrough test.)
+- `test_phase35_one_minus_sin_closes` — ∫ 1/(2 − 2·sin x) dx.
+- `test_phase35_one_plus_cos_closes` — ∫ 1/(1 + cos x) dx → tan(x/2).
+- `test_phase35_one_minus_cos_closes` — ∫ 1/(1 − cos x) dx → −cot(x/2).
+- `test_phase35_with_numerator_coefficient` — ∫ 5/(2 + 2·sin x) dx.
+- `test_phase35_rational_coefficients` — ∫ 1/(3/2 + 3/2·cos x) dx.
+
+### Deferred to a future phase
+
+- `a² < b²` — log form on `(a·tan(x/2) + b ± √(b²−a²))` requires sign
+  analysis on the log argument; not implemented in this release.
+- Non-bare trig arguments (e.g. `sin(2x)`) and symbolic coefficients
+  remain unchanged from Phase 34.
+
 ## 0.59.0 — 2026-05-18
 
 **Phase 34 integration — Weierstrass substitution for `∫ c/(a + b·sin(x)) dx`

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.59.0"
+version = "0.60.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -928,6 +928,82 @@ def _parse_a_plus_b_sincos(
     return None
 
 
+def _try_weierstrass_degenerate(
+    c: Fraction,
+    a: Fraction,
+    b: Fraction,
+    trig_head: IRSymbol,
+    x: IRSymbol,
+) -> IRNode | None:
+    """Phase 35: degenerate ``a² = b²`` Weierstrass cases.
+
+    Four sign combinations on ``(a, b, trig_head)``:
+
+    +------------+------------+---------+--------------------------------------+
+    | b vs a     | trig       | a sign  | Closed form                          |
+    +============+============+=========+======================================+
+    | b = a > 0  | sin        | any     | -2c / (a · (tan(x/2) + 1))           |
+    | b = -a < 0 | sin        | any     |  2c / (a · (1 − tan(x/2)))           |
+    | b = a > 0  | cos        | any     |  c · tan(x/2) / a   (since 1+cos=2cos²(x/2)) |
+    | b = -a < 0 | cos        | any     | -c / (a · tan(x/2))                  |
+    +------------+------------+---------+--------------------------------------+
+
+    Derivations (all from u = tan(x/2)):
+
+    ``∫ 1/(a + a·sin x) dx``:
+       ``1 + sin x = (1+u)²/(1+u²)``, so the integrand becomes
+       ``2/(a(1+u)²) du`` → ``-2/(a(1+u)) + C``.
+
+    ``∫ 1/(a − a·sin x) dx``:
+       ``1 − sin x = (1−u)²/(1+u²)``, so the integrand becomes
+       ``2/(a(1−u)²) du`` → ``2/(a(1−u)) + C``.
+
+    ``∫ 1/(a + a·cos x) dx``:
+       ``1 + cos x = 2/(1+u²)``, so the integrand becomes
+       ``1/a du`` → ``u/a + C = tan(x/2)/a + C``.
+
+    ``∫ 1/(a − a·cos x) dx``:
+       ``1 − cos x = 2u²/(1+u²)``, so the integrand becomes
+       ``1/(a·u²) du`` → ``-1/(a·u) + C = -cot(x/2)/a + C``.
+
+    Returns ``None`` if neither ``b == a`` nor ``b == -a`` (caller will then
+    leave the integral unevaluated).
+    """
+    if a == 0:
+        # disc = 0 and a = 0 implies b = 0 too — degenerate denominator
+        # ``0 + 0·sin x = 0``; integrating 1/0 is undefined.  Punt.
+        return None
+    tan_half = IRApply(TAN, (IRApply(DIV, (x, TWO)),))
+    if trig_head == SIN:
+        if b == a:
+            # ∫ c/(a + a·sin x) dx = -2c / (a · (tan(x/2) + 1))
+            numer = _frac_ir(-2 * c)
+            denom = IRApply(
+                MUL,
+                (_frac_ir(a), IRApply(ADD, (tan_half, ONE))),
+            )
+            return IRApply(DIV, (numer, denom))
+        if b == -a:
+            # ∫ c/(a − a·sin x) dx = 2c / (a · (1 − tan(x/2)))
+            numer = _frac_ir(2 * c)
+            denom = IRApply(
+                MUL,
+                (_frac_ir(a), IRApply(SUB, (ONE, tan_half))),
+            )
+            return IRApply(DIV, (numer, denom))
+        return None
+    # trig_head == COS
+    if b == a:
+        # ∫ c/(a + a·cos x) dx = c · tan(x/2) / a
+        return IRApply(DIV, (IRApply(MUL, (_frac_ir(c), tan_half)), _frac_ir(a)))
+    if b == -a:
+        # ∫ c/(a − a·cos x) dx = -c / (a · tan(x/2))
+        numer = _frac_ir(-c)
+        denom = IRApply(MUL, (_frac_ir(a), tan_half))
+        return IRApply(DIV, (numer, denom))
+    return None
+
+
 def _try_weierstrass_one_over_linear_trig(
     integrand: IRNode, x: IRSymbol
 ) -> IRNode | None:
@@ -954,9 +1030,18 @@ def _try_weierstrass_one_over_linear_trig(
         return None
     a, b, trig_head = parsed
     disc = a * a - b * b
-    if disc <= 0:
-        # a² ≤ b² → log form (a² < b²) or degenerate (a² = b²).
-        # Not implemented in this phase; leave unevaluated.
+    if disc == 0:
+        # Phase 35: degenerate a² = b² cases — closed forms in tan(x/2)
+        # without an outer arctan.  Four sign combinations are handled
+        # below; cases where a + b = 0 (sin/cos coefficient cancel) are
+        # picked up via the `b == -a` / `b == a` checks.
+        degen = _try_weierstrass_degenerate(c, a, b, trig_head, x)
+        if degen is not None:
+            return degen
+        # Defensive: if degenerate matcher can't close it, leave unevaluated.
+        return None
+    if disc < 0:
+        # a² < b² → log form (deferred — sign analysis required).
         return None
     sqrt_disc_ir = _sqrt_fraction_ir(disc)
     tan_half = IRApply(TAN, (IRApply(DIV, (x, TWO)),))

--- a/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
@@ -238,11 +238,103 @@ def test_fallthrough_a_less_than_b(vm: VM) -> None:
     )
 
 
-def test_fallthrough_a_equals_b(vm: VM) -> None:
-    """``∫ 1/(1 + sin(x)) dx`` — a² = b²; linear-in-tan form not implemented."""
+def test_phase35_a_equals_b_now_closes(vm: VM) -> None:
+    """``∫ 1/(1 + sin(x)) dx`` — Phase 35 (this release) closes the degenerate
+    ``a² = b²`` case that Phase 34 left unevaluated.
+
+    Closed form: ``-2 / (tan(x/2) + 1)``.
+    """
     integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (IRInteger(1), IRApply(SIN, (X,))))))
-    result = vm.eval(_integrate(integrand))
-    assert isinstance(result, IRApply) and result.head == INTEGRATE
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE), (
+        f"Phase 35 should close ∫ 1/(1+sin x) dx; got {phi!r}"
+    )
+    for x_val in (-2.0, -1.0, -0.3, 0.3, 1.0, 2.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.0 + math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Phase 35: degenerate ``a² = b²`` cases — explicit coverage of all four
+# sign combinations.
+# ---------------------------------------------------------------------------
+
+
+def test_phase35_one_minus_sin_closes(vm: VM) -> None:
+    """``∫ 1/(2 − 2·sin x) dx`` — sin, b = −a.  Closed form: ``2/(2·(1−tan(x/2)))``."""
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(SUB, (IRInteger(2), IRApply(MUL, (IRInteger(2), IRApply(SIN, (X,)))))),
+        ),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-2.0, -1.0, -0.3, 0.3, 1.0, 2.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 - 2.0 * math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase35_one_plus_cos_closes(vm: VM) -> None:
+    """``∫ 1/(1 + cos x) dx`` — cos, b = a > 0.  Closed form: ``tan(x/2)``."""
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (IRInteger(1), IRApply(COS, (X,))))))
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-2.0, -1.0, -0.3, 0.3, 1.0, 2.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.0 + math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_phase35_one_minus_cos_closes(vm: VM) -> None:
+    """``∫ 1/(1 − cos x) dx`` — cos, b = −a.  Closed form: ``−cot(x/2)``."""
+    integrand = IRApply(
+        DIV,
+        (IRInteger(1), IRApply(SUB, (IRInteger(1), IRApply(COS, (X,))))),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    # Sample away from x = 0, 2π where 1 − cos x = 0.
+    for x_val in (0.5, 1.0, 1.5, 2.0, 2.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.0 - math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase35_with_numerator_coefficient(vm: VM) -> None:
+    """``∫ 5/(2 + 2·sin x) dx`` — coefficient c=5 scales the closed form."""
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(5),
+            IRApply(ADD, (IRInteger(2), IRApply(MUL, (IRInteger(2), IRApply(SIN, (X,)))))),
+        ),
+    )
+    phi = vm.eval(_integrate(integrand))
+    for x_val in (-2.0, -1.0, -0.3, 0.3, 1.0, 2.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 5.0 / (2.0 + 2.0 * math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase35_rational_coefficients(vm: VM) -> None:
+    """``∫ 1/((3/2) + (3/2)·cos x) dx`` — rational a = b > 0."""
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(ADD, (IRRational(3, 2), IRApply(MUL, (IRRational(3, 2), IRApply(COS, (X,)))))),
+        ),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-2.0, -1.0, -0.3, 0.3, 1.0, 2.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.5 + 1.5 * math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
 
 
 def test_fallthrough_non_bare_argument(vm: VM) -> None:


### PR DESCRIPTION
## Summary

Closes the four degenerate `a² = b²` Weierstrass branches that Phase 34
(PR #3472) deliberately deferred:

    ∫ 1/(a + a·sin x) dx = -2/(a·(tan(x/2)+1))
    ∫ 1/(a − a·sin x) dx =  2/(a·(1−tan(x/2)))
    ∫ 1/(a + a·cos x) dx =  tan(x/2)/a
    ∫ 1/(a − a·cos x) dx = -1/(a·tan(x/2))   (= -cot(x/2)/a)

Each formula is **exact** — no Sqrt, no Atan — because the post-substitution
quadratic in `u = tan(x/2)` factors as `a(u ± 1)²` for sin and reduces to
`2a` (constant) or `2a·u²` for cos.

New helper `_try_weierstrass_degenerate(c, a, b, trig_head, x)` plumbed
into the existing `_try_weierstrass_one_over_linear_trig` dispatcher
(disc == 0 path).

## Test plan

- [x] 5 new tests in `tests/test_phase34_weierstrass.py` covering all 4
  sign combinations + rational `a` + numerator coefficient
- [x] 1 promoted test (formerly fallthrough): `∫ 1/(1+sin x) dx` now closes
- [x] Full suite: **1679 passed, 85 skipped, 81.41% coverage**
- [x] Security review: passed

## Dependencies

Branched from `feat/phase34-weierstrass-python` (PR #3472). Merge order:
**#3472 first, then this PR**. The CHANGELOG entry for 0.60.0 references
0.59.0 which depends on #3472 landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)