### PR TITLE
Add WHATWG seeded attribute boundary fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -66,6 +66,8 @@ documented in this file.
 - A generated WHATWG tokenizer text-mode boundary fixture and Rust conformance
   test that pins parser-seeded RCDATA, RAWTEXT, and PLAINTEXT less-than,
   end-tag-open/name, NULL, EOF, and literal markup recovery.
+- A generated WHATWG tokenizer attribute boundary fixture and Rust conformance
+  test that pins seeded start-tag and current-attribute continuation recovery.
 - A generated WHATWG tokenizer script escape boundary fixture and Rust
   conformance test that pins escaped and double-escaped script data, escape
   start/end delimiters, EOF diagnostics, NULL replacement, and seeded

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -85,6 +85,10 @@ The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup
 preservation.
+The generated attribute boundary suite adds seeded start-tag continuation
+coverage for before-attribute-name, attribute-name, after-attribute-name,
+before-attribute-value, quoted/unquoted value, after-quoted-value, and
+self-closing states.
 The generated markup declaration suite pins comment, bogus-comment, DOCTYPE,
 default HTML CDATA-looking bogus-comment recovery, explicit seeded CDATA
 continuation, and seeded declaration continuation behavior.
@@ -341,6 +345,18 @@ PLAINTEXT literal markup. Regenerate or check it with:
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py \
+  --check
+```
+
+The checked-in `whatwg-attribute-boundaries.json` fixture exercises seeded
+start-tag attribute continuation states, including current-attribute recovery,
+quoted and unquoted value completion, NULL replacement, EOF diagnostics,
+missing-whitespace recovery, and self-closing boundaries. Regenerate or check it
+with:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py
+python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -7,8 +7,8 @@
 use state_machine::{EffectfulStateMachine, StateMachineDefinition};
 
 pub use state_machine_tokenizer::{
-    Attribute, Diagnostic, DoctypeSeed, Result, SourcePosition, Token, Tokenizer as HtmlLexer,
-    TokenizerError, TokenizerTraceEntry,
+    Attribute, Diagnostic, DoctypeSeed, Result, SourcePosition, StartTagSeed, Token,
+    Tokenizer as HtmlLexer, TokenizerError, TokenizerTraceEntry,
 };
 
 mod generated_html1;

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -404,6 +404,9 @@ currently supports:
 - generated text-mode boundary coverage across parser-seeded RCDATA, RAWTEXT,
   and PLAINTEXT less-than recovery, end-tag-open/name continuations, NULL/EOF
   recovery, character-reference differences, and literal markup preservation
+- generated attribute boundary coverage across seeded start-tag and
+  current-attribute continuation states, quoted/unquoted values, EOF recovery,
+  missing-whitespace recovery, and self-closing boundaries
 - generated attribute-edge coverage across quoted/unquoted values, duplicate
   attributes, missing whitespace recovery, unexpected attribute characters,
   NULL replacement, self-closing delimiters, unexpected solidus recovery, and

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's WHATWG tokenizer seeded attribute boundary fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-attribute-boundaries.json")
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).expanduser().resolve()
+    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if args.check:
+        if output.read_text() != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate WHATWG tokenizer seeded attribute boundary fixture JSON."
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def build_fixture() -> dict[str, object]:
+    return {
+        "format": "whatwg-html-tokenizer-attribute-boundaries/v1",
+        "description": (
+            "Seeded start-tag attribute continuation states for before/name/"
+            "value/quoted/unquoted/self-closing boundaries."
+        ),
+        "cases": [normalize_case(case) for case in build_cases()],
+    }
+
+
+def build_cases() -> list[dict[str, object]]:
+    return [
+        case(
+            "before-attribute-name-commits-new-attribute",
+            "before_attribute_name",
+            " foo=bar>",
+            ["StartTag(name=a, attributes=[id=root, foo=bar], self_closing=false)", "EOF"],
+            seed=seed("a", attributes=[attr("id", "root")]),
+        ),
+        case(
+            "before-attribute-name-self-closing",
+            "before_attribute_name",
+            "/>",
+            ["StartTag(name=img, attributes=[alt=x], self_closing=true)", "EOF"],
+            seed=seed("img", attributes=[attr("alt", "x")]),
+        ),
+        case(
+            "before-attribute-name-eof-drops-partial-tag",
+            "before_attribute_name",
+            "",
+            ["EOF"],
+            seed=seed("a", attributes=[attr("href", "x")]),
+            diagnostics=["eof-in-tag"],
+        ),
+        case(
+            "attribute-name-finishes-on-equals",
+            "attribute_name",
+            "=bar>",
+            ["StartTag(name=a, attributes=[data=bar], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("data", "")),
+        ),
+        case(
+            "attribute-name-whitespace-commits-boolean",
+            "attribute_name",
+            " next=2>",
+            ["StartTag(name=a, attributes=[checked=, next=2], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("checked", "")),
+        ),
+        case(
+            "attribute-name-null-replacement",
+            "attribute_name",
+            "\u0000=value>",
+            ["StartTag(name=a, attributes=[data�=value], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("data", "")),
+            diagnostics=["unexpected-null-character"],
+        ),
+        case(
+            "after-attribute-name-equals-value",
+            "after_attribute_name",
+            "=bar>",
+            ["StartTag(name=a, attributes=[foo=bar], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("foo", "")),
+        ),
+        case(
+            "after-attribute-name-next-attribute",
+            "after_attribute_name",
+            " bar=2>",
+            ["StartTag(name=a, attributes=[foo=, bar=2], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("foo", "")),
+        ),
+        case(
+            "before-attribute-value-double-quoted",
+            "before_attribute_value",
+            "\"hello\">",
+            ["StartTag(name=a, attributes=[title=hello], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("title", "")),
+        ),
+        case(
+            "before-attribute-value-single-quoted",
+            "before_attribute_value",
+            "'hello'>",
+            ["StartTag(name=a, attributes=[title=hello], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("title", "")),
+        ),
+        case(
+            "before-attribute-value-unquoted",
+            "before_attribute_value",
+            "hello>",
+            ["StartTag(name=a, attributes=[title=hello], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("title", "")),
+        ),
+        case(
+            "attribute-value-double-quoted-charref",
+            "attribute_value_double_quoted",
+            "&amp;B\">",
+            ["StartTag(name=a, attributes=[title=A&B], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("title", "A")),
+        ),
+        case(
+            "attribute-value-single-quoted-null",
+            "attribute_value_single_quoted",
+            "\u0000B'>",
+            ["StartTag(name=a, attributes=[title=A�B], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("title", "A")),
+            diagnostics=["unexpected-null-character"],
+        ),
+        case(
+            "attribute-value-unquoted-space-delimiter",
+            "attribute_value_unquoted",
+            "B next=2>",
+            ["StartTag(name=a, attributes=[title=AB, next=2], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("title", "A")),
+        ),
+        case(
+            "attribute-value-unquoted-unexpected-equals",
+            "attribute_value_unquoted",
+            "=B>",
+            ["StartTag(name=a, attributes=[title=A=B], self_closing=false)", "EOF"],
+            seed=seed("a", current_attribute=attr("title", "A")),
+            diagnostics=["unexpected-character-in-unquoted-attribute-value"],
+        ),
+        case(
+            "after-attribute-value-quoted-next-attribute",
+            "after_attribute_value_quoted",
+            " next=2>",
+            ["StartTag(name=a, attributes=[title=A, next=2], self_closing=false)", "EOF"],
+            seed=seed("a", attributes=[attr("title", "A")]),
+        ),
+        case(
+            "after-attribute-value-quoted-missing-whitespace",
+            "after_attribute_value_quoted",
+            "next=2>",
+            ["StartTag(name=a, attributes=[title=A, next=2], self_closing=false)", "EOF"],
+            seed=seed("a", attributes=[attr("title", "A")]),
+            diagnostics=["missing-whitespace-between-attributes"],
+        ),
+        case(
+            "self-closing-start-tag-emits",
+            "self_closing_start_tag",
+            ">",
+            ["StartTag(name=br, attributes=[], self_closing=true)", "EOF"],
+            seed=seed("br", self_closing=True),
+        ),
+        case(
+            "self-closing-start-tag-reconsumes-attribute",
+            "self_closing_start_tag",
+            "x=1>",
+            ["StartTag(name=br, attributes=[x=1], self_closing=false)", "EOF"],
+            seed=seed("br"),
+            diagnostics=["unexpected-solidus-in-tag"],
+        ),
+    ]
+
+
+def case(
+    case_id: str,
+    initial_state: str,
+    input_text: str,
+    tokens: list[str],
+    *,
+    seed: dict[str, object],
+    diagnostics: list[str] | None = None,
+) -> dict[str, object]:
+    item: dict[str, object] = {
+        "id": case_id,
+        "description": f"{initial_state} seeded attribute boundary case `{case_id}`",
+        "input": input_text,
+        "initial_state": initial_state,
+        "start_tag": seed,
+        "tokens": tokens,
+    }
+    if diagnostics is not None:
+        item["diagnostics"] = diagnostics
+    return item
+
+
+def seed(
+    name: str,
+    *,
+    attributes: list[dict[str, str]] | None = None,
+    current_attribute: dict[str, str] | None = None,
+    self_closing: bool = False,
+) -> dict[str, object]:
+    item: dict[str, object] = {
+        "name": name,
+        "attributes": attributes or [],
+        "self_closing": self_closing,
+    }
+    if current_attribute is not None:
+        item["current_attribute"] = current_attribute
+    return item
+
+
+def attr(name: str, value: str) -> dict[str, str]:
+    return {"name": name, "value": value}
+
+
+def normalize_case(case: dict[str, object]) -> dict[str, object]:
+    normalized = dict(case)
+    normalized.setdefault("diagnostics", [])
+    return normalized
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/whatwg-attribute-boundaries.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/whatwg-attribute-boundaries.json
@@ -1,0 +1,394 @@
+{
+  "cases": [
+    {
+      "description": "before_attribute_name seeded attribute boundary case `before-attribute-name-commits-new-attribute`",
+      "diagnostics": [],
+      "id": "before-attribute-name-commits-new-attribute",
+      "initial_state": "before_attribute_name",
+      "input": " foo=bar>",
+      "start_tag": {
+        "attributes": [
+          {
+            "name": "id",
+            "value": "root"
+          }
+        ],
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[id=root, foo=bar], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "before_attribute_name seeded attribute boundary case `before-attribute-name-self-closing`",
+      "diagnostics": [],
+      "id": "before-attribute-name-self-closing",
+      "initial_state": "before_attribute_name",
+      "input": "/>",
+      "start_tag": {
+        "attributes": [
+          {
+            "name": "alt",
+            "value": "x"
+          }
+        ],
+        "name": "img",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=img, attributes=[alt=x], self_closing=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "before_attribute_name seeded attribute boundary case `before-attribute-name-eof-drops-partial-tag`",
+      "diagnostics": [
+        "eof-in-tag"
+      ],
+      "id": "before-attribute-name-eof-drops-partial-tag",
+      "initial_state": "before_attribute_name",
+      "input": "",
+      "start_tag": {
+        "attributes": [
+          {
+            "name": "href",
+            "value": "x"
+          }
+        ],
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute_name seeded attribute boundary case `attribute-name-finishes-on-equals`",
+      "diagnostics": [],
+      "id": "attribute-name-finishes-on-equals",
+      "initial_state": "attribute_name",
+      "input": "=bar>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "data",
+          "value": ""
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[data=bar], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute_name seeded attribute boundary case `attribute-name-whitespace-commits-boolean`",
+      "diagnostics": [],
+      "id": "attribute-name-whitespace-commits-boolean",
+      "initial_state": "attribute_name",
+      "input": " next=2>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "checked",
+          "value": ""
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[checked=, next=2], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute_name seeded attribute boundary case `attribute-name-null-replacement`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "attribute-name-null-replacement",
+      "initial_state": "attribute_name",
+      "input": "\u0000=value>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "data",
+          "value": ""
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[data�=value], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "after_attribute_name seeded attribute boundary case `after-attribute-name-equals-value`",
+      "diagnostics": [],
+      "id": "after-attribute-name-equals-value",
+      "initial_state": "after_attribute_name",
+      "input": "=bar>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "foo",
+          "value": ""
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[foo=bar], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "after_attribute_name seeded attribute boundary case `after-attribute-name-next-attribute`",
+      "diagnostics": [],
+      "id": "after-attribute-name-next-attribute",
+      "initial_state": "after_attribute_name",
+      "input": " bar=2>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "foo",
+          "value": ""
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[foo=, bar=2], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "before_attribute_value seeded attribute boundary case `before-attribute-value-double-quoted`",
+      "diagnostics": [],
+      "id": "before-attribute-value-double-quoted",
+      "initial_state": "before_attribute_value",
+      "input": "\"hello\">",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "title",
+          "value": ""
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=hello], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "before_attribute_value seeded attribute boundary case `before-attribute-value-single-quoted`",
+      "diagnostics": [],
+      "id": "before-attribute-value-single-quoted",
+      "initial_state": "before_attribute_value",
+      "input": "'hello'>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "title",
+          "value": ""
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=hello], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "before_attribute_value seeded attribute boundary case `before-attribute-value-unquoted`",
+      "diagnostics": [],
+      "id": "before-attribute-value-unquoted",
+      "initial_state": "before_attribute_value",
+      "input": "hello>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "title",
+          "value": ""
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=hello], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute_value_double_quoted seeded attribute boundary case `attribute-value-double-quoted-charref`",
+      "diagnostics": [],
+      "id": "attribute-value-double-quoted-charref",
+      "initial_state": "attribute_value_double_quoted",
+      "input": "&amp;B\">",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "title",
+          "value": "A"
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=A&B], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute_value_single_quoted seeded attribute boundary case `attribute-value-single-quoted-null`",
+      "diagnostics": [
+        "unexpected-null-character"
+      ],
+      "id": "attribute-value-single-quoted-null",
+      "initial_state": "attribute_value_single_quoted",
+      "input": "\u0000B'>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "title",
+          "value": "A"
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=A�B], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute_value_unquoted seeded attribute boundary case `attribute-value-unquoted-space-delimiter`",
+      "diagnostics": [],
+      "id": "attribute-value-unquoted-space-delimiter",
+      "initial_state": "attribute_value_unquoted",
+      "input": "B next=2>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "title",
+          "value": "A"
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=AB, next=2], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "attribute_value_unquoted seeded attribute boundary case `attribute-value-unquoted-unexpected-equals`",
+      "diagnostics": [
+        "unexpected-character-in-unquoted-attribute-value"
+      ],
+      "id": "attribute-value-unquoted-unexpected-equals",
+      "initial_state": "attribute_value_unquoted",
+      "input": "=B>",
+      "start_tag": {
+        "attributes": [],
+        "current_attribute": {
+          "name": "title",
+          "value": "A"
+        },
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=A=B], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "after_attribute_value_quoted seeded attribute boundary case `after-attribute-value-quoted-next-attribute`",
+      "diagnostics": [],
+      "id": "after-attribute-value-quoted-next-attribute",
+      "initial_state": "after_attribute_value_quoted",
+      "input": " next=2>",
+      "start_tag": {
+        "attributes": [
+          {
+            "name": "title",
+            "value": "A"
+          }
+        ],
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=A, next=2], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "after_attribute_value_quoted seeded attribute boundary case `after-attribute-value-quoted-missing-whitespace`",
+      "diagnostics": [
+        "missing-whitespace-between-attributes"
+      ],
+      "id": "after-attribute-value-quoted-missing-whitespace",
+      "initial_state": "after_attribute_value_quoted",
+      "input": "next=2>",
+      "start_tag": {
+        "attributes": [
+          {
+            "name": "title",
+            "value": "A"
+          }
+        ],
+        "name": "a",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=a, attributes=[title=A, next=2], self_closing=false)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "self_closing_start_tag seeded attribute boundary case `self-closing-start-tag-emits`",
+      "diagnostics": [],
+      "id": "self-closing-start-tag-emits",
+      "initial_state": "self_closing_start_tag",
+      "input": ">",
+      "start_tag": {
+        "attributes": [],
+        "name": "br",
+        "self_closing": true
+      },
+      "tokens": [
+        "StartTag(name=br, attributes=[], self_closing=true)",
+        "EOF"
+      ]
+    },
+    {
+      "description": "self_closing_start_tag seeded attribute boundary case `self-closing-start-tag-reconsumes-attribute`",
+      "diagnostics": [
+        "unexpected-solidus-in-tag"
+      ],
+      "id": "self-closing-start-tag-reconsumes-attribute",
+      "initial_state": "self_closing_start_tag",
+      "input": "x=1>",
+      "start_tag": {
+        "attributes": [],
+        "name": "br",
+        "self_closing": false
+      },
+      "tokens": [
+        "StartTag(name=br, attributes=[x=1], self_closing=false)",
+        "EOF"
+      ]
+    }
+  ],
+  "description": "Seeded start-tag attribute continuation states for before/name/value/quoted/unquoted/self-closing boundaries.",
+  "format": "whatwg-html-tokenizer-attribute-boundaries/v1"
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
@@ -1,0 +1,212 @@
+use coding_adventures_html_lexer::{create_html_lexer, Attribute, StartTagSeed, Token};
+use serde::Deserialize;
+
+const WHATWG_ATTRIBUTE_BOUNDARIES: &str = include_str!("fixtures/whatwg-attribute-boundaries.json");
+
+#[derive(Debug, Deserialize)]
+struct AttributeBoundarySuite {
+    format: String,
+    description: String,
+    cases: Vec<AttributeBoundaryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AttributeBoundaryCase {
+    id: String,
+    description: String,
+    input: String,
+    initial_state: String,
+    start_tag: FixtureStartTagSeed,
+    tokens: Vec<String>,
+    #[serde(default)]
+    diagnostics: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureStartTagSeed {
+    name: String,
+    #[serde(default)]
+    attributes: Vec<FixtureAttribute>,
+    #[serde(default)]
+    self_closing: bool,
+    #[serde(default)]
+    current_attribute: Option<FixtureAttribute>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureAttribute {
+    name: String,
+    value: String,
+}
+
+#[test]
+fn whatwg_attribute_boundaries_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(
+        suite.format,
+        "whatwg-html-tokenizer-attribute-boundaries/v1"
+    );
+    assert!(!suite.description.is_empty());
+    assert!(suite.cases.len() >= 18);
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "attribute-name-null-replacement"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "after-attribute-value-quoted-missing-whitespace"));
+    assert!(suite
+        .cases
+        .iter()
+        .any(|case| case.id == "self-closing-start-tag-reconsumes-attribute"));
+}
+
+#[test]
+fn whatwg_attribute_boundaries_cases_match_default_lexer() {
+    let suite = load_suite();
+
+    for case in &suite.cases {
+        assert!(
+            !case.description.is_empty(),
+            "case `{}` should describe its attribute boundary",
+            case.id
+        );
+        let mut lexer = create_html_lexer().expect("HTML lexer should build");
+        lexer
+            .set_initial_state(&case.initial_state)
+            .unwrap_or_else(|error| {
+                panic!("case `{}` initial-state seed failed: {error:?}", case.id)
+            });
+        lexer.set_current_start_tag(start_tag_seed(&case.start_tag));
+        lexer
+            .push(&case.input)
+            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
+        lexer
+            .finish()
+            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
+
+        let actual_tokens = lexer
+            .drain_tokens()
+            .into_iter()
+            .map(token_summary)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            coalesce_adjacent_text_summaries(actual_tokens),
+            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            "case `{}` token mismatch",
+            case.id
+        );
+
+        let actual_diagnostics = lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_diagnostics, case.diagnostics,
+            "case `{}` diagnostic mismatch",
+            case.id
+        );
+    }
+}
+
+fn load_suite() -> AttributeBoundarySuite {
+    serde_json::from_str(WHATWG_ATTRIBUTE_BOUNDARIES)
+        .expect("WHATWG attribute boundary fixture should parse")
+}
+
+fn start_tag_seed(seed: &FixtureStartTagSeed) -> StartTagSeed {
+    StartTagSeed {
+        name: seed.name.clone(),
+        attributes: seed.attributes.iter().cloned().map(Into::into).collect(),
+        self_closing: seed.self_closing,
+        current_attribute: seed.current_attribute.clone().map(Into::into),
+    }
+}
+
+impl From<FixtureAttribute> for Attribute {
+    fn from(attribute: FixtureAttribute) -> Self {
+        Self {
+            name: attribute.name,
+            value: attribute.value,
+        }
+    }
+}
+
+fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -50,3 +50,6 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
   identifier, and force-quirks data.
 - Added public return-state seeding helpers so wrapper packages can resume
   continuation states such as HTML character-reference recovery.
+- Added `StartTagSeed` and current-start-tag seeding helpers so wrapper
+  packages can resume HTML attribute continuation states with partial
+  attributes.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -126,12 +126,14 @@ duplicates can continue using plain `commit_attribute`.
 
 The runtime also exposes context-seeding helpers such as
 `Tokenizer::set_initial_state`, `Tokenizer::set_last_start_tag`,
+`Tokenizer::set_current_start_tag` with `StartTagSeed`,
 `Tokenizer::set_current_end_tag`, `Tokenizer::set_current_comment`, and
 `Tokenizer::set_current_doctype` with `DoctypeSeed`, plus
 `Tokenizer::set_temporary_buffer` and `Tokenizer::set_return_state`, so wrapper
-packages can execute HTML submodes and continuation states like RCDATA
-end-tag-name, comment end-dash, character-reference recovery, or DOCTYPE public
-identifier continuation without loading definition files at runtime.
+packages can execute HTML submodes and continuation states like attribute value
+continuation, RCDATA end-tag-name, comment end-dash, character-reference
+recovery, or DOCTYPE public identifier continuation without loading definition
+files at runtime.
 
 Wrapper packages can opt into HTML-style input-stream newline preprocessing
 with `Tokenizer::with_normalized_carriage_returns`. That maps CRLF pairs and

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -75,6 +75,59 @@ impl DoctypeSeed {
     }
 }
 
+/// Seed data for resuming tokenizer states with an in-progress start tag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StartTagSeed {
+    /// Start-tag name accumulated so far.
+    pub name: String,
+    /// Attributes that have already been committed to the start tag.
+    pub attributes: Vec<Attribute>,
+    /// Whether the partial start tag has already seen a self-closing marker.
+    pub self_closing: bool,
+    /// Optional in-progress attribute for attribute continuation states.
+    pub current_attribute: Option<Attribute>,
+}
+
+impl StartTagSeed {
+    /// Build a start-tag seed with no committed attributes.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            attributes: Vec::new(),
+            self_closing: false,
+            current_attribute: None,
+        }
+    }
+
+    /// Add an already-committed attribute to the seed.
+    pub fn with_attribute(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.push(Attribute {
+            name: name.into(),
+            value: value.into(),
+        });
+        self
+    }
+
+    /// Add the current in-progress attribute to the seed.
+    pub fn with_current_attribute(
+        mut self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.current_attribute = Some(Attribute {
+            name: name.into(),
+            value: value.into(),
+        });
+        self
+    }
+
+    /// Mark the in-progress start tag as self-closing.
+    pub fn self_closing(mut self) -> Self {
+        self.self_closing = true;
+        self
+    }
+}
+
 /// Attribute attached to a start tag.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Attribute {
@@ -301,6 +354,22 @@ impl Tokenizer {
     /// Clear the last emitted start-tag name used by tokenizer submodes.
     pub fn clear_last_start_tag(&mut self) {
         self.last_start_tag = None;
+    }
+
+    /// Seed the in-progress start-tag token used by tokenizer continuation states.
+    pub fn with_current_start_tag(mut self, seed: StartTagSeed) -> Self {
+        self.set_current_start_tag(seed);
+        self
+    }
+
+    /// Store the in-progress start-tag token used by tokenizer continuation states.
+    pub fn set_current_start_tag(&mut self, seed: StartTagSeed) {
+        self.current_token = Some(CurrentToken::StartTag {
+            name: seed.name,
+            attributes: seed.attributes,
+            self_closing: seed.self_closing,
+        });
+        self.current_attribute = seed.current_attribute;
     }
 
     /// Seed the in-progress end-tag token used by tokenizer continuation states.

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use state_machine::{EffectfulMatcher, EffectfulStateMachine, EffectfulTransition};
-use state_machine_tokenizer::{Attribute, Token, Tokenizer, TokenizerError};
+use state_machine_tokenizer::{Attribute, StartTagSeed, Token, Tokenizer, TokenizerError};
 
 #[test]
 fn tokenizer_rejects_unknown_actions() {
@@ -171,6 +171,58 @@ fn tokenizer_builds_start_tag_attributes_and_self_closing_markers() {
                 value: "Xy".to_string(),
             }],
             self_closing: true,
+        }]
+    );
+}
+
+#[test]
+fn tokenizer_can_seed_current_start_tag_and_attribute() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["attr_value", "done"]),
+            set(&["X", ">"]),
+            vec![
+                EffectfulTransition::new(
+                    "attr_value",
+                    EffectfulMatcher::Event("X".to_string()),
+                    "attr_value",
+                )
+                .with_effects(&["append_attribute_value(current)"]),
+                EffectfulTransition::new(
+                    "attr_value",
+                    EffectfulMatcher::Event(">".to_string()),
+                    "done",
+                )
+                .with_effects(&["commit_attribute", "emit_current_token"]),
+            ],
+            "attr_value".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    )
+    .with_current_start_tag(
+        StartTagSeed::new("a")
+            .with_attribute("id", "root")
+            .with_current_attribute("data", "seed-"),
+    );
+
+    tokenizer.push("X>").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::StartTag {
+            name: "a".to_string(),
+            attributes: vec![
+                Attribute {
+                    name: "id".to_string(),
+                    value: "root".to_string(),
+                },
+                Attribute {
+                    name: "data".to_string(),
+                    value: "seed-X".to_string(),
+                },
+            ],
+            self_closing: false,
         }]
     );
 }


### PR DESCRIPTION
## Summary
- add StartTagSeed/current-start-tag seeding to the tokenizer runtime for attribute continuation states
- add a generated WHATWG seeded attribute boundary fixture and Rust conformance runner
- document the new generator and runtime seeding hook in lexer/tokenizer docs and changelogs

## Validation
- rustfmt --check code/packages/rust/state-machine-tokenizer/src/lib.rs code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs code/packages/rust/html-lexer/src/lib.rs code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- git diff --check