### PR TITLE
feat(matrix-rust-napi): MX07 Phase 1 — Node.js N-API addon skeleton

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -387,6 +387,7 @@ members = [
     "matrix-metal",
     "matrix-profile",
     "matrix-runtime",
+    "matrix-rust-napi",
     "metal-compute",
     "paint-metal",
     "paint-vm-direct2d-c",

--- a/code/packages/rust/matrix-rust-napi/BUILD
+++ b/code/packages/rust/matrix-rust-napi/BUILD
@@ -1,0 +1,1 @@
+cargo test -p matrix-rust-napi -- --nocapture

--- a/code/packages/rust/matrix-rust-napi/BUILD_windows
+++ b/code/packages/rust/matrix-rust-napi/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p matrix-rust-napi -- --nocapture

--- a/code/packages/rust/matrix-rust-napi/CHANGELOG.md
+++ b/code/packages/rust/matrix-rust-napi/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable changes to `matrix-rust-napi` are documented here.  The
+format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-05-18
+
+### Added — MX07 Phase 1: crate skeleton + Graph JSON round-trip
+
+First cut of the Node.js N-API addon for the Rust matrix execution
+layer.  Establishes the build pipeline, the napi boundary, and the
+JSON wire format as the interop surface.  Real execution
+(`Runtime::run` on `matrix-cpu`) lands in Phase 2.
+
+**Exported function**
+
+```javascript
+const m = require("./matrix_rust_napi.node");
+
+const out = m.graphRoundTripJson(jsonString);
+// jsonString -> matrix_ir::Graph -> jsonString
+```
+
+`graphRoundTripJson` decodes its input via `matrix-ir-json::decode`,
+then re-encodes via `matrix-ir-json::encode`.  Malformed JSON throws
+a `JS Error`.
+
+**Pure-Rust core**
+
+The work happens in `pub fn round_trip_json(input: &str) ->
+Result<String, String>`, which is unit-testable without a Node
+toolchain:
+
+* `round_trip_preserves_graph_under_binary_wire_format` — a small
+  ReLU layer round-trips and the result is byte-equal to the
+  original under `matrix-ir`'s binary wire format.
+* `round_trip_handles_multi_op_graph` — multi-op graph
+  (`Add + Mul + Neg`) round-trips intact.
+* `round_trip_rejects_garbage_json` — non-JSON input returns `Err`.
+* `round_trip_rejects_unsupported_version` — schema-version
+  mismatch returns `Err`.
+* `round_trip_is_idempotent` — `round_trip_json(round_trip_json(x))
+  == round_trip_json(x)`.
+
+The N-API wrapper (`napi_graph_round_trip_json`) is one
+un-marshal + one call + one marshal.  Errors thrown via
+`node-bridge::throw_error` become JS exceptions.
+
+### Why `node-bridge` instead of `napi-rs`
+
+The workspace convention (established by `font-parser-node`) is to
+depend on the sibling `node-bridge` crate — a zero-dep safe Rust
+wrapper over the raw N-API `extern "C"` interface — rather than
+pulling in `napi-rs` / `napi-sys` / `napi-derive`.  N-API is
+ABI-stable; extern declarations work on every Node version that
+supports the targeted N-API revision.
+
+The MX07 spec originally cited `napi-rs`; it has been updated in
+this same PR to reflect the workspace pattern.  See the spec's
+"Open questions" and "Where the crate lives" sections.
+
+### Dependencies
+
+```toml
+matrix-ir       = { path = "../matrix-ir" }       # zero-dep IR types
+matrix-ir-json  = { path = "../matrix-ir-json" }  # JSON wire format
+node-bridge     = { path = "../node-bridge" }     # raw N-API wrappers
+```
+
+No external crates from crates.io.  The upstream crates remain
+MX00-zero-dep; this addon is the workspace's binding edge to Node.
+
+### Crate type
+
+`crate-type = ["cdylib"]` — single output that Node.js renames from
+`libmatrix_rust_napi.{dylib,so,dll}` to `matrix_rust_napi.node` and
+`require`s.  Matching `font-parser-node`'s shape.
+
+### Out of scope (deferred to later phases)
+
+* `Graph` / `Runtime` classes with handle-based API — Phase 2.
+* Actual execution on `matrix-cpu` — Phase 2.
+* `package.json` + per-platform prebuilt-binary workflow — Phase 3.
+* TypeScript wrapper package — Phase 4.
+* `typescript/matrix` refactor — Phase 5 (separately scoped as MX08).
+* Async / `runAsync()` — v1+ once profiling shows it matters.
+* Zero-copy output buffers — v1+.
+
+### Security
+
+* No `unsafe` outside the `extern "C"` shim layer.
+* The N-API wrapper validates argument count and type before
+  un-marshalling; mismatched shape throws a JS error rather than
+  panicking.
+* All decoder fallibility is mapped to `Result<_, String>` and then
+  to a JS `Error`; no panics reachable from adversarial input.
+* `required_capabilities.json` is empty: the addon opens no
+  filesystem, network, process, or environment access.

--- a/code/packages/rust/matrix-rust-napi/Cargo.toml
+++ b/code/packages/rust/matrix-rust-napi/Cargo.toml
@@ -1,0 +1,30 @@
+# matrix-rust-napi — Node.js N-API addon exposing the Rust matrix
+# execution layer to JavaScript / TypeScript.
+#
+# Phase 1 (MX07 §"Phases"): crate skeleton + Graph JSON round-trip
+# only.  Runtime + Graph execution land in Phase 2.
+#
+# Build produces a .node file that Node.js loads via `require()`.
+# crate-type = ["cdylib"]: emit a C-compatible shared library.
+#
+# Follows the workspace convention established by font-parser-node:
+# zero-dependency on napi-rs / napi-sys.  All N-API access goes
+# through node-bridge, which declares the extern "C" functions
+# itself.  N-API is ABI-stable by design.
+
+[package]
+name = "matrix-rust-napi"
+version = "0.1.0"
+edition = "2021"
+description = "MX07 Phase 1 — Node.js N-API addon exposing the Rust matrix execution layer (matrix-ir / matrix-ir-json / matrix-runtime / matrix-cpu / matrix-metal / matrix-cuda) to JavaScript.  v0.1 exposes only graphRoundTripJson(jsonString) -> jsonString — a smoke function that proves the matrix-ir-json wire format survives a trip through the napi boundary.  v0.2+ adds Graph + Runtime classes with actual execution per MX07.  Zero external Rust dependencies beyond the workspace; no napi-rs."
+license = "MIT"
+
+[lib]
+# cdylib: produce a .so / .dylib / .dll that Node.js renames to .node.
+crate-type = ["cdylib"]
+name = "matrix_rust_napi"
+
+[dependencies]
+matrix-ir       = { path = "../matrix-ir" }
+matrix-ir-json  = { path = "../matrix-ir-json" }
+node-bridge     = { path = "../node-bridge" }

--- a/code/packages/rust/matrix-rust-napi/README.md
+++ b/code/packages/rust/matrix-rust-napi/README.md
@@ -1,0 +1,97 @@
+# matrix-rust-napi
+
+Node.js N-API addon exposing the Rust matrix execution layer
+(`matrix-ir`, `matrix-ir-json`, future `matrix-runtime` /
+`matrix-cpu` / `matrix-metal` / `matrix-cuda`) to JavaScript and
+TypeScript.
+
+This is **Phase 1** of [MX07](../../../specs/MX07-matrix-rust-napi.md)
+— the minimal crate skeleton that proves the build pipeline and
+the JSON wire format survive the napi boundary.  Real execution
+lands in Phase 2.
+
+## What's here (v0.1)
+
+One exported function:
+
+```javascript
+const m = require("./matrix_rust_napi.node");
+
+const roundTripped = m.graphRoundTripJson(jsonString);
+// jsonString -> matrix_ir::Graph -> jsonString
+```
+
+`graphRoundTripJson` parses its input via the `matrix-ir-json`
+crate, re-encodes the resulting `matrix_ir::Graph`, and returns the
+canonical JSON form.  Malformed input throws a JS error.
+
+That's deliberately tiny.  It proves three things — see the source
+of `lib.rs` for the full rationale — and gives Phase 2 a known-good
+build pipeline to extend.
+
+## Why N-API instead of napi-rs?
+
+The workspace convention (established by `font-parser-node`) is to
+use **`node-bridge`**, a sibling crate that wraps the raw N-API
+`extern "C"` interface in safe Rust.  Zero dependencies on
+`napi-rs`, `napi-sys`, or `napi-derive`.  N-API is ABI-stable by
+design (that is its entire purpose), so the extern declarations
+just work on every Node version that supports the targeted N-API
+revision.
+
+This matches the broader workspace ethos: minimise the dependency
+graph, depend on what's necessary, write the rest by hand.
+
+Note: the MX07 spec originally mentioned napi-rs.  When the
+implementation started, the workspace pattern won out; MX07 has
+been updated in this same PR to record the divergence.
+
+## What lands when
+
+| Phase | Lands |
+|-------|-------|
+| 1 (this PR) | `graphRoundTripJson(jsonString)` — round-trip smoke. |
+| 2 | `Graph` + `Runtime` classes; `runtime.run(graph, inputs)` on CPU. |
+| 3 | `package.json` + workflow that builds the `.node` artifact on `darwin-arm64` and `linux-x64-gnu` and confirms it loads. |
+| 4 | TypeScript wrapper package with `node --test` smoke. |
+| 5 (MX08) | `typescript/matrix` refactor — separately scoped. |
+
+## Building
+
+```sh
+cargo build -p matrix-rust-napi --release
+```
+
+The output `target/release/libmatrix_rust_napi.{dylib,so,dll}` is
+what Node.js renames to `matrix_rust_napi.node` and loads via
+`require()`.  Phase 3 adds the build script that does the rename
+and the per-platform packaging.
+
+## Testing
+
+```sh
+cargo test -p matrix-rust-napi
+```
+
+Tests cover the pure-Rust `round_trip_json` helper — no Node
+toolchain required.  End-to-end Node-side tests land with Phase 4.
+
+## Layout
+
+```
+matrix-rust-napi/
+  Cargo.toml             # cdylib only; depends on matrix-ir,
+                         # matrix-ir-json, node-bridge
+  src/
+    lib.rs               # round_trip_json (pure) + N-API wrapper
+                         # + #[no_mangle] napi_register_module_v1
+  BUILD                  # cargo test invocation
+  BUILD_windows
+  README.md              # this file
+  CHANGELOG.md
+  required_capabilities.json  # capabilities: []
+```
+
+## License
+
+MIT

--- a/code/packages/rust/matrix-rust-napi/required_capabilities.json
+++ b/code/packages/rust/matrix-rust-napi/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/matrix-rust-napi",
+  "capabilities": [],
+  "justification": "Phase 1 surface area is one pure-function N-API export (graphRoundTripJson) that converts JSON in -> matrix_ir::Graph -> JSON out via the matrix-ir-json crate. No filesystem, no network, no process spawn, no environment access. All extern \"C\" N-API symbols are resolved at runtime by the embedding Node.js process; the addon itself opens no resources."
+}

--- a/code/packages/rust/matrix-rust-napi/src/lib.rs
+++ b/code/packages/rust/matrix-rust-napi/src/lib.rs
@@ -1,0 +1,299 @@
+//! # `matrix-rust-napi` — Node.js N-API addon for the Rust matrix execution layer
+//!
+//! **Phase 1** of [MX07](../../../specs/MX07-matrix-rust-napi.md).
+//! This is the minimal-viable shape of the napi crate: one exported
+//! function (`graphRoundTripJson`) that takes the canonical JSON wire
+//! format for a `matrix_ir::Graph`, parses it via `matrix-ir-json`,
+//! re-encodes it back to JSON, and returns the result.
+//!
+//! The round-trip is intentionally trivial in v0.1 — it only proves
+//! three things:
+//!
+//! 1. **The build pipeline works.**  We can compile a `cdylib` that
+//!    depends on the matrix-ir-json crate (which transitively pulls
+//!    the workspace JSON tooling) and have it load as a Node addon.
+//! 2. **The N-API boundary works.**  Strings can move into the addon
+//!    via `str_from_js`, get processed by Rust code, and come back
+//!    out via `str_to_js` without losing data.
+//! 3. **The matrix-ir-json schema is the right interop boundary.**
+//!    A graph constructed anywhere — Rust, browser TS via a future
+//!    `matrix-ir-ts`, hand-written JSON — can be checked for schema
+//!    validity by round-tripping through this function.  Anything
+//!    that fails to round-trip is a bug.
+//!
+//! **Phase 2** adds `Graph` and `Runtime` classes and actual
+//! execution on `matrix-cpu`.  This file stays small and grows
+//! gradually with each PR.
+//!
+//! ## What Node sees
+//!
+//! ```javascript
+//! const m = require("./matrix_rust_napi.node");
+//!
+//! const json = JSON.stringify({
+//!   matrix_ir_version: 1,
+//!   tensors: [
+//!     { id: 0, dtype: "f32", shape: [1, 4] },
+//!     { id: 1, dtype: "f32", shape: [4, 1] },
+//!     { id: 2, dtype: "f32", shape: [1, 1] },
+//!   ],
+//!   inputs:  [0],
+//!   outputs: [2],
+//!   ops: [
+//!     { kind: "MatMul", lhs: 0, rhs: 1, output: 2 }
+//!   ],
+//!   constants: [
+//!     { tensor_id: 1, dtype: "f32", shape: [4, 1],
+//!       bytes_hex: "00000000000000000000000000000000" }
+//!   ],
+//! });
+//!
+//! const roundTripped = m.graphRoundTripJson(json);
+//! // roundTripped is a JSON string that decodes to the same Graph value.
+//! ```
+//!
+//! ## Internals
+//!
+//! Two layers:
+//!
+//! 1. **Pure Rust** (`pub fn round_trip_json`) — the actual work.
+//!    Cargo-testable: no Node required.  This is the function that
+//!    Phase 2 will compose into `Graph` / `Runtime` exports.
+//! 2. **N-API wrapper** (`extern "C" fn napi_graph_round_trip_json`)
+//!    — un-marshals the JS string, calls `round_trip_json`, marshals
+//!    the result back.  Errors get thrown as JS exceptions via
+//!    `node-bridge::throw_error`.
+
+#![allow(non_camel_case_types)]
+
+use matrix_ir_json::{decode, encode};
+use node_bridge::{
+    create_function, get_cb_info, napi_callback_info, napi_env, napi_value,
+    set_named_property, str_from_js, str_to_js, throw_error, undefined,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure Rust core: the testable round-trip.
+//
+// Splitting this from the N-API wrapper lets `cargo test` exercise the
+// round-trip without any Node toolchain.  It also keeps the wrapper
+// trivial — one un-marshal, one call, one marshal — so the unsafe
+// surface stays small.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Round-trip a `matrix_ir::Graph` through its JSON wire format.
+///
+/// Returns the re-encoded JSON string.  The output is byte-equal to
+/// the input *modulo*:
+///
+/// * whitespace (input may be pretty-printed; output is compact);
+/// * key ordering inside objects (input may be in any order; output
+///   follows the canonical order from `matrix-ir-json`).
+///
+/// The decoded `Graph` value is semantically identical to one
+/// constructed natively in Rust — that is the property we rely on for
+/// Phase 2+ execution.
+pub fn round_trip_json(input: &str) -> Result<String, String> {
+    let graph = decode(input).map_err(|e| format!("matrix-ir-json decode failed: {:?}", e))?;
+    Ok(encode(&graph))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// N-API wrapper
+//
+// Every napi callback has the same signature:
+//   fn(env, info) -> napi_value
+//
+// We extract args via `get_cb_info`, do work, and return a napi_value.
+// On error we throw a JS exception (via `throw_error`) and return
+// `undefined` — Node treats the throw as the actual return.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `graphRoundTripJson(jsonString: string): string`
+///
+/// JS entry point.  Argument arity is 1; any other arity throws.
+///
+/// # Safety
+///
+/// This function is invoked by Node via the registered N-API binding.
+/// `env` and `info` are valid for the duration of the call per N-API
+/// contract.
+unsafe extern "C" fn napi_graph_round_trip_json(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    // We request 2 arg slots so the wrapper can detect strict
+    // over-arity ("you passed too many"); requesting exactly 1
+    // would silently accept extras because `get_cb_info` truncates
+    // `argv` to `min(actual_argc, max_args)`.
+    let (_this, args) = get_cb_info(env, info, 2);
+    if args.len() != 1 {
+        throw_error(
+            env,
+            &format!(
+                "graphRoundTripJson: expected exactly 1 argument (jsonString), got {}",
+                args.len()
+            ),
+        );
+        return undefined(env);
+    }
+
+    let json = match str_from_js(env, args[0]) {
+        Some(s) => s,
+        None => {
+            throw_error(env, "graphRoundTripJson: argument 0 must be a string");
+            return undefined(env);
+        }
+    };
+
+    match round_trip_json(&json) {
+        Ok(out) => str_to_js(env, &out),
+        Err(msg) => {
+            throw_error(env, &format!("graphRoundTripJson: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module registration — the entry point Node.js calls on require()
+//
+// `napi_register_module_v1` is the standard symbol Node looks up when
+// loading a `.node` file.  We attach our exported function(s) to the
+// `exports` object and return it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Module entry point — called by Node.js when the addon is `require`d.
+///
+/// # Safety
+///
+/// Invoked exactly once per Node load, with `env` and `exports` valid
+/// for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn napi_register_module_v1(
+    env: napi_env,
+    exports: napi_value,
+) -> napi_value {
+    let f = create_function(
+        env,
+        "graphRoundTripJson",
+        Some(napi_graph_round_trip_json),
+    );
+    set_named_property(env, exports, "graphRoundTripJson", f);
+    exports
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+//
+// The unit tests cover the pure-Rust `round_trip_json` helper without
+// involving Node.  They prove that:
+//
+//  * a valid Graph JSON survives the round-trip;
+//  * the output decodes to a Graph that's byte-equal under the binary
+//    wire format (the cross-format equivalence we rely on for Phase
+//    2+);
+//  * malformed JSON returns an Err, not a panic.
+//
+// The N-API wrapper is exercised by Phase 3+ end-to-end tests
+// (`node --test`).  Here we keep things pure-Rust.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_ir::{DType, GraphBuilder, Shape};
+
+    /// Build a small ReLU layer and confirm the JSON round-trip is
+    /// semantically identical (binary wire format byte-equal).
+    #[test]
+    fn round_trip_preserves_graph_under_binary_wire_format() {
+        let mut g = GraphBuilder::new();
+        let x = g.input(DType::F32, Shape::from(&[1, 4]));
+        let w = g.constant(DType::F32, Shape::from(&[4, 2]), vec![0u8; 32]);
+        let b = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+        let zero = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+        let xw = g.matmul(&x, &w);
+        let xwb = g.add(&xw, &b);
+        let relu = g.max(&xwb, &zero);
+        g.output(&relu);
+        let original = g.build().expect("graph builds");
+
+        let json_in = encode(&original);
+        let json_out = round_trip_json(&json_in).expect("round-trip succeeds");
+
+        // Decode the output JSON and compare bytes with the original
+        // graph's binary wire format.  Byte equality is the canonical
+        // "same graph value" test (see matrix-ir-json README).
+        let round_tripped = decode(&json_out).expect("decode round-trip output");
+        assert_eq!(
+            original.to_bytes(),
+            round_tripped.to_bytes(),
+            "round-tripped graph must be byte-equal to the original under \
+             the binary wire format"
+        );
+    }
+
+    /// A graph with every Op family is non-trivial enough to be a
+    /// stress test of `matrix-ir-json` end-to-end through our wrapper.
+    /// We don't replicate the full all-ops test from `matrix-ir-json`
+    /// here (that's its job), but we do confirm a representative
+    /// 3-op graph survives.
+    #[test]
+    fn round_trip_handles_multi_op_graph() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let b = g.input(DType::F32, Shape::from(&[2, 3]));
+        let sum = g.add(&a, &b);
+        let prod = g.mul(&sum, &a);
+        let neg = g.neg(&prod);
+        g.output(&neg);
+        let original = g.build().expect("graph builds");
+
+        let json_in = encode(&original);
+        let json_out = round_trip_json(&json_in).expect("round-trip succeeds");
+        let round_tripped = decode(&json_out).expect("decode round-trip output");
+
+        assert_eq!(original.to_bytes(), round_tripped.to_bytes());
+    }
+
+    /// Garbage JSON must produce an Err — not panic, not crash the
+    /// addon, not produce a corrupted graph value.  This is the
+    /// fail-closed property we need at the FFI boundary.
+    #[test]
+    fn round_trip_rejects_garbage_json() {
+        let err = round_trip_json("not even close to json").expect_err("garbage rejected");
+        assert!(err.contains("decode failed"), "got: {}", err);
+    }
+
+    /// JSON that's syntactically valid but schema-invalid (wrong
+    /// version) must also fail cleanly.
+    #[test]
+    fn round_trip_rejects_unsupported_version() {
+        let err = round_trip_json(
+            r#"{"matrix_ir_version": 9999, "tensors": [], "inputs": [],
+                 "outputs": [], "ops": [], "constants": []}"#,
+        )
+        .expect_err("unsupported version rejected");
+        assert!(err.contains("decode failed"), "got: {}", err);
+    }
+
+    /// The output of the round-trip must itself be valid JSON that
+    /// re-round-trips identically.  Idempotence: `f(f(x)) == f(x)`.
+    /// (Useful to catch any drift introduced by the encoder — e.g.
+    /// if it ever started canonicalising fields differently between
+    /// runs.)
+    #[test]
+    fn round_trip_is_idempotent() {
+        let mut g = GraphBuilder::new();
+        let x = g.input(DType::F32, Shape::from(&[3]));
+        let y = g.input(DType::F32, Shape::from(&[3]));
+        let z = g.add(&x, &y);
+        g.output(&z);
+        let graph = g.build().expect("graph builds");
+
+        let once = round_trip_json(&encode(&graph)).unwrap();
+        let twice = round_trip_json(&once).unwrap();
+        assert_eq!(once, twice, "round_trip_json must be idempotent");
+    }
+}

--- a/code/specs/MX07-matrix-rust-napi.md
+++ b/code/specs/MX07-matrix-rust-napi.md
@@ -38,21 +38,18 @@ This spec answers each.
 
 ```
 code/packages/rust/matrix-rust-napi/
-  Cargo.toml             # rlib + cdylib
+  Cargo.toml             # cdylib only (workspace convention)
   BUILD                  # cargo test invocation
   BUILD_windows
   CHANGELOG.md
   README.md
-  build.rs               # napi-build setup
-  package.json           # napi-rs CLI consumes this for build/publish
+  package.json           # Phase 3: lists the per-platform .node packages
   src/
-    lib.rs               # public napi exports
-    graph.rs             # JsGraph wrapper (handle-based)
-    runtime.rs           # JsRuntime wrapper
-    error.rs             # napi::Error mapping
+    lib.rs               # round_trip_json (Phase 1) + future
+                         # Graph / Runtime wrappers + N-API exports
   required_capabilities.json
   __test__/
-    smoke.test.mjs       # node --test
+    smoke.test.mjs       # node --test (lands with Phase 4)
 ```
 
 It lives under `code/packages/rust/` because it **is** a Rust crate
@@ -60,6 +57,33 @@ It lives under `code/packages/rust/` because it **is** a Rust crate
 build output ends up in a Node.js consumer is incidental — the same
 way `font-parser-node` is a Rust crate that happens to be consumed by
 a Node-side wrapper.
+
+### N-API binding: `node-bridge`, not `napi-rs`
+
+The workspace convention — established by `font-parser-node` — is
+to use the sibling **`node-bridge`** crate: a zero-dependency safe
+Rust wrapper over the raw N-API `extern "C"` interface.  No
+`napi-rs`, no `napi-sys`, no `napi-derive`, no `napi-build`, no
+build-time header requirements.  N-API is ABI-stable by design;
+extern declarations work on every Node version that supports the
+targeted N-API revision.
+
+This is the **default for every Node binding in the workspace**.
+An earlier draft of this spec specified `napi` + `napi-derive` +
+`napi-build`; that draft has been superseded.  Reasons to prefer
+`node-bridge`:
+
+* Zero crates.io dependencies (matches the workspace's broader
+  minimum-dependency ethos).
+* Same pattern as the existing `font-parser-node` addon — one
+  reviewer skillset, one debugging surface.
+* No proc-macro at the binding boundary — easier to read, easier
+  to step through under `lldb`.
+
+If a future addon hits a real ceiling that only `napi-rs` can
+break through (very complex async patterns, heavy class wrapping,
+etc.), the option remains open — but each addon makes that call
+on its own merits, and the default is `node-bridge`.
 
 Companion TypeScript wrapper:
 
@@ -245,37 +269,47 @@ a dependency from this work.
 
 `matrix-rust-napi` is **not** bound by MX00.  It is explicitly an
 FFI/binding crate at the edge of the workspace — its job is to
-glue the zero-dep core to external runtimes.  Its `Cargo.toml`
-dependencies:
+glue the zero-dep core to external runtimes.
+
+But because it depends on `node-bridge` rather than `napi-rs`, it
+still has **zero crates.io dependencies**.  Its `Cargo.toml` reads:
 
 ```toml
 [dependencies]
 matrix-ir                          = { path = "../matrix-ir" }
 matrix-ir-json                     = { path = "../matrix-ir-json" }
-matrix-runtime                     = { path = "../matrix-runtime" }
-matrix-cpu                         = { path = "../matrix-cpu" }
-compute-ir                         = { path = "../compute-ir" }
-executor-protocol                  = { path = "../executor-protocol" }
-napi                               = { version = "2", features = ["napi8"] }
-napi-derive                        = "2"
+node-bridge                        = { path = "../node-bridge" }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-matrix-metal                       = { path = "../matrix-metal" }
-
-[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
-matrix-cuda                        = { path = "../matrix-cuda" }
-
-[build-dependencies]
-napi-build                         = "2"
+# Phase 2 adds:
+# matrix-runtime  = { path = "../matrix-runtime" }
+# matrix-cpu      = { path = "../matrix-cpu" }
+# compute-ir      = { path = "../compute-ir" }
+# executor-protocol = { path = "../executor-protocol" }
+#
+# Phase 2+ platform-conditional GPU deps:
+# [target.'cfg(target_os = "macos")'.dependencies]
+# matrix-metal = { path = "../matrix-metal" }
+# [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+# matrix-cuda  = { path = "../matrix-cuda" }
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
+name = "matrix_rust_napi"
 ```
 
-The `cdylib` is what `napi build` packages into `index.node`.  The
-`rlib` keeps the crate `cargo test`-able as a normal Rust library —
-without it, `cargo test` can't link the test harness against a
-cdylib-only crate.
+The single `cdylib` target produces
+`libmatrix_rust_napi.{dylib,so,dll}`, which Phase 3's
+`package.json` build script renames to `matrix_rust_napi.node` for
+Node to `require()`.
+
+**Why `cdylib`-only and not `cdylib + rlib`?**  `font-parser-node`
+uses cdylib-only; an empty cargo test (zero `#[test]` functions in
+the lib) still compiles and "runs" successfully because the test
+harness builds the lib as cdylib + a tiny test binary that
+references it.  We confirmed locally: a cdylib-only crate with
+`#[cfg(test)] mod tests` *does* compile and run tests under
+`cargo test`.  Adding an `rlib` target would double the build time
+and produce an extra artifact for no benefit.
 
 ---
 
@@ -327,8 +361,8 @@ end.
 
 | Phase | Lands | Status |
 |-------|-------|--------|
-| 0 | This spec. | **this PR** |
-| 1 | Rust crate skeleton — `Cargo.toml` (`cdylib + rlib`), `build.rs`, `src/lib.rs` exporting only `Graph` (JSON round-trip via `matrix-ir-json`). One smoke `cargo test`. No Node side yet. | pending |
+| 0 | This spec. | shipped (#3508) |
+| 1 | Rust crate skeleton — `Cargo.toml` (`cdylib`), `src/lib.rs` exporting `graphRoundTripJson` (one function, JSON in → `matrix-ir-json::decode` → `matrix-ir-json::encode` → JSON out), 5 unit tests on the pure-Rust core. No Node side yet. | **this PR** |
 | 2 | `Runtime::create()` + `Runtime::run(graph, inputs)` on the CPU executor.  Internal-testing feature flag for in-Rust round-trip tests of `graph_in → run → outputs_out`. | pending |
 | 3 | `package.json` + `napi build` workflow file.  CI step that builds the `.node` artifact on `darwin-arm64` and `linux-x64-gnu` and confirms it loads.  No publish step. | pending |
 | 4 | TypeScript wrapper package `typescript/matrix-rust-napi/` — re-exports the napi binding with typed declarations.  `__test__/smoke.test.mjs` round-trips a `MatMul` graph through the binding. | pending |
@@ -372,12 +406,16 @@ To pre-empt overreach:
 
 These are deferred until the implementation PRs hit them:
 
-* **napi-rs version pin** — `napi@2` is current stable; whether to
-  pin to `2.16` exactly or `^2` is a Phase 1 decision.
-* **MSRV** — must match the workspace; bumped only if napi-rs
-  requires newer rustc.
-* **Whether the wrapper package republishes the `.node` binary or
-  uses napi-rs's `@napi-rs/cli`-managed per-platform packages** is
-  a Phase 3 question.  This spec assumes the latter (standard
-  napi-rs model); we revisit if it doesn't fit the workspace's
-  npm publishing setup.
+* **N-API revision target** — `font-parser-node` targets N-API v4
+  (Node 10.16+ / 12+).  `matrix-rust-napi` defaults to the same
+  unless a needed function requires a newer revision.  Decided per
+  Phase as new N-API calls are added.
+* **MSRV** — matches the workspace; revisited only if `node-bridge`
+  or a workspace upstream crate forces a bump.
+* **Per-platform packaging strategy** — Phase 3 question.  The
+  workspace pattern (font-parser-node's `package.json` runs
+  `cargo build --release` then `cp` the `.dylib` to `.node`) works
+  for a single platform; cross-platform distribution needs a
+  publish workflow.  Likely a GitHub Actions matrix builds each
+  triple's `.node`, the wrapper consumes them as
+  `optionalDependencies`.  Decided when Phase 3 lands.


### PR DESCRIPTION
## Summary

- **New crate `matrix-rust-napi`** — first implementation step of [ARCH02 Phase 2](./code/specs/ARCH02-rust-native-execution-backbone.md) / [MX07 Phase 1](./code/specs/MX07-matrix-rust-napi.md). A Rust `cdylib` that becomes a Node.js `.node` addon.
- **One exported function**: `graphRoundTripJson(jsonString: string): string` — decodes via `matrix-ir-json::decode`, re-encodes via `matrix-ir-json::encode`. Proves the build pipeline and the JSON wire format survive the napi boundary.
- **Architecture**: `node-bridge` (workspace zero-dep N-API wrapper, used by `font-parser-node`), **not napi-rs**. Zero crates.io dependencies.
- **5 unit tests** on the pure-Rust core: byte-equality round-trip, multi-op preservation, garbage JSON rejection, version-mismatch rejection, idempotence. End-to-end Node-side tests land with Phase 4.
- **Spec sync**: MX07 originally cited napi-rs + napi-derive + napi-build with cdylib+rlib. Updated in this same PR to reflect the workspace convention (node-bridge, cdylib only). Per CLAUDE.md "Specs must stay in sync".

## Test plan

- [x] `cargo build -p matrix-rust-napi` — clean (only pre-existing matrix-ir warning)
- [x] `cargo test -p matrix-rust-napi` — 5/5 pass
- [x] Security review by senior-Rust-N-API security sub-agent — passed, no findings
- [x] No new crates.io dependencies (matches workspace convention)
- [x] `required_capabilities.json` empty (addon opens no resources)
- [ ] CI: workspace build, lint, fmt on the new crate
- [ ] CI: existing matrix-ir / matrix-ir-json / node-bridge crates still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)