### PR TITLE
Share HTML lexer fixture summary helpers

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -109,6 +109,8 @@ documented in this file.
 - The generic html5lib smoke importer now builds default-wrapper seeded lexer
   cases through the same typed `HtmlLexContext` constructors used by generated
   WHATWG boundary runners.
+- Generated WHATWG lexer fixture runners now share a test-only token summary
+  helper for token, attribute, DOCTYPE, and adjacent-text normalization.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -97,6 +97,9 @@ The normalized html5lib smoke importer follows that same wrapper path for
 default-lexer cases: seeded start-tag, end-tag, comment, DOCTYPE, and
 character-reference continuations now enter through the public typed
 constructors instead of test-local context field assembly.
+The generated WHATWG lexer runners share the same test-only token-summary
+helpers, so boundary fixtures compare token text, attributes, doctypes, and
+coalesced text recovery through one normalization path.
 The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup

--- a/code/packages/rust/html-lexer/tests/common/mod.rs
+++ b/code/packages/rust/html-lexer/tests/common/mod.rs
@@ -1,0 +1,77 @@
+use coding_adventures_html_lexer::{Attribute, Token};
+
+pub fn token_summary(token: Token) -> String {
+    match token {
+        Token::Text(data) => format!("Text(data={data})"),
+        Token::StartTag {
+            name,
+            attributes,
+            self_closing,
+        } => format!(
+            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
+            attribute_summary(&attributes)
+        ),
+        Token::EndTag { name } => format!("EndTag(name={name})"),
+        Token::Comment(data) => format!("Comment(data={data})"),
+        Token::Doctype {
+            name,
+            public_identifier,
+            system_identifier,
+            force_quirks,
+        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
+        Token::Eof => "EOF".to_string(),
+    }
+}
+
+fn doctype_summary(
+    name: Option<String>,
+    public_identifier: Option<String>,
+    system_identifier: Option<String>,
+    force_quirks: bool,
+) -> String {
+    let name = name.unwrap_or_else(|| "null".to_string());
+    match (public_identifier, system_identifier) {
+        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
+        (public_identifier, system_identifier) => format!(
+            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
+            public_identifier.unwrap_or_else(|| "null".to_string()),
+            system_identifier.unwrap_or_else(|| "null".to_string())
+        ),
+    }
+}
+
+fn attribute_summary(attributes: &[Attribute]) -> String {
+    if attributes.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = attributes
+            .iter()
+            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    }
+}
+
+pub fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+    let mut coalesced: Vec<String> = Vec::new();
+    for token in tokens {
+        let Some(text) = token
+            .strip_prefix("Text(data=")
+            .and_then(|text| text.strip_suffix(')'))
+        else {
+            coalesced.push(token);
+            continue;
+        };
+        if let Some(previous) = coalesced.last_mut() {
+            if previous.starts_with("Text(data=") && previous.ends_with(')') {
+                previous.pop();
+                previous.push_str(text);
+                previous.push(')');
+                continue;
+            }
+        }
+        coalesced.push(token);
+    }
+    coalesced
+}

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
@@ -1,8 +1,9 @@
 use coding_adventures_html_lexer::{
     create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlTokenizerState, StartTagSeed,
-    Token,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_ATTRIBUTE_BOUNDARIES: &str = include_str!("fixtures/whatwg-attribute-boundaries.json");
 
@@ -98,11 +99,11 @@ fn whatwg_attribute_boundaries_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -141,80 +142,4 @@ impl From<FixtureAttribute> for Attribute {
             value: attribute.value,
         }
     }
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
@@ -1,5 +1,7 @@
-use coding_adventures_html_lexer::{create_html_lexer, Attribute, Token};
+use coding_adventures_html_lexer::create_html_lexer;
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_ATTRIBUTE_EDGES: &str = include_str!("fixtures/whatwg-attribute-edges.json");
 
@@ -62,11 +64,11 @@ fn whatwg_attribute_edge_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -87,80 +89,4 @@ fn whatwg_attribute_edge_cases_match_default_lexer() {
 fn load_suite() -> AttributeEdgeSuite {
     serde_json::from_str(WHATWG_ATTRIBUTE_EDGES)
         .expect("WHATWG attribute-edge fixture should parse")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
@@ -1,7 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
+    create_html_lexer_with_context, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_CDATA_BOUNDARIES: &str = include_str!("fixtures/whatwg-cdata-boundaries.json");
 
@@ -66,11 +68,11 @@ fn whatwg_cdata_boundaries_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -106,80 +108,4 @@ fn configured_lexer(case: &CdataBoundaryCase) -> HtmlLexer {
     };
 
     create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
@@ -1,7 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
+    create_html_lexer_with_context, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_CHARACTER_REFERENCE_BOUNDARIES: &str =
     include_str!("fixtures/whatwg-character-reference-boundaries.json");
@@ -76,11 +78,11 @@ fn whatwg_character_reference_boundaries_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -123,80 +125,4 @@ fn configured_lexer(case: &CharacterReferenceBoundaryCase) -> HtmlLexer {
     }
 
     create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
@@ -1,7 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
+    create_html_lexer_with_context, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_COMMENT_BOUNDARIES: &str = include_str!("fixtures/whatwg-comment-boundaries.json");
 
@@ -68,11 +70,11 @@ fn whatwg_comment_boundaries_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -109,80 +111,4 @@ fn configured_lexer(case: &CommentBoundaryCase) -> HtmlLexer {
     };
 
     create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
@@ -1,8 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_DOCTYPE_BOUNDARIES: &str = include_str!("fixtures/whatwg-doctype-boundaries.json");
 
@@ -81,11 +82,11 @@ fn whatwg_doctype_boundaries_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -130,80 +131,4 @@ fn configured_lexer(case: &DoctypeBoundaryCase) -> HtmlLexer {
     };
 
     create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
@@ -1,8 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_EOF_RECOVERY: &str = include_str!("fixtures/whatwg-eof-recovery.json");
 
@@ -84,11 +85,11 @@ fn whatwg_eof_recovery_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -168,80 +169,4 @@ fn doctype_seed(seed: &FixtureDoctypeSeed) -> DoctypeSeed {
         system_identifier: seed.system_identifier.clone(),
         force_quirks: seed.force_quirks,
     }
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
@@ -1,8 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_MARKUP_DECLARATIONS: &str = include_str!("fixtures/whatwg-markup-declarations.json");
 
@@ -91,11 +92,11 @@ fn whatwg_markup_declaration_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -176,80 +177,4 @@ fn doctype_seed(seed: &FixtureDoctypeSeed) -> DoctypeSeed {
         system_identifier: seed.system_identifier.clone(),
         force_quirks: seed.force_quirks,
     }
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
@@ -1,7 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
+    create_html_lexer_with_context, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_SCRIPT_ESCAPE_BOUNDARIES: &str =
     include_str!("fixtures/whatwg-script-escape-boundaries.json");
@@ -72,11 +74,11 @@ fn whatwg_script_escape_boundaries_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -112,80 +114,4 @@ fn configured_lexer(case: &ScriptEscapeBoundaryCase) -> HtmlLexer {
     }
 
     create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
@@ -1,5 +1,7 @@
-use coding_adventures_html_lexer::{create_html_lexer, Attribute, Token};
+use coding_adventures_html_lexer::create_html_lexer;
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_TAG_OPEN_RECOVERY: &str = include_str!("fixtures/whatwg-tag-open-recovery.json");
 
@@ -62,11 +64,11 @@ fn whatwg_tag_open_recovery_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -87,80 +89,4 @@ fn whatwg_tag_open_recovery_cases_match_default_lexer() {
 fn load_suite() -> TagOpenRecoverySuite {
     serde_json::from_str(WHATWG_TAG_OPEN_RECOVERY)
         .expect("WHATWG tag-open recovery fixture should parse")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
@@ -1,7 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
+    create_html_lexer_with_context, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_TEXT_MODE_BOUNDARIES: &str = include_str!("fixtures/whatwg-text-mode-boundaries.json");
 
@@ -74,11 +76,11 @@ fn whatwg_text_mode_boundaries_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -116,78 +118,4 @@ fn configured_lexer(case: &TextModeBoundaryCase) -> HtmlLexer {
     }
 
     create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.insert_str(previous.len() - 1, text);
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
@@ -1,8 +1,9 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer_with_context, Attribute, DoctypeSeed, HtmlLexContext, HtmlLexer,
-    HtmlTokenizerState, Token,
+    create_html_lexer_with_context, DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlTokenizerState,
 };
 use serde::Deserialize;
+
+mod common;
 
 const WHATWG_TEXT_MODE_DELIMITERS: &str = include_str!("fixtures/whatwg-text-mode-delimiters.json");
 
@@ -90,11 +91,11 @@ fn whatwg_text_mode_delimiter_cases_match_default_lexer() {
         let actual_tokens = lexer
             .drain_tokens()
             .into_iter()
-            .map(token_summary)
+            .map(common::token_summary)
             .collect::<Vec<_>>();
         assert_eq!(
-            coalesce_adjacent_text_summaries(actual_tokens),
-            coalesce_adjacent_text_summaries(case.tokens.clone()),
+            common::coalesce_adjacent_text_summaries(actual_tokens),
+            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
             "case `{}` token mismatch",
             case.id
         );
@@ -153,80 +154,4 @@ fn configured_lexer(case: &TextModeDelimiterCase) -> HtmlLexer {
     }
 
     create_html_lexer_with_context(&context).expect("HTML lexer context should apply")
-}
-
-fn token_summary(token: Token) -> String {
-    match token {
-        Token::Text(data) => format!("Text(data={data})"),
-        Token::StartTag {
-            name,
-            attributes,
-            self_closing,
-        } => format!(
-            "StartTag(name={name}, attributes={}, self_closing={self_closing})",
-            attribute_summary(&attributes)
-        ),
-        Token::EndTag { name } => format!("EndTag(name={name})"),
-        Token::Comment(data) => format!("Comment(data={data})"),
-        Token::Doctype {
-            name,
-            public_identifier,
-            system_identifier,
-            force_quirks,
-        } => doctype_summary(name, public_identifier, system_identifier, force_quirks),
-        Token::Eof => "EOF".to_string(),
-    }
-}
-
-fn doctype_summary(
-    name: Option<String>,
-    public_identifier: Option<String>,
-    system_identifier: Option<String>,
-    force_quirks: bool,
-) -> String {
-    let name = name.unwrap_or_else(|| "null".to_string());
-    match (public_identifier, system_identifier) {
-        (None, None) => format!("Doctype(name={name}, force_quirks={force_quirks})"),
-        (public_identifier, system_identifier) => format!(
-            "Doctype(name={name}, public_identifier={}, system_identifier={}, force_quirks={force_quirks})",
-            public_identifier.unwrap_or_else(|| "null".to_string()),
-            system_identifier.unwrap_or_else(|| "null".to_string())
-        ),
-    }
-}
-
-fn attribute_summary(attributes: &[Attribute]) -> String {
-    if attributes.is_empty() {
-        "[]".to_string()
-    } else {
-        let joined = attributes
-            .iter()
-            .map(|attribute| format!("{}={}", attribute.name, attribute.value))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{joined}]")
-    }
-}
-
-fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
-    let mut coalesced: Vec<String> = Vec::new();
-    for token in tokens {
-        let Some(text) = token
-            .strip_prefix("Text(data=")
-            .and_then(|text| text.strip_suffix(')'))
-        else {
-            coalesced.push(token);
-            continue;
-        };
-        if let Some(previous) = coalesced.last_mut() {
-            if previous.starts_with("Text(data=") && previous.ends_with(')') {
-                previous.pop();
-                previous.push_str(text);
-                previous.push(')');
-                continue;
-            }
-        }
-        coalesced.push(token);
-    }
-    coalesced
 }


### PR DESCRIPTION
## Summary
- add a shared test-only WHATWG lexer token summary helper
- migrate generated boundary/recovery runner tests to use the common helper
- document the shared fixture normalization path

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- git diff --check