### PR TITLE
feat(forme-index-renderer): FM00 v0 index / archive page renderer

### DIFF
--- a/code/packages/typescript/forme-index-renderer/BUILD
+++ b/code/packages/typescript/forme-index-renderer/BUILD
@@ -1,0 +1,3 @@
+cd ../document-ast && npm install --silent
+cd ../forme-types && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-index-renderer/CHANGELOG.md
+++ b/code/packages/typescript/forme-index-renderer/CHANGELOG.md
@@ -1,0 +1,112 @@
+# Changelog — @coding-adventures/forme-index-renderer
+
+## 0.1.0 — 2026-05-18
+
+Initial release.  Third FM00 v0 stage package — index / archive page
+renderer producing reproducible HTML `<ul>` (optionally grouped by
+category / year / month) from `IndexItem[]` + `IndexOptions`.
+
+Companion to `forme-feeds` and `forme-opengraph`; pairs with
+`forme-aot-page-emitter` which writes the surrounding `.html`
+wrapper.
+
+### Added
+
+- `renderIndexPage(items, options?): string` — emits an HTML `<ul
+  class="forme-index">` (or a sequence of `<section
+  class="forme-index-group"><h2>...</h2><ul>...</ul></section>`
+  blocks when grouping is enabled).  Drop straight into an archive
+  page body.
+- `groupItems(items, groupBy): ItemGroup[]` — exposed sub-helper so
+  callers can build custom navigation widgets, year-archive sidebars,
+  or category clouds without re-rendering.
+- `sortItems(items, sortBy): IndexItem[]` — exposed sub-helper for
+  callers that want the deterministic sort order without rendering.
+- `escapeHtmlAttr`, `escapeHtmlText`, `assertItemUrl` re-exported
+  for callers wiring custom item renderers.
+- `IndexItem`, `IndexOptions`, `ItemGroup` type definitions.
+
+### Spec adherence
+
+Implements FM00 v0 index renderer.  No spec divergences.
+
+### Behavioural notes
+
+- **URL validation FIRST.**  Every `item.url` is validated against
+  the accept-list (absolute `http(s)://`, root-relative `/path`,
+  bare `/`) BEFORE any output is emitted.  Mixed good/bad inputs
+  throw synchronously with no partial output.
+- **Stable sort with id tiebreaker.**  Two inputs that differ only
+  in caller-array order produce byte-identical HTML (FM03
+  reproducibility requirement).
+- **Undated / Uncategorized buckets sort LAST.**  Missing `pubDate`
+  → `"Undated"` group / sorted to end.  Missing `category` →
+  `"Uncategorized"` group / sorted last.
+- **Within-group order preserved.**  Sort happens before grouping,
+  so `sortBy: "pubDate-desc"` + `groupBy: "year"` gives
+  reverse-chrono within each year heading.
+- **HTML attribute escaping uniform across all interpolations.**
+  Single-pass replace of the five HTML entities (CodeQL-friendly
+  form).  Control-byte stripping (`U+0000-U+001F`, `U+007F`) runs
+  before the escape pass.
+- **Display toggles are opt-in.**  `showDate` / `showSummary`
+  default to `false`; items without `pubDate` / `summary` skip the
+  respective markup rather than emitting empty tags.
+
+### Security posture
+
+Three concerns explicitly addressed (pre-push review):
+
+- **HTML attribute injection.**  `escapeHtmlAttr` covers all five
+  HTML entities in single-pass replacement.  Every interpolated
+  string (title, summary, URL, category heading) routes through it
+  (or `escapeHtmlText`, which is an alias).
+- **URL scheme validation.**  `assertItemUrl` rejects
+  `javascript:`, `data:`, `file:`, protocol-relative `//host`,
+  bare relative paths (`about`, `./about`), empty strings, and
+  non-string inputs.  These are real XSS / payload-delivery vectors
+  in archive pages whose link list comes from user-authored
+  frontmatter.  Tests pin every rejected form.
+- **Attacker-controlled category heading.**  A hostile
+  `category: "<script>alert(1)</script>"` lands as
+  `<h2>&lt;script&gt;alert(1)&lt;/script&gt;</h2>` rather than
+  executable HTML.  Pinned by `index-renderer.test.ts`.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, no network, no shell, no env.
+
+### Tests
+
+60 tests across 4 files:
+
+- `escape.test.ts` (13) — every HTML entity (single + composite),
+  control-byte stripping for `0x00-0x1F` and `0x7F`, URL
+  acceptance (http, https, root-relative, bare `/`) and rejection
+  (javascript:, data:, file:, protocol-relative, bare relative,
+  empty, non-string)
+- `sort.test.ts` (10) — every sort mode (`pubDate-desc`,
+  `pubDate-asc`, `title-asc`), undated-items-last,
+  ties-broken-by-id, input-not-mutated, malformed-pubDate handling
+- `group.test.ts` (13) — every groupBy mode (`none` / `category` /
+  `year` / `month`), Uncategorized / Undated buckets, deterministic
+  group order, within-group order preservation, empty input
+- `index-renderer.test.ts` (24) — flat list, sort dispatch, all
+  three groupings, `showDate` / `showSummary` / `dateFormat`
+  toggles, HTML escaping (title, summary, URL attribute, category
+  heading), URL validation rejecting each forbidden form,
+  reproducibility including reshuffled-input invariance
+
+Coverage: **100% line / 92.45% branch** across all source files
+with logic (`types.ts` is type-only declarations).
+
+### v0 simplifications (documented)
+
+- **Tags not displayed** — `tags` field is declared on `IndexItem`
+  for forward compat but the v0 renderer does not emit them.
+  Rendering would need taxonomy navigation (cloud / list / filter)
+  which v0 defers.
+- **No pagination.**  The full list renders in one pass; consumers
+  wanting paginated archives slice their `items[]` before calling.
+- **No per-group sort override.**  All groups share the same
+  `sortBy` (since grouping happens after sorting).

--- a/code/packages/typescript/forme-index-renderer/README.md
+++ b/code/packages/typescript/forme-index-renderer/README.md
@@ -1,0 +1,173 @@
+# @coding-adventures/forme-index-renderer
+
+Index / archive page renderer for the Forme pipeline (FM00 v0).
+
+Pure transform: `IndexItem[]` + `IndexOptions` → reproducible HTML
+`<ul>` (optionally grouped by category/year/month) suitable for
+blog archives and index pages.  Pairs with
+[`forme-aot-page-emitter`](../forme-aot-page-emitter): the emitter
+writes the `.html` wrapper, this renderer fills the body.
+
+Third FM00 v0 stage package — sits alongside
+[`forme-feeds`](../forme-feeds) and
+[`forme-opengraph`](../forme-opengraph).
+
+## Quick start
+
+```ts
+import { renderIndexPage } from "@coding-adventures/forme-index-renderer";
+
+const html = renderIndexPage(posts, {
+  groupBy: "year",
+  sortBy: "pubDate-desc",
+  showDate: true,
+  showSummary: true,
+  dateFormat: (iso) => new Date(iso).toLocaleDateString("en-US"),
+});
+```
+
+Output (with grouping):
+
+```html
+<section class="forme-index-group">
+  <h2>2026</h2>
+  <ul class="forme-index">
+    <li>
+      <a href="/posts/second">Second Post</a>
+      <time datetime="2026-02-20T00:00:00Z">2/20/2026</time>
+      <p class="summary">World</p>
+    </li>
+    ...
+  </ul>
+</section>
+```
+
+## API
+
+### `renderIndexPage(items, options?): string`
+
+Renders an HTML `<ul>` (or sequence of `<section>` blocks when
+grouped) — drop straight into the body of an archive page.
+
+### Types
+
+```ts
+interface IndexItem {
+  id: string;                      // mandatory, used as sort tiebreaker
+  title: string;
+  url: string;                     // absolute http(s) OR root-relative "/path"
+  pubDate?: string;                // ISO-8601
+  summary?: string;
+  category?: string;
+  tags?: readonly string[];        // declared for forward compat; v0 doesn't render
+}
+
+interface IndexOptions {
+  groupBy?: "none" | "category" | "year" | "month";   // default "none"
+  sortBy?: "pubDate-desc" | "pubDate-asc" | "title-asc";   // default "pubDate-desc"
+  showSummary?: boolean;           // default false
+  showDate?: boolean;              // default false
+  dateFormat?: (iso: string) => string;   // default: passthrough
+}
+```
+
+### `groupItems(items, groupBy): ItemGroup[]`
+
+Exposed sub-helper for callers who want the grouping logic without
+rendering — e.g. building custom navigation widgets, year-archive
+sidebars, or category clouds.
+
+### `sortItems(items, sortBy): IndexItem[]`
+
+Exposed sub-helper for callers who want deterministic sort without
+rendering.
+
+## Sort + group rules
+
+| sortBy            | Order                                                  |
+|-------------------|--------------------------------------------------------|
+| `pubDate-desc` (default) | newest first; undated items last; ties → id asc |
+| `pubDate-asc`     | oldest first; undated items last; ties → id asc        |
+| `title-asc`       | alphabetical by title; ties → id asc                   |
+
+| groupBy      | Headings                                                    |
+|--------------|-------------------------------------------------------------|
+| `none` (default) | single flat `<ul>`, no headings                         |
+| `category`   | item.category (missing → `"Uncategorized"`); alphabetical; Uncategorized last |
+| `year`       | 4-digit UTC year; missing pubDate → `"Undated"`; reverse-chronological; Undated last |
+| `month`      | `YYYY-MM`; missing pubDate → `"Undated"`; reverse-chronological; Undated last |
+
+Within each group, item order is preserved (so the sort happens
+first, then grouping respects that order — `sortBy: "pubDate-desc"`
++ `groupBy: "year"` gives reverse-chrono inside each year).
+
+## URL validation (security-critical)
+
+`item.url` is validated:
+
+- **Accepted:** absolute `http(s)://...` OR root-relative `/path` OR bare `/`
+- **Rejected** (`TypeError` thrown BEFORE any output is emitted):
+  - `javascript:alert(1)` → XSS injection vector
+  - `data:text/html,...` → payload delivery
+  - `file:///etc/passwd` → local file leak
+  - Protocol-relative `//host/path` (ambiguous scheme)
+  - Bare relative (`about`, `./about`) — caller should normalise to `/about`
+
+## HTML escaping
+
+All string fields (title, summary, category, URL) route through
+`escapeHtmlAttr` / `escapeHtmlText` — both wrap a single-pass
+replacement of the five HTML entities (`& < > " '`) over the input
+*after* ASCII control bytes are stripped.
+
+This handles the **attacker-controlled-category** case: a hostile
+`category: "<script>alert(1)</script>"` lands as
+`<h2>&lt;script&gt;alert(1)&lt;/script&gt;</h2>` rather than
+executable HTML.
+
+## Reproducibility (FM03)
+
+Same inputs → byte-identical output.  Stable sort uses `id` as
+tiebreaker, so two inputs that differ only in caller-array order
+produce identical HTML.
+
+## Capabilities — `[]`
+
+Pure transform.  No I/O, no network, no shell.
+
+## Tests
+
+60 tests across 4 files:
+
+- `escape.test.ts` (13) — entity escaping, control-byte stripping,
+  URL acceptance (http/https/root-relative/bare-`/`) and rejection
+  (javascript:, data:, file:, protocol-relative, bare relative,
+  empty/non-string)
+- `sort.test.ts` (10) — every sort mode, undated-items-last,
+  ties-broken-by-id, input-not-mutated, malformed-pubDate handling
+- `group.test.ts` (13) — every groupBy mode (none / category / year /
+  month), Uncategorized / Undated buckets, deterministic group order,
+  within-group order preservation, empty input
+- `index-renderer.test.ts` (24) — flat list, sort dispatch, all three
+  groupings, showDate / showSummary / dateFormat toggles, HTML
+  escaping (title, summary, URL attribute, category heading),
+  URL validation rejecting each forbidden form, reproducibility
+  including reshuffled-input invariance
+
+Coverage: **100% line / 92.45% branch** across all source files
+with logic.  `types.ts` is type-only.
+
+## Spec adherence
+
+Implements FM00 v0 index renderer.  No spec divergences.
+
+## v0 simplifications
+
+- **Tags not displayed** — type slot reserved for forward compat;
+  rendering would need taxonomy navigation (cloud / list / filter)
+  which v0 defers.
+- **No pagination.**  Render the full list; consumers wanting
+  paginated archives slice their `items[]` before calling.
+- **No per-group sort override.**  All groups share the same
+  `sortBy` (since grouping happens after sorting).
+- **`tags` field is declared but unused in v0 renderer.**

--- a/code/packages/typescript/forme-index-renderer/package-lock.json
+++ b/code/packages/typescript/forme-index-renderer/package-lock.json
@@ -1,0 +1,2320 @@
+{
+  "name": "@coding-adventures/forme-index-renderer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-index-renderer",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-types": "file:../forme-types"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-types": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-types": {
+      "resolved": "../forme-types",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-index-renderer/package.json
+++ b/code/packages/typescript/forme-index-renderer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@coding-adventures/forme-index-renderer",
+  "version": "0.1.0",
+  "description": "Index / archive page renderer for the Forme pipeline (FM00 v0).  Pure transform: IndexItem[] + options → reproducible HTML <ul> list (optionally grouped by category/year/month) suitable for blog archives and index pages.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-types": "file:../forme-types"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-index-renderer/required_capabilities.json
+++ b/code/packages/typescript/forme-index-renderer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-index-renderer",
+  "capabilities": [],
+  "justification": "Pure transform: IndexItem[] + options → HTML string.  No I/O, no network, no env, no shell.  Same posture as forme-feeds / forme-opengraph."
+}

--- a/code/packages/typescript/forme-index-renderer/src/escape.ts
+++ b/code/packages/typescript/forme-index-renderer/src/escape.ts
@@ -1,0 +1,74 @@
+/**
+ * escape.ts — HTML escaping + URL validation.
+ *
+ * Same patterns as `forme-feeds` / `forme-opengraph`:
+ *   - All five HTML entities (& < > " ') in a single-pass replace
+ *   - ASCII control bytes stripped first
+ *
+ * URL policy: this package targets internal site URLs (the items in
+ * an index page link to other pages on the same site).  We accept:
+ *   - absolute http(s)://  URLs (cross-origin links to other sites)
+ *   - root-relative /path  URLs (the common case for blog archives)
+ * and reject everything else (javascript:, data:, file:, schemes
+ * with embedded `:`).
+ *
+ * @module escape
+ */
+
+const HTML_ATTR_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;",
+  "'": "&#39;",
+});
+
+const HTML_ATTR_SPECIAL_RE = /[&<>"']/g;
+
+// eslint-disable-next-line no-control-regex
+const ASCII_CONTROL_RE = /[\x00-\x1F\x7F]/g;
+
+/** Escape for HTML attribute value. */
+export function escapeHtmlAttr(s: string): string {
+  return s.replace(ASCII_CONTROL_RE, "").replace(HTML_ATTR_SPECIAL_RE, (ch) => HTML_ATTR_ESCAPE_MAP[ch]!);
+}
+
+/** Escape for HTML element text content. */
+export function escapeHtmlText(s: string): string {
+  return escapeHtmlAttr(s);
+}
+
+// ─── URL validation ─────────────────────────────────────────────────────
+
+/**
+ * Allowed URL forms for `item.url`:
+ *   - absolute http(s):  ^https?://
+ *   - root-relative:     ^/[^/]   (single leading slash; rejects `//` protocol-relative)
+ *
+ * Rejected:
+ *   - javascript:, data:, file:, vbscript:, etc.
+ *   - protocol-relative `//example.com/...`
+ *   - bare relative `foo` (ambiguous in archives — caller should
+ *     normalise to root-relative)
+ *   - empty string / non-string
+ */
+const ABSOLUTE_HTTP_URL_RE = /^https?:\/\//i;
+const ROOT_RELATIVE_URL_RE = /^\/[^/]/;
+const ROOT_ALONE_RE        = /^\/$/;
+
+export function assertItemUrl(value: unknown): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(
+      `forme-index-renderer: item.url must be a non-empty string (got ${JSON.stringify(value)})`,
+    );
+  }
+  if (
+    !ABSOLUTE_HTTP_URL_RE.test(value)
+    && !ROOT_RELATIVE_URL_RE.test(value)
+    && !ROOT_ALONE_RE.test(value)
+  ) {
+    throw new TypeError(
+      `forme-index-renderer: item.url must be absolute http(s) or root-relative "/path" (got ${JSON.stringify(value)})`,
+    );
+  }
+}

--- a/code/packages/typescript/forme-index-renderer/src/group.ts
+++ b/code/packages/typescript/forme-index-renderer/src/group.ts
@@ -1,0 +1,87 @@
+/**
+ * group.ts — partition items into headed sections.
+ *
+ * Group headings:
+ *   "none"     → single group with empty heading (caller renders flat)
+ *   "category" → item.category (missing → "Uncategorized")
+ *   "year"     → 4-digit year from pubDate (missing pubDate → "Undated")
+ *   "month"    → "YYYY-MM" from pubDate (missing pubDate → "Undated")
+ *
+ * Group order:
+ *   "category" — alphabetical (uncategorised sorts last)
+ *   "year" / "month" — reverse chronological (newest first; Undated last)
+ *
+ * Within each group, items keep the order the caller passed in (so
+ * the caller's sortItems() result is preserved).
+ *
+ * @module group
+ */
+
+import type { IndexItem, IndexOptions, ItemGroup } from "./types.js";
+
+const UNCATEGORISED = "Uncategorized";
+const UNDATED       = "Undated";
+
+/** Partition items into groups per `groupBy`.  Items keep relative
+ *  order within each group; group order is deterministic per the
+ *  rules above. */
+export function groupItems(
+  items: readonly IndexItem[],
+  groupBy: NonNullable<IndexOptions["groupBy"]>,
+): readonly ItemGroup[] {
+  if (groupBy === "none") {
+    return [{ heading: "", items }];
+  }
+
+  const buckets = new Map<string, IndexItem[]>();
+  for (const item of items) {
+    const key = bucketKey(item, groupBy);
+    let arr = buckets.get(key);
+    if (!arr) {
+      arr = [];
+      buckets.set(key, arr);
+    }
+    arr.push(item);
+  }
+
+  const keys = [...buckets.keys()];
+  keys.sort(groupSort(groupBy));
+  return keys.map((heading) => ({ heading, items: buckets.get(heading)! }));
+}
+
+function bucketKey(item: IndexItem, groupBy: "category" | "year" | "month"): string {
+  if (groupBy === "category") {
+    const c = item.category;
+    return (typeof c === "string" && c.length > 0) ? c : UNCATEGORISED;
+  }
+  // year / month
+  const iso = item.pubDate;
+  if (iso === undefined) return UNDATED;
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return UNDATED;
+  const d = new Date(t);
+  const year = d.getUTCFullYear();
+  if (groupBy === "year") return String(year);
+  // groupBy === "month"
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+function groupSort(groupBy: "category" | "year" | "month"): (a: string, b: string) => number {
+  if (groupBy === "category") {
+    // Alphabetical; UNCATEGORISED last regardless of letter.
+    return (a, b) => {
+      if (a === UNCATEGORISED && b === UNCATEGORISED) return 0;
+      if (a === UNCATEGORISED) return 1;
+      if (b === UNCATEGORISED) return -1;
+      return a < b ? -1 : a > b ? 1 : 0;
+    };
+  }
+  // year / month: reverse chronological; UNDATED last.
+  return (a, b) => {
+    if (a === UNDATED && b === UNDATED) return 0;
+    if (a === UNDATED) return 1;
+    if (b === UNDATED) return -1;
+    return a < b ? 1 : a > b ? -1 : 0;
+  };
+}

--- a/code/packages/typescript/forme-index-renderer/src/index-renderer.ts
+++ b/code/packages/typescript/forme-index-renderer/src/index-renderer.ts
@@ -1,0 +1,97 @@
+/**
+ * index-renderer.ts — `renderIndexPage(items, options)`.
+ *
+ * Emits an HTML `<ul>` (or sequence of `<h2>` + `<ul>` sections
+ * when grouped) suitable for an archive / blog-index page.
+ * Pairs with `forme-aot-page-emitter` — the emitter writes the
+ * `.html` wrapper, this renderer fills the body.
+ *
+ * Output shape (groupBy: "none"):
+ *
+ *   <ul class="forme-index">
+ *     <li><a href="...">Title</a></li>
+ *     ...
+ *   </ul>
+ *
+ * Output shape (grouped):
+ *
+ *   <section class="forme-index-group">
+ *     <h2>Heading</h2>
+ *     <ul class="forme-index">
+ *       <li>...</li>
+ *     </ul>
+ *   </section>
+ *   ...
+ *
+ * With `showDate` / `showSummary`:
+ *
+ *   <li>
+ *     <a href="...">Title</a>
+ *     <time datetime="iso">formatted</time>
+ *     <p class="summary">Summary text</p>
+ *   </li>
+ *
+ * @module index-renderer
+ */
+
+import { assertItemUrl, escapeHtmlAttr, escapeHtmlText } from "./escape.js";
+import { sortItems } from "./sort.js";
+import { groupItems } from "./group.js";
+import type { IndexItem, IndexOptions } from "./types.js";
+
+export function renderIndexPage(
+  items: readonly IndexItem[],
+  options: IndexOptions = {},
+): string {
+  // Validate every URL FIRST so we never emit partial output on bad input.
+  for (const item of items) assertItemUrl(item.url);
+
+  const sortBy = options.sortBy ?? "pubDate-desc";
+  const groupBy = options.groupBy ?? "none";
+
+  const sorted = sortItems(items, sortBy);
+  const groups = groupItems(sorted, groupBy);
+
+  // Empty input → empty <ul>.  Callers can then conditionally
+  // render a "no posts yet" message at a higher layer.
+  if (items.length === 0) {
+    return `<ul class="forme-index"></ul>`;
+  }
+
+  // groupBy === "none" → single flat <ul>.
+  if (groupBy === "none") {
+    return renderList(groups[0]!.items, options);
+  }
+
+  // Grouped — wrap each group in <section><h2>...</h2><ul>...</ul></section>.
+  return groups.map((g) => {
+    const heading = `<h2>${escapeHtmlText(g.heading)}</h2>`;
+    const list    = renderList(g.items, options);
+    return `<section class="forme-index-group">\n${heading}\n${list}\n</section>`;
+  }).join("\n");
+}
+
+function renderList(items: readonly IndexItem[], options: IndexOptions): string {
+  const showDate    = options.showDate === true;
+  const showSummary = options.showSummary === true;
+  const dateFormat  = options.dateFormat ?? identity;
+
+  const lis = items.map((item) => {
+    const parts: string[] = [];
+    parts.push(`<a href="${escapeHtmlAttr(item.url)}">${escapeHtmlText(item.title)}</a>`);
+    if (showDate && item.pubDate !== undefined) {
+      parts.push(`<time datetime="${escapeHtmlAttr(item.pubDate)}">${escapeHtmlText(dateFormat(item.pubDate))}</time>`);
+    }
+    if (showSummary && item.summary !== undefined) {
+      parts.push(`<p class="summary">${escapeHtmlText(item.summary)}</p>`);
+    }
+    return `  <li>${parts.join(" ")}</li>`;
+  });
+  return `<ul class="forme-index">\n${lis.join("\n")}\n</ul>`;
+}
+
+function identity(s: string): string { return s; }
+
+// Re-export the grouping helper at module level so the public
+// barrel can pick it up.
+export { groupItems };

--- a/code/packages/typescript/forme-index-renderer/src/index.ts
+++ b/code/packages/typescript/forme-index-renderer/src/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @coding-adventures/forme-index-renderer
+ *
+ * Index / archive page renderer for the Forme pipeline (FM00 v0).
+ *
+ * Pure transform: `IndexItem[]` + `IndexOptions` → reproducible
+ * HTML `<ul>` (optionally grouped) suitable for blog archives.
+ * Pairs with `forme-aot-page-emitter` (the emitter writes the
+ * `.html` wrapper, this renderer fills the body).
+ *
+ * ```ts
+ * import { renderIndexPage } from "@coding-adventures/forme-index-renderer";
+ *
+ * const html = renderIndexPage(items, {
+ *   groupBy: "year",
+ *   sortBy: "pubDate-desc",
+ *   showDate: true,
+ *   showSummary: true,
+ *   dateFormat: (iso) => new Date(iso).toLocaleDateString("en-US"),
+ * });
+ * ```
+ *
+ * @module index
+ */
+
+export { renderIndexPage } from "./index-renderer.js";
+export { groupItems } from "./group.js";
+export { sortItems } from "./sort.js";
+export { escapeHtmlAttr, escapeHtmlText, assertItemUrl } from "./escape.js";
+export type { IndexItem, IndexOptions, ItemGroup } from "./types.js";

--- a/code/packages/typescript/forme-index-renderer/src/sort.ts
+++ b/code/packages/typescript/forme-index-renderer/src/sort.ts
@@ -1,0 +1,78 @@
+/**
+ * sort.ts — deterministic comparators for IndexItem arrays.
+ *
+ * All comparators break ties with `id` ascending so reordered-but-
+ * equivalent inputs produce byte-identical output (FM03
+ * reproducibility).
+ *
+ * @module sort
+ */
+
+import type { IndexItem, IndexOptions } from "./types.js";
+
+/** Return a sorted COPY of items per `sortBy`. */
+export function sortItems(
+  items: readonly IndexItem[],
+  sortBy: NonNullable<IndexOptions["sortBy"]>,
+): readonly IndexItem[] {
+  const copy = [...items];
+  switch (sortBy) {
+    case "pubDate-desc":
+      copy.sort(combine(byPubDateDesc, byIdAsc));
+      break;
+    case "pubDate-asc":
+      copy.sort(combine(byPubDateAsc, byIdAsc));
+      break;
+    case "title-asc":
+      copy.sort(combine(byTitleAsc, byIdAsc));
+      break;
+  }
+  return copy;
+}
+
+// ─── Comparators ─────────────────────────────────────────────────────────
+
+type Cmp = (a: IndexItem, b: IndexItem) => number;
+
+function combine(primary: Cmp, secondary: Cmp): Cmp {
+  return (a, b) => {
+    const r = primary(a, b);
+    return r === 0 ? secondary(a, b) : r;
+  };
+}
+
+function byIdAsc(a: IndexItem, b: IndexItem): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * pubDate-desc: newer first.  Items without pubDate sort to the END.
+ * Items with malformed pubDate (Date.parse → NaN) also sort to the END.
+ */
+function byPubDateDesc(a: IndexItem, b: IndexItem): number {
+  const ta = parseDate(a.pubDate);
+  const tb = parseDate(b.pubDate);
+  if (ta === null && tb === null) return 0;
+  if (ta === null) return 1;   // a goes after b
+  if (tb === null) return -1;
+  return tb - ta;              // descending
+}
+
+function byPubDateAsc(a: IndexItem, b: IndexItem): number {
+  const ta = parseDate(a.pubDate);
+  const tb = parseDate(b.pubDate);
+  if (ta === null && tb === null) return 0;
+  if (ta === null) return 1;   // a goes after b
+  if (tb === null) return -1;
+  return ta - tb;
+}
+
+function byTitleAsc(a: IndexItem, b: IndexItem): number {
+  return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
+}
+
+function parseDate(iso: string | undefined): number | null {
+  if (iso === undefined) return null;
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? t : null;
+}

--- a/code/packages/typescript/forme-index-renderer/src/types.ts
+++ b/code/packages/typescript/forme-index-renderer/src/types.ts
@@ -1,0 +1,59 @@
+/**
+ * types.ts — public types for the index renderer.
+ *
+ * @module types
+ */
+
+/** A single item in an index/archive list. */
+export interface IndexItem {
+  /** Stable identifier — used as the secondary sort key (tiebreaker)
+   *  to ensure deterministic ordering when primary sort keys tie. */
+  readonly id: string;
+  /** Display title. */
+  readonly title: string;
+  /** Link target.  Absolute http(s) or root-relative `/path`. */
+  readonly url: string;
+  /** ISO-8601 datetime.  Used by `pubDate-*` sorts and `year`/`month`
+   *  grouping.  Items without a pubDate sort to the END of the list
+   *  in pubDate-desc, and to the START in pubDate-asc. */
+  readonly pubDate?: string;
+  /** Optional one-line summary shown under the title when
+   *  `options.showSummary === true`. */
+  readonly summary?: string;
+  /** Category name — used by `groupBy: "category"`.  Items with no
+   *  category land in a synthetic `"Uncategorized"` bucket. */
+  readonly category?: string;
+  /** Tags — currently exposed in the IndexItem type for forward
+   *  compatibility, but the v0 renderer doesn't display them. */
+  readonly tags?: readonly string[];
+}
+
+/** Options controlling render layout. */
+export interface IndexOptions {
+  /**
+   * How to partition items into sections.  Defaults to `"none"`
+   * (flat `<ul>` with no headings).
+   */
+  readonly groupBy?: "none" | "category" | "year" | "month";
+  /**
+   * Sort order.  Defaults to `"pubDate-desc"` (newest first).
+   * Stable: ties broken by `id` ascending.
+   */
+  readonly sortBy?: "pubDate-desc" | "pubDate-asc" | "title-asc";
+  /** Show item.summary under each title.  Default `false`. */
+  readonly showSummary?: boolean;
+  /** Show item.pubDate inline.  Default `false`. */
+  readonly showDate?: boolean;
+  /**
+   * Format function for dates when `showDate === true`.
+   * Default: ISO-8601 string passed through unchanged.
+   */
+  readonly dateFormat?: (iso: string) => string;
+}
+
+/** Result of `groupItems()` — exposed for callers that want the
+ *  grouping logic without the HTML rendering. */
+export interface ItemGroup {
+  readonly heading: string;
+  readonly items: readonly IndexItem[];
+}

--- a/code/packages/typescript/forme-index-renderer/tests/escape.test.ts
+++ b/code/packages/typescript/forme-index-renderer/tests/escape.test.ts
@@ -1,0 +1,74 @@
+/**
+ * escape.test.ts — HTML escape + URL validation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { escapeHtmlAttr, escapeHtmlText, assertItemUrl } from "../src/index.js";
+
+describe("escapeHtmlAttr", () => {
+  it("escapes the five HTML entities", () => {
+    expect(escapeHtmlAttr(`<a href="x">'AT&T'</a>`))
+      .toBe(`&lt;a href=&quot;x&quot;&gt;&#39;AT&amp;T&#39;&lt;/a&gt;`);
+  });
+
+  it("strips ASCII control bytes", () => {
+    expect(escapeHtmlAttr("Hello\x00\x1fWorld")).toBe("HelloWorld");
+  });
+
+  it("passes through Unicode unchanged", () => {
+    expect(escapeHtmlAttr("café — résumé")).toBe("café — résumé");
+  });
+
+  it("escapeHtmlText is an alias", () => {
+    expect(escapeHtmlText("<a>")).toBe("&lt;a&gt;");
+  });
+});
+
+describe("assertItemUrl", () => {
+  it("accepts absolute http(s)", () => {
+    expect(() => assertItemUrl("https://example.com/x")).not.toThrow();
+    expect(() => assertItemUrl("http://example.com/x")).not.toThrow();
+  });
+
+  it("accepts root-relative /path", () => {
+    expect(() => assertItemUrl("/about")).not.toThrow();
+    expect(() => assertItemUrl("/blog/post.html")).not.toThrow();
+  });
+
+  it("accepts bare root /", () => {
+    expect(() => assertItemUrl("/")).not.toThrow();
+  });
+
+  it("rejects javascript: URL", () => {
+    expect(() => assertItemUrl("javascript:alert(1)"))
+      .toThrow(/absolute http\(s\) or root-relative/);
+  });
+
+  it("rejects data: URL", () => {
+    expect(() => assertItemUrl("data:text/html,<script>alert(1)</script>"))
+      .toThrow(/absolute http\(s\) or root-relative/);
+  });
+
+  it("rejects file: URL", () => {
+    expect(() => assertItemUrl("file:///etc/passwd"))
+      .toThrow(/absolute http\(s\) or root-relative/);
+  });
+
+  it("rejects protocol-relative //host", () => {
+    expect(() => assertItemUrl("//example.com/x"))
+      .toThrow(/absolute http\(s\) or root-relative/);
+  });
+
+  it("rejects bare relative path", () => {
+    expect(() => assertItemUrl("about"))
+      .toThrow(/absolute http\(s\) or root-relative/);
+    expect(() => assertItemUrl("./about"))
+      .toThrow(/absolute http\(s\) or root-relative/);
+  });
+
+  it("rejects empty / non-string", () => {
+    expect(() => assertItemUrl("")).toThrow(/non-empty string/);
+    expect(() => assertItemUrl(null)).toThrow(/non-empty string/);
+    expect(() => assertItemUrl(42)).toThrow(/non-empty string/);
+  });
+});

--- a/code/packages/typescript/forme-index-renderer/tests/group.test.ts
+++ b/code/packages/typescript/forme-index-renderer/tests/group.test.ts
@@ -1,0 +1,105 @@
+/**
+ * group.test.ts — grouping by category / year / month.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupItems, type IndexItem } from "../src/index.js";
+
+const ITEMS: IndexItem[] = [
+  { id: "1", title: "T1", url: "/1", pubDate: "2026-01-15T00:00:00Z", category: "Code" },
+  { id: "2", title: "T2", url: "/2", pubDate: "2026-02-20T00:00:00Z", category: "Life" },
+  { id: "3", title: "T3", url: "/3", pubDate: "2025-12-01T00:00:00Z", category: "Code" },
+  { id: "4", title: "T4", url: "/4" }, // no pubDate, no category
+];
+
+describe("groupItems — none", () => {
+  it("returns a single group with empty heading", () => {
+    const groups = groupItems(ITEMS, "none");
+    expect(groups.length).toBe(1);
+    expect(groups[0]!.heading).toBe("");
+    expect(groups[0]!.items.length).toBe(ITEMS.length);
+  });
+});
+
+describe("groupItems — category", () => {
+  it("buckets by category", () => {
+    const groups = groupItems(ITEMS, "category");
+    const code = groups.find((g) => g.heading === "Code");
+    const life = groups.find((g) => g.heading === "Life");
+    expect(code?.items.map((i) => i.id).sort()).toEqual(["1", "3"]);
+    expect(life?.items.map((i) => i.id)).toEqual(["2"]);
+  });
+
+  it("items without a category land in `Uncategorized`", () => {
+    const groups = groupItems(ITEMS, "category");
+    const u = groups.find((g) => g.heading === "Uncategorized");
+    expect(u?.items.map((i) => i.id)).toEqual(["4"]);
+  });
+
+  it("category groups are alphabetical with Uncategorized last", () => {
+    const headings = groupItems(ITEMS, "category").map((g) => g.heading);
+    expect(headings).toEqual(["Code", "Life", "Uncategorized"]);
+  });
+});
+
+describe("groupItems — year", () => {
+  it("buckets by 4-digit UTC year", () => {
+    const groups = groupItems(ITEMS, "year");
+    expect(groups.find((g) => g.heading === "2026")?.items.map((i) => i.id).sort()).toEqual(["1", "2"]);
+    expect(groups.find((g) => g.heading === "2025")?.items.map((i) => i.id)).toEqual(["3"]);
+  });
+
+  it("undated items land in Undated", () => {
+    const groups = groupItems(ITEMS, "year");
+    const u = groups.find((g) => g.heading === "Undated");
+    expect(u?.items.map((i) => i.id)).toEqual(["4"]);
+  });
+
+  it("year groups are reverse-chronological with Undated last", () => {
+    const headings = groupItems(ITEMS, "year").map((g) => g.heading);
+    expect(headings).toEqual(["2026", "2025", "Undated"]);
+  });
+
+  it("malformed pubDate → Undated", () => {
+    const bad: IndexItem[] = [{ id: "x", title: "X", url: "/x", pubDate: "trash" }];
+    const groups = groupItems(bad, "year");
+    expect(groups[0]!.heading).toBe("Undated");
+  });
+});
+
+describe("groupItems — month", () => {
+  it("buckets by YYYY-MM", () => {
+    const groups = groupItems(ITEMS, "month");
+    expect(groups.find((g) => g.heading === "2026-01")?.items.map((i) => i.id)).toEqual(["1"]);
+    expect(groups.find((g) => g.heading === "2026-02")?.items.map((i) => i.id)).toEqual(["2"]);
+    expect(groups.find((g) => g.heading === "2025-12")?.items.map((i) => i.id)).toEqual(["3"]);
+  });
+
+  it("month groups are reverse-chronological with Undated last", () => {
+    const headings = groupItems(ITEMS, "month").map((g) => g.heading);
+    expect(headings).toEqual(["2026-02", "2026-01", "2025-12", "Undated"]);
+  });
+});
+
+describe("groupItems — preserves caller's item order within group", () => {
+  it("two items in the same bucket keep input order", () => {
+    const sameMonth: IndexItem[] = [
+      { id: "c", title: "C", url: "/c", pubDate: "2026-01-15T00:00:00Z" },
+      { id: "a", title: "A", url: "/a", pubDate: "2026-01-10T00:00:00Z" },
+      { id: "b", title: "B", url: "/b", pubDate: "2026-01-20T00:00:00Z" },
+    ];
+    // groupItems doesn't sort within groups — preserves order.
+    const groups = groupItems(sameMonth, "month");
+    expect(groups[0]!.items.map((i) => i.id)).toEqual(["c", "a", "b"]);
+  });
+});
+
+describe("groupItems — empty input", () => {
+  it("none → one group, no items", () => {
+    expect(groupItems([], "none")).toEqual([{ heading: "", items: [] }]);
+  });
+
+  it("category → no groups", () => {
+    expect(groupItems([], "category")).toEqual([]);
+  });
+});

--- a/code/packages/typescript/forme-index-renderer/tests/index-renderer.test.ts
+++ b/code/packages/typescript/forme-index-renderer/tests/index-renderer.test.ts
@@ -1,0 +1,202 @@
+/**
+ * index-renderer.test.ts — end-to-end renderIndexPage behaviour.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderIndexPage, type IndexItem } from "../src/index.js";
+
+const ITEMS: IndexItem[] = [
+  { id: "1", title: "First Post",  url: "/posts/first",  pubDate: "2026-01-15T00:00:00Z", category: "Code", summary: "Hello" },
+  { id: "2", title: "Second Post", url: "/posts/second", pubDate: "2026-02-20T00:00:00Z", category: "Life", summary: "World" },
+  { id: "3", title: "Third Post",  url: "/posts/third",  pubDate: "2025-12-01T00:00:00Z", category: "Code", summary: "!" },
+];
+
+describe("renderIndexPage — flat list (groupBy: none default)", () => {
+  it("renders <ul class=forme-index> with one <li> per item", () => {
+    const html = renderIndexPage(ITEMS);
+    expect(html.startsWith(`<ul class="forme-index">`)).toBe(true);
+    expect(html.endsWith(`</ul>`)).toBe(true);
+    const liCount = (html.match(/<li>/g) ?? []).length;
+    expect(liCount).toBe(3);
+  });
+
+  it("each <li> includes <a href=...>title</a>", () => {
+    const html = renderIndexPage(ITEMS);
+    expect(html).toContain(`<a href="/posts/first">First Post</a>`);
+    expect(html).toContain(`<a href="/posts/second">Second Post</a>`);
+  });
+
+  it("items sorted pubDate-desc by default (newest first)", () => {
+    const html = renderIndexPage(ITEMS);
+    const firstIdx  = html.indexOf("First Post");
+    const secondIdx = html.indexOf("Second Post");
+    const thirdIdx  = html.indexOf("Third Post");
+    // Second (newest) → First → Third.
+    expect(secondIdx).toBeLessThan(firstIdx);
+    expect(firstIdx).toBeLessThan(thirdIdx);
+  });
+
+  it("empty items → empty <ul>", () => {
+    expect(renderIndexPage([])).toBe(`<ul class="forme-index"></ul>`);
+  });
+});
+
+describe("renderIndexPage — sortBy modes", () => {
+  it("pubDate-asc reverses order", () => {
+    const html = renderIndexPage(ITEMS, { sortBy: "pubDate-asc" });
+    const a = html.indexOf("Third Post");
+    const b = html.indexOf("Second Post");
+    expect(a).toBeLessThan(b);
+  });
+
+  it("title-asc sorts alphabetically by title", () => {
+    const html = renderIndexPage(ITEMS, { sortBy: "title-asc" });
+    const f = html.indexOf("First Post");
+    const s = html.indexOf("Second Post");
+    const t = html.indexOf("Third Post");
+    expect(f).toBeLessThan(s);
+    expect(s).toBeLessThan(t);
+  });
+});
+
+describe("renderIndexPage — grouping", () => {
+  it("groupBy: category emits <section><h2>...</h2><ul>...</ul></section>", () => {
+    const html = renderIndexPage(ITEMS, { groupBy: "category" });
+    expect(html).toContain(`<section class="forme-index-group">`);
+    expect(html).toContain(`<h2>Code</h2>`);
+    expect(html).toContain(`<h2>Life</h2>`);
+  });
+
+  it("groupBy: year groups by 4-digit year", () => {
+    const html = renderIndexPage(ITEMS, { groupBy: "year" });
+    expect(html).toContain(`<h2>2026</h2>`);
+    expect(html).toContain(`<h2>2025</h2>`);
+  });
+
+  it("groupBy: month groups by YYYY-MM", () => {
+    const html = renderIndexPage(ITEMS, { groupBy: "month" });
+    expect(html).toContain(`<h2>2026-02</h2>`);
+    expect(html).toContain(`<h2>2026-01</h2>`);
+    expect(html).toContain(`<h2>2025-12</h2>`);
+  });
+});
+
+describe("renderIndexPage — display toggles", () => {
+  it("showDate emits <time datetime=iso>iso</time>", () => {
+    const html = renderIndexPage(ITEMS, { showDate: true });
+    expect(html).toContain(`<time datetime="2026-01-15T00:00:00Z">2026-01-15T00:00:00Z</time>`);
+  });
+
+  it("dateFormat callback rewrites the visible text but datetime attr stays raw ISO", () => {
+    const html = renderIndexPage([ITEMS[0]!], {
+      showDate: true,
+      dateFormat: (iso) => `pretty-${iso.slice(0, 10)}`,
+    });
+    expect(html).toContain(`<time datetime="2026-01-15T00:00:00Z">pretty-2026-01-15</time>`);
+  });
+
+  it("showSummary emits <p class=summary>...</p>", () => {
+    const html = renderIndexPage(ITEMS, { showSummary: true });
+    expect(html).toContain(`<p class="summary">Hello</p>`);
+  });
+
+  it("showSummary skips items with no summary (no empty <p>)", () => {
+    const noSummary: IndexItem[] = [
+      { id: "x", title: "X", url: "/x" },
+    ];
+    const html = renderIndexPage(noSummary, { showSummary: true });
+    expect(html).not.toContain(`<p class="summary"`);
+  });
+
+  it("showDate skips items with no pubDate (no empty <time>)", () => {
+    const noDate: IndexItem[] = [
+      { id: "x", title: "X", url: "/x" },
+    ];
+    const html = renderIndexPage(noDate, { showDate: true });
+    expect(html).not.toContain(`<time`);
+  });
+});
+
+describe("renderIndexPage — HTML escaping", () => {
+  it("escapes title", () => {
+    const evil: IndexItem[] = [
+      { id: "x", title: `<script>alert("xss")</script>`, url: "/x" },
+    ];
+    const html = renderIndexPage(evil);
+    expect(html).toContain(`&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;`);
+    expect(html).not.toContain(`<script>alert`);
+  });
+
+  it("escapes summary", () => {
+    const evil: IndexItem[] = [
+      { id: "x", title: "T", url: "/x", summary: `<img src=x onerror=alert(1)>` },
+    ];
+    const html = renderIndexPage(evil, { showSummary: true });
+    expect(html).toContain(`&lt;img src=x onerror=alert(1)&gt;`);
+  });
+
+  it("escapes URL when interpolated into href attribute", () => {
+    const evil: IndexItem[] = [
+      { id: "x", title: "T", url: `https://example.com/?a=1&b=2"` },
+    ];
+    const html = renderIndexPage(evil);
+    expect(html).toContain(`href="https://example.com/?a=1&amp;b=2&quot;"`);
+  });
+
+  it("escapes attacker-controlled category in <h2>", () => {
+    const evil: IndexItem[] = [
+      { id: "x", title: "T", url: "/x", category: `<script>alert(1)</script>` },
+    ];
+    const html = renderIndexPage(evil, { groupBy: "category" });
+    expect(html).toContain(`<h2>&lt;script&gt;alert(1)&lt;/script&gt;</h2>`);
+    expect(html).not.toContain(`<h2><script>`);
+  });
+});
+
+describe("renderIndexPage — URL validation", () => {
+  it("rejects javascript: in item.url", () => {
+    const evil: IndexItem[] = [
+      { id: "x", title: "T", url: "javascript:alert(1)" },
+    ];
+    expect(() => renderIndexPage(evil)).toThrow(/absolute http\(s\) or root-relative/);
+  });
+
+  it("rejects data: in item.url", () => {
+    const evil: IndexItem[] = [
+      { id: "x", title: "T", url: "data:text/html,<script>" },
+    ];
+    expect(() => renderIndexPage(evil)).toThrow(/absolute http\(s\) or root-relative/);
+  });
+
+  it("rejects protocol-relative //host", () => {
+    const evil: IndexItem[] = [
+      { id: "x", title: "T", url: "//example.com" },
+    ];
+    expect(() => renderIndexPage(evil)).toThrow(/absolute http\(s\) or root-relative/);
+  });
+
+  it("validates URLs BEFORE rendering (no partial output)", () => {
+    const mixed: IndexItem[] = [
+      { id: "good", title: "G", url: "/g" },
+      { id: "bad",  title: "B", url: "javascript:alert(1)" },
+    ];
+    try {
+      renderIndexPage(mixed);
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toMatch(/javascript:/);
+    }
+  });
+});
+
+describe("renderIndexPage — reproducibility", () => {
+  it("same input → byte-identical output", () => {
+    expect(renderIndexPage(ITEMS)).toBe(renderIndexPage(ITEMS));
+  });
+
+  it("reshuffled items → same output (deterministic sort + id tiebreaker)", () => {
+    const a = renderIndexPage(ITEMS);
+    const b = renderIndexPage([ITEMS[2]!, ITEMS[0]!, ITEMS[1]!]);
+    expect(a).toBe(b);
+  });
+});

--- a/code/packages/typescript/forme-index-renderer/tests/sort.test.ts
+++ b/code/packages/typescript/forme-index-renderer/tests/sort.test.ts
@@ -1,0 +1,88 @@
+/**
+ * sort.test.ts — comparators.
+ */
+
+import { describe, it, expect } from "vitest";
+import { sortItems, type IndexItem } from "../src/index.js";
+
+const items: IndexItem[] = [
+  { id: "b", title: "Bravo",  url: "/b", pubDate: "2026-01-02T00:00:00Z" },
+  { id: "a", title: "Alpha",  url: "/a", pubDate: "2026-01-03T00:00:00Z" },
+  { id: "c", title: "Charlie", url: "/c", pubDate: "2026-01-01T00:00:00Z" },
+  { id: "d", title: "Delta",  url: "/d" },  // no pubDate
+];
+
+describe("sortItems — pubDate-desc (default)", () => {
+  it("newest first", () => {
+    const out = sortItems(items, "pubDate-desc").map((i) => i.id);
+    expect(out).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("undated items sort to the end", () => {
+    const out = sortItems([items[3]!, items[0]!], "pubDate-desc").map((i) => i.id);
+    expect(out).toEqual(["b", "d"]);
+  });
+
+  it("ties broken by id ascending", () => {
+    const same: IndexItem[] = [
+      { id: "z", title: "Z", url: "/z", pubDate: "2026-01-01T00:00:00Z" },
+      { id: "a", title: "A", url: "/a", pubDate: "2026-01-01T00:00:00Z" },
+    ];
+    const out = sortItems(same, "pubDate-desc").map((i) => i.id);
+    expect(out).toEqual(["a", "z"]);
+  });
+});
+
+describe("sortItems — pubDate-asc", () => {
+  it("oldest first", () => {
+    const out = sortItems(items, "pubDate-asc").map((i) => i.id);
+    expect(out).toEqual(["c", "b", "a", "d"]);
+  });
+
+  it("undated items sort to the end", () => {
+    const out = sortItems([items[3]!, items[0]!], "pubDate-asc").map((i) => i.id);
+    expect(out).toEqual(["b", "d"]);
+  });
+});
+
+describe("sortItems — title-asc", () => {
+  it("alphabetical by title", () => {
+    const out = sortItems(items, "title-asc").map((i) => i.id);
+    expect(out).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("ties broken by id ascending", () => {
+    const same: IndexItem[] = [
+      { id: "z", title: "Same", url: "/z" },
+      { id: "a", title: "Same", url: "/a" },
+    ];
+    const out = sortItems(same, "title-asc").map((i) => i.id);
+    expect(out).toEqual(["a", "z"]);
+  });
+});
+
+describe("sortItems — returns a copy (input not mutated)", () => {
+  it("input array order is preserved after sort", () => {
+    const original = [...items];
+    sortItems(items, "pubDate-desc");
+    expect(items).toEqual(original);
+  });
+});
+
+describe("sortItems — malformed pubDate", () => {
+  it("malformed pubDate treated as undated (sorts to end)", () => {
+    const mixed: IndexItem[] = [
+      { id: "good", title: "G", url: "/g", pubDate: "2026-01-01T00:00:00Z" },
+      { id: "bad",  title: "B", url: "/b", pubDate: "not-a-date" },
+    ];
+    expect(sortItems(mixed, "pubDate-desc").map((i) => i.id)).toEqual(["good", "bad"]);
+  });
+
+  it("all malformed → ties broken by id", () => {
+    const all: IndexItem[] = [
+      { id: "z", title: "Z", url: "/z", pubDate: "garbage" },
+      { id: "a", title: "A", url: "/a", pubDate: "trash" },
+    ];
+    expect(sortItems(all, "pubDate-desc").map((i) => i.id)).toEqual(["a", "z"]);
+  });
+});

--- a/code/packages/typescript/forme-index-renderer/tsconfig.json
+++ b/code/packages/typescript/forme-index-renderer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-index-renderer/vitest.config.ts
+++ b/code/packages/typescript/forme-index-renderer/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Third FM00 v0 stage package — pure transform from `IndexItem[]` + `IndexOptions` to reproducible HTML `<ul>` (optionally grouped by category / year / month). Suitable for blog archives and index pages.

Pairs with [`forme-aot-page-emitter`](../forme-aot-page-emitter) (writes the surrounding `.html` wrapper) and complements [`forme-feeds`](../forme-feeds) / [`forme-opengraph`](../forme-opengraph) as the third FM00 v0 stage.

## API

```ts
import { renderIndexPage } from "@coding-adventures/forme-index-renderer";

const html = renderIndexPage(posts, {
  groupBy: "year",
  sortBy: "pubDate-desc",
  showDate: true,
  showSummary: true,
  dateFormat: (iso) => new Date(iso).toLocaleDateString("en-US"),
});
```

Also exports `groupItems` / `sortItems` sub-helpers for callers building custom navigation widgets, plus `escapeHtmlAttr` / `escapeHtmlText` / `assertItemUrl` for custom item renderers.

## Behaviour

- **sortBy**: `pubDate-desc` (default) / `pubDate-asc` / `title-asc`; undated items always last; ties broken by `id` ascending (reproducibility).
- **groupBy**: `none` (default) / `category` / `year` / `month`; Uncategorized / Undated buckets sorted last; within-group order preserved (sort happens before grouping).
- **URL validation runs BEFORE any HTML emission** — `javascript:`, `data:`, `file:`, protocol-relative `//host`, bare relative, empty and non-string all throw synchronously with no partial output.
- **HTML attribute escaping** covers all five entities (`& < > " '`) in a single-pass replacement (CodeQL-friendly); ASCII control bytes (`U+0000-U+001F`, `U+007F`) stripped first.
- **Attacker-controlled categories** land as escaped text in `<h2>` rather than executable HTML.

## Security

Three concerns explicitly addressed pre-push:
- HTML attribute injection — every interpolated string routes through `escapeHtmlAttr` / `escapeHtmlText`.
- URL scheme validation — `assertItemUrl` allowlists `http(s)://`, root-relative `/path`, bare `/`; everything else rejected.
- Attacker-controlled `<h2>` headings — pinned by `index-renderer.test.ts`.

Security review (general-purpose sub-agent): **no exploitable findings**.

## Capabilities

`[]` — pure transform.  No I/O, no network, no shell, no env.

## Tests

**60 tests across 4 files**, **100% line / 92.45% branch** coverage:

- `escape.test.ts` (13) — every entity, control-byte stripping, URL accept/reject matrix
- `sort.test.ts` (10) — every sort mode, undated-last, id tiebreaker, input-not-mutated, malformed pubDate
- `group.test.ts` (13) — every groupBy mode, sentinel buckets, deterministic order, within-group preservation
- `index-renderer.test.ts` (24) — end-to-end behaviour, sort dispatch, all groupings, display toggles, HTML escaping, URL validation, reproducibility

## v0 simplifications

- `tags` field declared on `IndexItem` for forward compat — v0 doesn't render them (would need taxonomy navigation).
- No pagination — render the full list; callers slice `items[]` themselves.
- No per-group sort override — grouping happens after sorting so all groups share `sortBy`.

## Spec adherence

Implements FM00 v0 index renderer.  No divergences.

## Test plan

- [x] All 60 tests pass locally
- [x] 100% line coverage / 92.45% branch
- [x] TypeScript build clean (`tsc --noEmit`)
- [x] Security review clean (HTML injection / URL scheme / attacker-controlled headings)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)