### PR TITLE
Expose HTML start-tag continuation contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -68,6 +68,13 @@ documented in this file.
   end-tag-open/name, NULL, EOF, and literal markup recovery.
 - A generated WHATWG tokenizer attribute boundary fixture and Rust conformance
   test that pins seeded start-tag and current-attribute continuation recovery.
+- Parser/importer-facing seeded start-tag continuation contexts, including
+  tag-name, before/after attribute name, before attribute value,
+  quoted/unquoted attribute value, and self-closing substates with
+  `StartTagSeed` current-token seeding through `HtmlLexContext`.
+- html5lib-style smoke metadata for generic tag-open, tag-name, and seeded
+  start-tag/attribute continuation states, keeping the normalizer's supported
+  state set aligned with `HTML_TOKENIZER_STATES`.
 - A generated WHATWG tokenizer script escape boundary fixture and Rust
   conformance test that pins escaped and double-escaped script data, escape
   start/end delimiters, EOF diagnostics, NULL replacement, and seeded

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -242,6 +242,13 @@ strings. The accepted script entry states are also available as
 `HTML_SCRIPT_TOKENIZER_STATES`, and `HtmlTokenizerState::is_script_substate()`
 lets parser adapters validate user-selected fragment contexts before seeding a
 lexer.
+Generic start-tag and attribute continuation states are exposed the same way:
+`HtmlLexContext::start_tag_continuation(...)` accepts a `StartTagSeed` so
+parser adapters and html5lib-style importers can resume `tag name`,
+`before/after attribute name`, quoted/unquoted attribute value, and
+self-closing start-tag states through the public wrapper. The accepted seeded
+start-tag states are available as `HTML_START_TAG_TOKENIZER_STATES`, and
+`HtmlTokenizerState::requires_start_tag_seed()` keeps validation in one place.
 For importers and parser fragment APIs that need to enumerate the whole
 supported surface, `HTML_TOKENIZER_STATES` lists every parser-facing tokenizer
 entry state and `HTML_FRAGMENT_TOKENIZER_STATES` lists the non-data fragment
@@ -349,10 +356,10 @@ python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_b
 ```
 
 The checked-in `whatwg-attribute-boundaries.json` fixture exercises seeded
-start-tag attribute continuation states, including current-attribute recovery,
-quoted and unquoted value completion, NULL replacement, EOF diagnostics,
-missing-whitespace recovery, and self-closing boundaries. Regenerate or check it
-with:
+start-tag attribute continuation states through `HtmlLexContext`, including
+current-attribute recovery, quoted and unquoted value completion, NULL
+replacement, EOF diagnostics, missing-whitespace recovery, and self-closing
+boundaries. Regenerate or check it with:
 
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py
@@ -380,9 +387,10 @@ without coupling the shared harness to upstream file formats or requiring raw
 fixture normalization logic to live forever inside the Rust tests.
 
 The normalized corpus now carries optional tokenizer-context metadata such as
-`initial_state` and `last_start_tag`, so upstream RCDATA, RAWTEXT, PLAINTEXT,
-CDATA section, comment, character-reference, and DOCTYPE continuation states,
-script data, script data escaped/dash/less-than/end-tag-open substates, and script data
+`initial_state`, `last_start_tag`, and seeded current-token data, so upstream
+RCDATA, RAWTEXT, PLAINTEXT, CDATA section, comment, start-tag,
+character-reference, and DOCTYPE continuation states, script data, script data
+escaped/dash/less-than/end-tag-open substates, and script data
 double-escaped/dash/less-than substates can already live in the shared Venture
 fixture format. Current Rust conformance tests now seed that context into the
 generated lexer so non-data-state cases execute through the same static Rust

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -25,6 +25,18 @@ pub enum HtmlScriptingMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HtmlTokenizerState {
     Data,
+    TagOpen,
+    EndTagOpen,
+    TagName,
+    BeforeAttributeName,
+    AttributeName,
+    AfterAttributeName,
+    BeforeAttributeValue,
+    AttributeValueDoubleQuoted,
+    AttributeValueSingleQuoted,
+    AttributeValueUnquoted,
+    AfterAttributeValueQuoted,
+    SelfClosingStartTag,
     Rcdata,
     RcdataLessThanSign,
     RcdataEndTagOpen,
@@ -119,8 +131,20 @@ pub enum HtmlTokenizerState {
 }
 
 /// Tokenizer states that are valid parser-facing entry points.
-pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 92] = [
+pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 104] = [
     HtmlTokenizerState::Data,
+    HtmlTokenizerState::TagOpen,
+    HtmlTokenizerState::EndTagOpen,
+    HtmlTokenizerState::TagName,
+    HtmlTokenizerState::BeforeAttributeName,
+    HtmlTokenizerState::AttributeName,
+    HtmlTokenizerState::AfterAttributeName,
+    HtmlTokenizerState::BeforeAttributeValue,
+    HtmlTokenizerState::AttributeValueDoubleQuoted,
+    HtmlTokenizerState::AttributeValueSingleQuoted,
+    HtmlTokenizerState::AttributeValueUnquoted,
+    HtmlTokenizerState::AfterAttributeValueQuoted,
+    HtmlTokenizerState::SelfClosingStartTag,
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::RcdataEndTagOpen,
@@ -215,7 +239,19 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 92] = [
 ];
 
 /// Tokenizer states used for parser-controlled text or foreign-content fragments.
-pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 91] = [
+pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 103] = [
+    HtmlTokenizerState::TagOpen,
+    HtmlTokenizerState::EndTagOpen,
+    HtmlTokenizerState::TagName,
+    HtmlTokenizerState::BeforeAttributeName,
+    HtmlTokenizerState::AttributeName,
+    HtmlTokenizerState::AfterAttributeName,
+    HtmlTokenizerState::BeforeAttributeValue,
+    HtmlTokenizerState::AttributeValueDoubleQuoted,
+    HtmlTokenizerState::AttributeValueSingleQuoted,
+    HtmlTokenizerState::AttributeValueUnquoted,
+    HtmlTokenizerState::AfterAttributeValueQuoted,
+    HtmlTokenizerState::SelfClosingStartTag,
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::RcdataEndTagOpen,
@@ -373,11 +409,37 @@ pub const HTML_DOCTYPE_TOKENIZER_STATES: [HtmlTokenizerState; 32] = [
     HtmlTokenizerState::BogusDoctype,
 ];
 
+/// Tokenizer states that resume an already-started start tag.
+pub const HTML_START_TAG_TOKENIZER_STATES: [HtmlTokenizerState; 10] = [
+    HtmlTokenizerState::TagName,
+    HtmlTokenizerState::BeforeAttributeName,
+    HtmlTokenizerState::AttributeName,
+    HtmlTokenizerState::AfterAttributeName,
+    HtmlTokenizerState::BeforeAttributeValue,
+    HtmlTokenizerState::AttributeValueDoubleQuoted,
+    HtmlTokenizerState::AttributeValueSingleQuoted,
+    HtmlTokenizerState::AttributeValueUnquoted,
+    HtmlTokenizerState::AfterAttributeValueQuoted,
+    HtmlTokenizerState::SelfClosingStartTag,
+];
+
 impl HtmlTokenizerState {
     /// Machine-state identifier used by the generated static lexer.
     pub fn as_machine_state(self) -> &'static str {
         match self {
             Self::Data => "data",
+            Self::TagOpen => "tag_open",
+            Self::EndTagOpen => "end_tag_open",
+            Self::TagName => "tag_name",
+            Self::BeforeAttributeName => "before_attribute_name",
+            Self::AttributeName => "attribute_name",
+            Self::AfterAttributeName => "after_attribute_name",
+            Self::BeforeAttributeValue => "before_attribute_value",
+            Self::AttributeValueDoubleQuoted => "attribute_value_double_quoted",
+            Self::AttributeValueSingleQuoted => "attribute_value_single_quoted",
+            Self::AttributeValueUnquoted => "attribute_value_unquoted",
+            Self::AfterAttributeValueQuoted => "after_attribute_value_quoted",
+            Self::SelfClosingStartTag => "self_closing_start_tag",
             Self::Rcdata => "rcdata",
             Self::RcdataLessThanSign => "rcdata_less_than_sign",
             Self::RcdataEndTagOpen => "rcdata_end_tag_open",
@@ -484,6 +546,18 @@ impl HtmlTokenizerState {
     pub fn as_html5lib_state(self) -> &'static str {
         match self {
             Self::Data => "Data state",
+            Self::TagOpen => "Tag open state",
+            Self::EndTagOpen => "End tag open state",
+            Self::TagName => "Tag name state",
+            Self::BeforeAttributeName => "Before attribute name state",
+            Self::AttributeName => "Attribute name state",
+            Self::AfterAttributeName => "After attribute name state",
+            Self::BeforeAttributeValue => "Before attribute value state",
+            Self::AttributeValueDoubleQuoted => "Attribute value (double-quoted) state",
+            Self::AttributeValueSingleQuoted => "Attribute value (single-quoted) state",
+            Self::AttributeValueUnquoted => "Attribute value (unquoted) state",
+            Self::AfterAttributeValueQuoted => "After attribute value (quoted) state",
+            Self::SelfClosingStartTag => "Self-closing start tag state",
             Self::Rcdata => "RCDATA state",
             Self::RcdataLessThanSign => "RCDATA less-than sign state",
             Self::RcdataEndTagOpen => "RCDATA end tag open state",
@@ -642,6 +716,11 @@ impl HtmlTokenizerState {
         )
     }
 
+    /// Return whether this state resumes an already-started start tag.
+    pub fn requires_start_tag_seed(self) -> bool {
+        HTML_START_TAG_TOKENIZER_STATES.contains(&self)
+    }
+
     /// Return whether this state can receive recovered character-reference text.
     pub fn is_character_reference_return_state(self) -> bool {
         matches!(self, Self::Data | Self::Rcdata)
@@ -720,6 +799,7 @@ impl HtmlTokenizerState {
 pub struct HtmlLexContext {
     pub initial_state: HtmlTokenizerState,
     pub last_start_tag: Option<String>,
+    pub current_start_tag: Option<StartTagSeed>,
     pub current_end_tag: Option<String>,
     pub current_comment: Option<String>,
     pub current_doctype: Option<DoctypeSeed>,
@@ -732,6 +812,7 @@ impl HtmlLexContext {
         Self {
             initial_state,
             last_start_tag: None,
+            current_start_tag: None,
             current_end_tag: None,
             current_comment: None,
             current_doctype: None,
@@ -777,6 +858,11 @@ impl HtmlLexContext {
         self
     }
 
+    pub fn with_current_start_tag(mut self, seed: StartTagSeed) -> Self {
+        self.current_start_tag = Some(seed);
+        self
+    }
+
     pub fn with_current_comment(mut self, data: impl Into<String>) -> Self {
         self.current_comment = Some(data.into());
         self
@@ -800,6 +886,7 @@ impl HtmlLexContext {
     pub fn is_data(&self) -> bool {
         self.initial_state == HtmlTokenizerState::Data
             && self.last_start_tag.is_none()
+            && self.current_start_tag.is_none()
             && self.current_end_tag.is_none()
             && self.current_comment.is_none()
             && self.current_doctype.is_none()
@@ -819,6 +906,23 @@ impl HtmlLexContext {
     ) -> Option<Self> {
         if initial_state.requires_comment_seed() {
             Some(Self::new(initial_state).with_current_comment(data))
+        } else {
+            None
+        }
+    }
+
+    /// Return a start-tag tokenizer continuation context.
+    ///
+    /// These states resume after the tokenizer has already created a start-tag
+    /// token and, for attribute states, possibly an in-progress current
+    /// attribute. The seed carries the committed start-tag name, attributes,
+    /// self-closing marker, and current attribute data accumulated so far.
+    pub fn start_tag_continuation(
+        initial_state: HtmlTokenizerState,
+        seed: StartTagSeed,
+    ) -> Option<Self> {
+        if initial_state.requires_start_tag_seed() {
+            Some(Self::new(initial_state).with_current_start_tag(seed))
         } else {
             None
         }
@@ -939,7 +1043,9 @@ pub fn apply_html_lex_context(lexer: &mut HtmlLexer, context: &HtmlLexContext) -
     } else {
         lexer.clear_last_start_tag();
     }
-    if let Some(current_end_tag) = context.current_end_tag.as_deref() {
+    if let Some(current_start_tag) = context.current_start_tag.as_ref() {
+        lexer.set_current_start_tag(current_start_tag.clone());
+    } else if let Some(current_end_tag) = context.current_end_tag.as_deref() {
         lexer.set_current_end_tag(current_end_tag);
     } else if let Some(current_comment) = context.current_comment.as_deref() {
         lexer.set_current_comment(current_comment);

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -1,6 +1,7 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, html1_machine, html_skeleton_machine, Attribute,
-    DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token, HTML_TOKENIZER_STATES,
+    DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlTokenizerState, StartTagSeed, Token,
+    HTML_TOKENIZER_STATES,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -33,6 +34,8 @@ struct FixtureCase {
     #[serde(default)]
     last_start_tag: Option<String>,
     #[serde(default)]
+    current_start_tag: Option<FixtureStartTagSeed>,
+    #[serde(default)]
     current_end_tag: Option<String>,
     #[serde(default)]
     current_comment: Option<String>,
@@ -57,6 +60,25 @@ struct FixtureDoctypeSeed {
     force_quirks: bool,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+struct FixtureStartTagSeed {
+    name: String,
+    #[serde(default)]
+    attributes: Vec<FixtureAttribute>,
+    #[serde(default)]
+    self_closing: bool,
+    #[serde(default)]
+    current_attribute: Option<FixtureAttribute>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+struct FixtureAttribute {
+    name: String,
+    value: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct Html5libTokenizerFile {
     tests: Vec<Html5libTokenizerTest>,
@@ -72,6 +94,8 @@ struct Html5libTokenizerTest {
     initial_states: Vec<String>,
     #[serde(default, rename = "lastStartTag")]
     last_start_tag: Option<String>,
+    #[serde(default, rename = "currentStartTag")]
+    current_start_tag: Option<FixtureStartTagSeed>,
     #[serde(default, rename = "currentEndTag")]
     current_end_tag: Option<String>,
     #[serde(default, rename = "temporaryBuffer")]
@@ -421,6 +445,7 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
     match case.initial_state.as_deref() {
         None => {
             case.last_start_tag.is_none()
+                && case.current_start_tag.is_none()
                 && case.current_end_tag.is_none()
                 && case.current_comment.is_none()
                 && case.current_doctype.is_none()
@@ -433,6 +458,7 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
             };
             let has_end_tag_seed =
                 case.current_end_tag.is_some() && case.temporary_buffer.is_some();
+            let has_start_tag_seed = case.current_start_tag.is_some();
             let has_comment_seed = case.current_comment.is_some();
             let has_doctype_seed = case.current_doctype.is_some();
             let has_character_reference_seed =
@@ -446,6 +472,7 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
                     && return_state == Some(HtmlTokenizerState::Rcdata));
             needs_last_start_tag == case.last_start_tag.is_some()
                 && state.requires_end_tag_seed() == has_end_tag_seed
+                && state.requires_start_tag_seed() == has_start_tag_seed
                 && state.requires_comment_seed() == has_comment_seed
                 && state.requires_doctype_seed() == has_doctype_seed
                 && state.requires_character_reference_seed() == has_character_reference_seed
@@ -454,10 +481,12 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
                     || (case.current_end_tag.is_none() && case.temporary_buffer.is_none()))
                 && (!has_doctype_seed
                     || (case.current_end_tag.is_none()
+                        && case.current_start_tag.is_none()
                         && case.current_comment.is_none()
                         && case.temporary_buffer.is_none()))
                 && (!has_character_reference_seed
                     || (case.current_end_tag.is_none()
+                        && case.current_start_tag.is_none()
                         && case.current_comment.is_none()
                         && case.current_doctype.is_none()
                         && return_state
@@ -546,6 +575,9 @@ fn configure_lexer_for_case(
     if let Some(last_start_tag) = case.last_start_tag.as_deref() {
         context = context.with_last_start_tag(last_start_tag);
     }
+    if let Some(current_start_tag) = case.current_start_tag.as_ref() {
+        context = context.with_current_start_tag(start_tag_seed(current_start_tag));
+    }
     if let Some(current_end_tag) = case.current_end_tag.as_deref() {
         context = context.with_current_end_tag(current_end_tag);
     }
@@ -571,6 +603,24 @@ fn configure_lexer_for_case(
         context = context.with_return_state(return_state);
     }
     apply_html_lex_context(lexer, &context)
+}
+
+fn start_tag_seed(seed: &FixtureStartTagSeed) -> StartTagSeed {
+    StartTagSeed {
+        name: seed.name.clone(),
+        attributes: seed.attributes.iter().cloned().map(Into::into).collect(),
+        self_closing: seed.self_closing,
+        current_attribute: seed.current_attribute.clone().map(Into::into),
+    }
+}
+
+impl From<FixtureAttribute> for Attribute {
+    fn from(attribute: FixtureAttribute) -> Self {
+        Self {
+            name: attribute.name,
+            value: attribute.value,
+        }
+    }
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -29,6 +29,7 @@ Each file is a JSON object with this shape:
       ],
       "initial_state": "optional tokenizer state context",
       "last_start_tag": "optional tokenizer tag context",
+      "current_start_tag": "optional in-progress start-tag token context",
       "current_end_tag": "optional in-progress end-tag token context",
       "current_doctype": "optional in-progress doctype token context",
       "temporary_buffer": "optional tokenizer temporary-buffer context",
@@ -295,6 +296,10 @@ lowered to `current_doctype`, with optional `name`, `public_identifier`,
 Character-reference continuation fixtures accept `temporaryBuffer` plus
 `returnState`, lowered to `temporary_buffer` and `return_state`, so seeded
 named/numeric reference substates can recover back into data or RCDATA.
+Start-tag and attribute continuation fixtures accept a `currentStartTag`
+extension object, lowered to `current_start_tag`, with a required `name`, an
+optional `attributes` list, an optional `current_attribute`, and an optional
+`self_closing` flag.
 
 `normalize_html5lib_fixtures.py` is the checked-in importer for this shape. It
 currently supports:
@@ -329,6 +334,9 @@ currently supports:
 - RCDATA, RAWTEXT, script-data, and script-data-escaped end-tag `name`,
   `whitespace`, `attributes`, and `self-closing` continuation substates
   together with `lastStartTag`, `currentEndTag`, and `temporaryBuffer`
+- generic `tag open` and `end tag open` states, plus seeded start-tag `name`,
+  attribute name/value, after-attribute-value, and `self-closing` continuation
+  substates together with `currentStartTag`
 - multi-state html5lib fixture entries for supported states, expanded into
   stable per-state Venture fixture cases
 - `StartTag`, `EndTag`, `Character`, `Comment`, and `DOCTYPE` output tokens

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -10,9 +10,17 @@
     "After DOCTYPE public keyword state",
     "After DOCTYPE system identifier state",
     "After DOCTYPE system keyword state",
+    "After attribute name state",
+    "After attribute value (quoted) state",
+    "Attribute name state",
+    "Attribute value (double-quoted) state",
+    "Attribute value (single-quoted) state",
+    "Attribute value (unquoted) state",
     "Before DOCTYPE name state",
     "Before DOCTYPE public identifier state",
     "Before DOCTYPE system identifier state",
+    "Before attribute name state",
+    "Before attribute value state",
     "Between DOCTYPE public and system identifiers state",
     "Bogus DOCTYPE state",
     "Bogus comment state",
@@ -54,6 +62,7 @@
     "DOCTYPE system keyword Y state",
     "Data state",
     "Decimal character reference state",
+    "End tag open state",
     "Hexadecimal character reference start state",
     "Hexadecimal character reference state",
     "Named character reference state",
@@ -96,7 +105,10 @@
     "Script data escaped state",
     "Script data less-than sign state",
     "Script data self-closing end tag state",
-    "Script data state"
+    "Script data state",
+    "Self-closing start tag state",
+    "Tag name state",
+    "Tag open state"
   ],
   "cases": [
     {

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -16,6 +16,8 @@ SUPPORTED_INITIAL_STATES = {
     "CDATA section end state",
     "CDATA section state",
     "Character reference state",
+    "After attribute name state",
+    "After attribute value (quoted) state",
     "Bogus comment state",
     "Comment end bang state",
     "Comment end dash state",
@@ -28,6 +30,11 @@ SUPPORTED_INITIAL_STATES = {
     "Comment start state",
     "Comment state",
     "Data state",
+    "End tag open state",
+    "Attribute name state",
+    "Attribute value (double-quoted) state",
+    "Attribute value (single-quoted) state",
+    "Attribute value (unquoted) state",
     "DOCTYPE after keyword state",
     "DOCTYPE keyword C state",
     "DOCTYPE keyword E state",
@@ -58,6 +65,8 @@ SUPPORTED_INITIAL_STATES = {
     "Before DOCTYPE name state",
     "Before DOCTYPE public identifier state",
     "Before DOCTYPE system identifier state",
+    "Before attribute name state",
+    "Before attribute value state",
     "Between DOCTYPE public and system identifiers state",
     "Bogus DOCTYPE state",
     "Decimal character reference state",
@@ -104,6 +113,9 @@ SUPPORTED_INITIAL_STATES = {
     "Script data less-than sign state",
     "Script data self-closing end tag state",
     "Script data state",
+    "Self-closing start tag state",
+    "Tag name state",
+    "Tag open state",
 }
 
 LAST_START_TAG_INITIAL_STATES = {
@@ -229,6 +241,19 @@ CHARACTER_REFERENCE_RETURN_STATES = {
     "RCDATA state",
 }
 
+START_TAG_SEED_INITIAL_STATES = {
+    "After attribute name state",
+    "After attribute value (quoted) state",
+    "Attribute name state",
+    "Attribute value (double-quoted) state",
+    "Attribute value (single-quoted) state",
+    "Attribute value (unquoted) state",
+    "Before attribute name state",
+    "Before attribute value state",
+    "Self-closing start tag state",
+    "Tag name state",
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -339,6 +364,21 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if has_end_tag_seed and len(needs_end_tag_seed) != len(initial_states):
         return False, "currentEndTag/temporaryBuffer only supported for continuation states"
 
+    needs_start_tag_seed = [
+        initial_state
+        for initial_state in initial_states
+        if initial_state in START_TAG_SEED_INITIAL_STATES
+    ]
+    has_start_tag_seed = isinstance(test.get("currentStartTag"), dict)
+    if needs_start_tag_seed and not has_start_tag_seed:
+        return False, f"{needs_start_tag_seed[0]} requires currentStartTag"
+
+    if has_start_tag_seed and len(needs_start_tag_seed) != len(initial_states):
+        return False, "currentStartTag only supported for start-tag continuation states"
+
+    if has_start_tag_seed and (has_end_tag_seed or has_partial_end_tag_seed):
+        return False, "currentStartTag cannot be combined with end-tag continuation context"
+
     needs_character_reference_seed = [
         initial_state
         for initial_state in initial_states
@@ -378,10 +418,11 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if has_comment_seed and (
         has_end_tag_seed
         or has_partial_end_tag_seed
+        or has_start_tag_seed
         or has_character_reference_seed
         or has_partial_character_reference_seed
     ):
-        return False, "currentComment cannot be combined with end-tag continuation context"
+        return False, "currentComment cannot be combined with other current-token context"
 
     needs_doctype_seed = [
         initial_state
@@ -398,6 +439,7 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if has_doctype_seed and (
         has_end_tag_seed
         or has_partial_end_tag_seed
+        or has_start_tag_seed
         or has_comment_seed
         or has_character_reference_seed
         or has_partial_character_reference_seed
@@ -483,6 +525,10 @@ def normalize_case(
     current_end_tag = test.get("currentEndTag")
     if current_end_tag is not None:
         normalized["current_end_tag"] = current_end_tag
+
+    current_start_tag = test.get("currentStartTag")
+    if current_start_tag is not None:
+        normalized["current_start_tag"] = current_start_tag
 
     temporary_buffer = test.get("temporaryBuffer")
     if temporary_buffer is not None:

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,9 +1,9 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, create_html_lexer_with_context, html1_definition,
     html1_machine, html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment,
-    Attribute, DoctypeSeed, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token,
-    HTML_DOCTYPE_TOKENIZER_STATES, HTML_FRAGMENT_TOKENIZER_STATES, HTML_SCRIPT_TOKENIZER_STATES,
-    HTML_TOKENIZER_STATES,
+    Attribute, DoctypeSeed, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, StartTagSeed,
+    Token, HTML_DOCTYPE_TOKENIZER_STATES, HTML_FRAGMENT_TOKENIZER_STATES,
+    HTML_SCRIPT_TOKENIZER_STATES, HTML_START_TAG_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
 };
 use state_machine::END_INPUT;
 
@@ -5065,6 +5065,18 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
         HTML_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),
         [
             "data",
+            "tag_open",
+            "end_tag_open",
+            "tag_name",
+            "before_attribute_name",
+            "attribute_name",
+            "after_attribute_name",
+            "before_attribute_value",
+            "attribute_value_double_quoted",
+            "attribute_value_single_quoted",
+            "attribute_value_unquoted",
+            "after_attribute_value_quoted",
+            "self_closing_start_tag",
             "rcdata",
             "rcdata_less_than_sign",
             "rcdata_end_tag_open",
@@ -5203,8 +5215,19 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
         HtmlTokenizerState::from_html5lib_state("RCDATA end tag open state"),
         Some(HtmlTokenizerState::RcdataEndTagOpen)
     );
+    assert_eq!(
+        HtmlTokenizerState::from_html5lib_state("Attribute value (double-quoted) state"),
+        Some(HtmlTokenizerState::AttributeValueDoubleQuoted)
+    );
     assert_eq!(HtmlTokenizerState::from_html5lib_state("Bogus state"), None);
 
+    assert!(HtmlTokenizerState::TagName.requires_start_tag_seed());
+    assert!(HtmlTokenizerState::BeforeAttributeName.requires_start_tag_seed());
+    assert!(HtmlTokenizerState::AttributeName.requires_start_tag_seed());
+    assert!(HtmlTokenizerState::BeforeAttributeValue.requires_start_tag_seed());
+    assert!(HtmlTokenizerState::SelfClosingStartTag.requires_start_tag_seed());
+    assert!(!HtmlTokenizerState::TagOpen.requires_start_tag_seed());
+    assert!(!HtmlTokenizerState::EndTagOpen.requires_start_tag_seed());
     assert!(HtmlTokenizerState::RcdataLessThanSign.requires_last_start_tag());
     assert!(HtmlTokenizerState::RcdataEndTagOpen.requires_last_start_tag());
     assert!(HtmlTokenizerState::RcdataEndTagName.requires_last_start_tag());
@@ -5274,6 +5297,21 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "doctype_system_identifier_single_quoted",
             "after_doctype_system_identifier",
             "bogus_doctype",
+        ]
+    );
+    assert_eq!(
+        HTML_START_TAG_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),
+        [
+            "tag_name",
+            "before_attribute_name",
+            "attribute_name",
+            "after_attribute_name",
+            "before_attribute_value",
+            "attribute_value_double_quoted",
+            "attribute_value_single_quoted",
+            "attribute_value_unquoted",
+            "after_attribute_value_quoted",
+            "self_closing_start_tag",
         ]
     );
 }
@@ -5407,6 +5445,153 @@ fn parser_facing_context_seeds_intermediate_text_states() {
             },
             Token::Eof
         ]
+    );
+}
+
+#[test]
+fn parser_facing_context_seeds_start_tag_continuation_states() {
+    let tag_name =
+        HtmlLexContext::start_tag_continuation(HtmlTokenizerState::TagName, StartTagSeed::new("s"))
+            .unwrap();
+    assert_eq!(
+        lex_html_fragment("pan class=x>tail", &tag_name).unwrap(),
+        vec![
+            Token::StartTag {
+                name: "span".to_string(),
+                attributes: vec![Attribute {
+                    name: "class".to_string(),
+                    value: "x".to_string(),
+                }],
+                self_closing: false,
+            },
+            Token::Text("tail".to_string()),
+            Token::Eof,
+        ]
+    );
+
+    let before_attribute_name = HtmlLexContext::start_tag_continuation(
+        HtmlTokenizerState::BeforeAttributeName,
+        StartTagSeed::new("a").with_attribute("href", "/"),
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment(" title=home>", &before_attribute_name).unwrap(),
+        vec![
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "href".to_string(),
+                        value: "/".to_string(),
+                    },
+                    Attribute {
+                        name: "title".to_string(),
+                        value: "home".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+
+    let attribute_name = HtmlLexContext::start_tag_continuation(
+        HtmlTokenizerState::AttributeName,
+        StartTagSeed::new("button").with_current_attribute("aria-l", ""),
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("abel=Save>", &attribute_name).unwrap(),
+        vec![
+            Token::StartTag {
+                name: "button".to_string(),
+                attributes: vec![Attribute {
+                    name: "aria-label".to_string(),
+                    value: "Save".to_string(),
+                }],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+
+    let before_attribute_value = HtmlLexContext::start_tag_continuation(
+        HtmlTokenizerState::BeforeAttributeValue,
+        StartTagSeed::new("img").with_current_attribute("alt", ""),
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("\"Cover\">", &before_attribute_value).unwrap(),
+        vec![
+            Token::StartTag {
+                name: "img".to_string(),
+                attributes: vec![Attribute {
+                    name: "alt".to_string(),
+                    value: "Cover".to_string(),
+                }],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+
+    let after_attribute_value = HtmlLexContext::start_tag_continuation(
+        HtmlTokenizerState::AfterAttributeValueQuoted,
+        StartTagSeed::new("input").with_attribute("value", "A"),
+    )
+    .unwrap();
+    let mut lexer = create_html_lexer_with_context(&after_attribute_value).unwrap();
+    lexer.push("checked>").unwrap();
+    lexer.finish().unwrap();
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "input".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "value".to_string(),
+                        value: "A".to_string(),
+                    },
+                    Attribute {
+                        name: "checked".to_string(),
+                        value: "".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec!["missing-whitespace-between-attributes"]
+    );
+
+    let self_closing = HtmlLexContext::start_tag_continuation(
+        HtmlTokenizerState::SelfClosingStartTag,
+        StartTagSeed::new("br").self_closing(),
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment(">", &self_closing).unwrap(),
+        vec![
+            Token::StartTag {
+                name: "br".to_string(),
+                attributes: Vec::new(),
+                self_closing: true,
+            },
+            Token::Eof,
+        ]
+    );
+
+    assert_eq!(
+        HtmlLexContext::start_tag_continuation(HtmlTokenizerState::Data, StartTagSeed::new("p")),
+        None
     );
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
@@ -1,4 +1,7 @@
-use coding_adventures_html_lexer::{create_html_lexer, Attribute, StartTagSeed, Token};
+use coding_adventures_html_lexer::{
+    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlTokenizerState, StartTagSeed,
+    Token,
+};
 use serde::Deserialize;
 
 const WHATWG_ATTRIBUTE_BOUNDARIES: &str = include_str!("fixtures/whatwg-attribute-boundaries.json");
@@ -73,13 +76,18 @@ fn whatwg_attribute_boundaries_cases_match_default_lexer() {
             "case `{}` should describe its attribute boundary",
             case.id
         );
-        let mut lexer = create_html_lexer().expect("HTML lexer should build");
-        lexer
-            .set_initial_state(&case.initial_state)
-            .unwrap_or_else(|error| {
-                panic!("case `{}` initial-state seed failed: {error:?}", case.id)
-            });
-        lexer.set_current_start_tag(start_tag_seed(&case.start_tag));
+        let initial_state = HtmlTokenizerState::from_machine_state(&case.initial_state)
+            .unwrap_or_else(|| panic!("case `{}` unknown initial state", case.id));
+        let context =
+            HtmlLexContext::start_tag_continuation(initial_state, start_tag_seed(&case.start_tag))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "case `{}` initial state should accept a start-tag seed",
+                        case.id
+                    )
+                });
+        let mut lexer =
+            create_html_lexer_with_context(&context).expect("HTML lexer should build with context");
         lexer
             .push(&case.input)
             .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));


### PR DESCRIPTION
## Summary
- expose tag-name and attribute continuation tokenizer states through `HtmlTokenizerState` and `HtmlLexContext`
- add seeded start-tag continuation helpers for parser/importer-facing wrapper tests
- normalize html5lib-style `currentStartTag` metadata and route the attribute boundary fixture through the public context API

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `rustfmt --check code/packages/rust/html-lexer/src/lib.rs code/packages/rust/html-lexer/tests/html_lexer_test.rs code/packages/rust/html-lexer/tests/conformance_test.rs code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs`
- `python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check`
- `git diff --check`
