### PR TITLE
spice: add PSS period estimation

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **PSS source-period estimation** — `waveform_period` reports periodic `SIN`
+  and `PULSE` source periods, and `estimate_period` derives a harmonic common
+  period across independent source waveforms as a foothold for shooting-Newton
+  periodic steady-state analysis.
+
 - **Multi-corner transfer-function analysis** — `tf_corners` runs the same
   `.TF` query at each named corner and returns per-corner gain and impedance
   values.

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -23,6 +23,7 @@ from spice_engine.elements import (
     VoltageSource,
     Waveform,
     XInstance,
+    waveform_period,
 )
 from spice_engine.engine import (
     AcPoint,
@@ -59,6 +60,7 @@ from spice_engine.engine import (
     dc_corners,
     dc_sweep,
     dc_sweep_corners,
+    estimate_period,
     mc_dc,
     noise_ac,
     sens_dc,
@@ -128,6 +130,7 @@ __all__ = [
     "dc_corners",
     "dc_sweep",
     "dc_sweep_corners",
+    "estimate_period",
     "mc_dc",
     "noise_ac",
     "sens_dc",
@@ -135,4 +138,5 @@ __all__ = [
     "tf",
     "tf_corners",
     "transient",
+    "waveform_period",
 ]

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -234,6 +234,22 @@ class ExpWaveform:
 Waveform = PwlWaveform | SinWaveform | PulseWaveform | ExpWaveform
 
 
+def waveform_period(waveform: Waveform) -> float | None:
+    """Return the waveform's repeat period in seconds, when it is periodic."""
+    if isinstance(waveform, SinWaveform):
+        if (
+            math.isfinite(waveform.frequency)
+            and waveform.frequency > 0.0
+            and waveform.damping == 0.0
+        ):
+            return 1.0 / waveform.frequency
+        return None
+    if isinstance(waveform, PulseWaveform):
+        if math.isfinite(waveform.period) and waveform.period > 0.0:
+            return waveform.period
+    return None
+
+
 @dataclass(frozen=True, slots=True)
 class AcSource:
     """Small-signal AC source specification.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -73,6 +73,7 @@ from spice_engine.elements import (
     SubcircuitDefinition,
     VoltageSource,
     XInstance,
+    waveform_period,
 )
 
 
@@ -101,6 +102,42 @@ class Circuit:
 
     def instantiate(self, instance: XInstance) -> None:
         self.elements.extend(_expand_xinstance(instance, self.subcircuits, ()))
+
+
+def _is_integer_multiple(candidate: float, period: float, tolerance: float) -> bool:
+    ratio = candidate / period
+    nearest = round(ratio)
+    return nearest >= 1 and math.isclose(
+        ratio, nearest, rel_tol=tolerance, abs_tol=tolerance
+    )
+
+
+def estimate_period(circuit: Circuit, *, tolerance: float = 1.0e-9) -> float | None:
+    """Estimate a PSS source period from periodic independent-source waveforms.
+
+    Static independent sources do not constrain the period.  If any time-varying
+    independent source is non-periodic, or if periodic source periods are not
+    harmonic multiples of a common candidate, no reliable period is reported.
+    """
+    periods: list[float] = []
+    for element in circuit.elements:
+        if (
+            isinstance(element, (VoltageSource, CurrentSource))
+            and element.waveform is not None
+        ):
+            period = waveform_period(element.waveform)
+            if period is None:
+                return None
+            periods.append(period)
+    if not periods:
+        return None
+
+    candidate = max(periods)
+    if not math.isfinite(candidate) or candidate <= 0.0:
+        return None
+    if all(_is_integer_multiple(candidate, period, tolerance) for period in periods):
+        return candidate
+    return None
 
 
 def _expand_xinstance(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -124,6 +124,7 @@ from spice_engine import (
     dc_op,
     dc_sweep,
     dc_sweep_corners,
+    estimate_period,
     mc_dc,
     noise_ac,
     sens_dc,
@@ -131,6 +132,7 @@ from spice_engine import (
     tf,
     tf_corners,
     transient,
+    waveform_period,
 )
 from spice_engine.engine import (
     _build_ss_matrix,
@@ -145,6 +147,58 @@ from spice_engine.engine import (
     _voltage_sources,
     _x_from_result,
 )
+
+
+def test_waveform_period_reports_periodic_source_forms() -> None:
+    assert waveform_period(SinWaveform(frequency=2.0)) == pytest.approx(0.5)
+    assert waveform_period(SinWaveform(frequency=2.0, damping=1.0)) is None
+    assert waveform_period(SinWaveform(frequency=0.0)) is None
+    assert waveform_period(PulseWaveform(period=2.5)) == pytest.approx(2.5)
+    assert waveform_period(PwlWaveform(((0.0, 0.0), (1.0, 1.0)))) is None
+    assert waveform_period(ExpWaveform()) is None
+
+
+def test_estimate_period_finds_harmonic_periodic_source_period() -> None:
+    c = Circuit()
+    c.add(
+        VoltageSource("V1", "in", "0", 0.0, waveform=SinWaveform(frequency=1_000.0))
+    )
+    c.add(
+        CurrentSource(
+            "I1",
+            "out",
+            "0",
+            0.0,
+            waveform=PulseWaveform(
+                v_initial=0.0, v_pulsed=1.0e-3, pulse_width=0.25e-3, period=0.5e-3
+            ),
+        )
+    )
+    c.add(Resistor("R1", "in", "out", 1_000.0))
+
+    assert estimate_period(c) == pytest.approx(1.0e-3)
+
+
+def test_estimate_period_rejects_nonperiodic_or_incommensurate_sources() -> None:
+    non_periodic = Circuit()
+    non_periodic.add(VoltageSource(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        waveform=PwlWaveform(((0.0, 0.0), (1.0e-3, 1.0))),
+    ))
+    assert estimate_period(non_periodic) is None
+
+    incommensurate = Circuit()
+    incommensurate.add(
+        VoltageSource("V1", "in", "0", 0.0, waveform=PulseWaveform(period=1.0e-3))
+    )
+    incommensurate.add(
+        CurrentSource("I1", "out", "0", 0.0, waveform=PulseWaveform(period=0.7e-3))
+    )
+    assert estimate_period(incommensurate) is None
+
 
 # ---- Linear solver ----
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add PSS source-period estimation with `Waveform::period_seconds`,
+  `estimate_period`, and `estimate_period_with_tolerance` for deriving a
+  harmonic common independent-source period.
 - Add multi-corner transfer-function analysis with `tf_corners`, returning the
   same `.TF` query evaluated under each named corner.
 - Add multi-corner AC frequency sweeps with `ac_sweep_corners`, returning the

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -353,6 +353,24 @@ impl Waveform {
         }
     }
 
+    pub fn period_seconds(&self) -> Option<f64> {
+        match self {
+            Self::Sin(waveform)
+                if waveform.frequency_hz.is_finite()
+                    && waveform.frequency_hz > 0.0
+                    && waveform.damping == 0.0 =>
+            {
+                Some(1.0 / waveform.frequency_hz)
+            }
+            Self::Pulse(waveform)
+                if waveform.period_seconds.is_finite() && waveform.period_seconds > 0.0 =>
+            {
+                Some(waveform.period_seconds)
+            }
+            _ => None,
+        }
+    }
+
     fn validate(&self) -> Result<(), String> {
         match self {
             Self::Pwl(waveform) => waveform.validate(),
@@ -651,6 +669,43 @@ pub enum Element {
     Vcvs(Vcvs),
     Cccs(Cccs),
     Ccvs(Ccvs),
+}
+
+fn is_integer_multiple(candidate: f64, period: f64, tolerance: f64) -> bool {
+    let ratio = candidate / period;
+    let nearest = ratio.round();
+    nearest >= 1.0 && (ratio - nearest).abs() <= tolerance * ratio.abs().max(1.0)
+}
+
+pub fn estimate_period(circuit: &Circuit) -> Option<f64> {
+    estimate_period_with_tolerance(circuit, 1.0e-9)
+}
+
+pub fn estimate_period_with_tolerance(circuit: &Circuit, tolerance: f64) -> Option<f64> {
+    let mut periods = Vec::new();
+    for element in circuit.elements() {
+        let waveform = match element {
+            Element::VoltageSource(source) => source.waveform.as_ref(),
+            Element::CurrentSource(source) => source.waveform.as_ref(),
+            _ => None,
+        };
+        if let Some(waveform) = waveform {
+            let period = waveform.period_seconds()?;
+            periods.push(period);
+        }
+    }
+    if periods.is_empty() {
+        return None;
+    }
+
+    let candidate = periods.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    if !candidate.is_finite() || candidate <= 0.0 {
+        return None;
+    }
+    periods
+        .iter()
+        .all(|period| is_integer_multiple(candidate, *period, tolerance))
+        .then_some(candidate)
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1,6 +1,7 @@
 use spice_engine::{
-    transient, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element, ExpWaveform, Inductor,
-    PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, VoltageSource, Waveform,
+    estimate_period, transient, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element,
+    ExpWaveform, Inductor, PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError,
+    VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -8,6 +9,96 @@ fn assert_close(actual: f64, expected: f64) {
         (actual - expected).abs() < 1.0e-9,
         "expected {expected}, got {actual}"
     );
+}
+
+#[test]
+fn waveform_period_reports_periodic_source_forms() {
+    assert_close(
+        Waveform::Sin(SinWaveform::new(0.0, 1.0, 2.0))
+            .period_seconds()
+            .unwrap(),
+        0.5,
+    );
+    assert!(
+        Waveform::Sin(SinWaveform::with_delay_damping(0.0, 1.0, 2.0, 0.0, 1.0))
+            .period_seconds()
+            .is_none()
+    );
+    assert!(Waveform::Sin(SinWaveform::new(0.0, 1.0, 0.0))
+        .period_seconds()
+        .is_none());
+    assert_close(
+        Waveform::Pulse(PulseWaveform::new(0.0, 1.0, 0.0, 0.0, 0.0, 0.5, 2.5))
+            .period_seconds()
+            .unwrap(),
+        2.5,
+    );
+    assert!(
+        Waveform::Pwl(PwlWaveform::new(vec![(0.0, 0.0), (1.0, 1.0)]))
+            .period_seconds()
+            .is_none()
+    );
+    assert!(
+        Waveform::Exp(ExpWaveform::new(0.0, 1.0, 0.0, 0.5, 1.0, 0.5))
+            .period_seconds()
+            .is_none()
+    );
+}
+
+#[test]
+fn estimate_period_finds_harmonic_periodic_source_period() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        Waveform::Sin(SinWaveform::new(0.0, 1.0, 1_000.0)),
+    )));
+    circuit.add(Element::CurrentSource(CurrentSource::with_waveform(
+        "I1",
+        "out",
+        "0",
+        0.0,
+        Waveform::Pulse(PulseWaveform::new(
+            0.0, 1.0e-3, 0.0, 0.0, 0.0, 0.25e-3, 0.5e-3,
+        )),
+    )));
+    circuit.add(Element::Resistor(Resistor::new("R1", "in", "out", 1_000.0)));
+
+    assert_close(estimate_period(&circuit).unwrap(), 1.0e-3);
+}
+
+#[test]
+fn estimate_period_rejects_nonperiodic_or_incommensurate_sources() {
+    let mut non_periodic = Circuit::new();
+    non_periodic.add(Element::VoltageSource(VoltageSource::with_waveform(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        Waveform::Pwl(PwlWaveform::new(vec![(0.0, 0.0), (1.0e-3, 1.0)])),
+    )));
+    assert!(estimate_period(&non_periodic).is_none());
+
+    let mut incommensurate = Circuit::new();
+    incommensurate.add(Element::VoltageSource(VoltageSource::with_waveform(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        Waveform::Pulse(PulseWaveform::new(0.0, 1.0, 0.0, 0.0, 0.0, 0.25e-3, 1.0e-3)),
+    )));
+    incommensurate.add(Element::CurrentSource(CurrentSource::with_waveform(
+        "I1",
+        "out",
+        "0",
+        0.0,
+        Waveform::Pulse(PulseWaveform::new(
+            0.0, 1.0e-3, 0.0, 0.0, 0.0, 0.25e-3, 0.7e-3,
+        )),
+    )));
+    assert!(estimate_period(&incommensurate).is_none());
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add PSS source-period estimation with `waveformPeriod` for periodic `SIN` and
+  `PULSE` source forms plus `estimatePeriod` for deriving a harmonic common
+  independent-source period.
 - Add multi-corner transfer-function analysis with `tfCorners`, returning the
   same `.TF` query evaluated under each named corner.
 - Add multi-corner AC frequency sweeps with `acSweepCorners`, returning the

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -263,6 +263,25 @@ export class ExpWaveform {
   }
 }
 
+export function waveformPeriod(waveform: Waveform): number | undefined {
+  if (waveform instanceof SinWaveform) {
+    if (
+      Number.isFinite(waveform.frequencyHz) &&
+      waveform.frequencyHz > 0.0 &&
+      waveform.damping === 0.0
+    ) {
+      return 1.0 / waveform.frequencyHz;
+    }
+    return undefined;
+  }
+  if (waveform instanceof PulseWaveform) {
+    if (Number.isFinite(waveform.periodSeconds) && waveform.periodSeconds > 0.0) {
+      return waveform.periodSeconds;
+    }
+  }
+  return undefined;
+}
+
 export interface VoltageSource {
   readonly kind: "voltage-source";
   readonly name: string;
@@ -615,6 +634,49 @@ export class Circuit {
   instantiate(instance: XInstance): void {
     this._elements.push(...expandXInstance(instance, this._subcircuits, []));
   }
+}
+
+function isIntegerMultiple(
+  candidate: number,
+  period: number,
+  tolerance: number,
+): boolean {
+  const ratio = candidate / period;
+  const nearest = Math.round(ratio);
+  return (
+    nearest >= 1 &&
+    Math.abs(ratio - nearest) <= tolerance * Math.max(1.0, Math.abs(ratio))
+  );
+}
+
+export function estimatePeriod(
+  circuit: Circuit,
+  tolerance = 1.0e-9,
+): number | undefined {
+  const periods: number[] = [];
+  for (const element of circuit.elements()) {
+    if (
+      (element.kind === "voltage-source" || element.kind === "current-source") &&
+      element.waveform !== undefined
+    ) {
+      const period = waveformPeriod(element.waveform);
+      if (period === undefined) {
+        return undefined;
+      }
+      periods.push(period);
+    }
+  }
+  if (periods.length === 0) {
+    return undefined;
+  }
+
+  const candidate = Math.max(...periods);
+  if (!Number.isFinite(candidate) || candidate <= 0.0) {
+    return undefined;
+  }
+  return periods.every((period) => isIntegerMultiple(candidate, period, tolerance))
+    ? candidate
+    : undefined;
 }
 
 function expandXInstance(

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -11,12 +11,14 @@ import {
   cccs,
   ccvs,
   currentSourceWithWaveform,
+  estimatePeriod,
   inductor,
   inductorWithInitialCurrent,
   resistor,
   transient,
   voltageSource,
   voltageSourceWithWaveform,
+  waveformPeriod,
 } from "../src/index.js";
 
 function expectClose(actual: number | undefined, expected: number): void {
@@ -25,6 +27,75 @@ function expectClose(actual: number | undefined, expected: number): void {
 }
 
 describe("transient", () => {
+  it("reports periods for periodic source waveforms", () => {
+    expectClose(waveformPeriod(new SinWaveform(0.0, 1.0, 2.0)), 0.5);
+    expect(waveformPeriod(new SinWaveform(0.0, 1.0, 2.0, 0.0, 1.0))).toBeUndefined();
+    expect(waveformPeriod(new SinWaveform(0.0, 1.0, 0.0))).toBeUndefined();
+    expectClose(waveformPeriod(new PulseWaveform(0.0, 1.0, 0.0, 0.0, 0.0, 0.5, 2.5)), 2.5);
+    expect(waveformPeriod(new PwlWaveform([[0.0, 0.0], [1.0, 1.0]]))).toBeUndefined();
+    expect(waveformPeriod(new ExpWaveform())).toBeUndefined();
+  });
+
+  it("estimates a harmonic period for periodic independent sources", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        new SinWaveform(0.0, 1.0, 1_000.0),
+      ),
+    );
+    circuit.add(
+      currentSourceWithWaveform(
+        "I1",
+        "out",
+        "0",
+        0.0,
+        new PulseWaveform(0.0, 1.0e-3, 0.0, 0.0, 0.0, 0.25e-3, 0.5e-3),
+      ),
+    );
+    circuit.add(resistor("R1", "in", "out", 1_000.0));
+
+    expectClose(estimatePeriod(circuit), 1.0e-3);
+  });
+
+  it("does not estimate a period for nonperiodic or incommensurate sources", () => {
+    const nonPeriodic = new Circuit();
+    nonPeriodic.add(
+      voltageSourceWithWaveform(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([[0.0, 0.0], [1.0e-3, 1.0]]),
+      ),
+    );
+    expect(estimatePeriod(nonPeriodic)).toBeUndefined();
+
+    const incommensurate = new Circuit();
+    incommensurate.add(
+      voltageSourceWithWaveform(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        new PulseWaveform(0.0, 1.0, 0.0, 0.0, 0.0, 0.25e-3, 1.0e-3),
+      ),
+    );
+    incommensurate.add(
+      currentSourceWithWaveform(
+        "I1",
+        "out",
+        "0",
+        0.0,
+        new PulseWaveform(0.0, 1.0e-3, 0.0, 0.0, 0.0, 0.25e-3, 0.7e-3),
+      ),
+    );
+    expect(estimatePeriod(incommensurate)).toBeUndefined();
+  });
+
   it("uses a backward-Euler capacitor companion for an RC step", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("V1", "vin", "0", 1.0));

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -106,10 +106,10 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- Multi-corner transfer-function analysis across Python, TypeScript, and Rust
-  SPICE engines: named corner specs apply core linear element-parameter
-  overrides, then reuse the existing `.TF` query to collect gain and impedance
-  values per corner.
+- PSS source-period estimation across Python, TypeScript, and Rust SPICE
+  engines: periodic `SIN` and `PULSE` independent-source waveforms expose their
+  period, and circuit-level helpers derive a harmonic common source period as
+  the first foothold for shooting-Newton periodic steady-state analysis.
 
 ---
 
@@ -131,8 +131,8 @@ and the sparse real solver path landed in PR #3391.
 | Feature | Design notes |
 |---|---|
 | **S-parameter extraction** | Two-port network characterisation. Run AC sweep, compute Y-parameters from node voltages and port currents, convert to S-parameters. Shipped in PR #3490. |
-| **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Requires a good oscillation-period estimator. |
-| **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners are in flight. |
+| **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Source-period estimation for periodic `SIN` / `PULSE` waveforms is in flight as the first foothold. |
+| **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners shipped in PR #3516. |
 | **Mixed-signal coupling with `hardware-vm`** | AMS simulation — digital events feed into analog SPICE nodes and vice versa. Long-range project; `hardware-vm.md` spec describes the interface. |
 | **Verilog-A compact models** | Custom device models. Requires a Verilog-A parser (`code/specs/verilog-a-parser.md` is referenced but not written). |
 


### PR DESCRIPTION
## Summary
- Add waveform period helpers for periodic SIN and PULSE source forms across Python, TypeScript, and Rust SPICE engines.
- Add circuit-level PSS period estimators that derive a harmonic common independent-source period and return no estimate for nonperiodic or incommensurate sources.
- Refresh the SPICE/MACSYMA pending-work notes now that transfer-function corners landed in #3516.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pss-period sh BUILD` in `code/packages/python/spice-engine`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pss-period sh BUILD` in `code/packages/typescript/spice-engine`
- `rustfmt code/packages/rust/spice-engine/src/lib.rs code/packages/rust/spice-engine/tests/transient_tests.rs`
- isolated `cargo test` copy of `code/packages/rust/spice-engine` because the sparse checkout intentionally omits unrelated workspace members on a low-disk machine
- `git diff --check`
