### PR TITLE
Share HTML lexer fixture assertion helpers

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -109,8 +109,9 @@ documented in this file.
 - The generic html5lib smoke importer now builds default-wrapper seeded lexer
   cases through the same typed `HtmlLexContext` constructors used by generated
   WHATWG boundary runners.
-- Generated WHATWG lexer fixture runners now share a test-only token summary
-  helper for token, attribute, DOCTYPE, and adjacent-text normalization.
+- Generated WHATWG lexer fixture runners now share test-only assertion helpers
+  for token, attribute, DOCTYPE, adjacent-text, and diagnostic-code
+  normalization.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -97,9 +97,9 @@ The normalized html5lib smoke importer follows that same wrapper path for
 default-lexer cases: seeded start-tag, end-tag, comment, DOCTYPE, and
 character-reference continuations now enter through the public typed
 constructors instead of test-local context field assembly.
-The generated WHATWG lexer runners share the same test-only token-summary
-helpers, so boundary fixtures compare token text, attributes, doctypes, and
-coalesced text recovery through one normalization path.
+The generated WHATWG lexer runners share the same test-only assertion helpers,
+so boundary fixtures compare token text, attributes, doctypes, coalesced text
+recovery, and diagnostic codes through one normalization path.
 The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup

--- a/code/packages/rust/html-lexer/tests/common/mod.rs
+++ b/code/packages/rust/html-lexer/tests/common/mod.rs
@@ -1,6 +1,41 @@
-use coding_adventures_html_lexer::{Attribute, Token};
+use coding_adventures_html_lexer::{Attribute, Diagnostic, Token};
 
-pub fn token_summary(token: Token) -> String {
+pub fn assert_token_summaries(
+    case_id: &str,
+    actual_tokens: Vec<Token>,
+    expected_tokens: &[String],
+) {
+    assert_eq!(
+        token_summaries(actual_tokens),
+        coalesce_adjacent_text_summaries(expected_tokens.to_vec()),
+        "case `{case_id}` token mismatch"
+    );
+}
+
+pub fn assert_diagnostic_codes(
+    case_id: &str,
+    actual_diagnostics: &[Diagnostic],
+    expected_diagnostics: &[String],
+) {
+    assert_eq!(
+        diagnostic_codes(actual_diagnostics),
+        expected_diagnostics,
+        "case `{case_id}` diagnostic mismatch"
+    );
+}
+
+fn token_summaries(tokens: Vec<Token>) -> Vec<String> {
+    coalesce_adjacent_text_summaries(tokens.into_iter().map(token_summary).collect())
+}
+
+fn diagnostic_codes(diagnostics: &[Diagnostic]) -> Vec<String> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code.clone())
+        .collect()
+}
+
+fn token_summary(token: Token) -> String {
     match token {
         Token::Text(data) => format!("Text(data={data})"),
         Token::StartTag {
@@ -53,7 +88,7 @@ fn attribute_summary(attributes: &[Attribute]) -> String {
     }
 }
 
-pub fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
+fn coalesce_adjacent_text_summaries(tokens: Vec<String>) -> Vec<String> {
     let mut coalesced: Vec<String> = Vec::new();
     for token in tokens {
         let Some(text) = token

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
@@ -96,28 +96,8 @@ fn whatwg_attribute_boundaries_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
@@ -61,28 +61,8 @@ fn whatwg_attribute_edge_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
@@ -65,28 +65,8 @@ fn whatwg_cdata_boundaries_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
@@ -75,28 +75,8 @@ fn whatwg_character_reference_boundaries_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
@@ -67,28 +67,8 @@ fn whatwg_comment_boundaries_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
@@ -79,28 +79,8 @@ fn whatwg_doctype_boundaries_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
@@ -82,28 +82,8 @@ fn whatwg_eof_recovery_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
@@ -89,28 +89,8 @@ fn whatwg_markup_declaration_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
@@ -71,28 +71,8 @@ fn whatwg_script_escape_boundaries_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
@@ -61,28 +61,8 @@ fn whatwg_tag_open_recovery_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
@@ -73,28 +73,8 @@ fn whatwg_text_mode_boundaries_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
@@ -88,28 +88,8 @@ fn whatwg_text_mode_delimiter_cases_match_default_lexer() {
             .finish()
             .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
 
-        let actual_tokens = lexer
-            .drain_tokens()
-            .into_iter()
-            .map(common::token_summary)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            common::coalesce_adjacent_text_summaries(actual_tokens),
-            common::coalesce_adjacent_text_summaries(case.tokens.clone()),
-            "case `{}` token mismatch",
-            case.id
-        );
-
-        let actual_diagnostics = lexer
-            .diagnostics()
-            .iter()
-            .map(|diagnostic| diagnostic.code.clone())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            actual_diagnostics, case.diagnostics,
-            "case `{}` diagnostic mismatch",
-            case.id
-        );
+        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
+        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
     }
 }
 


### PR DESCRIPTION
## Summary
- extend the shared WHATWG lexer test helper to own token and diagnostic assertions
- migrate generated boundary/recovery runner tests to use common assertions
- document the shared fixture assertion normalization path

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- git diff --check