### PR TITLE
Add WHATWG script escape boundary fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -63,6 +63,10 @@ documented in this file.
 - A generated WHATWG tokenizer text-mode delimiter fixture and Rust conformance
   test that pins RCDATA, RAWTEXT, script-data, escaped-script, and seeded
   end-tag continuation recovery.
+- A generated WHATWG tokenizer script escape boundary fixture and Rust
+  conformance test that pins escaped and double-escaped script data, escape
+  start/end delimiters, EOF diagnostics, NULL replacement, and seeded
+  continuation recovery.
 - A generated WHATWG tokenizer markup declaration fixture and Rust conformance
   test that pins comment, bogus-comment, CDATA-looking declaration, DOCTYPE,
   and seeded declaration continuation recovery.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -317,6 +317,17 @@ python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_bou
   --check
 ```
 
+The checked-in `whatwg-script-escape-boundaries.json` fixture exercises
+script-data escaped and double-escaped tokenizer boundary recovery, including
+escape start/end delimiters, EOF diagnostics, NULL replacement, and seeded
+continuation states. Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py \
+  --check
+```
+
 There is also an `upstream-html5lib-smoke.test` file that mirrors the raw
 html5lib tokenizer JSON shape in a small supported subset. The Rust test
 harness now targets a checked-in generated `html5lib-smoke.json` corpus, which

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -70,6 +70,9 @@ binary while production code continues to link only static Rust source.
 - `whatwg-text-mode-delimiters.json`: generated HTML tokenizer text-mode
   delimiter cases used by Rust tests to pin RCDATA, RAWTEXT, script-data,
   escaped-script, and seeded end-tag continuation recovery
+- `whatwg-script-escape-boundaries.json`: generated HTML tokenizer script
+  escape boundary cases used by Rust tests to pin escaped/double-escaped
+  script data, NULL, EOF, and seeded continuation recovery
 - `whatwg-markup-declarations.json`: generated HTML tokenizer markup
   declaration cases used by Rust tests to pin comment, bogus-comment, CDATA,
   DOCTYPE, and seeded declaration continuation recovery
@@ -114,6 +117,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_text_mode_delimiters_fixture.py`: importer that generates
   text-mode end-tag delimiter cases for the checked-in
   `whatwg-text-mode-delimiters.json` fixture
+- `generate_whatwg_script_escape_boundaries_fixture.py`: importer that
+  generates focused script escape boundary cases for the checked-in
+  `whatwg-script-escape-boundaries.json` fixture
 - `generate_whatwg_markup_declarations_fixture.py`: importer that generates
   markup declaration recovery cases for the checked-in
   `whatwg-markup-declarations.json` fixture
@@ -185,6 +191,14 @@ Regenerate or verify the WHATWG text-mode delimiter fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG script escape boundary fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer script escape boundary fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-script-escape-boundaries.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        if output.read_text() != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer script escape boundary fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-script-escape-boundaries/v1",
+        "description": (
+            "Script data escaped, double-escaped, escape-start, escape-end, "
+            "NULL, EOF, and seeded continuation boundary recovery."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    return [
+        data("script-data-comment-open-then-end-tag", "a<!--b</script>c", ["Text(data=a<!--b)", "EndTag(name=script)", "Text(data=c)", "EOF"]),
+        data("script-data-comment-close-returns-to-script", "a<!--b-->c</script>", ["Text(data=a<!--b-->c)", "EndTag(name=script)", "EOF"]),
+        data("script-data-comment-eof", "a<!--open", ["Text(data=a<!--open)", "EOF"], diagnostics=["eof-in-script-html-comment-like-text"]),
+        data("script-data-comment-null", "a<!--x\u0000y</script>", ["Text(data=a<!--x�y)", "EndTag(name=script)", "EOF"], diagnostics=["unexpected-null-character"]),
+        data("script-data-double-escaped-inner-script", "a<!--<script>x</script>y</script>", ["Text(data=a<!--<script>x</script>y)", "EndTag(name=script)", "EOF"]),
+        state("script-less-than-non-end", "Script data less-than sign state", "x</script>", ["Text(data=<x)", "EndTag(name=script)", "EOF"]),
+        state("script-less-than-eof", "Script data less-than sign state", "", ["Text(data=<)", "EOF"]),
+        state("script-less-than-end-tag-open", "Script data less-than sign state", "/script>tail", ["EndTag(name=script)", "Text(data=tail)", "EOF"]),
+        state("script-escape-start-nondash", "Script data escape start state", "x</script>", ["Text(data=x)", "EndTag(name=script)", "EOF"]),
+        state("script-escape-start-eof", "Script data escape start state", "", ["EOF"]),
+        state("script-escape-start-dash-dash", "Script data escape start state", "--x</script>", ["Text(data=--x)", "EndTag(name=script)", "EOF"]),
+        state("script-escape-start-dash-nondash", "Script data escape start dash state", "x</script>", ["Text(data=x)", "EndTag(name=script)", "EOF"]),
+        state("script-escape-start-dash-eof", "Script data escape start dash state", "", ["EOF"]),
+        state("script-escaped-end-tag", "Script data escaped state", "x</script>tail", ["Text(data=x)", "EndTag(name=script)", "Text(data=tail)", "EOF"]),
+        state("script-escaped-mismatched-end-tag", "Script data escaped state", "x</style>y</script>", ["Text(data=x</style>y)", "EndTag(name=script)", "EOF"]),
+        state("script-escaped-comment-close", "Script data escaped state", "x-->y</script>", ["Text(data=x-->y)", "EndTag(name=script)", "EOF"]),
+        state("script-escaped-null", "Script data escaped state", "x\u0000y</script>", ["Text(data=x�y)", "EndTag(name=script)", "EOF"], diagnostics=["unexpected-null-character"]),
+        state("script-escaped-eof", "Script data escaped state", "x", ["Text(data=x)", "EOF"], diagnostics=["eof-in-script-html-comment-like-text"]),
+        state("script-escaped-dash-second-dash", "Script data escaped dash state", "-x</script>", ["Text(data=-x)", "EndTag(name=script)", "EOF"]),
+        state("script-escaped-dash-less-than", "Script data escaped dash state", "<x</script>", ["Text(data=<x)", "EndTag(name=script)", "EOF"]),
+        state("script-escaped-dash-null", "Script data escaped dash state", "\u0000x</script>", ["Text(data=�x)", "EndTag(name=script)", "EOF"], diagnostics=["unexpected-null-character"]),
+        state("script-escaped-dash-eof", "Script data escaped dash state", "", ["EOF"], diagnostics=["eof-in-script-html-comment-like-text"]),
+        state("script-escaped-dash-dash-close", "Script data escaped dash dash state", ">x</script>", ["Text(data=>x)", "EndTag(name=script)", "EOF"]),
+        state("script-escaped-dash-dash-more-dashes", "Script data escaped dash dash state", "-->x</script>", ["Text(data=-->x)", "EndTag(name=script)", "EOF"]),
+        state("script-escaped-dash-dash-null", "Script data escaped dash dash state", "\u0000x</script>", ["Text(data=�x)", "EndTag(name=script)", "EOF"], diagnostics=["unexpected-null-character"]),
+        state("script-escaped-less-than-non-special", "Script data escaped less-than sign state", "x</script>", ["Text(data=<x)", "EndTag(name=script)", "EOF"]),
+        state("script-escaped-less-than-slash-end", "Script data escaped less-than sign state", "/script>tail", ["EndTag(name=script)", "Text(data=tail)", "EOF"]),
+        state("script-escaped-less-than-uppercase-script", "Script data escaped less-than sign state", "SCRIPT>x</script>tail</script>", ["Text(data=<SCRIPT>x</script>tail)", "EndTag(name=script)", "EOF"]),
+        state("script-escaped-less-than-nonscript", "Script data escaped less-than sign state", "style>x</script>", ["Text(data=<style>x)", "EndTag(name=script)", "EOF"]),
+        state("script-double-escape-start-script", "Script data double escape start state", ">x</script>tail</script>", ["Text(data=>x</script>tail)", "EndTag(name=script)", "EOF"], temporary_buffer="script"),
+        state("script-double-escape-start-nonscript", "Script data double escape start state", ">x</script>", ["Text(data=>x)", "EndTag(name=script)", "EOF"], temporary_buffer="style"),
+        state("script-double-escape-start-eof", "Script data double escape start state", "", ["EOF"], temporary_buffer="script"),
+        state("script-double-escaped-end-script", "Script data double escaped state", "x</script>tail</script>", ["Text(data=x</script>tail)", "EndTag(name=script)", "EOF"]),
+        state("script-double-escaped-null", "Script data double escaped state", "x\u0000y</script>tail</script>", ["Text(data=x�y</script>tail)", "EndTag(name=script)", "EOF"], diagnostics=["unexpected-null-character"]),
+        state("script-double-escaped-eof", "Script data double escaped state", "x", ["Text(data=x)", "EOF"], diagnostics=["eof-in-script-html-comment-like-text"]),
+        state("script-double-escaped-dash-dash-close", "Script data double escaped dash dash state", ">x</script>", ["Text(data=>x)", "EndTag(name=script)", "EOF"]),
+        state("script-double-escaped-dash-null", "Script data double escaped dash state", "\u0000x</script>tail</script>", ["Text(data=�x</script>tail)", "EndTag(name=script)", "EOF"], diagnostics=["unexpected-null-character"]),
+        state("script-double-escaped-less-than-slash-script", "Script data double escaped less-than sign state", "/script>tail</script>", ["Text(data=/script>tail)", "EndTag(name=script)", "EOF"]),
+        state("script-double-escaped-less-than-nonslash", "Script data double escaped less-than sign state", "x</script>tail</script>", ["Text(data=x</script>tail)", "EndTag(name=script)", "EOF"]),
+        state("script-double-escape-end-script", "Script data double escape end state", ">tail</script>", ["Text(data=>tail)", "EndTag(name=script)", "EOF"], temporary_buffer="script"),
+        state("script-double-escape-end-nonscript", "Script data double escape end state", ">tail</script>outer</script>", ["Text(data=>tail</script>outer)", "EndTag(name=script)", "EOF"], temporary_buffer="style"),
+        state("script-double-escape-end-eof", "Script data double escape end state", "", ["EOF"], temporary_buffer="script"),
+    ]
+
+
+def data(
+    case_id: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    diagnostics: list[str] | None = None,
+) -> dict[str, object]:
+    return state(
+        case_id,
+        "Script data state",
+        input_text,
+        tokens,
+        diagnostics=diagnostics,
+    )
+
+
+def state(
+    case_id: str,
+    initial_state: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    diagnostics: list[str] | None = None,
+    temporary_buffer: str | None = None,
+) -> dict[str, object]:
+    item: dict[str, object] = {
+        "id": case_id,
+        "description": f"{initial_state} boundary case `{case_id}`",
+        "input": input_text,
+        "initial_state": initial_state,
+        "last_start_tag": "script",
+        "tokens": tokens,
+    }
+    if diagnostics is not None:
+        item["diagnostics"] = diagnostics
+    if temporary_buffer is not None:
+        item["temporary_buffer"] = temporary_buffer
+    return item
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-script-escape-boundaries.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-script-escape-boundaries.json
@@ -1,0 +1,566 @@
+{
+  "cases": [
+    {
+      "description": "Script data state boundary case `script-data-comment-open-then-end-tag`",
+      "diagnostics": [],
+      "id": "script-data-comment-open-then-end-tag",
+      "initial_state": "Script data state",
+      "input": "a<!--b</script>c",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=a<!--b)",
+        "EndTag(name=script)",
+        "Text(data=c)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state boundary case `script-data-comment-close-returns-to-script`",
+      "diagnostics": [],
+      "id": "script-data-comment-close-returns-to-script",
+      "initial_state": "Script data state",
+      "input": "a<!--b-->c</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=a<!--b-->c)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state boundary case `script-data-comment-eof`",
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "id": "script-data-comment-eof",
+      "initial_state": "Script data state",
+      "input": "a<!--open",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=a<!--open)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state boundary case `script-data-comment-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "script-data-comment-null",
+      "initial_state": "Script data state",
+      "input": "a<!--x\u0000y</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=a<!--x�y)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data state boundary case `script-data-double-escaped-inner-script`",
+      "diagnostics": [],
+      "id": "script-data-double-escaped-inner-script",
+      "initial_state": "Script data state",
+      "input": "a<!--<script>x</script>y</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=a<!--<script>x</script>y)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data less-than sign state boundary case `script-less-than-non-end`",
+      "diagnostics": [],
+      "id": "script-less-than-non-end",
+      "initial_state": "Script data less-than sign state",
+      "input": "x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=<x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data less-than sign state boundary case `script-less-than-eof`",
+      "diagnostics": [],
+      "id": "script-less-than-eof",
+      "initial_state": "Script data less-than sign state",
+      "input": "",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=<)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data less-than sign state boundary case `script-less-than-end-tag-open`",
+      "diagnostics": [],
+      "id": "script-less-than-end-tag-open",
+      "initial_state": "Script data less-than sign state",
+      "input": "/script>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escape start state boundary case `script-escape-start-nondash`",
+      "diagnostics": [],
+      "id": "script-escape-start-nondash",
+      "initial_state": "Script data escape start state",
+      "input": "x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escape start state boundary case `script-escape-start-eof`",
+      "diagnostics": [],
+      "id": "script-escape-start-eof",
+      "initial_state": "Script data escape start state",
+      "input": "",
+      "last_start_tag": "script",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escape start state boundary case `script-escape-start-dash-dash`",
+      "diagnostics": [],
+      "id": "script-escape-start-dash-dash",
+      "initial_state": "Script data escape start state",
+      "input": "--x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=--x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escape start dash state boundary case `script-escape-start-dash-nondash`",
+      "diagnostics": [],
+      "id": "script-escape-start-dash-nondash",
+      "initial_state": "Script data escape start dash state",
+      "input": "x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escape start dash state boundary case `script-escape-start-dash-eof`",
+      "diagnostics": [],
+      "id": "script-escape-start-dash-eof",
+      "initial_state": "Script data escape start dash state",
+      "input": "",
+      "last_start_tag": "script",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state boundary case `script-escaped-end-tag`",
+      "diagnostics": [],
+      "id": "script-escaped-end-tag",
+      "initial_state": "Script data escaped state",
+      "input": "x</script>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x)",
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state boundary case `script-escaped-mismatched-end-tag`",
+      "diagnostics": [],
+      "id": "script-escaped-mismatched-end-tag",
+      "initial_state": "Script data escaped state",
+      "input": "x</style>y</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x</style>y)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state boundary case `script-escaped-comment-close`",
+      "diagnostics": [],
+      "id": "script-escaped-comment-close",
+      "initial_state": "Script data escaped state",
+      "input": "x-->y</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x-->y)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state boundary case `script-escaped-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "script-escaped-null",
+      "initial_state": "Script data escaped state",
+      "input": "x\u0000y</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x�y)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped state boundary case `script-escaped-eof`",
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "id": "script-escaped-eof",
+      "initial_state": "Script data escaped state",
+      "input": "x",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped dash state boundary case `script-escaped-dash-second-dash`",
+      "diagnostics": [],
+      "id": "script-escaped-dash-second-dash",
+      "initial_state": "Script data escaped dash state",
+      "input": "-x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=-x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped dash state boundary case `script-escaped-dash-less-than`",
+      "diagnostics": [],
+      "id": "script-escaped-dash-less-than",
+      "initial_state": "Script data escaped dash state",
+      "input": "<x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=<x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped dash state boundary case `script-escaped-dash-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "script-escaped-dash-null",
+      "initial_state": "Script data escaped dash state",
+      "input": "\u0000x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=�x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped dash state boundary case `script-escaped-dash-eof`",
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "id": "script-escaped-dash-eof",
+      "initial_state": "Script data escaped dash state",
+      "input": "",
+      "last_start_tag": "script",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped dash dash state boundary case `script-escaped-dash-dash-close`",
+      "diagnostics": [],
+      "id": "script-escaped-dash-dash-close",
+      "initial_state": "Script data escaped dash dash state",
+      "input": ">x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=>x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped dash dash state boundary case `script-escaped-dash-dash-more-dashes`",
+      "diagnostics": [],
+      "id": "script-escaped-dash-dash-more-dashes",
+      "initial_state": "Script data escaped dash dash state",
+      "input": "-->x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=-->x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped dash dash state boundary case `script-escaped-dash-dash-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "script-escaped-dash-dash-null",
+      "initial_state": "Script data escaped dash dash state",
+      "input": "\u0000x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=�x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped less-than sign state boundary case `script-escaped-less-than-non-special`",
+      "diagnostics": [],
+      "id": "script-escaped-less-than-non-special",
+      "initial_state": "Script data escaped less-than sign state",
+      "input": "x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=<x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped less-than sign state boundary case `script-escaped-less-than-slash-end`",
+      "diagnostics": [],
+      "id": "script-escaped-less-than-slash-end",
+      "initial_state": "Script data escaped less-than sign state",
+      "input": "/script>tail",
+      "last_start_tag": "script",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped less-than sign state boundary case `script-escaped-less-than-uppercase-script`",
+      "diagnostics": [],
+      "id": "script-escaped-less-than-uppercase-script",
+      "initial_state": "Script data escaped less-than sign state",
+      "input": "SCRIPT>x</script>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=<SCRIPT>x</script>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data escaped less-than sign state boundary case `script-escaped-less-than-nonscript`",
+      "diagnostics": [],
+      "id": "script-escaped-less-than-nonscript",
+      "initial_state": "Script data escaped less-than sign state",
+      "input": "style>x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=<style>x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escape start state boundary case `script-double-escape-start-script`",
+      "diagnostics": [],
+      "id": "script-double-escape-start-script",
+      "initial_state": "Script data double escape start state",
+      "input": ">x</script>tail</script>",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "Text(data=>x</script>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escape start state boundary case `script-double-escape-start-nonscript`",
+      "diagnostics": [],
+      "id": "script-double-escape-start-nonscript",
+      "initial_state": "Script data double escape start state",
+      "input": ">x</script>",
+      "last_start_tag": "script",
+      "temporary_buffer": "style",
+      "tokens": [
+        "Text(data=>x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escape start state boundary case `script-double-escape-start-eof`",
+      "diagnostics": [],
+      "id": "script-double-escape-start-eof",
+      "initial_state": "Script data double escape start state",
+      "input": "",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escaped state boundary case `script-double-escaped-end-script`",
+      "diagnostics": [],
+      "id": "script-double-escaped-end-script",
+      "initial_state": "Script data double escaped state",
+      "input": "x</script>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x</script>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escaped state boundary case `script-double-escaped-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "script-double-escaped-null",
+      "initial_state": "Script data double escaped state",
+      "input": "x\u0000y</script>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x�y</script>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escaped state boundary case `script-double-escaped-eof`",
+      "diagnostics": [
+        "eof-in-script-html-comment-like-text"
+      ],
+      "id": "script-double-escaped-eof",
+      "initial_state": "Script data double escaped state",
+      "input": "x",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escaped dash dash state boundary case `script-double-escaped-dash-dash-close`",
+      "diagnostics": [],
+      "id": "script-double-escaped-dash-dash-close",
+      "initial_state": "Script data double escaped dash dash state",
+      "input": ">x</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=>x)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escaped dash state boundary case `script-double-escaped-dash-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "script-double-escaped-dash-null",
+      "initial_state": "Script data double escaped dash state",
+      "input": "\u0000x</script>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=�x</script>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escaped less-than sign state boundary case `script-double-escaped-less-than-slash-script`",
+      "diagnostics": [],
+      "id": "script-double-escaped-less-than-slash-script",
+      "initial_state": "Script data double escaped less-than sign state",
+      "input": "/script>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=/script>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escaped less-than sign state boundary case `script-double-escaped-less-than-nonslash`",
+      "diagnostics": [],
+      "id": "script-double-escaped-less-than-nonslash",
+      "initial_state": "Script data double escaped less-than sign state",
+      "input": "x</script>tail</script>",
+      "last_start_tag": "script",
+      "tokens": [
+        "Text(data=x</script>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escape end state boundary case `script-double-escape-end-script`",
+      "diagnostics": [],
+      "id": "script-double-escape-end-script",
+      "initial_state": "Script data double escape end state",
+      "input": ">tail</script>",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "Text(data=>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escape end state boundary case `script-double-escape-end-nonscript`",
+      "diagnostics": [],
+      "id": "script-double-escape-end-nonscript",
+      "initial_state": "Script data double escape end state",
+      "input": ">tail</script>outer</script>",
+      "last_start_tag": "script",
+      "temporary_buffer": "style",
+      "tokens": [
+        "Text(data=>tail</script>outer)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "Script data double escape end state boundary case `script-double-escape-end-eof`",
+      "diagnostics": [],
+      "id": "script-double-escape-end-eof",
+      "initial_state": "Script data double escape end state",
+      "input": "",
+      "last_start_tag": "script",
+      "temporary_buffer": "script",
+      "tokens": [
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Script data escaped, double-escaped, escape-start, escape-end, NULL, EOF, and seeded continuation boundary recovery.",
+  "format": "whatwg-html-tokenizer-script-escape-boundaries/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
@@ -1,0 +1,190 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_SCRIPT_ESCAPE_BOUNDARIES: &str =
+    include_str!("fixtures/whatwg-script-escape-boundaries.json");
+
+#[derive(Debug, Deserialize)]
+struct ScriptEscapeBoundarySuite {
+    format: String,
+    description: String,
+    cases: Vec<ScriptEscapeBoundaryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ScriptEscapeBoundaryCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    initial_state: String,
+    last_start_tag: String,
+    #[serde(default)]
+    temporary_buffer: Option<String>,
+}
+
+#[test]
+fn whatwg_script_escape_boundaries_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(
+        suite.format,
+        "whatwg-html-tokenizer-script-escape-boundaries/v1"
+    );
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 40);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "script-data-comment-eof"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "script-escaped-less-than-uppercase-script"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "script-double-escape-end-script"));
+}
+
+#[test]
+fn whatwg_script_escape_boundaries_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its script escape boundary",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> ScriptEscapeBoundarySuite {
+    serde_json::from_str(WHATWG_SCRIPT_ESCAPE_BOUNDARIES)
+        .expect("WHATWG script escape boundary fixture should parse")
+}
+
+fn configured_lexer(case: &ScriptEscapeBoundaryCase) -> HtmlLexer {
+    let state = HtmlTokenizerState::from_html5lib_state(&case.initial_state)
+        .unwrap_or_else(|| panic!("case `{}` has unknown initial state", case.id));
+    let mut context = HtmlLexContext::new(state).with_last_start_tag(&case.last_start_tag);
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        context = context.with_temporary_buffer(temporary_buffer);
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG script escape boundary fixture covering script-data escaped and double-escaped tokenizer states
- add a Rust conformance harness for the new fixture
- document regeneration/check commands in the html-lexer docs and changelog

## Validation
- rustfmt --check code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- git diff --check