### PR TITLE
feat(forme-opengraph): FM00 v0 OpenGraph + Twitter Card + basic meta generators

### DIFF
--- a/code/packages/typescript/forme-opengraph/BUILD
+++ b/code/packages/typescript/forme-opengraph/BUILD
@@ -1,0 +1,3 @@
+cd ../document-ast && npm install --silent
+cd ../forme-types && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-opengraph/CHANGELOG.md
+++ b/code/packages/typescript/forme-opengraph/CHANGELOG.md
@@ -1,0 +1,110 @@
+# Changelog — @coding-adventures/forme-opengraph
+
+## 0.1.0 — 2026-05-18
+
+Initial release.  Second FM00 v0 stage package — OpenGraph + Twitter
+Card + basic `<meta>`/`<title>`/`<link>` HTML tag generators.
+Companion to `forme-feeds`.
+
+### Added
+
+- `generateOpenGraphTags(meta): string` — emits OpenGraph
+  `<meta property="og:...">` tags per https://ogp.me/.
+  Conventional tag order: title → type → image → url → description
+  → siteName → locale → video.
+- `generateTwitterCardTags(meta): string` — emits Twitter Card
+  `<meta name="twitter:...">` tags per Twitter Cards spec.
+- `generateBasicTags(meta): string` — emits `<title>`,
+  `<meta name="description">`, `<link rel="canonical">` for
+  search-engine snippet metadata.
+- `generateMetaTags({ basic?, og?, twitter? }): string` —
+  convenience wrapper combining all three in
+  basic → og → twitter order.
+- `OpenGraphMeta`, `TwitterCardMeta`, `BasicMeta`, `CombinedMeta`
+  type definitions.
+- `escapeHtmlAttr`, `escapeHtmlText`, `assertAbsoluteUrl`
+  re-exported for callers wiring custom generators.
+
+### Spec adherence
+
+- OpenGraph per https://ogp.me/
+- Twitter Cards per https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup
+- HTML5 attribute syntax per WHATWG HTML
+
+No spec divergences.
+
+### Behavioural notes
+
+- **URL validation FIRST.**  All URL-bearing fields (og:image,
+  og:url, og:video, twitter:image, canonical) are validated against
+  `/^https?:\/\//i` BEFORE any output is emitted.  Malformed URLs
+  throw `TypeError` synchronously — no partial output.
+- **HTML attribute escaping uniform across all generators.**
+  Single-pass replace of the five entities (CodeQL-friendly form).
+- **Control-byte stripping** (`U+0000-U+001F`, `U+007F`) before
+  any escape pass.  Unicode `> U+007F` passes through (HTML5 UTF-8).
+- **Tag order is deterministic** within each block.  Block-level
+  order in `generateMetaTags` is basic → og → twitter.
+- **Empty blocks emit empty strings** (filtered before joining)
+  so the combined output never has spurious blank lines.
+- **Twitter card type validation.**  Unknown card values throw
+  with the allowed set in the error message.
+
+### Security posture
+
+Three concerns explicitly addressed (pre-push review):
+
+- **HTML attribute injection.**  `escapeHtmlAttr` covers all five
+  HTML entities in single-pass replacement.  Every interpolated
+  string in `opengraph.ts` / `twitter.ts` / `basic.ts` routes
+  through it (or `escapeHtmlText`, which is an alias).
+- **URL scheme validation.**  `assertAbsoluteUrl` rejects
+  `javascript:`, `data:`, `file:`, protocol-relative `//host`,
+  relative paths, empty strings, and non-string inputs.  These
+  are real injection vectors in social-card scrapers that render
+  previews — XSS via `javascript:` in `og:image`, payload delivery
+  via `data:`.  Tests pin every rejected form.
+- **Control-character stripping** removes ASCII control bytes
+  before escaping, so a meta-tag value containing NUL or DEL
+  can't confuse downstream HTML parsers.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, no network, no shell, no env.
+
+### Tests
+
+68 tests across 5 files:
+
+- `escape.test.ts` (19) — every HTML entity (single + composite),
+  control-byte stripping for 0x00-0x1F and 0x7F, Unicode passthrough,
+  URL scheme acceptance (http, https, port, query, fragment,
+  case-insensitive) and rejection (relative, javascript:, data:,
+  file:, protocol-relative, empty, non-string), field-name in
+  error messages
+- `opengraph.test.ts` (16) — required fields in conventional order,
+  every optional field, URL validation rejects each forbidden form
+  for image/url/video, HTML escaping, control-byte stripping,
+  pre-output throw verification, reproducibility
+- `twitter.test.ts` (18) — all four card types parameterised,
+  unknown card rejection, optional fields with order check,
+  emits-only-supplied-tags policy, URL validation for image,
+  escaping, reproducibility
+- `basic.test.ts` (9) — each tag individually, all-three order,
+  empty input → empty string, canonical URL validation, escaping,
+  control-byte stripping
+- `combined.test.ts` (6) — basic → og → twitter ordering,
+  skip-when-not-supplied, URL-error propagation, no spurious
+  blank lines, reproducibility
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only declarations).
+
+### v0 simplifications (documented)
+
+- No `og:image:width` / `og:image:height` / `og:image:alt`
+  sub-tags.
+- No `article:author` / `article:published_time` Open Graph
+  Article extensions.
+- No `twitter:player` extra metadata.
+- No multi-image arrays.

--- a/code/packages/typescript/forme-opengraph/README.md
+++ b/code/packages/typescript/forme-opengraph/README.md
@@ -1,0 +1,150 @@
+# @coding-adventures/forme-opengraph
+
+**OpenGraph** + **Twitter Card** + **basic `<meta>` tag** generators for the Forme pipeline (FM00 v0 SEO stage).
+
+Pure transform: meta records → reproducible HTML `<meta>` / `<link>` / `<title>` tag sequence.  Companion to [`forme-feeds`](../forme-feeds) in the FM00 v0 stage family.
+
+## Quick start
+
+```ts
+import { generateMetaTags } from "@coding-adventures/forme-opengraph";
+
+const head = generateMetaTags({
+  basic: {
+    title: "Hello World",
+    description: "A first post on my blog",
+    canonical: "https://example.com/hello",
+  },
+  og: {
+    title: "Hello World",
+    type: "article",
+    image: "https://example.com/og.png",
+    url: "https://example.com/hello",
+    description: "A first post on my blog",
+    siteName: "My Blog",
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@myblog",
+    creator: "@me",
+  },
+});
+
+// → <title>Hello World</title>
+//   <meta name="description" content="A first post on my blog">
+//   <link rel="canonical" href="https://example.com/hello">
+//   <meta property="og:title" content="Hello World">
+//   <meta property="og:type" content="article">
+//   ...
+```
+
+## API
+
+### `generateOpenGraphTags(meta): string`
+
+Emits OpenGraph `<meta>` tags per https://ogp.me/.  Conventional tag order: title → type → image → url → description → siteName → locale → video.
+
+```ts
+interface OpenGraphMeta {
+  title: string;
+  type: string;          // "website", "article", "video.movie", ...
+  image: string;         // MUST be absolute http(s)
+  url: string;           // MUST be absolute http(s)
+  description?: string;
+  siteName?: string;     // emitted as og:site_name
+  locale?: string;       // e.g. "en_US"
+  video?: string;        // MUST be absolute http(s) if supplied
+}
+```
+
+### `generateTwitterCardTags(meta): string`
+
+Emits Twitter Card `<meta>` tags per https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup.
+
+```ts
+interface TwitterCardMeta {
+  card: "summary" | "summary_large_image" | "player" | "app";
+  title?: string;
+  description?: string;
+  image?: string;        // MUST be absolute http(s) if supplied
+  site?: string;         // @site Twitter handle for the publishing site
+  creator?: string;      // @creator Twitter handle for the content author
+}
+```
+
+### `generateBasicTags(meta): string`
+
+Emits `<title>`, `<meta name="description">`, `<link rel="canonical">` — drives search-engine snippets independently of social previews.
+
+```ts
+interface BasicMeta {
+  title?: string;
+  description?: string;
+  canonical?: string;    // MUST be absolute http(s) if supplied
+}
+```
+
+### `generateMetaTags({ basic?, og?, twitter? }): string`
+
+Convenience wrapper — combines all three blocks in `basic → og → twitter` order.
+
+## URL validation (security-critical)
+
+The fields that resolve to a fetch target — `og:image`, `og:url`, `og:video`, `twitter:image`, canonical — are validated against `/^https?:\/\//i`.  Anything else **throws `TypeError`** synchronously before any output is emitted:
+
+- Relative paths (`/path`, `path`, `./x`)
+- `javascript:alert(1)` (XSS in scrapers that render previews)
+- `data:text/html,…` (tracker / payload injection)
+- `file:///etc/passwd`
+- Protocol-relative `//host/path`
+
+The error message includes the field name so callers can diagnose which input failed.
+
+## HTML attribute escaping
+
+All meta-tag content values land inside `content="..."` attributes.  All five HTML entities (`& < > " '`) are escaped in a single-pass replacement (CodeQL-friendly form).  ASCII control bytes (`U+0000-U+001F`, `U+007F`) are stripped before escaping — they have no legitimate place in a meta-tag value and they confuse downstream HTML parsers.
+
+Unicode `> U+007F` passes through unchanged (HTML5 is UTF-8 by default).
+
+## Capabilities — `[]`
+
+Pure transform.  No I/O, no network, no shell.
+
+## Reproducibility (FM03)
+
+Same inputs → byte-identical output.  Tag order is fixed by spec convention (deterministic across runs).
+
+## Security posture
+
+Three concerns explicitly addressed:
+
+1. **HTML attribute injection.**  `escapeHtmlAttr` handles all five entities in single-pass replacement.  Every value landing in a `content=` / `href=` attribute routes through it.  Tests pin escape coverage and explicitly verify control-byte stripping.
+2. **URL scheme validation.**  `assertAbsoluteUrl` rejects everything except `http(s)://...` — `javascript:` / `data:` / `file:` / protocol-relative all throw `TypeError` before output is emitted.  Tests pin every rejected form.
+3. **Control-character stripping.**  ASCII control bytes removed from every string field; preserves Unicode and standard whitespace.
+
+## Tests
+
+68 tests across 5 files:
+
+- `escape.test.ts` (19) — every HTML entity, control-byte stripping, URL scheme acceptance and rejection (10+ cases), field-name in error messages, non-string rejection
+- `opengraph.test.ts` (16) — required fields in order, all optional fields, URL validation rejects each forbidden form, HTML escaping, reproducibility
+- `twitter.test.ts` (18) — all four card types, unknown card rejection, optional fields with order check, URL validation, escaping, reproducibility
+- `basic.test.ts` (9) — each tag individually, all-three order, empty input, canonical URL validation, escaping
+- `combined.test.ts` (6) — block ordering, skip-when-empty, URL-error propagation, no spurious blank lines, reproducibility
+
+Coverage: **100% line / 100% branch** across all source files with logic (`types.ts` is type-only declarations).
+
+## Spec adherence
+
+- OpenGraph per https://ogp.me/
+- Twitter Cards per https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup
+- HTML5 attribute syntax per WHATWG HTML
+
+No spec divergences.
+
+## v0 simplifications
+
+- No `og:image:width` / `og:image:height` / `og:image:alt` — add when a use case demands.
+- No `article:author` / `article:published_time` Open Graph Article object extensions.
+- No `twitter:player` extra metadata (height, width, stream).
+- No multi-image arrays.

--- a/code/packages/typescript/forme-opengraph/package-lock.json
+++ b/code/packages/typescript/forme-opengraph/package-lock.json
@@ -1,0 +1,2320 @@
+{
+  "name": "@coding-adventures/forme-opengraph",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-opengraph",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-types": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-types": {
+      "resolved": "../forme-types",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-opengraph/package.json
+++ b/code/packages/typescript/forme-opengraph/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@coding-adventures/forme-opengraph",
+  "version": "0.1.0",
+  "description": "OpenGraph + Twitter Card + basic <meta> tag generators for the Forme pipeline (FM00 v0 SEO stage).  Pure transform: meta records → reproducible HTML <meta>/<link>/<title> tag sequence.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-types": "file:../forme-types"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-opengraph/required_capabilities.json
+++ b/code/packages/typescript/forme-opengraph/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-opengraph",
+  "capabilities": [],
+  "justification": "Pure transform: meta records (OpenGraph, Twitter Card, basic) → HTML <meta>/<link>/<title> tag string.  No I/O, no network, no env, no shell.  Same posture as forme-feeds and the FM04 translator packages."
+}

--- a/code/packages/typescript/forme-opengraph/src/basic.ts
+++ b/code/packages/typescript/forme-opengraph/src/basic.ts
@@ -1,0 +1,30 @@
+/**
+ * basic.ts — `generateBasicTags(meta)`.
+ *
+ * Emits the three basic HTML head tags that drive search-engine
+ * snippets (independent of OpenGraph / Twitter, which drive social
+ * preview cards).
+ *
+ *   <title>...</title>
+ *   <meta name="description" content="...">
+ *   <link rel="canonical" href="...">
+ *
+ * Each field is optional — omit any and the corresponding tag is
+ * skipped.  `canonical` MUST be an absolute http(s) URL when
+ * supplied.
+ *
+ * @module basic
+ */
+
+import { assertAbsoluteUrl, escapeHtmlAttr, escapeHtmlText } from "./escape.js";
+import type { BasicMeta } from "./types.js";
+
+export function generateBasicTags(meta: BasicMeta): string {
+  if (meta.canonical !== undefined) assertAbsoluteUrl("link rel=canonical", meta.canonical);
+
+  const tags: string[] = [];
+  if (meta.title       !== undefined) tags.push(`<title>${escapeHtmlText(meta.title)}</title>`);
+  if (meta.description !== undefined) tags.push(`<meta name="description" content="${escapeHtmlAttr(meta.description)}">`);
+  if (meta.canonical   !== undefined) tags.push(`<link rel="canonical" href="${escapeHtmlAttr(meta.canonical)}">`);
+  return tags.join("\n");
+}

--- a/code/packages/typescript/forme-opengraph/src/combined.ts
+++ b/code/packages/typescript/forme-opengraph/src/combined.ts
@@ -1,0 +1,31 @@
+/**
+ * combined.ts — `generateMetaTags({ basic?, og?, twitter? })`.
+ *
+ * Convenience wrapper combining all three generators into one call.
+ * Tag-block order is: basic → opengraph → twitter (mirrors what
+ * hand-authored heads look like; search-engine basic tags first,
+ * then social preview cards).
+ *
+ * @module combined
+ */
+
+import { generateBasicTags } from "./basic.js";
+import { generateOpenGraphTags } from "./opengraph.js";
+import { generateTwitterCardTags } from "./twitter.js";
+import type { BasicMeta, OpenGraphMeta, TwitterCardMeta } from "./types.js";
+
+export interface CombinedMeta {
+  readonly basic?: BasicMeta;
+  readonly og?: OpenGraphMeta;
+  readonly twitter?: TwitterCardMeta;
+}
+
+export function generateMetaTags(combined: CombinedMeta): string {
+  const blocks: string[] = [];
+  if (combined.basic   !== undefined) blocks.push(generateBasicTags(combined.basic));
+  if (combined.og      !== undefined) blocks.push(generateOpenGraphTags(combined.og));
+  if (combined.twitter !== undefined) blocks.push(generateTwitterCardTags(combined.twitter));
+  // Filter empty strings (a meta block with zero supplied fields
+  // produces "" — don't emit double blank lines).
+  return blocks.filter((b) => b.length > 0).join("\n");
+}

--- a/code/packages/typescript/forme-opengraph/src/escape.ts
+++ b/code/packages/typescript/forme-opengraph/src/escape.ts
@@ -1,0 +1,93 @@
+/**
+ * escape.ts — HTML attribute escaping + URL scheme validation.
+ *
+ * Two concerns:
+ *
+ * 1. **HTML attribute-value escaping.**  All meta-tag content
+ *    values land inside `content="..."` / `href="..."` attributes.
+ *    The five XHTML predefined entities (`& < > " '`) must be
+ *    escaped — `"` and `'` to keep the attribute literal closed,
+ *    `&` because it can introduce a different entity, and `< >`
+ *    for parser safety even though strict HTML5 only requires `&`
+ *    + the active quote character.  Single-pass replace via a
+ *    character-class regex (CodeQL incomplete-string-escape rule
+ *    accepts this form).
+ *
+ * 2. **URL scheme validation.**  `og:image`, `og:url`, `og:video`,
+ *    `twitter:image`, and `<link rel="canonical">` MUST be ABSOLUTE
+ *    URLs per the respective specs.  We additionally enforce that
+ *    the scheme is `http://` or `https://` — `javascript:` and
+ *    `data:` URLs in social-card meta tags are an injection vector
+ *    (a scraper rendering the URL in a preview could execute JS in
+ *    its own origin, or load a tracker via `data:`).
+ *
+ * ASCII control bytes (0x00–0x1F, 0x7F) are stripped from every
+ * string before escaping — they have no legitimate place in a
+ * meta-tag value and they can confuse downstream HTML parsers.
+ *
+ * @module escape
+ */
+
+const HTML_ATTR_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;",
+  "'": "&#39;",   // &#39; is more portable than &apos; (older HTML4 parsers)
+});
+
+// Single-pass replacement (CodeQL incomplete-string-escape friendly).
+const HTML_ATTR_SPECIAL_RE = /[&<>"']/g;
+
+// ASCII control bytes + DEL.  Excludes the high-bit C1 range
+// (0x80–0x9F) — those are valid Unicode code points in HTML5 (text
+// content is UTF-8) and shouldn't be stripped from meta-tag values.
+// eslint-disable-next-line no-control-regex
+const ASCII_CONTROL_RE = /[\x00-\x1F\x7F]/g;
+
+/**
+ * Escape a string for use inside an HTML attribute value (double-
+ * quoted).  Strips ASCII control bytes first.
+ */
+export function escapeHtmlAttr(s: string): string {
+  return s.replace(ASCII_CONTROL_RE, "").replace(HTML_ATTR_SPECIAL_RE, (ch) => HTML_ATTR_ESCAPE_MAP[ch]!);
+}
+
+/**
+ * Escape a string for use inside an HTML text node (e.g. inside
+ * `<title>`).  Same rules apply — we escape all five entities for
+ * uniformity even though `<title>` content is RCDATA (only `&` and
+ * `<` strictly need escaping there).
+ */
+export function escapeHtmlText(s: string): string {
+  return escapeHtmlAttr(s);
+}
+
+// ─── URL validation ─────────────────────────────────────────────────────
+
+/**
+ * Allowed URL schemes for meta-tag fields that resolve to a fetch
+ * target (og:image, og:url, og:video, twitter:image, canonical).
+ * `javascript:` and `data:` are explicitly rejected — they're
+ * injection vectors in social-card scrapers that render previews.
+ */
+const ABSOLUTE_HTTP_URL_RE = /^https?:\/\//i;
+
+/**
+ * Assert that a URL is an absolute http(s) URL.  Throws `TypeError`
+ * on anything else (relative path, `javascript:`, `data:`, `file:`,
+ * empty string, non-string input).  The error message includes the
+ * field name to help callers diagnose which input failed.
+ */
+export function assertAbsoluteUrl(field: string, value: unknown): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(
+      `forme-opengraph: ${field} must be a non-empty string (got ${JSON.stringify(value)})`,
+    );
+  }
+  if (!ABSOLUTE_HTTP_URL_RE.test(value)) {
+    throw new TypeError(
+      `forme-opengraph: ${field} must be an absolute http(s) URL (got ${JSON.stringify(value)})`,
+    );
+  }
+}

--- a/code/packages/typescript/forme-opengraph/src/index.ts
+++ b/code/packages/typescript/forme-opengraph/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @coding-adventures/forme-opengraph
+ *
+ * OpenGraph + Twitter Card + basic `<meta>` tag generators for the
+ * Forme pipeline (FM00 v0 SEO stage).
+ *
+ * Pure transform — meta records → reproducible HTML
+ * `<meta>` / `<link>` / `<title>` tag sequence.
+ *
+ * ```ts
+ * import { generateMetaTags } from "@coding-adventures/forme-opengraph";
+ *
+ * const head = generateMetaTags({
+ *   basic: {
+ *     title: "Hello World",
+ *     description: "A first post",
+ *     canonical: "https://example.com/hello",
+ *   },
+ *   og: {
+ *     title: "Hello World",
+ *     type: "article",
+ *     image: "https://example.com/og.png",
+ *     url: "https://example.com/hello",
+ *   },
+ *   twitter: {
+ *     card: "summary_large_image",
+ *     site: "@example",
+ *   },
+ * });
+ * ```
+ *
+ * @module index
+ */
+
+export { generateOpenGraphTags } from "./opengraph.js";
+export { generateTwitterCardTags } from "./twitter.js";
+export { generateBasicTags } from "./basic.js";
+export { generateMetaTags } from "./combined.js";
+export type { CombinedMeta } from "./combined.js";
+export type { OpenGraphMeta, TwitterCardMeta, BasicMeta } from "./types.js";
+export { escapeHtmlAttr, escapeHtmlText, assertAbsoluteUrl } from "./escape.js";

--- a/code/packages/typescript/forme-opengraph/src/opengraph.ts
+++ b/code/packages/typescript/forme-opengraph/src/opengraph.ts
@@ -1,0 +1,38 @@
+/**
+ * opengraph.ts — `generateOpenGraphTags(meta)`.
+ *
+ * Emits a newline-separated sequence of OpenGraph `<meta>` tags
+ * suitable for dropping into `<head>`.  Tag order follows the
+ * conventional OpenGraph documentation order (title, type, image,
+ * url, then optional fields) — deterministic for reproducible
+ * builds.
+ *
+ * @module opengraph
+ */
+
+import { assertAbsoluteUrl, escapeHtmlAttr } from "./escape.js";
+import type { OpenGraphMeta } from "./types.js";
+
+export function generateOpenGraphTags(meta: OpenGraphMeta): string {
+  // URL validation FIRST — throw before emitting anything if a
+  // URL is malformed.  We don't want partial output that silently
+  // drops a malformed image.
+  assertAbsoluteUrl("og:image", meta.image);
+  assertAbsoluteUrl("og:url",   meta.url);
+  if (meta.video !== undefined) assertAbsoluteUrl("og:video", meta.video);
+
+  const tags: string[] = [];
+  tags.push(metaTag("og:title", meta.title));
+  tags.push(metaTag("og:type",  meta.type));
+  tags.push(metaTag("og:image", meta.image));
+  tags.push(metaTag("og:url",   meta.url));
+  if (meta.description !== undefined) tags.push(metaTag("og:description", meta.description));
+  if (meta.siteName    !== undefined) tags.push(metaTag("og:site_name",   meta.siteName));
+  if (meta.locale      !== undefined) tags.push(metaTag("og:locale",      meta.locale));
+  if (meta.video       !== undefined) tags.push(metaTag("og:video",       meta.video));
+  return tags.join("\n");
+}
+
+function metaTag(property: string, content: string): string {
+  return `<meta property="${escapeHtmlAttr(property)}" content="${escapeHtmlAttr(content)}">`;
+}

--- a/code/packages/typescript/forme-opengraph/src/twitter.ts
+++ b/code/packages/typescript/forme-opengraph/src/twitter.ts
@@ -1,0 +1,45 @@
+/**
+ * twitter.ts — `generateTwitterCardTags(meta)`.
+ *
+ * Emits a newline-separated sequence of Twitter Card `<meta>` tags
+ * suitable for dropping into `<head>` per
+ * https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup.
+ *
+ * Note: Twitter Cards use `name="twitter:..."`, not `property=`
+ * (which is what OpenGraph uses).  This is per the Twitter spec —
+ * `name=` is the historical HTML4 form; `property=` is RDFa.
+ *
+ * @module twitter
+ */
+
+import { assertAbsoluteUrl, escapeHtmlAttr } from "./escape.js";
+import type { TwitterCardMeta } from "./types.js";
+
+const ALLOWED_CARDS: ReadonlySet<TwitterCardMeta["card"]> = new Set([
+  "summary",
+  "summary_large_image",
+  "player",
+  "app",
+]);
+
+export function generateTwitterCardTags(meta: TwitterCardMeta): string {
+  if (!ALLOWED_CARDS.has(meta.card)) {
+    throw new TypeError(
+      `forme-opengraph: twitter:card must be one of ${[...ALLOWED_CARDS].join(", ")} (got ${JSON.stringify(meta.card)})`,
+    );
+  }
+  if (meta.image !== undefined) assertAbsoluteUrl("twitter:image", meta.image);
+
+  const tags: string[] = [];
+  tags.push(metaTag("twitter:card", meta.card));
+  if (meta.title       !== undefined) tags.push(metaTag("twitter:title",       meta.title));
+  if (meta.description !== undefined) tags.push(metaTag("twitter:description", meta.description));
+  if (meta.image       !== undefined) tags.push(metaTag("twitter:image",       meta.image));
+  if (meta.site        !== undefined) tags.push(metaTag("twitter:site",        meta.site));
+  if (meta.creator     !== undefined) tags.push(metaTag("twitter:creator",     meta.creator));
+  return tags.join("\n");
+}
+
+function metaTag(name: string, content: string): string {
+  return `<meta name="${escapeHtmlAttr(name)}" content="${escapeHtmlAttr(content)}">`;
+}

--- a/code/packages/typescript/forme-opengraph/src/types.ts
+++ b/code/packages/typescript/forme-opengraph/src/types.ts
@@ -1,0 +1,64 @@
+/**
+ * types.ts — meta-record types for the three generators.
+ *
+ * @module types
+ */
+
+/**
+ * OpenGraph metadata per https://ogp.me/.  The four required
+ * fields (title, type, image, url) are mandatory; the rest are
+ * optional.  Image/url/video MUST be absolute http(s) URLs —
+ * `generateOpenGraphTags` throws TypeError on relative paths
+ * (Facebook's scraper requires absolute) or `javascript:`/`data:`
+ * schemes (injection vectors).
+ */
+export interface OpenGraphMeta {
+  /** Page / object title. */
+  readonly title: string;
+  /** `og:type` — `"website"`, `"article"`, `"video.movie"`, etc. */
+  readonly type: string;
+  /** Cover image URL.  MUST be absolute http(s). */
+  readonly image: string;
+  /** Canonical object URL.  MUST be absolute http(s). */
+  readonly url: string;
+  readonly description?: string;
+  /** `og:site_name`. */
+  readonly siteName?: string;
+  /** `og:locale` — e.g. `"en_US"`. */
+  readonly locale?: string;
+  /** `og:video` URL.  MUST be absolute http(s) if supplied. */
+  readonly video?: string;
+}
+
+/**
+ * Twitter Card metadata per
+ * https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup.
+ * Only `card` is mandatory; the rest fall back to og:* tags when
+ * a Twitter-specific value isn't supplied (the consumer's choice —
+ * `generateTwitterCardTags` only emits what you give it).
+ */
+export interface TwitterCardMeta {
+  /** Twitter card type. */
+  readonly card: "summary" | "summary_large_image" | "player" | "app";
+  readonly title?: string;
+  readonly description?: string;
+  /** Image URL.  MUST be absolute http(s) if supplied. */
+  readonly image?: string;
+  /** `@site` Twitter handle for the publishing site. */
+  readonly site?: string;
+  /** `@creator` Twitter handle for the content author. */
+  readonly creator?: string;
+}
+
+/**
+ * Basic HTML head metadata — `<title>`, `<meta name="description">`,
+ * `<link rel="canonical">`.  Independent of OpenGraph / Twitter
+ * because a page may want all three concerns served from one place
+ * (and the basic tags drive search-engine snippets, not just
+ * social previews).  Canonical URL MUST be absolute http(s).
+ */
+export interface BasicMeta {
+  readonly title?: string;
+  readonly description?: string;
+  readonly canonical?: string;
+}

--- a/code/packages/typescript/forme-opengraph/tests/basic.test.ts
+++ b/code/packages/typescript/forme-opengraph/tests/basic.test.ts
@@ -1,0 +1,60 @@
+/**
+ * basic.test.ts — basic <title> / <meta description> / <link canonical> generator.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateBasicTags } from "../src/index.js";
+
+describe("generateBasicTags", () => {
+  it("emits <title> when supplied", () => {
+    expect(generateBasicTags({ title: "Hello" })).toBe(`<title>Hello</title>`);
+  });
+
+  it("emits <meta description> when supplied", () => {
+    expect(generateBasicTags({ description: "A nice page" }))
+      .toBe(`<meta name="description" content="A nice page">`);
+  });
+
+  it("emits <link rel=canonical> when supplied", () => {
+    expect(generateBasicTags({ canonical: "https://example.com/x" }))
+      .toBe(`<link rel="canonical" href="https://example.com/x">`);
+  });
+
+  it("emits all three in conventional order when all supplied", () => {
+    const lines = generateBasicTags({
+      title: "T",
+      description: "D",
+      canonical: "https://example.com/x",
+    }).split("\n");
+    expect(lines.length).toBe(3);
+    expect(lines[0]).toContain("<title>");
+    expect(lines[1]).toContain("description");
+    expect(lines[2]).toContain("canonical");
+  });
+
+  it("empty meta → empty string (no spurious whitespace)", () => {
+    expect(generateBasicTags({})).toBe("");
+  });
+
+  it("escapes special chars in <title>", () => {
+    expect(generateBasicTags({ title: `AT&T "Blog"` }))
+      .toBe(`<title>AT&amp;T &quot;Blog&quot;</title>`);
+  });
+
+  it("escapes special chars in description attribute", () => {
+    expect(generateBasicTags({ description: `<script>` }))
+      .toBe(`<meta name="description" content="&lt;script&gt;">`);
+  });
+
+  it("validates canonical URL is absolute http(s)", () => {
+    expect(() => generateBasicTags({ canonical: "/relative" }))
+      .toThrow(/canonical.*absolute/);
+    expect(() => generateBasicTags({ canonical: "javascript:alert(1)" }))
+      .toThrow(/canonical.*absolute/);
+  });
+
+  it("strips ASCII control bytes from title", () => {
+    expect(generateBasicTags({ title: "Hello\x00World" }))
+      .toBe(`<title>HelloWorld</title>`);
+  });
+});

--- a/code/packages/typescript/forme-opengraph/tests/combined.test.ts
+++ b/code/packages/typescript/forme-opengraph/tests/combined.test.ts
@@ -1,0 +1,75 @@
+/**
+ * combined.test.ts — `generateMetaTags` convenience wrapper.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateMetaTags } from "../src/index.js";
+
+describe("generateMetaTags", () => {
+  it("combines all three blocks in basic → og → twitter order", () => {
+    const out = generateMetaTags({
+      basic: { title: "T", canonical: "https://example.com/" },
+      og: {
+        title: "OG-T", type: "article",
+        image: "https://example.com/og.png",
+        url: "https://example.com/x",
+      },
+      twitter: { card: "summary_large_image", site: "@acme" },
+    });
+    const idxBasic   = out.indexOf("<title>T</title>");
+    const idxOg      = out.indexOf("og:title");
+    const idxTwitter = out.indexOf("twitter:card");
+    expect(idxBasic).toBeGreaterThanOrEqual(0);
+    expect(idxOg).toBeGreaterThan(idxBasic);
+    expect(idxTwitter).toBeGreaterThan(idxOg);
+  });
+
+  it("skips a block when not supplied", () => {
+    const out = generateMetaTags({
+      basic: { title: "T" },
+    });
+    expect(out).toBe(`<title>T</title>`);
+    expect(out).not.toContain("og:");
+    expect(out).not.toContain("twitter:");
+  });
+
+  it("empty combined input → empty string", () => {
+    expect(generateMetaTags({})).toBe("");
+  });
+
+  it("propagates URL-validation errors from any block", () => {
+    expect(() => generateMetaTags({
+      og: {
+        title: "x", type: "article",
+        image: "/relative",
+        url: "https://example.com/x",
+      },
+    })).toThrow(/og:image.*absolute/);
+  });
+
+  it("filters empty meta blocks (e.g. basic with no fields) without spurious blank lines", () => {
+    const out = generateMetaTags({
+      basic: {},
+      og: {
+        title: "x", type: "article",
+        image: "https://example.com/i.png",
+        url: "https://example.com/p",
+      },
+    });
+    // Block separator is single \n; no double-blank lines.
+    expect(out).not.toMatch(/\n\n/);
+  });
+
+  it("reproducibility — same input → byte-identical output", () => {
+    const input = {
+      basic: { title: "T" },
+      og: {
+        title: "x", type: "article",
+        image: "https://example.com/i.png",
+        url: "https://example.com/p",
+      },
+      twitter: { card: "summary" as const },
+    };
+    expect(generateMetaTags(input)).toBe(generateMetaTags(input));
+  });
+});

--- a/code/packages/typescript/forme-opengraph/tests/escape.test.ts
+++ b/code/packages/typescript/forme-opengraph/tests/escape.test.ts
@@ -1,0 +1,110 @@
+/**
+ * escape.test.ts — HTML attribute escaping + URL validation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { escapeHtmlAttr, escapeHtmlText, assertAbsoluteUrl } from "../src/index.js";
+
+describe("escapeHtmlAttr", () => {
+  it("escapes the five HTML entities", () => {
+    expect(escapeHtmlAttr("&")).toBe("&amp;");
+    expect(escapeHtmlAttr("<")).toBe("&lt;");
+    expect(escapeHtmlAttr(">")).toBe("&gt;");
+    expect(escapeHtmlAttr(`"`)).toBe("&quot;");
+    expect(escapeHtmlAttr("'")).toBe("&#39;");
+  });
+
+  it("escapes all five in one string (single-pass)", () => {
+    expect(escapeHtmlAttr(`<a href="x">'AT&T'</a>`))
+      .toBe("&lt;a href=&quot;x&quot;&gt;&#39;AT&amp;T&#39;&lt;/a&gt;");
+  });
+
+  it("passes through plain ASCII unchanged", () => {
+    expect(escapeHtmlAttr("Hello world 123")).toBe("Hello world 123");
+  });
+
+  it("passes through Unicode > 0x7F unchanged (HTML5 UTF-8)", () => {
+    expect(escapeHtmlAttr("café — résumé 你好")).toBe("café — résumé 你好");
+  });
+
+  it("strips ASCII control bytes (0x00-0x1F)", () => {
+    expect(escapeHtmlAttr("a\x00b\x01c\x1fd")).toBe("abcd");
+  });
+
+  it("strips DEL (0x7F)", () => {
+    expect(escapeHtmlAttr("a\x7fb")).toBe("ab");
+  });
+
+  it("escapeHtmlText is an alias of escapeHtmlAttr", () => {
+    const samples = [`&`, `<`, `"`, `'`, `Hello`, `a\x00b`];
+    for (const s of samples) {
+      expect(escapeHtmlText(s)).toBe(escapeHtmlAttr(s));
+    }
+  });
+});
+
+describe("assertAbsoluteUrl", () => {
+  it("accepts http:// URLs", () => {
+    expect(() => assertAbsoluteUrl("test", "http://example.com/x")).not.toThrow();
+  });
+
+  it("accepts https:// URLs", () => {
+    expect(() => assertAbsoluteUrl("test", "https://example.com/x")).not.toThrow();
+  });
+
+  it("accepts URLs with query / fragment / port", () => {
+    expect(() => assertAbsoluteUrl("test", "https://example.com:8443/x?a=1&b=2#frag")).not.toThrow();
+  });
+
+  it("is case-insensitive on the scheme", () => {
+    expect(() => assertAbsoluteUrl("test", "HTTPS://example.com")).not.toThrow();
+  });
+
+  it("rejects relative paths", () => {
+    expect(() => assertAbsoluteUrl("test", "/path"))
+      .toThrow(/must be an absolute http\(s\) URL/);
+    expect(() => assertAbsoluteUrl("test", "path"))
+      .toThrow(/must be an absolute http\(s\) URL/);
+    expect(() => assertAbsoluteUrl("test", "./x"))
+      .toThrow(/must be an absolute http\(s\) URL/);
+  });
+
+  it("rejects javascript: URLs (injection vector)", () => {
+    expect(() => assertAbsoluteUrl("test", "javascript:alert(1)"))
+      .toThrow(/must be an absolute http\(s\) URL/);
+  });
+
+  it("rejects data: URLs (injection vector)", () => {
+    expect(() => assertAbsoluteUrl("test", "data:text/html,<script>alert(1)</script>"))
+      .toThrow(/must be an absolute http\(s\) URL/);
+  });
+
+  it("rejects file: URLs", () => {
+    expect(() => assertAbsoluteUrl("test", "file:///etc/passwd"))
+      .toThrow(/must be an absolute http\(s\) URL/);
+  });
+
+  it("rejects protocol-relative URLs (no scheme)", () => {
+    expect(() => assertAbsoluteUrl("test", "//example.com/x"))
+      .toThrow(/must be an absolute http\(s\) URL/);
+  });
+
+  it("rejects empty string", () => {
+    expect(() => assertAbsoluteUrl("test", ""))
+      .toThrow(/must be a non-empty string/);
+  });
+
+  it("rejects non-string values", () => {
+    expect(() => assertAbsoluteUrl("test", null))
+      .toThrow(/must be a non-empty string/);
+    expect(() => assertAbsoluteUrl("test", 42))
+      .toThrow(/must be a non-empty string/);
+    expect(() => assertAbsoluteUrl("test", undefined))
+      .toThrow(/must be a non-empty string/);
+  });
+
+  it("includes the field name in the error message", () => {
+    expect(() => assertAbsoluteUrl("og:image", "relative"))
+      .toThrow(/og:image/);
+  });
+});

--- a/code/packages/typescript/forme-opengraph/tests/opengraph.test.ts
+++ b/code/packages/typescript/forme-opengraph/tests/opengraph.test.ts
@@ -1,0 +1,125 @@
+/**
+ * opengraph.test.ts — OpenGraph generator.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateOpenGraphTags, type OpenGraphMeta } from "../src/index.js";
+
+const MIN: OpenGraphMeta = {
+  title: "Hello",
+  type: "article",
+  image: "https://example.com/og.png",
+  url: "https://example.com/hello",
+};
+
+describe("generateOpenGraphTags — required fields", () => {
+  it("emits the four mandatory tags in conventional order", () => {
+    const out = generateOpenGraphTags(MIN);
+    const lines = out.split("\n");
+    expect(lines[0]).toBe(`<meta property="og:title" content="Hello">`);
+    expect(lines[1]).toBe(`<meta property="og:type" content="article">`);
+    expect(lines[2]).toBe(`<meta property="og:image" content="https://example.com/og.png">`);
+    expect(lines[3]).toBe(`<meta property="og:url" content="https://example.com/hello">`);
+    expect(lines.length).toBe(4);
+  });
+});
+
+describe("generateOpenGraphTags — optional fields", () => {
+  it("includes description when supplied", () => {
+    expect(generateOpenGraphTags({ ...MIN, description: "A nice page" }))
+      .toContain(`<meta property="og:description" content="A nice page">`);
+  });
+
+  it("includes site_name (note: kebab→snake) when supplied", () => {
+    expect(generateOpenGraphTags({ ...MIN, siteName: "Acme Blog" }))
+      .toContain(`<meta property="og:site_name" content="Acme Blog">`);
+  });
+
+  it("includes locale when supplied", () => {
+    expect(generateOpenGraphTags({ ...MIN, locale: "en_US" }))
+      .toContain(`<meta property="og:locale" content="en_US">`);
+  });
+
+  it("includes video when supplied (URL-validated)", () => {
+    expect(generateOpenGraphTags({ ...MIN, video: "https://example.com/v.mp4" }))
+      .toContain(`<meta property="og:video" content="https://example.com/v.mp4">`);
+  });
+
+  it("optional tags appear in spec-conventional order after required ones", () => {
+    const out = generateOpenGraphTags({
+      ...MIN,
+      description: "d",
+      siteName: "s",
+      locale: "l",
+      video: "https://example.com/v.mp4",
+    });
+    const lines = out.split("\n");
+    // 4 required + 4 optional
+    expect(lines.length).toBe(8);
+    expect(lines[4]).toContain("og:description");
+    expect(lines[5]).toContain("og:site_name");
+    expect(lines[6]).toContain("og:locale");
+    expect(lines[7]).toContain("og:video");
+  });
+});
+
+describe("generateOpenGraphTags — URL validation", () => {
+  it("throws on relative og:image", () => {
+    expect(() => generateOpenGraphTags({ ...MIN, image: "/img.png" }))
+      .toThrow(/og:image.*absolute/);
+  });
+
+  it("throws on relative og:url", () => {
+    expect(() => generateOpenGraphTags({ ...MIN, url: "/page" }))
+      .toThrow(/og:url.*absolute/);
+  });
+
+  it("throws on relative og:video", () => {
+    expect(() => generateOpenGraphTags({ ...MIN, video: "/v.mp4" }))
+      .toThrow(/og:video.*absolute/);
+  });
+
+  it("throws on javascript: og:image", () => {
+    expect(() => generateOpenGraphTags({ ...MIN, image: "javascript:alert(1)" }))
+      .toThrow(/og:image.*absolute/);
+  });
+
+  it("throws on data: og:image", () => {
+    expect(() => generateOpenGraphTags({ ...MIN, image: "data:image/png;base64,xx" }))
+      .toThrow(/og:image.*absolute/);
+  });
+
+  it("validates URLs BEFORE emitting any output", () => {
+    // If validation happened after emission, this would write partial
+    // output.  We assert that the throw is the only observable.
+    try {
+      generateOpenGraphTags({ ...MIN, image: "/relative" });
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toMatch(/og:image/);
+    }
+  });
+});
+
+describe("generateOpenGraphTags — HTML escaping", () => {
+  it("escapes special chars in title", () => {
+    expect(generateOpenGraphTags({ ...MIN, title: `AT&T "Blog"` }))
+      .toContain(`content="AT&amp;T &quot;Blog&quot;"`);
+  });
+
+  it("escapes special chars in description", () => {
+    expect(generateOpenGraphTags({ ...MIN, description: `<script>x</script>` }))
+      .toContain(`content="&lt;script&gt;x&lt;/script&gt;"`);
+  });
+
+  it("strips ASCII control bytes from title", () => {
+    expect(generateOpenGraphTags({ ...MIN, title: "Hello\x00World" }))
+      .toContain(`content="HelloWorld"`);
+  });
+});
+
+describe("generateOpenGraphTags — reproducibility", () => {
+  it("same input → byte-identical output", () => {
+    expect(generateOpenGraphTags(MIN)).toBe(generateOpenGraphTags(MIN));
+  });
+});

--- a/code/packages/typescript/forme-opengraph/tests/twitter.test.ts
+++ b/code/packages/typescript/forme-opengraph/tests/twitter.test.ts
@@ -1,0 +1,115 @@
+/**
+ * twitter.test.ts — Twitter Card generator.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateTwitterCardTags, type TwitterCardMeta } from "../src/index.js";
+
+describe("generateTwitterCardTags — card types", () => {
+  it.each(["summary", "summary_large_image", "player", "app"] as const)(
+    "accepts card type %s",
+    (card) => {
+      const out = generateTwitterCardTags({ card });
+      expect(out).toContain(`<meta name="twitter:card" content="${card}">`);
+    },
+  );
+
+  it("rejects unknown card type", () => {
+    expect(() => generateTwitterCardTags({ card: "wonky" as never }))
+      .toThrow(/twitter:card must be one of/);
+  });
+});
+
+describe("generateTwitterCardTags — optional fields", () => {
+  it("includes title when supplied", () => {
+    expect(generateTwitterCardTags({ card: "summary", title: "Hello" }))
+      .toContain(`<meta name="twitter:title" content="Hello">`);
+  });
+
+  it("includes description when supplied", () => {
+    expect(generateTwitterCardTags({ card: "summary", description: "Nice" }))
+      .toContain(`<meta name="twitter:description" content="Nice">`);
+  });
+
+  it("includes image when supplied (URL-validated)", () => {
+    expect(generateTwitterCardTags({ card: "summary_large_image", image: "https://example.com/img.png" }))
+      .toContain(`<meta name="twitter:image" content="https://example.com/img.png">`);
+  });
+
+  it("includes site handle when supplied", () => {
+    expect(generateTwitterCardTags({ card: "summary", site: "@acme" }))
+      .toContain(`<meta name="twitter:site" content="@acme">`);
+  });
+
+  it("includes creator handle when supplied", () => {
+    expect(generateTwitterCardTags({ card: "summary", creator: "@author" }))
+      .toContain(`<meta name="twitter:creator" content="@author">`);
+  });
+
+  it("emits ONLY the supplied tags (no auto-fallbacks)", () => {
+    const out = generateTwitterCardTags({ card: "summary" });
+    // Just one tag — the card type.
+    expect(out.split("\n").length).toBe(1);
+  });
+
+  it("fields appear in conventional order", () => {
+    const lines = generateTwitterCardTags({
+      card: "summary",
+      title: "t",
+      description: "d",
+      image: "https://example.com/i.png",
+      site: "@s",
+      creator: "@c",
+    }).split("\n");
+    expect(lines.length).toBe(6);
+    expect(lines[0]).toContain("twitter:card");
+    expect(lines[1]).toContain("twitter:title");
+    expect(lines[2]).toContain("twitter:description");
+    expect(lines[3]).toContain("twitter:image");
+    expect(lines[4]).toContain("twitter:site");
+    expect(lines[5]).toContain("twitter:creator");
+  });
+});
+
+describe("generateTwitterCardTags — URL validation", () => {
+  it("throws on relative twitter:image", () => {
+    expect(() => generateTwitterCardTags({ card: "summary", image: "/img.png" }))
+      .toThrow(/twitter:image.*absolute/);
+  });
+
+  it("throws on javascript: twitter:image", () => {
+    expect(() => generateTwitterCardTags({ card: "summary", image: "javascript:alert(1)" }))
+      .toThrow(/twitter:image.*absolute/);
+  });
+
+  it("throws on data: twitter:image", () => {
+    expect(() => generateTwitterCardTags({ card: "summary", image: "data:image/png;base64,xx" }))
+      .toThrow(/twitter:image.*absolute/);
+  });
+});
+
+describe("generateTwitterCardTags — HTML escaping", () => {
+  it("escapes special chars in title / description / handles", () => {
+    const out = generateTwitterCardTags({
+      card: "summary",
+      title: `AT&T "Blog"`,
+      description: `<x>`,
+      site: `@a"b`,
+    });
+    expect(out).toContain(`content="AT&amp;T &quot;Blog&quot;"`);
+    expect(out).toContain(`content="&lt;x&gt;"`);
+    expect(out).toContain(`content="@a&quot;b"`);
+  });
+
+  it("strips ASCII control bytes", () => {
+    expect(generateTwitterCardTags({ card: "summary", title: "Hello\x00World" }))
+      .toContain(`content="HelloWorld"`);
+  });
+});
+
+describe("generateTwitterCardTags — reproducibility", () => {
+  it("same input → byte-identical output", () => {
+    const m: TwitterCardMeta = { card: "summary_large_image", title: "t", site: "@x" };
+    expect(generateTwitterCardTags(m)).toBe(generateTwitterCardTags(m));
+  });
+});

--- a/code/packages/typescript/forme-opengraph/tsconfig.json
+++ b/code/packages/typescript/forme-opengraph/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-opengraph/vitest.config.ts
+++ b/code/packages/typescript/forme-opengraph/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

**Second FM00 v0 stage package** — pure HTML meta-tag generators for social previews and search-engine snippets.  Companion to [`forme-feeds`](../forme-feeds).

```ts
import { generateMetaTags } from "@coding-adventures/forme-opengraph";

const head = generateMetaTags({
  basic: { title: "Hello", description: "...", canonical: "https://example.com/" },
  og: { title: "Hello", type: "article", image: "https://example.com/og.png", url: "https://example.com/" },
  twitter: { card: "summary_large_image", site: "@acme" },
});
```

## Four public functions

- **`generateOpenGraphTags(meta)`** — `<meta property="og:...">` per https://ogp.me/.  Conventional order: title → type → image → url → description → siteName → locale → video.
- **`generateTwitterCardTags(meta)`** — `<meta name="twitter:...">` per https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup.  Card type allowlisted; unknown values throw.
- **`generateBasicTags(meta)`** — `<title>` + `<meta name="description">` + `<link rel="canonical">`.  Drives search-engine snippets independently of social cards.
- **`generateMetaTags({ basic?, og?, twitter? })`** — convenience combining all three in basic → og → twitter order.

## Security posture

Pre-push focused review = **PASS** (zero blockers, one LOW deferred):

1. **HTML attribute injection.**  All five HTML entities (`& < > " '`) escaped via single-pass replacement (CodeQL-friendly form).  Every interpolated string in every generator routes through `escapeHtmlAttr` or `escapeHtmlText`.
2. **URL scheme validation.**  `og:image`, `og:url`, `og:video`, `twitter:image`, canonical MUST be absolute `http(s)://...`.  Anything else throws `TypeError` **before any output is emitted**:
   - `javascript:alert(1)` → critical: social-card scrapers that render previews would execute it
   - `data:text/html,…` → payload delivery vector
   - `file:///etc/passwd` → local content leak
   - Relative / protocol-relative / empty / non-string also rejected
3. **Control-character stripping.**  ASCII `U+0000-U+001F` + `U+007F` stripped before escaping.  Unicode `> U+007F` passes through unchanged (HTML5 is UTF-8).
4. **No XML parsing surface** — emit-only; no `DOMParser` / `xml2js` imports.

## Capabilities — `[]`

Pure transform.  No I/O, no network, no shell.

## Reproducibility (FM03)

Same inputs → byte-identical output.  Deterministic tag order per spec convention.

## Tests

**68 tests across 5 files**, **100% line / 100% branch** coverage on all source files with logic:

- `escape.test.ts` (19) — every HTML entity, control-byte stripping, URL scheme acceptance (http/https/port/query/fragment/case-insensitive) and rejection (relative, javascript:, data:, file:, protocol-relative, empty, non-string), field-name in error messages
- `opengraph.test.ts` (16) — required fields in conventional order, every optional field, URL validation for image/url/video, escaping, pre-output throw verification
- `twitter.test.ts` (18) — all four card types parameterised, unknown card rejection, optional fields with order check, emits-only-supplied-tags policy, URL validation for image, escaping
- `basic.test.ts` (9) — each tag individually, all-three order, empty → empty string, canonical URL validation, escaping
- `combined.test.ts` (6) — basic → og → twitter ordering, skip-when-not-supplied, URL-error propagation, no spurious blank lines

## Spec adherence

- OpenGraph per https://ogp.me/
- Twitter Cards per https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup
- HTML5 attribute syntax per WHATWG HTML

No spec divergences.

## v0 simplifications (documented in CHANGELOG)

- No `og:image:width` / `og:image:height` / `og:image:alt`
- No `article:author` / `article:published_time`
- No `twitter:player` extra metadata
- No multi-image arrays

## Test plan

- [x] `vitest run --coverage` — 68 / 68 pass, 100% line / 100% branch
- [x] `tsc --noEmit` — clean
- [x] Security review — PASS (zero blockers)
- [x] File names split (`opengraph`, `twitter`, `basic`, `combined`, `escape`) to avoid the `compile.*` gitignore trap
- [ ] CI: lint, build, security scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)