### PR TITLE
feat(forme-transform-toc): FM00 v0 §5.3 hierarchical TOC extraction

### DIFF
--- a/code/packages/typescript/forme-transform-toc/BUILD
+++ b/code/packages/typescript/forme-transform-toc/BUILD
@@ -1,0 +1,3 @@
+cd ../document-ast && npm install --silent
+cd ../forme-transform-autolink-headings && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-transform-toc/CHANGELOG.md
+++ b/code/packages/typescript/forme-transform-toc/CHANGELOG.md
@@ -1,0 +1,129 @@
+# Changelog — @coding-adventures/forme-transform-toc
+
+## 0.1.0 — 2026-05-18
+
+Initial release.  Sixth FM00 v0 stage package — extracts a
+hierarchical Table-of-Contents tree from a `DocumentNode` (or
+pre-computed `HeadingSlug[]`).
+
+Sits alongside `forme-feeds`, `forme-opengraph`,
+`forme-index-renderer`, `forme-transforms`, and
+`forme-transform-autolink-headings`.
+
+### Added
+
+- `buildToc(doc, options?): TocNode[]` — top-level entry.  Walks
+  `doc` via `autolinkHeadings` to get the slug stream, filters
+  by level range, builds the hierarchical tree.
+- `buildTocFromSlugs(slugs, options?): TocNode[]` — same, but
+  takes a pre-computed `HeadingSlug[]`.  Use when caller already
+  invoked `autolinkHeadings` for the renderer and doesn't want
+  to walk the AST twice.
+- `buildTree(slugs): TocNode[]` — sub-helper: pure flat →
+  hierarchical tree construction without filtering.
+- `filterByLevel(slugs, minLevel, maxLevel): HeadingSlug[]` —
+  sub-helper: drop slugs outside the level range.
+- `TocNode` and `TocOptions` types.
+
+### Spec adherence
+
+Implements FM00 v0 §5.3 `transform-toc`.  No spec divergences.
+Spec calls for "extract TOC, inject anchor points"; the anchor
+points are produced by `forme-transform-autolink-headings`
+upstream, and this package builds the extraction tree.
+
+### Behavioural notes
+
+- **Stack-based tree construction.**  Single forward pass over
+  the flat heading list, maintaining a stack of currently-open
+  ancestor nodes.  For each incoming heading: pop ancestors at
+  the same or deeper level (their subtrees close), append as
+  child of stack-top (or as root if stack empty), push the new
+  node.  O(N) — each heading pushed once, popped at most once.
+- **Malformed sequences handled gracefully.**  Skipped levels
+  (h1 → h3) just nest the deeper heading as a child of the
+  shallower one — no interpolated empty heading, no throw.
+  Documents starting at a deep level (first heading is h3)
+  treat that h3 as a root.  Outdent past root (h1 after deep
+  nesting) closes all open subtrees and starts a new root.
+- **Source level preserved.**  Filtering by `minLevel: 2` doesn't
+  remap surviving h2 headings down to h1; the `level` field
+  stays at its source value for callers that want level-
+  specific styling.
+- **Filter then build, not build then prune.**  Filtering
+  happens before tree construction.  A filtered-out heading
+  does not preserve its nesting — its children promote to roots
+  if no surviving ancestor exists.
+- **Out-of-range options clamp.**  `minLevel: 0` clamps to 1;
+  `maxLevel: 99` clamps to 6.  NaN clamps to 1.  Inverted
+  ranges (`minLevel > maxLevel`) return an empty array.
+- **`href` is always `"#" + slug`.**  Preserved from
+  `HeadingSlug.anchorHref` directly; not re-concatenated to
+  avoid accidental encoding bugs.
+
+### Security posture
+
+Three concerns explicitly addressed (pre-push review):
+
+- **No AST mutation.**  Input arrays are never `.push`-ed into;
+  the source `DocumentNode` is never modified.  JSON-snapshot
+  tests confirm.
+- **Heading text passthrough.**  The `text` field on `TocNode`
+  preserves raw heading content verbatim — renderers must
+  HTML-escape it when emitting markup.  Only the `slug` /
+  `href` are sanitised (by `slugify` upstream).  This is the
+  same contract every other FM00 stage observes: text is data,
+  not markup, and the renderer owns the escape boundary.
+- **Bounded computation.**  Tree construction is O(N) — stack
+  pushes once, pops at most once per heading.  Adversarial
+  inputs like 10,000 h6 headings under one h1 produce a tree of
+  10,000 children, not exponential nesting.  No regex
+  backtracking surface (no regex used).
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, network, fs, shell, env.
+
+### Tests
+
+55 tests across 3 files:
+
+- `filter.test.ts` (17) — defaults [1, 6] keep everything,
+  minLevel drops shallow / maxLevel drops deep, combined,
+  out-of-range clamping (negative, NaN, Infinity, fractional),
+  inverted range → empty, purity (no mutation, fresh array,
+  empty input).
+- `build-tree.test.ts` (20) — well-formed (empty, single
+  heading, h1+h2, h1+two siblings, h1>h2>h3, realistic blog
+  post with mixed nesting), multiple roots (two h1s, doc
+  starting at h2, outdent past root), malformed (h1→h3 skip,
+  h1→h6 skip, orphan h3 root, h2→h4→h3 stack-pop semantics,
+  same-level repeats become siblings), href preservation,
+  purity (no input mutation, byte-identical output across
+  calls, fresh tree per call with no shared substructure),
+  100-heading stress test.
+- `build-toc.test.ts` (18) — DocumentNode entry point with
+  collision-suffix hrefs (`#setup`, `#setup-2`), empty doc /
+  no-heading doc, options (minLevel, maxLevel, combo,
+  defaults), `buildTocFromSlugs` parity with `buildToc` given
+  the same slug stream, security (hostile heading text
+  preserves raw text but sanitises slug, control bytes
+  stripped from slug), reproducibility (FM03 byte-identical,
+  no mutation of input doc), defaults match no-options call.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only declarations).
+
+### v0 simplifications (documented)
+
+- **No level remapping.**  An h2 stays an h2 in the output
+  even with `minLevel: 2`.  Renderers can shift levels
+  themselves.
+- **No inclusion / exclusion by slug pattern.**  Only level-
+  range filtering.  Per-heading omit hints (e.g. trailing
+  `<!-- omit-toc -->`) are not in v0.
+- **No max-nesting-depth cap.**  `maxLevel` caps absolute
+  source level, not nesting depth from the first surviving
+  ancestor.  Different option, deferred.
+- **No counter / numbering.**  Renderers apply CSS counters to
+  produce "1.1.2" prefixes; this package emits the raw tree.

--- a/code/packages/typescript/forme-transform-toc/README.md
+++ b/code/packages/typescript/forme-transform-toc/README.md
@@ -1,0 +1,199 @@
+# @coding-adventures/forme-transform-toc
+
+Build a hierarchical Table-of-Contents tree from a
+`DocumentNode` (or a pre-computed `HeadingSlug[]`).  FM00 v0 §5.3
+transform.
+
+Pure transform: heading sequence → nested `TocNode[]` tree that
+renderers consume to emit
+
+```html
+<nav class="forme-toc">
+  <ul>
+    <li>
+      <a href="#installation">Installation</a>
+      <ul>
+        <li><a href="#requirements">Requirements</a></li>
+        <li><a href="#install-steps">Install steps</a></li>
+      </ul>
+    </li>
+  </ul>
+</nav>
+```
+
+Sixth FM00 v0 stage package — joins
+[`forme-feeds`](../forme-feeds),
+[`forme-opengraph`](../forme-opengraph),
+[`forme-index-renderer`](../forme-index-renderer),
+[`forme-transforms`](../forme-transforms), and
+[`forme-transform-autolink-headings`](../forme-transform-autolink-headings).
+
+## Quick start
+
+```ts
+import { buildToc } from "@coding-adventures/forme-transform-toc";
+
+// Default: include every heading level 1-6.
+const toc = buildToc(doc);
+
+// Common idiom: skip the page title (h1), cap depth at h3.
+const sidebarToc = buildToc(doc, { minLevel: 2, maxLevel: 3 });
+
+// Walk the tree to emit HTML:
+function render(nodes: readonly TocNode[]): string {
+  if (nodes.length === 0) return "";
+  return `<ul>${nodes.map((n) =>
+    `<li><a href="${n.href}">${n.text}</a>${render(n.children)}</li>`
+  ).join("")}</ul>`;
+}
+```
+
+## Why this package exists
+
+A flat `HeadingSlug[]` (from `forme-transform-autolink-headings`)
+is the right shape for renderers walking the document body —
+each heading consumed in document order.  But TOCs are nested:
+`<h3>`s live inside their parent `<h2>`'s subtree.
+
+This package is the bridge: stack-based one-pass tree
+construction that handles:
+
+- Skipped levels (`<h1>` directly to `<h3>`) without throwing.
+- Outdent past root (`<h1>` after deep nesting) cleanly.
+- Documents that start at a deep level (first heading is `<h3>`).
+- Multiple top-level roots (docs with no `<h1>`).
+- Repeated peer levels (sibling `<h2>`s under one `<h1>`).
+
+All deterministic; same input → byte-identical tree.  Safe to
+use as cache key input.
+
+## API
+
+### `buildToc(doc, options?): TocNode[]`
+
+Build a TOC tree directly from a `DocumentNode`.  Internally
+calls `autolinkHeadings(doc)` for the slug stream.
+
+### `buildTocFromSlugs(slugs, options?): TocNode[]`
+
+Build from a pre-computed `HeadingSlug[]`.  Use when the caller
+already invoked `autolinkHeadings` for the renderer and doesn't
+want to walk the AST twice.
+
+### `buildTree(slugs): TocNode[]`
+
+Sub-helper: pure flat → hierarchical tree construction, no
+filtering.  Exposed for callers wiring custom pipelines.
+
+### `filterByLevel(slugs, minLevel, maxLevel): HeadingSlug[]`
+
+Sub-helper: drop slugs outside the level range.  Out-of-range
+parameters clamp to `[1, 6]`; inverted ranges return `[]`.
+
+### Types
+
+```ts
+interface TocNode {
+  readonly level: 1 | 2 | 3 | 4 | 5 | 6;
+  readonly text: string;
+  readonly slug: string;
+  readonly href: string;        // === "#" + slug
+  readonly children: readonly TocNode[];
+}
+
+interface TocOptions {
+  readonly minLevel?: 1 | 2 | 3 | 4 | 5 | 6;  // default 1
+  readonly maxLevel?: 1 | 2 | 3 | 4 | 5 | 6;  // default 6
+}
+```
+
+## Behavioural contract
+
+| Aspect                              | Behaviour                            |
+|-------------------------------------|--------------------------------------|
+| Input AST / slugs                   | Never mutated                        |
+| Output                              | Fresh tree each call (no shared refs)|
+| Skipped levels (h1→h3)              | h3 becomes direct child of h1        |
+| First heading at deep level         | Becomes a top-level root             |
+| Outdent past root                   | Closes subtrees, starts new root     |
+| Repeated peer levels                | Become siblings (not nested)         |
+| `minLevel` filtered-out heading     | Does NOT preserve nesting; children promote to roots if no surviving parent |
+| Source level                        | Preserved verbatim (no remapping)    |
+| `href`                              | Always `"#" + slug`                  |
+| Inverted range (minLevel > maxLevel)| Returns `[]`                         |
+
+## Reproducibility (FM03)
+
+Same `DocumentNode` → byte-identical `TocNode[]`.  The stack
+algorithm is a pure function of input order; `autolinkHeadings`
+already guarantees deterministic slug generation.  Safe to feed
+into cache key derivation.
+
+## Security posture
+
+Three concerns explicitly addressed (pre-push review):
+
+- **AST mutation.** Input arrays are never `.push`-ed into; the
+  source AST is never modified.  Verified by JSON-snapshot tests.
+- **Heading text passthrough.**  The `text` field on `TocNode`
+  preserves the raw heading content verbatim — renderers must
+  HTML-escape it when emitting markup.  Only the `slug` / `href`
+  are sanitised (by `slugify` upstream); the `text` is data, not
+  markup.
+- **Bounded computation.**  Tree construction is O(N) — stack
+  pushes once, pops at most once per heading.  Adversarial inputs
+  like 10,000 `<h6>` headings under one `<h1>` produce a tree of
+  10,000 children, not exponential nesting.
+
+## Capabilities — `[]`
+
+Pure transform.  No I/O, no network, no shell, no env, no fs.
+
+## Tests
+
+55 tests across 3 files:
+
+- `filter.test.ts` (17) — defaults, minLevel / maxLevel
+  filtering, combined, out-of-range clamping (negative, NaN,
+  Infinity, fractional), inverted range, purity (no mutation,
+  fresh array, empty input).
+- `build-tree.test.ts` (20) — well-formed hierarchies (empty,
+  single, parent-child, three-deep, realistic blog post),
+  multiple roots (two h1s, starting at h2, outdent past root),
+  malformed sequences (h1→h3 skip, h1→h6 skip, orphan h3,
+  h2→h4→h3 stack-pop semantics, same-level repeats), href
+  preservation, purity (no input mutation, byte-identical
+  output, fresh tree per call), 100-heading stress test.
+- `build-toc.test.ts` (18) — DocumentNode entry point with
+  collision-suffix hrefs, empty/no-heading docs, options
+  (minLevel, maxLevel, combo, defaults), `buildTocFromSlugs`
+  parity, security (hostile heading text, control bytes),
+  reproducibility, defaults match no-options call.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only).
+
+## Spec adherence
+
+Implements FM00 v0 §5.3 `transform-toc`.  No spec divergences.
+Spec calls for "extract TOC, inject anchor points"; the anchor
+points are produced by `forme-transform-autolink-headings`
+upstream, and this package builds the extraction tree.
+
+## v0 simplifications
+
+- **No level remapping.**  An `<h2>` stays an `<h2>` in the
+  output tree even with `minLevel: 2`.  Renderers that want
+  "shift everything to start at h1" do that themselves.  v0
+  preserves source levels for callers that need them.
+- **No inclusion / exclusion by slug pattern.**  Only level-
+  range filtering.  Headings can be skipped from a TOC via
+  Markdown source convention (e.g. trailing `<!-- omit-toc -->`)
+  but the heuristic is not in v0.
+- **No max-depth cap (different from `maxLevel`).**  `maxLevel`
+  caps absolute heading level; "stop after 2 levels of nesting
+  regardless of source level" would be a separate option,
+  deferred.
+- **No counter / numbering.**  Renderers can apply CSS
+  counters to produce "1.1.2" prefixes; this package emits the
+  raw tree only.

--- a/code/packages/typescript/forme-transform-toc/package-lock.json
+++ b/code/packages/typescript/forme-transform-toc/package-lock.json
@@ -1,0 +1,2334 @@
+{
+  "name": "@coding-adventures/forme-transform-toc",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-transform-toc",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast",
+        "@coding-adventures/forme-transform-autolink-headings": "file:../forme-transform-autolink-headings"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../document-ast": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-transform-autolink-headings": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/document-ast": {
+      "resolved": "../document-ast",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-transform-autolink-headings": {
+      "resolved": "../forme-transform-autolink-headings",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-transform-toc/package.json
+++ b/code/packages/typescript/forme-transform-toc/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/forme-transform-toc",
+  "version": "0.1.0",
+  "description": "Build a hierarchical Table-of-Contents tree from a DocumentNode (or a pre-computed HeadingSlug[] stream).  Pure transform: heading sequence → nested TocNode[] (level + text + slug + href + children) that renderers consume to emit `<nav><ul><li><a href=\"#slug\">…</a><ul>…</ul></li></ul></nav>`.  FM00 v0 §5.3 transform.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/document-ast": "file:../document-ast",
+    "@coding-adventures/forme-transform-autolink-headings": "file:../forme-transform-autolink-headings"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-transform-toc/required_capabilities.json
+++ b/code/packages/typescript/forme-transform-toc/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-transform-toc",
+  "capabilities": [],
+  "justification": "Pure transform: HeadingSlug[] (or DocumentNode) → hierarchical TocNode[].  Walks an immutable input and produces a nested tree.  No I/O, no network, no env, no shell, no fs.  Same posture as forme-feeds / forme-opengraph / forme-index-renderer / forme-transforms / forme-transform-autolink-headings."
+}

--- a/code/packages/typescript/forme-transform-toc/src/build-toc.ts
+++ b/code/packages/typescript/forme-transform-toc/src/build-toc.ts
@@ -1,0 +1,59 @@
+/**
+ * build-toc.ts — top-level entry points.
+ *
+ * Two flavours of the same transform, depending on what the
+ * caller already has:
+ *
+ *   - `buildToc(doc, options?)` — caller has a fresh
+ *     `DocumentNode`; we walk it via `autolinkHeadings` to get
+ *     the flat slug stream, then build the tree.  Use this in
+ *     simple pipelines.
+ *   - `buildTocFromSlugs(slugs, options?)` — caller already
+ *     called `autolinkHeadings` for some other reason (e.g. to
+ *     pass slugs to the renderer) and doesn't want to repeat
+ *     the walk.  Cheaper.
+ *
+ * Both go through the same `filterByLevel` → `buildTree`
+ * pipeline, so behaviour is identical given the same effective
+ * slug stream.
+ *
+ * @module build-toc
+ */
+
+import type { DocumentNode } from "@coding-adventures/document-ast";
+import {
+  autolinkHeadings,
+  type HeadingSlug,
+} from "@coding-adventures/forme-transform-autolink-headings";
+import { filterByLevel } from "./filter.js";
+import { buildTree } from "./build-tree.js";
+import type { TocNode, TocOptions } from "./types.js";
+
+/**
+ * Build a TOC tree directly from a `DocumentNode`.
+ *
+ * Internally runs `autolinkHeadings(doc)` to get the slug
+ * stream.  Callers who already have the slugs should use
+ * `buildTocFromSlugs` to avoid the duplicate walk.
+ */
+export function buildToc(doc: DocumentNode, options: TocOptions = {}): TocNode[] {
+  return buildTocFromSlugs(autolinkHeadings(doc), options);
+}
+
+/**
+ * Build a TOC tree from a pre-computed `HeadingSlug[]`.
+ *
+ * Useful when the caller is already running `autolinkHeadings`
+ * for other purposes (renderer consumes the slug stream
+ * directly to emit `<h2 id="…">` markup) and doesn't want to
+ * walk the AST twice.
+ */
+export function buildTocFromSlugs(
+  slugs: readonly HeadingSlug[],
+  options: TocOptions = {},
+): TocNode[] {
+  const minLevel = options.minLevel ?? 1;
+  const maxLevel = options.maxLevel ?? 6;
+  const filtered = filterByLevel(slugs, minLevel, maxLevel);
+  return buildTree(filtered);
+}

--- a/code/packages/typescript/forme-transform-toc/src/build-tree.ts
+++ b/code/packages/typescript/forme-transform-toc/src/build-tree.ts
@@ -1,0 +1,101 @@
+/**
+ * build-tree.ts — flat `HeadingSlug[]` → hierarchical `TocNode[]`.
+ *
+ * The algorithm is a single forward pass over the flat heading
+ * list, maintaining a stack of "currently-open" ancestor nodes.
+ * For each incoming heading:
+ *
+ *   1. Pop ancestors whose level is >= the new heading's level
+ *      (their subtree is closed).
+ *   2. If the stack is empty after popping, the new node is a
+ *      top-level root.
+ *   3. Otherwise, the new node is appended as a child of the
+ *      stack top.
+ *   4. Push the new node onto the stack so deeper headings
+ *      attach beneath it.
+ *
+ * Cost: O(N) — each heading is pushed once and popped at most
+ * once.
+ *
+ * Malformed sequences (the spec calls this out as a v0
+ * requirement):
+ *
+ *   - **Skipped levels** (`h1` directly to `h3`) — the `h3` just
+ *     becomes a child of the `h1`.  No interpolated empty `h2`,
+ *     no thrown error.  Most TOC renderers handle this fine
+ *     (the nested `<ul>` just appears one level deeper).
+ *   - **Outdent past root** — a `h1` after a deep nesting closes
+ *     all open subtrees and starts a new root.  Standard stack
+ *     pop semantics.
+ *   - **Repeated peer levels** — three sibling `h2`s under one
+ *     `h1` produce three children in the parent's `children`
+ *     array, in input order.
+ *   - **Document starts with a deep level** (e.g. first heading
+ *     is `h3`) — that `h3` becomes a top-level root.  The TOC
+ *     reflects what the document actually contains; it doesn't
+ *     manufacture missing ancestors.
+ *
+ * Determinism: same input → byte-identical output.  The stack
+ * algorithm is a pure function of the input order.
+ *
+ * @module build-tree
+ */
+
+import type { HeadingSlug } from "@coding-adventures/forme-transform-autolink-headings";
+import type { TocNode } from "./types.js";
+
+/**
+ * Mutable scratch type used during construction.  Once the tree
+ * is built, every node is frozen-ish (children is read as
+ * `readonly TocNode[]` by the public type).  We don't `Object.freeze`
+ * for performance; the `readonly` contract is the API guarantee.
+ */
+interface MutableTocNode {
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  text: string;
+  slug: string;
+  href: string;
+  children: MutableTocNode[];
+}
+
+/**
+ * Build the TOC tree from an ordered `HeadingSlug[]`.  Returns
+ * the top-level roots.
+ *
+ * Roots are headings whose level is shallower than every
+ * preceding heading at the point of insertion (i.e. they pop the
+ * whole stack).  In a well-formed document with one `h1`, there
+ * is exactly one root.  In a documentation site with multiple
+ * top-level sections starting at `h2`, there can be multiple
+ * roots.
+ *
+ * Input is never mutated.  Output `children` arrays are mutable
+ * during construction but exposed as `readonly` via the public
+ * type.
+ */
+export function buildTree(slugs: readonly HeadingSlug[]): TocNode[] {
+  const roots: MutableTocNode[] = [];
+  const stack: MutableTocNode[] = [];
+  for (let i = 0; i < slugs.length; i++) {
+    const s = slugs[i]!;
+    const node: MutableTocNode = {
+      level: s.level,
+      text: s.text,
+      slug: s.slug,
+      href: s.anchorHref,
+      children: [],
+    };
+    // Pop ancestors at the same or deeper level — they cannot be
+    // this node's parent.
+    while (stack.length > 0 && stack[stack.length - 1]!.level >= s.level) {
+      stack.pop();
+    }
+    if (stack.length === 0) {
+      roots.push(node);
+    } else {
+      stack[stack.length - 1]!.children.push(node);
+    }
+    stack.push(node);
+  }
+  return roots;
+}

--- a/code/packages/typescript/forme-transform-toc/src/filter.ts
+++ b/code/packages/typescript/forme-transform-toc/src/filter.ts
@@ -1,0 +1,70 @@
+/**
+ * filter.ts — apply minLevel / maxLevel range filter to a flat heading list.
+ *
+ * Done as a separate step (before tree construction) so the
+ * hierarchy reflects only the surviving headings.  Two
+ * consequences worth knowing:
+ *
+ *   - **Filtered-out headings do not preserve their nesting.**
+ *     If `<h1>` is filtered out by `minLevel: 2`, the surviving
+ *     `<h2>`s become roots — they don't get an artificial
+ *     `<h1>` parent.
+ *   - **No level remapping.**  An `<h2>` stays an `<h2>` in the
+ *     output even if `minLevel: 2`.  Renderers that want
+ *     "shift everything to start at h1" should do that
+ *     themselves; this package preserves source levels for
+ *     callers that need them (e.g. for level-specific styling).
+ *
+ * @module filter
+ */
+
+import type { HeadingSlug } from "@coding-adventures/forme-transform-autolink-headings";
+
+/**
+ * Drop slugs whose level is outside `[minLevel, maxLevel]`.
+ * Returns a fresh array; input is never mutated.
+ *
+ * Defaults: `minLevel: 1`, `maxLevel: 6` (no filtering).  Out-of-
+ * range options are clamped to the 1-6 valid range so callers
+ * who pass `minLevel: 0` or `maxLevel: 10` get sensible
+ * behaviour instead of throwing.
+ */
+export function filterByLevel(
+  slugs: readonly HeadingSlug[],
+  minLevel: number,
+  maxLevel: number,
+): HeadingSlug[] {
+  const lo = clampLevel(minLevel);
+  const hi = clampLevel(maxLevel);
+  // If the range is inverted (minLevel > maxLevel) we return an
+  // empty array rather than the unintuitive "no headings match
+  // the impossible range" — which is the same outcome but
+  // explicit short-circuit avoids an O(N) walk.
+  if (lo > hi) return [];
+  const out: HeadingSlug[] = [];
+  for (let i = 0; i < slugs.length; i++) {
+    const s = slugs[i]!;
+    if (s.level >= lo && s.level <= hi) out.push(s);
+  }
+  return out;
+}
+
+/**
+ * Snap any number into the `[1, 6]` heading-level range.
+ *
+ * Order of guards matters:
+ *   - `NaN` first — NaN comparisons always return false, so the
+ *     `<` / `>` checks would fall through and `Math.floor(NaN)`
+ *     would return `NaN`.  Treat as "1" (most permissive lower
+ *     bound; safe default).
+ *   - `+Infinity` and `-Infinity` naturally fall through to the
+ *     `< 1` / `> 6` checks, so they clamp to 1 and 6
+ *     respectively (no special-case needed).
+ *   - Fractional values get `Math.floor`-ed so `2.7` → `2`.
+ */
+function clampLevel(n: number): number {
+  if (Number.isNaN(n)) return 1;
+  if (n < 1) return 1;
+  if (n > 6) return 6;
+  return Math.floor(n);
+}

--- a/code/packages/typescript/forme-transform-toc/src/index.ts
+++ b/code/packages/typescript/forme-transform-toc/src/index.ts
@@ -1,0 +1,39 @@
+/**
+ * @coding-adventures/forme-transform-toc
+ *
+ * FM00 v0 §5.3 transform — build a hierarchical Table-of-Contents
+ * tree from a `DocumentNode` (or a pre-computed `HeadingSlug[]`).
+ *
+ * Pure transform: heading sequence → nested `TocNode[]`
+ * (`{ level, text, slug, href, children: TocNode[] }`).
+ * Renderers walk the tree depth-first to emit
+ *
+ *   <nav class="forme-toc">
+ *     <ul>
+ *       <li>
+ *         <a href="#installation">Installation</a>
+ *         <ul>
+ *           <li><a href="#requirements">Requirements</a></li>
+ *         </ul>
+ *       </li>
+ *     </ul>
+ *   </nav>
+ *
+ * ```ts
+ * import { buildToc } from "@coding-adventures/forme-transform-toc";
+ *
+ * const toc = buildToc(doc, { minLevel: 2, maxLevel: 4 });
+ * ```
+ *
+ * Built on top of `forme-transform-autolink-headings` for the
+ * slug stream.  Sixth FM00 v0 stage package — joins
+ * `forme-feeds`, `forme-opengraph`, `forme-index-renderer`,
+ * `forme-transforms`, `forme-transform-autolink-headings`.
+ *
+ * @module index
+ */
+
+export { buildToc, buildTocFromSlugs } from "./build-toc.js";
+export { buildTree } from "./build-tree.js";
+export { filterByLevel } from "./filter.js";
+export type { TocNode, TocOptions } from "./types.js";

--- a/code/packages/typescript/forme-transform-toc/src/types.ts
+++ b/code/packages/typescript/forme-transform-toc/src/types.ts
@@ -1,0 +1,66 @@
+/**
+ * types.ts — TOC tree node shape and options.
+ *
+ * A `TocNode` is the hierarchical counterpart of the flat
+ * `HeadingSlug` from `forme-transform-autolink-headings`: each
+ * heading becomes one node, and `children` holds deeper-level
+ * headings nested beneath it.
+ *
+ * Renderers consume the tree depth-first to emit
+ *
+ *   <nav class="forme-toc">
+ *     <ul>
+ *       <li>
+ *         <a href="#installation">Installation</a>
+ *         <ul>
+ *           <li><a href="#requirements">Requirements</a></li>
+ *           <li><a href="#install-steps">Install steps</a></li>
+ *         </ul>
+ *       </li>
+ *     </ul>
+ *   </nav>
+ *
+ * The `level` field is preserved so renderers can apply
+ * level-specific classes if desired (e.g. `class="toc-h1"`).
+ *
+ * @module types
+ */
+
+/**
+ * One node in the TOC tree.  Mirrors `HeadingSlug` plus a
+ * `children` array for nested headings.
+ *
+ * Invariants enforced by `buildToc`:
+ *   - `children[i].level > this.level` (children are always
+ *     deeper).
+ *   - `slug` is unique within the whole tree (collision-resolved
+ *     upstream).
+ *   - `href === "#" + slug`.
+ */
+export interface TocNode {
+  readonly level: 1 | 2 | 3 | 4 | 5 | 6;
+  readonly text: string;
+  readonly slug: string;
+  readonly href: string;
+  readonly children: readonly TocNode[];
+}
+
+/**
+ * Options controlling which headings appear in the output tree.
+ *
+ *   - `minLevel` (default `1`) — drop headings shallower than
+ *     this.  E.g. `minLevel: 2` skips `<h1>` (the page title is
+ *     usually outside the TOC).
+ *   - `maxLevel` (default `6`) — drop headings deeper than this.
+ *     E.g. `maxLevel: 3` keeps only `<h1>`/`<h2>`/`<h3>` in the
+ *     TOC; `<h4>`+ get omitted entirely (and don't contribute
+ *     nesting either).
+ *
+ * Out-of-range filtering happens BEFORE tree construction.  A
+ * filtered-out heading does not interrupt the hierarchy of its
+ * surviving neighbours.
+ */
+export interface TocOptions {
+  readonly minLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  readonly maxLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+}

--- a/code/packages/typescript/forme-transform-toc/tests/build-toc.test.ts
+++ b/code/packages/typescript/forme-transform-toc/tests/build-toc.test.ts
@@ -1,0 +1,176 @@
+/**
+ * build-toc.test.ts — end-to-end: DocumentNode (or slugs) → TocNode[].
+ */
+
+import { describe, it, expect } from "vitest";
+import type { BlockNode, DocumentNode, InlineNode } from "@coding-adventures/document-ast";
+import type { HeadingSlug } from "@coding-adventures/forme-transform-autolink-headings";
+import { buildToc, buildTocFromSlugs } from "../src/index.js";
+
+function txt(value: string): InlineNode { return { type: "text", value }; }
+function h(level: 1|2|3|4|5|6, text: string): BlockNode {
+  return { type: "heading", level, children: [txt(text)] };
+}
+function doc(...children: BlockNode[]): DocumentNode {
+  return { type: "document", children };
+}
+function s(level: 1|2|3|4|5|6, slug: string): HeadingSlug {
+  return { level, text: slug, slug, anchorHref: `#${slug}` };
+}
+
+describe("buildToc — DocumentNode entry point", () => {
+  it("calls autolinkHeadings internally", () => {
+    const t = buildToc(doc(
+      h(1, "Title"),
+      h(2, "Section A"),
+      h(2, "Section B"),
+    ));
+    expect(t.length).toBe(1);
+    expect(t[0]!.slug).toBe("title");
+    expect(t[0]!.children.map((c) => c.slug)).toEqual(["section-a", "section-b"]);
+  });
+
+  it("uses slug-resolved hrefs with collision suffixes", () => {
+    const t = buildToc(doc(
+      h(1, "Title"),
+      h(2, "Setup"),
+      h(2, "Setup"),  // duplicate
+    ));
+    expect(t[0]!.children.map((c) => c.href)).toEqual(["#setup", "#setup-2"]);
+  });
+
+  it("empty doc → empty array", () => {
+    expect(buildToc(doc())).toEqual([]);
+  });
+
+  it("doc with no headings → empty array", () => {
+    const t = buildToc(doc({
+      type: "paragraph",
+      children: [txt("just prose")],
+    }));
+    expect(t).toEqual([]);
+  });
+});
+
+describe("buildToc — options", () => {
+  it("minLevel: 2 drops the h1", () => {
+    const t = buildToc(doc(
+      h(1, "Title"),
+      h(2, "Section A"),
+      h(3, "Sub one"),
+    ), { minLevel: 2 });
+    expect(t.length).toBe(1);
+    expect(t[0]!.slug).toBe("section-a");
+    expect(t[0]!.children[0]!.slug).toBe("sub-one");
+  });
+
+  it("maxLevel: 2 drops h3+", () => {
+    const t = buildToc(doc(
+      h(1, "Title"),
+      h(2, "Section"),
+      h(3, "Skipped"),
+    ), { maxLevel: 2 });
+    expect(t[0]!.children.map((c) => c.slug)).toEqual(["section"]);
+    expect(t[0]!.children[0]!.children).toEqual([]);
+  });
+
+  it("minLevel + maxLevel combo", () => {
+    const t = buildToc(doc(
+      h(1, "Title"),
+      h(2, "Alpha"),
+      h(3, "Sub"),
+      h(4, "Deep"),
+    ), { minLevel: 2, maxLevel: 3 });
+    expect(t.length).toBe(1);
+    expect(t[0]!.slug).toBe("alpha");
+    expect(t[0]!.children[0]!.slug).toBe("sub");
+    expect(t[0]!.children[0]!.children).toEqual([]); // h4 filtered out
+  });
+
+  it("default options keep everything (minLevel 1, maxLevel 6)", () => {
+    const t = buildToc(doc(h(1, "A"), h(6, "Z")));
+    expect(t[0]!.children[0]!.slug).toBe("z");
+  });
+});
+
+describe("buildTocFromSlugs — pre-computed slug entry point", () => {
+  it("builds tree from caller-supplied slug array", () => {
+    const t = buildTocFromSlugs([
+      s(1, "title"),
+      s(2, "a"),
+      s(2, "b"),
+    ]);
+    expect(t.length).toBe(1);
+    expect(t[0]!.children.length).toBe(2);
+  });
+
+  it("same options as buildToc", () => {
+    const slugs = [s(1, "title"), s(2, "a"), s(3, "a-1")];
+    const t = buildTocFromSlugs(slugs, { minLevel: 2 });
+    expect(t.length).toBe(1);
+    expect(t[0]!.slug).toBe("a");
+  });
+
+  it("does not mutate input slugs array", () => {
+    const slugs = [s(1, "a"), s(2, "b")];
+    const before = JSON.stringify(slugs);
+    buildTocFromSlugs(slugs);
+    expect(JSON.stringify(slugs)).toBe(before);
+  });
+
+  it("equivalent to buildToc with the same slug stream", () => {
+    const d = doc(h(1, "T"), h(2, "A"), h(3, "B"));
+    const viaDoc = buildToc(d);
+    // Derive slugs the same way buildToc does — text is preserved
+    // verbatim (uppercase "T", "A", "B"), slugs are lowercased.
+    const slugs: HeadingSlug[] = [
+      { level: 1, text: "T", slug: "t", anchorHref: "#t" },
+      { level: 2, text: "A", slug: "a", anchorHref: "#a" },
+      { level: 3, text: "B", slug: "b", anchorHref: "#b" },
+    ];
+    const viaSlugs = buildTocFromSlugs(slugs);
+    expect(JSON.stringify(viaDoc)).toBe(JSON.stringify(viaSlugs));
+  });
+});
+
+describe("buildToc — security / hostile heading text", () => {
+  it("attacker-controlled heading produces safe slug + href", () => {
+    const t = buildToc(doc(h(1, `<script>alert("xss")</script>`)));
+    expect(t[0]!.slug).toMatch(/^[a-z0-9-]+$/);
+    expect(t[0]!.href).toMatch(/^#[a-z0-9-]+$/);
+    // The TEXT preserves the raw heading content (renderers
+    // escape it when emitting); only the slug/href are sanitised.
+    expect(t[0]!.text).toBe(`<script>alert("xss")</script>`);
+  });
+
+  it("control bytes stripped from slug even though text preserves them", () => {
+    const t = buildToc(doc(h(1, "hel\x00lo")));
+    expect(t[0]!.slug).toBe("hello");
+  });
+});
+
+describe("buildToc — reproducibility", () => {
+  it("same DocumentNode → byte-identical tree", () => {
+    const d = doc(h(1, "T"), h(2, "A"), h(2, "B"));
+    expect(JSON.stringify(buildToc(d))).toBe(JSON.stringify(buildToc(d)));
+  });
+
+  it("does not mutate input document", () => {
+    const d = doc(h(1, "T"), h(2, "A"));
+    const before = JSON.stringify(d);
+    buildToc(d);
+    expect(JSON.stringify(d)).toBe(before);
+  });
+});
+
+describe("buildToc — defaults match no-options call", () => {
+  it("buildToc(doc) === buildToc(doc, {})", () => {
+    const d = doc(h(1, "A"), h(2, "B"), h(3, "C"));
+    expect(JSON.stringify(buildToc(d))).toBe(JSON.stringify(buildToc(d, {})));
+  });
+
+  it("buildTocFromSlugs(slugs) === buildTocFromSlugs(slugs, {})", () => {
+    const slugs = [s(1, "a"), s(2, "b")];
+    expect(JSON.stringify(buildTocFromSlugs(slugs))).toBe(JSON.stringify(buildTocFromSlugs(slugs, {})));
+  });
+});

--- a/code/packages/typescript/forme-transform-toc/tests/build-tree.test.ts
+++ b/code/packages/typescript/forme-transform-toc/tests/build-tree.test.ts
@@ -1,0 +1,170 @@
+/**
+ * build-tree.test.ts — flat HeadingSlug[] → hierarchical TocNode[].
+ */
+
+import { describe, it, expect } from "vitest";
+import type { HeadingSlug } from "@coding-adventures/forme-transform-autolink-headings";
+import { buildTree } from "../src/index.js";
+
+function s(level: 1|2|3|4|5|6, slug: string): HeadingSlug {
+  return { level, text: slug, slug, anchorHref: `#${slug}` };
+}
+
+describe("buildTree — well-formed hierarchies", () => {
+  it("empty input → empty roots", () => {
+    expect(buildTree([])).toEqual([]);
+  });
+
+  it("single heading → single root with no children", () => {
+    const t = buildTree([s(1, "title")]);
+    expect(t).toEqual([{
+      level: 1, text: "title", slug: "title", href: "#title", children: [],
+    }]);
+  });
+
+  it("h1 + h2 → h1 root with one child", () => {
+    const t = buildTree([s(1, "h1"), s(2, "h2a")]);
+    expect(t.length).toBe(1);
+    expect(t[0]!.children.length).toBe(1);
+    expect(t[0]!.children[0]!.slug).toBe("h2a");
+  });
+
+  it("h1 + two h2 siblings", () => {
+    const t = buildTree([s(1, "title"), s(2, "intro"), s(2, "main")]);
+    expect(t.length).toBe(1);
+    expect(t[0]!.children.length).toBe(2);
+    expect(t[0]!.children.map((c) => c.slug)).toEqual(["intro", "main"]);
+  });
+
+  it("h1 > h2 > h3 chain (3 levels deep)", () => {
+    const t = buildTree([s(1, "a"), s(2, "b"), s(3, "c")]);
+    expect(t[0]!.slug).toBe("a");
+    expect(t[0]!.children[0]!.slug).toBe("b");
+    expect(t[0]!.children[0]!.children[0]!.slug).toBe("c");
+  });
+
+  it("realistic blog post: h1 > (h2 > h3, h3), h2 > h3", () => {
+    const t = buildTree([
+      s(1, "post"),
+      s(2, "intro"),
+      s(3, "background"),
+      s(3, "motivation"),
+      s(2, "details"),
+      s(3, "step-1"),
+    ]);
+    expect(t.length).toBe(1);
+    const post = t[0]!;
+    expect(post.children.map((c) => c.slug)).toEqual(["intro", "details"]);
+    expect(post.children[0]!.children.map((c) => c.slug)).toEqual(["background", "motivation"]);
+    expect(post.children[1]!.children.map((c) => c.slug)).toEqual(["step-1"]);
+  });
+});
+
+describe("buildTree — multiple roots", () => {
+  it("two h1s → two roots", () => {
+    const t = buildTree([s(1, "a"), s(1, "b")]);
+    expect(t.length).toBe(2);
+    expect(t.map((n) => n.slug)).toEqual(["a", "b"]);
+  });
+
+  it("starting at h2 (no h1) → h2 roots", () => {
+    const t = buildTree([s(2, "a"), s(2, "b")]);
+    expect(t.length).toBe(2);
+    expect(t.every((n) => n.level === 2)).toBe(true);
+  });
+
+  it("outdent past root: h1 > h2 > h1 → two h1 roots", () => {
+    const t = buildTree([s(1, "first"), s(2, "child"), s(1, "second")]);
+    expect(t.length).toBe(2);
+    expect(t.map((n) => n.slug)).toEqual(["first", "second"]);
+    expect(t[0]!.children.length).toBe(1);
+    expect(t[1]!.children.length).toBe(0);
+  });
+});
+
+describe("buildTree — malformed sequences (skipped levels)", () => {
+  it("h1 → h3 skip: h3 becomes direct child of h1", () => {
+    const t = buildTree([s(1, "a"), s(3, "deep")]);
+    expect(t[0]!.children.map((c) => c.slug)).toEqual(["deep"]);
+    expect(t[0]!.children[0]!.level).toBe(3); // level preserved, no fake h2 inserted
+  });
+
+  it("h1 → h6 (skip 4 levels) just becomes direct child", () => {
+    const t = buildTree([s(1, "a"), s(6, "deepest")]);
+    expect(t[0]!.children[0]!.slug).toBe("deepest");
+    expect(t[0]!.children[0]!.level).toBe(6);
+  });
+
+  it("first heading is h3 (no preceding h1/h2) → h3 root", () => {
+    const t = buildTree([s(3, "orphan")]);
+    expect(t.length).toBe(1);
+    expect(t[0]!.level).toBe(3);
+  });
+
+  it("h2 > h4 > h3: h4 child of h2; h3 closes h4 and becomes sibling of h4", () => {
+    const t = buildTree([s(2, "a"), s(4, "b"), s(3, "c")]);
+    // Stack walk:
+    //   h2 "a" → root, stack [a]
+    //   h4 "b" → child of a, stack [a, b]
+    //   h3 "c" → pop b (level 4 >= 3), stack [a]; child of a
+    expect(t[0]!.children.map((c) => c.slug)).toEqual(["b", "c"]);
+    expect(t[0]!.children[0]!.children).toEqual([]);
+    expect(t[0]!.children[1]!.children).toEqual([]);
+  });
+
+  it("same-level repeats become siblings, not nested", () => {
+    const t = buildTree([s(2, "a"), s(2, "b"), s(2, "c")]);
+    expect(t.length).toBe(3);
+    expect(t.every((n) => n.level === 2)).toBe(true);
+  });
+});
+
+describe("buildTree — href preserved from HeadingSlug.anchorHref", () => {
+  it("href === slug.anchorHref (not regenerated)", () => {
+    const custom: HeadingSlug = { level: 1, text: "T", slug: "my-slug", anchorHref: "#my-slug" };
+    const t = buildTree([custom]);
+    expect(t[0]!.href).toBe("#my-slug");
+  });
+});
+
+describe("buildTree — purity", () => {
+  it("does not mutate input slugs array", () => {
+    const input = [s(1, "a"), s(2, "b"), s(2, "c")];
+    const before = JSON.stringify(input);
+    buildTree(input);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+
+  it("does not mutate individual HeadingSlug entries", () => {
+    const slug = s(1, "a");
+    const before = JSON.stringify(slug);
+    buildTree([slug]);
+    expect(JSON.stringify(slug)).toBe(before);
+  });
+
+  it("same input → byte-identical output (FM03)", () => {
+    const input = [s(1, "a"), s(2, "b"), s(3, "c"), s(2, "d")];
+    expect(JSON.stringify(buildTree(input))).toBe(JSON.stringify(buildTree(input)));
+  });
+
+  it("returns a fresh tree each call (no shared substructure)", () => {
+    const input = [s(1, "a"), s(2, "b")];
+    const t1 = buildTree(input);
+    const t2 = buildTree(input);
+    expect(t1).not.toBe(t2);
+    expect(t1[0]).not.toBe(t2[0]);
+    expect(t1[0]!.children[0]).not.toBe(t2[0]!.children[0]);
+  });
+});
+
+describe("buildTree — stress / large input", () => {
+  it("handles 100 alternating h2/h3", () => {
+    const slugs: HeadingSlug[] = [];
+    for (let i = 0; i < 50; i++) {
+      slugs.push(s(2, `a${i}`), s(3, `b${i}`));
+    }
+    const t = buildTree(slugs);
+    expect(t.length).toBe(50);
+    expect(t.every((n) => n.level === 2 && n.children.length === 1)).toBe(true);
+  });
+});

--- a/code/packages/typescript/forme-transform-toc/tests/filter.test.ts
+++ b/code/packages/typescript/forme-transform-toc/tests/filter.test.ts
@@ -1,0 +1,112 @@
+/**
+ * filter.test.ts — level-range filtering.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { HeadingSlug } from "@coding-adventures/forme-transform-autolink-headings";
+import { filterByLevel } from "../src/index.js";
+
+function s(level: 1|2|3|4|5|6, label = `h${level}`): HeadingSlug {
+  return { level, text: label, slug: label, anchorHref: `#${label}` };
+}
+
+const SAMPLE: HeadingSlug[] = [
+  s(1, "title"),
+  s(2, "a"),
+  s(3, "a1"),
+  s(2, "b"),
+  s(4, "b1a"),
+];
+
+describe("filterByLevel — defaults [1, 6] keep everything", () => {
+  it("returns all 5 entries", () => {
+    expect(filterByLevel(SAMPLE, 1, 6)).toEqual(SAMPLE);
+  });
+
+  it("preserves input order", () => {
+    expect(filterByLevel(SAMPLE, 1, 6).map((x) => x.slug))
+      .toEqual(["title", "a", "a1", "b", "b1a"]);
+  });
+});
+
+describe("filterByLevel — minLevel drops shallow headings", () => {
+  it("minLevel: 2 drops the h1", () => {
+    const out = filterByLevel(SAMPLE, 2, 6);
+    expect(out.map((x) => x.slug)).toEqual(["a", "a1", "b", "b1a"]);
+  });
+
+  it("minLevel: 3 drops h1 and h2", () => {
+    const out = filterByLevel(SAMPLE, 3, 6);
+    expect(out.map((x) => x.slug)).toEqual(["a1", "b1a"]);
+  });
+});
+
+describe("filterByLevel — maxLevel drops deep headings", () => {
+  it("maxLevel: 3 drops the h4", () => {
+    const out = filterByLevel(SAMPLE, 1, 3);
+    expect(out.map((x) => x.slug)).toEqual(["title", "a", "a1", "b"]);
+  });
+
+  it("maxLevel: 2 drops h3+h4", () => {
+    const out = filterByLevel(SAMPLE, 1, 2);
+    expect(out.map((x) => x.slug)).toEqual(["title", "a", "b"]);
+  });
+});
+
+describe("filterByLevel — combined min+max", () => {
+  it("[2, 3] keeps only h2/h3", () => {
+    expect(filterByLevel(SAMPLE, 2, 3).map((x) => x.slug))
+      .toEqual(["a", "a1", "b"]);
+  });
+});
+
+describe("filterByLevel — out-of-range options clamped to [1, 6]", () => {
+  it("minLevel < 1 clamps to 1", () => {
+    expect(filterByLevel(SAMPLE, 0, 6)).toEqual(SAMPLE);
+  });
+
+  it("minLevel negative clamps to 1", () => {
+    expect(filterByLevel(SAMPLE, -10, 6)).toEqual(SAMPLE);
+  });
+
+  it("maxLevel > 6 clamps to 6", () => {
+    expect(filterByLevel(SAMPLE, 1, 99)).toEqual(SAMPLE);
+  });
+
+  it("NaN clamps", () => {
+    expect(filterByLevel(SAMPLE, NaN, NaN)).toEqual([s(1, "title")]);
+  });
+
+  it("Infinity clamps", () => {
+    expect(filterByLevel(SAMPLE, -Infinity, Infinity)).toEqual(SAMPLE);
+  });
+
+  it("fractional minLevel floors", () => {
+    expect(filterByLevel(SAMPLE, 2.7, 6).map((x) => x.slug))
+      .toEqual(["a", "a1", "b", "b1a"]);
+  });
+});
+
+describe("filterByLevel — inverted range", () => {
+  it("minLevel > maxLevel → empty array", () => {
+    expect(filterByLevel(SAMPLE, 5, 2)).toEqual([]);
+  });
+});
+
+describe("filterByLevel — purity", () => {
+  it("does not mutate input", () => {
+    const before = JSON.stringify(SAMPLE);
+    filterByLevel(SAMPLE, 2, 4);
+    expect(JSON.stringify(SAMPLE)).toBe(before);
+  });
+
+  it("returns a fresh array each call", () => {
+    const a = filterByLevel(SAMPLE, 1, 6);
+    const b = filterByLevel(SAMPLE, 1, 6);
+    expect(a).not.toBe(b);
+  });
+
+  it("empty input → empty output", () => {
+    expect(filterByLevel([], 1, 6)).toEqual([]);
+  });
+});

--- a/code/packages/typescript/forme-transform-toc/tsconfig.json
+++ b/code/packages/typescript/forme-transform-toc/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-transform-toc/vitest.config.ts
+++ b/code/packages/typescript/forme-transform-toc/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Sixth FM00 v0 stage package — second concrete §5.3 transform.  Builds a hierarchical `TocNode[]` tree from a `DocumentNode` (or pre-computed `HeadingSlug[]` from [`forme-transform-autolink-headings`](../forme-transform-autolink-headings)).

Renderers walk the tree depth-first to emit:

```html
<nav class="forme-toc">
  <ul>
    <li><a href="#installation">Installation</a>
      <ul><li><a href="#requirements">Requirements</a></li></ul>
    </li>
  </ul>
</nav>
```

Joins [`forme-feeds`](../forme-feeds), [`forme-opengraph`](../forme-opengraph), [`forme-index-renderer`](../forme-index-renderer), [`forme-transforms`](../forme-transforms), [`forme-transform-autolink-headings`](../forme-transform-autolink-headings) in the FM00 v0 stage cluster.

## API

```ts
import { buildToc } from "@coding-adventures/forme-transform-toc";

// Default: include every heading level 1-6.
const toc = buildToc(doc);

// Common idiom: skip the page title (h1), cap depth at h3.
const sidebarToc = buildToc(doc, { minLevel: 2, maxLevel: 3 });
```

Sub-helpers exported: `buildTocFromSlugs` (when caller already has slugs), `buildTree` (pure flat→hierarchical), `filterByLevel` (range filter).

## Key design choices

- **Stack-based one-pass construction.** O(N) — each heading pushed once, popped at most once. Pure function of input order.
- **Malformed sequences handled.** Skipped levels (h1→h3) just nest deeper. Documents starting at deep level treat that heading as a root. Outdent past root cleanly starts a new root. Same-level repeats become siblings. No throws on any pathological input.
- **Filter then build.** Range filtering happens before tree construction; a filtered-out h1 doesn't preserve nesting — its h2 children promote to roots.
- **Source level preserved.** No remapping; an h2 stays h2 even with `minLevel: 2`.
- **Out-of-range options clamp.** `minLevel<1→1`, `maxLevel>6→6`, NaN→1, Infinity clamps via comparison. Inverted range → empty array.

## Security

Three concerns addressed pre-push:
- **No AST mutation** — input arrays never `.push`-ed into; source `DocumentNode` never modified.
- **Heading text passthrough** — `text` field preserves raw content verbatim; renderers must HTML-escape when emitting (same contract as every FM00 stage; text is data, not markup).
- **Bounded computation** — O(N) construction; no regex (no backtracking surface); 10k h6s under one h1 stays linear.

Security review (general-purpose sub-agent): **no exploitable findings**.

## Capabilities

`[]` — pure transform.

## Tests

**55 tests across 3 files**, **100% line / 100% branch** coverage:

- `filter.test.ts` (17) — defaults, min/max filtering, combined, out-of-range clamping (negative, NaN, Infinity, fractional), inverted range, purity
- `build-tree.test.ts` (20) — well-formed hierarchies (empty, single, two-level, three-deep, realistic blog post), multiple roots, malformed sequences (h1→h3 skip, h1→h6 skip, orphan h3, h2→h4→h3 stack-pop, same-level repeats), href preservation, purity, 100-heading stress
- `build-toc.test.ts` (18) — DocumentNode entry, collision-suffix hrefs (`#setup`, `#setup-2`), empty/no-heading docs, options matrix, `buildTocFromSlugs` parity, security (hostile text preserves raw + sanitises slug, control bytes), reproducibility, defaults

## Spec adherence

Implements FM00 v0 §5.3 `transform-toc`. No spec divergences.

## v0 simplifications

- No level remapping (h2 stays h2 even with `minLevel: 2`)
- No per-heading omit hints (e.g. `<!-- omit-toc -->`)
- No max-nesting-depth cap (different from `maxLevel`)
- No counter / numbering (CSS counter responsibility)

## Test plan

- [x] All 55 tests pass locally
- [x] 100% line / 100% branch coverage
- [x] TypeScript build clean
- [x] Security review clean
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)