### PR TITLE
Add Board VM UDP socket bytecode

### DIFF
--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -5,7 +5,8 @@ use board_vm_ir::{
     CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_I2C_OPEN,
     CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
     CAP_LED_MATRIX_FRAME, CAP_NETWORK_TCP_CLOSE, CAP_NETWORK_TCP_OPEN, CAP_NETWORK_TCP_READ,
-    CAP_NETWORK_TCP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_SPI_TRANSFER,
+    CAP_NETWORK_TCP_WRITE, CAP_NETWORK_UDP_CLOSE, CAP_NETWORK_UDP_OPEN, CAP_NETWORK_UDP_READ,
+    CAP_NETWORK_UDP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_SPI_TRANSFER,
     CAP_STORAGE_READ, CAP_STORAGE_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, CAP_UART_OPEN,
     CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE, CAP_WATCHDOG_KICK,
 };
@@ -235,6 +236,30 @@ const NETWORK_TCP_CLOSE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDe
     version: 1,
     flags: CAP_FLAG_BYTECODE_CALLABLE,
     name: "network.tcp.close",
+};
+const NETWORK_UDP_OPEN_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_NETWORK_UDP_OPEN,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "network.udp.open",
+};
+const NETWORK_UDP_WRITE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_NETWORK_UDP_WRITE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "network.udp.write",
+};
+const NETWORK_UDP_READ_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_NETWORK_UDP_READ,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "network.udp.read",
+};
+const NETWORK_UDP_CLOSE_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
+    id: CAP_NETWORK_UDP_CLOSE,
+    version: 1,
+    flags: CAP_FLAG_BYTECODE_CALLABLE,
+    name: "network.udp.close",
 };
 const LED_MATRIX_FRAME_DESCRIPTOR: CapabilityDescriptor<'static> = CapabilityDescriptor {
     id: CAP_LED_MATRIX_FRAME,
@@ -1273,6 +1298,50 @@ pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWO
     NETWORK_TCP_WRITE_DESCRIPTOR,
     NETWORK_TCP_READ_DESCRIPTOR,
     NETWORK_TCP_CLOSE_DESCRIPTOR,
+    LED_MATRIX_FRAME_DESCRIPTOR,
+    PROGRAM_RAM_EXEC_DESCRIPTOR,
+    PROGRAM_STORE_DESCRIPTOR,
+];
+
+pub const BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_UDP_AND_LED_MATRIX_CAPABILITIES:
+    [CapabilityDescriptor<'static>; 40] = [
+    GPIO_OPEN_DESCRIPTOR,
+    GPIO_WRITE_DESCRIPTOR,
+    GPIO_READ_DESCRIPTOR,
+    GPIO_CLOSE_DESCRIPTOR,
+    TIME_SLEEP_MS_DESCRIPTOR,
+    TIME_NOW_MS_DESCRIPTOR,
+    PWM_WRITE_DESCRIPTOR,
+    ADC_READ_DESCRIPTOR,
+    DAC_WRITE_U12_DESCRIPTOR,
+    I2C_OPEN_DESCRIPTOR,
+    I2C_WRITE_U8_DESCRIPTOR,
+    I2C_READ_U8_DESCRIPTOR,
+    I2C_WRITE_DESCRIPTOR,
+    I2C_READ_DESCRIPTOR,
+    I2C_TRANSFER_DESCRIPTOR,
+    SPI_OPEN_DESCRIPTOR,
+    SPI_TRANSFER_DESCRIPTOR,
+    UART_OPEN_DESCRIPTOR,
+    UART_WRITE_DESCRIPTOR,
+    UART_READ_DESCRIPTOR,
+    CAN_OPEN_DESCRIPTOR,
+    CAN_WRITE_DESCRIPTOR,
+    CAN_READ_DESCRIPTOR,
+    RTC_NOW_DESCRIPTOR,
+    RTC_SET_DESCRIPTOR,
+    WATCHDOG_CONFIGURE_DESCRIPTOR,
+    WATCHDOG_KICK_DESCRIPTOR,
+    STORAGE_WRITE_DESCRIPTOR,
+    STORAGE_READ_DESCRIPTOR,
+    NETWORK_TCP_OPEN_DESCRIPTOR,
+    NETWORK_TCP_WRITE_DESCRIPTOR,
+    NETWORK_TCP_READ_DESCRIPTOR,
+    NETWORK_TCP_CLOSE_DESCRIPTOR,
+    NETWORK_UDP_OPEN_DESCRIPTOR,
+    NETWORK_UDP_WRITE_DESCRIPTOR,
+    NETWORK_UDP_READ_DESCRIPTOR,
+    NETWORK_UDP_CLOSE_DESCRIPTOR,
     LED_MATRIX_FRAME_DESCRIPTOR,
     PROGRAM_RAM_EXEC_DESCRIPTOR,
     PROGRAM_STORE_DESCRIPTOR,
@@ -2440,7 +2509,7 @@ mod tests {
         PROGRAM_STORE_DESCRIPTOR,
     ];
 
-    const NETWORK_TCP_CAPABILITIES: [CapabilityDescriptor<'static>; 11] = [
+    const NETWORK_SOCKET_CAPABILITIES: [CapabilityDescriptor<'static>; 15] = [
         GPIO_OPEN_DESCRIPTOR,
         GPIO_WRITE_DESCRIPTOR,
         GPIO_READ_DESCRIPTOR,
@@ -2451,6 +2520,10 @@ mod tests {
         NETWORK_TCP_WRITE_DESCRIPTOR,
         NETWORK_TCP_READ_DESCRIPTOR,
         NETWORK_TCP_CLOSE_DESCRIPTOR,
+        NETWORK_UDP_OPEN_DESCRIPTOR,
+        NETWORK_UDP_WRITE_DESCRIPTOR,
+        NETWORK_UDP_READ_DESCRIPTOR,
+        NETWORK_UDP_CLOSE_DESCRIPTOR,
         PROGRAM_RAM_EXEC_DESCRIPTOR,
     ];
 
@@ -2743,7 +2816,7 @@ mod tests {
     }
 
     #[test]
-    fn descriptor_reports_network_tcp_bytecode_capabilities() {
+    fn descriptor_reports_network_socket_bytecode_capabilities() {
         let mut device = BoardVmDevice::new(
             DeviceDescriptor {
                 board_id: "test-board",
@@ -2751,14 +2824,18 @@ mod tests {
                 board_nonce: 0xB04D_1001,
                 max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
                 supports_store_program: false,
-                capabilities: &NETWORK_TCP_CAPABILITIES,
+                capabilities: &NETWORK_SOCKET_CAPABILITIES,
             },
-            FakeHal::new(CapabilitySet::blink_mvp().with_network_tcp()),
+            FakeHal::new(
+                CapabilitySet::blink_mvp()
+                    .with_network_tcp()
+                    .with_network_udp(),
+            ),
         );
         let mut session = HostSession::new();
         let mut request = [0u8; 128];
-        let mut device_payload = [0u8; 256];
-        let mut response = [0u8; 320];
+        let mut device_payload = [0u8; 384];
+        let mut response = [0u8; 448];
 
         let caps = session.caps_query_frame(&mut request).unwrap();
         let response_len = handle(
@@ -2772,9 +2849,9 @@ mod tests {
 
         assert_eq!(
             header.capability_count,
-            NETWORK_TCP_CAPABILITIES.len() as u32
+            NETWORK_SOCKET_CAPABILITIES.len() as u32
         );
-        let mut found = [false; 4];
+        let mut found = [false; 8];
         for _ in 0..header.capability_count {
             let capability = decoder.read_capability_descriptor().unwrap();
             match capability.id {
@@ -2798,11 +2875,31 @@ mod tests {
                     assert_eq!(capability.name, "network.tcp.close");
                     assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
                 }
+                CAP_NETWORK_UDP_OPEN => {
+                    found[4] = true;
+                    assert_eq!(capability.name, "network.udp.open");
+                    assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
+                }
+                CAP_NETWORK_UDP_WRITE => {
+                    found[5] = true;
+                    assert_eq!(capability.name, "network.udp.write");
+                    assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
+                }
+                CAP_NETWORK_UDP_READ => {
+                    found[6] = true;
+                    assert_eq!(capability.name, "network.udp.read");
+                    assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
+                }
+                CAP_NETWORK_UDP_CLOSE => {
+                    found[7] = true;
+                    assert_eq!(capability.name, "network.udp.close");
+                    assert_eq!(capability.flags, CAP_FLAG_BYTECODE_CALLABLE);
+                }
                 _ => {}
             }
         }
         decoder.finish().unwrap();
-        assert_eq!(found, [true; 4]);
+        assert_eq!(found, [true; 8]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -3,7 +3,8 @@ use board_vm_ir::{
     CAP_CAN_READ, CAP_CAN_WRITE, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ,
     CAP_GPIO_WRITE, CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE,
     CAP_I2C_WRITE_U8, CAP_LED_MATRIX_FRAME, CAP_NETWORK_TCP_CLOSE, CAP_NETWORK_TCP_OPEN,
-    CAP_NETWORK_TCP_READ, CAP_NETWORK_TCP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET,
+    CAP_NETWORK_TCP_READ, CAP_NETWORK_TCP_WRITE, CAP_NETWORK_UDP_CLOSE, CAP_NETWORK_UDP_OPEN,
+    CAP_NETWORK_UDP_READ, CAP_NETWORK_UDP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET,
     CAP_SPI_OPEN, CAP_SPI_TRANSFER, CAP_STORAGE_READ, CAP_STORAGE_WRITE, CAP_TIME_NOW_MS,
     CAP_TIME_SLEEP_MS, CAP_UART_OPEN, CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE,
     CAP_WATCHDOG_KICK, FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
@@ -98,6 +99,14 @@ pub const NETWORK_TCP_READ_CODE_LEN: usize = 4;
 pub const NETWORK_TCP_READ_MODULE_LEN: usize = 14;
 pub const NETWORK_TCP_CLOSE_CODE_LEN: usize = 2;
 pub const NETWORK_TCP_CLOSE_MODULE_LEN: usize = 12;
+pub const NETWORK_UDP_OPEN_CODE_LEN: usize = 14;
+pub const NETWORK_UDP_OPEN_MODULE_LEN: usize = 24;
+pub const NETWORK_UDP_WRITE_CODE_LEN: usize = 5;
+pub const NETWORK_UDP_WRITE_MODULE_LEN: usize = 15;
+pub const NETWORK_UDP_READ_CODE_LEN: usize = 4;
+pub const NETWORK_UDP_READ_MODULE_LEN: usize = 14;
+pub const NETWORK_UDP_CLOSE_CODE_LEN: usize = 2;
+pub const NETWORK_UDP_CLOSE_MODULE_LEN: usize = 12;
 pub const LED_MATRIX_FRAME_CODE_LEN: usize = 18;
 pub const LED_MATRIX_FRAME_MODULE_LEN: usize = 28;
 
@@ -343,6 +352,30 @@ pub struct NetworkTcpCloseProgram {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkUdpOpenProgram {
+    pub interface: u8,
+    pub remote_ipv4: u32,
+    pub remote_port: u16,
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkUdpWriteProgram {
+    pub byte: u8,
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkUdpReadProgram {
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkUdpCloseProgram {
+    pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct I2cWriteU8Program {
     pub address: u16,
     pub byte: u8,
@@ -559,6 +592,47 @@ impl NetworkTcpCloseProgram {
 }
 
 impl Default for NetworkTcpCloseProgram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NetworkUdpOpenProgram {
+    pub const fn new(interface: u8, remote_ipv4: u32, remote_port: u16) -> Self {
+        Self {
+            interface,
+            remote_ipv4,
+            remote_port,
+            max_stack: 4,
+        }
+    }
+}
+
+impl NetworkUdpWriteProgram {
+    pub const fn new(byte: u8) -> Self {
+        Self { byte, max_stack: 3 }
+    }
+}
+
+impl NetworkUdpReadProgram {
+    pub const fn new() -> Self {
+        Self { max_stack: 2 }
+    }
+}
+
+impl Default for NetworkUdpReadProgram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NetworkUdpCloseProgram {
+    pub const fn new() -> Self {
+        Self { max_stack: 1 }
+    }
+}
+
+impl Default for NetworkUdpCloseProgram {
     fn default() -> Self {
         Self::new()
     }
@@ -2296,6 +2370,173 @@ pub fn write_network_tcp_close_module(
     Ok(offset)
 }
 
+pub fn write_network_udp_open_code(
+    program: NetworkUdpOpenProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_UDP_OPEN_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.interface)?;
+    write_push_u32(out, &mut offset, program.remote_ipv4)?;
+    write_push_u16(out, &mut offset, program.remote_port)?;
+    write_call_u8(out, &mut offset, CAP_NETWORK_UDP_OPEN)?;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_network_udp_open_module(
+    program: NetworkUdpOpenProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_UDP_OPEN_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; NETWORK_UDP_OPEN_CODE_LEN];
+    let code_len = write_network_udp_open_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(0, program.max_stack, &code[..code_len]),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_network_udp(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
+pub fn write_network_udp_write_code(
+    program: NetworkUdpWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_UDP_WRITE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.byte)?;
+    write_call_u8(out, &mut offset, CAP_NETWORK_UDP_WRITE)?;
+    Ok(offset)
+}
+
+pub fn write_network_udp_write_module(
+    program: NetworkUdpWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_UDP_WRITE_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; NETWORK_UDP_WRITE_CODE_LEN];
+    let code_len = write_network_udp_write_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_network_udp(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
+pub fn write_network_udp_read_code(
+    _program: NetworkUdpReadProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_UDP_READ_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_call_u8(out, &mut offset, CAP_NETWORK_UDP_READ)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_network_udp_read_module(
+    program: NetworkUdpReadProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_UDP_READ_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; NETWORK_UDP_READ_CODE_LEN];
+    let code_len = write_network_udp_read_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_network_udp(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
+pub fn write_network_udp_close_code(
+    _program: NetworkUdpCloseProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_UDP_CLOSE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_call_u8(out, &mut offset, CAP_NETWORK_UDP_CLOSE)?;
+    Ok(offset)
+}
+
+pub fn write_network_udp_close_module(
+    program: NetworkUdpCloseProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < NETWORK_UDP_CLOSE_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; NETWORK_UDP_CLOSE_CODE_LEN];
+    let code_len = write_network_udp_close_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(
+        &module,
+        CapabilitySet::blink_mvp().with_network_udp(),
+        program.max_stack,
+    )?;
+    Ok(offset)
+}
+
 pub fn spi_transfer_module_len(write_len: usize) -> Result<usize, HostError> {
     if write_len > MAX_BYTE_BUFFER_LEN {
         return Err(HostError::ProgramTooLarge);
@@ -2830,7 +3071,8 @@ mod tests {
         CAP_ADC_READ, CAP_CAN_OPEN, CAP_CAN_READ, CAP_CAN_WRITE, CAP_DAC_WRITE_U12, CAP_I2C_OPEN,
         CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
         CAP_LED_MATRIX_FRAME, CAP_NETWORK_TCP_CLOSE, CAP_NETWORK_TCP_OPEN, CAP_NETWORK_TCP_READ,
-        CAP_NETWORK_TCP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN,
+        CAP_NETWORK_TCP_WRITE, CAP_NETWORK_UDP_CLOSE, CAP_NETWORK_UDP_OPEN, CAP_NETWORK_UDP_READ,
+        CAP_NETWORK_UDP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN,
         CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE, CAP_WATCHDOG_KICK,
     };
     use board_vm_protocol::{
@@ -2922,6 +3164,19 @@ mod tests {
     ];
     const NETWORK_TCP_CLOSE_MODULE_HEX: [u8; NETWORK_TCP_CLOSE_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x01, 0x00, 0x02, 0x40, 0x3D, 0x00,
+    ];
+    const NETWORK_UDP_OPEN_MODULE_HEX: [u8; NETWORK_UDP_OPEN_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x04, 0x00, 0x0E, 0x12, 0x00, 0x14, 0x2A, 0x01, 0xA8,
+        0xC0, 0x13, 0x35, 0x12, 0x40, 0x3E, 0x20, 0x50, 0x00,
+    ];
+    const NETWORK_UDP_WRITE_A5_MODULE_HEX: [u8; NETWORK_UDP_WRITE_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x03, 0x00, 0x05, 0x20, 0x12, 0xA5, 0x40, 0x3F, 0x00,
+    ];
+    const NETWORK_UDP_READ_MODULE_HEX: [u8; NETWORK_UDP_READ_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x02, 0x00, 0x04, 0x20, 0x40, 0x40, 0x50, 0x00,
+    ];
+    const NETWORK_UDP_CLOSE_MODULE_HEX: [u8; NETWORK_UDP_CLOSE_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x01, 0x00, 0x02, 0x40, 0x41, 0x00,
     ];
     const RTC_NOW_MODULE_HEX: [u8; RTC_NOW_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x03, 0x40, 0x34, 0x50, 0x00,
@@ -3312,6 +3567,60 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_NETWORK_TCP_CLOSE]);
+    }
+
+    #[test]
+    fn builds_network_udp_open_module() {
+        let mut module = [0u8; NETWORK_UDP_OPEN_MODULE_LEN];
+        let len = write_network_udp_open_module(
+            NetworkUdpOpenProgram::new(0, 0xc0a8_012a, 0x1235),
+            &mut module,
+        )
+        .unwrap();
+        assert_eq!(len, NETWORK_UDP_OPEN_MODULE_LEN);
+        assert_eq!(module, NETWORK_UDP_OPEN_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_network_udp(), 4).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_NETWORK_UDP_OPEN]);
+    }
+
+    #[test]
+    fn builds_network_udp_byte_io_and_close_modules() {
+        let mut write = [0u8; NETWORK_UDP_WRITE_MODULE_LEN];
+        let write_len =
+            write_network_udp_write_module(NetworkUdpWriteProgram::new(0xa5), &mut write).unwrap();
+        assert_eq!(write_len, NETWORK_UDP_WRITE_MODULE_LEN);
+        assert_eq!(write, NETWORK_UDP_WRITE_A5_MODULE_HEX);
+        let parsed = parse_module(&write).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_network_udp(), 3).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_NETWORK_UDP_WRITE]);
+
+        let mut read = [0u8; NETWORK_UDP_READ_MODULE_LEN];
+        let read_len =
+            write_network_udp_read_module(NetworkUdpReadProgram::new(), &mut read).unwrap();
+        assert_eq!(read_len, NETWORK_UDP_READ_MODULE_LEN);
+        assert_eq!(read, NETWORK_UDP_READ_MODULE_HEX);
+        let parsed = parse_module(&read).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_network_udp(), 2).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_NETWORK_UDP_READ]);
+
+        let mut close = [0u8; NETWORK_UDP_CLOSE_MODULE_LEN];
+        let close_len =
+            write_network_udp_close_module(NetworkUdpCloseProgram::new(), &mut close).unwrap();
+        assert_eq!(close_len, NETWORK_UDP_CLOSE_MODULE_LEN);
+        assert_eq!(close, NETWORK_UDP_CLOSE_MODULE_HEX);
+        let parsed = parse_module(&close).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp().with_network_udp(), 1).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_NETWORK_UDP_CLOSE]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -45,6 +45,10 @@ pub const CAP_NETWORK_TCP_OPEN: u16 = 0x3A;
 pub const CAP_NETWORK_TCP_WRITE: u16 = 0x3B;
 pub const CAP_NETWORK_TCP_READ: u16 = 0x3C;
 pub const CAP_NETWORK_TCP_CLOSE: u16 = 0x3D;
+pub const CAP_NETWORK_UDP_OPEN: u16 = 0x3E;
+pub const CAP_NETWORK_UDP_WRITE: u16 = 0x3F;
+pub const CAP_NETWORK_UDP_READ: u16 = 0x40;
+pub const CAP_NETWORK_UDP_CLOSE: u16 = 0x41;
 
 const CAP_GPIO_OPEN_U8: u8 = CAP_GPIO_OPEN as u8;
 const CAP_GPIO_WRITE_U8: u8 = CAP_GPIO_WRITE as u8;
@@ -80,6 +84,10 @@ const CAP_NETWORK_TCP_OPEN_U8: u8 = CAP_NETWORK_TCP_OPEN as u8;
 const CAP_NETWORK_TCP_WRITE_U8: u8 = CAP_NETWORK_TCP_WRITE as u8;
 const CAP_NETWORK_TCP_READ_U8: u8 = CAP_NETWORK_TCP_READ as u8;
 const CAP_NETWORK_TCP_CLOSE_U8: u8 = CAP_NETWORK_TCP_CLOSE as u8;
+const CAP_NETWORK_UDP_OPEN_U8: u8 = CAP_NETWORK_UDP_OPEN as u8;
+const CAP_NETWORK_UDP_WRITE_U8: u8 = CAP_NETWORK_UDP_WRITE as u8;
+const CAP_NETWORK_UDP_READ_U8: u8 = CAP_NETWORK_UDP_READ as u8;
+const CAP_NETWORK_UDP_CLOSE_U8: u8 = CAP_NETWORK_UDP_CLOSE as u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Op {
@@ -166,6 +174,7 @@ pub struct CapabilitySet {
     pub watchdog: bool,
     pub storage: bool,
     pub network_tcp: bool,
+    pub network_udp: bool,
 }
 
 impl CapabilitySet {
@@ -185,6 +194,7 @@ impl CapabilitySet {
             watchdog: false,
             storage: false,
             network_tcp: false,
+            network_udp: false,
         }
     }
 
@@ -204,6 +214,7 @@ impl CapabilitySet {
             watchdog: false,
             storage: false,
             network_tcp: false,
+            network_udp: false,
         }
     }
 
@@ -267,6 +278,13 @@ impl CapabilitySet {
         }
     }
 
+    pub const fn with_network_udp(self) -> Self {
+        Self {
+            network_udp: true,
+            ..self
+        }
+    }
+
     pub const fn supports(self, capability_id: u16) -> bool {
         match capability_id {
             CAP_GPIO_OPEN | CAP_GPIO_WRITE | CAP_GPIO_READ | CAP_GPIO_CLOSE => self.gpio_digital,
@@ -287,6 +305,10 @@ impl CapabilitySet {
             | CAP_NETWORK_TCP_WRITE
             | CAP_NETWORK_TCP_READ
             | CAP_NETWORK_TCP_CLOSE => self.network_tcp,
+            CAP_NETWORK_UDP_OPEN
+            | CAP_NETWORK_UDP_WRITE
+            | CAP_NETWORK_UDP_READ
+            | CAP_NETWORK_UDP_CLOSE => self.network_udp,
             _ => false,
         }
     }
@@ -576,6 +598,10 @@ fn stack_effect(op: Op) -> (i16, i16) {
         Op::CallU8(CAP_NETWORK_TCP_WRITE_U8) | Op::CallU16(CAP_NETWORK_TCP_WRITE) => (2, 0),
         Op::CallU8(CAP_NETWORK_TCP_READ_U8) | Op::CallU16(CAP_NETWORK_TCP_READ) => (1, 1),
         Op::CallU8(CAP_NETWORK_TCP_CLOSE_U8) | Op::CallU16(CAP_NETWORK_TCP_CLOSE) => (1, 0),
+        Op::CallU8(CAP_NETWORK_UDP_OPEN_U8) | Op::CallU16(CAP_NETWORK_UDP_OPEN) => (3, 1),
+        Op::CallU8(CAP_NETWORK_UDP_WRITE_U8) | Op::CallU16(CAP_NETWORK_UDP_WRITE) => (2, 0),
+        Op::CallU8(CAP_NETWORK_UDP_READ_U8) | Op::CallU16(CAP_NETWORK_UDP_READ) => (1, 1),
+        Op::CallU8(CAP_NETWORK_UDP_CLOSE_U8) | Op::CallU16(CAP_NETWORK_UDP_CLOSE) => (1, 0),
         Op::CallU8(_) | Op::CallU16(_) => (0, 0),
         Op::ReturnTop => (1, 0),
     }

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -3810,6 +3810,10 @@ mod tests {
         assert!(uno.capabilities.contains(&"network.tcp.write".to_owned()));
         assert!(uno.capabilities.contains(&"network.tcp.read".to_owned()));
         assert!(uno.capabilities.contains(&"network.tcp.close".to_owned()));
+        assert!(uno.capabilities.contains(&"network.udp.open".to_owned()));
+        assert!(uno.capabilities.contains(&"network.udp.write".to_owned()));
+        assert!(uno.capabilities.contains(&"network.udp.read".to_owned()));
+        assert!(uno.capabilities.contains(&"network.udp.close".to_owned()));
         assert_eq!(uno.network_interfaces.len(), 1);
         let uno_network = &uno.network_interfaces[0];
         assert_eq!(uno_network.interface, 0);

--- a/code/packages/rust/board-vm-runtime/src/lib.rs
+++ b/code/packages/rust/board-vm-runtime/src/lib.rs
@@ -5,7 +5,8 @@ use board_vm_ir::{
     CAP_CAN_WRITE, CAP_DAC_WRITE_U12, CAP_GPIO_CLOSE, CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE,
     CAP_I2C_OPEN, CAP_I2C_READ, CAP_I2C_READ_U8, CAP_I2C_TRANSFER, CAP_I2C_WRITE, CAP_I2C_WRITE_U8,
     CAP_LED_MATRIX_FRAME, CAP_NETWORK_TCP_CLOSE, CAP_NETWORK_TCP_OPEN, CAP_NETWORK_TCP_READ,
-    CAP_NETWORK_TCP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_SPI_TRANSFER,
+    CAP_NETWORK_TCP_WRITE, CAP_NETWORK_UDP_CLOSE, CAP_NETWORK_UDP_OPEN, CAP_NETWORK_UDP_READ,
+    CAP_NETWORK_UDP_WRITE, CAP_PWM_WRITE, CAP_RTC_NOW, CAP_RTC_SET, CAP_SPI_OPEN, CAP_SPI_TRANSFER,
     CAP_STORAGE_READ, CAP_STORAGE_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS, CAP_UART_OPEN,
     CAP_UART_READ, CAP_UART_WRITE, CAP_WATCHDOG_CONFIGURE, CAP_WATCHDOG_KICK, MAX_BYTE_BUFFER_LEN,
 };
@@ -245,6 +246,27 @@ pub trait BoardHal {
         Err(HalError::UnsupportedMode)
     }
 
+    fn network_udp_open(
+        &mut self,
+        _interface: u16,
+        _remote_ipv4: u32,
+        _remote_port: u16,
+    ) -> Result<u32, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn network_udp_write(&mut self, _token: u32, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn network_udp_read(&mut self, _token: u32) -> Result<u8, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn network_udp_close(&mut self, _token: u32) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
     fn store_program(
         &mut self,
         _program_id: u16,
@@ -338,6 +360,7 @@ enum HandleKind {
     Uart,
     Can,
     NetworkTcp,
+    NetworkUdp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -942,6 +965,54 @@ where
                     })?;
                 self.close_handle(handle, ip)
             }
+            CAP_NETWORK_UDP_OPEN => {
+                let remote_port = self.pop_u16(ip)?;
+                let remote_ipv4 = self.pop_u32(ip)?;
+                let interface = self.pop_u16(ip)?;
+                let token = self
+                    .hal
+                    .network_udp_open(interface, remote_ipv4, remote_port)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                let handle = self.alloc_handle(HandleKind::NetworkUdp, token, ip)?;
+                self.push(Value::Handle(handle), ip)
+            }
+            CAP_NETWORK_UDP_WRITE => {
+                let byte = self.pop_u8(ip)?;
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::NetworkUdp, ip)?;
+                self.hal
+                    .network_udp_write(token, byte)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })
+            }
+            CAP_NETWORK_UDP_READ => {
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::NetworkUdp, ip)?;
+                let byte = self
+                    .hal
+                    .network_udp_read(token)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                self.push(Value::U8(byte), ip)
+            }
+            CAP_NETWORK_UDP_CLOSE => {
+                let handle = self.pop_handle(ip)?;
+                let token = self.handle_token(handle, HandleKind::NetworkUdp, ip)?;
+                self.hal
+                    .network_udp_close(token)
+                    .map_err(|err| RuntimeError {
+                        ip,
+                        kind: hal_error_kind(err),
+                    })?;
+                self.close_handle(handle, ip)
+            }
             CAP_LED_MATRIX_FRAME => {
                 let word2 = self.pop_u32(ip)?;
                 let word1 = self.pop_u32(ip)?;
@@ -1219,6 +1290,10 @@ mod tests {
         NetworkTcpWrite(u32, u8),
         NetworkTcpRead(u32),
         NetworkTcpClose(u32),
+        NetworkUdpOpen(u16, u32, u16),
+        NetworkUdpWrite(u32, u8),
+        NetworkUdpRead(u32),
+        NetworkUdpClose(u32),
         LedMatrixFrame([u32; 3]),
     }
 
@@ -1252,6 +1327,7 @@ mod tests {
                 .with_watchdog()
                 .with_storage()
                 .with_network_tcp()
+                .with_network_udp()
                 .with_led_matrix()
         }
 
@@ -1474,6 +1550,32 @@ mod tests {
 
         fn network_tcp_close(&mut self, token: u32) -> Result<(), HalError> {
             self.events.push(Event::NetworkTcpClose(token));
+            Ok(())
+        }
+
+        fn network_udp_open(
+            &mut self,
+            interface: u16,
+            remote_ipv4: u32,
+            remote_port: u16,
+        ) -> Result<u32, HalError> {
+            self.events
+                .push(Event::NetworkUdpOpen(interface, remote_ipv4, remote_port));
+            Ok(0x6_2003)
+        }
+
+        fn network_udp_write(&mut self, token: u32, byte: u8) -> Result<(), HalError> {
+            self.events.push(Event::NetworkUdpWrite(token, byte));
+            Ok(())
+        }
+
+        fn network_udp_read(&mut self, token: u32) -> Result<u8, HalError> {
+            self.events.push(Event::NetworkUdpRead(token));
+            Ok(0x43)
+        }
+
+        fn network_udp_close(&mut self, token: u32) -> Result<(), HalError> {
+            self.events.push(Event::NetworkUdpClose(token));
             Ok(())
         }
 
@@ -1947,6 +2049,50 @@ mod tests {
                 Event::NetworkTcpWrite(0x5_2002, 0x41),
                 Event::NetworkTcpRead(0x5_2002),
                 Event::NetworkTcpClose(0x5_2002),
+            ]
+        );
+    }
+
+    #[test]
+    fn network_udp_dispatches_socket_open_byte_io_and_close() {
+        let mut runtime: Runtime<FakeHal, 4, 1> = Runtime::new(FakeHal::new());
+        let code = [
+            0x12,
+            0x00,
+            0x14,
+            0x2a,
+            0x01,
+            0xa8,
+            0xc0,
+            0x13,
+            0x35,
+            0x12,
+            0x40,
+            CAP_NETWORK_UDP_OPEN as u8,
+            0x20,
+            0x12,
+            0x41,
+            0x40,
+            CAP_NETWORK_UDP_WRITE as u8,
+            0x20,
+            0x40,
+            CAP_NETWORK_UDP_READ as u8,
+            0x21,
+            0x40,
+            CAP_NETWORK_UDP_CLOSE as u8,
+        ];
+
+        let report = runtime.run_code(&code, 20).unwrap();
+
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.open_handles, 0);
+        assert_eq!(
+            runtime.hal().events,
+            vec![
+                Event::NetworkUdpOpen(0, 0xc0a8_012a, 0x1235),
+                Event::NetworkUdpWrite(0x6_2003, 0x41),
+                Event::NetworkUdpRead(0x6_2003),
+                Event::NetworkUdpClose(0x6_2003),
             ]
         );
     }

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -229,7 +229,7 @@ pub const UNO_R4_MINIMA_CAPABILITIES: [&str; 32] = [
     "program.store",
 ];
 
-pub const UNO_R4_WIFI_CAPABILITIES: [&str; 43] = [
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 47] = [
     "transport.serial",
     "transport.wifi",
     "transport.bluetooth_le",
@@ -241,6 +241,10 @@ pub const UNO_R4_WIFI_CAPABILITIES: [&str; 43] = [
     "network.tcp.write",
     "network.tcp.read",
     "network.tcp.close",
+    "network.udp.open",
+    "network.udp.write",
+    "network.udp.read",
+    "network.udp.close",
     "gpio.open",
     "gpio.write",
     "gpio.read",
@@ -1130,6 +1134,10 @@ mod tests {
         assert!(uno_r4_wifi.capabilities.contains(&"network.tcp.write"));
         assert!(uno_r4_wifi.capabilities.contains(&"network.tcp.read"));
         assert!(uno_r4_wifi.capabilities.contains(&"network.tcp.close"));
+        assert!(uno_r4_wifi.capabilities.contains(&"network.udp.open"));
+        assert!(uno_r4_wifi.capabilities.contains(&"network.udp.write"));
+        assert!(uno_r4_wifi.capabilities.contains(&"network.udp.read"));
+        assert!(uno_r4_wifi.capabilities.contains(&"network.udp.close"));
         assert_eq!(
             uno_r4_wifi.network_interfaces,
             &UNO_R4_WIFI_NETWORK_INTERFACES

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -24,6 +24,7 @@ use board_vm_device::{
     BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_AND_STORAGE_CAPABILITIES,
     BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_AND_LED_MATRIX_CAPABILITIES,
     BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_AND_LED_MATRIX_CAPABILITIES,
+    BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_UDP_AND_LED_MATRIX_CAPABILITIES,
     BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_RTC_AND_LED_MATRIX_CAPABILITIES,
     BLINK_MVP_WITH_PWM_AND_ADC_CAPABILITIES, BLINK_MVP_WITH_PWM_AND_DAC_CAPABILITIES,
     BLINK_MVP_WITH_PWM_AND_LED_MATRIX_CAPABILITIES, BLINK_MVP_WITH_PWM_CAPABILITIES,
@@ -533,7 +534,8 @@ pub const UNO_R4_WIFI: TargetDescriptor = TargetDescriptor {
         .with_rtc()
         .with_watchdog()
         .with_storage()
-        .with_network_tcp(),
+        .with_network_tcp()
+        .with_network_udp(),
     digital_pins: &UNO_R4_DIGITAL_PINS,
     i2c_buses: &UNO_R4_WIFI_I2C_BUSES,
     spi_buses: &UNO_R4_SPI_BUSES,
@@ -592,6 +594,10 @@ pub trait UnoR4Backend {
     }
 
     fn supports_network_tcp(&self) -> bool {
+        false
+    }
+
+    fn supports_network_udp(&self) -> bool {
         false
     }
 
@@ -690,6 +696,27 @@ pub trait UnoR4Backend {
     }
 
     fn close_network_tcp(&mut self, _socket: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn open_network_udp(
+        &mut self,
+        _interface: u8,
+        _remote_ipv4: u32,
+        _remote_port: u16,
+    ) -> Result<u32, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn write_network_udp(&mut self, _socket: u8, _byte: u8) -> Result<(), HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn read_network_udp(&mut self, _socket: u8) -> Result<u8, HalError> {
+        Err(HalError::UnsupportedMode)
+    }
+
+    fn close_network_udp(&mut self, _socket: u8) -> Result<(), HalError> {
         Err(HalError::UnsupportedMode)
     }
 
@@ -795,6 +822,8 @@ where
         capabilities.storage = self.backend.supports_storage();
         capabilities.network_tcp =
             self.target.supports_wifi_module && self.backend.supports_network_tcp();
+        capabilities.network_udp =
+            self.target.supports_wifi_module && self.backend.supports_network_udp();
         capabilities
     }
 }
@@ -961,6 +990,35 @@ where
     fn network_tcp_close(&mut self, token: u32) -> Result<(), HalError> {
         let socket = normalize_network_socket(token)?;
         self.backend.close_network_tcp(socket)
+    }
+
+    fn network_udp_open(
+        &mut self,
+        interface: u16,
+        remote_ipv4: u32,
+        remote_port: u16,
+    ) -> Result<u32, HalError> {
+        if !self.target.supports_wifi_module {
+            return Err(HalError::UnsupportedMode);
+        }
+        let interface = normalize_network_interface(interface)?;
+        self.backend
+            .open_network_udp(interface, remote_ipv4, remote_port)
+    }
+
+    fn network_udp_write(&mut self, token: u32, byte: u8) -> Result<(), HalError> {
+        let socket = normalize_network_socket(token)?;
+        self.backend.write_network_udp(socket, byte)
+    }
+
+    fn network_udp_read(&mut self, token: u32) -> Result<u8, HalError> {
+        let socket = normalize_network_socket(token)?;
+        self.backend.read_network_udp(socket)
+    }
+
+    fn network_udp_close(&mut self, token: u32) -> Result<(), HalError> {
+        let socket = normalize_network_socket(token)?;
+        self.backend.close_network_udp(socket)
     }
 
     fn store_program(
@@ -1278,6 +1336,22 @@ fn uno_r4_device_descriptor_for_capabilities(
             && capabilities.watchdog
             && capabilities.storage
             && capabilities.network_tcp
+            && capabilities.network_udp
+        {
+            &BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_UDP_AND_LED_MATRIX_CAPABILITIES
+        } else if target.supports_wifi_module
+            && target.supports_led_matrix
+            && capabilities.pwm
+            && capabilities.adc
+            && capabilities.dac
+            && capabilities.i2c
+            && capabilities.spi
+            && capabilities.uart
+            && capabilities.can
+            && capabilities.rtc
+            && capabilities.watchdog
+            && capabilities.storage
+            && capabilities.network_tcp
         {
             &BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_AND_LED_MATRIX_CAPABILITIES
         } else if target.supports_led_matrix
@@ -1543,6 +1617,10 @@ mod tests {
         NetworkTcpWrite(u8, u8),
         NetworkTcpRead(u8),
         NetworkTcpClose(u8),
+        NetworkUdpOpen(u8, u32, u16),
+        NetworkUdpWrite(u8, u8),
+        NetworkUdpRead(u8),
+        NetworkUdpClose(u8),
         LedMatrixFrame([u32; 3]),
         BootloaderReboot,
     }
@@ -1627,6 +1705,10 @@ mod tests {
         }
 
         fn supports_network_tcp(&self) -> bool {
+            true
+        }
+
+        fn supports_network_udp(&self) -> bool {
             true
         }
 
@@ -1753,6 +1835,32 @@ mod tests {
 
         fn close_network_tcp(&mut self, socket: u8) -> Result<(), HalError> {
             self.events.push(Event::NetworkTcpClose(socket));
+            Ok(())
+        }
+
+        fn open_network_udp(
+            &mut self,
+            interface: u8,
+            remote_ipv4: u32,
+            remote_port: u16,
+        ) -> Result<u32, HalError> {
+            self.events
+                .push(Event::NetworkUdpOpen(interface, remote_ipv4, remote_port));
+            Ok(0x6_2003)
+        }
+
+        fn write_network_udp(&mut self, socket: u8, byte: u8) -> Result<(), HalError> {
+            self.events.push(Event::NetworkUdpWrite(socket, byte));
+            Ok(())
+        }
+
+        fn read_network_udp(&mut self, socket: u8) -> Result<u8, HalError> {
+            self.events.push(Event::NetworkUdpRead(socket));
+            Ok(0x43)
+        }
+
+        fn close_network_udp(&mut self, socket: u8) -> Result<(), HalError> {
+            self.events.push(Event::NetworkUdpClose(socket));
             Ok(())
         }
 
@@ -1985,7 +2093,7 @@ mod tests {
         assert!(descriptor.supports_store_program);
         assert_eq!(
             descriptor.capabilities.len(),
-            BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_AND_LED_MATRIX_CAPABILITIES
+            BLINK_MVP_WITH_PWM_ADC_DAC_I2C_SPI_UART_CAN_RTC_WATCHDOG_STORAGE_NETWORK_TCP_UDP_AND_LED_MATRIX_CAPABILITIES
                 .len()
         );
         assert!(descriptor
@@ -1998,6 +2106,10 @@ mod tests {
         assert!(descriptor.capabilities.iter().any(|capability| {
             capability.id == board_vm_ir::CAP_NETWORK_TCP_OPEN
                 && capability.name == "network.tcp.open"
+        }));
+        assert!(descriptor.capabilities.iter().any(|capability| {
+            capability.id == board_vm_ir::CAP_NETWORK_UDP_OPEN
+                && capability.name == "network.udp.open"
         }));
         assert!(UNO_R4_WIFI
             .capabilities
@@ -2064,9 +2176,24 @@ mod tests {
         assert!(UNO_R4_WIFI
             .capabilities
             .supports(board_vm_ir::CAP_NETWORK_TCP_CLOSE));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_UDP_OPEN));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_UDP_WRITE));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_UDP_READ));
+        assert!(UNO_R4_WIFI
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_UDP_CLOSE));
         assert!(!UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_NETWORK_TCP_OPEN));
+        assert!(!UNO_R4_MINIMA
+            .capabilities
+            .supports(board_vm_ir::CAP_NETWORK_UDP_OPEN));
         assert!(UNO_R4_MINIMA
             .capabilities
             .supports(board_vm_ir::CAP_PWM_WRITE));
@@ -2431,16 +2558,45 @@ mod tests {
     }
 
     #[test]
-    fn network_tcp_rejects_non_wifi_target_or_unknown_interface() {
+    fn network_udp_runs_through_wifi_backend() {
+        let mut board = UnoR4Board::wifi(FakeBackend::new());
+
+        let token = board.network_udp_open(0, 0xc0a8_012a, 0x1235).unwrap();
+        board.network_udp_write(token, 0x41).unwrap();
+        let byte = board.network_udp_read(token).unwrap();
+        board.network_udp_close(token).unwrap();
+
+        assert_eq!(byte, 0x43);
+        assert_eq!(
+            board.backend().events,
+            vec![
+                Event::NetworkUdpOpen(0, 0xc0a8_012a, 0x1235),
+                Event::NetworkUdpWrite(3, 0x41),
+                Event::NetworkUdpRead(3),
+                Event::NetworkUdpClose(3),
+            ]
+        );
+    }
+
+    #[test]
+    fn network_sockets_reject_non_wifi_target_or_unknown_interface() {
         let mut minima = UnoR4Board::minima(FakeBackend::new());
         assert_eq!(
             minima.network_tcp_open(0, 0xc0a8_012a, 8080),
+            Err(HalError::UnsupportedMode)
+        );
+        assert_eq!(
+            minima.network_udp_open(0, 0xc0a8_012a, 0x1235),
             Err(HalError::UnsupportedMode)
         );
 
         let mut wifi = UnoR4Board::wifi(FakeBackend::new());
         assert_eq!(
             wifi.network_tcp_open(1, 0xc0a8_012a, 8080),
+            Err(HalError::InvalidPin)
+        );
+        assert_eq!(
+            wifi.network_udp_open(1, 0xc0a8_012a, 0x1235),
             Err(HalError::InvalidPin)
         );
     }

--- a/code/specs/BVM03-board-vm-rust-runtime.md
+++ b/code/specs/BVM03-board-vm-rust-runtime.md
@@ -131,13 +131,14 @@ The current no-heap Rust HAL exposes this first tranche as
 may lower that protocol-level request into their existing bounded storage writes,
 while leaving language frontends as thin builders for the `STORE_PROGRAM` frame.
 
-The first network tranche keeps the same no-heap shape: `network.tcp.open`
-accepts an interface id, an IPv4 address encoded as a `u32`, and a remote port,
-then returns a portable socket handle. `network.tcp.write`, `network.tcp.read`,
-and `network.tcp.close` operate on that handle and delegate to narrow
-`BoardHal::network_tcp_*` hooks. Host SDKs build bytecode for these calls; board
-ports decide when a concrete backend can actually drive a WiFi or Ethernet
-module.
+The first network tranches keep the same no-heap shape: `network.tcp.open` and
+`network.udp.open` accept an interface id, an IPv4 address encoded as a `u32`,
+and a remote port, then return a portable socket handle. `network.tcp.write`,
+`network.tcp.read`, `network.tcp.close`, `network.udp.write`,
+`network.udp.read`, and `network.udp.close` operate on those handles and
+delegate to narrow `BoardHal::network_tcp_*` and `BoardHal::network_udp_*`
+hooks. Host SDKs build bytecode for these calls; board ports decide when a
+concrete backend can actually drive a WiFi or Ethernet module.
 
 `HandleToken` is private to the board adapter. The portable VM only sees compact
 `Handle` ids.
@@ -151,6 +152,7 @@ CALL_U8 0x01 -> gpio.open
 CALL_U8 0x02 -> gpio.write
 CALL_U8 0x10 -> time.sleep_ms
 CALL_U8 0x3a -> network.tcp.open
+CALL_U8 0x3e -> network.udp.open
 ```
 
 Each handler:

--- a/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
+++ b/code/specs/BVM07-uno-r4-wifi-feature-inventory.md
@@ -37,7 +37,7 @@ Source snapshot:
 | EEPROM/flash emulation | 8 KiB flash-backed EEPROM area | descriptor metadata and bounded bytecode read/write implemented | `storage.write`, `storage.read`; stored program / KV layers later |
 | Watchdog | Renesas WDT library | descriptor metadata and direct bytecode operations implemented | `watchdog.configure`, `watchdog.kick` |
 | OPAMP | UNO R4 OPAMP library | pending | analog board-specific capability after ADC/DAC |
-| WiFi | WiFiS3 library through onboard network module | descriptor metadata, network capability strings, and first TCP socket bytecode tranche implemented | `transport.wifi`, `network.ipv4`, `network.tcp`, `network.udp`, `network.tcp.open`, `network.tcp.write`, `network.tcp.read`, `network.tcp.close`; UDP and WiFi association control later |
+| WiFi | WiFiS3 library through onboard network module | descriptor metadata, network capability strings, and first TCP/UDP socket bytecode tranches implemented | `transport.wifi`, `network.ipv4`, `network.tcp`, `network.udp`, `network.tcp.open`, `network.tcp.write`, `network.tcp.read`, `network.tcp.close`, `network.udp.open`, `network.udp.write`, `network.udp.read`, `network.udp.close`; WiFi association control and DNS later |
 | USB/HID | TinyUSB device support | pending | transport/device descriptors first; HID later |
 | OTA/SDU | OTAUpdate and SDU libraries | pending | firmware-management capability, separate from bytecode VM |
 
@@ -94,9 +94,11 @@ reject conflicting handles.
    Rust-owned descriptor metadata for the onboard WiFiS3 interface plus
    `network.ipv4`, `network.tcp`, and `network.udp` capability strings surfaced
    through the language target APIs. `network.tcp.open`, `network.tcp.write`,
-   `network.tcp.read`, and `network.tcp.close` now establish the first socket
-   bytecode tranche with runtime handle-table ownership, host builders, device
-   capability descriptors, and UNO R4 WiFi backend hooks. `program.store` now
+   `network.tcp.read`, `network.tcp.close`, `network.udp.open`,
+   `network.udp.write`, `network.udp.read`, and `network.udp.close` now
+   establish the first socket bytecode tranches with runtime handle-table
+   ownership, host builders, device capability descriptors, and UNO R4 WiFi
+   backend hooks. `program.store` now
    has a protocol capability descriptor, `STORE_PROGRAM` device dispatch,
    runtime HAL hook, and an initial UNO R4 storage-backed slot-0 layout that
    writes a compact header plus module chunks through the same bounded storage


### PR DESCRIPTION
## Summary
- Add Board VM UDP socket bytecode capabilities for `network.udp.open`, `network.udp.write`, `network.udp.read`, and `network.udp.close`.
- Wire UDP through the runtime handle table, HAL traits, device capability descriptors, UNO R4 WiFi backend hooks, host module builders, and target metadata.
- Update the Board VM runtime and UNO R4 WiFi specs to mark the TCP/UDP socket bytecode tranches as implemented.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-udp-bytecode cargo fmt -p board-vm-ir -p board-vm-runtime -p board-vm-device -p board-vm-uno-r4 -p board-vm-host -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-udp-bytecode cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-udp-bytecode cargo test -p board-vm-uno-r4-firmware`
- `bundle exec ruby -c lib/coding_adventures/board_vm/session.rb`
- `bundle exec ruby -c lib/coding_adventures/board_vm/connection.rb`
- `bundle exec rake test`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Generated `build-plan.json`, Cargo.lock files, `Gemfile.lock`, and `board_vm_native.bundle` were removed before committing.
