### PR TITLE
spice: add two-port s-parameters

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Two-port S-parameter extraction** — `s_parameters` derives a two-port
+  Y-parameter matrix from named AC voltage-source ports and converts it to
+  S11/S21/S12/S22 for a configurable reference impedance.
+
 - **Sparse real solver path** — large DC / real small-signal matrices now route
   through a sparse-row Gaussian elimination path while small systems keep the
   dense solver.

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -38,6 +38,8 @@ from spice_engine.engine import (
     NoiseResult,
     SensEntry,
     SensResult,
+    SParameterPoint,
+    SParameterResult,
     TfResult,
     TransientPoint,
     TransientResult,
@@ -47,6 +49,7 @@ from spice_engine.engine import (
     mc_dc,
     noise_ac,
     sens_dc,
+    s_parameters,
     tf,
     transient,
 )
@@ -82,6 +85,8 @@ __all__ = [
     "Resistor",
     "SensEntry",
     "SensResult",
+    "SParameterPoint",
+    "SParameterResult",
     "SinWaveform",
     "SubcircuitDefinition",
     "TfResult",
@@ -99,6 +104,7 @@ __all__ = [
     "mc_dc",
     "noise_ac",
     "sens_dc",
+    "s_parameters",
     "tf",
     "transient",
 ]

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -53,7 +53,7 @@ import math
 import random
 import re
 import statistics
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from spice_engine.elements import (
     AcSource,
@@ -273,6 +273,7 @@ class AcPoint:
 
     freq: float
     node_voltages: dict[str, complex]
+    branch_currents: dict[str, complex] = field(default_factory=dict)
 
 
 @dataclass
@@ -287,6 +288,27 @@ class AcResult:
     """
 
     points: list[AcPoint]
+
+
+@dataclass(frozen=True)
+class SParameterPoint:
+    """Two-port scattering parameters at one frequency point."""
+
+    freq: float
+    s11: complex
+    s21: complex
+    s12: complex
+    s22: complex
+
+
+@dataclass(frozen=True)
+class SParameterResult:
+    """Two-port S-parameter sweep result."""
+
+    port1_source: str
+    port2_source: str
+    reference_impedance: float
+    points: list[SParameterPoint]
 
 
 @dataclass(frozen=True)
@@ -2556,9 +2578,134 @@ def ac_sweep(
             x_c = [0j] * size  # singular — return zeros for this frequency
 
         node_v = {name: x_c[idx] for name, idx in node_to_idx.items()}
-        ac_points.append(AcPoint(freq=freq, node_voltages=node_v))
+        branch_i = {
+            f"I({src.name})": x_c[n_nodes + i] for i, src in enumerate(branch_srcs)
+        }
+        ac_points.append(AcPoint(freq=freq, node_voltages=node_v, branch_currents=branch_i))
 
     return AcResult(points=ac_points)
+
+
+def _circuit_with_sparameter_drive(
+    circuit: Circuit,
+    port_sources: tuple[str, str],
+    driven_source: str,
+) -> Circuit:
+    elements: list[Element] = []
+    seen_ports: set[str] = set()
+    port_set = set(port_sources)
+
+    for element in circuit.elements:
+        if isinstance(element, VoltageSource) and element.name in port_set:
+            seen_ports.add(element.name)
+            magnitude = 1.0 if element.name == driven_source else 0.0
+            elements.append(replace(element, ac=AcSource(magnitude=magnitude)))
+        else:
+            elements.append(element)
+
+    missing = [source for source in port_sources if source not in seen_ports]
+    if missing:
+        raise ValueError(f"s_parameters: missing voltage-source port(s): {missing}")
+
+    return Circuit(elements)
+
+
+def _branch_current_into_network(point: AcPoint, source_name: str) -> complex:
+    key = source_name if source_name.startswith("I(") else f"I({source_name})"
+    if key not in point.branch_currents:
+        raise ValueError(f"s_parameters: missing branch current for {source_name!r}")
+    return -point.branch_currents[key]
+
+
+def _y_to_s_2port(
+    y11: complex,
+    y21: complex,
+    y12: complex,
+    y22: complex,
+    z0: float,
+) -> tuple[complex, complex, complex, complex]:
+    a11 = 1.0 - z0 * y11
+    a12 = -z0 * y12
+    a21 = -z0 * y21
+    a22 = 1.0 - z0 * y22
+
+    b11 = 1.0 + z0 * y11
+    b12 = z0 * y12
+    b21 = z0 * y21
+    b22 = 1.0 + z0 * y22
+    det = b11 * b22 - b12 * b21
+    if abs(det) < 1.0e-18:
+        raise ZeroDivisionError("s_parameters: singular Y-to-S conversion")
+
+    inv_b11 = b22 / det
+    inv_b12 = -b12 / det
+    inv_b21 = -b21 / det
+    inv_b22 = b11 / det
+
+    return (
+        a11 * inv_b11 + a12 * inv_b21,
+        a21 * inv_b11 + a22 * inv_b21,
+        a11 * inv_b12 + a12 * inv_b22,
+        a21 * inv_b12 + a22 * inv_b22,
+    )
+
+
+def s_parameters(
+    circuit: Circuit,
+    *,
+    port1_source: str,
+    port2_source: str,
+    frequencies: list[float],
+    reference_impedance: float = 50.0,
+) -> SParameterResult:
+    """Extract two-port S-parameters from AC small-signal solves.
+
+    The two ports are represented by named independent voltage sources.  For
+    each frequency the engine drives one port source with a 1 V AC phasor,
+    shorts the other port source with a 0 V AC phasor, measures the port
+    currents, builds the 2x2 Y-parameter matrix, then converts Y to S for the
+    requested reference impedance.
+    """
+    if reference_impedance <= 0.0 or not math.isfinite(reference_impedance):
+        raise ValueError("s_parameters: reference_impedance must be finite and positive")
+    if any(freq <= 0.0 or not math.isfinite(freq) for freq in frequencies):
+        raise ValueError("s_parameters: frequencies must be finite and positive")
+
+    ports = (port1_source, port2_source)
+    points: list[SParameterPoint] = []
+    for freq in frequencies:
+        y_columns: list[tuple[complex, complex]] = []
+        for driven in ports:
+            driven_circuit = _circuit_with_sparameter_drive(circuit, ports, driven)
+            ac_point = ac_sweep(
+                driven_circuit,
+                f_start=freq,
+                f_stop=freq,
+                n_points=1,
+                sweep="lin",
+            ).points[0]
+            y_columns.append(
+                (
+                    _branch_current_into_network(ac_point, port1_source),
+                    _branch_current_into_network(ac_point, port2_source),
+                )
+            )
+
+        s11, s21, s12, s22 = _y_to_s_2port(
+            y_columns[0][0],
+            y_columns[0][1],
+            y_columns[1][0],
+            y_columns[1][1],
+            reference_impedance,
+        )
+        points.append(SParameterPoint(freq=freq, s11=s11, s21=s21, s12=s12, s22=s22))
+
+    return SParameterResult(
+        port1_source=port1_source,
+        port2_source=port2_source,
+        reference_impedance=reference_impedance,
+        points=points,
+    )
 
 
 # Keep the cmath import visible to callers that ``from spice_engine import cmath``

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -106,6 +106,8 @@ from spice_engine import (
     SensEntry,
     SensResult,
     SinWaveform,
+    SParameterPoint,
+    SParameterResult,
     SubcircuitDefinition,
     TfResult,
     VoltageSource,
@@ -116,6 +118,7 @@ from spice_engine import (
     mc_dc,
     noise_ac,
     sens_dc,
+    s_parameters,
     tf,
     transient,
 )
@@ -5253,3 +5256,30 @@ def test_x_from_result_round_trip() -> None:
     # Node voltage entries should match result
     for i, nd in enumerate(nodes):
         assert x[i] == pytest.approx(result.node_voltages[nd])
+
+
+def test_s_parameters_series_resistor_two_port() -> None:
+    """A 50 ohm series resistor between 50 ohm ports has S11=1/3, S21=2/3."""
+    c = Circuit([
+        VoltageSource("P1", "p1", "0", 0.0),
+        VoltageSource("P2", "p2", "0", 0.0),
+        Resistor("Rseries", "p1", "p2", 50.0),
+    ])
+
+    result = s_parameters(
+        c,
+        port1_source="P1",
+        port2_source="P2",
+        frequencies=[1.0e6],
+        reference_impedance=50.0,
+    )
+
+    assert isinstance(result, SParameterResult)
+    assert isinstance(result.points[0], SParameterPoint)
+    point = result.points[0]
+    assert point.s11.real == pytest.approx(1.0 / 3.0)
+    assert point.s22.real == pytest.approx(1.0 / 3.0)
+    assert point.s21.real == pytest.approx(2.0 / 3.0)
+    assert point.s12.real == pytest.approx(2.0 / 3.0)
+    assert abs(point.s11.imag) < 1.0e-12
+    assert abs(point.s21.imag) < 1.0e-12

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add two-port S-parameter extraction from named AC voltage-source ports,
+  returning S11/S21/S12/S22 for a configurable reference impedance.
 - Add a sparse-row real linear solver path for large DC / real small-signal
   matrices while keeping the dense solver for small systems.
 - Add programmatic subcircuits with `SubcircuitDefinition` and `XInstance`

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1460,6 +1460,23 @@ impl AcPoint {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct SParameterPoint {
+    pub frequency_hz: f64,
+    pub s11: Complex,
+    pub s21: Complex,
+    pub s12: Complex,
+    pub s22: Complex,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SParameterResult {
+    pub port1_source: String,
+    pub port2_source: String,
+    pub reference_impedance_ohms: f64,
+    pub points: Vec<SParameterPoint>,
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum NoiseType {
     Thermal,
@@ -1950,6 +1967,161 @@ pub fn ac_sweep(
         frequency *= ratio;
     }
     Ok(points)
+}
+
+pub fn s_parameters(
+    circuit: &Circuit,
+    port1_source: &str,
+    port2_source: &str,
+    frequencies_hz: &[f64],
+    reference_impedance_ohms: f64,
+) -> Result<SParameterResult, SpiceError> {
+    if !reference_impedance_ohms.is_finite() || reference_impedance_ohms <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: "s_parameters".to_string(),
+            reason: "reference impedance must be finite and positive".to_string(),
+        });
+    }
+    for frequency in frequencies_hz {
+        if !frequency.is_finite() || *frequency <= 0.0 {
+            return Err(SpiceError::InvalidElement {
+                name: "s_parameters".to_string(),
+                reason: "frequencies must be finite and positive".to_string(),
+            });
+        }
+    }
+
+    let ports = [port1_source, port2_source];
+    validate_sparameter_ports(circuit, &ports)?;
+
+    let mut points = Vec::new();
+    for frequency_hz in frequencies_hz {
+        let mut columns = Vec::new();
+        for driven_source in ports {
+            let driven_circuit = circuit_with_sparameter_drive(circuit, &ports, driven_source);
+            let point = ac_sweep(&driven_circuit, *frequency_hz, *frequency_hz, 1)?
+                .into_iter()
+                .next()
+                .ok_or(SpiceError::SingularMatrix)?;
+            columns.push([
+                branch_current_into_network(&point, port1_source)?,
+                branch_current_into_network(&point, port2_source)?,
+            ]);
+        }
+
+        let (s11, s21, s12, s22) = y_to_s_2port(
+            columns[0][0],
+            columns[0][1],
+            columns[1][0],
+            columns[1][1],
+            reference_impedance_ohms,
+        )?;
+        points.push(SParameterPoint {
+            frequency_hz: *frequency_hz,
+            s11,
+            s21,
+            s12,
+            s22,
+        });
+    }
+
+    Ok(SParameterResult {
+        port1_source: port1_source.to_string(),
+        port2_source: port2_source.to_string(),
+        reference_impedance_ohms,
+        points,
+    })
+}
+
+fn validate_sparameter_ports(circuit: &Circuit, ports: &[&str; 2]) -> Result<(), SpiceError> {
+    for port in ports {
+        let found = circuit.elements().iter().any(
+            |element| matches!(element, Element::VoltageSource(source) if source.name == *port),
+        );
+        if !found {
+            return Err(SpiceError::InvalidElement {
+                name: "s_parameters".to_string(),
+                reason: format!("missing voltage-source port {port:?}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn circuit_with_sparameter_drive(
+    circuit: &Circuit,
+    ports: &[&str; 2],
+    driven_source: &str,
+) -> Circuit {
+    let mut driven = Circuit::new();
+    for element in circuit.elements() {
+        if let Element::VoltageSource(source) = element {
+            if ports.iter().any(|port| *port == source.name) {
+                let mut source = source.clone();
+                source.ac = Some(AcSource::new(
+                    if source.name == driven_source {
+                        1.0
+                    } else {
+                        0.0
+                    },
+                    0.0,
+                ));
+                driven.add(Element::VoltageSource(source));
+                continue;
+            }
+        }
+        driven.add(element.clone());
+    }
+    driven
+}
+
+fn branch_current_into_network(point: &AcPoint, source_name: &str) -> Result<Complex, SpiceError> {
+    point
+        .branch_current(source_name)
+        .map(|current| current * Complex::new(-1.0, 0.0))
+        .ok_or_else(|| SpiceError::InvalidElement {
+            name: "s_parameters".to_string(),
+            reason: format!("missing branch current for {source_name:?}"),
+        })
+}
+
+fn y_to_s_2port(
+    y11: Complex,
+    y21: Complex,
+    y12: Complex,
+    y22: Complex,
+    z0: f64,
+) -> Result<(Complex, Complex, Complex, Complex), SpiceError> {
+    let one = Complex::new(1.0, 0.0);
+    let z0_c = Complex::new(z0, 0.0);
+    let a11 = one - y11 * z0_c;
+    let a12 = y12 * Complex::new(-z0, 0.0);
+    let a21 = y21 * Complex::new(-z0, 0.0);
+    let a22 = one - y22 * z0_c;
+
+    let b11 = one + y11 * z0_c;
+    let b12 = y12 * z0_c;
+    let b21 = y21 * z0_c;
+    let b22 = one + y22 * z0_c;
+    let det = b11 * b22 - b12 * b21;
+    if det.abs() < 1.0e-18 {
+        return Err(SpiceError::InvalidElement {
+            name: "s_parameters".to_string(),
+            reason: "singular Y-to-S conversion".to_string(),
+        });
+    }
+
+    let inv_b11 = b22 / det;
+    let inv_b12 = b12 * Complex::new(-1.0, 0.0) / det;
+    let inv_b21 = b21 * Complex::new(-1.0, 0.0) / det;
+    let inv_b22 = b11 / det;
+
+    Ok((
+        a11 * inv_b11 + a12 * inv_b21,
+        a21 * inv_b11 + a22 * inv_b21,
+        a11 * inv_b12 + a12 * inv_b22,
+        a21 * inv_b12 + a22 * inv_b22,
+    ))
 }
 
 pub fn noise_ac(

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,6 +1,7 @@
 use spice_engine::{
-    ac_sweep, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor,
-    Mosfet, MosfetLevel1Params, MosfetType, Resistor, SpiceError, Vcvs, VoltageSource,
+    ac_sweep, s_parameters, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource,
+    Element, Inductor, Mosfet, MosfetLevel1Params, MosfetType, Resistor, SpiceError, Vcvs,
+    VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -309,4 +310,28 @@ fn ac_sweep_rejects_invalid_frequency_bounds() {
         ac_sweep(&circuit, 10.0, 1.0, 10),
         Err(SpiceError::InvalidElement { name, .. }) if name == "ac_sweep"
     ));
+}
+
+#[test]
+fn s_parameters_series_resistor_two_port() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "P1", "p1", "0", 0.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "P2", "p2", "0", 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rseries", "p1", "p2", 50.0,
+    )));
+
+    let result = s_parameters(&circuit, "P1", "P2", &[1.0e6], 50.0).unwrap();
+    let point = result.points[0];
+
+    assert_close(point.s11.real, 1.0 / 3.0);
+    assert_close(point.s22.real, 1.0 / 3.0);
+    assert_close(point.s21.real, 2.0 / 3.0);
+    assert_close(point.s12.real, 2.0 / 3.0);
+    assert_close(point.s11.imag, 0.0);
+    assert_close(point.s21.imag, 0.0);
 }

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add two-port S-parameter extraction from named AC voltage-source ports,
+  returning S11/S21/S12/S22 for a configurable reference impedance.
 - Add a sparse-row real linear solver path for large DC / real small-signal
   matrices while keeping the dense solver for small systems.
 - Add programmatic subcircuits with `SubcircuitDefinition` and `XInstance`

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -477,6 +477,21 @@ export interface AcPoint {
   branchCurrent(sourceName: string): Complex | undefined;
 }
 
+export interface SParameterPoint {
+  readonly frequencyHz: number;
+  readonly s11: Complex;
+  readonly s21: Complex;
+  readonly s12: Complex;
+  readonly s22: Complex;
+}
+
+export interface SParameterResult {
+  readonly port1Source: string;
+  readonly port2Source: string;
+  readonly referenceImpedanceOhms: number;
+  readonly points: readonly SParameterPoint[];
+}
+
 export type NoiseType = "thermal";
 
 export interface NoiseEntry {
@@ -1289,6 +1304,52 @@ export function acSweep(
     );
   }
   return points;
+}
+
+export function sParameters(
+  circuit: Circuit,
+  port1Source: string,
+  port2Source: string,
+  frequenciesHz: readonly number[],
+  referenceImpedanceOhms = 50.0,
+): SParameterResult {
+  if (!Number.isFinite(referenceImpedanceOhms) || referenceImpedanceOhms <= 0.0) {
+    throw invalidElement("sParameters", "reference impedance must be finite and positive");
+  }
+  for (const frequency of frequenciesHz) {
+    if (!Number.isFinite(frequency) || frequency <= 0.0) {
+      throw invalidElement("sParameters", "frequencies must be finite and positive");
+    }
+  }
+
+  const ports = [port1Source, port2Source] as const;
+  validateSParameterPorts(circuit, ports);
+
+  const points = frequenciesHz.map((frequencyHz) => {
+    const columns = ports.map((drivenSource) => {
+      const drivenCircuit = circuitWithSParameterDrive(circuit, ports, drivenSource);
+      const point = acSweep(drivenCircuit, frequencyHz, frequencyHz, 1)[0];
+      return [
+        branchCurrentIntoNetwork(point, port1Source),
+        branchCurrentIntoNetwork(point, port2Source),
+      ] as const;
+    });
+    const [s11, s21, s12, s22] = yToS2Port(
+      columns[0][0],
+      columns[0][1],
+      columns[1][0],
+      columns[1][1],
+      referenceImpedanceOhms,
+    );
+    return { frequencyHz, s11, s21, s12, s22 };
+  });
+
+  return {
+    port1Source,
+    port2Source,
+    referenceImpedanceOhms,
+    points,
+  };
 }
 
 export function noiseAc(
@@ -2118,6 +2179,81 @@ function circuitFromElements(elements: readonly Element[]): Circuit {
     circuit.add(element);
   }
   return circuit;
+}
+
+function validateSParameterPorts(
+  circuit: Circuit,
+  ports: readonly [string, string],
+): void {
+  for (const port of ports) {
+    const element = circuit.elements().find(
+      (candidate) => candidate.kind === "voltage-source" && candidate.name === port,
+    );
+    if (element === undefined) {
+      throw invalidElement("sParameters", `missing voltage-source port ${JSON.stringify(port)}`);
+    }
+  }
+}
+
+function circuitWithSParameterDrive(
+  circuit: Circuit,
+  ports: readonly [string, string],
+  drivenSource: string,
+): Circuit {
+  const portNames = new Set<string>(ports);
+  return circuitFromElements(
+    circuit.elements().map((element) => {
+      if (element.kind !== "voltage-source" || !portNames.has(element.name)) {
+        return element;
+      }
+      return {
+        ...element,
+        ac: acSource(element.name === drivenSource ? 1.0 : 0.0),
+      };
+    }),
+  );
+}
+
+function branchCurrentIntoNetwork(point: AcPoint, sourceName: string): Complex {
+  const current = point.branchCurrent(sourceName);
+  if (current === undefined) {
+    throw invalidElement("sParameters", `missing branch current for ${JSON.stringify(sourceName)}`);
+  }
+  return complexScale(current, -1.0);
+}
+
+function yToS2Port(
+  y11: Complex,
+  y21: Complex,
+  y12: Complex,
+  y22: Complex,
+  z0: number,
+): [Complex, Complex, Complex, Complex] {
+  const a11 = complexSub(complex(1.0, 0.0), complexScale(y11, z0));
+  const a12 = complexScale(y12, -z0);
+  const a21 = complexScale(y21, -z0);
+  const a22 = complexSub(complex(1.0, 0.0), complexScale(y22, z0));
+
+  const b11 = complexAdd(complex(1.0, 0.0), complexScale(y11, z0));
+  const b12 = complexScale(y12, z0);
+  const b21 = complexScale(y21, z0);
+  const b22 = complexAdd(complex(1.0, 0.0), complexScale(y22, z0));
+  const det = complexSub(complexMul(b11, b22), complexMul(b12, b21));
+  if (complexAbs(det) < 1.0e-18) {
+    throw invalidElement("sParameters", "singular Y-to-S conversion");
+  }
+
+  const invB11 = complexDiv(b22, det);
+  const invB12 = complexDiv(complexScale(b12, -1.0), det);
+  const invB21 = complexDiv(complexScale(b21, -1.0), det);
+  const invB22 = complexDiv(b11, det);
+
+  return [
+    complexAdd(complexMul(a11, invB11), complexMul(a12, invB21)),
+    complexAdd(complexMul(a21, invB11), complexMul(a22, invB21)),
+    complexAdd(complexMul(a11, invB12), complexMul(a12, invB22)),
+    complexAdd(complexMul(a21, invB12), complexMul(a22, invB22)),
+  ];
 }
 
 function solveLinearCircuitAtOperatingPoint(
@@ -4643,6 +4779,10 @@ function complexMul(left: Complex, right: Complex): Complex {
     left.real * right.real - left.imag * right.imag,
     left.real * right.imag + left.imag * right.real,
   );
+}
+
+function complexScale(value: Complex, scale: number): Complex {
+  return complex(value.real * scale, value.imag * scale);
 }
 
 function complexDiv(left: Complex, right: Complex): Complex {

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -12,6 +12,7 @@ import {
   currentSourceWithAc,
   inductor,
   resistor,
+  sParameters,
   vcvs,
   voltageSource,
   voltageSourceWithAc,
@@ -193,5 +194,24 @@ describe("acSweep", () => {
     expect(() => acSweep(circuit, 10.0, 1.0, 10)).toThrowError(
       "stop frequency",
     );
+  });
+});
+
+describe("sParameters", () => {
+  it("extracts a series-resistor two-port from AC port solves", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("P1", "p1", "0", 0.0));
+    circuit.add(voltageSource("P2", "p2", "0", 0.0));
+    circuit.add(resistor("Rseries", "p1", "p2", 50.0));
+
+    const result = sParameters(circuit, "P1", "P2", [1.0e6], 50.0);
+    const point = result.points[0];
+
+    expect(point.s11.real).toBeCloseTo(1.0 / 3.0, 9);
+    expect(point.s22.real).toBeCloseTo(1.0 / 3.0, 9);
+    expect(point.s21.real).toBeCloseTo(2.0 / 3.0, 9);
+    expect(point.s12.real).toBeCloseTo(2.0 / 3.0, 9);
+    expect(point.s11.imag).toBeCloseTo(0.0, 12);
+    expect(point.s21.imag).toBeCloseTo(0.0, 12);
   });
 });

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -106,9 +106,10 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- Sparse real solver path across Python, TypeScript, and Rust SPICE engines:
-  large DC / real small-signal matrices route through sparse-row Gaussian
-  elimination while small systems keep the dense solver.
+- Two-port S-parameter extraction across Python, TypeScript, and Rust SPICE
+  engines: named AC voltage-source ports are used to build a 2x2 Y-parameter
+  matrix and convert it to S11/S21/S12/S22 for a configurable reference
+  impedance.
 
 ---
 
@@ -122,16 +123,14 @@ All Group 1 items have shipped. See "What is on main" above.
 
 #### Group 2 — Medium value
 
-| Feature | Why it matters | Design notes |
-|---|---|---|
-| **Sub-circuit support (`.subckt` / X-element)** | Essential for hierarchical design — reusing a cell (e.g. an inverter) multiple times with different parameter values. | Add an `XInstance` element class. At circuit build time, expand each X-element by cloning its `.subckt` definition with renamed nodes (prefix with instance name). Parameters propagate via a dict of `{param: value}` substitutions. |
-| **Sparse matrix solver** | Dense LU is O(n³). At ~100 nodes it becomes the bottleneck. SPICE netlists for a small IC cell can have 300+ nodes. | Replace `numpy.linalg.solve` with `scipy.sparse.linalg.splu` (already a dependency). MNA matrices are naturally sparse (each element touches only 2–4 nodes). Keep dense path as fallback for small circuits (< 30 nodes). |
+All Group 2 items have shipped: programmatic subcircuits landed in PR #3389
+and the sparse real solver path landed in PR #3391.
 
 #### Group 3 — Lower priority / longer horizon
 
 | Feature | Design notes |
 |---|---|
-| **S-parameter extraction** | Two-port network characterisation. Run AC sweep, compute Y-parameters from node voltages and port currents, convert to S-parameters. |
+| **S-parameter extraction** | Two-port network characterisation. Run AC sweep, compute Y-parameters from node voltages and port currents, convert to S-parameters. In flight across Python, TypeScript, and Rust. |
 | **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Requires a good oscillation-period estimator. |
 | **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. |
 | **Mixed-signal coupling with `hardware-vm`** | AMS simulation — digital events feed into analog SPICE nodes and vice versa. Long-range project; `hardware-vm.md` spec describes the interface. |


### PR DESCRIPTION
## Summary
- Add two-port S-parameter extraction to the Python, TypeScript, and Rust SPICE engines.
- Build Y-parameters by driving named AC voltage-source ports one at a time, then convert to S11/S21/S12/S22 for a configurable reference impedance.
- Add cross-language series-resistor two-port tests and update SPICE/MACSYMA pending-work notes.

## Validation
- sh BUILD (code/packages/python/spice-engine)
- sh BUILD (code/packages/typescript/spice-engine)
- cargo test -p spice-engine (code/packages/rust)
- git diff --check