### PR TITLE
feat(grid-v2): alternating row stripes via data-row:even/:odd (WA4)

### DIFF
--- a/code/packages/rust/mosaic-emit-react/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-react/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Grid row stripes via `data-row:even` / `:odd` (WA4, UI27 §5)
+
+- Authors can now declare alternating row colours by attaching `state
+  even { ... }` and / or `state odd { ... }` blocks to the
+  `sheet/data-row` sub-part. The emitter resolves them via the existing
+  composite-key map (`sheet/data-row:even`, `sheet/data-row:odd`) and
+  emits a conditional spread per `<tr>`:
+  `<tr key={r} style={{ ...base, ...(r % 2 === 0 ? { evenProps } : {}), ...(r % 2 === 1 ? { oddProps } : {}) }}>`.
+- Either state can be declared independently — only the declared spread
+  appears in the output. When neither is declared, the static
+  `style={{ <data-row defaults> }}` path is preserved exactly
+  (backwards-compatible).
+- `lookup_state` (formerly hardcoded to look up `cell:{state}`) was
+  generalised to `lookup_state_on(subpart, state)` so other sub-parts
+  can grow state blocks in the same way (e.g. `header-cell:hover` for
+  future column-header hover styling).
+- 5 new tests covering: even-only emits one conditional spread,
+  even+odd emits two in source order, base data-row props precede
+  conditional stripes (UI27 §2 cascade), no states keeps the static
+  pre-WA4 output, stripes without base props emit solo conditionals.
+- End-to-end smoke: a 3-file grid with `state even / odd` blocks
+  compiles to TSX with the expected conditional `<tr>` style. Verified.
+
+
 ### Added — Input `placeholder` from string-literal prop values
 
 - The Input emitter consumes the new `LayoutPropValue::String` variant

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -755,15 +755,23 @@ fn emit_grid_jsx(
     // `state editing { ... }` blocks declared under `part sheet/cell`.
     // Empty when the author left those state blocks out — the emitter
     // then falls back to its hardcoded defaults (see `build_grid_cell_style_expr`).
-    let lookup_state = |state_name: &str| -> String {
+    let lookup_state_on = |subpart: &str, state_name: &str| -> String {
         node.part_name
             .as_deref()
-            .map(|n| format!("{n}/cell:{state_name}"))
+            .map(|n| format!("{n}/{subpart}:{state_name}"))
             .and_then(|key| part_styles.get(&key).map(String::clone))
             .unwrap_or_default()
     };
-    let selected_state_style = lookup_state("selected");
-    let editing_state_style = lookup_state("editing");
+    let selected_state_style = lookup_state_on("cell", "selected");
+    let editing_state_style = lookup_state_on("cell", "editing");
+
+    // WA4: alternating row stripes. The author declares
+    //   part sheet/data-row { state even { background: ... } state odd { ... } }
+    // and the per-`<tr>` style spreads conditionally on `r % 2 === 0`.
+    // When neither state block is declared, the data-row style stays
+    // static (the pre-WA4 behaviour) and no conditional is emitted.
+    let data_row_even_state_style = lookup_state_on("data-row", "even");
+    let data_row_odd_state_style = lookup_state_on("data-row", "odd");
 
     let table_style_attr = if table_style_str.is_empty() {
         String::new()
@@ -775,10 +783,37 @@ fn emit_grid_jsx(
     } else {
         format!(" style={{{{ {header_row_subpart_style} }}}}")
     };
-    let data_row_style_attr = if data_row_subpart_style.is_empty() {
-        String::new()
+    // The per-row style attribute. Three shapes depending on what the
+    // author declared:
+    //   1. No defaults, no stripes → no `style` attribute on `<tr>`.
+    //   2. Defaults, no stripes → static `style={{ <defaults> }}` (pre-WA4 path).
+    //   3. Stripes declared → dynamic `style={{ <defaults>, ...(r % 2 === 0 ? {...} : {}), ...(r % 2 === 1 ? {...} : {}) }}`.
+    // Stripes never need React keys — they ride along inside the existing
+    // `<tr key={r}>`'s style spread.
+    let has_stripes = !data_row_even_state_style.is_empty()
+        || !data_row_odd_state_style.is_empty();
+    let data_row_style_attr = if !has_stripes {
+        if data_row_subpart_style.is_empty() {
+            String::new()
+        } else {
+            format!(" style={{{{ {data_row_subpart_style} }}}}")
+        }
     } else {
-        format!(" style={{{{ {data_row_subpart_style} }}}}")
+        let mut parts: Vec<String> = Vec::new();
+        if !data_row_subpart_style.is_empty() {
+            parts.push(data_row_subpart_style.clone());
+        }
+        if !data_row_even_state_style.is_empty() {
+            parts.push(format!(
+                "...(r % 2 === 0 ? {{ {data_row_even_state_style} }} : {{}})"
+            ));
+        }
+        if !data_row_odd_state_style.is_empty() {
+            parts.push(format!(
+                "...(r % 2 === 1 ? {{ {data_row_odd_state_style} }} : {{}})"
+            ));
+        }
+        format!(" style={{{{ {} }}}}", parts.join(", "))
     };
     let header_cell_style_attr = if header_cell_subpart_style.is_empty() {
         String::new()
@@ -3129,6 +3164,211 @@ mod tests {
         assert!(
             result.output.contains("<td key={c} style={{ padding: \"4px\" }}>"),
             "expected just the sub-part fragment on <td>; got:\n{}",
+            result.output
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // WA4 — alternating row stripes via `data-row:even` / `:odd` state
+    // blocks on the `sheet/data-row` sub-part.
+    // -----------------------------------------------------------------
+
+    /// Helper: build a Grid StyleDef whose `sheet/data-row` sub-part
+    /// declares `state even` and `state odd` blocks with the given props.
+    fn style_with_data_row_states(
+        component: &str,
+        even: &[(&str, &str)],
+        odd: &[(&str, &str)],
+    ) -> StyleDef {
+        let mut states: Vec<StateStyle> = Vec::new();
+        if !even.is_empty() {
+            states.push(StateStyle {
+                state: "even".to_string(),
+                props: even
+                    .iter()
+                    .map(|(k, v)| StyleProp {
+                        name: k.to_string(),
+                        value: v.to_string(),
+                    })
+                    .collect(),
+            });
+        }
+        if !odd.is_empty() {
+            states.push(StateStyle {
+                state: "odd".to_string(),
+                props: odd
+                    .iter()
+                    .map(|(k, v)| StyleProp {
+                        name: k.to_string(),
+                        value: v.to_string(),
+                    })
+                    .collect(),
+            });
+        }
+        StyleDef {
+            component_name: component.to_string(),
+            parts: vec![PartStyle {
+                name: "sheet/data-row".to_string(),
+                base: Vec::new(),
+                states,
+            }],
+        }
+    }
+
+    fn grid_with_stripes_layout(component: &str) -> LayoutDef {
+        LayoutDef {
+            component_name: component.to_string(),
+            root: LayoutNode {
+                tag: "Grid".to_string(),
+                part_name: Some("sheet".to_string()),
+                props: vec![
+                    slot_ref_prop("headers", "col-labels"),
+                    slot_ref_prop("rows", "data-rows"),
+                ],
+                children: Vec::new(),
+            },
+        }
+    }
+
+    fn grid_with_stripes_component(name: &str) -> MosmodelComponent {
+        component(
+            name,
+            vec![
+                slot("col-labels", SlotType::List(Box::new(ListInnerType::Text)), true),
+                slot("data-rows", SlotType::List(Box::new(ListInnerType::Text)), true),
+            ],
+            vec![],
+        )
+    }
+
+    /// When the author declares only `state even { ... }` on
+    /// `sheet/data-row`, every `<tr>` carries a conditional spread that
+    /// applies the even-row props on rows where `r % 2 === 0` and
+    /// nothing on odd rows.
+    #[test]
+    fn grid_data_row_state_even_emits_conditional_spread() {
+        let m = grid_with_stripes_component("G");
+        let s = style_with_data_row_states("G", &[("background", "#252526")], &[]);
+        let l = grid_with_stripes_layout("G");
+        let result = from_pipeline(&m, &l, &s).unwrap();
+        assert!(
+            result
+                .output
+                .contains("...(r % 2 === 0 ? { background: \"#252526\" } : {})"),
+            "expected even-row conditional spread, got:\n{}",
+            result.output
+        );
+        // No odd-state spread.
+        assert!(
+            !result.output.contains("r % 2 === 1"),
+            "no odd state was declared, so the odd-row spread must be absent"
+        );
+    }
+
+    /// Author declares both `state even` and `state odd` — both spreads
+    /// appear on the same `<tr>`, in source-declaration order.
+    #[test]
+    fn grid_data_row_state_even_and_odd_both_emit_spreads() {
+        let m = grid_with_stripes_component("G");
+        let s = style_with_data_row_states(
+            "G",
+            &[("background", "#1e1e1e")],
+            &[("background", "#252526")],
+        );
+        let l = grid_with_stripes_layout("G");
+        let result = from_pipeline(&m, &l, &s).unwrap();
+        let out = &result.output;
+        let even_pos = out
+            .find("...(r % 2 === 0 ? { background: \"#1e1e1e\" } : {})")
+            .expect("even conditional spread present");
+        let odd_pos = out
+            .find("...(r % 2 === 1 ? { background: \"#252526\" } : {})")
+            .expect("odd conditional spread present");
+        assert!(even_pos < odd_pos, "even spread must appear before odd");
+    }
+
+    /// When data-row also has *base* properties (e.g. `height: 22px`),
+    /// they appear first in the style spread, followed by the conditional
+    /// even/odd spreads. This is the cascade defined in UI27 §2.
+    #[test]
+    fn grid_data_row_base_props_precede_conditional_stripes() {
+        let m = grid_with_stripes_component("G");
+        let s = StyleDef {
+            component_name: "G".to_string(),
+            parts: vec![PartStyle {
+                name: "sheet/data-row".to_string(),
+                base: vec![StyleProp {
+                    name: "height".to_string(),
+                    value: "22px".to_string(),
+                }],
+                states: vec![StateStyle {
+                    state: "even".to_string(),
+                    props: vec![StyleProp {
+                        name: "background".to_string(),
+                        value: "#222".to_string(),
+                    }],
+                }],
+            }],
+        };
+        let l = grid_with_stripes_layout("G");
+        let result = from_pipeline(&m, &l, &s).unwrap();
+        let out = &result.output;
+        let height_pos = out.find("height: \"22px\"").expect("base height present");
+        let even_pos = out
+            .find("...(r % 2 === 0 ? { background: \"#222\" } : {})")
+            .expect("even spread present");
+        assert!(
+            height_pos < even_pos,
+            "base data-row props must precede conditional stripes, got:\n{out}"
+        );
+    }
+
+    /// Backwards-compatible: when the author declares neither stripe
+    /// state, the existing static `style={{ <data-row defaults> }}`
+    /// path is preserved exactly. This guards the pre-WA4 behaviour.
+    #[test]
+    fn grid_without_data_row_states_keeps_static_data_row_style() {
+        let m = grid_with_stripes_component("G");
+        let s = StyleDef {
+            component_name: "G".to_string(),
+            parts: vec![PartStyle {
+                name: "sheet/data-row".to_string(),
+                base: vec![StyleProp {
+                    name: "height".to_string(),
+                    value: "22px".to_string(),
+                }],
+                states: Vec::new(),
+            }],
+        };
+        let l = grid_with_stripes_layout("G");
+        let result = from_pipeline(&m, &l, &s).unwrap();
+        // Static spread, no conditional expression.
+        assert!(
+            result.output.contains("<tr key={r} style={{ height: \"22px\" }}>"),
+            "expected static data-row style, got:\n{}",
+            result.output
+        );
+        assert!(!result.output.contains("r % 2 ==="),
+            "no conditional spread should be emitted when no stripe state declared");
+    }
+
+    /// Stripes work when there are *no* base data-row properties —
+    /// the conditional spreads stand alone inside `style={{ ... }}`.
+    #[test]
+    fn grid_data_row_stripes_without_base_props() {
+        let m = grid_with_stripes_component("G");
+        let s = style_with_data_row_states(
+            "G",
+            &[("background", "#222")],
+            &[("background", "#111")],
+        );
+        let l = grid_with_stripes_layout("G");
+        let result = from_pipeline(&m, &l, &s).unwrap();
+        assert!(
+            result.output.contains(
+                "<tr key={r} style={{ ...(r % 2 === 0 ? { background: \"#222\" } : {}), ...(r % 2 === 1 ? { background: \"#111\" } : {}) }}>"
+            ),
+            "expected solo conditional spreads inside <tr> style, got:\n{}",
             result.output
         );
     }

--- a/code/packages/rust/mosstyle-compiler/CHANGELOG.md
+++ b/code/packages/rust/mosstyle-compiler/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — mosstyle-compiler
 
+## [Unreleased]
+
+### Added — structural states (`even`, `odd`) for row-stripe sub-parts
+
+- `VALID_STATES` now includes `even` and `odd` alongside the existing
+  interaction states (`hover`/`pressed`/`focused`/`disabled`/`selected`/
+  `editing`/`error`).
+- Unlike interaction states (which depend on input devices), structural
+  states resolve from a primitive's child position. Used by Grid's
+  `sheet/data-row` sub-part (WA4) to declare alternating row colours:
+  `part sheet/data-row { state even { ... } state odd { ... } }`.
+- Backwards-compatible: existing `.msl` files don't reference these
+  state names; no behaviour change for them.
+
 ## [0.1.0] — 2026-05-11
 
 ### Added

--- a/code/packages/rust/mosstyle-compiler/src/lib.rs
+++ b/code/packages/rust/mosstyle-compiler/src/lib.rs
@@ -216,7 +216,15 @@ fn resolve_token(token_name: &str, extra: &HashMap<String, String>) -> Option<St
 // ===========================================================================
 
 const VALID_STATES: &[&str] = &[
+    // Interaction states (UI15 §3.1) — visible at runtime via input devices.
     "hover", "pressed", "focused", "disabled", "selected", "editing", "error",
+    // Structural states (UI27 §5) — visible at structural positions in a
+    // primitive's child list. Used by Grid's `sheet/data-row` to declare
+    // alternating row backgrounds (WA4) and similar list-position patterns
+    // that other primitives may grow over time. They are not interaction
+    // states; the emitter resolves them at index time (`r % 2 === 0`) rather
+    // than from user input.
+    "even", "odd",
 ];
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
WA4 of the Grid v2 (UI27) loop. Adds row-stripe support to the Grid primitive by reusing the existing mosstyle composite-key state mechanism.

## Author API

```mosstyle
part sheet/data-row {
  state even { background: #1e1e1e ; }
  state odd  { background: #252526 ; }
}
```

## Generated output

```tsx
<tr key={r} style={{
  <data-row defaults>,
  ...(r % 2 === 0 ? { evenProps } : {}),
  ...(r % 2 === 1 ? { oddProps  } : {})
}}>
```

## Implementation

- `lookup_state` (formerly hardcoded to `cell:{state}`) generalised to `lookup_state_on(subpart, state)` so other sub-parts can grow state blocks in the same way (e.g. `header-cell:hover`).
- `mosstyle-compiler::VALID_STATES` extended with `even` and `odd` (structural states, not interaction states).
- Backwards-compatible: when neither stripe state is declared, the static `style={{ <data-row defaults> }}` path is preserved.

## Files
- `code/packages/rust/mosaic-emit-react/src/pipeline.rs` (+pipeline emit + 5 tests)
- `code/packages/rust/mosaic-emit-react/CHANGELOG.md`
- `code/packages/rust/mosstyle-compiler/src/lib.rs` (VALID_STATES + comment)
- `code/packages/rust/mosstyle-compiler/CHANGELOG.md`

## Test plan
- [x] 5 new tests: even-only, even+odd in source order, base + stripes cascade, no states stays static, stripes without base
- [x] All 90 mosaic-emit-react tests pass (was 85 + 5 WA4)
- [x] All 26 mosstyle-compiler tests pass
- [x] End-to-end smoke via mosaic-compile → expected conditional `<tr>` style spread

🤖 Generated with [Claude Code](https://claude.com/claude-code)