### PR TITLE
feat(symbolic-vm): Phase 35 — degenerate a²=b² Weierstrass cases (TS 0.8.0)

### DIFF
--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## [0.8.0] — 2026-05-18
+
+### Added — Phase 35: degenerate `a² = b²` Weierstrass cases
+
+Closes the four degenerate branches that Phase 34 (0.7.0) deliberately
+deferred:
+
+    ∫ 1/(a + a·sin x) dx = -2 / (a · (tan(x/2) + 1))
+    ∫ 1/(a − a·sin x) dx =  2 / (a · (1 − tan(x/2)))
+    ∫ 1/(a + a·cos x) dx =  tan(x/2) / a
+    ∫ 1/(a − a·cos x) dx = -1 / (a · tan(x/2))     (= -cot(x/2)/a)
+
+Each formula is exact — no `Sqrt`, no `Atan` — because the
+post-substitution quadratic in `u = tan(x/2)` factors as `a(u ± 1)²`
+for sin and reduces to `2a` (constant) or `2a·u²` for cos.
+
+#### Added (`src/index.ts`)
+
+- **`tryWeierstrassDegenerate(c, a, b, trigHead, x)`** — Phase 35
+  helper.  Pattern-matches the four `(b == a, b == -a) × (SIN, COS)`
+  combinations and emits the corresponding closed form via `app(DIV, ...)`
+  with `tan(x/2)` inside.  Returns `undefined` for `a == 0` (zero
+  denominator).
+
+- **`isZeroNumeric(v)`** — strict-zero predicate complementing
+  `isPositiveNumeric`.  Used to detect `disc == 0` after the existing
+  `subNumeric(mulNumeric(a, a), mulNumeric(b, b))`.
+
+- **`eqNumeric(a, b)`** — exact equality on `Numeric` (int/rat),
+  used to test `b == a` and `b == -a`.  Float values are conservatively
+  rejected so they only ever take the strictly-positive arctan path.
+
+- Updated `tryWeierstrassOneOverLinearTrig` (Phase 34) to call
+  `tryWeierstrassDegenerate` when `isZeroNumeric(disc)` and to return
+  `undefined` (defer) when `!isPositiveNumeric(disc)` (i.e. `disc < 0`,
+  log form, still open).
+
+#### Tests (`tests/phase34-weierstrass.test.ts`)
+
+5 new `it()` cases under a new `Phase 35: degenerate a² = b² cases`
+describe block + 1 promoted from fallthrough to closed form:
+
+- ∫ 1/(2 − 2·sin x) dx — sin, b = −a.
+- ∫ 1/(1 + cos x) dx — cos, b = a → tan(x/2).
+- ∫ 1/(1 − cos x) dx — cos, b = −a → −cot(x/2).
+- ∫ 5/(2 + 2·sin x) dx — numerator coefficient scaling.
+- ∫ 1/(3/2 + (3/2)·cos x) dx — rational a = b.
+- Promoted: ∫ 1/(1 + sin x) dx now closes (was previously asserted
+  to stay unevaluated).
+
+Each verifies the closed form via numerical differentiation, avoiding
+the `tan(x/2)` pole at `x = π` and the `1/(1−cos x)` pole at `x = 0`.
+
+Full suite: 84 passed (79 prior + 5 net new).
+
+### Note on version sequencing
+
+This release builds on the in-flight Phase 34 (PR #3473, 0.7.0) which
+itself jumped 0.5.0 → 0.7.0 to leave 0.6.0 for the in-flight Phase
+29-33 port (PR #3468).  Final order when all four PRs land:
+0.5.0 → 0.6.0 → 0.7.0 → 0.8.0.
+
 ## [0.7.0] — 2026-05-18
 
 ### Added — Phase 34: Weierstrass substitution for ∫ 1/(a + b·sin/cos x) dx

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1724,7 +1724,13 @@ function tryWeierstrassOneOverLinearTrig(
   const { a, b, trigHead } = parsed;
   // disc = a² − b² (exact Numeric arithmetic — both a, b are Int/Rat).
   const disc = subNumeric(mulNumeric(a, a), mulNumeric(b, b));
-  // disc must be strictly positive; reject zero (a² = b²) and negative.
+  // Three-way dispatch on the discriminant:
+  //   disc > 0  → Phase 34 arctan form (below)
+  //   disc == 0 → Phase 35 degenerate form (four sign combinations)
+  //   disc < 0  → log form (still deferred)
+  if (isZeroNumeric(disc)) {
+    return tryWeierstrassDegenerate(c, a, b, trigHead, x);
+  }
   if (!isPositiveNumeric(disc)) return undefined;
   const sqrtDiscIR = weierstrassSqrtFractionIR(disc);
   const tanHalf = app(TAN, [app(DIV, [x, int(2)])]);
@@ -1753,6 +1759,79 @@ function isPositiveNumeric(v: Numeric): boolean {
   if (v.kind === "int") return v.value > 0n;
   if (v.kind === "rat") return v.numer > 0n; // denominator is always positive
   return v.value > 0;
+}
+
+/** True when ``v`` is exactly zero (integer 0, rational 0/q, or float 0.0). */
+function isZeroNumeric(v: Numeric): boolean {
+  if (v.kind === "int") return v.value === 0n;
+  if (v.kind === "rat") return v.numer === 0n;
+  return v.value === 0;
+}
+
+/** True when two Numeric values are exactly equal (Int/Rat only — float
+ *  comparisons elsewhere use tolerance; Phase 35 needs exact equality). */
+function eqNumeric(a: Numeric, b: Numeric): boolean {
+  if (a.kind === "int" && b.kind === "int") return a.value === b.value;
+  if (a.kind === "rat" && b.kind === "rat")
+    return a.numer === b.numer && a.denom === b.denom;
+  if (a.kind === "int" && b.kind === "rat")
+    return b.denom === 1n && b.numer === a.value;
+  if (a.kind === "rat" && b.kind === "int")
+    return a.denom === 1n && a.numer === b.value;
+  return false;
+}
+
+/**
+ * Phase 35: degenerate ``a² = b²`` Weierstrass cases. Four sign
+ * combinations × {SIN, COS} yield clean closed forms in ``tan(x/2)``
+ * without any ``Sqrt`` or ``Atan`` wrapper:
+ *
+ *  - sin, b ==  a : ``-2c / (a · (tan(x/2) + 1))``
+ *  - sin, b == -a : `` 2c / (a · (1 − tan(x/2)))``
+ *  - cos, b ==  a : ``c · tan(x/2) / a``
+ *  - cos, b == -a : ``-c / (a · tan(x/2))``  (= -c·cot(x/2)/a)
+ *
+ * Returns ``undefined`` when neither ``b == a`` nor ``b == -a``, or when
+ * ``a == 0`` (zero denominator, not integrable).
+ */
+function tryWeierstrassDegenerate(
+  c: Numeric,
+  a: Numeric,
+  b: Numeric,
+  trigHead: IRNode,
+  x: IRNode
+): IRNode | undefined {
+  if (isZeroNumeric(a)) return undefined;
+  const tanHalf = app(TAN, [app(DIV, [x, int(2)])]);
+  const negA = negNumeric(a);
+  if (equals(trigHead, SIN)) {
+    if (eqNumeric(b, a)) {
+      // -2c / (a · (tan(x/2) + 1))
+      const neg2c = negNumeric(mulNumeric(c, { kind: "int", value: 2n }));
+      const denom = app(MUL, [fromNumeric(a), app(ADD, [tanHalf, int(1)])]);
+      return app(DIV, [fromNumeric(neg2c), denom]);
+    }
+    if (eqNumeric(b, negA)) {
+      // 2c / (a · (1 − tan(x/2)))
+      const two_c = mulNumeric(c, { kind: "int", value: 2n });
+      const denom = app(MUL, [fromNumeric(a), app(SUB, [int(1), tanHalf])]);
+      return app(DIV, [fromNumeric(two_c), denom]);
+    }
+    return undefined;
+  }
+  // COS branch
+  if (eqNumeric(b, a)) {
+    // c · tan(x/2) / a
+    const numer = app(MUL, [fromNumeric(c), tanHalf]);
+    return app(DIV, [numer, fromNumeric(a)]);
+  }
+  if (eqNumeric(b, negA)) {
+    // -c / (a · tan(x/2))
+    const negC = negNumeric(c);
+    const denom = app(MUL, [fromNumeric(a), tanHalf]);
+    return app(DIV, [fromNumeric(negC), denom]);
+  }
+  return undefined;
 }
 
 function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {

--- a/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
@@ -19,6 +19,7 @@ import {
   NEG,
   SIN,
   SQRT,
+  SUB,
   app,
   equals,
   int,
@@ -192,11 +193,16 @@ describe("Phase 34: deferred discriminant cases", () => {
     expect(isUnevaluatedIntegrate(result)).toBe(true);
   });
 
-  it("a² = b² (∫ 1/(1 + sin x) dx) — degenerate form deferred", () => {
+  it("Phase 35: a² = b² (∫ 1/(1 + sin x) dx) now closes via the degenerate form", () => {
     const vm = makeVM();
     const integrand = app(DIV, [int(1), app(ADD, [int(1), app(SIN, [X])])]);
-    const result = vm.eval(integrate(integrand));
-    expect(isUnevaluatedIntegrate(result)).toBe(true);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-2.0, -1.0, -0.3, 0.3, 1.0, 2.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (1 + Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
   });
 
   it("non-bare argument (∫ 1/(2 + sin 2x) dx) — Phase 34 doesn't compose with subs", () => {
@@ -238,6 +244,75 @@ describe("Phase 34: regression — must not interfere with existing rules", () =
     // a top-level Atan (which would only come from Phase 34).
     if (result.kind === "apply" && equals(result.head, ATAN)) {
       throw new Error(`Phase 34 incorrectly fired on ∫ 1/cos(x) dx: got ${JSON.stringify(result)}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 35: degenerate a² = b² cases — all four sign combinations
+// ---------------------------------------------------------------------------
+
+describe("Phase 35: degenerate a² = b² cases", () => {
+  it("∫ 1/(2 − 2·sin x) dx — sin, b = −a", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(SUB, [int(2), app(MUL, [int(2), app(SIN, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-2.0, -1.0, -0.3, 0.3, 1.0, 2.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (2 - 2 * Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("∫ 1/(1 + cos x) dx — cos, b = a → tan(x/2)", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(1), app(COS, [X])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-2.0, -1.0, -0.3, 0.3, 1.0, 2.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (1 + Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("∫ 1/(1 − cos x) dx — cos, b = −a → −cot(x/2)", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(SUB, [int(1), app(COS, [X])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    // Sample on (0, π) — avoid x = 0, 2π where 1 − cos x = 0.
+    for (const xVal of [0.5, 1.0, 1.5, 2.0, 2.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (1 - Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("numerator coefficient (∫ 5/(2 + 2·sin x) dx) scales the closed form", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(5), app(ADD, [int(2), app(MUL, [int(2), app(SIN, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    for (const xVal of [-2.0, -1.0, -0.3, 0.3, 1.0, 2.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 5 / (2 + 2 * Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("rational coefficients (a = b = 3/2) close cleanly", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [
+      int(1),
+      app(ADD, [rational(3, 2), app(MUL, [rational(3, 2), app(COS, [X])])]),
+    ]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-2.0, -1.0, -0.3, 0.3, 1.0, 2.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (1.5 + 1.5 * Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
     }
   });
 });


### PR DESCRIPTION
## Summary

Ports Phase 35 (degenerate `a² = b²` Weierstrass cases) from Python
PR #3479 and Rust PR #3480 to TypeScript. Closes the four degenerate
branches that Phase 34 (PR #3473, TS 0.7.0) deferred:

    ∫ 1/(a + a·sin x) dx = -2/(a·(tan(x/2)+1))
    ∫ 1/(a − a·sin x) dx =  2/(a·(1−tan(x/2)))
    ∫ 1/(a + a·cos x) dx =  tan(x/2)/a
    ∫ 1/(a − a·cos x) dx = -1/(a·tan(x/2))   (= -cot(x/2)/a)

New helper `tryWeierstrassDegenerate(c, a, b, trigHead, x)` plus two
small Numeric utilities (`isZeroNumeric`, `eqNumeric`). Plumbed into
the existing Phase 34 dispatcher.

## Test plan

- [x] 5 new `it()` cases in `tests/phase34-weierstrass.test.ts` covering
  all 4 sign combinations + rational `a` + numerator coefficient
- [x] 1 promoted test (formerly fallthrough): `∫ 1/(1+sin x) dx` now closes
- [x] Full suite: **84 passed** (79 prior + 5 net new)
- [x] `npx tsc --noEmit` clean

## Dependencies / version sequencing

Branched from `feat/phase34-weierstrass-ts` (PR #3473). Merge order:
**#3473 first, then this PR**. Version: 0.7.0 → 0.8.0.

Full version chain across the in-flight PRs:
- 0.5.0 (main today)
- → 0.6.0 (PR #3468, Phase 29-33)
- → 0.7.0 (PR #3473, Phase 34)
- → 0.8.0 (this PR, Phase 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)