### PR TITLE
Add WHATWG character reference boundary fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -47,6 +47,9 @@ documented in this file.
 - A generated WHATWG numeric character reference edge fixture and Rust
   conformance test that exercises decimal, hexadecimal, semicolon, and
   missing-semicolon forms across data, attribute, and RCDATA contexts.
+- A generated WHATWG tokenizer character-reference boundary fixture and Rust
+  conformance test that pins text, attribute, RCDATA, and seeded named/numeric
+  continuation recovery around ambiguous ampersands and numeric boundaries.
 - A generated WHATWG input-stream preprocessing fixture and Rust conformance
   test that exercises CRLF and bare-CR normalization across tokenizer contexts,
   every chunk split point, and diagnostic line/column positions.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -261,7 +261,8 @@ Today the package carries these fixture suites:
 - `html1.json` for the current Mosaic-era compatibility floor
 - generated WHATWG conformance slices for named references, numeric
   references, input-stream preprocessing, chunk-boundary invariance, EOF
-  recovery, text-mode delimiters, and markup declarations
+  recovery, text-mode delimiters, markup declarations, and focused tokenizer
+  boundary states
 
 The checked-in `whatwg-entities.json` fixture is generated from the HTML
 Standard's `entities.json` table and is exercised directly by Rust tests across
@@ -283,6 +284,16 @@ outside-range values. Regenerate or check it with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py \
+  --check
+```
+
+The checked-in `whatwg-character-reference-boundaries.json` fixture exercises
+text, attribute, RCDATA, and seeded continuation boundary recovery around named
+and numeric character references. Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -55,6 +55,9 @@ binary while production code continues to link only static Rust source.
   reference edge table used by Rust tests to exercise decimal, hexadecimal,
   semicolon, and missing-semicolon forms across data, attribute, and RCDATA
   contexts
+- `whatwg-character-reference-boundaries.json`: generated HTML tokenizer
+  character-reference boundary cases used by Rust tests to pin text,
+  attribute, RCDATA, and seeded named/numeric continuation recovery
 - `whatwg-input-stream.json`: generated HTML Standard input-stream
   preprocessing cases used by Rust tests to exercise CRLF and bare-CR
   normalization across tokenizer contexts and chunk boundaries
@@ -97,6 +100,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_numeric_references_fixture.py`: importer that generates the
   finite numeric character reference edge table for the checked-in
   `whatwg-numeric-references.json` fixture
+- `generate_whatwg_character_reference_boundaries_fixture.py`: importer that
+  generates focused character-reference boundary cases for the checked-in
+  `whatwg-character-reference-boundaries.json` fixture
 - `generate_whatwg_input_stream_fixture.py`: importer that generates finite
   CRLF/bare-CR preprocessing cases for the checked-in
   `whatwg-input-stream.json` fixture
@@ -139,6 +145,14 @@ Regenerate or verify the WHATWG numeric-reference fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG character-reference boundary fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer character-reference boundary fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name(
+    "whatwg-character-reference-boundaries.json"
+)
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        if output.read_text() != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer character-reference boundary fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-character-reference-boundaries/v1",
+        "description": (
+            "Character-reference boundary recovery for named, numeric, "
+            "attribute, RCDATA, and seeded continuation tokenizer states."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = [
+        case("data-named-semicolon", "semicolon named reference in data", "a&amp;b", ["Text(data=a&b)", "EOF"]),
+        case("data-legacy-missing-semicolon-before-space", "legacy semicolonless name before whitespace in data", "a&copy b", ["Text(data=a© b)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        case("data-nonlegacy-missing-semicolon-literal", "non-legacy semicolonless name stays literal", "a&trade b", ["Text(data=a&trade b)", "EOF"]),
+        case("data-longest-prefix-semicolon", "longest semicolon named reference wins", "a&notin;b", ["Text(data=a∉b)", "EOF"]),
+        case("data-legacy-prefix-in-longer-name", "legacy prefix decodes inside longer data names", "a&notin b", ["Text(data=a¬in b)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        case("data-unknown-name", "unknown name stays literal in data", "a&nosuch;b", ["Text(data=a&nosuch;b)", "EOF"]),
+        case("data-ambiguous-name-text", "legacy text reference decodes before alphanumeric text", "a&copycat b", ["Text(data=a©cat b)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        case("attribute-named-semicolon", "semicolon named reference in attributes", '<p title="a&amp;b">', ["StartTag(name=p, attributes=[title=a&b], self_closing=false)", "EOF"]),
+        case("attribute-ambiguous-preserved", "attribute ambiguous ampersand preserves alphanumeric suffix", '<p title="a&copycat b">', ["StartTag(name=p, attributes=[title=a&copycat b], self_closing=false)", "EOF"]),
+        case("attribute-legacy-before-space", "legacy semicolonless name before whitespace in attributes", '<p title="a&copy b">', ["StartTag(name=p, attributes=[title=a© b], self_closing=false)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        case("attribute-unknown-name", "unknown name stays literal in attributes", '<p title="a&nosuch;b">', ["StartTag(name=p, attributes=[title=a&nosuch;b], self_closing=false)", "EOF"]),
+        case("rcdata-named-semicolon", "semicolon named reference in RCDATA", "a&amp;</title>", ["Text(data=a&)", "EndTag(name=title)", "EOF"], initial_state="RCDATA state", last_start_tag="title"),
+        case("rcdata-ambiguous-name-text", "RCDATA follows text ambiguous ampersand recovery", "a&copycat</title>", ["Text(data=a©cat)", "EndTag(name=title)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"], initial_state="RCDATA state", last_start_tag="title"),
+        case("rcdata-legacy-prefix-in-longer-name", "legacy prefix decodes inside longer RCDATA names", "a&notin </title>", ["Text(data=a¬in )", "EndTag(name=title)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"], initial_state="RCDATA state", last_start_tag="title"),
+        case("data-numeric-decimal-semicolon", "decimal numeric reference with semicolon", "a&#65;b", ["Text(data=aAb)", "EOF"]),
+        case("data-numeric-hex-semicolon", "hex numeric reference with semicolon", "a&#x41;b", ["Text(data=aAb)", "EOF"]),
+        case("data-numeric-decimal-missing-semicolon", "decimal numeric reference missing semicolon", "a&#65 b", ["Text(data=aA b)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        case("data-numeric-hex-missing-semicolon", "hex numeric reference missing semicolon", "a&#x41z", ["Text(data=aAz)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        case("data-numeric-decimal-zero", "numeric null maps to replacement character", "a&#0;b", ["Text(data=a�b)", "EOF"], diagnostics=["null-character-reference"]),
+        case("data-numeric-surrogate", "numeric surrogate maps to replacement character", "a&#xD800;b", ["Text(data=a�b)", "EOF"], diagnostics=["surrogate-character-reference"]),
+        case("data-numeric-outside-range", "outside-Unicode numeric reference maps to replacement character", "a&#x110000;b", ["Text(data=a�b)", "EOF"], diagnostics=["character-reference-outside-unicode-range"]),
+        case("data-numeric-windows-1252", "Windows-1252 control reference remaps", "a&#x80;b", ["Text(data=a€b)", "EOF"], diagnostics=["control-character-reference"]),
+        case("data-numeric-digitless-decimal", "digitless decimal reference stays literal", "a&#;b", ["Text(data=a&#;b)", "EOF"], diagnostics=["absence-of-digits-in-numeric-character-reference"]),
+        case("data-numeric-digitless-hex", "digitless hex reference stays literal", "a&#x;b", ["Text(data=a&#x;b)", "EOF"], diagnostics=["absence-of-digits-in-numeric-character-reference"]),
+        seeded("seeded-character-reference-named-data", "character-reference state dispatches to names", "Character reference state", "Data state", "&", "amp;!", ["Text(data=&!)", "EOF"]),
+        seeded("seeded-character-reference-fallback-data", "character-reference state flushes literal ampersand", "Character reference state", "Data state", "&", " nope", ["Text(data=& nope)", "EOF"]),
+        seeded("seeded-character-reference-eof-data", "character-reference state flushes temporary buffer at EOF", "Character reference state", "Data state", "&", "", ["Text(data=&)", "EOF"]),
+        seeded("seeded-character-reference-numeric-data", "character-reference state dispatches to numeric references", "Character reference state", "Data state", "&", "#65;!", ["Text(data=A!)", "EOF"]),
+        seeded("seeded-character-reference-named-rcdata", "character-reference state returns to RCDATA", "Character reference state", "RCDATA state", "&", "amp;</title>", ["Text(data=&)", "EndTag(name=title)", "EOF"], last_start_tag="title"),
+        seeded("seeded-named-reference-complete-data", "named-reference state completes an entity name", "Named character reference state", "Data state", "&co", "py;!", ["Text(data=©!)", "EOF"]),
+        seeded("seeded-named-reference-ambiguous-data", "named-reference state handles legacy prefixes in data", "Named character reference state", "Data state", "&copy", "cat!", ["Text(data=©cat!)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        seeded("seeded-named-reference-nonlegacy-literal", "named-reference state preserves non-legacy semicolonless names", "Named character reference state", "Data state", "&trade", "!", ["Text(data=&trade!)", "EOF"]),
+        seeded("seeded-named-reference-eof", "named-reference state flushes partial names at EOF", "Named character reference state", "Data state", "&co", "", ["Text(data=&co)", "EOF"]),
+        seeded("seeded-named-reference-rcdata-end-tag", "named-reference state returns to RCDATA before an end tag", "Named character reference state", "RCDATA state", "&a", "mp;</title>", ["Text(data=&)", "EndTag(name=title)", "EOF"], last_start_tag="title"),
+        seeded("seeded-numeric-reference-decimal", "numeric-reference state continues decimal digits", "Numeric character reference state", "Data state", "&#", "65;!", ["Text(data=A!)", "EOF"]),
+        seeded("seeded-numeric-reference-hex", "numeric-reference state dispatches to hex digits", "Numeric character reference state", "Data state", "&#", "x41;!", ["Text(data=A!)", "EOF"]),
+        seeded("seeded-numeric-reference-absent-digits", "numeric-reference state reports missing digits before boundary", "Numeric character reference state", "Data state", "&#", ";!", ["Text(data=&#;!)", "EOF"], diagnostics=["absence-of-digits-in-numeric-character-reference"]),
+        seeded("seeded-numeric-reference-eof", "numeric-reference state reports missing digits at EOF", "Numeric character reference state", "Data state", "&#", "", ["Text(data=&#)", "EOF"], diagnostics=["absence-of-digits-in-numeric-character-reference"]),
+        seeded("seeded-hex-start-reference-complete", "hex-start state continues hex digits", "Hexadecimal character reference start state", "Data state", "&#x", "41;!", ["Text(data=A!)", "EOF"]),
+        seeded("seeded-hex-start-reference-absent-digits", "hex-start state reports missing digits before boundary", "Hexadecimal character reference start state", "Data state", "&#x", ";!", ["Text(data=&#x;!)", "EOF"], diagnostics=["absence-of-digits-in-numeric-character-reference"]),
+        seeded("seeded-hex-start-reference-eof", "hex-start state reports missing digits at EOF", "Hexadecimal character reference start state", "Data state", "&#x", "", ["Text(data=&#x)", "EOF"], diagnostics=["absence-of-digits-in-numeric-character-reference"]),
+        seeded("seeded-hex-reference-missing-semicolon", "hex state decodes and reports missing semicolon", "Hexadecimal character reference state", "Data state", "&#x4", "1!", ["Text(data=A!)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        seeded("seeded-hex-reference-null", "hex state decodes null as replacement character", "Hexadecimal character reference state", "Data state", "&#x0", ";!", ["Text(data=�!)", "EOF"], diagnostics=["null-character-reference"]),
+        seeded("seeded-decimal-reference-complete", "decimal state completes decimal digits", "Decimal character reference state", "Data state", "&#6", "5;!", ["Text(data=A!)", "EOF"]),
+        seeded("seeded-decimal-reference-missing-semicolon", "decimal state decodes and reports missing semicolon", "Decimal character reference state", "Data state", "&#6", "5!", ["Text(data=A!)", "EOF"], diagnostics=["missing-semicolon-after-character-reference"]),
+        seeded("seeded-decimal-reference-outside-range", "decimal state decodes outside-Unicode values as replacement", "Decimal character reference state", "Data state", "&#1114112", ";!", ["Text(data=�!)", "EOF"], diagnostics=["character-reference-outside-unicode-range"]),
+        seeded("seeded-decimal-reference-rcdata", "decimal state returns to RCDATA before an end tag", "Decimal character reference state", "RCDATA state", "&#6", "5;</title>", ["Text(data=A)", "EndTag(name=title)", "EOF"], last_start_tag="title"),
+    ]
+    return cases
+
+
+def case(
+    case_id: str,
+    description: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    diagnostics: list[str] | None = None,
+    initial_state: str | None = None,
+    last_start_tag: str | None = None,
+) -> dict[str, object]:
+    item: dict[str, object] = {
+        "id": case_id,
+        "description": description,
+        "input": input_text,
+        "tokens": tokens,
+    }
+    if diagnostics is not None:
+        item["diagnostics"] = diagnostics
+    if initial_state is not None:
+        item["initial_state"] = initial_state
+    if last_start_tag is not None:
+        item["last_start_tag"] = last_start_tag
+    return item
+
+
+def seeded(
+    case_id: str,
+    description: str,
+    initial_state: str,
+    return_state: str,
+    temporary_buffer: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    diagnostics: list[str] | None = None,
+    last_start_tag: str | None = None,
+) -> dict[str, object]:
+    item = case(
+        case_id,
+        description,
+        input_text,
+        tokens,
+        diagnostics=diagnostics,
+        initial_state=initial_state,
+        last_start_tag=last_start_tag,
+    )
+    item["return_state"] = return_state
+    item["temporary_buffer"] = temporary_buffer
+    return item
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-character-reference-boundaries.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-character-reference-boundaries.json
@@ -1,0 +1,606 @@
+{
+  "cases": [
+    {
+      "description": "semicolon named reference in data",
+      "diagnostics": [],
+      "id": "data-named-semicolon",
+      "input": "a&amp;b",
+      "tokens": [
+        "Text(data=a&b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "legacy semicolonless name before whitespace in data",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "data-legacy-missing-semicolon-before-space",
+      "input": "a&copy b",
+      "tokens": [
+        "Text(data=a© b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "non-legacy semicolonless name stays literal",
+      "diagnostics": [],
+      "id": "data-nonlegacy-missing-semicolon-literal",
+      "input": "a&trade b",
+      "tokens": [
+        "Text(data=a&trade b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "longest semicolon named reference wins",
+      "diagnostics": [],
+      "id": "data-longest-prefix-semicolon",
+      "input": "a&notin;b",
+      "tokens": [
+        "Text(data=a∉b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "legacy prefix decodes inside longer data names",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "data-legacy-prefix-in-longer-name",
+      "input": "a&notin b",
+      "tokens": [
+        "Text(data=a¬in b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unknown name stays literal in data",
+      "diagnostics": [],
+      "id": "data-unknown-name",
+      "input": "a&nosuch;b",
+      "tokens": [
+        "Text(data=a&nosuch;b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "legacy text reference decodes before alphanumeric text",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "data-ambiguous-name-text",
+      "input": "a&copycat b",
+      "tokens": [
+        "Text(data=a©cat b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "semicolon named reference in attributes",
+      "diagnostics": [],
+      "id": "attribute-named-semicolon",
+      "input": "<p title=\"a&amp;b\">",
+      "tokens": [
+        "StartTag(name=p, attributes=[title=a&b], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute ambiguous ampersand preserves alphanumeric suffix",
+      "diagnostics": [],
+      "id": "attribute-ambiguous-preserved",
+      "input": "<p title=\"a&copycat b\">",
+      "tokens": [
+        "StartTag(name=p, attributes=[title=a&copycat b], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "legacy semicolonless name before whitespace in attributes",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "attribute-legacy-before-space",
+      "input": "<p title=\"a&copy b\">",
+      "tokens": [
+        "StartTag(name=p, attributes=[title=a© b], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "unknown name stays literal in attributes",
+      "diagnostics": [],
+      "id": "attribute-unknown-name",
+      "input": "<p title=\"a&nosuch;b\">",
+      "tokens": [
+        "StartTag(name=p, attributes=[title=a&nosuch;b], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "semicolon named reference in RCDATA",
+      "diagnostics": [],
+      "id": "rcdata-named-semicolon",
+      "initial_state": "RCDATA state",
+      "input": "a&amp;</title>",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=a&)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA follows text ambiguous ampersand recovery",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "rcdata-ambiguous-name-text",
+      "initial_state": "RCDATA state",
+      "input": "a&copycat</title>",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=a©cat)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "legacy prefix decodes inside longer RCDATA names",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "rcdata-legacy-prefix-in-longer-name",
+      "initial_state": "RCDATA state",
+      "input": "a&notin </title>",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=a¬in )",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "decimal numeric reference with semicolon",
+      "diagnostics": [],
+      "id": "data-numeric-decimal-semicolon",
+      "input": "a&#65;b",
+      "tokens": [
+        "Text(data=aAb)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "hex numeric reference with semicolon",
+      "diagnostics": [],
+      "id": "data-numeric-hex-semicolon",
+      "input": "a&#x41;b",
+      "tokens": [
+        "Text(data=aAb)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "decimal numeric reference missing semicolon",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "data-numeric-decimal-missing-semicolon",
+      "input": "a&#65 b",
+      "tokens": [
+        "Text(data=aA b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "hex numeric reference missing semicolon",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "data-numeric-hex-missing-semicolon",
+      "input": "a&#x41z",
+      "tokens": [
+        "Text(data=aAz)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "numeric null maps to replacement character",
+      "diagnostics": [
+        "null-character-reference"
+      ],
+      "id": "data-numeric-decimal-zero",
+      "input": "a&#0;b",
+      "tokens": [
+        "Text(data=a�b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "numeric surrogate maps to replacement character",
+      "diagnostics": [
+        "surrogate-character-reference"
+      ],
+      "id": "data-numeric-surrogate",
+      "input": "a&#xD800;b",
+      "tokens": [
+        "Text(data=a�b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "outside-Unicode numeric reference maps to replacement character",
+      "diagnostics": [
+        "character-reference-outside-unicode-range"
+      ],
+      "id": "data-numeric-outside-range",
+      "input": "a&#x110000;b",
+      "tokens": [
+        "Text(data=a�b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Windows-1252 control reference remaps",
+      "diagnostics": [
+        "control-character-reference"
+      ],
+      "id": "data-numeric-windows-1252",
+      "input": "a&#x80;b",
+      "tokens": [
+        "Text(data=a€b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "digitless decimal reference stays literal",
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference"
+      ],
+      "id": "data-numeric-digitless-decimal",
+      "input": "a&#;b",
+      "tokens": [
+        "Text(data=a&#;b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "digitless hex reference stays literal",
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference"
+      ],
+      "id": "data-numeric-digitless-hex",
+      "input": "a&#x;b",
+      "tokens": [
+        "Text(data=a&#x;b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "character-reference state dispatches to names",
+      "diagnostics": [],
+      "id": "seeded-character-reference-named-data",
+      "initial_state": "Character reference state",
+      "input": "amp;!",
+      "return_state": "Data state",
+      "temporary_buffer": "&",
+      "tokens": [
+        "Text(data=&!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "character-reference state flushes literal ampersand",
+      "diagnostics": [],
+      "id": "seeded-character-reference-fallback-data",
+      "initial_state": "Character reference state",
+      "input": " nope",
+      "return_state": "Data state",
+      "temporary_buffer": "&",
+      "tokens": [
+        "Text(data=& nope)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "character-reference state flushes temporary buffer at EOF",
+      "diagnostics": [],
+      "id": "seeded-character-reference-eof-data",
+      "initial_state": "Character reference state",
+      "input": "",
+      "return_state": "Data state",
+      "temporary_buffer": "&",
+      "tokens": [
+        "Text(data=&)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "character-reference state dispatches to numeric references",
+      "diagnostics": [],
+      "id": "seeded-character-reference-numeric-data",
+      "initial_state": "Character reference state",
+      "input": "#65;!",
+      "return_state": "Data state",
+      "temporary_buffer": "&",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "character-reference state returns to RCDATA",
+      "diagnostics": [],
+      "id": "seeded-character-reference-named-rcdata",
+      "initial_state": "Character reference state",
+      "input": "amp;</title>",
+      "last_start_tag": "title",
+      "return_state": "RCDATA state",
+      "temporary_buffer": "&",
+      "tokens": [
+        "Text(data=&)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "named-reference state completes an entity name",
+      "diagnostics": [],
+      "id": "seeded-named-reference-complete-data",
+      "initial_state": "Named character reference state",
+      "input": "py;!",
+      "return_state": "Data state",
+      "temporary_buffer": "&co",
+      "tokens": [
+        "Text(data=©!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "named-reference state handles legacy prefixes in data",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "seeded-named-reference-ambiguous-data",
+      "initial_state": "Named character reference state",
+      "input": "cat!",
+      "return_state": "Data state",
+      "temporary_buffer": "&copy",
+      "tokens": [
+        "Text(data=©cat!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "named-reference state preserves non-legacy semicolonless names",
+      "diagnostics": [],
+      "id": "seeded-named-reference-nonlegacy-literal",
+      "initial_state": "Named character reference state",
+      "input": "!",
+      "return_state": "Data state",
+      "temporary_buffer": "&trade",
+      "tokens": [
+        "Text(data=&trade!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "named-reference state flushes partial names at EOF",
+      "diagnostics": [],
+      "id": "seeded-named-reference-eof",
+      "initial_state": "Named character reference state",
+      "input": "",
+      "return_state": "Data state",
+      "temporary_buffer": "&co",
+      "tokens": [
+        "Text(data=&co)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "named-reference state returns to RCDATA before an end tag",
+      "diagnostics": [],
+      "id": "seeded-named-reference-rcdata-end-tag",
+      "initial_state": "Named character reference state",
+      "input": "mp;</title>",
+      "last_start_tag": "title",
+      "return_state": "RCDATA state",
+      "temporary_buffer": "&a",
+      "tokens": [
+        "Text(data=&)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "numeric-reference state continues decimal digits",
+      "diagnostics": [],
+      "id": "seeded-numeric-reference-decimal",
+      "initial_state": "Numeric character reference state",
+      "input": "65;!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "numeric-reference state dispatches to hex digits",
+      "diagnostics": [],
+      "id": "seeded-numeric-reference-hex",
+      "initial_state": "Numeric character reference state",
+      "input": "x41;!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "numeric-reference state reports missing digits before boundary",
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference"
+      ],
+      "id": "seeded-numeric-reference-absent-digits",
+      "initial_state": "Numeric character reference state",
+      "input": ";!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#",
+      "tokens": [
+        "Text(data=&#;!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "numeric-reference state reports missing digits at EOF",
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference"
+      ],
+      "id": "seeded-numeric-reference-eof",
+      "initial_state": "Numeric character reference state",
+      "input": "",
+      "return_state": "Data state",
+      "temporary_buffer": "&#",
+      "tokens": [
+        "Text(data=&#)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "hex-start state continues hex digits",
+      "diagnostics": [],
+      "id": "seeded-hex-start-reference-complete",
+      "initial_state": "Hexadecimal character reference start state",
+      "input": "41;!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#x",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "hex-start state reports missing digits before boundary",
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference"
+      ],
+      "id": "seeded-hex-start-reference-absent-digits",
+      "initial_state": "Hexadecimal character reference start state",
+      "input": ";!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#x",
+      "tokens": [
+        "Text(data=&#x;!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "hex-start state reports missing digits at EOF",
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference"
+      ],
+      "id": "seeded-hex-start-reference-eof",
+      "initial_state": "Hexadecimal character reference start state",
+      "input": "",
+      "return_state": "Data state",
+      "temporary_buffer": "&#x",
+      "tokens": [
+        "Text(data=&#x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "hex state decodes and reports missing semicolon",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "seeded-hex-reference-missing-semicolon",
+      "initial_state": "Hexadecimal character reference state",
+      "input": "1!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#x4",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "hex state decodes null as replacement character",
+      "diagnostics": [
+        "null-character-reference"
+      ],
+      "id": "seeded-hex-reference-null",
+      "initial_state": "Hexadecimal character reference state",
+      "input": ";!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#x0",
+      "tokens": [
+        "Text(data=�!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "decimal state completes decimal digits",
+      "diagnostics": [],
+      "id": "seeded-decimal-reference-complete",
+      "initial_state": "Decimal character reference state",
+      "input": "5;!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#6",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "decimal state decodes and reports missing semicolon",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "seeded-decimal-reference-missing-semicolon",
+      "initial_state": "Decimal character reference state",
+      "input": "5!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#6",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "decimal state decodes outside-Unicode values as replacement",
+      "diagnostics": [
+        "character-reference-outside-unicode-range"
+      ],
+      "id": "seeded-decimal-reference-outside-range",
+      "initial_state": "Decimal character reference state",
+      "input": ";!",
+      "return_state": "Data state",
+      "temporary_buffer": "&#1114112",
+      "tokens": [
+        "Text(data=�!)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "decimal state returns to RCDATA before an end tag",
+      "diagnostics": [],
+      "id": "seeded-decimal-reference-rcdata",
+      "initial_state": "Decimal character reference state",
+      "input": "5;</title>",
+      "last_start_tag": "title",
+      "return_state": "RCDATA state",
+      "temporary_buffer": "&#6",
+      "tokens": [
+        "Text(data=A)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Character-reference boundary recovery for named, numeric, attribute, RCDATA, and seeded continuation tokenizer states.",
+  "format": "whatwg-html-tokenizer-character-reference-boundaries/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
@@ -1,0 +1,205 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_CHARACTER_REFERENCE_BOUNDARIES: &str =
+    include_str!("fixtures/whatwg-character-reference-boundaries.json");
+
+#[derive(Debug, Deserialize)]
+struct CharacterReferenceBoundarySuite {
+    format: String,
+    description: String,
+    cases: Vec<CharacterReferenceBoundaryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CharacterReferenceBoundaryCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    #[serde(default)]
+    initial_state: Option<String>,
+    #[serde(default)]
+    return_state: Option<String>,
+    #[serde(default)]
+    temporary_buffer: Option<String>,
+    #[serde(default)]
+    last_start_tag: Option<String>,
+}
+
+#[test]
+fn whatwg_character_reference_boundaries_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(
+        suite.format,
+        "whatwg-html-tokenizer-character-reference-boundaries/v1"
+    );
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 40);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "data-ambiguous-name-text"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "attribute-ambiguous-preserved"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "seeded-decimal-reference-rcdata"));
+}
+
+#[test]
+fn whatwg_character_reference_boundaries_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its character-reference boundary",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> CharacterReferenceBoundarySuite {
+    serde_json::from_str(WHATWG_CHARACTER_REFERENCE_BOUNDARIES)
+        .expect("WHATWG character-reference boundary fixture should parse")
+}
+
+fn configured_lexer(case: &CharacterReferenceBoundaryCase) -> HtmlLexer {
+    let state = case
+        .initial_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let mut context = HtmlLexContext::new(state);
+    if let Some(return_state) = case.return_state.as_deref() {
+        let return_state = HtmlTokenizerState::from_html5lib_state(return_state)
+            .unwrap_or_else(|| panic!("case `{}` has unknown return state", case.id));
+        context = context.with_return_state(return_state);
+    }
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        context = context.with_temporary_buffer(temporary_buffer);
+    }
+    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
+        context = context.with_last_start_tag(last_start_tag);
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG character-reference boundary fixture covering text, attributes, RCDATA, numeric boundaries, and seeded continuation states
- add a Rust conformance harness for the new fixture
- document regeneration/check commands in the html-lexer docs and changelog

## Validation
- rustfmt --check code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- git diff --check