### PR TITLE
Expose HTML text-mode continuation contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -75,6 +75,9 @@ documented in this file.
 - html5lib-style smoke metadata for generic tag-open, tag-name, and seeded
   start-tag/attribute continuation states, keeping the normalizer's supported
   state set aligned with `HTML_TOKENIZER_STATES`.
+- Parser/importer-facing seeded text-mode end-tag continuation contexts through
+  `HtmlLexContext::end_tag_continuation`, plus exported text-mode and end-tag
+  tokenizer state families used by wrapper-level fixture tests.
 - A generated WHATWG tokenizer script escape boundary fixture and Rust
   conformance test that pins escaped and double-escaped script data, escape
   start/end delimiters, EOF diagnostics, NULL replacement, and seeded

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -81,6 +81,12 @@ continuation states so parser-facing recovery stays pinned at stream end.
 The generated text-mode delimiter suite pins how RCDATA, RAWTEXT, script data,
 escaped script data, and seeded end-tag continuation states distinguish real
 matching end tags from literal apparent end tags.
+The public wrapper exposes those parser-facing text-mode families through
+`HTML_TEXT_MODE_TOKENIZER_STATES`, `HTML_SCRIPT_TOKENIZER_STATES`, and
+`HTML_END_TAG_TOKENIZER_STATES`; seeded end-tag continuation tests now enter
+the lexer through `HtmlLexContext::end_tag_continuation` and
+`create_html_lexer_with_context`, matching the surface a parser or importer
+would use.
 The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -373,6 +373,49 @@ pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 24] = [
     HtmlTokenizerState::ScriptDataDoubleEscapeEnd,
 ];
 
+/// Tokenizer states used by parser-selected text modes.
+pub const HTML_TEXT_MODE_TOKENIZER_STATES: [HtmlTokenizerState; 39] = [
+    HtmlTokenizerState::Rcdata,
+    HtmlTokenizerState::RcdataLessThanSign,
+    HtmlTokenizerState::RcdataEndTagOpen,
+    HtmlTokenizerState::RcdataEndTagName,
+    HtmlTokenizerState::RcdataEndTagWhitespace,
+    HtmlTokenizerState::RcdataEndTagAttributes,
+    HtmlTokenizerState::RcdataSelfClosingEndTag,
+    HtmlTokenizerState::Rawtext,
+    HtmlTokenizerState::RawtextLessThanSign,
+    HtmlTokenizerState::RawtextEndTagOpen,
+    HtmlTokenizerState::RawtextEndTagName,
+    HtmlTokenizerState::RawtextEndTagWhitespace,
+    HtmlTokenizerState::RawtextEndTagAttributes,
+    HtmlTokenizerState::RawtextSelfClosingEndTag,
+    HtmlTokenizerState::Plaintext,
+    HtmlTokenizerState::ScriptData,
+    HtmlTokenizerState::ScriptDataLessThanSign,
+    HtmlTokenizerState::ScriptDataEndTagOpen,
+    HtmlTokenizerState::ScriptDataEndTagName,
+    HtmlTokenizerState::ScriptDataEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEndTagAttributes,
+    HtmlTokenizerState::ScriptDataSelfClosingEndTag,
+    HtmlTokenizerState::ScriptDataEscapeStart,
+    HtmlTokenizerState::ScriptDataEscapeStartDash,
+    HtmlTokenizerState::ScriptDataEscaped,
+    HtmlTokenizerState::ScriptDataEscapedDash,
+    HtmlTokenizerState::ScriptDataEscapedDashDash,
+    HtmlTokenizerState::ScriptDataEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataEscapedEndTagOpen,
+    HtmlTokenizerState::ScriptDataEscapedEndTagName,
+    HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+    HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
+    HtmlTokenizerState::ScriptDataDoubleEscapeStart,
+    HtmlTokenizerState::ScriptDataDoubleEscaped,
+    HtmlTokenizerState::ScriptDataDoubleEscapedDash,
+    HtmlTokenizerState::ScriptDataDoubleEscapedDashDash,
+    HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscapeEnd,
+];
+
 /// Tokenizer states that resume an already-created DOCTYPE token.
 pub const HTML_DOCTYPE_TOKENIZER_STATES: [HtmlTokenizerState; 32] = [
     HtmlTokenizerState::DoctypeKeywordO,
@@ -407,6 +450,26 @@ pub const HTML_DOCTYPE_TOKENIZER_STATES: [HtmlTokenizerState; 32] = [
     HtmlTokenizerState::DoctypeSystemIdentifierSingleQuoted,
     HtmlTokenizerState::AfterDoctypeSystemIdentifier,
     HtmlTokenizerState::BogusDoctype,
+];
+
+/// Tokenizer states that resume an already-started text-mode end tag.
+pub const HTML_END_TAG_TOKENIZER_STATES: [HtmlTokenizerState; 16] = [
+    HtmlTokenizerState::RcdataEndTagName,
+    HtmlTokenizerState::RcdataEndTagWhitespace,
+    HtmlTokenizerState::RcdataEndTagAttributes,
+    HtmlTokenizerState::RcdataSelfClosingEndTag,
+    HtmlTokenizerState::RawtextEndTagName,
+    HtmlTokenizerState::RawtextEndTagWhitespace,
+    HtmlTokenizerState::RawtextEndTagAttributes,
+    HtmlTokenizerState::RawtextSelfClosingEndTag,
+    HtmlTokenizerState::ScriptDataEndTagName,
+    HtmlTokenizerState::ScriptDataEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEndTagAttributes,
+    HtmlTokenizerState::ScriptDataSelfClosingEndTag,
+    HtmlTokenizerState::ScriptDataEscapedEndTagName,
+    HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+    HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
 ];
 
 /// Tokenizer states that resume an already-started start tag.
@@ -733,25 +796,7 @@ impl HtmlTokenizerState {
 
     /// Return whether this state resumes an already-started end tag.
     pub fn requires_end_tag_seed(self) -> bool {
-        matches!(
-            self,
-            Self::RcdataEndTagName
-                | Self::RcdataEndTagWhitespace
-                | Self::RcdataEndTagAttributes
-                | Self::RcdataSelfClosingEndTag
-                | Self::RawtextEndTagName
-                | Self::RawtextEndTagWhitespace
-                | Self::RawtextEndTagAttributes
-                | Self::RawtextSelfClosingEndTag
-                | Self::ScriptDataEndTagName
-                | Self::ScriptDataEndTagWhitespace
-                | Self::ScriptDataEndTagAttributes
-                | Self::ScriptDataSelfClosingEndTag
-                | Self::ScriptDataEscapedEndTagName
-                | Self::ScriptDataEscapedEndTagWhitespace
-                | Self::ScriptDataEscapedEndTagAttributes
-                | Self::ScriptDataEscapedSelfClosingEndTag
-        )
+        HTML_END_TAG_TOKENIZER_STATES.contains(&self)
     }
 
     /// Return whether this state resumes an already-started comment token.
@@ -923,6 +968,31 @@ impl HtmlLexContext {
     ) -> Option<Self> {
         if initial_state.requires_start_tag_seed() {
             Some(Self::new(initial_state).with_current_start_tag(seed))
+        } else {
+            None
+        }
+    }
+
+    /// Return a text-mode end-tag continuation context.
+    ///
+    /// These states resume after the tokenizer has already created an end-tag
+    /// token while scanning RCDATA, RAWTEXT, script data, or escaped script
+    /// data. The current end-tag seed and temporary buffer must stay aligned
+    /// because literal mismatch recovery re-emits the temporary buffer with the
+    /// appropriate `</` or `</.../` delimiter text.
+    pub fn end_tag_continuation(
+        initial_state: HtmlTokenizerState,
+        last_start_tag: impl Into<String>,
+        current_end_tag: impl Into<String>,
+        temporary_buffer: impl Into<String>,
+    ) -> Option<Self> {
+        if initial_state.requires_end_tag_seed() {
+            Some(
+                Self::new(initial_state)
+                    .with_last_start_tag(last_start_tag)
+                    .with_current_end_tag(current_end_tag)
+                    .with_temporary_buffer(temporary_buffer),
+            )
         } else {
             None
         }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -2,8 +2,9 @@ use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, create_html_lexer_with_context, html1_definition,
     html1_machine, html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment,
     Attribute, DoctypeSeed, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, StartTagSeed,
-    Token, HTML_DOCTYPE_TOKENIZER_STATES, HTML_FRAGMENT_TOKENIZER_STATES,
-    HTML_SCRIPT_TOKENIZER_STATES, HTML_START_TAG_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
+    Token, HTML_DOCTYPE_TOKENIZER_STATES, HTML_END_TAG_TOKENIZER_STATES,
+    HTML_FRAGMENT_TOKENIZER_STATES, HTML_SCRIPT_TOKENIZER_STATES, HTML_START_TAG_TOKENIZER_STATES,
+    HTML_TEXT_MODE_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
 };
 use state_machine::END_INPUT;
 
@@ -5314,6 +5315,35 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "self_closing_start_tag",
         ]
     );
+    assert_eq!(
+        HTML_END_TAG_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),
+        [
+            "rcdata_end_tag_name",
+            "rcdata_end_tag_whitespace",
+            "rcdata_end_tag_attributes",
+            "rcdata_self_closing_end_tag",
+            "rawtext_end_tag_name",
+            "rawtext_end_tag_whitespace",
+            "rawtext_end_tag_attributes",
+            "rawtext_self_closing_end_tag",
+            "script_data_end_tag_name",
+            "script_data_end_tag_whitespace",
+            "script_data_end_tag_attributes",
+            "script_data_self_closing_end_tag",
+            "script_data_escaped_end_tag_name",
+            "script_data_escaped_end_tag_whitespace",
+            "script_data_escaped_end_tag_attributes",
+            "script_data_escaped_self_closing_end_tag",
+        ]
+    );
+    assert_eq!(HTML_TEXT_MODE_TOKENIZER_STATES.len(), 39);
+    assert!(HTML_TEXT_MODE_TOKENIZER_STATES.contains(&HtmlTokenizerState::Rcdata));
+    assert!(HTML_TEXT_MODE_TOKENIZER_STATES.contains(&HtmlTokenizerState::Rawtext));
+    assert!(HTML_TEXT_MODE_TOKENIZER_STATES.contains(&HtmlTokenizerState::Plaintext));
+    assert!(HTML_TEXT_MODE_TOKENIZER_STATES.contains(&HtmlTokenizerState::ScriptDataEscaped));
+    assert!(
+        HTML_TEXT_MODE_TOKENIZER_STATES.contains(&HtmlTokenizerState::ScriptDataDoubleEscapeEnd)
+    );
 }
 
 #[test]
@@ -6108,10 +6138,13 @@ fn parser_facing_end_tag_continuation_contexts_resume_seeded_tokens() {
             "tail",
         ),
     ] {
-        let context = HtmlLexContext::new(state)
-            .with_last_start_tag(last_start_tag)
-            .with_current_end_tag(current_end_tag)
-            .with_temporary_buffer(temporary_buffer);
+        let context = HtmlLexContext::end_tag_continuation(
+            state,
+            last_start_tag,
+            current_end_tag,
+            temporary_buffer,
+        )
+        .unwrap();
 
         assert_eq!(
             lex_html_fragment(input, &context).unwrap(),
@@ -6174,12 +6207,14 @@ fn parser_facing_end_tag_continuation_contexts_recover_seeded_text_and_diagnosti
         } else {
             "title"
         };
-        let context = HtmlLexContext::new(state)
-            .with_last_start_tag(last_start_tag)
-            .with_current_end_tag(last_start_tag)
-            .with_temporary_buffer(temporary_buffer);
-        let mut lexer = create_html_lexer().unwrap();
-        apply_html_lex_context(&mut lexer, &context).unwrap();
+        let context = HtmlLexContext::end_tag_continuation(
+            state,
+            last_start_tag,
+            last_start_tag,
+            temporary_buffer,
+        )
+        .unwrap();
+        let mut lexer = create_html_lexer_with_context(&context).unwrap();
 
         lexer.push(input).unwrap();
         lexer.finish().unwrap();
@@ -6243,10 +6278,13 @@ fn parser_facing_end_tag_continuation_contexts_keep_mismatches_literal() {
             "</style/>tail",
         ),
     ] {
-        let context = HtmlLexContext::new(state)
-            .with_last_start_tag(last_start_tag)
-            .with_current_end_tag(current_end_tag)
-            .with_temporary_buffer(temporary_buffer);
+        let context = HtmlLexContext::end_tag_continuation(
+            state,
+            last_start_tag,
+            current_end_tag,
+            temporary_buffer,
+        )
+        .unwrap();
 
         assert_eq!(
             lex_html_fragment(input, &context).unwrap(),
@@ -6260,6 +6298,11 @@ fn parser_facing_end_tag_continuation_contexts_keep_mismatches_literal() {
             "context {state:?}"
         );
     }
+
+    assert_eq!(
+        HtmlLexContext::end_tag_continuation(HtmlTokenizerState::Rcdata, "title", "title", "title"),
+        None
+    );
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_chunk_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_chunk_boundaries_test.rs
@@ -1,5 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Diagnostic, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    create_html_lexer_with_context, Diagnostic, DoctypeSeed, HtmlLexContext, HtmlLexer,
     HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
@@ -137,9 +137,7 @@ fn configured_lexer(case: &ChunkBoundaryCase) -> HtmlLexer {
         context = context.with_return_state(return_state);
     }
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
 }
 
 fn chunkings(source: &str) -> Vec<Vec<&str>> {

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
@@ -1,6 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
 
@@ -116,9 +115,7 @@ fn configured_lexer(case: &TextModeBoundaryCase) -> HtmlLexer {
         context = context.with_temporary_buffer(temporary_buffer);
     }
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
@@ -1,11 +1,10 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    create_html_lexer_with_context, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
     HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
 
-const WHATWG_TEXT_MODE_DELIMITERS: &str =
-    include_str!("fixtures/whatwg-text-mode-delimiters.json");
+const WHATWG_TEXT_MODE_DELIMITERS: &str = include_str!("fixtures/whatwg-text-mode-delimiters.json");
 
 #[derive(Debug, Deserialize)]
 struct TextModeDelimiterSuite {
@@ -153,9 +152,7 @@ fn configured_lexer(case: &TextModeDelimiterCase) -> HtmlLexer {
         context = context.with_return_state(return_state);
     }
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
 }
 
 fn token_summary(token: Token) -> String {


### PR DESCRIPTION
## Summary
- expose parser-facing text-mode and end-tag continuation state families from the HTML lexer wrapper
- add `HtmlLexContext::end_tag_continuation` for seeded RCDATA/RAWTEXT/script end-tag states
- route text-mode delimiter, text-mode boundary, and chunk-boundary fixture runners through `create_html_lexer_with_context`

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `rustfmt --check code/packages/rust/html-lexer/src/lib.rs code/packages/rust/html-lexer/tests/html_lexer_test.rs code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs code/packages/rust/html-lexer/tests/whatwg_chunk_boundaries_test.rs`
- `python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check`
- `git diff --check`
