### PR TITLE
feat(forme-transform-autolink-headings): FM00 v0 §5.3 heading slug + anchor transform

### DIFF
--- a/code/packages/typescript/forme-transform-autolink-headings/BUILD
+++ b/code/packages/typescript/forme-transform-autolink-headings/BUILD
@@ -1,0 +1,2 @@
+cd ../document-ast && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-transform-autolink-headings/CHANGELOG.md
+++ b/code/packages/typescript/forme-transform-autolink-headings/CHANGELOG.md
@@ -1,0 +1,146 @@
+# Changelog — @coding-adventures/forme-transform-autolink-headings
+
+## 0.1.0 — 2026-05-18
+
+Initial release.  Fifth FM00 v0 stage package — first concrete
+spec §5.3 transform.  Generates deterministic slug ids +
+self-link anchor metadata for every `HeadingNode` in a
+`DocumentNode`.
+
+Sits alongside `forme-feeds`, `forme-opengraph`,
+`forme-index-renderer`, and `forme-transforms`.
+
+### Added
+
+- `autolinkHeadings(doc): HeadingSlug[]` — walks `doc` depth-first
+  in document order, finds every `HeadingNode`, slugifies its
+  plain-text content via `extractText` + `slugify`, resolves
+  collisions globally via `resolveCollisions`, returns one
+  annotation per heading.
+- `slugify(text): string` — GitHub-flavoured slugification.
+  Lowercase, strip control bytes, strip non-`[a-z0-9 -]`,
+  collapse runs, trim, fall back to `"section"` if empty.
+- `resolveCollisions(candidates): string[]` — disambiguate
+  repeated slug candidates by appending `-2`, `-3`, ... to later
+  occurrences.  First occurrence stays unsuffixed.  Skips
+  already-taken numeric suffixes.
+- `extractText(inlines): string` — flatten an `InlineNode[]` to
+  plain text.  Recurses into formatting wrappers, uses image alt
+  text, treats breaks as single spaces, skips `raw_inline`.
+- `HeadingSlug` type:
+  `{ level: 1-6, text: string, slug: string, anchorHref: string }`.
+
+### Spec adherence
+
+Implements FM00 v0 §5.3 `transform-autolink-headings`.  No spec
+divergences.  Spec calls for "add id + self-link to headings";
+this package produces the annotation stream that renderers
+consume to emit exactly that markup.
+
+### Behavioural notes
+
+- **Annotations, not AST mutation.**  The `document-ast` IR is
+  immutable and has no `id` field on `HeadingNode`.  Rather than
+  introducing a coordinated cross-package extension, this
+  transform returns a parallel `HeadingSlug[]` indexed by
+  encounter order.  Renderers walk the document and consume the
+  annotation stream in lockstep.  Side benefit: the annotation
+  stream is JSON-serialisable, supporting cross-process Forme
+  deployments where parser and renderer run separately.
+- **Global collision namespace.**  All headings in the document
+  share one slug namespace — `## Setup` followed by `### Setup`
+  produces `setup` / `setup-2` regardless of nesting depth.
+  Matches GitHub's behaviour; prevents broken in-page links.
+- **Walks nested containers.**  Headings inside blockquote, list,
+  list_item, task_item are all found in document order.  Tables
+  don't contain blocks (cell children are inline), so no walk
+  into tables.
+- **Defensive no-op for non-tree BlockNode variants.**  The
+  `BlockNode` union includes `DocumentNode` / `ListItemNode` /
+  `TaskItemNode` / `TableRowNode` / `TableCellNode` for type-
+  system simplicity, but well-formed AST never places these as
+  direct siblings of other blocks.  The walker silently ignores
+  them rather than throwing — keeps the transform robust against
+  hand-constructed inputs.
+- **GitHub-flavoured slugify.**  Lowercase, ASCII-only (no
+  Unicode preservation), digits kept, runs collapsed, fallback
+  `"section"` for empty inputs.  Output guaranteed to match
+  `/^[a-z0-9-]+$/`.
+
+### Security posture
+
+Three concerns explicitly addressed (pre-push review):
+
+- **HTML injection via attacker-controlled heading text.**
+  `slugify` strips everything except `[a-z0-9 -]`, so
+  `<script>alert(1)</script>` becomes `scriptalert1script` —
+  safe to interpolate into an `id="..."` attribute without
+  escaping.  Pinned by `slugify.test.ts` and `autolink.test.ts`.
+- **Attribute-breakout via quotes / equals / brackets.**  All of
+  `"`, `'`, `=`, `<`, `>`, `&` are outside the kept character
+  class and get stripped before the slug is ever emitted.
+- **ASCII control-byte smuggling.**  NUL (`\x00`), DEL (`\x7F`),
+  and every other ASCII control character is stripped explicitly
+  before the main regex pass — defence-in-depth against a
+  hypothetical parser that lets controls leak through.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, network, fs, shell, env.
+
+### Tests
+
+85 tests across 4 files:
+
+- `slugify.test.ts` (25) — basic shape (lowercase, hyphen
+  replacement, run collapse, trim, digit preservation, GitHub
+  idiom matching), fallback for empty / whitespace / punctuation /
+  non-ASCII / hyphens-only inputs, security (control bytes:
+  NUL/ESC/DEL; HTML injection; quotes/angle brackets/ampersands),
+  output guarantees (matches `/^[a-z0-9-]+$/`, non-empty,
+  idempotent, deterministic), non-string defensive coercion.
+- `collisions.test.ts` (15) — basic numbering (no collision /
+  duplicate / triple / interleaved / first-unsuffixed), skip
+  already-taken suffixes (single / multiple / non-contiguous
+  gaps), determinism (same input byte-identical output,
+  no-mutation, fresh-array), edge cases (empty / single / output
+  length invariant / empty-string slugs).
+- `extract-text.test.ts` (17) — basic text nodes, formatting
+  wrappers (emphasis / strong / strikethrough / nested),
+  link / code_span / image / autolink (URL + email) handling,
+  hard / soft breaks → space, raw_inline skipped, real-world
+  mixed-inline heading shapes.
+- `autolink.test.ts` (28) — end-to-end (flat doc, document order
+  preservation, level propagation, empty inputs, no-heading
+  inputs), anchorHref = #slug invariant, global collision
+  resolution (within doc, across nesting levels, across
+  different-text-same-slug pairs), text extraction from mixed
+  inline content (strong+code+text, empty → section fallback,
+  multiple empty → section-2/-3), nested container walks
+  (blockquote / list / task_item / deep nesting), skip non-
+  walkable blocks (paragraph/code_block/thematic_break/raw_block/
+  table), defensive no-op for non-tree BlockNode variants,
+  reproducibility (FM03 byte-identical output, no-mutation of
+  input AST), security (script tags, NUL, attribute-breakout
+  chars).
+
+Coverage: **95.77% line / 95.74% branch**.  Uncovered lines are
+TypeScript `never` exhaustiveness guards in switch defaults
+that cannot fire at runtime (`autolink.ts` line 123-125,
+`extract-text.ts` line 80-82).
+
+### v0 simplifications (documented)
+
+- **Annotations, not AST mutation** — see Behavioural notes.  A
+  future v1 might extend `document-ast` with an optional `id`
+  field on `HeadingNode`, but that's a coordinated cross-package
+  change deferred from v0.
+- **No anchor-text customisation.**  All anchors get `#slug`;
+  no `prefix` option for namespaced docs.
+- **No Unicode slug preservation.**  Non-ASCII text gets stripped
+  (heading may reduce to `"section"`).  Matches GitHub; full
+  Unicode support requires percent-encoding decisions deferred
+  to v1.
+- **No anchor-link visibility class / icon.**  Renderers decide
+  how to present the self-link visually; this package emits only
+  the slug + href.

--- a/code/packages/typescript/forme-transform-autolink-headings/README.md
+++ b/code/packages/typescript/forme-transform-autolink-headings/README.md
@@ -1,0 +1,208 @@
+# @coding-adventures/forme-transform-autolink-headings
+
+Generate deterministic slug ids + self-link anchor metadata for
+every `HeadingNode` in a `DocumentNode`.  FM00 v0 §5.3 transform.
+
+Pure transform: walks a `DocumentNode` once, produces an ordered
+`HeadingSlug[]` (one entry per heading in document order).
+Renderers consume the annotation stream to emit
+
+```html
+<h2 id="my-slug"><a href="#my-slug" class="forme-anchor">Heading text</a></h2>
+```
+
+Fifth FM00 v0 stage package — sits alongside
+[`forme-feeds`](../forme-feeds),
+[`forme-opengraph`](../forme-opengraph),
+[`forme-index-renderer`](../forme-index-renderer), and
+[`forme-transforms`](../forme-transforms).
+
+## Quick start
+
+```ts
+import { autolinkHeadings } from "@coding-adventures/forme-transform-autolink-headings";
+
+const slugs = autolinkHeadings(doc);
+for (const { level, text, slug, anchorHref } of slugs) {
+  console.log(`h${level} → ${anchorHref}  (${text})`);
+}
+// h1 → #installation  (Installation)
+// h2 → #setup  (Setup)
+// h2 → #setup-2  (Setup)   ← second occurrence gets -2 suffix
+```
+
+## Why this package exists
+
+Headings in Forme docs become deep-link targets — feeds reference
+them, TOCs link to them, social cards anchor to them.  The IR
+(`document-ast`) is immutable and doesn't carry an `id` on
+`HeadingNode`, so this transform produces the parallel annotation
+stream that downstream stages consume.
+
+Two non-obvious design choices:
+
+1. **Annotations, not AST mutation.**  Returns a `HeadingSlug[]`
+   indexed by encounter order rather than modifying the document.
+   This keeps the AST contract intact and makes the annotation
+   stream JSON-serialisable for cross-process Forme deployments
+   where parser and renderer run separately.
+2. **Global collision resolution.**  All headings in the document
+   participate in one collision namespace — `## Setup` followed by
+   `### Setup` produces `setup` and `setup-2` regardless of
+   nesting depth.  Matches GitHub's behaviour and prevents
+   broken in-page links.
+
+## API
+
+### `autolinkHeadings(doc): HeadingSlug[]`
+
+Walks `doc` depth-first in document order, finds every
+`HeadingNode`, slugifies its plain-text content, resolves
+collisions, and returns one annotation per heading.
+
+```ts
+interface HeadingSlug {
+  readonly level: 1 | 2 | 3 | 4 | 5 | 6;
+  readonly text: string;        // plain-text label
+  readonly slug: string;        // [a-z0-9-]+, never empty
+  readonly anchorHref: string;  // "#" + slug
+}
+```
+
+### `slugify(text): string`
+
+GitHub-flavoured slugification.  Algorithm:
+
+1. Lowercase (locale-independent).
+2. Strip ASCII control bytes (`U+0000-U+001F`, `U+007F`).
+3. Strip everything except `[a-z0-9 -]`.
+4. Collapse whitespace + hyphen runs into one hyphen.
+5. Trim leading / trailing hyphens.
+6. Empty result → `"section"` fallback.
+
+Output guarantees:
+- non-empty,
+- matches `/^[a-z0-9-]+$/`,
+- never begins or ends with `-`,
+- contains no consecutive hyphens.
+
+### `resolveCollisions(candidates): string[]`
+
+Disambiguate a stream of slug candidates by appending `-2`, `-3`,
+... to later occurrences.  First occurrence stays unsuffixed
+(matches the most-likely link target for external references).
+Skips already-taken numeric suffixes:
+
+```
+["setup", "setup-2", "setup"] → ["setup", "setup-2", "setup-3"]
+                                                       ^ jumps past -2
+```
+
+### `extractText(inlines): string`
+
+Flatten an `InlineNode[]` to plain text — used internally for slug
+generation and useful for TOC labels.  Recurses into formatting
+wrappers (emphasis, strong, link, etc.), uses image alt text,
+treats breaks as single spaces, skips `raw_inline` (back-end-
+specific).
+
+## Behavioural contract
+
+| Aspect                          | Behaviour                              |
+|---------------------------------|----------------------------------------|
+| Input AST                       | Never mutated                          |
+| Output array length             | Exactly one entry per `HeadingNode`    |
+| Order                           | Document-order DFS                     |
+| Walks into                      | blockquote, list (item / task_item)    |
+| Walks past (no nested blocks)   | paragraph, code_block, thematic_break, raw_block, table |
+| Defensive no-op                 | document / list_item / task_item / table_row / table_cell as direct siblings (well-formed AST never has this) |
+| Empty / non-heading document    | `[]`                                   |
+| Slug always matches             | `/^[a-z0-9-]+$/`                       |
+| `anchorHref` always equals      | `#${slug}`                             |
+
+## Reproducibility (FM03)
+
+Same `DocumentNode` → byte-identical `HeadingSlug[]`.  The
+collision resolver is deterministic; slugify is deterministic;
+the walk order is deterministic.  Safe to use as a cache key
+input.
+
+## Security posture
+
+Three concerns explicitly addressed (pre-push review):
+
+- **HTML injection via attacker-controlled heading text.**
+  Heading text like `<script>alert(1)</script>` is stripped to
+  `scriptalert1script` by `slugify` — the `[^a-z0-9 -]` strip
+  pass removes angle brackets, quotes, ampersands, parens, equals
+  signs.  Slugs are guaranteed safe to interpolate into HTML
+  `id` attributes without escaping.
+- **Attribute-breakout via quotes / equals.**  `"`, `'`, `=`, `<`,
+  `>`, `&` all live outside `[a-z0-9 -]` and get stripped before
+  the slug is ever emitted.
+- **Control-byte smuggling.**  NUL (`\x00`), DEL (`\x7F`), and
+  every other ASCII control character is stripped explicitly
+  before the regex pass — defence-in-depth against a
+  hypothetical parser that lets controls leak through into
+  heading text.
+
+## Capabilities — `[]`
+
+Pure transform.  No I/O, no network, no shell, no env, no fs.
+Same posture as `forme-feeds` / `forme-opengraph` /
+`forme-index-renderer` / `forme-transforms`.
+
+## Tests
+
+85 tests across 4 files:
+
+- `slugify.test.ts` (25) — basic shape, fallback for empty /
+  whitespace / punctuation / non-ASCII, security (control bytes,
+  script tags, attribute-breakout chars), output guarantees
+  (regex, non-empty, idempotent, deterministic).
+- `collisions.test.ts` (15) — basic numbering, skip-taken-suffix
+  semantics, non-contiguous gap behaviour, determinism, edge
+  cases (empty / single, output length invariants).
+- `extract-text.test.ts` (17) — every inline node kind, nested
+  formatting wrappers, link/code/image/autolink handling,
+  hard/soft break → space, `raw_inline` skipped, real-world
+  heading shapes.
+- `autolink.test.ts` (28) — end-to-end transform, document order
+  preservation, level propagation, anchorHref = #slug, global
+  collision resolution across nesting, text extraction from
+  mixed inline content, walks blockquote / list / task_item /
+  deep nesting, defensive no-op for non-tree BlockNode variants,
+  reproducibility, no-mutation, security (script tags, NUL,
+  attribute-breakout chars).
+
+Coverage: **95.77% line / 95.74% branch**.  Uncovered lines are
+TypeScript `never` exhaustiveness guards that cannot fire at
+runtime.
+
+## Spec adherence
+
+Implements FM00 v0 §5.3 `transform-autolink-headings`.  No spec
+divergences.  The spec calls for "add id + self-link to
+headings"; this package produces the annotation stream that
+renderers consume to emit exactly that markup.  The annotation
+shape — list of `{ level, text, slug, anchorHref }` — is the
+v0 contract.
+
+## v0 simplifications
+
+- **Annotations, not AST mutation** — see "Why this package
+  exists".  A future v1 might extend `document-ast` with an
+  optional `id` field on `HeadingNode`, but that's a coordinated
+  change across every front-end / back-end and was deferred.
+- **No anchor-text customisation.**  All anchors get `#slug`;
+  there's no `prefix` option for namespaced docs (e.g. one big
+  page with sections from multiple chapters).  Add an `options`
+  arg in v1 if the need materialises.
+- **No Unicode slug support.**  Non-ASCII text is stripped (the
+  whole heading might reduce to `"section"`).  GitHub does the
+  same; full Unicode support would require percent-encoding
+  decisions deferred to v1.
+- **No anchor-link visibility class.**  Renderers add their own
+  `class="forme-anchor"` (or omit it) when consuming the
+  `anchorHref` — this package only emits the slug + href, not
+  the surrounding markup.

--- a/code/packages/typescript/forme-transform-autolink-headings/package-lock.json
+++ b/code/packages/typescript/forme-transform-autolink-headings/package-lock.json
@@ -1,0 +1,2317 @@
+{
+  "name": "@coding-adventures/forme-transform-autolink-headings",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-transform-autolink-headings",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../document-ast": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/document-ast": {
+      "resolved": "../document-ast",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/package.json
+++ b/code/packages/typescript/forme-transform-autolink-headings/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@coding-adventures/forme-transform-autolink-headings",
+  "version": "0.1.0",
+  "description": "Generate deterministic slug ids + self-link anchor metadata for every HeadingNode in a Document AST.  Pure transform: DocumentNode → ordered HeadingSlug[] (level, text, slug, anchor href) that renderers consume to emit `<h2 id=\"slug\"><a href=\"#slug\">…</a></h2>`.  FM00 v0 §5.3 transform.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/document-ast": "file:../document-ast"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/required_capabilities.json
+++ b/code/packages/typescript/forme-transform-autolink-headings/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-transform-autolink-headings",
+  "capabilities": [],
+  "justification": "Pure transform: DocumentNode → HeadingSlug[].  Walks an immutable AST and produces an ordered list of slug annotations.  No I/O, no network, no env, no shell, no fs.  Same posture as forme-feeds / forme-opengraph / forme-index-renderer / forme-transforms."
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/src/autolink.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/src/autolink.ts
@@ -1,0 +1,128 @@
+/**
+ * autolink.ts — the top-level transform entry point.
+ *
+ * Walks a `DocumentNode` once, finds every `HeadingNode` in
+ * document order, extracts plain-text content, slugifies, and
+ * resolves collisions deterministically.  Returns an ordered
+ * `HeadingSlug[]` for downstream consumers (renderers, TOC
+ * extractors, deep-link validators).
+ *
+ * The input document is NEVER mutated — the AST is immutable by
+ * contract, and this transform is pure.
+ *
+ * Walk strategy: depth-first, document-order traversal of every
+ * block whose body can contain other blocks (blockquote, list,
+ * list_item, task_item, table cell).  Headings nested inside
+ * blockquotes are slugified just like top-level ones; some
+ * Markdown flavours allow this and Forme renderers must too.
+ *
+ * @module autolink
+ */
+
+import type {
+  BlockNode,
+  DocumentNode,
+  HeadingNode,
+} from "@coding-adventures/document-ast";
+import { extractText } from "./extract-text.js";
+import { slugify } from "./slugify.js";
+import { resolveCollisions } from "./collisions.js";
+import type { HeadingSlug } from "./types.js";
+
+/**
+ * Generate slug annotations for every heading in `doc`.
+ *
+ * Returned array is in document order — i.e. the same order a
+ * pre-order DFS over `doc` would encounter the headings.
+ *
+ * ```ts
+ * const slugs = autolinkHeadings(doc);
+ * // slugs[0] is the first heading in the document, regardless of
+ * // its level or nesting depth.
+ * ```
+ *
+ * Reproducibility: same `DocumentNode` → byte-identical
+ * `HeadingSlug[]`.
+ */
+export function autolinkHeadings(doc: DocumentNode): HeadingSlug[] {
+  const headings: HeadingNode[] = [];
+  collectHeadings(doc.children, headings);
+
+  // Stage 1: compute the "base" slug for each heading from its text.
+  const candidates: string[] = new Array(headings.length);
+  const texts: string[] = new Array(headings.length);
+  for (let i = 0; i < headings.length; i++) {
+    const text = extractText(headings[i]!.children);
+    texts[i] = text;
+    candidates[i] = slugify(text);
+  }
+
+  // Stage 2: resolve collisions globally across the whole document.
+  const resolved = resolveCollisions(candidates);
+
+  // Stage 3: pack into HeadingSlug annotations.
+  const out: HeadingSlug[] = new Array(headings.length);
+  for (let i = 0; i < headings.length; i++) {
+    const slug = resolved[i]!;
+    out[i] = {
+      level: headings[i]!.level,
+      text: texts[i]!,
+      slug,
+      anchorHref: `#${slug}`,
+    };
+  }
+  return out;
+}
+
+/**
+ * Depth-first walk that pushes every `HeadingNode` found in
+ * `blocks` into `acc` in document order.  Recurses into every
+ * container-block kind defined by document-ast.
+ */
+function collectHeadings(blocks: readonly BlockNode[], acc: HeadingNode[]): void {
+  for (let i = 0; i < blocks.length; i++) {
+    const b = blocks[i]!;
+    switch (b.type) {
+      case "heading":
+        acc.push(b);
+        break;
+      case "blockquote":
+        collectHeadings(b.children, acc);
+        break;
+      case "list":
+        // ListNode.children is ListItemNode | TaskItemNode.
+        // Each item.children is BlockNode[].
+        for (let j = 0; j < b.children.length; j++) {
+          collectHeadings(b.children[j]!.children, acc);
+        }
+        break;
+      case "table":
+        // TableCellNode.children is InlineNode[] — no nested
+        // blocks, so no headings to find.  Nothing to walk.
+        break;
+      case "paragraph":
+      case "code_block":
+      case "thematic_break":
+      case "raw_block":
+        // No nested blocks of interest.
+        break;
+      case "document":
+      case "list_item":
+      case "task_item":
+      case "table_row":
+      case "table_cell":
+        // These BlockNode variants are not direct children of
+        // other blocks in well-formed AST (DocumentNode is
+        // root-only; list_item/task_item only appear inside
+        // ListNode; table_row/table_cell only inside TableNode).
+        // The walker reaches their content through the parent
+        // cases above (list / table).  Defensive no-op for
+        // type completeness.
+        break;
+      default: {
+        const _exhaustive: never = b;
+        void _exhaustive;
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/src/collisions.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/src/collisions.ts
@@ -1,0 +1,77 @@
+/**
+ * collisions.ts — deterministic resolution of repeated slug candidates.
+ *
+ * Two headings can produce the same slug — e.g. `## Setup` appears
+ * twice in a doc, or `## Step 1` and `## Step.1!` both reduce to
+ * `step-1`.  HTML `id`s must be unique within a document; the
+ * algorithm here disambiguates by appending `-2`, `-3`, ... to
+ * later occurrences:
+ *
+ *   Input:  ["setup", "setup", "intro", "setup"]
+ *   Output: ["setup", "setup-2", "intro", "setup-3"]
+ *
+ * **First occurrence is unsuffixed** — preserves the most-likely
+ * link target for external references that copy a heading's
+ * slug from elsewhere in the docs.  Numbering matches GitHub's
+ * behaviour exactly.
+ *
+ * **Reserved suffixes.**  If a heading naturally produces a slug
+ * like `setup-2` and is followed by another `setup`, the resolver
+ * skips taken suffixes:
+ *
+ *   Input:  ["setup", "setup-2", "setup"]
+ *   Output: ["setup", "setup-2", "setup-3"]
+ *                                   ^ not "setup-2" (taken)
+ *                                   ^ jumps straight to -3
+ *
+ * The implementation maintains a `Set` of taken slugs and a
+ * `Map<baseSlug, nextCandidate>` counter so the next-candidate
+ * search is amortised O(1).
+ *
+ * @module collisions
+ */
+
+/**
+ * Resolve a stream of slug candidates so every emitted slug is
+ * unique.  Returns a new array of the same length; input order
+ * preserved.
+ *
+ * Determinism: given the same input array, the output is byte-
+ * identical.  Two callers running this in parallel with the same
+ * input get the same result.  Input is never mutated.
+ */
+export function resolveCollisions(candidates: readonly string[]): string[] {
+  const taken = new Set<string>();
+  /**
+   * For each base slug, the next integer suffix to *try*.  Starts
+   * at 2 for the second occurrence and increments past any taken
+   * suffixes so we never test an already-claimed slug twice.
+   */
+  const nextSuffix = new Map<string, number>();
+
+  const out: string[] = new Array(candidates.length);
+  for (let i = 0; i < candidates.length; i++) {
+    const base = candidates[i]!;
+    if (!taken.has(base)) {
+      taken.add(base);
+      out[i] = base;
+      continue;
+    }
+    // Collision — pick the smallest available `base-N`.
+    let n = nextSuffix.get(base) ?? 2;
+    let candidate: string;
+    // The `taken.has` check inside the loop also catches the case
+    // where the *natural* slug of an earlier heading happened to
+    // be e.g. `setup-2` already (see module docstring example).
+    // Walk past those without redoing them.
+    while (true) {
+      candidate = `${base}-${n}`;
+      if (!taken.has(candidate)) break;
+      n++;
+    }
+    taken.add(candidate);
+    nextSuffix.set(base, n + 1);
+    out[i] = candidate;
+  }
+  return out;
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/src/extract-text.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/src/extract-text.ts
@@ -1,0 +1,85 @@
+/**
+ * extract-text.ts — flatten a heading's inline children to plain text.
+ *
+ * Headings can contain rich inline content — text, emphasis,
+ * strong, code spans, links, images, raw HTML.  Slug generation
+ * (and TOC labels) need a plain-text view.  This walk concatenates
+ * the textual content of every inline child, recursing into
+ * formatting wrappers.
+ *
+ * Per-node behaviour:
+ *
+ * | Inline node       | Text contribution                          |
+ * |-------------------|--------------------------------------------|
+ * | `text`            | `value` verbatim                           |
+ * | `emphasis`        | recurse into children                      |
+ * | `strong`          | recurse into children                      |
+ * | `strikethrough`   | recurse into children                      |
+ * | `link`            | recurse into children (link label)         |
+ * | `code_span`       | `value` verbatim (preserves source code)   |
+ * | `image`           | `alt` text (matches screen-reader output)  |
+ * | `autolink`        | `destination` (URL or email address)       |
+ * | `raw_inline`      | skipped (back-end-specific markup)         |
+ * | `hard_break`      | single space                               |
+ * | `soft_break`      | single space                               |
+ *
+ * `raw_inline` is intentionally skipped — its content is back-end-
+ * specific (e.g. `<sup>x</sup>` for HTML) and including it would
+ * leak markup into slugs (`stepx` vs `step`) and TOC labels.
+ *
+ * @module extract-text
+ */
+
+import type { InlineNode } from "@coding-adventures/document-ast";
+
+/**
+ * Concatenate the plain-text content of an inline node list.
+ * Returns a single string with leading / trailing whitespace
+ * trimmed and internal whitespace collapsed via `slugify` later
+ * (this function preserves spacing so TOC labels read naturally).
+ */
+export function extractText(nodes: readonly InlineNode[]): string {
+  const parts: string[] = [];
+  walk(nodes, parts);
+  return parts.join("");
+}
+
+function walk(nodes: readonly InlineNode[], out: string[]): void {
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i]!;
+    switch (n.type) {
+      case "text":
+        out.push(n.value);
+        break;
+      case "emphasis":
+      case "strong":
+      case "strikethrough":
+      case "link":
+        walk(n.children, out);
+        break;
+      case "code_span":
+        out.push(n.value);
+        break;
+      case "image":
+        out.push(n.alt);
+        break;
+      case "autolink":
+        out.push(n.destination);
+        break;
+      case "hard_break":
+      case "soft_break":
+        out.push(" ");
+        break;
+      case "raw_inline":
+        // Intentionally skipped — back-end-specific markup
+        // shouldn't leak into slugs / TOC labels.
+        break;
+      default: {
+        // Exhaustiveness guard.  If a new InlineNode kind is
+        // added to document-ast, TypeScript flags this branch.
+        const _exhaustive: never = n;
+        void _exhaustive;
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/src/index.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/src/index.ts
@@ -1,0 +1,38 @@
+/**
+ * @coding-adventures/forme-transform-autolink-headings
+ *
+ * FM00 v0 §5.3 transform — produce deterministic slug ids and
+ * self-link anchors for every `HeadingNode` in a `DocumentNode`.
+ *
+ * Pure transform: `DocumentNode` → `HeadingSlug[]` (one entry per
+ * heading, in document order).  Renderers consume the annotation
+ * stream while walking the AST to emit
+ *
+ *   <h2 id="my-slug"><a href="#my-slug" class="forme-anchor">Heading</a></h2>
+ *
+ * ```ts
+ * import { autolinkHeadings } from "@coding-adventures/forme-transform-autolink-headings";
+ *
+ * const slugs = autolinkHeadings(doc);
+ * for (const { level, text, slug, anchorHref } of slugs) {
+ *   console.log(`h${level} → ${anchorHref}  (${text})`);
+ * }
+ * ```
+ *
+ * Sub-helpers (`slugify`, `resolveCollisions`, `extractText`) are
+ * re-exported for callers building custom transforms — e.g. a
+ * TOC extractor that wants the same slug as this transform
+ * generated, or a tooling step that validates external deep links
+ * against the document's slug set.
+ *
+ * Fifth FM00 v0 stage package — joins `forme-feeds`,
+ * `forme-opengraph`, `forme-index-renderer`, `forme-transforms`.
+ *
+ * @module index
+ */
+
+export { autolinkHeadings } from "./autolink.js";
+export { slugify } from "./slugify.js";
+export { resolveCollisions } from "./collisions.js";
+export { extractText } from "./extract-text.js";
+export type { HeadingSlug } from "./types.js";

--- a/code/packages/typescript/forme-transform-autolink-headings/src/slugify.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/src/slugify.ts
@@ -1,0 +1,72 @@
+/**
+ * slugify.ts — text → URL-safe slug, GitHub-flavoured.
+ *
+ * Why "GitHub-flavoured" specifically?  Markdown authors writing
+ * Forme-targeted content overwhelmingly read content elsewhere
+ * (GitHub READMEs, GitLab wikis, gitiles).  Matching the de-facto
+ * convention means a heading `## Step 2: Install dependencies`
+ * gets the same slug here as it would in a `README.md` rendered
+ * on GitHub: `step-2-install-dependencies`.
+ *
+ * Algorithm (in order):
+ *
+ *   1. Lowercase via `String.prototype.toLowerCase()` — locale-
+ *      independent (no `toLocaleLowerCase` Turkish-İ surprise).
+ *   2. Strip ASCII control bytes (`U+0000-U+001F`, `U+007F`) so
+ *      a hostile heading text can't smuggle a NUL or DEL into the
+ *      slug — even though the regex below would already strip
+ *      them, doing it explicitly is faster and self-documenting.
+ *   3. Strip everything except `[a-z0-9 -]` (kept set: ASCII
+ *      letters, digits, spaces, hyphens).  Note: Unicode letters
+ *      (CJK, Cyrillic, accented Latin) get stripped — matches
+ *      GitHub's behaviour and avoids percent-encoding decisions.
+ *   4. Replace runs of whitespace + hyphens with a single hyphen.
+ *   5. Trim leading + trailing hyphens.
+ *
+ * Empty input or input that reduces to empty → `"section"`
+ * fallback.  Collision resolution (in `collisions.ts`) makes the
+ * fallback safe even if multiple empty-textHeadings appear:
+ * `section`, `section-2`, `section-3`, ...
+ *
+ * @module slugify
+ */
+
+/** ASCII control bytes — stripped before anything else. */
+const ASCII_CONTROL_RE = /[\x00-\x1F\x7F]/g;
+
+/** Everything except a-z, 0-9, space, hyphen. */
+const NON_SLUG_RE = /[^a-z0-9 \-]+/g;
+
+/** Runs of whitespace and hyphens collapse to one hyphen. */
+const SPACE_HYPHEN_RUN_RE = /[\s\-]+/g;
+
+/** Leading / trailing hyphens. */
+const TRIM_HYPHEN_RE = /^-+|-+$/g;
+
+/**
+ * Convert a heading's plain text into a GitHub-flavoured slug.
+ *
+ * ```
+ * slugify("Hello, World!")               // "hello-world"
+ * slugify("Step 2: Install dependencies") // "step-2-install-dependencies"
+ * slugify("")                             // "section"
+ * slugify("   ")                          // "section"
+ * slugify("<script>alert(1)</script>")    // "scriptalert1script"
+ * slugify("日本語")                       // "section"  (non-ASCII stripped)
+ * ```
+ *
+ * Output is guaranteed to:
+ *   - be non-empty (fallback `"section"` for collapsed input).
+ *   - match `/^[a-z0-9-]+$/`.
+ *   - not begin or end with `-`.
+ *   - contain no consecutive `-` runs.
+ */
+export function slugify(text: string): string {
+  const cleaned = String(text)
+    .toLowerCase()
+    .replace(ASCII_CONTROL_RE, "")
+    .replace(NON_SLUG_RE, "")
+    .replace(SPACE_HYPHEN_RUN_RE, "-")
+    .replace(TRIM_HYPHEN_RE, "");
+  return cleaned === "" ? "section" : cleaned;
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/src/slugify.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/src/slugify.ts
@@ -8,51 +8,62 @@
  * gets the same slug here as it would in a `README.md` rendered
  * on GitHub: `step-2-install-dependencies`.
  *
- * Algorithm (in order):
+ * Algorithm (single-pass character loop):
  *
  *   1. Lowercase via `String.prototype.toLowerCase()` — locale-
  *      independent (no `toLocaleLowerCase` Turkish-İ surprise).
- *   2. Strip ASCII control bytes (`U+0000-U+001F`, `U+007F`) so
- *      a hostile heading text can't smuggle a NUL or DEL into the
- *      slug — even though the regex below would already strip
- *      them, doing it explicitly is faster and self-documenting.
- *   3. Strip everything except `[a-z0-9 -]` (kept set: ASCII
- *      letters, digits, spaces, hyphens).  Note: Unicode letters
- *      (CJK, Cyrillic, accented Latin) get stripped — matches
- *      GitHub's behaviour and avoids percent-encoding decisions.
- *   4. Replace runs of whitespace + hyphens with a single hyphen.
- *   5. Trim leading + trailing hyphens.
+ *   2. Walk character-by-character:
+ *        - Keep `[a-z0-9]` verbatim.
+ *        - Collapse runs of `[\t\n\r -]` (ASCII whitespace + hyphen)
+ *          to a single `-`, suppressing leading hyphens with a
+ *          `lastHyphen` flag.
+ *        - Drop everything else silently (control bytes,
+ *          punctuation, non-ASCII).
+ *   3. Trim a trailing hyphen.
+ *   4. Empty result → `"section"` fallback.
  *
- * Empty input or input that reduces to empty → `"section"`
- * fallback.  Collision resolution (in `collisions.ts`) makes the
- * fallback safe even if multiple empty-textHeadings appear:
+ * Why a manual loop instead of chained `String.prototype.replace`?
+ *
+ *   - **No regex backtracking surface.**  Patterns like `[\s\-]+`
+ *     combined with `/^-+|-+$/g` trigger CodeQL's "polynomial regex
+ *     on uncontrolled data" warning even though the actual runtime
+ *     is linear.  A character loop is unambiguously O(n) and
+ *     trivially passes any ReDoS analysis.
+ *   - **One pass, not three.**  The old chained version walked the
+ *     string four times (lowercase + 3× replace).  The loop walks
+ *     it once.
+ *   - **Explicit semantics.**  Each branch is one line; what gets
+ *     kept and what gets dropped is obvious from reading.
+ *
+ * Collision resolution (in `collisions.ts`) makes the `"section"`
+ * fallback safe even if multiple empty-text headings appear:
  * `section`, `section-2`, `section-3`, ...
  *
  * @module slugify
  */
 
-/** ASCII control bytes — stripped before anything else. */
-const ASCII_CONTROL_RE = /[\x00-\x1F\x7F]/g;
-
-/** Everything except a-z, 0-9, space, hyphen. */
-const NON_SLUG_RE = /[^a-z0-9 \-]+/g;
-
-/** Runs of whitespace and hyphens collapse to one hyphen. */
-const SPACE_HYPHEN_RUN_RE = /[\s\-]+/g;
-
-/** Leading / trailing hyphens. */
-const TRIM_HYPHEN_RE = /^-+|-+$/g;
+// Character codes used in the hot loop — named so the loop reads.
+const CC_DIGIT_0 = 48;   // '0'
+const CC_DIGIT_9 = 57;   // '9'
+const CC_LOWER_A = 97;   // 'a'
+const CC_LOWER_Z = 122;  // 'z'
+const CC_SPACE = 32;
+const CC_HYPHEN = 45;
+const CC_TAB = 9;
+const CC_LF = 10;
+const CC_CR = 13;
 
 /**
  * Convert a heading's plain text into a GitHub-flavoured slug.
  *
  * ```
- * slugify("Hello, World!")               // "hello-world"
+ * slugify("Hello, World!")                // "hello-world"
  * slugify("Step 2: Install dependencies") // "step-2-install-dependencies"
  * slugify("")                             // "section"
  * slugify("   ")                          // "section"
  * slugify("<script>alert(1)</script>")    // "scriptalert1script"
- * slugify("日本語")                       // "section"  (non-ASCII stripped)
+ * slugify("日本語")                       // "section"  (non-ASCII dropped)
+ * slugify("hel\x00lo")                    // "hello"   (control byte dropped)
  * ```
  *
  * Output is guaranteed to:
@@ -60,13 +71,37 @@ const TRIM_HYPHEN_RE = /^-+|-+$/g;
  *   - match `/^[a-z0-9-]+$/`.
  *   - not begin or end with `-`.
  *   - contain no consecutive `-` runs.
+ *
+ * Complexity: O(n) in input length.  No regex, no backtracking.
  */
 export function slugify(text: string): string {
-  const cleaned = String(text)
-    .toLowerCase()
-    .replace(ASCII_CONTROL_RE, "")
-    .replace(NON_SLUG_RE, "")
-    .replace(SPACE_HYPHEN_RUN_RE, "-")
-    .replace(TRIM_HYPHEN_RE, "");
-  return cleaned === "" ? "section" : cleaned;
+  const s = String(text).toLowerCase();
+  const out: string[] = [];
+  // Start "true" so leading ASCII whitespace / hyphens never emit
+  // a leading "-" in the output.
+  let lastHyphen = true;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (
+      (c >= CC_LOWER_A && c <= CC_LOWER_Z) ||
+      (c >= CC_DIGIT_0 && c <= CC_DIGIT_9)
+    ) {
+      out.push(s[i]!);
+      lastHyphen = false;
+    } else if (
+      c === CC_SPACE || c === CC_HYPHEN ||
+      c === CC_TAB || c === CC_LF || c === CC_CR
+    ) {
+      // Whitespace / hyphen — collapse to one "-" per run.
+      if (!lastHyphen) {
+        out.push("-");
+        lastHyphen = true;
+      }
+    }
+    // All other code points (control bytes, punctuation, symbols,
+    // non-ASCII) drop silently — no emission, no state change.
+  }
+  // Trim a trailing "-" left by terminal whitespace / hyphens.
+  if (out.length > 0 && out[out.length - 1] === "-") out.pop();
+  return out.length === 0 ? "section" : out.join("");
 }

--- a/code/packages/typescript/forme-transform-autolink-headings/src/types.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/src/types.ts
@@ -1,0 +1,46 @@
+/**
+ * types.ts — annotation types produced by the autolink-headings transform.
+ *
+ * The Document AST is immutable and closed (no `id` field on
+ * `HeadingNode`), so this transform does not modify the document.
+ * Instead it produces a parallel ordered list of slug annotations
+ * that renderers consume in document order to emit
+ *
+ *   <h2 id="my-slug"><a href="#my-slug" class="forme-anchor">Heading text</a></h2>
+ *
+ * Why a list, not a `Map<HeadingNode, string>`?
+ *
+ *   1. **Determinism.**  Two equal-by-value documents that differ
+ *      only in `HeadingNode` object identity (because each was
+ *      parsed independently) produce the same `HeadingSlug[]`.
+ *      A `Map` keyed by identity would not.
+ *   2. **JSON-serialisable.**  Renderers run in separate processes
+ *      from parsers in some Forme deployments; the annotation
+ *      stream survives serialisation losslessly.
+ *   3. **Position-coupled to a document walk.**  Renderers walk
+ *      the AST and consume slugs in heading-encounter order.  An
+ *      array indexed by encounter is the natural fit.
+ *
+ * @module types
+ */
+
+/**
+ * One annotation entry per `HeadingNode` in document order.
+ *
+ *   - `level` — copy of `HeadingNode.level` (1-6).  Lets TOC
+ *     consumers reconstruct hierarchy without a second AST walk.
+ *   - `text` — flattened plain-text content of the heading's
+ *     inline children.  Used by TOC consumers as the link label.
+ *   - `slug` — the deterministic, collision-resolved id assigned
+ *     to this heading.  Safe to interpolate into an HTML
+ *     attribute value (only `[a-z0-9-]`).
+ *   - `anchorHref` — `#${slug}`.  Provided so renderers don't
+ *     re-concatenate (and accidentally introduce a URL-encoding
+ *     bug).
+ */
+export interface HeadingSlug {
+  readonly level: 1 | 2 | 3 | 4 | 5 | 6;
+  readonly text: string;
+  readonly slug: string;
+  readonly anchorHref: string;
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/tests/autolink.test.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/tests/autolink.test.ts
@@ -1,0 +1,265 @@
+/**
+ * autolink.test.ts — end-to-end autolinkHeadings transform.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { BlockNode, DocumentNode, InlineNode } from "@coding-adventures/document-ast";
+import { autolinkHeadings } from "../src/index.js";
+
+function txt(value: string): InlineNode { return { type: "text", value }; }
+function h(level: 1|2|3|4|5|6, text: string): BlockNode {
+  return { type: "heading", level, children: [txt(text)] };
+}
+function doc(...children: BlockNode[]): DocumentNode {
+  return { type: "document", children };
+}
+
+describe("autolinkHeadings — flat document", () => {
+  it("one heading → one slug", () => {
+    const out = autolinkHeadings(doc(h(1, "Hello World")));
+    expect(out).toEqual([
+      { level: 1, text: "Hello World", slug: "hello-world", anchorHref: "#hello-world" },
+    ]);
+  });
+
+  it("preserves document order", () => {
+    const out = autolinkHeadings(doc(
+      h(1, "First"),
+      h(2, "Second"),
+      h(2, "Third"),
+    ));
+    expect(out.map((s) => s.text)).toEqual(["First", "Second", "Third"]);
+  });
+
+  it("preserves level on each annotation", () => {
+    const out = autolinkHeadings(doc(
+      h(1, "h1"),
+      h(2, "h2"),
+      h(3, "h3"),
+      h(6, "h6"),
+    ));
+    expect(out.map((s) => s.level)).toEqual([1, 2, 3, 6]);
+  });
+
+  it("empty document → empty array", () => {
+    expect(autolinkHeadings(doc())).toEqual([]);
+  });
+
+  it("document with no headings → empty array", () => {
+    const out = autolinkHeadings(doc(
+      { type: "paragraph", children: [txt("just a paragraph")] },
+    ));
+    expect(out).toEqual([]);
+  });
+});
+
+describe("autolinkHeadings — anchorHref always equals #slug", () => {
+  it("simple", () => {
+    const [first] = autolinkHeadings(doc(h(1, "Hi")));
+    expect(first!.anchorHref).toBe(`#${first!.slug}`);
+  });
+
+  it("after collision suffix", () => {
+    const out = autolinkHeadings(doc(h(1, "Setup"), h(1, "Setup")));
+    expect(out[0]!.anchorHref).toBe("#setup");
+    expect(out[1]!.anchorHref).toBe("#setup-2");
+  });
+});
+
+describe("autolinkHeadings — collision resolution applies globally", () => {
+  it("two headings with the same text get -2 on the second", () => {
+    const out = autolinkHeadings(doc(h(2, "Setup"), h(2, "Setup")));
+    expect(out.map((s) => s.slug)).toEqual(["setup", "setup-2"]);
+  });
+
+  it("three same-text headings: -2, -3", () => {
+    const out = autolinkHeadings(doc(h(2, "Setup"), h(2, "Setup"), h(2, "Setup")));
+    expect(out.map((s) => s.slug)).toEqual(["setup", "setup-2", "setup-3"]);
+  });
+
+  it("different texts producing the same slug also collide", () => {
+    // "Hello World" and "Hello, World!" both slugify to "hello-world"
+    // (the comma + bang are stripped, multi-space collapses).
+    const out = autolinkHeadings(doc(h(2, "Hello World"), h(2, "Hello, World!")));
+    expect(out.map((s) => s.slug)).toEqual(["hello-world", "hello-world-2"]);
+  });
+});
+
+describe("autolinkHeadings — extracts heading text correctly", () => {
+  it("heading with mixed inline content", () => {
+    const out = autolinkHeadings(doc({
+      type: "heading", level: 2,
+      children: [
+        txt("Step "),
+        { type: "strong", children: [txt("2")] },
+        txt(": install "),
+        { type: "code_span", value: "npm" },
+        txt(" deps"),
+      ],
+    }));
+    expect(out[0]!.text).toBe("Step 2: install npm deps");
+    expect(out[0]!.slug).toBe("step-2-install-npm-deps");
+  });
+
+  it("heading whose flattened text is empty → 'section' fallback", () => {
+    const out = autolinkHeadings(doc({
+      type: "heading", level: 1,
+      children: [{ type: "raw_inline", format: "html", value: "<!--x-->" }],
+    }));
+    expect(out[0]!.slug).toBe("section");
+  });
+
+  it("multiple empty-text headings get section, section-2, section-3", () => {
+    const out = autolinkHeadings(doc(
+      { type: "heading", level: 1, children: [] },
+      { type: "heading", level: 2, children: [] },
+      { type: "heading", level: 3, children: [] },
+    ));
+    expect(out.map((s) => s.slug)).toEqual(["section", "section-2", "section-3"]);
+  });
+});
+
+describe("autolinkHeadings — walks nested containers", () => {
+  it("headings inside blockquote are found", () => {
+    const out = autolinkHeadings(doc({
+      type: "blockquote",
+      children: [h(2, "Quoted Heading")],
+    }));
+    expect(out.map((s) => s.text)).toEqual(["Quoted Heading"]);
+  });
+
+  it("headings inside list items are found", () => {
+    const out = autolinkHeadings(doc({
+      type: "list", ordered: false, start: null, tight: true,
+      children: [
+        { type: "list_item", checked: null, children: [h(3, "Item Heading")] },
+      ],
+    }));
+    expect(out.map((s) => s.text)).toEqual(["Item Heading"]);
+  });
+
+  it("headings inside task items are found", () => {
+    const out = autolinkHeadings(doc({
+      type: "list", ordered: false, start: null, tight: true,
+      children: [
+        { type: "task_item", checked: true, children: [h(3, "Task Heading")] },
+      ],
+    }));
+    expect(out.map((s) => s.text)).toEqual(["Task Heading"]);
+  });
+
+  it("deeply nested headings (blockquote → list → heading)", () => {
+    const out = autolinkHeadings(doc({
+      type: "blockquote",
+      children: [{
+        type: "list", ordered: false, start: null, tight: true,
+        children: [
+          { type: "list_item", checked: null, children: [h(4, "Deep")] },
+        ],
+      }],
+    }));
+    expect(out.map((s) => s.slug)).toEqual(["deep"]);
+  });
+
+  it("blocks without nested-block content (paragraph, code_block, thematic_break, raw_block, table) don't break the walk", () => {
+    const out = autolinkHeadings(doc(
+      { type: "paragraph", children: [txt("p")] },
+      { type: "code_block", language: null, value: "x\n" },
+      { type: "thematic_break" },
+      { type: "raw_block", format: "html", value: "<hr>" },
+      { type: "table", align: [null], children: [
+        { type: "table_row", children: [{ type: "table_cell", header: true, children: [txt("c")] }] },
+      ]},
+      h(1, "Real Heading"),
+    ));
+    expect(out.map((s) => s.text)).toEqual(["Real Heading"]);
+  });
+});
+
+describe("autolinkHeadings — defensive: non-tree BlockNode variants ignored", () => {
+  // The BlockNode union includes DocumentNode / ListItemNode /
+  // TaskItemNode / TableRowNode / TableCellNode for type-system
+  // simplicity, but they never appear as direct siblings of
+  // other blocks in well-formed AST.  The walker silently
+  // ignores them (defensive no-op).  These tests exercise the
+  // defensive branches.
+
+  it("DocumentNode in doc.children is ignored", () => {
+    const out = autolinkHeadings(doc(
+      h(1, "Real"),
+      { type: "document", children: [h(1, "Nested-doc heading")] } as BlockNode,
+    ));
+    // Only the real heading is picked up; the nested DocumentNode
+    // is treated as a defensive no-op and its inner heading is NOT
+    // walked.
+    expect(out.map((s) => s.text)).toEqual(["Real"]);
+  });
+
+  it("ListItemNode in doc.children is ignored", () => {
+    const out = autolinkHeadings(doc(
+      h(1, "Real"),
+      { type: "list_item", checked: null, children: [h(2, "Stray")] } as BlockNode,
+    ));
+    expect(out.map((s) => s.text)).toEqual(["Real"]);
+  });
+
+  it("TaskItemNode in doc.children is ignored", () => {
+    const out = autolinkHeadings(doc(
+      h(1, "Real"),
+      { type: "task_item", checked: false, children: [h(2, "Stray")] } as BlockNode,
+    ));
+    expect(out.map((s) => s.text)).toEqual(["Real"]);
+  });
+
+  it("TableRowNode in doc.children is ignored", () => {
+    const out = autolinkHeadings(doc(
+      h(1, "Real"),
+      { type: "table_row", children: [] } as BlockNode,
+    ));
+    expect(out.map((s) => s.text)).toEqual(["Real"]);
+  });
+
+  it("TableCellNode in doc.children is ignored", () => {
+    const out = autolinkHeadings(doc(
+      h(1, "Real"),
+      { type: "table_cell", header: false, children: [] } as BlockNode,
+    ));
+    expect(out.map((s) => s.text)).toEqual(["Real"]);
+  });
+});
+
+describe("autolinkHeadings — reproducibility (FM03)", () => {
+  it("same input → byte-identical output", () => {
+    const d = doc(h(1, "A"), h(2, "B"), h(2, "B"));
+    expect(autolinkHeadings(d)).toEqual(autolinkHeadings(d));
+  });
+
+  it("does not mutate the input document", () => {
+    const d = doc(h(1, "A"), h(2, "B"));
+    const snapshot = JSON.stringify(d);
+    autolinkHeadings(d);
+    expect(JSON.stringify(d)).toBe(snapshot);
+  });
+});
+
+describe("autolinkHeadings — security / hostile inputs", () => {
+  it("heading text with script tag → slug stripped, no markup leaks", () => {
+    const out = autolinkHeadings(doc(h(2, "<script>alert(1)</script>")));
+    expect(out[0]!.slug).toMatch(/^[a-z0-9-]+$/);
+    expect(out[0]!.anchorHref).toMatch(/^#[a-z0-9-]+$/);
+    expect(out[0]!.slug).not.toContain("<");
+    expect(out[0]!.slug).not.toContain(">");
+  });
+
+  it("heading text with NUL byte → slug stripped clean", () => {
+    const out = autolinkHeadings(doc(h(2, "hel\x00lo")));
+    expect(out[0]!.slug).toBe("hello");
+  });
+
+  it("heading with attribute-breakout chars → all stripped", () => {
+    const out = autolinkHeadings(doc(h(2, `evil"onload=alert(1)//`)));
+    expect(out[0]!.slug).not.toContain('"');
+    expect(out[0]!.slug).not.toContain("=");
+    expect(out[0]!.slug).toMatch(/^[a-z0-9-]+$/);
+  });
+});

--- a/code/packages/typescript/forme-transform-autolink-headings/tests/collisions.test.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/tests/collisions.test.ts
@@ -1,0 +1,100 @@
+/**
+ * collisions.test.ts — deterministic resolution of repeated slugs.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveCollisions } from "../src/index.js";
+
+describe("resolveCollisions — basic numbering", () => {
+  it("no collisions → identity", () => {
+    expect(resolveCollisions(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("two collisions → first unsuffixed, second -2", () => {
+    expect(resolveCollisions(["setup", "setup"])).toEqual(["setup", "setup-2"]);
+  });
+
+  it("three collisions → -2, -3", () => {
+    expect(resolveCollisions(["setup", "setup", "setup"])).toEqual(
+      ["setup", "setup-2", "setup-3"],
+    );
+  });
+
+  it("interleaved collisions counted independently", () => {
+    expect(resolveCollisions(["setup", "intro", "setup", "intro", "setup"])).toEqual(
+      ["setup", "intro", "setup-2", "intro-2", "setup-3"],
+    );
+  });
+
+  it("preserves first occurrence as unsuffixed (GitHub idiom)", () => {
+    const out = resolveCollisions(["x", "y", "x"]);
+    expect(out[0]).toBe("x");
+    expect(out[2]).toBe("x-2");
+  });
+});
+
+describe("resolveCollisions — skip naturally-taken suffixes", () => {
+  it("skips an already-taken numeric suffix", () => {
+    // 1st heading naturally slugs to "setup-2" (e.g. "Setup 2").
+    // Then "Setup" appears — needs a suffix.  Must NOT use -2.
+    expect(resolveCollisions(["setup", "setup-2", "setup"])).toEqual(
+      ["setup", "setup-2", "setup-3"],
+    );
+  });
+
+  it("skips multiple taken suffixes in a row", () => {
+    expect(resolveCollisions(["x", "x-2", "x-3", "x"])).toEqual(
+      ["x", "x-2", "x-3", "x-4"],
+    );
+  });
+
+  it("non-contiguous taken suffixes still pick the smallest gap", () => {
+    // "x-3" exists; next "x" collision should be "x-2".
+    expect(resolveCollisions(["x", "x-3", "x"])).toEqual(["x", "x-3", "x-2"]);
+  });
+});
+
+describe("resolveCollisions — determinism", () => {
+  it("same input → byte-identical output", () => {
+    const input = ["a", "b", "a", "c", "b", "a"];
+    expect(resolveCollisions(input)).toEqual(resolveCollisions(input));
+  });
+
+  it("does not mutate input array", () => {
+    const input = ["a", "a", "a"];
+    const before = [...input];
+    resolveCollisions(input);
+    expect(input).toEqual(before);
+  });
+
+  it("returns a fresh array each call", () => {
+    const input = ["x"];
+    expect(resolveCollisions(input)).not.toBe(input);
+  });
+});
+
+describe("resolveCollisions — edge cases", () => {
+  it("empty input → empty output", () => {
+    expect(resolveCollisions([])).toEqual([]);
+  });
+
+  it("single-element input → identity", () => {
+    expect(resolveCollisions(["only"])).toEqual(["only"]);
+  });
+
+  it("output length always equals input length", () => {
+    const inputs: string[][] = [
+      [],
+      ["a"],
+      ["a", "a"],
+      ["a", "b", "a", "a", "b"],
+    ];
+    for (const input of inputs) {
+      expect(resolveCollisions(input).length).toBe(input.length);
+    }
+  });
+
+  it("preserves empty-string slugs (caller responsibility to feed 'section' fallback)", () => {
+    expect(resolveCollisions(["", "", ""])).toEqual(["", "-2", "-3"]);
+  });
+});

--- a/code/packages/typescript/forme-transform-autolink-headings/tests/extract-text.test.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/tests/extract-text.test.ts
@@ -1,0 +1,124 @@
+/**
+ * extract-text.test.ts — inline-node flattening to plain text.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { InlineNode } from "@coding-adventures/document-ast";
+import { extractText } from "../src/index.js";
+
+function txt(value: string): InlineNode { return { type: "text", value }; }
+
+describe("extractText — basic nodes", () => {
+  it("single text node", () => {
+    expect(extractText([txt("hello")])).toBe("hello");
+  });
+
+  it("multiple text nodes concatenate", () => {
+    expect(extractText([txt("hello "), txt("world")])).toBe("hello world");
+  });
+
+  it("empty list → empty string", () => {
+    expect(extractText([])).toBe("");
+  });
+});
+
+describe("extractText — formatting wrappers (recurse)", () => {
+  it("emphasis", () => {
+    expect(extractText([
+      txt("hello "),
+      { type: "emphasis", children: [txt("world")] },
+    ])).toBe("hello world");
+  });
+
+  it("strong", () => {
+    expect(extractText([
+      { type: "strong", children: [txt("bold")] },
+    ])).toBe("bold");
+  });
+
+  it("strikethrough", () => {
+    expect(extractText([
+      { type: "strikethrough", children: [txt("old")] },
+    ])).toBe("old");
+  });
+
+  it("nested emphasis + strong", () => {
+    expect(extractText([
+      { type: "strong", children: [
+        { type: "emphasis", children: [txt("bold-italic")] },
+      ]},
+    ])).toBe("bold-italic");
+  });
+});
+
+describe("extractText — link / code / image", () => {
+  it("link uses children text (the label)", () => {
+    expect(extractText([
+      { type: "link", destination: "https://example.com", title: null, children: [txt("click here")] },
+    ])).toBe("click here");
+  });
+
+  it("code_span value verbatim", () => {
+    expect(extractText([
+      txt("call "),
+      { type: "code_span", value: "doStuff()" },
+    ])).toBe("call doStuff()");
+  });
+
+  it("image contributes alt text", () => {
+    expect(extractText([
+      { type: "image", destination: "/cat.png", title: null, alt: "a cat" },
+    ])).toBe("a cat");
+  });
+
+  it("autolink uses destination (URL or email)", () => {
+    expect(extractText([
+      { type: "autolink", destination: "https://example.com", isEmail: false },
+    ])).toBe("https://example.com");
+  });
+
+  it("autolink email destination", () => {
+    expect(extractText([
+      { type: "autolink", destination: "user@example.com", isEmail: true },
+    ])).toBe("user@example.com");
+  });
+});
+
+describe("extractText — breaks become spaces", () => {
+  it("hard_break", () => {
+    expect(extractText([txt("a"), { type: "hard_break" }, txt("b")])).toBe("a b");
+  });
+
+  it("soft_break", () => {
+    expect(extractText([txt("a"), { type: "soft_break" }, txt("b")])).toBe("a b");
+  });
+});
+
+describe("extractText — raw_inline is skipped", () => {
+  it("raw_inline value not included (back-end-specific)", () => {
+    expect(extractText([
+      txt("hello "),
+      { type: "raw_inline", format: "html", value: "<sup>x</sup>" },
+      txt(" world"),
+    ])).toBe("hello  world");
+  });
+});
+
+describe("extractText — mixed real-world headings", () => {
+  it("'Step **2**: install `npm` deps'", () => {
+    expect(extractText([
+      txt("Step "),
+      { type: "strong", children: [txt("2")] },
+      txt(": install "),
+      { type: "code_span", value: "npm" },
+      txt(" deps"),
+    ])).toBe("Step 2: install npm deps");
+  });
+
+  it("link inside heading: '[Forme](https://...) overview'", () => {
+    expect(extractText([
+      { type: "link", destination: "https://forme.example", title: null, children: [txt("Forme")] },
+      txt(" overview"),
+    ])).toBe("Forme overview");
+  });
+});

--- a/code/packages/typescript/forme-transform-autolink-headings/tests/slugify.test.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/tests/slugify.test.ts
@@ -1,0 +1,128 @@
+/**
+ * slugify.test.ts — GitHub-flavoured slugification rules.
+ */
+
+import { describe, it, expect } from "vitest";
+import { slugify } from "../src/index.js";
+
+describe("slugify — basic shape", () => {
+  it("lowercases", () => {
+    expect(slugify("Hello")).toBe("hello");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(slugify("hello world")).toBe("hello-world");
+  });
+
+  it("collapses multi-space runs into one hyphen", () => {
+    expect(slugify("hello   world")).toBe("hello-world");
+  });
+
+  it("strips punctuation", () => {
+    expect(slugify("Hello, World!")).toBe("hello-world");
+  });
+
+  it("keeps digits", () => {
+    expect(slugify("Step 2: Install")).toBe("step-2-install");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(slugify("--hello--")).toBe("hello");
+  });
+
+  it("trims hyphens after punctuation stripping", () => {
+    expect(slugify("!! hello !!")).toBe("hello");
+  });
+
+  it("collapses adjacent hyphens", () => {
+    expect(slugify("hello---world")).toBe("hello-world");
+  });
+
+  it("matches GitHub idiom: 'Step 2: Install dependencies'", () => {
+    expect(slugify("Step 2: Install dependencies")).toBe("step-2-install-dependencies");
+  });
+});
+
+describe("slugify — fallback for empty / collapsed input", () => {
+  it("empty string → 'section'", () => {
+    expect(slugify("")).toBe("section");
+  });
+
+  it("whitespace-only → 'section'", () => {
+    expect(slugify("   ")).toBe("section");
+  });
+
+  it("punctuation-only → 'section'", () => {
+    expect(slugify("!!!")).toBe("section");
+  });
+
+  it("hyphens-only → 'section'", () => {
+    expect(slugify("---")).toBe("section");
+  });
+
+  it("non-ASCII-only (CJK) → 'section'", () => {
+    expect(slugify("日本語")).toBe("section");
+  });
+});
+
+describe("slugify — security / hostile inputs", () => {
+  it("strips ASCII control bytes (NUL, ESC, DEL)", () => {
+    expect(slugify("hel\x00lo\x1bwor\x7fld")).toBe("helloworld");
+  });
+
+  it("strips HTML-injection attempts", () => {
+    expect(slugify("<script>alert(1)</script>")).toBe("scriptalert1script");
+  });
+
+  it("strips quotes (cannot break out of HTML attribute)", () => {
+    expect(slugify(`hello"world'`)).toBe("helloworld");
+  });
+
+  it("strips angle brackets", () => {
+    expect(slugify("a<b>c")).toBe("abc");
+  });
+
+  it("strips ampersands (no entity injection)", () => {
+    expect(slugify("a&amp;b")).toBe("aampb");
+  });
+});
+
+describe("slugify — output guarantees", () => {
+  it("output matches /^[a-z0-9-]+$/", () => {
+    const inputs = ["Hello!", "Step 2", "<a>", "日本語", "  spaces  ", "a/b/c"];
+    for (const input of inputs) {
+      expect(slugify(input)).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it("output is never empty", () => {
+    const inputs = ["", "   ", "!!!", "日本語", "\x00"];
+    for (const input of inputs) {
+      expect(slugify(input).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("idempotent: slugify(slugify(x)) === slugify(x)", () => {
+    const inputs = ["Hello World", "Step 2: Install", "  weird  "];
+    for (const input of inputs) {
+      const once = slugify(input);
+      expect(slugify(once)).toBe(once);
+    }
+  });
+
+  it("deterministic: same input → same output across calls", () => {
+    expect(slugify("Hello World")).toBe(slugify("Hello World"));
+  });
+});
+
+describe("slugify — non-string defensive coercion", () => {
+  it("coerces non-strings via String(...)", () => {
+    // @ts-expect-error — defensive runtime coercion
+    expect(slugify(42)).toBe("42");
+  });
+
+  it("null coerces to 'null'", () => {
+    // @ts-expect-error — defensive runtime coercion
+    expect(slugify(null)).toBe("null");
+  });
+});

--- a/code/packages/typescript/forme-transform-autolink-headings/tsconfig.json
+++ b/code/packages/typescript/forme-transform-autolink-headings/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-transform-autolink-headings/vitest.config.ts
+++ b/code/packages/typescript/forme-transform-autolink-headings/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Fifth FM00 v0 stage package — first concrete §5.3 transform.  Walks a `DocumentNode` once, finds every `HeadingNode` in document order, slugifies its plain-text content, resolves collisions globally, and returns an ordered `HeadingSlug[]` (one annotation per heading) for renderers to consume:

```html
<h2 id="my-slug"><a href="#my-slug" class="forme-anchor">Heading text</a></h2>
```

Joins [`forme-feeds`](../forme-feeds), [`forme-opengraph`](../forme-opengraph), [`forme-index-renderer`](../forme-index-renderer), [`forme-transforms`](../forme-transforms) in the FM00 v0 stage cluster.

## API

```ts
import { autolinkHeadings } from "@coding-adventures/forme-transform-autolink-headings";

const slugs = autolinkHeadings(doc);
for (const { level, text, slug, anchorHref } of slugs) {
  console.log(`h${level} → ${anchorHref}  (${text})`);
}
// h1 → #installation  (Installation)
// h2 → #setup         (Setup)
// h2 → #setup-2       (Setup)  ← second occurrence gets -2 suffix
```

Sub-helpers exported for callers building custom transforms (TOC extractors, deep-link validators): `slugify`, `resolveCollisions`, `extractText`.

## Key design choices

- **Annotations, not AST mutation.** The IR is immutable and has no `id` field on `HeadingNode`; returning a parallel ordered list keeps the AST contract intact and the annotation stream JSON-serialisable for cross-process Forme deployments.
- **Global collision namespace.** Headings at any nesting depth share one slug space — `## Setup` + `### Setup` produces `setup` / `setup-2` regardless of where the second occurs. Matches GitHub.
- **Walks blockquote / list / task_item.** Headings inside any container are found in document order. Skips past tables / code blocks / thematic breaks / raw blocks (no nested blocks).
- **Defensive no-op for non-tree `BlockNode` variants.** The union includes `Document` / `ListItem` / `TaskItem` / `TableRow` / `TableCell` for type-system simplicity; well-formed AST never places these as direct siblings. Walker silently ignores them.

## Security

Three concerns addressed pre-push:

- **HTML injection** — `slugify` strips everything except `[a-z0-9 -]`, so attacker-controlled heading text like `<script>alert(1)</script>` becomes `scriptalert1script` — safe to interpolate into `id="..."` without escaping.
- **Attribute-breakout chars** (`"`, `'`, `=`, `<`, `>`, `&`) all stripped by the whitelist regex.
- **ASCII control-byte smuggling** — explicit strip pass for `\x00-\x1F` and `\x7F` before the main regex.
- **Prototype pollution** — collisions use `Map` / `Set`; no attacker-controlled keys reach `Object` property assignment.
- **DoS** — O(N) amortised collision resolution via `nextSuffix` counter map; linear-time regexes (no alternation / nested quantifiers).

Security review (general-purpose sub-agent): **no exploitable findings**.

## Capabilities

`[]` — pure transform. No I/O, network, fs, shell, env.

## Tests

**85 tests across 4 files**, **95.77% line / 95.74% branch** coverage:

- `slugify.test.ts` (25) — basic shape, fallback for empty / whitespace / punctuation / non-ASCII / hyphens-only, security (control bytes, HTML injection, quotes / brackets / ampersands), output guarantees, non-string defensive coercion
- `collisions.test.ts` (15) — basic numbering, skip-taken-suffix semantics, non-contiguous gaps, determinism, edge cases
- `extract-text.test.ts` (17) — every inline node kind, nested formatting wrappers, link / code / image / autolink (URL + email), breaks → space, raw_inline skipped, real-world heading shapes
- `autolink.test.ts` (28) — end-to-end transform, document order, level propagation, anchorHref invariant, global collision resolution, text extraction from mixed inlines, nested container walks, defensive no-op branches, reproducibility (FM03), security pin

Uncovered lines are TypeScript `never` exhaustiveness guards that cannot fire at runtime.

## Spec adherence

Implements FM00 v0 §5.3 `transform-autolink-headings`. No spec divergences. Spec calls for "add id + self-link to headings"; this package produces the annotation stream that renderers consume to emit exactly that markup.

## v0 simplifications

- Annotations vs AST mutation (deferred to coordinated v1)
- No anchor-text prefix customisation
- No Unicode slug preservation (matches GitHub)
- No anchor-link visibility class (renderer decides presentation)

## Test plan

- [x] All 85 tests pass locally
- [x] 95.77% line / 95.74% branch coverage (≥95% target)
- [x] TypeScript build clean (`tsc --noEmit`)
- [x] Security review clean (HTML / attribute / control / prototype / DoS / prohibited APIs)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)