### PR TITLE
feat(forme-transforms): FM00 v0 foundational sequence helpers

### DIFF
--- a/code/packages/typescript/forme-transforms/BUILD
+++ b/code/packages/typescript/forme-transforms/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-transforms/CHANGELOG.md
+++ b/code/packages/typescript/forme-transforms/CHANGELOG.md
@@ -1,0 +1,140 @@
+# Changelog — @coding-adventures/forme-transforms
+
+## 0.1.0 — 2026-05-18
+
+Initial release.  Fourth FM00 v0 stage package — foundational
+sequence-helper layer providing filter / map / sort / limit /
+partition / group / unique / pipe over arrays of anything.
+
+Companion to `forme-feeds` / `forme-opengraph` /
+`forme-index-renderer`; consumed by renderers, collectors, and
+the orchestrator as the building block they all need.
+
+### Added
+
+- `filter(items, predicate)` — keep matching items.
+- `map(items, mapper)` — project each item.
+- `flatMap(items, mapper)` — project + one-level flatten.
+- `take(items, n)` — first N items.  Clamps negative / NaN /
+  Infinity to 0.
+- `drop(items, n)` — skip first N.  Clamps negative / NaN /
+  Infinity to 0 (returns copy).
+- `slice(items, start?, end?)` — `items[start..end)` with
+  clamped, never-negative-from-end indices.
+- `chunk(items, size)` — split into batches of `size`.  Throws
+  `RangeError` on non-positive or non-integer `size`.
+- `sortBy(items, keyFn, dir?)` — stable sort.  `null` / `undefined`
+  keys sort last regardless of direction.  Index tiebreaker
+  locks in stability.
+- `sortBy2(items, primary, secondary, primaryDir?, secondaryDir?)`
+  — primary-then-secondary stable sort in one pass.
+- `partition(items, predicate)` — `{ yes, no }` split in one pass.
+- `groupBy(items, keyFn)` — bucket into `Map<K, T[]>`.
+- `unique(items, keyFn?)` — dedupe by identity or by extracted
+  key; first occurrence wins.
+- `pipe(items, ...steps)` — left-to-right function composition
+  with type inference up to 5 steps.
+- Type definitions: `Predicate`, `Mapper`, `FlatMapper`, `KeyFn`,
+  `SortDirection`, `Partition`, `PipeStep`.
+
+### Spec adherence
+
+Extends the FM00 v0 stage surface area with a foundational
+sequence layer.  The spec's §5.3 lists individual `transform-*`
+packages by name; this package is the building block they (and
+collectors, renderers, the orchestrator) all use.  No spec
+divergences.
+
+### Behavioural notes
+
+- **Every helper is pure** — `readonly T[]` in, fresh array (or
+  `Map`) out.  Input arrays are never mutated.
+- **`sortBy` puts null / undefined keys LAST regardless of
+  direction.**  Asking for "newest first" puts undated items at
+  the end, not at the top.
+- **`sortBy` uses an index tiebreaker** so output is deterministic
+  even on JS engines whose `Array.prototype.sort` stability we
+  haven't independently verified.  Cost is one integer compare
+  per tied pair.
+- **`sortBy` memoises keys** — `keyFn` is invoked exactly once
+  per item, not O(N log N) times.  Side effects (if any) fire
+  predictably.
+- **`groupBy` returns a `Map`, not a plain object** — protection
+  against `__proto__` injection from caller-controlled keyFn
+  output, plus support for non-string keys.
+- **`chunk` is the only helper that throws** — `RangeError` on
+  bad `size`.  Every other helper clamps out-of-range inputs to
+  array bounds and returns an empty / copy result, so they're
+  safe to chain on caller-controlled lengths.
+- **`pipe` returns input unchanged when no steps supplied** —
+  useful in conditional pipeline-building code where some steps
+  are toggled off.
+
+### Security posture
+
+Three concerns explicitly addressed (pre-push review):
+
+- **Prototype pollution via key functions.**  `groupBy` and
+  `unique` use `Map` / `Set` internally, never plain objects.
+  A hostile `keyFn` returning `"__proto__"` lands as a normal
+  Map / Set key with no `Object.prototype` reach.  Pinned by
+  `group.test.ts` (`__proto__` key doesn't pollute `{}`).
+- **No URL / HTML / shell surface.**  This is pure data
+  transformation; there's no string-rendering path that could
+  emit XSS, no fs/shell that could leak data, no network that
+  could exfiltrate.
+- **Bounded computation.**  `chunk` throws on non-positive size
+  rather than looping forever / dividing by zero; `take` /
+  `drop` / `slice` clamp to array bounds rather than dispatching
+  arbitrary-length allocations.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, no network, no shell, no env, no
+fs.
+
+### Tests
+
+101 tests across 5 files:
+
+- `filter-map.test.ts` (18) — filter / map / flatMap purity,
+  index passthrough, type-changes, no-mutation, empty inputs,
+  one-level-only flatten verification.
+- `slice.test.ts` (32) — take / drop / slice / chunk on every
+  edge: negative, NaN, Infinity, fractional, zero, out-of-range;
+  input-not-mutated; fresh-array guarantee (`drop(input, 0)`
+  returns a copy, not the input itself).
+- `sort.test.ts` (18) — `sortBy` / `sortBy2` with asc + desc
+  parameterisation, null-last on both directions, NaN ties
+  preserve input order, stable index tiebreaker, keyFn-called-
+  once memoisation, numeric and bigint keys, FM00 archive idiom
+  (pubDate-desc + title-asc).
+- `group.test.ts` (24) — partition halves preserve input order,
+  groupBy returns Map (not Object) with `__proto__`-safety,
+  insertion-order iteration, within-bucket order preservation,
+  numeric keys, both unique overloads (identity + keyFn), object
+  identity for reference dedupe.
+- `pipe.test.ts` (9) — composition order verification (each
+  step's output → next step's input), type-changes between
+  steps (T → U → V), no-mutation through full pipelines,
+  real-world Forme pipeline shapes ("recent published posts",
+  "IDs of all non-drafts"), empty input survives.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only declarations).
+
+### v0 simplifications (documented)
+
+- **No streaming / generator variants.**  Array-in, array-out.
+  Forme datasets are small enough (single-machine blog scale)
+  that materialising intermediates is cheaper than iterator-
+  protocol overhead.
+- **No partial application / curried forms.**  `pipe` callers
+  write arrows directly (`(xs) => filter(xs, p)`) rather than
+  `filter(p)`.  Reduces TypeScript inference weight and API
+  surface.
+- **No reduce / fold.**  Too shape-dependent to wrap usefully —
+  native `for` loop wins.
+- **No async variants.**  All helpers are synchronous; the Forme
+  stages handle their own async boundaries before/after the
+  transform layer.

--- a/code/packages/typescript/forme-transforms/README.md
+++ b/code/packages/typescript/forme-transforms/README.md
@@ -1,0 +1,197 @@
+# @coding-adventures/forme-transforms
+
+Pure-data sequence helpers — `filter` / `map` / `flatMap` / `take`
+/ `drop` / `slice` / `chunk` / `sortBy` / `sortBy2` / `partition` /
+`groupBy` / `unique` / `pipe` — for the Forme pipeline (FM00 v0).
+
+Fourth FM00 v0 stage package — sits alongside
+[`forme-feeds`](../forme-feeds),
+[`forme-opengraph`](../forme-opengraph), and
+[`forme-index-renderer`](../forme-index-renderer).  Renderers and
+collectors compose these helpers; the pipeline never has to reach
+for `Array.prototype` discipline directly.
+
+## Quick start
+
+```ts
+import { pipe, filter, sortBy, take } from "@coding-adventures/forme-transforms";
+
+// Recent published posts, newest-first, top 10.
+const recent = pipe(posts,
+  (xs) => filter(xs, (p) => !p.draft),
+  (xs) => sortBy(xs, (p) => p.pubDate, "desc"),
+  (xs) => take(xs, 10),
+);
+```
+
+## Why this package exists
+
+The Forme stages all touch arrays of stuff — `Document[]` (pages),
+`IndexItem[]` (archive entries), `ContentNode[]` (AST children).
+Each stage would otherwise grow its own ad-hoc sort/filter logic
+with subtle bugs:
+
+- `Array.prototype.sort` is stable on modern V8 but undefined on
+  ancient JS engines that some embedded runtimes still ship — and
+  our reproducibility contract requires "same input → byte-
+  identical output."
+- Plain-object `groupBy` (`{ [key]: [...] }`) is a `__proto__`
+  injection vector when keys come from user-authored frontmatter.
+- `Array.prototype.filter` / `.map` accept `readonly T[]` but the
+  callback can mutate by reference, so the no-mutation invariant
+  has to be enforced by convention.
+
+This package solves all three by exposing a single uniform
+algebra: every helper takes `readonly T[]`, returns a fresh array
+(or `Map`), and has documented behaviour for ties / nulls / empty
+inputs.
+
+## API
+
+### `filter(items, predicate): T[]`
+### `map(items, mapper): U[]`
+### `flatMap(items, mapper): U[]`
+
+Thin wrappers over the obvious `Array.prototype` operations.  Why
+re-export?  See the package docstring — uniform `readonly`
+discipline, pipe-shaped signatures, single documentation surface.
+
+### `take(items, n): T[]`
+### `drop(items, n): T[]`
+### `slice(items, start?, end?): T[]`
+### `chunk(items, size): T[][]`
+
+Windows over a sequence.  All clamp out-of-range indices to array
+bounds (so `take(posts, options.max)` is safe whether `max` is 0,
+5, or a million).  `chunk` is the only one that throws — `RangeError`
+on non-positive or non-integer `size`, since the operation is
+undefined there.
+
+### `sortBy(items, keyFn, dir?): T[]`
+### `sortBy2(items, primary, secondary, primaryDir?, secondaryDir?): T[]`
+
+Stable sort with two non-default behaviours:
+
+1. **`null` / `undefined` keys sort LAST regardless of direction.**
+   Asking for "newest first" puts undated items at the end, not
+   the top.
+2. **Deterministic index tiebreaker.**  Locks in stability even on
+   engines whose `Array.prototype.sort` stability we haven't
+   independently verified.
+
+`sortBy2` adds a secondary key — common Forme use:
+`sortBy2(posts, p => p.pubDate, p => p.id, "desc", "asc")` gives
+reverse-chrono with `id` as the within-same-date tiebreaker.
+
+### `partition(items, predicate): { yes, no }`
+
+Single-pass split into the two halves.  Both arrays preserve
+input order.
+
+### `groupBy(items, keyFn): Map<K, T[]>`
+
+Buckets items by an extracted key.  Returns a `Map` (not a plain
+`Object`):
+
+- **Prototype-pollution defence** — hostile keys like `"__proto__"`
+  go into the `Map`'s internal slot, not `Object.prototype`.
+- **Non-string keys** round-trip without `String(...)` coercion.
+- **Insertion-order iteration** — buckets appear in the order
+  their first item appeared in the input.
+
+### `unique(items, keyFn?): T[]`
+
+Dedupe.  First occurrence wins, input order preserved among the
+survivors.  Without `keyFn`, uses identity (`SameValueZero` via
+`Set`).  With `keyFn`, two items are duplicates iff their keys are
+equal.
+
+### `pipe(items, ...steps): U[]`
+
+Left-to-right function composition.  Each step takes a
+`readonly T[]` and returns a `readonly U[]`.  Type inference
+covers chains up to length 5; past that, break into a named
+intermediate.
+
+```ts
+const recent = pipe(posts,
+  (xs) => filter(xs, (p) => !p.draft),
+  (xs) => sortBy(xs, (p) => p.pubDate, "desc"),
+  (xs) => take(xs, 10),
+);
+```
+
+## Behavioural contract
+
+| Helper            | Mutates input? | Throws?                          | Empty input behaviour |
+|-------------------|----------------|----------------------------------|-----------------------|
+| `filter` / `map` / `flatMap` | never  | never                            | empty output          |
+| `take` / `drop` / `slice`    | never  | never                            | empty / copy          |
+| `chunk`           | never          | `RangeError` on bad `size`       | empty output          |
+| `sortBy` / `sortBy2` | never       | never                            | empty output          |
+| `partition`       | never          | never                            | `{ yes: [], no: [] }` |
+| `groupBy`         | never          | never                            | empty `Map`           |
+| `unique`          | never          | never                            | empty output          |
+| `pipe`            | never          | only if a step throws            | passes through        |
+
+## Reproducibility (FM03)
+
+Same input → byte-identical output, given a deterministic
+`keyFn` / `predicate`.
+
+The index tiebreaker in `sortBy` is what makes two inputs that
+differ only in caller-array order *also* produce the same output
+*when paired with a deterministic key* (e.g. sort by a unique
+`id`).  If you want order-independent output, sort by a unique
+stable key.
+
+## Capabilities — `[]`
+
+Pure transforms.  No I/O, no network, no shell, no env, no fs.
+Same posture as `forme-feeds` / `forme-opengraph` /
+`forme-index-renderer`.
+
+## Tests
+
+101 tests across 5 files:
+
+- `filter-map.test.ts` (18) — filter / map / flatMap purity, index
+  passthrough, type-changes, no-mutation, empty inputs.
+- `slice.test.ts` (32) — take / drop / slice / chunk including
+  every edge case (negative, NaN, Infinity, fractional, out of
+  range), input-not-mutated, fresh-array guarantee.
+- `sort.test.ts` (18) — sortBy / sortBy2 with asc + desc,
+  null-last on both directions, NaN ties, stable index tiebreaker,
+  keyFn-called-once memoisation, numeric/bigint keys, FM00
+  archive idiom (pubDate-desc + id-asc).
+- `group.test.ts` (24) — partition, groupBy (Map-based,
+  __proto__-safe, numeric keys, insertion order), unique (identity
+  + keyFn overloads).
+- `pipe.test.ts` (9) — composition order, type changes between
+  steps, no-mutation, real-world Forme pipeline shapes.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only).
+
+## Spec adherence
+
+The FM00 v0 spec (§5.3) calls out individual `transform-*`
+packages (`transform-syntax-highlight`, `transform-typography`,
+etc.).  This package is the **foundational sequence layer** that
+those transforms — and collectors, renderers, and the
+orchestrator — all build on.  No spec divergences; the package
+extends the FM00 v0 surface area with a building block that
+every higher layer needs.
+
+## v0 simplifications
+
+- **No streaming / generator variants.**  Everything is array-in,
+  array-out.  Forme datasets are small enough (single-machine
+  blog scale) that materialising intermediate arrays is cheaper
+  than the iterator-protocol overhead.
+- **No partial application helpers.**  `pipe` callers write
+  arrows directly (`(xs) => filter(xs, p)`) rather than a curried
+  `filter(p)` form.  Reduces API surface and TypeScript inference
+  weight.
+- **No reduce / fold.**  If you need fold, use a native `for`
+  loop — that operation is too shape-dependent to wrap usefully.

--- a/code/packages/typescript/forme-transforms/package-lock.json
+++ b/code/packages/typescript/forme-transforms/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-transforms",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-transforms",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-transforms/package.json
+++ b/code/packages/typescript/forme-transforms/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-transforms",
+  "version": "0.1.0",
+  "description": "Filter / map / sort / limit / partition / compose helpers over IR sequences (Document arrays, IndexItem arrays, anything keyed) for the Forme pipeline (FM00 v0).  Pure transforms — no I/O.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-transforms/required_capabilities.json
+++ b/code/packages/typescript/forme-transforms/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-transforms",
+  "capabilities": [],
+  "justification": "Pure transforms over arrays — filter, map, sort, limit, partition, compose.  No I/O, no network, no env, no shell, no fs.  Same posture as forme-feeds / forme-opengraph / forme-index-renderer."
+}

--- a/code/packages/typescript/forme-transforms/src/filter-map.ts
+++ b/code/packages/typescript/forme-transforms/src/filter-map.ts
@@ -1,0 +1,81 @@
+/**
+ * filter-map.ts — the workhorse pair, plus flatMap.
+ *
+ * All three functions:
+ *
+ *   - accept `readonly T[]` (do not mutate the input)
+ *   - return a fresh `T[]` (so callers can mutate safely)
+ *   - pass the index as the second arg to the callback (consistent
+ *     with `Array.prototype.filter` / `.map`)
+ *
+ * Why re-export the obvious operations?  Three reasons:
+ *
+ *   1. **Uniform `readonly T[]` discipline.**  `Array.prototype.filter`
+ *      accepts `readonly` but the callback can technically still mutate
+ *      the input by reference.  Wrapping enforces the no-mutation
+ *      invariant that every other helper in this package shares.
+ *   2. **Pipe-shaped signature.**  Our wrappers can be partially
+ *      applied (`(items) => map(items, fn)`) and dropped into `pipe`
+ *      without the awkward `Array.prototype` dance.
+ *   3. **Documentation surface.**  When a junior reader sees
+ *      `filter(posts, isPublished)` in a Forme stage they know
+ *      exactly which package the helper comes from and what its
+ *      reproducibility guarantees are.
+ *
+ * @module filter-map
+ */
+
+import type { FlatMapper, Mapper, Predicate } from "./types.js";
+
+/**
+ * Return a new array of items for which `predicate` returned true.
+ * Input order preserved.  Input not mutated.
+ *
+ * ```ts
+ * const published = filter(posts, (p) => !p.draft);
+ * ```
+ */
+export function filter<T>(items: readonly T[], predicate: Predicate<T>): T[] {
+  const out: T[] = [];
+  for (let i = 0; i < items.length; i++) {
+    if (predicate(items[i]!, i)) out.push(items[i]!);
+  }
+  return out;
+}
+
+/**
+ * Return a new array where each item has been replaced by
+ * `mapper(item, index)`.  Input order preserved.  Input not mutated.
+ *
+ * ```ts
+ * const slugs = map(posts, (p) => p.slug);
+ * ```
+ */
+export function map<T, U>(items: readonly T[], mapper: Mapper<T, U>): U[] {
+  const out: U[] = new Array(items.length);
+  for (let i = 0; i < items.length; i++) {
+    out[i] = mapper(items[i]!, i);
+  }
+  return out;
+}
+
+/**
+ * Like `map`, but the mapper returns an array per item and the
+ * result is flattened by one level.  Input order preserved.  Input
+ * not mutated.
+ *
+ * ```ts
+ * const allTags = flatMap(posts, (p) => p.tags);
+ * ```
+ *
+ * Note: this is a single-level flatten (like `Array.prototype.flatMap`).
+ * For deeper flattening, compose `flatMap` repeatedly via `pipe`.
+ */
+export function flatMap<T, U>(items: readonly T[], mapper: FlatMapper<T, U>): U[] {
+  const out: U[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const chunk = mapper(items[i]!, i);
+    for (let j = 0; j < chunk.length; j++) out.push(chunk[j]!);
+  }
+  return out;
+}

--- a/code/packages/typescript/forme-transforms/src/group.ts
+++ b/code/packages/typescript/forme-transforms/src/group.ts
@@ -1,0 +1,114 @@
+/**
+ * group.ts — `partition`, `groupBy`, `unique`.
+ *
+ * Three operations that bucket items by a derived key.  All return
+ * fresh containers; inputs are never mutated.
+ *
+ * Why `Map` (not plain `Object`) for `groupBy`?
+ *
+ *   - **Prototype pollution defence.**  A hostile `keyFn` returning
+ *     `"__proto__"` would otherwise reach `Object.prototype` and
+ *     pollute every object in the running process.  `Map` is
+ *     immune — its keys are stored in a separate internal slot
+ *     with no `__proto__` lookup.
+ *   - **Non-string keys.**  Numeric, bigint, boolean, and object
+ *     keys round-trip without `String(...)` coercion.  Useful for
+ *     `groupBy(items, i => i.year)` returning numeric-keyed buckets.
+ *   - **Insertion-order iteration.**  `Map` iterates in insertion
+ *     order, which combined with our input traversal order makes
+ *     the output deterministic regardless of key type.
+ *
+ * @module group
+ */
+
+import type { KeyFn, Partition, Predicate } from "./types.js";
+
+/**
+ * Split `items` into a `{ yes, no }` pair based on the predicate.
+ * Both arrays preserve input order.  Same as
+ * `{ yes: filter(items, p), no: filter(items, (x,i) => !p(x,i)) }`
+ * but does one pass.
+ *
+ * ```ts
+ * const { yes: published, no: drafts } = partition(posts, (p) => !p.draft);
+ * ```
+ */
+export function partition<T>(items: readonly T[], predicate: Predicate<T>): Partition<T> {
+  const yes: T[] = [];
+  const no: T[] = [];
+  for (let i = 0; i < items.length; i++) {
+    if (predicate(items[i]!, i)) yes.push(items[i]!);
+    else no.push(items[i]!);
+  }
+  return { yes, no };
+}
+
+/**
+ * Bucket items by a derived key.  Returns a `Map<K, T[]>` whose
+ * iteration order is the order in which each bucket's first item
+ * appeared in the input.  Within each bucket, items preserve input
+ * order.
+ *
+ * ```ts
+ * const byCategory = groupBy(posts, (p) => p.category ?? "uncategorised");
+ * for (const [cat, posts] of byCategory) { ... }
+ * ```
+ *
+ * Note: returns a `Map`, not an `Object`.  Use `Object.fromEntries`
+ * if a plain-object view is needed — but be aware that doing so
+ * loses non-string keys and re-opens the `__proto__` injection
+ * vector.
+ */
+export function groupBy<T, K>(items: readonly T[], keyFn: KeyFn<T, K>): Map<K, T[]> {
+  const out = new Map<K, T[]>();
+  for (let i = 0; i < items.length; i++) {
+    const k = keyFn(items[i]!);
+    const bucket = out.get(k);
+    if (bucket) bucket.push(items[i]!);
+    else out.set(k, [items[i]!]);
+  }
+  return out;
+}
+
+/**
+ * Remove duplicate items.  First occurrence wins (preserves input
+ * order for the surviving items).
+ *
+ * Without `keyFn`: deduplicates by identity (`===` / `SameValueZero`)
+ * via a `Set`.  Works for primitives and references.
+ *
+ * With `keyFn`: two items are duplicates iff their keys are equal.
+ * Useful for "dedupe posts by slug" where two source files
+ * accidentally produced the same canonical URL.
+ *
+ * ```ts
+ * const uniqueTags  = unique(["js", "ts", "js"]);              // ["js","ts"]
+ * const uniqueSlugs = unique(posts, (p) => p.slug);            // first wins
+ * ```
+ */
+export function unique<T>(items: readonly T[]): T[];
+export function unique<T, K>(items: readonly T[], keyFn: KeyFn<T, K>): T[];
+export function unique<T, K>(items: readonly T[], keyFn?: KeyFn<T, K>): T[] {
+  const out: T[] = [];
+  if (keyFn === undefined) {
+    const seen = new Set<T>();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i]!;
+      if (!seen.has(it)) {
+        seen.add(it);
+        out.push(it);
+      }
+    }
+    return out;
+  }
+  const seen = new Set<K>();
+  for (let i = 0; i < items.length; i++) {
+    const it = items[i]!;
+    const k = keyFn(it);
+    if (!seen.has(k)) {
+      seen.add(k);
+      out.push(it);
+    }
+  }
+  return out;
+}

--- a/code/packages/typescript/forme-transforms/src/index.ts
+++ b/code/packages/typescript/forme-transforms/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * @coding-adventures/forme-transforms
+ *
+ * Pure-data sequence helpers for the Forme pipeline (FM00 v0).
+ *
+ * Filter / map / sort / limit / partition / group / unique / pipe
+ * over arrays of anything — `Document[]` (pages), `IndexItem[]`
+ * (archive), `ContentNode[]` (AST), or your own types.  Every
+ * helper is:
+ *
+ *   - **Pure** — input arrays are never mutated.
+ *   - **Deterministic** — same input → byte-identical output
+ *     (subject to deterministic `keyFn` / `predicate`).
+ *   - **Capability-free** — no I/O, no network, no env, no shell.
+ *
+ * ```ts
+ * import { pipe, filter, sortBy, take } from "@coding-adventures/forme-transforms";
+ *
+ * const recentPublished = pipe(posts,
+ *   (xs) => filter(xs, (p) => !p.draft),
+ *   (xs) => sortBy(xs, (p) => p.pubDate, "desc"),
+ *   (xs) => take(xs, 10),
+ * );
+ * ```
+ *
+ * Sits alongside `forme-feeds` / `forme-opengraph` /
+ * `forme-index-renderer` as the fourth FM00 v0 stage package.
+ * Renderers and collectors compose these helpers; the pipeline
+ * never has to reach for `Array.prototype` discipline directly.
+ *
+ * @module index
+ */
+
+export { filter, map, flatMap } from "./filter-map.js";
+export { take, drop, slice, chunk } from "./slice.js";
+export { sortBy, sortBy2 } from "./sort.js";
+export { partition, groupBy, unique } from "./group.js";
+export { pipe } from "./pipe.js";
+export type {
+  Predicate,
+  Mapper,
+  FlatMapper,
+  KeyFn,
+  SortDirection,
+  Partition,
+  PipeStep,
+} from "./types.js";

--- a/code/packages/typescript/forme-transforms/src/pipe.ts
+++ b/code/packages/typescript/forme-transforms/src/pipe.ts
@@ -1,0 +1,86 @@
+/**
+ * pipe.ts — left-to-right function composition over arrays.
+ *
+ * `pipe` is the readability win that justifies every other helper
+ * having a uniform `(items, ...args) => result` shape: callers can
+ * partially-apply each step and feed the chain into `pipe` to read
+ * top-to-bottom rather than inside-out.
+ *
+ * ```ts
+ * // Without pipe — inside-out, parens-heavy.
+ * const recent = take(
+ *   sortBy(
+ *     filter(posts, (p) => !p.draft),
+ *     (p) => p.pubDate,
+ *     "desc",
+ *   ),
+ *   10,
+ * );
+ *
+ * // With pipe — top-to-bottom narrative.
+ * const recent = pipe(posts,
+ *   (xs) => filter(xs, (p) => !p.draft),
+ *   (xs) => sortBy(xs, (p) => p.pubDate, "desc"),
+ *   (xs) => take(xs, 10),
+ * );
+ * ```
+ *
+ * The signature is intentionally untyped between steps (each step
+ * sees `readonly unknown[]` internally), with overloads providing
+ * type inference for the common 1-5 step cases.  Past five steps,
+ * either break the pipeline into a named intermediate or accept
+ * that the final type is `unknown[]` and assert at the boundary.
+ *
+ * @module pipe
+ */
+
+import type { PipeStep } from "./types.js";
+
+// Overload set — TypeScript picks the most specific match based
+// on arity, giving inference for chains up to length 5.
+
+export function pipe<A>(items: readonly A[]): readonly A[];
+export function pipe<A, B>(items: readonly A[], s1: PipeStep<A, B>): readonly B[];
+export function pipe<A, B, C>(
+  items: readonly A[],
+  s1: PipeStep<A, B>,
+  s2: PipeStep<B, C>,
+): readonly C[];
+export function pipe<A, B, C, D>(
+  items: readonly A[],
+  s1: PipeStep<A, B>,
+  s2: PipeStep<B, C>,
+  s3: PipeStep<C, D>,
+): readonly D[];
+export function pipe<A, B, C, D, E>(
+  items: readonly A[],
+  s1: PipeStep<A, B>,
+  s2: PipeStep<B, C>,
+  s3: PipeStep<C, D>,
+  s4: PipeStep<D, E>,
+): readonly E[];
+export function pipe<A, B, C, D, E, F>(
+  items: readonly A[],
+  s1: PipeStep<A, B>,
+  s2: PipeStep<B, C>,
+  s3: PipeStep<C, D>,
+  s4: PipeStep<D, E>,
+  s5: PipeStep<E, F>,
+): readonly F[];
+
+/**
+ * Implementation — applies each step in order; each step's output
+ * becomes the next step's input.  Returns the original items
+ * unchanged if no steps were supplied (useful in conditional
+ * pipeline-building code where some steps are toggled off).
+ */
+export function pipe(
+  items: readonly unknown[],
+  ...steps: ReadonlyArray<PipeStep<unknown, unknown>>
+): readonly unknown[] {
+  let current: readonly unknown[] = items;
+  for (let i = 0; i < steps.length; i++) {
+    current = steps[i]!(current);
+  }
+  return current;
+}

--- a/code/packages/typescript/forme-transforms/src/slice.ts
+++ b/code/packages/typescript/forme-transforms/src/slice.ts
@@ -1,0 +1,88 @@
+/**
+ * slice.ts — `take`, `drop`, `slice`, `chunk`.
+ *
+ * Window-into-sequence operations.  All are pure (input not
+ * mutated), return fresh arrays, and clamp out-of-range indices
+ * to the array bounds rather than throwing — making them safe to
+ * chain in a pipeline where the upstream length is unknown.
+ *
+ * ```
+ *   take(items, 3)    — first 3 items
+ *   drop(items, 3)    — everything except the first 3
+ *   slice(items, 1, 4)— items[1..4)  (start inclusive, end exclusive)
+ *   chunk(items, 10)  — split into batches of 10
+ * ```
+ *
+ * @module slice
+ */
+
+/**
+ * First `n` items.  Negative `n` is clamped to 0 (returns empty
+ * array); `n` larger than the input length returns a copy of the
+ * input.
+ *
+ * Why clamp instead of throw?  `take(posts, options.maxRecent)`
+ * is the common shape, and `options.maxRecent` is often
+ * caller-controlled.  A defensive clamp lets the pipeline stage
+ * stay simple — "give me at most N" works whether N is 0, 5, or
+ * a million.
+ */
+export function take<T>(items: readonly T[], n: number): T[] {
+  if (!Number.isFinite(n) || n <= 0) return [];
+  const end = Math.min(items.length, Math.floor(n));
+  const out: T[] = new Array(end);
+  for (let i = 0; i < end; i++) out[i] = items[i]!;
+  return out;
+}
+
+/**
+ * Everything after the first `n` items.  Negative `n` is treated
+ * as 0 (returns a copy of the input); `n` larger than the input
+ * length returns an empty array.
+ */
+export function drop<T>(items: readonly T[], n: number): T[] {
+  if (!Number.isFinite(n) || n <= 0) {
+    return items.slice();
+  }
+  const start = Math.min(items.length, Math.floor(n));
+  return items.slice(start);
+}
+
+/**
+ * `items[start..end)` — start inclusive, end exclusive, both
+ * defaulting to the array bounds.  Negative indices are clamped to
+ * 0 (no negative-from-end behaviour, unlike `Array.prototype.slice`).
+ *
+ * Why drop the negative-from-end overload?  `pipe` works best when
+ * step parameters are unambiguous — "the 3rd item from the end"
+ * needs `items.length - 3` to be computed by the caller, who
+ * already knows whether they want a fixed-position window or a
+ * tail-relative one.
+ */
+export function slice<T>(items: readonly T[], start = 0, end: number = items.length): T[] {
+  const s = Math.max(0, Math.floor(start));
+  const e = Math.min(items.length, Math.max(s, Math.floor(end)));
+  return items.slice(s, e);
+}
+
+/**
+ * Split into consecutive batches of `size`.  The final batch may
+ * be smaller if the input length is not a multiple of `size`.
+ *
+ * Pagination uses this: `chunk(posts, 10)[pageIndex]` gives the
+ * items on page N (0-indexed).
+ *
+ * Throws `RangeError` if `size <= 0` — the operation is undefined
+ * for non-positive batch sizes (would loop forever or divide by
+ * zero).
+ */
+export function chunk<T>(items: readonly T[], size: number): T[][] {
+  if (!Number.isFinite(size) || size <= 0 || !Number.isInteger(size)) {
+    throw new RangeError(`chunk size must be a positive integer (got ${size})`);
+  }
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}

--- a/code/packages/typescript/forme-transforms/src/sort.ts
+++ b/code/packages/typescript/forme-transforms/src/sort.ts
@@ -1,0 +1,126 @@
+/**
+ * sort.ts — deterministic, stable `sortBy` over key functions.
+ *
+ * V8's `Array.prototype.sort` has been stable since 2018 (Node ≥10),
+ * but we re-implement on top of it with two non-default behaviours
+ * that the Forme pipeline requires:
+ *
+ *   1. **`null` / `undefined` keys sort LAST** regardless of
+ *      direction.  Asking for "newest first" should put undated
+ *      items at the end of the list, not at the top (where they
+ *      would land if `null` were compared as zero or NaN).
+ *   2. **Deterministic tiebreaker via the original index.**  Even
+ *      though V8 sort IS stable, we lock that in explicitly so the
+ *      function is portable to engines whose stability we have not
+ *      independently verified (e.g. ancient embedded V8 forks, or
+ *      custom builds).  Cost is one integer compare per tied pair.
+ *
+ * @module sort
+ */
+
+import type { KeyFn, SortDirection } from "./types.js";
+
+/**
+ * Internal helper: 3-way compare of two keys with `null` /
+ * `undefined` sorting last.
+ *
+ * Truth table (for `dir = "asc"`):
+ *
+ * | a           | b           | result            |
+ * |-------------|-------------|-------------------|
+ * | null        | null        | 0 (tie)           |
+ * | null        | anything    | +1 (a after b)    |
+ * | anything    | null        | -1 (a before b)   |
+ * | x           | y, x < y    | -1                |
+ * | x           | y, x > y    | +1                |
+ * | x           | y, x === y  | 0                 |
+ *
+ * For `dir = "desc"` the non-null comparison flips.  Null
+ * placement stays the same — undated/missing always last.
+ */
+function compareKeys<K>(a: K, b: K, dir: SortDirection): number {
+  const aMissing = a === null || a === undefined;
+  const bMissing = b === null || b === undefined;
+  if (aMissing && bMissing) return 0;
+  if (aMissing) return 1;
+  if (bMissing) return -1;
+  // Both present.  `<` / `>` work for strings, numbers, bigints
+  // (with same-type comparands).  NaN propagates as "not less, not
+  // greater" — both comparisons return false, so result is 0,
+  // which combined with the index tiebreaker keeps NaN-keyed items
+  // in stable input order.
+  if (a < b) return dir === "asc" ? -1 : 1;
+  if (a > b) return dir === "asc" ? 1 : -1;
+  return 0;
+}
+
+/**
+ * Stable sort by an extracted key.  Returns a fresh array; input
+ * is never mutated.
+ *
+ * ```ts
+ * // Posts newest-first; undated to the end.
+ * const sorted = sortBy(posts, (p) => p.pubDate, "desc");
+ *
+ * // Stable alphabetical (ties by input order).
+ * const alpha  = sortBy(authors, (a) => a.name);
+ * ```
+ *
+ * Reproducibility (FM03): same input array produces byte-identical
+ * output.  The index tiebreaker is what makes two inputs that
+ * differ only in caller-array order *also* produce the same output
+ * *when paired with a deterministic key*.  If you want order-
+ * independent output, sort by a unique stable key (e.g. an `id`).
+ */
+export function sortBy<T, K>(
+  items: readonly T[],
+  keyFn: KeyFn<T, K>,
+  dir: SortDirection = "asc",
+): T[] {
+  // Decorate-sort-undecorate.  Computing keys once is both faster
+  // (avoids re-invocation per compare in an N log N loop) and safer
+  // (keyFn side-effects, if any, fire exactly once per item).
+  const decorated = items.map((item, index) => ({
+    item,
+    key: keyFn(item),
+    index,
+  }));
+  decorated.sort((a, b) => {
+    const c = compareKeys(a.key, b.key, dir);
+    if (c !== 0) return c;
+    return a.index - b.index;
+  });
+  return decorated.map((d) => d.item);
+}
+
+/**
+ * Like `sortBy`, but with two key functions.  The second is used
+ * only as a tiebreaker when the first ties.  Equivalent to
+ * `sortBy(sortBy(items, secondary), primary)` but does one pass.
+ *
+ * Common Forme use: `sortBy2(posts, p => p.pubDate, p => p.id, "desc", "asc")`
+ * gives reverse-chrono with id as the within-same-date tiebreaker —
+ * exactly what `forme-index-renderer` does internally.
+ */
+export function sortBy2<T, K1, K2>(
+  items: readonly T[],
+  primary: KeyFn<T, K1>,
+  secondary: KeyFn<T, K2>,
+  primaryDir: SortDirection = "asc",
+  secondaryDir: SortDirection = "asc",
+): T[] {
+  const decorated = items.map((item, index) => ({
+    item,
+    k1: primary(item),
+    k2: secondary(item),
+    index,
+  }));
+  decorated.sort((a, b) => {
+    const c1 = compareKeys(a.k1, b.k1, primaryDir);
+    if (c1 !== 0) return c1;
+    const c2 = compareKeys(a.k2, b.k2, secondaryDir);
+    if (c2 !== 0) return c2;
+    return a.index - b.index;
+  });
+  return decorated.map((d) => d.item);
+}

--- a/code/packages/typescript/forme-transforms/src/types.ts
+++ b/code/packages/typescript/forme-transforms/src/types.ts
@@ -1,0 +1,53 @@
+/**
+ * types.ts — shared signatures for the sequence transforms.
+ *
+ * All helpers in this package are generic over `T` (the item type).
+ * The Forme pipeline uses them for:
+ *
+ *   - lists of `Document` (page-level: filter drafts, sort by date)
+ *   - lists of `IndexItem` (archive-level: limit to 100 newest)
+ *   - lists of `ContentNode` (AST-level: extract headings, count tables)
+ *
+ * Keeping these signatures in one place gives every helper the same
+ * shape so callers can reason about them as a single algebra rather
+ * than 12 ad-hoc functions.
+ *
+ * @module types
+ */
+
+/** Standard predicate — true keeps the item, false drops it. */
+export type Predicate<T> = (item: T, index: number) => boolean;
+
+/** Standard projection — maps `T` to `U`. */
+export type Mapper<T, U> = (item: T, index: number) => U;
+
+/** Many-to-many projection — flatMap building block. */
+export type FlatMapper<T, U> = (item: T, index: number) => readonly U[];
+
+/**
+ * Sort key extractor.  The returned key is compared with `<` / `>`
+ * after coercion, so it should be a string, number, bigint, or
+ * `null` (treated as "absent" — sorted to the end regardless of
+ * direction).
+ */
+export type KeyFn<T, K> = (item: T) => K;
+
+/** Sort direction — `"asc"` (default) or `"desc"`. */
+export type SortDirection = "asc" | "desc";
+
+/**
+ * Result of `partition` — items where the predicate returned true
+ * land in `yes`; the rest in `no`.  Both arrays preserve input
+ * order.
+ */
+export interface Partition<T> {
+  readonly yes: readonly T[];
+  readonly no: readonly T[];
+}
+
+/**
+ * A single step in a `pipe` chain.  Each step takes a readonly
+ * input array and returns a (possibly differently-typed) readonly
+ * output array.  Pipelines never mutate.
+ */
+export type PipeStep<T, U> = (items: readonly T[]) => readonly U[];

--- a/code/packages/typescript/forme-transforms/tests/filter-map.test.ts
+++ b/code/packages/typescript/forme-transforms/tests/filter-map.test.ts
@@ -1,0 +1,97 @@
+/**
+ * filter-map.test.ts — filter, map, flatMap pure-transform behaviour.
+ */
+
+import { describe, it, expect } from "vitest";
+import { filter, map, flatMap } from "../src/index.js";
+
+describe("filter", () => {
+  it("keeps items where predicate returns true", () => {
+    expect(filter([1, 2, 3, 4], (n) => n % 2 === 0)).toEqual([2, 4]);
+  });
+
+  it("passes index as the second arg", () => {
+    expect(filter(["a", "b", "c"], (_v, i) => i > 0)).toEqual(["b", "c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [1, 2, 3];
+    filter(input, (n) => n > 1);
+    expect(input).toEqual([1, 2, 3]);
+  });
+
+  it("returns a fresh array each call", () => {
+    const input = [1, 2, 3];
+    const a = filter(input, () => true);
+    const b = filter(input, () => true);
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(input);
+  });
+
+  it("empty input → empty output", () => {
+    expect(filter([], () => true)).toEqual([]);
+  });
+
+  it("everything-rejected → empty output", () => {
+    expect(filter([1, 2, 3], () => false)).toEqual([]);
+  });
+});
+
+describe("map", () => {
+  it("applies mapper to each item", () => {
+    expect(map([1, 2, 3], (n) => n * 2)).toEqual([2, 4, 6]);
+  });
+
+  it("passes index as the second arg", () => {
+    expect(map(["a", "b", "c"], (v, i) => `${i}:${v}`)).toEqual(["0:a", "1:b", "2:c"]);
+  });
+
+  it("preserves input length exactly", () => {
+    expect(map([10, 20, 30, 40], (n) => n + 1).length).toBe(4);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [{ x: 1 }, { x: 2 }];
+    map(input, (o) => o.x);
+    expect(input).toEqual([{ x: 1 }, { x: 2 }]);
+  });
+
+  it("empty input → empty output", () => {
+    expect(map([], (n: number) => n * 2)).toEqual([]);
+  });
+
+  it("type-changes input → output (T → U)", () => {
+    const out: string[] = map([1, 2, 3], (n) => `n=${n}`);
+    expect(out).toEqual(["n=1", "n=2", "n=3"]);
+  });
+});
+
+describe("flatMap", () => {
+  it("flattens one level", () => {
+    expect(flatMap([1, 2, 3], (n) => [n, n * 10])).toEqual([1, 10, 2, 20, 3, 30]);
+  });
+
+  it("empty inner arrays are dropped", () => {
+    expect(flatMap([1, 2, 3], (n) => (n === 2 ? [] : [n]))).toEqual([1, 3]);
+  });
+
+  it("passes index as the second arg", () => {
+    expect(flatMap(["a", "b"], (v, i) => [`${i}-${v}`])).toEqual(["0-a", "1-b"]);
+  });
+
+  it("empty input → empty output", () => {
+    expect(flatMap([], () => [1])).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [1, 2];
+    flatMap(input, (n) => [n, n]);
+    expect(input).toEqual([1, 2]);
+  });
+
+  it("does NOT flatten nested arrays deeper than one level", () => {
+    const out = flatMap([1, 2], (n) => [[n, n + 1]] as unknown as number[]);
+    // First-level flatten produces [[1,2],[2,3]] not [1,2,2,3].
+    expect(out.length).toBe(2);
+  });
+});

--- a/code/packages/typescript/forme-transforms/tests/group.test.ts
+++ b/code/packages/typescript/forme-transforms/tests/group.test.ts
@@ -1,0 +1,160 @@
+/**
+ * group.test.ts — partition, groupBy, unique.
+ */
+
+import { describe, it, expect } from "vitest";
+import { partition, groupBy, unique } from "../src/index.js";
+
+describe("partition", () => {
+  it("splits into { yes, no }", () => {
+    const { yes, no } = partition([1, 2, 3, 4, 5], (n) => n % 2 === 0);
+    expect(yes).toEqual([2, 4]);
+    expect(no).toEqual([1, 3, 5]);
+  });
+
+  it("preserves input order in both halves", () => {
+    const { yes, no } = partition([5, 4, 3, 2, 1], (n) => n > 2);
+    expect(yes).toEqual([5, 4, 3]);
+    expect(no).toEqual([2, 1]);
+  });
+
+  it("all-true → empty no", () => {
+    const { yes, no } = partition([1, 2, 3], () => true);
+    expect(yes).toEqual([1, 2, 3]);
+    expect(no).toEqual([]);
+  });
+
+  it("all-false → empty yes", () => {
+    const { yes, no } = partition([1, 2, 3], () => false);
+    expect(yes).toEqual([]);
+    expect(no).toEqual([1, 2, 3]);
+  });
+
+  it("empty input → empty both", () => {
+    const { yes, no } = partition([], () => true);
+    expect(yes).toEqual([]);
+    expect(no).toEqual([]);
+  });
+
+  it("passes index to predicate", () => {
+    const { yes } = partition(["a", "b", "c", "d"], (_, i) => i % 2 === 0);
+    expect(yes).toEqual(["a", "c"]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [1, 2, 3];
+    partition(input, (n) => n > 1);
+    expect(input).toEqual([1, 2, 3]);
+  });
+});
+
+describe("groupBy", () => {
+  it("buckets items by key", () => {
+    const out = groupBy(["apple", "ant", "bear", "boa"], (s) => s[0]);
+    expect(out.get("a")).toEqual(["apple", "ant"]);
+    expect(out.get("b")).toEqual(["bear", "boa"]);
+  });
+
+  it("returns a Map (not a plain object) — protection against __proto__ keys", () => {
+    const out = groupBy(["x"], () => "__proto__");
+    expect(out).toBeInstanceOf(Map);
+    expect(out.get("__proto__")).toEqual(["x"]);
+    // The Object prototype must not have been polluted.
+    expect(({} as Record<string, unknown>).x).toBeUndefined();
+  });
+
+  it("Map iteration order = first-seen-bucket order", () => {
+    const out = groupBy(
+      [{ k: "b" }, { k: "a" }, { k: "b" }, { k: "c" }],
+      (o) => o.k,
+    );
+    expect([...out.keys()]).toEqual(["b", "a", "c"]);
+  });
+
+  it("within-bucket order = input order", () => {
+    const out = groupBy([1, 4, 2, 5, 3, 6], (n) => n % 2 === 0 ? "even" : "odd");
+    expect(out.get("odd")).toEqual([1, 5, 3]);
+    expect(out.get("even")).toEqual([4, 2, 6]);
+  });
+
+  it("supports numeric keys", () => {
+    const out = groupBy([1.1, 2.2, 1.5, 2.9], (n) => Math.floor(n));
+    expect(out.get(1)).toEqual([1.1, 1.5]);
+    expect(out.get(2)).toEqual([2.2, 2.9]);
+  });
+
+  it("empty input → empty Map", () => {
+    const out = groupBy([], () => "x");
+    expect(out.size).toBe(0);
+  });
+
+  it("does not mutate input", () => {
+    const input = [1, 2, 3];
+    groupBy(input, (n) => n);
+    expect(input).toEqual([1, 2, 3]);
+  });
+});
+
+describe("unique — identity dedupe", () => {
+  it("removes duplicate primitives, first occurrence wins", () => {
+    expect(unique([1, 2, 1, 3, 2, 4])).toEqual([1, 2, 3, 4]);
+  });
+
+  it("works on strings", () => {
+    expect(unique(["js", "ts", "js", "rs"])).toEqual(["js", "ts", "rs"]);
+  });
+
+  it("empty input → empty output", () => {
+    expect(unique([])).toEqual([]);
+  });
+
+  it("all-unique → copy of input", () => {
+    expect(unique([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [1, 2, 1, 3];
+    unique(input);
+    expect(input).toEqual([1, 2, 1, 3]);
+  });
+
+  it("preserves first reference for object identity", () => {
+    const obj = { x: 1 };
+    const out = unique([obj, { x: 1 }, obj]);
+    expect(out.length).toBe(2);
+    expect(out[0]).toBe(obj);
+  });
+});
+
+describe("unique — keyFn dedupe", () => {
+  it("dedupes by extracted key, first occurrence wins", () => {
+    const posts = [
+      { slug: "hello", title: "Hello v1" },
+      { slug: "hello", title: "Hello v2" },
+      { slug: "world", title: "World" },
+    ];
+    const out = unique(posts, (p) => p.slug);
+    expect(out).toEqual([
+      { slug: "hello", title: "Hello v1" },
+      { slug: "world", title: "World" },
+    ]);
+  });
+
+  it("keyFn can return non-string keys", () => {
+    const out = unique(
+      [{ a: 1, b: 1 }, { a: 2, b: 1 }, { a: 3, b: 2 }],
+      (o) => o.b,
+    );
+    expect(out.length).toBe(2);
+  });
+
+  it("empty input → empty output", () => {
+    expect(unique([], (n: number) => n)).toEqual([]);
+  });
+
+  it("__proto__ key doesn't pollute Object.prototype", () => {
+    const out = unique([1, 2, 3], () => "__proto__");
+    expect(out).toEqual([1]);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/code/packages/typescript/forme-transforms/tests/pipe.test.ts
+++ b/code/packages/typescript/forme-transforms/tests/pipe.test.ts
@@ -1,0 +1,98 @@
+/**
+ * pipe.test.ts — left-to-right composition over arrays.
+ */
+
+import { describe, it, expect } from "vitest";
+import { pipe, filter, map, sortBy, take } from "../src/index.js";
+
+describe("pipe — basic composition", () => {
+  it("no steps → returns input unchanged", () => {
+    const input = [1, 2, 3];
+    const out = pipe(input);
+    expect(out).toEqual([1, 2, 3]);
+  });
+
+  it("one step", () => {
+    const out = pipe([1, 2, 3], (xs) => map(xs, (n) => n * 2));
+    expect(out).toEqual([2, 4, 6]);
+  });
+
+  it("multiple steps run left-to-right", () => {
+    const out = pipe([5, 3, 1, 4, 2],
+      (xs) => filter(xs, (n) => n > 1),
+      (xs) => sortBy(xs, (n) => n),
+      (xs) => take(xs, 2),
+    );
+    expect(out).toEqual([2, 3]);
+  });
+
+  it("each step's output becomes the next step's input", () => {
+    const seen: number[][] = [];
+    pipe([1, 2, 3],
+      (xs) => { seen.push([...xs]); return map(xs, (n) => n + 10); },
+      (xs) => { seen.push([...xs]); return map(xs, (n) => n + 100); },
+      (xs) => { seen.push([...xs]); return xs; },
+    );
+    expect(seen).toEqual([
+      [1, 2, 3],
+      [11, 12, 13],
+      [111, 112, 113],
+    ]);
+  });
+
+  it("type-changes between steps (T → U → V)", () => {
+    const out = pipe(["a", "bb", "ccc"],
+      (xs) => map(xs, (s) => s.length),
+      (xs) => map(xs, (n) => `len=${n}`),
+    );
+    expect(out).toEqual(["len=1", "len=2", "len=3"]);
+  });
+});
+
+describe("pipe — real-world Forme pipeline shapes", () => {
+  interface Post { id: string; pubDate: string | null; draft: boolean; }
+
+  const POSTS: Post[] = [
+    { id: "a", pubDate: "2026-01-01", draft: false },
+    { id: "b", pubDate: "2026-02-01", draft: true },
+    { id: "c", pubDate: "2025-12-01", draft: false },
+    { id: "d", pubDate: null,         draft: false },
+    { id: "e", pubDate: "2026-03-01", draft: false },
+  ];
+
+  it("'recent published posts' shape", () => {
+    const recent = pipe(POSTS,
+      (xs) => filter(xs, (p) => !p.draft),
+      (xs) => sortBy(xs, (p) => p.pubDate, "desc"),
+      (xs) => take(xs, 2),
+    );
+    expect((recent as Post[]).map((p) => p.id)).toEqual(["e", "a"]);
+  });
+
+  it("'extract IDs of all non-draft posts' shape (map at the end)", () => {
+    const ids = pipe(POSTS,
+      (xs) => filter(xs, (p) => !p.draft),
+      (xs) => map(xs, (p) => p.id),
+    );
+    expect(ids).toEqual(["a", "c", "d", "e"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const before = [...POSTS];
+    pipe(POSTS,
+      (xs) => filter(xs, (p) => !p.draft),
+      (xs) => sortBy(xs, (p) => p.id),
+    );
+    expect(POSTS).toEqual(before);
+  });
+});
+
+describe("pipe — edge cases", () => {
+  it("empty input survives through all steps", () => {
+    const out = pipe([] as number[],
+      (xs) => map(xs, (n) => n * 2),
+      (xs) => filter(xs, (n) => n > 0),
+    );
+    expect(out).toEqual([]);
+  });
+});

--- a/code/packages/typescript/forme-transforms/tests/slice.test.ts
+++ b/code/packages/typescript/forme-transforms/tests/slice.test.ts
@@ -1,0 +1,152 @@
+/**
+ * slice.test.ts — take, drop, slice, chunk.
+ */
+
+import { describe, it, expect } from "vitest";
+import { take, drop, slice, chunk } from "../src/index.js";
+
+describe("take", () => {
+  it("returns the first N items", () => {
+    expect(take([1, 2, 3, 4, 5], 3)).toEqual([1, 2, 3]);
+  });
+
+  it("N larger than input → copy of input", () => {
+    expect(take([1, 2], 100)).toEqual([1, 2]);
+  });
+
+  it("N === 0 → empty", () => {
+    expect(take([1, 2, 3], 0)).toEqual([]);
+  });
+
+  it("negative N is clamped to 0 → empty", () => {
+    expect(take([1, 2, 3], -5)).toEqual([]);
+  });
+
+  it("NaN → empty", () => {
+    expect(take([1, 2, 3], NaN)).toEqual([]);
+  });
+
+  it("Infinity → empty (Number.isFinite gate)", () => {
+    expect(take([1, 2, 3], Infinity)).toEqual([]);
+  });
+
+  it("fractional N is floored", () => {
+    expect(take([1, 2, 3, 4], 2.7)).toEqual([1, 2]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [1, 2, 3];
+    take(input, 2);
+    expect(input).toEqual([1, 2, 3]);
+  });
+});
+
+describe("drop", () => {
+  it("skips the first N items", () => {
+    expect(drop([1, 2, 3, 4, 5], 2)).toEqual([3, 4, 5]);
+  });
+
+  it("N === 0 → copy of input", () => {
+    expect(drop([1, 2, 3], 0)).toEqual([1, 2, 3]);
+  });
+
+  it("negative N → copy of input", () => {
+    expect(drop([1, 2, 3], -5)).toEqual([1, 2, 3]);
+  });
+
+  it("N larger than input → empty", () => {
+    expect(drop([1, 2], 100)).toEqual([]);
+  });
+
+  it("NaN → copy of input", () => {
+    expect(drop([1, 2], NaN)).toEqual([1, 2]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [1, 2, 3];
+    drop(input, 1);
+    expect(input).toEqual([1, 2, 3]);
+  });
+
+  it("returns a fresh array (not the input itself) even when N=0", () => {
+    const input = [1, 2, 3];
+    const out = drop(input, 0);
+    expect(out).not.toBe(input);
+  });
+});
+
+describe("slice", () => {
+  it("returns items[start..end)", () => {
+    expect(slice([1, 2, 3, 4, 5], 1, 4)).toEqual([2, 3, 4]);
+  });
+
+  it("defaults: start=0, end=length → copy of input", () => {
+    expect(slice([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("end omitted → to end of array", () => {
+    expect(slice([1, 2, 3, 4, 5], 2)).toEqual([3, 4, 5]);
+  });
+
+  it("negative start clamps to 0 (no from-end behaviour)", () => {
+    expect(slice([1, 2, 3], -1)).toEqual([1, 2, 3]);
+  });
+
+  it("end < start collapses to empty", () => {
+    expect(slice([1, 2, 3, 4, 5], 3, 1)).toEqual([]);
+  });
+
+  it("end beyond length clamps to length", () => {
+    expect(slice([1, 2, 3], 1, 100)).toEqual([2, 3]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [1, 2, 3];
+    slice(input, 0, 2);
+    expect(input).toEqual([1, 2, 3]);
+  });
+});
+
+describe("chunk", () => {
+  it("splits into batches of N", () => {
+    expect(chunk([1, 2, 3, 4, 5, 6], 2)).toEqual([[1, 2], [3, 4], [5, 6]]);
+  });
+
+  it("final batch is smaller when not a multiple", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("empty input → empty output", () => {
+    expect(chunk([], 5)).toEqual([]);
+  });
+
+  it("size > input length → single batch of the whole input", () => {
+    expect(chunk([1, 2], 100)).toEqual([[1, 2]]);
+  });
+
+  it("throws RangeError on size 0", () => {
+    expect(() => chunk([1, 2, 3], 0)).toThrow(RangeError);
+  });
+
+  it("throws RangeError on negative size", () => {
+    expect(() => chunk([1, 2, 3], -1)).toThrow(RangeError);
+  });
+
+  it("throws RangeError on fractional size", () => {
+    expect(() => chunk([1, 2, 3], 2.5)).toThrow(RangeError);
+  });
+
+  it("throws RangeError on NaN size", () => {
+    expect(() => chunk([1, 2, 3], NaN)).toThrow(RangeError);
+  });
+
+  it("throws RangeError on Infinity size", () => {
+    expect(() => chunk([1, 2, 3], Infinity)).toThrow(RangeError);
+  });
+
+  it("does not mutate input", () => {
+    const input = [1, 2, 3, 4];
+    chunk(input, 2);
+    expect(input).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/code/packages/typescript/forme-transforms/tests/sort.test.ts
+++ b/code/packages/typescript/forme-transforms/tests/sort.test.ts
@@ -1,0 +1,158 @@
+/**
+ * sort.test.ts — stable sortBy / sortBy2 with null-last and id tiebreaker.
+ */
+
+import { describe, it, expect } from "vitest";
+import { sortBy, sortBy2 } from "../src/index.js";
+
+interface Post { id: string; title: string; pubDate: string | null; }
+
+const POSTS: Post[] = [
+  { id: "a", title: "Alpha",  pubDate: "2026-01-15" },
+  { id: "b", title: "Beta",   pubDate: "2026-02-20" },
+  { id: "c", title: "Carrot", pubDate: null },
+  { id: "d", title: "Delta",  pubDate: "2025-12-01" },
+];
+
+describe("sortBy — direction handling", () => {
+  it("asc (default): ascending by extracted key", () => {
+    const out = sortBy(POSTS, (p) => p.title);
+    expect(out.map((p) => p.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("desc: reverses non-null ordering", () => {
+    const out = sortBy(POSTS, (p) => p.title, "desc");
+    expect(out.map((p) => p.id)).toEqual(["d", "c", "b", "a"]);
+  });
+});
+
+describe("sortBy — null/undefined go last", () => {
+  it("null pubDate sorts to end on asc", () => {
+    const out = sortBy(POSTS, (p) => p.pubDate, "asc");
+    expect(out[out.length - 1]!.id).toBe("c");
+  });
+
+  it("null pubDate sorts to end on desc too (not flipped)", () => {
+    const out = sortBy(POSTS, (p) => p.pubDate, "desc");
+    expect(out[out.length - 1]!.id).toBe("c");
+  });
+
+  it("two nulls tie and stay in input order", () => {
+    const both: Post[] = [
+      { id: "x", title: "X", pubDate: null },
+      { id: "y", title: "Y", pubDate: null },
+    ];
+    const out = sortBy(both, (p) => p.pubDate);
+    expect(out.map((p) => p.id)).toEqual(["x", "y"]);
+  });
+
+  it("undefined treated same as null", () => {
+    const input = [{ id: "a", k: 5 }, { id: "b", k: undefined }, { id: "c", k: 3 }];
+    const out = sortBy(input, (p) => p.k);
+    expect(out.map((p) => p.id)).toEqual(["c", "a", "b"]);
+  });
+});
+
+describe("sortBy — stability", () => {
+  it("ties broken by input index (stable)", () => {
+    const input = [
+      { id: "a", k: 1 },
+      { id: "b", k: 1 },
+      { id: "c", k: 1 },
+    ];
+    const out = sortBy(input, (p) => p.k);
+    expect(out.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [...POSTS];
+    sortBy(input, (p) => p.pubDate);
+    expect(input).toEqual(POSTS);
+  });
+
+  it("keyFn invoked once per item (memoised internally)", () => {
+    let calls = 0;
+    sortBy([1, 2, 3, 4, 5], (n) => { calls++; return n; });
+    expect(calls).toBe(5);
+  });
+});
+
+describe("sortBy — numeric and bigint keys", () => {
+  it("numeric ascending", () => {
+    expect(sortBy([3, 1, 4, 1, 5], (n) => n)).toEqual([1, 1, 3, 4, 5]);
+  });
+
+  it("numeric descending", () => {
+    expect(sortBy([3, 1, 4, 1, 5], (n) => n, "desc")).toEqual([5, 4, 3, 1, 1]);
+  });
+
+  it("NaN keys treated as ties (kept in input order)", () => {
+    const input = [{ id: "a", k: NaN }, { id: "b", k: NaN }];
+    const out = sortBy(input, (p) => p.k);
+    expect(out.map((p) => p.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("sortBy2 — primary then secondary key", () => {
+  it("primary tie → secondary decides", () => {
+    const input = [
+      { id: "a", pri: 1, sec: 30 },
+      { id: "b", pri: 1, sec: 10 },
+      { id: "c", pri: 2, sec: 20 },
+    ];
+    const out = sortBy2(input, (p) => p.pri, (p) => p.sec);
+    expect(out.map((p) => p.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("primary alone is enough when no ties", () => {
+    const input = [
+      { id: "a", pri: 3, sec: 0 },
+      { id: "b", pri: 1, sec: 0 },
+      { id: "c", pri: 2, sec: 0 },
+    ];
+    const out = sortBy2(input, (p) => p.pri, (p) => p.sec);
+    expect(out.map((p) => p.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("primary desc + secondary asc (FM00 archive idiom)", () => {
+    const input = [
+      { id: "a", pubDate: "2026-01-01", title: "Z" },
+      { id: "b", pubDate: "2026-01-01", title: "A" },
+      { id: "c", pubDate: "2026-02-01", title: "M" },
+    ];
+    const out = sortBy2(
+      input,
+      (p) => p.pubDate,
+      (p) => p.title,
+      "desc",
+      "asc",
+    );
+    expect(out.map((p) => p.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("null primary still goes last; secondary then breaks ties among nulls", () => {
+    const input = [
+      { id: "a", pri: null, sec: 2 },
+      { id: "b", pri: null, sec: 1 },
+      { id: "c", pri: 5,    sec: 9 },
+    ];
+    const out = sortBy2(input, (p) => p.pri, (p) => p.sec);
+    expect(out.map((p) => p.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("both keys tie → input order preserved (index tiebreaker)", () => {
+    const input = [
+      { id: "a", pri: 1, sec: 1 },
+      { id: "b", pri: 1, sec: 1 },
+      { id: "c", pri: 1, sec: 1 },
+    ];
+    const out = sortBy2(input, (p) => p.pri, (p) => p.sec);
+    expect(out.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [...POSTS];
+    sortBy2(input, (p) => p.pubDate, (p) => p.id);
+    expect(input).toEqual(POSTS);
+  });
+});

--- a/code/packages/typescript/forme-transforms/tsconfig.json
+++ b/code/packages/typescript/forme-transforms/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-transforms/vitest.config.ts
+++ b/code/packages/typescript/forme-transforms/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Fourth FM00 v0 stage package — pure-data sequence helpers (`filter` / `map` / `flatMap` / `take` / `drop` / `slice` / `chunk` / `sortBy` / `sortBy2` / `partition` / `groupBy` / `unique` / `pipe`) over arrays of anything (`Document[]`, `IndexItem[]`, `ContentNode[]`, or caller types).

Sits alongside [`forme-feeds`](../forme-feeds), [`forme-opengraph`](../forme-opengraph), [`forme-index-renderer`](../forme-index-renderer) as the foundational sequence layer that renderers, collectors, and the orchestrator all build on.

## Why

Every Forme stage touches arrays. Without a shared algebra each one re-invents sort/filter logic with subtle bugs:
- `Array.prototype.sort` is stable on modern V8 but undefined on ancient JS engines some embedded runtimes still ship — and FM03 reproducibility requires "same input → byte-identical output."
- Plain-object `groupBy` (`{ [key]: [...] }`) is a `__proto__` injection vector when keys come from user-authored frontmatter.
- `Array.prototype.filter` / `.map` accept `readonly T[]` but callbacks can mutate by reference; no-mutation has to be enforced by convention.

This package solves all three with a single uniform algebra: every helper takes `readonly T[]`, returns a fresh array (or `Map`), and has documented behaviour for ties / nulls / empty inputs / out-of-range parameters.

## API at a glance

```ts
import { pipe, filter, sortBy, take } from "@coding-adventures/forme-transforms";

// Recent published posts, newest-first, top 10.
const recent = pipe(posts,
  (xs) => filter(xs, (p) => !p.draft),
  (xs) => sortBy(xs, (p) => p.pubDate, "desc"),
  (xs) => take(xs, 10),
);
```

Plus `sortBy2` for primary-then-secondary tie-breaks (e.g. `pubDate-desc` + `id-asc` — the FM00 archive idiom).

## Key behavioural choices

- **`sortBy` puts null / undefined keys LAST regardless of direction.** "Newest first" puts undated items at the end, not the top.
- **`sortBy` index tiebreaker** locks in stability even on engines whose `Array.prototype.sort` stability we haven't independently verified.
- **`sortBy` memoises keys** — `keyFn` called exactly once per item, not O(N log N) times.
- **`groupBy` returns `Map<K, T[]>`** (not plain `Object`) — `__proto__`-safe, supports non-string keys, insertion-order iteration.
- **`chunk` throws `RangeError`** on non-positive / non-integer size; every other helper clamps out-of-range inputs to array bounds.

## Security

Three concerns explicitly addressed pre-push:
- Prototype-pollution defence — `Map` / `Set` internally, never plain-Object property assignment. Tests pin `__proto__` key handling.
- Bounded computation — `chunk` rejects bad sizes; `take` / `drop` / `slice` clamp rather than dispatching unbounded allocations.
- No mutation — decorate-sort-undecorate for `sortBy*`; every helper returns fresh arrays.

Security review (general-purpose sub-agent): **no exploitable findings** across all six focus areas (prototype pollution, unbounded computation, caller-array mutation, sort determinism, pipe callback execution, prohibited APIs).

## Capabilities

`[]` — pure transform. No I/O, network, fs, shell, env, dynamic require / eval / Function.

## Tests

**101 tests across 5 files**, **100% line / 100% branch** coverage:

- `filter-map.test.ts` (18) — purity, index passthrough, type-changes, no-mutation, one-level-only flatten
- `slice.test.ts` (32) — take / drop / slice / chunk on every edge (negative, NaN, Infinity, fractional, zero, out-of-range)
- `sort.test.ts` (18) — sortBy / sortBy2 with asc + desc, null-last on both directions, NaN ties, stable index tiebreaker, keyFn memoisation, FM00 archive idiom
- `group.test.ts` (24) — partition halves, groupBy Map (`__proto__`-safe), insertion-order, both unique overloads, object identity
- `pipe.test.ts` (9) — composition order, type-changes between steps, no-mutation, real-world Forme pipeline shapes

## Spec adherence

Extends the FM00 v0 surface area with a foundational sequence layer. The spec's §5.3 lists individual `transform-*` packages; this is the building block they all use. No spec divergences.

## v0 simplifications

- No streaming / generator variants (array-in array-out fits Forme's single-machine blog scale)
- No curried / partially-applied forms (reduces TypeScript inference weight)
- No reduce / fold (too shape-dependent to wrap usefully)
- No async variants (stages handle their own async boundaries)

## Test plan

- [x] All 101 tests pass locally
- [x] 100% line / 100% branch coverage
- [x] TypeScript build clean (`tsc --noEmit`)
- [x] Security review clean (prototype pollution / unbounded compute / mutation / determinism / prohibited APIs)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)