### PR TITLE
spice: add multi-corner transfer functions

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Multi-corner transfer-function analysis** — `tf_corners` runs the same
+  `.TF` query at each named corner and returns per-corner gain and impedance
+  values.
+
 - **Multi-corner AC frequency sweeps** — `ac_sweep_corners` runs the same AC
   frequency grid at each named corner and returns per-corner phasor responses.
 

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -36,6 +36,8 @@ from spice_engine.engine import (
     CornerPoint,
     CornerSpec,
     CornerSweepResult,
+    CornerTfPoint,
+    CornerTfResult,
     DcResult,
     DcSweepPoint,
     DcSweepResult,
@@ -62,6 +64,7 @@ from spice_engine.engine import (
     sens_dc,
     s_parameters,
     tf,
+    tf_corners,
     transient,
 )
 
@@ -85,6 +88,8 @@ __all__ = [
     "CornerPoint",
     "CornerSpec",
     "CornerSweepResult",
+    "CornerTfPoint",
+    "CornerTfResult",
     "CurrentSource",
     "DcResult",
     "DcSweepPoint",
@@ -128,5 +133,6 @@ __all__ = [
     "sens_dc",
     "s_parameters",
     "tf",
+    "tf_corners",
     "transient",
 ]

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -496,6 +496,23 @@ class CornerAcSweepResult:
     points: list[CornerAcSweepPoint]
 
 
+@dataclass(frozen=True)
+class CornerTfPoint:
+    """Transfer-function result for one named analysis corner."""
+
+    corner_name: str
+    result: TfResult
+
+
+@dataclass(frozen=True)
+class CornerTfResult:
+    """Multi-corner transfer-function analysis result."""
+
+    points: list[CornerTfPoint]
+    input_source: str
+    output_node: str
+
+
 # ---------------------------------------------------------------------------
 # MNA infrastructure
 # ---------------------------------------------------------------------------
@@ -3539,6 +3556,40 @@ def ac_sweep_corners(
             )
             for corner in corners
         ]
+    )
+
+
+def tf_corners(
+    circuit: Circuit,
+    input_source: str,
+    output_node: str,
+    corners: list[CornerSpec],
+    *,
+    max_iterations: int = 50,
+    tol: float = 1e-6,
+) -> CornerTfResult:
+    """Run DC small-signal transfer-function analysis at each named corner.
+
+    Each corner clones the circuit with explicit element-parameter overrides,
+    then reuses :func:`tf` so every corner reports the same transfer-function
+    query with its own gain and impedance values.
+    """
+    return CornerTfResult(
+        points=[
+            CornerTfPoint(
+                corner_name=corner.name,
+                result=tf(
+                    _circuit_with_corner(circuit, corner),
+                    output_node=output_node,
+                    input_source=input_source,
+                    max_iterations=max_iterations,
+                    tol=tol,
+                ),
+            )
+            for corner in corners
+        ],
+        input_source=input_source,
+        output_node=output_node,
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -94,6 +94,7 @@ from spice_engine import (
     CornerOverride,
     CornerSpec,
     CornerSweepResult,
+    CornerTfResult,
     CurrentSource,
     DcSweepPoint,
     DcSweepResult,
@@ -128,6 +129,7 @@ from spice_engine import (
     sens_dc,
     s_parameters,
     tf,
+    tf_corners,
     transient,
 )
 from spice_engine.engine import (
@@ -5370,3 +5372,29 @@ def test_ac_sweep_corners_runs_frequency_sweeps_per_corner() -> None:
     fast_out = result.points[1].result.points[0].node_voltages["out"]
     assert abs(nominal_out) == pytest.approx(1.0 / math.sqrt(2.0))
     assert abs(fast_out) == pytest.approx(1.0 / math.sqrt(1.25))
+
+
+def test_tf_corners_runs_transfer_function_per_corner() -> None:
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 10.0),
+        Resistor("Rtop", "in", "out", 1000.0),
+        Resistor("Rbot", "out", "0", 1000.0),
+    ])
+
+    result = tf_corners(
+        c,
+        "Vin",
+        "out",
+        [
+            CornerSpec("nominal"),
+            CornerSpec("rbot-fast", (CornerOverride("Rbot", "resistance", 500.0),)),
+            CornerSpec("rbot-slow", (CornerOverride("Rbot", "resistance", 2000.0),)),
+        ],
+    )
+
+    assert isinstance(result, CornerTfResult)
+    assert result.input_source == "Vin"
+    assert result.output_node == "out"
+    assert [point.corner_name for point in result.points] == ["nominal", "rbot-fast", "rbot-slow"]
+    assert [point.result.gain for point in result.points] == pytest.approx([0.5, 1.0 / 3.0, 2.0 / 3.0])
+    assert [point.result.input_impedance for point in result.points] == pytest.approx([2000.0, 1500.0, 3000.0])

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add multi-corner transfer-function analysis with `tf_corners`, returning the
+  same `.TF` query evaluated under each named corner.
 - Add multi-corner AC frequency sweeps with `ac_sweep_corners`, returning the
   same frequency grid evaluated under each named corner.
 - Add multi-corner DC source sweeps with `dc_sweep_corners`, returning the same

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1398,6 +1398,19 @@ impl TfResult {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct CornerTfPoint {
+    pub corner_name: String,
+    pub result: TfResult,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CornerTfResult {
+    pub input_source: String,
+    pub output_node: String,
+    pub points: Vec<CornerTfPoint>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct SensEntry {
     pub element_name: String,
     pub parameter: String,
@@ -2081,6 +2094,27 @@ pub fn tf(
         transfer_ratio,
         input_impedance_ohms,
         output_impedance_ohms,
+    })
+}
+
+pub fn tf_corners(
+    circuit: &Circuit,
+    output_node: &str,
+    input_source: &str,
+    corners: &[CornerSpec],
+) -> Result<CornerTfResult, SpiceError> {
+    let mut points = Vec::with_capacity(corners.len());
+    for corner in corners {
+        let corner_circuit = circuit_with_corner(circuit, corner)?;
+        points.push(CornerTfPoint {
+            corner_name: corner.name.clone(),
+            result: tf(&corner_circuit, output_node, input_source)?,
+        });
+    }
+    Ok(CornerTfResult {
+        input_source: input_source.to_string(),
+        output_node: output_node.to_string(),
+        points,
     })
 }
 

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -1,6 +1,7 @@
 use spice_engine::{
-    tf, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, Inductor, Mosfet,
-    MosfetLevel1Params, MosfetType, Resistor, SpiceError, TfResult, Vccs, Vcvs, VoltageSource,
+    tf, tf_corners, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CornerOverride, CornerSpec,
+    CurrentSource, Element, Inductor, Mosfet, MosfetLevel1Params, MosfetType, Resistor, SpiceError,
+    TfResult, Vccs, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -57,6 +58,50 @@ fn tf_unequal_divider_matches_thevenin_values() {
     assert_close(result.gain(), 0.75);
     assert_close(result.input_impedance_ohms, 4_000.0);
     assert_close(result.output_impedance_ohms, 750.0);
+}
+
+#[test]
+fn tf_corners_runs_transfer_function_per_corner() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 10.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rtop", "in", "out", 1_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rbot", "out", "0", 1_000.0,
+    )));
+
+    let result = tf_corners(
+        &circuit,
+        "out",
+        "Vin",
+        &[
+            CornerSpec::new("nominal", vec![]),
+            CornerSpec::new(
+                "rbot-fast",
+                vec![CornerOverride::new("Rbot", "resistance", 500.0)],
+            ),
+            CornerSpec::new(
+                "rbot-slow",
+                vec![CornerOverride::new("Rbot", "resistance", 2_000.0)],
+            ),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(result.input_source, "Vin");
+    assert_eq!(result.output_node, "out");
+    assert_eq!(result.points[0].corner_name, "nominal");
+    assert_eq!(result.points[1].corner_name, "rbot-fast");
+    assert_eq!(result.points[2].corner_name, "rbot-slow");
+    assert_close(result.points[0].result.gain(), 0.5);
+    assert_close(result.points[1].result.gain(), 1.0 / 3.0);
+    assert_close(result.points[2].result.gain(), 2.0 / 3.0);
+    assert_close(result.points[0].result.input_impedance_ohms, 2_000.0);
+    assert_close(result.points[1].result.input_impedance_ohms, 1_500.0);
+    assert_close(result.points[2].result.input_impedance_ohms, 3_000.0);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add multi-corner transfer-function analysis with `tfCorners`, returning the
+  same `.TF` query evaluated under each named corner.
 - Add multi-corner AC frequency sweeps with `acSweepCorners`, returning the
   same frequency grid evaluated under each named corner.
 - Add multi-corner DC source sweeps with `dcSweepCorners`, returning the same

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -488,6 +488,17 @@ export interface TfResult {
   gain(): number;
 }
 
+export interface CornerTfPoint {
+  readonly cornerName: string;
+  readonly result: TfResult;
+}
+
+export interface CornerTfResult {
+  readonly inputSource: string;
+  readonly outputNode: string;
+  readonly points: readonly CornerTfPoint[];
+}
+
 export interface SensEntry {
   readonly elementName: string;
   readonly parameter: string;
@@ -1290,6 +1301,22 @@ export function tf(
     outputIndex === undefined ? 0.0 : output[outputIndex];
 
   return makeTfResult(transferRatio, inputImpedanceOhms, outputImpedanceOhms);
+}
+
+export function tfCorners(
+  circuit: Circuit,
+  outputNode: string,
+  inputSource: string,
+  corners: readonly CornerSpec[],
+): CornerTfResult {
+  return {
+    inputSource,
+    outputNode,
+    points: corners.map((corner) => ({
+      cornerName: corner.name,
+      result: tf(circuitWithCorner(circuit, corner), outputNode, inputSource),
+    })),
+  };
 }
 
 export function sensDc(circuit: Circuit, outputNode: string): SensResult {

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -8,6 +8,7 @@ import {
   inductor,
   resistor,
   tf,
+  tfCorners,
   vccs,
   voltageSource,
 } from "../src/index.js";
@@ -52,6 +53,39 @@ describe("tf", () => {
     expectClose(result.gain(), 0.75);
     expectClose(result.inputImpedanceOhms, 4_000.0);
     expectClose(result.outputImpedanceOhms, 750.0);
+  });
+
+  it("runs transfer-function analysis at each named corner", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "in", "0", 10.0));
+    circuit.add(resistor("Rtop", "in", "out", 1_000.0));
+    circuit.add(resistor("Rbot", "out", "0", 1_000.0));
+
+    const result = tfCorners(circuit, "out", "Vin", [
+      { name: "nominal", overrides: [] },
+      {
+        name: "rbot-fast",
+        overrides: [{ elementName: "Rbot", parameter: "resistance", value: 500.0 }],
+      },
+      {
+        name: "rbot-slow",
+        overrides: [{ elementName: "Rbot", parameter: "resistance", value: 2_000.0 }],
+      },
+    ]);
+
+    expect(result.inputSource).toBe("Vin");
+    expect(result.outputNode).toBe("out");
+    expect(result.points.map((point) => point.cornerName)).toEqual([
+      "nominal",
+      "rbot-fast",
+      "rbot-slow",
+    ]);
+    expectClose(result.points[0].result.gain(), 0.5);
+    expectClose(result.points[1].result.gain(), 1.0 / 3.0);
+    expectClose(result.points[2].result.gain(), 2.0 / 3.0);
+    expectClose(result.points[0].result.inputImpedanceOhms, 2_000.0);
+    expectClose(result.points[1].result.inputImpedanceOhms, 1_500.0);
+    expectClose(result.points[2].result.inputImpedanceOhms, 3_000.0);
   });
 
   it("reports current-source transimpedance", () => {

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -106,10 +106,10 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- Multi-corner AC frequency sweeps across Python, TypeScript, and Rust SPICE
-  engines: named corner specs apply core linear element-parameter overrides,
-  then reuse the existing `.AC` frequency sweep to collect one phasor trace per
-  corner.
+- Multi-corner transfer-function analysis across Python, TypeScript, and Rust
+  SPICE engines: named corner specs apply core linear element-parameter
+  overrides, then reuse the existing `.TF` query to collect gain and impedance
+  values per corner.
 
 ---
 
@@ -132,7 +132,7 @@ and the sparse real solver path landed in PR #3391.
 |---|---|
 | **S-parameter extraction** | Two-port network characterisation. Run AC sweep, compute Y-parameters from node voltages and port currents, convert to S-parameters. Shipped in PR #3490. |
 | **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Requires a good oscillation-period estimator. |
-| **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners are in flight. |
+| **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners are in flight. |
 | **Mixed-signal coupling with `hardware-vm`** | AMS simulation — digital events feed into analog SPICE nodes and vice versa. Long-range project; `hardware-vm.md` spec describes the interface. |
 | **Verilog-A compact models** | Custom device models. Requires a Verilog-A parser (`code/specs/verilog-a-parser.md` is referenced but not written). |
 


### PR DESCRIPTION
## Summary
- Add multi-corner transfer-function analysis to the Python, TypeScript, and Rust SPICE engines.
- Reuse named `CornerSpec` overrides to run the same `.TF` query per corner.
- Add cross-language divider transfer-ratio tests and refresh the SPICE/MACSYMA pending-work notes after #3511 merged.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-corner-tf sh BUILD` in `code/packages/python/spice-engine`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-corner-tf sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo fmt -p spice-engine` in `code/packages/rust`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`
