### PR TITLE
Add WHATWG text-mode boundary fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -63,6 +63,9 @@ documented in this file.
 - A generated WHATWG tokenizer text-mode delimiter fixture and Rust conformance
   test that pins RCDATA, RAWTEXT, script-data, escaped-script, and seeded
   end-tag continuation recovery.
+- A generated WHATWG tokenizer text-mode boundary fixture and Rust conformance
+  test that pins parser-seeded RCDATA, RAWTEXT, and PLAINTEXT less-than,
+  end-tag-open/name, NULL, EOF, and literal markup recovery.
 - A generated WHATWG tokenizer script escape boundary fixture and Rust
   conformance test that pins escaped and double-escaped script data, escape
   start/end delimiters, EOF diagnostics, NULL replacement, and seeded

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -81,6 +81,10 @@ continuation states so parser-facing recovery stays pinned at stream end.
 The generated text-mode delimiter suite pins how RCDATA, RAWTEXT, script data,
 escaped script data, and seeded end-tag continuation states distinguish real
 matching end tags from literal apparent end tags.
+The generated text-mode boundary suite drills into parser-seeded RCDATA,
+RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
+continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup
+preservation.
 The generated markup declaration suite pins comment, bogus-comment, DOCTYPE,
 default HTML CDATA-looking bogus-comment recovery, explicit seeded CDATA
 continuation, and seeded declaration continuation behavior.
@@ -325,6 +329,18 @@ continuation states. Regenerate or check it with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py \
+  --check
+```
+
+The checked-in `whatwg-text-mode-boundaries.json` fixture exercises
+parser-seeded RCDATA, RAWTEXT, and PLAINTEXT tokenizer boundaries, including
+less-than and end-tag-open continuation states, seeded end-tag-name delimiters,
+NULL replacement, EOF recovery, character-reference differences, and
+PLAINTEXT literal markup. Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -401,6 +401,9 @@ currently supports:
 - generated text-mode delimiter coverage across RCDATA, RAWTEXT, script data,
   escaped script data, matching/mismatched apparent end tags, recoverable
   whitespace/attribute/solidus delimiters, and seeded end-tag continuations
+- generated text-mode boundary coverage across parser-seeded RCDATA, RAWTEXT,
+  and PLAINTEXT less-than recovery, end-tag-open/name continuations, NULL/EOF
+  recovery, character-reference differences, and literal markup preservation
 - generated attribute-edge coverage across quoted/unquoted values, duplicate
   attributes, missing whitespace recovery, unexpected attribute characters,
   NULL replacement, self-closing delimiters, unexpected solidus recovery, and

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer text-mode boundary fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-text-mode-boundaries.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        if output.read_text() != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer text-mode boundary fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-text-mode-boundaries/v1",
+        "description": (
+            "Parser-seeded RCDATA, RAWTEXT, and PLAINTEXT text-mode boundaries "
+            "for less-than, end-tag-open, end-tag-name, NULL, EOF, and "
+            "literal markup recovery."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    return [
+        *rcdata_cases(),
+        *rawtext_cases(),
+        *plaintext_cases(),
+    ]
+
+
+def rcdata_cases() -> list[dict[str, object]]:
+    return [
+        state(
+            "rcdata-null-reference-and-delimiter",
+            "RCDATA state",
+            "a\u0000&amp;</title>tail",
+            ["Text(data=a�&)", "EndTag(name=title)", "Text(data=tail)", "EOF"],
+            last_start_tag="title",
+            diagnostics=["unexpected-null-character"],
+        ),
+        state(
+            "rcdata-ambiguous-ampersand-before-delimiter",
+            "RCDATA state",
+            "a&notanentity;</title>",
+            ["Text(data=a¬anentity;)", "EndTag(name=title)", "EOF"],
+            last_start_tag="title",
+            diagnostics=["missing-semicolon-after-character-reference"],
+        ),
+        state(
+            "rcdata-less-than-end-tag",
+            "RCDATA less-than sign state",
+            "/title>tail",
+            ["EndTag(name=title)", "Text(data=tail)", "EOF"],
+            last_start_tag="title",
+        ),
+        state(
+            "rcdata-less-than-non-slash",
+            "RCDATA less-than sign state",
+            "x</title>",
+            ["Text(data=<x)", "EndTag(name=title)", "EOF"],
+            last_start_tag="title",
+        ),
+        state(
+            "rcdata-less-than-eof",
+            "RCDATA less-than sign state",
+            "",
+            ["Text(data=<)", "EOF"],
+            last_start_tag="title",
+        ),
+        state(
+            "rcdata-end-tag-open-matching",
+            "RCDATA end tag open state",
+            "title>tail",
+            ["EndTag(name=title)", "Text(data=tail)", "EOF"],
+            last_start_tag="title",
+        ),
+        state(
+            "rcdata-end-tag-open-mismatch",
+            "RCDATA end tag open state",
+            "style>tail</title>",
+            ["Text(data=</style>tail)", "EndTag(name=title)", "EOF"],
+            last_start_tag="title",
+        ),
+        state(
+            "rcdata-end-tag-open-eof",
+            "RCDATA end tag open state",
+            "",
+            ["Text(data=</)", "EOF"],
+            last_start_tag="title",
+        ),
+        state(
+            "rcdata-end-tag-name-delimiter",
+            "RCDATA end tag name state",
+            ">tail",
+            ["EndTag(name=title)", "Text(data=tail)", "EOF"],
+            last_start_tag="title",
+            current_end_tag="title",
+            temporary_buffer="title",
+        ),
+        state(
+            "rcdata-end-tag-name-attribute-recovery",
+            "RCDATA end tag name state",
+            " class=x>tail",
+            ["EndTag(name=title)", "Text(data=tail)", "EOF"],
+            last_start_tag="title",
+            current_end_tag="title",
+            temporary_buffer="title",
+            diagnostics=["end-tag-with-attributes"],
+        ),
+        state(
+            "rcdata-end-tag-name-mismatch-eof",
+            "RCDATA end tag name state",
+            "",
+            ["Text(data=</style)", "EOF"],
+            last_start_tag="title",
+            current_end_tag="style",
+            temporary_buffer="style",
+        ),
+    ]
+
+
+def rawtext_cases() -> list[dict[str, object]]:
+    return [
+        state(
+            "rawtext-ampersand-stays-literal-before-delimiter",
+            "RAWTEXT state",
+            "a&amp;</style>tail",
+            ["Text(data=a&amp;)", "EndTag(name=style)", "Text(data=tail)", "EOF"],
+            last_start_tag="style",
+        ),
+        state(
+            "rawtext-null-before-delimiter",
+            "RAWTEXT state",
+            "a\u0000b</style>",
+            ["Text(data=a�b)", "EndTag(name=style)", "EOF"],
+            last_start_tag="style",
+            diagnostics=["unexpected-null-character"],
+        ),
+        state(
+            "rawtext-less-than-end-tag",
+            "RAWTEXT less-than sign state",
+            "/style>tail",
+            ["EndTag(name=style)", "Text(data=tail)", "EOF"],
+            last_start_tag="style",
+        ),
+        state(
+            "rawtext-less-than-non-slash",
+            "RAWTEXT less-than sign state",
+            "x</style>",
+            ["Text(data=<x)", "EndTag(name=style)", "EOF"],
+            last_start_tag="style",
+        ),
+        state(
+            "rawtext-less-than-eof",
+            "RAWTEXT less-than sign state",
+            "",
+            ["Text(data=<)", "EOF"],
+            last_start_tag="style",
+        ),
+        state(
+            "rawtext-end-tag-open-matching",
+            "RAWTEXT end tag open state",
+            "style>tail",
+            ["EndTag(name=style)", "Text(data=tail)", "EOF"],
+            last_start_tag="style",
+        ),
+        state(
+            "rawtext-end-tag-open-mismatch",
+            "RAWTEXT end tag open state",
+            "title>tail</style>",
+            ["Text(data=</title>tail)", "EndTag(name=style)", "EOF"],
+            last_start_tag="style",
+        ),
+        state(
+            "rawtext-end-tag-open-eof",
+            "RAWTEXT end tag open state",
+            "",
+            ["Text(data=</)", "EOF"],
+            last_start_tag="style",
+        ),
+        state(
+            "rawtext-end-tag-name-delimiter",
+            "RAWTEXT end tag name state",
+            ">tail",
+            ["EndTag(name=style)", "Text(data=tail)", "EOF"],
+            last_start_tag="style",
+            current_end_tag="style",
+            temporary_buffer="style",
+        ),
+        state(
+            "rawtext-end-tag-name-self-closing-recovery",
+            "RAWTEXT end tag name state",
+            "/>tail",
+            ["EndTag(name=style)", "Text(data=tail)", "EOF"],
+            last_start_tag="style",
+            current_end_tag="style",
+            temporary_buffer="style",
+            diagnostics=["end-tag-with-trailing-solidus"],
+        ),
+        state(
+            "rawtext-end-tag-name-mismatch-eof",
+            "RAWTEXT end tag name state",
+            "",
+            ["Text(data=</title)", "EOF"],
+            last_start_tag="style",
+            current_end_tag="title",
+            temporary_buffer="title",
+        ),
+    ]
+
+
+def plaintext_cases() -> list[dict[str, object]]:
+    return [
+        state(
+            "plaintext-markup-stays-text",
+            "PLAINTEXT state",
+            "<b>x</b></plaintext>",
+            ["Text(data=<b>x</b></plaintext>)", "EOF"],
+        ),
+        state(
+            "plaintext-ampersand-stays-literal",
+            "PLAINTEXT state",
+            "Tom &amp; Jerry",
+            ["Text(data=Tom &amp; Jerry)", "EOF"],
+        ),
+        state(
+            "plaintext-null-replacement",
+            "PLAINTEXT state",
+            "a\u0000b",
+            ["Text(data=a�b)", "EOF"],
+            diagnostics=["unexpected-null-character"],
+        ),
+        state(
+            "plaintext-less-than-and-slash-at-eof",
+            "PLAINTEXT state",
+            "alpha</",
+            ["Text(data=alpha</)", "EOF"],
+        ),
+        state(
+            "plaintext-comment-looking-text",
+            "PLAINTEXT state",
+            "<!--x--><p>y",
+            ["Text(data=<!--x--><p>y)", "EOF"],
+        ),
+        state(
+            "plaintext-cdata-looking-text",
+            "PLAINTEXT state",
+            "<![CDATA[x]]>",
+            ["Text(data=<![CDATA[x]]>)", "EOF"],
+        ),
+        state(
+            "plaintext-preserves-crlf-normalized-input",
+            "PLAINTEXT state",
+            "a\r\nb",
+            ["Text(data=a\nb)", "EOF"],
+        ),
+    ]
+
+
+def state(
+    case_id: str,
+    initial_state: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    diagnostics: list[str] | None = None,
+    last_start_tag: str | None = None,
+    current_end_tag: str | None = None,
+    temporary_buffer: str | None = None,
+) -> dict[str, object]:
+    item: dict[str, object] = {
+        "id": case_id,
+        "description": f"{initial_state} boundary case `{case_id}`",
+        "input": input_text,
+        "initial_state": initial_state,
+        "tokens": tokens,
+    }
+    if diagnostics is not None:
+        item["diagnostics"] = diagnostics
+    if last_start_tag is not None:
+        item["last_start_tag"] = last_start_tag
+    if current_end_tag is not None:
+        item["current_end_tag"] = current_end_tag
+    if temporary_buffer is not None:
+        item["temporary_buffer"] = temporary_buffer
+    return item
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-text-mode-boundaries.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-text-mode-boundaries.json
@@ -1,0 +1,389 @@
+{
+  "cases": [
+    {
+      "description": "RCDATA state boundary case `rcdata-null-reference-and-delimiter`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "rcdata-null-reference-and-delimiter",
+      "initial_state": "RCDATA state",
+      "input": "a\u0000&amp;</title>tail",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=a�&)",
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA state boundary case `rcdata-ambiguous-ampersand-before-delimiter`",
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "id": "rcdata-ambiguous-ampersand-before-delimiter",
+      "initial_state": "RCDATA state",
+      "input": "a&notanentity;</title>",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=a¬anentity;)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA less-than sign state boundary case `rcdata-less-than-end-tag`",
+      "diagnostics": [],
+      "id": "rcdata-less-than-end-tag",
+      "initial_state": "RCDATA less-than sign state",
+      "input": "/title>tail",
+      "last_start_tag": "title",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA less-than sign state boundary case `rcdata-less-than-non-slash`",
+      "diagnostics": [],
+      "id": "rcdata-less-than-non-slash",
+      "initial_state": "RCDATA less-than sign state",
+      "input": "x</title>",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=<x)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA less-than sign state boundary case `rcdata-less-than-eof`",
+      "diagnostics": [],
+      "id": "rcdata-less-than-eof",
+      "initial_state": "RCDATA less-than sign state",
+      "input": "",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=<)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA end tag open state boundary case `rcdata-end-tag-open-matching`",
+      "diagnostics": [],
+      "id": "rcdata-end-tag-open-matching",
+      "initial_state": "RCDATA end tag open state",
+      "input": "title>tail",
+      "last_start_tag": "title",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA end tag open state boundary case `rcdata-end-tag-open-mismatch`",
+      "diagnostics": [],
+      "id": "rcdata-end-tag-open-mismatch",
+      "initial_state": "RCDATA end tag open state",
+      "input": "style>tail</title>",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=</style>tail)",
+        "EndTag(name=title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RCDATA end tag open state boundary case `rcdata-end-tag-open-eof`",
+      "diagnostics": [],
+      "id": "rcdata-end-tag-open-eof",
+      "initial_state": "RCDATA end tag open state",
+      "input": "",
+      "last_start_tag": "title",
+      "tokens": [
+        "Text(data=</)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "title",
+      "description": "RCDATA end tag name state boundary case `rcdata-end-tag-name-delimiter`",
+      "diagnostics": [],
+      "id": "rcdata-end-tag-name-delimiter",
+      "initial_state": "RCDATA end tag name state",
+      "input": ">tail",
+      "last_start_tag": "title",
+      "temporary_buffer": "title",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "title",
+      "description": "RCDATA end tag name state boundary case `rcdata-end-tag-name-attribute-recovery`",
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "id": "rcdata-end-tag-name-attribute-recovery",
+      "initial_state": "RCDATA end tag name state",
+      "input": " class=x>tail",
+      "last_start_tag": "title",
+      "temporary_buffer": "title",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "style",
+      "description": "RCDATA end tag name state boundary case `rcdata-end-tag-name-mismatch-eof`",
+      "diagnostics": [],
+      "id": "rcdata-end-tag-name-mismatch-eof",
+      "initial_state": "RCDATA end tag name state",
+      "input": "",
+      "last_start_tag": "title",
+      "temporary_buffer": "style",
+      "tokens": [
+        "Text(data=</style)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state boundary case `rawtext-ampersand-stays-literal-before-delimiter`",
+      "diagnostics": [],
+      "id": "rawtext-ampersand-stays-literal-before-delimiter",
+      "initial_state": "RAWTEXT state",
+      "input": "a&amp;</style>tail",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=a&amp;)",
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT state boundary case `rawtext-null-before-delimiter`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "rawtext-null-before-delimiter",
+      "initial_state": "RAWTEXT state",
+      "input": "a\u0000b</style>",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=a�b)",
+        "EndTag(name=style)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT less-than sign state boundary case `rawtext-less-than-end-tag`",
+      "diagnostics": [],
+      "id": "rawtext-less-than-end-tag",
+      "initial_state": "RAWTEXT less-than sign state",
+      "input": "/style>tail",
+      "last_start_tag": "style",
+      "tokens": [
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT less-than sign state boundary case `rawtext-less-than-non-slash`",
+      "diagnostics": [],
+      "id": "rawtext-less-than-non-slash",
+      "initial_state": "RAWTEXT less-than sign state",
+      "input": "x</style>",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=<x)",
+        "EndTag(name=style)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT less-than sign state boundary case `rawtext-less-than-eof`",
+      "diagnostics": [],
+      "id": "rawtext-less-than-eof",
+      "initial_state": "RAWTEXT less-than sign state",
+      "input": "",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=<)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT end tag open state boundary case `rawtext-end-tag-open-matching`",
+      "diagnostics": [],
+      "id": "rawtext-end-tag-open-matching",
+      "initial_state": "RAWTEXT end tag open state",
+      "input": "style>tail",
+      "last_start_tag": "style",
+      "tokens": [
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT end tag open state boundary case `rawtext-end-tag-open-mismatch`",
+      "diagnostics": [],
+      "id": "rawtext-end-tag-open-mismatch",
+      "initial_state": "RAWTEXT end tag open state",
+      "input": "title>tail</style>",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=</title>tail)",
+        "EndTag(name=style)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "RAWTEXT end tag open state boundary case `rawtext-end-tag-open-eof`",
+      "diagnostics": [],
+      "id": "rawtext-end-tag-open-eof",
+      "initial_state": "RAWTEXT end tag open state",
+      "input": "",
+      "last_start_tag": "style",
+      "tokens": [
+        "Text(data=</)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "style",
+      "description": "RAWTEXT end tag name state boundary case `rawtext-end-tag-name-delimiter`",
+      "diagnostics": [],
+      "id": "rawtext-end-tag-name-delimiter",
+      "initial_state": "RAWTEXT end tag name state",
+      "input": ">tail",
+      "last_start_tag": "style",
+      "temporary_buffer": "style",
+      "tokens": [
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "style",
+      "description": "RAWTEXT end tag name state boundary case `rawtext-end-tag-name-self-closing-recovery`",
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "id": "rawtext-end-tag-name-self-closing-recovery",
+      "initial_state": "RAWTEXT end tag name state",
+      "input": "/>tail",
+      "last_start_tag": "style",
+      "temporary_buffer": "style",
+      "tokens": [
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ]
+    },
+    {
+      "current_end_tag": "title",
+      "description": "RAWTEXT end tag name state boundary case `rawtext-end-tag-name-mismatch-eof`",
+      "diagnostics": [],
+      "id": "rawtext-end-tag-name-mismatch-eof",
+      "initial_state": "RAWTEXT end tag name state",
+      "input": "",
+      "last_start_tag": "style",
+      "temporary_buffer": "title",
+      "tokens": [
+        "Text(data=</title)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PLAINTEXT state boundary case `plaintext-markup-stays-text`",
+      "diagnostics": [],
+      "id": "plaintext-markup-stays-text",
+      "initial_state": "PLAINTEXT state",
+      "input": "<b>x</b></plaintext>",
+      "tokens": [
+        "Text(data=<b>x</b></plaintext>)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PLAINTEXT state boundary case `plaintext-ampersand-stays-literal`",
+      "diagnostics": [],
+      "id": "plaintext-ampersand-stays-literal",
+      "initial_state": "PLAINTEXT state",
+      "input": "Tom &amp; Jerry",
+      "tokens": [
+        "Text(data=Tom &amp; Jerry)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PLAINTEXT state boundary case `plaintext-null-replacement`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "plaintext-null-replacement",
+      "initial_state": "PLAINTEXT state",
+      "input": "a\u0000b",
+      "tokens": [
+        "Text(data=a�b)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PLAINTEXT state boundary case `plaintext-less-than-and-slash-at-eof`",
+      "diagnostics": [],
+      "id": "plaintext-less-than-and-slash-at-eof",
+      "initial_state": "PLAINTEXT state",
+      "input": "alpha</",
+      "tokens": [
+        "Text(data=alpha</)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PLAINTEXT state boundary case `plaintext-comment-looking-text`",
+      "diagnostics": [],
+      "id": "plaintext-comment-looking-text",
+      "initial_state": "PLAINTEXT state",
+      "input": "<!--x--><p>y",
+      "tokens": [
+        "Text(data=<!--x--><p>y)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PLAINTEXT state boundary case `plaintext-cdata-looking-text`",
+      "diagnostics": [],
+      "id": "plaintext-cdata-looking-text",
+      "initial_state": "PLAINTEXT state",
+      "input": "<![CDATA[x]]>",
+      "tokens": [
+        "Text(data=<![CDATA[x]]>)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "PLAINTEXT state boundary case `plaintext-preserves-crlf-normalized-input`",
+      "diagnostics": [],
+      "id": "plaintext-preserves-crlf-normalized-input",
+      "initial_state": "PLAINTEXT state",
+      "input": "a\r\nb",
+      "tokens": [
+        "Text(data=a\nb)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Parser-seeded RCDATA, RAWTEXT, and PLAINTEXT text-mode boundaries for less-than, end-tag-open, end-tag-name, NULL, EOF, and literal markup recovery.",
+  "format": "whatwg-html-tokenizer-text-mode-boundaries/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
@@ -1,0 +1,196 @@
+use coding_adventures_html_lexer::{
+    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
+    HtmlTokenizerState, Token,
+};
+use serde::Deserialize;
+
+const WHATWG_TEXT_MODE_BOUNDARIES: &str = include_str!("fixtures/whatwg-text-mode-boundaries.json");
+
+#[derive(Debug, Deserialize)]
+struct TextModeBoundarySuite {
+    format: String,
+    description: String,
+    cases: Vec<TextModeBoundaryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TextModeBoundaryCase {
+    id: String,
+    description: String,
+    input: String,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+    initial_state: String,
+    #[serde(default)]
+    last_start_tag: Option<String>,
+    #[serde(default)]
+    current_end_tag: Option<String>,
+    #[serde(default)]
+    temporary_buffer: Option<String>,
+}
+
+#[test]
+fn whatwg_text_mode_boundaries_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(
+        suite.format,
+        "whatwg-html-tokenizer-text-mode-boundaries/v1"
+    );
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 25);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "rcdata-less-than-end-tag"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "rawtext-end-tag-name-self-closing-recovery"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "plaintext-markup-stays-text"));
+}
+
+#[test]
+fn whatwg_text_mode_boundaries_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its text-mode boundary",
+            case.id
+        );
+        let mut lexer = configured_lexer(case);
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> TextModeBoundarySuite {
+    serde_json::from_str(WHATWG_TEXT_MODE_BOUNDARIES)
+        .expect("WHATWG text-mode boundary fixture should parse")
+}
+
+fn configured_lexer(case: &TextModeBoundaryCase) -> HtmlLexer {
+    let state = HtmlTokenizerState::from_html5lib_state(&case.initial_state)
+        .unwrap_or_else(|| panic!("case `{}` has unknown initial state", case.id));
+    let mut context = HtmlLexContext::new(state);
+    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
+        context = context.with_last_start_tag(last_start_tag);
+    }
+    if let Some(current_end_tag) = case.current_end_tag.as_deref() {
+        context = context.with_current_end_tag(current_end_tag);
+    }
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        context = context.with_temporary_buffer(temporary_buffer);
+    }
+
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
+    lexer
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.insert_str(previous.len() - 1, text);
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG text-mode boundary fixture covering parser-seeded RCDATA, RAWTEXT, and PLAINTEXT state edges
- add a Rust conformance runner for less-than, end-tag-open/name, NULL, EOF, and PLAINTEXT literal-markup recovery
- document the new generator in html-lexer docs, fixture docs, and the changelog

## Validation
- rustfmt --check code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- git diff --check