### PR TITLE
Expose HTML control continuation contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -78,6 +78,10 @@ documented in this file.
 - Parser/importer-facing seeded text-mode end-tag continuation contexts through
   `HtmlLexContext::end_tag_continuation`, plus exported text-mode and end-tag
   tokenizer state families used by wrapper-level fixture tests.
+- Exported comment and character-reference tokenizer state families, plus the
+  valid character-reference return states, so generated conformance runners and
+  parser/importer adapters use the same public continuation predicates as
+  `HtmlLexContext`.
 - A generated WHATWG tokenizer script escape boundary fixture and Rust
   conformance test that pins escaped and double-escaped script data, escape
   start/end delimiters, EOF diagnostics, NULL replacement, and seeded

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -87,6 +87,12 @@ The public wrapper exposes those parser-facing text-mode families through
 the lexer through `HtmlLexContext::end_tag_continuation` and
 `create_html_lexer_with_context`, matching the surface a parser or importer
 would use.
+The same public context surface now exposes comment and character-reference
+continuation families through `HTML_COMMENT_TOKENIZER_STATES`,
+`HTML_CHARACTER_REFERENCE_TOKENIZER_STATES`, and
+`HTML_CHARACTER_REFERENCE_RETURN_STATES`, and the generated boundary,
+input-stream, EOF, and markup-declaration fixtures build their seeded lexers
+through the typed `HtmlLexContext` constructors.
 The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -452,6 +452,35 @@ pub const HTML_DOCTYPE_TOKENIZER_STATES: [HtmlTokenizerState; 32] = [
     HtmlTokenizerState::BogusDoctype,
 ];
 
+/// Tokenizer states that resume an already-created comment token.
+pub const HTML_COMMENT_TOKENIZER_STATES: [HtmlTokenizerState; 11] = [
+    HtmlTokenizerState::CommentStart,
+    HtmlTokenizerState::CommentStartDash,
+    HtmlTokenizerState::Comment,
+    HtmlTokenizerState::CommentLessThanSign,
+    HtmlTokenizerState::CommentLessThanSignBang,
+    HtmlTokenizerState::CommentLessThanSignBangDash,
+    HtmlTokenizerState::CommentLessThanSignBangDashDash,
+    HtmlTokenizerState::CommentEndDash,
+    HtmlTokenizerState::CommentEnd,
+    HtmlTokenizerState::CommentEndBang,
+    HtmlTokenizerState::BogusComment,
+];
+
+/// Tokenizer states that resume an in-progress text/RCDATA character reference.
+pub const HTML_CHARACTER_REFERENCE_TOKENIZER_STATES: [HtmlTokenizerState; 6] = [
+    HtmlTokenizerState::TextCharacterReference,
+    HtmlTokenizerState::TextNamedCharacterReference,
+    HtmlTokenizerState::TextNumericCharacterReference,
+    HtmlTokenizerState::TextNumericHexCharacterReferenceStart,
+    HtmlTokenizerState::TextNumericHexCharacterReference,
+    HtmlTokenizerState::TextNumericDecimalCharacterReference,
+];
+
+/// Tokenizer states that can receive recovered text from a character reference.
+pub const HTML_CHARACTER_REFERENCE_RETURN_STATES: [HtmlTokenizerState; 2] =
+    [HtmlTokenizerState::Data, HtmlTokenizerState::Rcdata];
+
 /// Tokenizer states that resume an already-started text-mode end tag.
 pub const HTML_END_TAG_TOKENIZER_STATES: [HtmlTokenizerState; 16] = [
     HtmlTokenizerState::RcdataEndTagName,
@@ -768,15 +797,7 @@ impl HtmlTokenizerState {
 
     /// Return whether this state resumes an in-progress text character reference.
     pub fn requires_character_reference_seed(self) -> bool {
-        matches!(
-            self,
-            Self::TextCharacterReference
-                | Self::TextNamedCharacterReference
-                | Self::TextNumericCharacterReference
-                | Self::TextNumericHexCharacterReferenceStart
-                | Self::TextNumericHexCharacterReference
-                | Self::TextNumericDecimalCharacterReference
-        )
+        HTML_CHARACTER_REFERENCE_TOKENIZER_STATES.contains(&self)
     }
 
     /// Return whether this state resumes an already-started start tag.
@@ -786,7 +807,7 @@ impl HtmlTokenizerState {
 
     /// Return whether this state can receive recovered character-reference text.
     pub fn is_character_reference_return_state(self) -> bool {
-        matches!(self, Self::Data | Self::Rcdata)
+        HTML_CHARACTER_REFERENCE_RETURN_STATES.contains(&self)
     }
 
     /// Return whether this state is a parser-approved fragment entry point.
@@ -801,20 +822,7 @@ impl HtmlTokenizerState {
 
     /// Return whether this state resumes an already-started comment token.
     pub fn requires_comment_seed(self) -> bool {
-        matches!(
-            self,
-            Self::CommentStart
-                | Self::CommentStartDash
-                | Self::Comment
-                | Self::CommentLessThanSign
-                | Self::CommentLessThanSignBang
-                | Self::CommentLessThanSignBangDash
-                | Self::CommentLessThanSignBangDashDash
-                | Self::CommentEndDash
-                | Self::CommentEnd
-                | Self::CommentEndBang
-                | Self::BogusComment
-        )
+        HTML_COMMENT_TOKENIZER_STATES.contains(&self)
     }
 
     /// Return whether a seeded state needs the parser's last-start-tag context.

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -2,7 +2,8 @@ use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, create_html_lexer_with_context, html1_definition,
     html1_machine, html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment,
     Attribute, DoctypeSeed, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, StartTagSeed,
-    Token, HTML_DOCTYPE_TOKENIZER_STATES, HTML_END_TAG_TOKENIZER_STATES,
+    Token, HTML_CHARACTER_REFERENCE_RETURN_STATES, HTML_CHARACTER_REFERENCE_TOKENIZER_STATES,
+    HTML_COMMENT_TOKENIZER_STATES, HTML_DOCTYPE_TOKENIZER_STATES, HTML_END_TAG_TOKENIZER_STATES,
     HTML_FRAGMENT_TOKENIZER_STATES, HTML_SCRIPT_TOKENIZER_STATES, HTML_START_TAG_TOKENIZER_STATES,
     HTML_TEXT_MODE_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
 };
@@ -5299,6 +5300,37 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "after_doctype_system_identifier",
             "bogus_doctype",
         ]
+    );
+    assert_eq!(
+        HTML_COMMENT_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),
+        [
+            "comment_start",
+            "comment_start_dash",
+            "comment",
+            "comment_less_than_sign",
+            "comment_less_than_sign_bang",
+            "comment_less_than_sign_bang_dash",
+            "comment_less_than_sign_bang_dash_dash",
+            "comment_end_dash",
+            "comment_end",
+            "comment_end_bang",
+            "bogus_comment",
+        ]
+    );
+    assert_eq!(
+        HTML_CHARACTER_REFERENCE_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),
+        [
+            "text_character_reference",
+            "text_named_character_reference",
+            "text_numeric_character_reference",
+            "text_numeric_hex_character_reference_start",
+            "text_numeric_hex_character_reference",
+            "text_numeric_decimal_character_reference",
+        ]
+    );
+    assert_eq!(
+        HTML_CHARACTER_REFERENCE_RETURN_STATES.map(HtmlTokenizerState::as_machine_state),
+        ["data", "rcdata"]
     );
     assert_eq!(
         HTML_START_TAG_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),

--- a/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
@@ -1,6 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
 
@@ -100,11 +99,13 @@ fn configured_lexer(case: &CdataBoundaryCase) -> HtmlLexer {
         .as_deref()
         .and_then(HtmlTokenizerState::from_html5lib_state)
         .unwrap_or(HtmlTokenizerState::Data);
-    let context = HtmlLexContext::new(state);
+    let context = if state == HtmlTokenizerState::CdataSection {
+        HtmlLexContext::cdata_section()
+    } else {
+        HtmlLexContext::new(state)
+    };
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
@@ -1,6 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
 
@@ -110,22 +109,20 @@ fn configured_lexer(case: &CharacterReferenceBoundaryCase) -> HtmlLexer {
         .as_deref()
         .and_then(HtmlTokenizerState::from_html5lib_state)
         .unwrap_or(HtmlTokenizerState::Data);
-    let mut context = HtmlLexContext::new(state);
-    if let Some(return_state) = case.return_state.as_deref() {
+    let mut context = if let Some(return_state) = case.return_state.as_deref() {
         let return_state = HtmlTokenizerState::from_html5lib_state(return_state)
             .unwrap_or_else(|| panic!("case `{}` has unknown return state", case.id));
-        context = context.with_return_state(return_state);
-    }
-    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
-        context = context.with_temporary_buffer(temporary_buffer);
-    }
+        let temporary_buffer = case.temporary_buffer.as_deref().unwrap_or("");
+        HtmlLexContext::character_reference_continuation(state, return_state, temporary_buffer)
+            .unwrap_or_else(|| panic!("case `{}` cannot seed character reference state", case.id))
+    } else {
+        HtmlLexContext::new(state)
+    };
     if let Some(last_start_tag) = case.last_start_tag.as_deref() {
         context = context.with_last_start_tag(last_start_tag);
     }
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
@@ -1,6 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
 
@@ -102,14 +101,14 @@ fn configured_lexer(case: &CommentBoundaryCase) -> HtmlLexer {
         .as_deref()
         .and_then(HtmlTokenizerState::from_html5lib_state)
         .unwrap_or(HtmlTokenizerState::Data);
-    let mut context = HtmlLexContext::new(state);
-    if let Some(current_comment) = case.current_comment.as_deref() {
-        context = context.with_current_comment(current_comment);
-    }
+    let context = if let Some(current_comment) = case.current_comment.as_deref() {
+        HtmlLexContext::comment_continuation(state, current_comment)
+            .unwrap_or_else(|| panic!("case `{}` cannot seed comment state", case.id))
+    } else {
+        HtmlLexContext::new(state)
+    };
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
@@ -1,5 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    create_html_lexer_with_context, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
     HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
@@ -114,19 +114,22 @@ fn configured_lexer(case: &DoctypeBoundaryCase) -> HtmlLexer {
         .as_deref()
         .and_then(HtmlTokenizerState::from_html5lib_state)
         .unwrap_or(HtmlTokenizerState::Data);
-    let mut context = HtmlLexContext::new(state);
-    if let Some(current_doctype) = case.current_doctype.as_ref() {
-        context = context.with_current_doctype(DoctypeSeed {
-            name: current_doctype.name.clone(),
-            public_identifier: current_doctype.public_identifier.clone(),
-            system_identifier: current_doctype.system_identifier.clone(),
-            force_quirks: current_doctype.force_quirks,
-        });
-    }
+    let context = if let Some(current_doctype) = case.current_doctype.as_ref() {
+        HtmlLexContext::doctype_continuation(
+            state,
+            DoctypeSeed {
+                name: current_doctype.name.clone(),
+                public_identifier: current_doctype.public_identifier.clone(),
+                system_identifier: current_doctype.system_identifier.clone(),
+                force_quirks: current_doctype.force_quirks,
+            },
+        )
+        .unwrap_or_else(|| panic!("case `{}` cannot seed DOCTYPE state", case.id))
+    } else {
+        HtmlLexContext::new(state)
+    };
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
@@ -1,5 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    create_html_lexer_with_context, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
     HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
@@ -116,38 +116,58 @@ fn configured_lexer(case: &EofRecoveryCase) -> HtmlLexer {
         .as_deref()
         .and_then(HtmlTokenizerState::from_html5lib_state)
         .unwrap_or(HtmlTokenizerState::Data);
-    let mut context = HtmlLexContext::new(state);
-    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
-        context = context.with_last_start_tag(last_start_tag);
-    }
-    if let Some(current_end_tag) = case.current_end_tag.as_deref() {
-        context = context.with_current_end_tag(current_end_tag);
-    }
-    if let Some(current_comment) = case.current_comment.as_deref() {
-        context = context.with_current_comment(current_comment);
-    }
-    if let Some(current_doctype) = case.current_doctype.as_ref() {
-        context = context.with_current_doctype(DoctypeSeed {
-            name: current_doctype.name.clone(),
-            public_identifier: current_doctype.public_identifier.clone(),
-            system_identifier: current_doctype.system_identifier.clone(),
-            force_quirks: current_doctype.force_quirks,
-        });
-    }
-    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
-        context = context.with_temporary_buffer(temporary_buffer);
-    }
-    if let Some(return_state) = case
+    let mut context = if let Some(current_doctype) = case.current_doctype.as_ref() {
+        HtmlLexContext::doctype_continuation(state, doctype_seed(current_doctype))
+            .unwrap_or_else(|| panic!("case `{}` cannot seed DOCTYPE state", case.id))
+    } else if let Some(current_comment) = case.current_comment.as_deref() {
+        HtmlLexContext::comment_continuation(state, current_comment)
+            .unwrap_or_else(|| panic!("case `{}` cannot seed comment state", case.id))
+    } else if let Some(current_end_tag) = case.current_end_tag.as_deref() {
+        HtmlLexContext::end_tag_continuation(
+            state,
+            case.last_start_tag.as_deref().unwrap_or(""),
+            current_end_tag,
+            case.temporary_buffer.as_deref().unwrap_or(""),
+        )
+        .unwrap_or_else(|| panic!("case `{}` cannot seed end-tag state", case.id))
+    } else if let Some(return_state) = case
         .return_state
         .as_deref()
         .and_then(HtmlTokenizerState::from_html5lib_state)
     {
-        context = context.with_return_state(return_state);
+        HtmlLexContext::character_reference_continuation(
+            state,
+            return_state,
+            case.temporary_buffer.as_deref().unwrap_or(""),
+        )
+        .unwrap_or_else(|| panic!("case `{}` cannot seed character reference state", case.id))
+    } else if state.is_script_substate() {
+        HtmlLexContext::script_substate(state)
+            .unwrap_or_else(|| panic!("case `{}` cannot seed script substate", case.id))
+    } else {
+        HtmlLexContext::new(state)
+    };
+    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
+        if context.last_start_tag.is_none() {
+            context = context.with_last_start_tag(last_start_tag);
+        }
+    }
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        if context.temporary_buffer.is_none() {
+            context = context.with_temporary_buffer(temporary_buffer);
+        }
     }
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
+}
+
+fn doctype_seed(seed: &FixtureDoctypeSeed) -> DoctypeSeed {
+    DoctypeSeed {
+        name: seed.name.clone(),
+        public_identifier: seed.public_identifier.clone(),
+        system_identifier: seed.system_identifier.clone(),
+        force_quirks: seed.force_quirks,
+    }
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/whatwg_input_stream_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_input_stream_test.rs
@@ -1,6 +1,6 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, DoctypeSeed, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, SourcePosition, Token,
+    create_html_lexer_with_context, DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
+    SourcePosition, Token,
 };
 use serde::Deserialize;
 
@@ -71,16 +71,14 @@ struct Lexed {
 fn whatwg_input_stream_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(
-        suite.format,
-        "whatwg-html-input-stream-preprocessing/v1"
-    );
+    assert_eq!(suite.format, "whatwg-html-input-stream-preprocessing/v1");
     assert_eq!(suite.newline_forms.len(), 4);
     assert_eq!(suite.cases.len(), 92);
     assert_eq!(suite.position_cases.len(), 16);
-    assert!(suite.newline_forms.iter().any(|form| {
-        form.id == "crlf" && form.source == "\r\n" && form.normalized == "\n"
-    }));
+    assert!(suite
+        .newline_forms
+        .iter()
+        .any(|form| { form.id == "crlf" && form.source == "\r\n" && form.normalized == "\n" }));
     assert!(suite.newline_forms.iter().any(|form| {
         form.id == "mixed" && form.source == "\r\n\r\n\r" && form.normalized == "\n\n\n"
     }));
@@ -115,7 +113,9 @@ fn whatwg_input_stream_newline_positions_are_stable_across_chunks() {
                 (position.line, position.column),
                 (case.expected_line, case.expected_column),
                 "case `{}` chunks {:?} should report {:?} at normalized line/column",
-                case.id, chunks, case.diagnostic
+                case.id,
+                chunks,
+                case.diagnostic
             );
         }
     }
@@ -178,25 +178,33 @@ fn configured_lexer(
     let state = initial_state
         .and_then(HtmlTokenizerState::from_html5lib_state)
         .unwrap_or(HtmlTokenizerState::Data);
-    let mut context = HtmlLexContext::new(state);
+    let mut context = if let Some(current_doctype) = current_doctype {
+        HtmlLexContext::doctype_continuation(state, doctype_seed(current_doctype))
+            .expect("HTML lexer DOCTYPE context should apply")
+    } else if let Some(current_comment) = current_comment {
+        HtmlLexContext::comment_continuation(state, current_comment)
+            .expect("HTML lexer comment context should apply")
+    } else if state.is_script_substate() {
+        HtmlLexContext::script_substate(state).expect("HTML lexer script context should apply")
+    } else {
+        HtmlLexContext::new(state)
+    };
     if let Some(last_start_tag) = last_start_tag {
-        context = context.with_last_start_tag(last_start_tag);
-    }
-    if let Some(current_comment) = current_comment {
-        context = context.with_current_comment(current_comment);
-    }
-    if let Some(current_doctype) = current_doctype {
-        context = context.with_current_doctype(DoctypeSeed {
-            name: current_doctype.name.clone(),
-            public_identifier: current_doctype.public_identifier.clone(),
-            system_identifier: current_doctype.system_identifier.clone(),
-            force_quirks: current_doctype.force_quirks,
-        });
+        if context.last_start_tag.is_none() {
+            context = context.with_last_start_tag(last_start_tag);
+        }
     }
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
+}
+
+fn doctype_seed(seed: &FixtureDoctypeSeed) -> DoctypeSeed {
+    DoctypeSeed {
+        name: seed.name.clone(),
+        public_identifier: seed.public_identifier.clone(),
+        system_identifier: seed.system_identifier.clone(),
+        force_quirks: seed.force_quirks,
+    }
 }
 
 fn chunkings(source: &str) -> Vec<Vec<&str>> {

--- a/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
@@ -1,5 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
+    create_html_lexer_with_context, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
     HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
@@ -124,38 +124,58 @@ fn configured_lexer(case: &MarkupDeclarationCase) -> HtmlLexer {
         .as_deref()
         .and_then(HtmlTokenizerState::from_html5lib_state)
         .unwrap_or(HtmlTokenizerState::Data);
-    let mut context = HtmlLexContext::new(state);
-    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
-        context = context.with_last_start_tag(last_start_tag);
-    }
-    if let Some(current_end_tag) = case.current_end_tag.as_deref() {
-        context = context.with_current_end_tag(current_end_tag);
-    }
-    if let Some(current_comment) = case.current_comment.as_deref() {
-        context = context.with_current_comment(current_comment);
-    }
-    if let Some(current_doctype) = case.current_doctype.as_ref() {
-        context = context.with_current_doctype(DoctypeSeed {
-            name: current_doctype.name.clone(),
-            public_identifier: current_doctype.public_identifier.clone(),
-            system_identifier: current_doctype.system_identifier.clone(),
-            force_quirks: current_doctype.force_quirks,
-        });
-    }
-    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
-        context = context.with_temporary_buffer(temporary_buffer);
-    }
-    if let Some(return_state) = case
+    let mut context = if let Some(current_doctype) = case.current_doctype.as_ref() {
+        HtmlLexContext::doctype_continuation(state, doctype_seed(current_doctype))
+            .unwrap_or_else(|| panic!("case `{}` cannot seed DOCTYPE state", case.id))
+    } else if let Some(current_comment) = case.current_comment.as_deref() {
+        HtmlLexContext::comment_continuation(state, current_comment)
+            .unwrap_or_else(|| panic!("case `{}` cannot seed comment state", case.id))
+    } else if let Some(current_end_tag) = case.current_end_tag.as_deref() {
+        HtmlLexContext::end_tag_continuation(
+            state,
+            case.last_start_tag.as_deref().unwrap_or(""),
+            current_end_tag,
+            case.temporary_buffer.as_deref().unwrap_or(""),
+        )
+        .unwrap_or_else(|| panic!("case `{}` cannot seed end-tag state", case.id))
+    } else if let Some(return_state) = case
         .return_state
         .as_deref()
         .and_then(HtmlTokenizerState::from_html5lib_state)
     {
-        context = context.with_return_state(return_state);
+        HtmlLexContext::character_reference_continuation(
+            state,
+            return_state,
+            case.temporary_buffer.as_deref().unwrap_or(""),
+        )
+        .unwrap_or_else(|| panic!("case `{}` cannot seed character reference state", case.id))
+    } else if state.is_script_substate() {
+        HtmlLexContext::script_substate(state)
+            .unwrap_or_else(|| panic!("case `{}` cannot seed script substate", case.id))
+    } else {
+        HtmlLexContext::new(state)
+    };
+    if let Some(last_start_tag) = case.last_start_tag.as_deref() {
+        if context.last_start_tag.is_none() {
+            context = context.with_last_start_tag(last_start_tag);
+        }
+    }
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        if context.temporary_buffer.is_none() {
+            context = context.with_temporary_buffer(temporary_buffer);
+        }
     }
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
+}
+
+fn doctype_seed(seed: &FixtureDoctypeSeed) -> DoctypeSeed {
+    DoctypeSeed {
+        name: seed.name.clone(),
+        public_identifier: seed.public_identifier.clone(),
+        system_identifier: seed.system_identifier.clone(),
+        force_quirks: seed.force_quirks,
+    }
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
@@ -1,6 +1,5 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, Attribute, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
 
@@ -103,14 +102,16 @@ fn load_suite() -> ScriptEscapeBoundarySuite {
 fn configured_lexer(case: &ScriptEscapeBoundaryCase) -> HtmlLexer {
     let state = HtmlTokenizerState::from_html5lib_state(&case.initial_state)
         .unwrap_or_else(|| panic!("case `{}` has unknown initial state", case.id));
-    let mut context = HtmlLexContext::new(state).with_last_start_tag(&case.last_start_tag);
+    let mut context = HtmlLexContext::script_substate(state)
+        .unwrap_or_else(|| panic!("case `{}` cannot seed script substate", case.id));
+    if context.last_start_tag.as_deref() != Some(case.last_start_tag.as_str()) {
+        context = context.with_last_start_tag(&case.last_start_tag);
+    }
     if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
         context = context.with_temporary_buffer(temporary_buffer);
     }
 
-    let mut lexer = create_html_lexer().expect("HTML lexer should build");
-    apply_html_lex_context(&mut lexer, &context).expect("HTML lexer context should apply");
-    lexer
+    create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
 }
 
 fn token_summary(token: Token) -> String {


### PR DESCRIPTION
## Summary
- export comment and character-reference tokenizer state families, plus valid character-reference return states
- route generated control-context fixtures through typed HtmlLexContext constructors and create_html_lexer_with_context
- document the public parser/importer continuation surface

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- rustfmt --check code/packages/rust/html-lexer/src/lib.rs code/packages/rust/html-lexer/tests/html_lexer_test.rs code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs code/packages/rust/html-lexer/tests/whatwg_input_stream_test.rs code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
- git diff --check