### PR TITLE
spice: add PSS residual convergence

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- **PSS residual convergence flag** — `pss_residual` now accepts a residual
+  tolerance and reports whether one-period node closure is within tolerance.
+
 - **PSS period-closure residual** — `pss_residual` runs one estimated source
   period and reports node-voltage closure residuals as the next foothold for
   shooting-Newton periodic steady-state analysis.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -327,6 +327,8 @@ class PssResidualResult:
     time_step: float
     node_residuals: dict[str, float]
     max_abs_residual: float
+    residual_tol: float
+    within_tolerance: bool
     converged: bool
 
 
@@ -2278,6 +2280,7 @@ def pss_residual(
     method: str = "trap",
     max_iterations: int = 50,
     tol: float = 1e-6,
+    residual_tol: float = 1e-6,
 ) -> PssResidualResult | None:
     """Run one estimated period and report the node-voltage closure residual.
 
@@ -2289,6 +2292,8 @@ def pss_residual(
         return None
     if steps_per_period <= 0:
         raise ValueError("steps_per_period must be positive")
+    if residual_tol < 0.0:
+        raise ValueError("residual_tol must be non-negative")
 
     time_step = period / steps_per_period
     result = transient(
@@ -2305,6 +2310,8 @@ def pss_residual(
             time_step=time_step,
             node_residuals={},
             max_abs_residual=0.0,
+            residual_tol=residual_tol,
+            within_tolerance=False,
             converged=False,
         )
 
@@ -2321,6 +2328,8 @@ def pss_residual(
         time_step=time_step,
         node_residuals=residuals,
         max_abs_residual=max_abs,
+        residual_tol=residual_tol,
+        within_tolerance=result.converged and max_abs <= residual_tol,
         converged=result.converged,
     )
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -221,6 +221,8 @@ def test_pss_residual_reports_one_period_node_closure() -> None:
     assert result.period == pytest.approx(1.0e-3)
     assert result.time_step == pytest.approx(1.0e-3 / 32.0)
     assert result.converged is True
+    assert result.residual_tol == pytest.approx(1.0e-6)
+    assert result.within_tolerance is True
     assert result.node_residuals["in"] == pytest.approx(0.0, abs=1.0e-12)
     assert result.max_abs_residual == pytest.approx(0.0, abs=1.0e-12)
 
@@ -238,6 +240,22 @@ def test_pss_residual_requires_periodic_sources() -> None:
     )
 
     assert pss_residual(c) is None
+
+
+def test_pss_residual_rejects_negative_residual_tolerance() -> None:
+    c = Circuit()
+    c.add(
+        VoltageSource(
+            "V1",
+            "in",
+            "0",
+            0.0,
+            waveform=SinWaveform(frequency=1_000.0),
+        )
+    )
+
+    with pytest.raises(ValueError, match="residual_tol"):
+        pss_residual(c, residual_tol=-1.0)
 
 
 # ---- Linear solver ----

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add tolerance-aware PSS residual convergence reporting through
+  `pss_residual_with_tolerance`, including `residual_tolerance` and
+  `within_tolerance` on `PssResidualResult`.
 - Add PSS period-closure residual reporting with `pss_residual` and
   `PssResidualResult`, which runs one estimated source period and returns
   node-voltage closure residuals as the next foothold for shooting-Newton

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1672,6 +1672,8 @@ pub struct PssResidualResult {
     pub time_step_seconds: f64,
     pub node_residuals: BTreeMap<String, f64>,
     pub max_abs_residual: f64,
+    pub residual_tolerance: f64,
+    pub within_tolerance: bool,
 }
 
 impl DcResult {
@@ -2647,6 +2649,14 @@ pub fn pss_residual(
     circuit: &Circuit,
     steps_per_period: usize,
 ) -> Result<Option<PssResidualResult>, SpiceError> {
+    pss_residual_with_tolerance(circuit, steps_per_period, 1.0e-6)
+}
+
+pub fn pss_residual_with_tolerance(
+    circuit: &Circuit,
+    steps_per_period: usize,
+    residual_tolerance: f64,
+) -> Result<Option<PssResidualResult>, SpiceError> {
     let Some(period) = estimate_period(circuit) else {
         return Ok(None);
     };
@@ -2654,6 +2664,12 @@ pub fn pss_residual(
         return Err(SpiceError::InvalidElement {
             name: "pss_residual".to_string(),
             reason: "steps per period must be positive".to_string(),
+        });
+    }
+    if !residual_tolerance.is_finite() || residual_tolerance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: "pss_residual".to_string(),
+            reason: "residual tolerance must be finite and non-negative".to_string(),
         });
     }
 
@@ -2672,6 +2688,8 @@ pub fn pss_residual(
             time_step_seconds: time_step,
             node_residuals: BTreeMap::new(),
             max_abs_residual: 0.0,
+            residual_tolerance,
+            within_tolerance: false,
         }));
     };
 
@@ -2704,6 +2722,8 @@ pub fn pss_residual(
         time_step_seconds: time_step,
         node_residuals,
         max_abs_residual,
+        residual_tolerance,
+        within_tolerance: max_abs_residual <= residual_tolerance,
     }))
 }
 

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1,7 +1,7 @@
 use spice_engine::{
-    estimate_period, pss_residual, transient, Capacitor, Cccs, Ccvs, Circuit, CurrentSource,
-    Element, ExpWaveform, Inductor, PssResidualResult, PulseWaveform, PwlWaveform, Resistor,
-    SinWaveform, SpiceError, VoltageSource, Waveform,
+    estimate_period, pss_residual, pss_residual_with_tolerance, transient, Capacitor, Cccs, Ccvs,
+    Circuit, CurrentSource, Element, ExpWaveform, Inductor, PssResidualResult, PulseWaveform,
+    PwlWaveform, Resistor, SinWaveform, SpiceError, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -118,6 +118,8 @@ fn pss_residual_reports_one_period_node_closure() {
     let _: PssResidualResult = result.clone();
     assert_close(result.period_seconds, 1.0e-3);
     assert_close(result.time_step_seconds, 1.0e-3 / 32.0);
+    assert_close(result.residual_tolerance, 1.0e-6);
+    assert!(result.within_tolerance);
     assert_close(*result.node_residuals.get("in").unwrap(), 0.0);
     assert_close(result.max_abs_residual, 0.0);
 }
@@ -134,6 +136,23 @@ fn pss_residual_requires_periodic_sources() {
     )));
 
     assert!(pss_residual(&circuit, 32).unwrap().is_none());
+}
+
+#[test]
+fn pss_residual_rejects_negative_residual_tolerance() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        Waveform::Sin(SinWaveform::new(0.0, 1.0, 1_000.0)),
+    )));
+
+    assert!(matches!(
+        pss_residual_with_tolerance(&circuit, 32, -1.0),
+        Err(SpiceError::InvalidElement { .. })
+    ));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add tolerance-aware PSS residual convergence reporting through
+  `pssResidual`, including `residualTolerance` and `withinTolerance`.
 - Add PSS period-closure residual reporting with `pssResidual`, which runs one
   estimated source period and returns node-voltage closure residuals as the
   next foothold for shooting-Newton periodic steady-state analysis.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -597,6 +597,8 @@ export interface PssResidualResult {
   readonly timeStepSeconds: number;
   readonly nodeResiduals: ReadonlyMap<string, number>;
   readonly maxAbsResidual: number;
+  readonly residualTolerance: number;
+  readonly withinTolerance: boolean;
 }
 
 export class SpiceError extends Error {
@@ -1681,6 +1683,7 @@ export function transient(
 export function pssResidual(
   circuit: Circuit,
   stepsPerPeriod = 64,
+  residualTolerance = 1.0e-6,
 ): PssResidualResult | undefined {
   const period = estimatePeriod(circuit);
   if (period === undefined) {
@@ -1690,6 +1693,12 @@ export function pssResidual(
     throw invalidElement(
       "pssResidual",
       "steps per period must be a positive integer",
+    );
+  }
+  if (!Number.isFinite(residualTolerance) || residualTolerance < 0.0) {
+    throw invalidElement(
+      "pssResidual",
+      "residual tolerance must be finite and non-negative",
     );
   }
 
@@ -1708,6 +1717,8 @@ export function pssResidual(
       timeStepSeconds: timeStep,
       nodeResiduals: new Map(),
       maxAbsResidual: 0.0,
+      residualTolerance,
+      withinTolerance: false,
     };
   }
 
@@ -1730,6 +1741,8 @@ export function pssResidual(
     timeStepSeconds: timeStep,
     nodeResiduals,
     maxAbsResidual,
+    residualTolerance,
+    withinTolerance: maxAbsResidual <= residualTolerance,
   };
 }
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -115,6 +115,8 @@ describe("transient", () => {
     expect(result).not.toBeUndefined();
     expectClose(result!.periodSeconds, 1.0e-3);
     expectClose(result!.timeStepSeconds, 1.0e-3 / 32.0);
+    expectClose(result!.residualTolerance, 1.0e-6);
+    expect(result!.withinTolerance).toBe(true);
     expectClose(result!.nodeResiduals.get("in"), 0.0);
     expectClose(result!.maxAbsResidual, 0.0);
   });
@@ -132,6 +134,21 @@ describe("transient", () => {
     );
 
     expect(pssResidual(circuit)).toBeUndefined();
+  });
+
+  it("rejects negative PSS residual tolerances", () => {
+    const circuit = new Circuit();
+    circuit.add(
+      voltageSourceWithWaveform(
+        "V1",
+        "in",
+        "0",
+        0.0,
+        new SinWaveform(0.0, 1.0, 1_000.0),
+      ),
+    );
+
+    expect(() => pssResidual(circuit, 32, -1.0)).toThrow(SpiceError);
   });
 
   it("uses a backward-Euler capacitor companion for an RC step", () => {

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -106,10 +106,10 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- PSS period-closure residuals across Python, TypeScript, and Rust SPICE
-  engines: one-period transient runs now report node-voltage residuals against
-  the initial source phase as the next foothold for shooting-Newton periodic
-  steady-state analysis.
+- PSS residual convergence checks across Python, TypeScript, and Rust SPICE
+  engines: one-period node-closure residuals now carry a tolerance and an
+  explicit in/out-of-tolerance decision as the next reusable stop condition for
+  shooting-Newton periodic steady-state analysis.
 
 ---
 
@@ -131,7 +131,7 @@ and the sparse real solver path landed in PR #3391.
 | Feature | Design notes |
 |---|---|
 | **S-parameter extraction** | Two-port network characterisation. Run AC sweep, compute Y-parameters from node voltages and port currents, convert to S-parameters. Shipped in PR #3490. |
-| **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Source-period estimation for periodic `SIN` / `PULSE` waveforms shipped in PR #3524; one-period node-closure residual helpers are in flight as the next foothold. |
+| **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Source-period estimation for periodic `SIN` / `PULSE` waveforms shipped in PR #3524; one-period node-closure residual helpers shipped in PR #3534; tolerance-aware residual closure is in flight as the next stop-condition foothold. |
 | **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners shipped in PR #3516. |
 | **Mixed-signal coupling with `hardware-vm`** | AMS simulation — digital events feed into analog SPICE nodes and vice versa. Long-range project; `hardware-vm.md` spec describes the interface. |
 | **Verilog-A compact models** | Custom device models. Requires a Verilog-A parser (`code/specs/verilog-a-parser.md` is referenced but not written). |


### PR DESCRIPTION
## Summary
- Add tolerance-aware PSS residual convergence reporting across Python, TypeScript, and Rust.
- Extend one-period residual results with the configured tolerance and an explicit within-tolerance decision.
- Refresh the SPICE/MACSYMA pending-work notes now that PSS residual helpers landed in #3534.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pss-convergence sh BUILD` in `code/packages/python/spice-engine`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pss-convergence sh BUILD` in `code/packages/typescript/spice-engine`
- isolated `cargo test` copy of `code/packages/rust/spice-engine` because the sparse checkout intentionally omits unrelated workspace members
- `rustfmt code/packages/rust/spice-engine/src/lib.rs code/packages/rust/spice-engine/tests/transient_tests.rs`
- `git diff --check`