### PR TITLE
Add WHATWG CDATA boundary fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -67,6 +67,9 @@ documented in this file.
   conformance test that pins escaped and double-escaped script data, escape
   start/end delimiters, EOF diagnostics, NULL replacement, and seeded
   continuation recovery.
+- A generated WHATWG tokenizer CDATA boundary fixture and Rust conformance test
+  that pins foreign-content CDATA delimiter recovery, NULL replacement, EOF,
+  HTML-content fallback, and seeded bracket/end states.
 - A generated WHATWG tokenizer markup declaration fixture and Rust conformance
   test that pins comment, bogus-comment, CDATA-looking declaration, DOCTYPE,
   and seeded declaration continuation recovery.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -328,6 +328,17 @@ python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_esca
   --check
 ```
 
+The checked-in `whatwg-cdata-boundaries.json` fixture exercises parser-controlled
+foreign-content CDATA section boundaries, including `]]>` delimiter recovery,
+NULL replacement, EOF recovery, HTML-content bogus-comment recovery, and seeded
+bracket/end states. Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py \
+  --check
+```
+
 There is also an `upstream-html5lib-smoke.test` file that mirrors the raw
 html5lib tokenizer JSON shape in a small supported subset. The Rust test
 harness now targets a checked-in generated `html5lib-smoke.json` corpus, which

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -73,6 +73,9 @@ binary while production code continues to link only static Rust source.
 - `whatwg-script-escape-boundaries.json`: generated HTML tokenizer script
   escape boundary cases used by Rust tests to pin escaped/double-escaped
   script data, NULL, EOF, and seeded continuation recovery
+- `whatwg-cdata-boundaries.json`: generated HTML tokenizer CDATA boundary
+  cases used by Rust tests to pin foreign-content delimiter recovery, NULL,
+  EOF, HTML-content fallback, and seeded bracket/end states
 - `whatwg-markup-declarations.json`: generated HTML tokenizer markup
   declaration cases used by Rust tests to pin comment, bogus-comment, CDATA,
   DOCTYPE, and seeded declaration continuation recovery
@@ -120,6 +123,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_script_escape_boundaries_fixture.py`: importer that
   generates focused script escape boundary cases for the checked-in
   `whatwg-script-escape-boundaries.json` fixture
+- `generate_whatwg_cdata_boundaries_fixture.py`: importer that generates
+  focused CDATA boundary cases for the checked-in
+  `whatwg-cdata-boundaries.json` fixture
 - `generate_whatwg_markup_declarations_fixture.py`: importer that generates
   markup declaration recovery cases for the checked-in
   `whatwg-markup-declarations.json` fixture
@@ -199,6 +205,14 @@ Regenerate or verify the WHATWG script escape boundary fixture with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py \
+  --check
+```
+
+Regenerate or verify the WHATWG CDATA boundary fixture with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer CDATA boundary fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-cdata-boundaries.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        if output.read_text() != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer CDATA boundary fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-cdata-boundaries/v1",
+        "description": (
+            "Foreign-content CDATA section text, delimiter, NULL, EOF, "
+            "HTML-content bogus-comment recovery, and seeded bracket/end states."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    return [
+        cdata("cdata-basic-delimiter", "a]]><p>x</p>", ["Text(data=a)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        cdata("cdata-markup-stays-text", "<b>&amp;</b>]]><p>x</p>", ["Text(data=<b>&amp;</b>)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        cdata("cdata-delimiter-at-start", "]]><p>x</p>", ["StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        cdata("cdata-extra-closing-bracket", "a]]]><p>x</p>", ["Text(data=a])", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        cdata("cdata-many-brackets-before-delimiter", "a]]]]><p>x</p>", ["Text(data=a]])", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        cdata("cdata-single-bracket-not-delimiter", "a]b]]><p>x</p>", ["Text(data=a]b)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        cdata("cdata-double-bracket-not-delimiter", "a]]b]]><p>x</p>", ["Text(data=a]]b)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        cdata("cdata-greater-than-alone", "a>b]]><p>x</p>", ["Text(data=a>b)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        cdata("cdata-null-replacement", "a\u0000b]]><p>x</p>", ["Text(data=a�b)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"], diagnostics=["unexpected-null-character"]),
+        cdata("cdata-eof-body", "open", ["Text(data=open)", "EOF"]),
+        cdata("cdata-eof-after-single-bracket", "open]", ["Text(data=open])", "EOF"]),
+        cdata("cdata-eof-after-double-bracket", "open]]", ["Text(data=open]])", "EOF"]),
+        data("html-cdata-looking-declaration", "a<![CDATA[x]]>b", ["Text(data=a)", "Comment(data=[CDATA[x]])", "Text(data=b)", "EOF"], diagnostics=["cdata-in-html-content"]),
+        data("html-cdata-looking-null", "a<![CDATA[x\u0000]]>b", ["Text(data=a)", "Comment(data=[CDATA[x�]])", "Text(data=b)", "EOF"], diagnostics=["cdata-in-html-content", "unexpected-null-character"]),
+        data("html-cdata-looking-eof", "a<![CDATA[x", ["Text(data=a)", "Comment(data=[CDATA[x)", "EOF"], diagnostics=["cdata-in-html-content"]),
+        state("seeded-cdata-bracket-delimiter", "CDATA section bracket state", ">tail", ["Text(data=]>tail)", "EOF"]),
+        state("seeded-cdata-bracket-extra-bracket", "CDATA section bracket state", "]><p>x</p>", ["StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        state("seeded-cdata-bracket-not-delimiter", "CDATA section bracket state", "x]]><p>x</p>", ["Text(data=]x)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        state("seeded-cdata-bracket-null", "CDATA section bracket state", "\u0000]]><p>x</p>", ["Text(data=]�)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"], diagnostics=["unexpected-null-character"]),
+        state("seeded-cdata-bracket-eof", "CDATA section bracket state", "", ["Text(data=])", "EOF"]),
+        state("seeded-cdata-end-delimiter", "CDATA section end state", ">tail", ["Text(data=tail)", "EOF"]),
+        state("seeded-cdata-end-more-brackets", "CDATA section end state", "]]><p>x</p>", ["Text(data=]])", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        state("seeded-cdata-end-not-delimiter", "CDATA section end state", "x]]><p>x</p>", ["Text(data=]]x)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"]),
+        state("seeded-cdata-end-null", "CDATA section end state", "\u0000]]><p>x</p>", ["Text(data=]]�)", "StartTag(name=p, attributes=[], self_closing=false)", "Text(data=x)", "EndTag(name=p)", "EOF"], diagnostics=["unexpected-null-character"]),
+        state("seeded-cdata-end-eof", "CDATA section end state", "", ["Text(data=]])", "EOF"]),
+    ]
+
+
+def data(
+    case_id: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    diagnostics: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": case_id,
+        "description": f"HTML data-state CDATA-looking recovery case `{case_id}`",
+        "input": input_text,
+        "tokens": tokens,
+        **({"diagnostics": diagnostics} if diagnostics is not None else {}),
+    }
+
+
+def cdata(
+    case_id: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    diagnostics: list[str] | None = None,
+) -> dict[str, object]:
+    return state(
+        case_id,
+        "CDATA section state",
+        input_text,
+        tokens,
+        diagnostics=diagnostics,
+    )
+
+
+def state(
+    case_id: str,
+    initial_state: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    diagnostics: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": case_id,
+        "description": f"{initial_state} boundary case `{case_id}`",
+        "input": input_text,
+        "initial_state": initial_state,
+        "tokens": tokens,
+        **({"diagnostics": diagnostics} if diagnostics is not None else {}),
+    }
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-cdata-boundaries.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-cdata-boundaries.json
@@ -1,0 +1,339 @@
+{
+  "cases": [
+    {
+      "description": "CDATA section state boundary case `cdata-basic-delimiter`",
+      "diagnostics": [],
+      "id": "cdata-basic-delimiter",
+      "initial_state": "CDATA section state",
+      "input": "a]]><p>x</p>",
+      "tokens": [
+        "Text(data=a)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-markup-stays-text`",
+      "diagnostics": [],
+      "id": "cdata-markup-stays-text",
+      "initial_state": "CDATA section state",
+      "input": "<b>&amp;</b>]]><p>x</p>",
+      "tokens": [
+        "Text(data=<b>&amp;</b>)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-delimiter-at-start`",
+      "diagnostics": [],
+      "id": "cdata-delimiter-at-start",
+      "initial_state": "CDATA section state",
+      "input": "]]><p>x</p>",
+      "tokens": [
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-extra-closing-bracket`",
+      "diagnostics": [],
+      "id": "cdata-extra-closing-bracket",
+      "initial_state": "CDATA section state",
+      "input": "a]]]><p>x</p>",
+      "tokens": [
+        "Text(data=a])",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-many-brackets-before-delimiter`",
+      "diagnostics": [],
+      "id": "cdata-many-brackets-before-delimiter",
+      "initial_state": "CDATA section state",
+      "input": "a]]]]><p>x</p>",
+      "tokens": [
+        "Text(data=a]])",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-single-bracket-not-delimiter`",
+      "diagnostics": [],
+      "id": "cdata-single-bracket-not-delimiter",
+      "initial_state": "CDATA section state",
+      "input": "a]b]]><p>x</p>",
+      "tokens": [
+        "Text(data=a]b)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-double-bracket-not-delimiter`",
+      "diagnostics": [],
+      "id": "cdata-double-bracket-not-delimiter",
+      "initial_state": "CDATA section state",
+      "input": "a]]b]]><p>x</p>",
+      "tokens": [
+        "Text(data=a]]b)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-greater-than-alone`",
+      "diagnostics": [],
+      "id": "cdata-greater-than-alone",
+      "initial_state": "CDATA section state",
+      "input": "a>b]]><p>x</p>",
+      "tokens": [
+        "Text(data=a>b)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-null-replacement`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "cdata-null-replacement",
+      "initial_state": "CDATA section state",
+      "input": "a\u0000b]]><p>x</p>",
+      "tokens": [
+        "Text(data=a�b)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-eof-body`",
+      "diagnostics": [],
+      "id": "cdata-eof-body",
+      "initial_state": "CDATA section state",
+      "input": "open",
+      "tokens": [
+        "Text(data=open)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-eof-after-single-bracket`",
+      "diagnostics": [],
+      "id": "cdata-eof-after-single-bracket",
+      "initial_state": "CDATA section state",
+      "input": "open]",
+      "tokens": [
+        "Text(data=open])",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section state boundary case `cdata-eof-after-double-bracket`",
+      "diagnostics": [],
+      "id": "cdata-eof-after-double-bracket",
+      "initial_state": "CDATA section state",
+      "input": "open]]",
+      "tokens": [
+        "Text(data=open]])",
+        "EOF"
+      ]
+    },
+    {
+      "description": "HTML data-state CDATA-looking recovery case `html-cdata-looking-declaration`",
+      "diagnostics": [
+        "cdata-in-html-content"
+      ],
+      "id": "html-cdata-looking-declaration",
+      "input": "a<![CDATA[x]]>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=[CDATA[x]])",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "HTML data-state CDATA-looking recovery case `html-cdata-looking-null`",
+      "diagnostics": [
+        "cdata-in-html-content",
+        "unexpected-null-character"
+      ],
+      "id": "html-cdata-looking-null",
+      "input": "a<![CDATA[x\u0000]]>b",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=[CDATA[x�]])",
+        "Text(data=b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "HTML data-state CDATA-looking recovery case `html-cdata-looking-eof`",
+      "diagnostics": [
+        "cdata-in-html-content"
+      ],
+      "id": "html-cdata-looking-eof",
+      "input": "a<![CDATA[x",
+      "tokens": [
+        "Text(data=a)",
+        "Comment(data=[CDATA[x)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section bracket state boundary case `seeded-cdata-bracket-delimiter`",
+      "diagnostics": [],
+      "id": "seeded-cdata-bracket-delimiter",
+      "initial_state": "CDATA section bracket state",
+      "input": ">tail",
+      "tokens": [
+        "Text(data=]>tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section bracket state boundary case `seeded-cdata-bracket-extra-bracket`",
+      "diagnostics": [],
+      "id": "seeded-cdata-bracket-extra-bracket",
+      "initial_state": "CDATA section bracket state",
+      "input": "]><p>x</p>",
+      "tokens": [
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section bracket state boundary case `seeded-cdata-bracket-not-delimiter`",
+      "diagnostics": [],
+      "id": "seeded-cdata-bracket-not-delimiter",
+      "initial_state": "CDATA section bracket state",
+      "input": "x]]><p>x</p>",
+      "tokens": [
+        "Text(data=]x)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section bracket state boundary case `seeded-cdata-bracket-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-cdata-bracket-null",
+      "initial_state": "CDATA section bracket state",
+      "input": "\u0000]]><p>x</p>",
+      "tokens": [
+        "Text(data=]�)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section bracket state boundary case `seeded-cdata-bracket-eof`",
+      "diagnostics": [],
+      "id": "seeded-cdata-bracket-eof",
+      "initial_state": "CDATA section bracket state",
+      "input": "",
+      "tokens": [
+        "Text(data=])",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section end state boundary case `seeded-cdata-end-delimiter`",
+      "diagnostics": [],
+      "id": "seeded-cdata-end-delimiter",
+      "initial_state": "CDATA section end state",
+      "input": ">tail",
+      "tokens": [
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section end state boundary case `seeded-cdata-end-more-brackets`",
+      "diagnostics": [],
+      "id": "seeded-cdata-end-more-brackets",
+      "initial_state": "CDATA section end state",
+      "input": "]]><p>x</p>",
+      "tokens": [
+        "Text(data=]])",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section end state boundary case `seeded-cdata-end-not-delimiter`",
+      "diagnostics": [],
+      "id": "seeded-cdata-end-not-delimiter",
+      "initial_state": "CDATA section end state",
+      "input": "x]]><p>x</p>",
+      "tokens": [
+        "Text(data=]]x)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section end state boundary case `seeded-cdata-end-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "seeded-cdata-end-null",
+      "initial_state": "CDATA section end state",
+      "input": "\u0000]]><p>x</p>",
+      "tokens": [
+        "Text(data=]]�)",
+        "StartTag(name=p, attributes=[], self_closing=false)",
+        "Text(data=x)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "CDATA section end state boundary case `seeded-cdata-end-eof`",
+      "diagnostics": [],
+      "id": "seeded-cdata-end-eof",
+      "initial_state": "CDATA section end state",
+      "input": "",
+      "tokens": [
+        "Text(data=]])",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Foreign-content CDATA section text, delimiter, NULL, EOF, HTML-content bogus-comment recovery, and seeded bracket/end states.",
+  "format": "whatwg-html-tokenizer-cdata-boundaries/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
@@ -1,0 +1,184 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_CDATA_BOUNDARIES: &str = include_str!("fixtures/whatwg-cdata-boundaries.json");
+
+#[derive(Debug, Deserialize)]
+struct CdataBoundarySuite {
+    format: String,
+    description: String,
+    cases: Vec<CdataBoundaryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CdataBoundaryCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    #[serde(default)]
+    initial_state: Option<String>,
+}
+
+#[test]
+fn whatwg_cdata_boundaries_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-tokenizer-cdata-boundaries/v1");
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 25);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "cdata-markup-stays-text"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "html-cdata-looking-declaration"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "seeded-cdata-end-eof"));
+}
+
+#[test]
+fn whatwg_cdata_boundaries_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its CDATA boundary",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> CdataBoundarySuite {
+    serde_json::from_str(WHATWG_CDATA_BOUNDARIES)
+        .expect("WHATWG CDATA boundary fixture should parse")
+}
+
+fn configured_lexer(case: &CdataBoundaryCase) -> HtmlLexer {
+    let state = case
+        .initial_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let context = HtmlLexContext::new(state);
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG CDATA boundary fixture covering foreign-content CDATA delimiter, NULL, EOF, HTML-content fallback, and seeded bracket/end states
- add a Rust conformance harness for the new fixture
- document regeneration/check commands in the html-lexer docs and changelog

## Validation
- rustfmt --check code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- git diff --check