### PR TITLE
feat(forme-transform-internal-links): FM00 v0 §5.3 internal-link resolution transform

### DIFF
--- a/code/packages/typescript/forme-transform-internal-links/BUILD
+++ b/code/packages/typescript/forme-transform-internal-links/BUILD
@@ -1,0 +1,2 @@
+cd ../document-ast && npm install --silent
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-transform-internal-links/CHANGELOG.md
+++ b/code/packages/typescript/forme-transform-internal-links/CHANGELOG.md
@@ -1,0 +1,142 @@
+# Changelog — @coding-adventures/forme-transform-internal-links
+
+## 0.1.0 — 2026-05-18
+
+Initial release.  Eighth FM00 v0 stage package — fourth concrete
+§5.3 transform.  Walks a `DocumentNode` and rewrites every
+internal `LinkNode.destination` (root-relative `/slug` references)
+to caller-supplied canonical URLs, with strict validation of the
+resolver's output to defend against malicious or buggy
+resolvers.
+
+Sits alongside the rest of the FM00 v0 stage cluster.
+
+### Added
+
+- `rewriteInternalLinks(doc, resolver, options?): DocumentNode`
+  — main entry.  Walks the document, calls the resolver on
+  every internal link, validates resolved URLs, returns a fresh
+  document copy.  Input never mutated.
+- `isInternalSlug(url): boolean` — exposed sub-helper for
+  callers wanting the same internal-link detection logic in
+  their own code paths.
+- `assertResolvedUrl(url): asserts url is string` — exposed
+  sub-helper.  Throws `TypeError` if the URL is not in the
+  http(s)://-or-root-relative accept set.
+- `SlugResolver`, `UnresolvedPolicy`, `InternalLinksOptions`
+  types.
+
+### Spec adherence
+
+Implements FM00 v0 §5.3 `transform-internal-links`.  No spec
+divergences.
+
+### Behavioural notes
+
+- **Internal-link detection.**  A `LinkNode.destination`
+  counts as internal iff it starts with exactly one `/` (single
+  slash, not protocol-relative `//`) and is a non-empty
+  string.  External (`http(s)://`, `mailto:`, etc.) and
+  fragment-only (`#section`) links pass through unchanged.
+- **Resolver contract.**  `(slug: string) => string | null`.
+  Must be pure and synchronous.  `null` / `undefined` mean
+  "unresolved".
+- **Resolved-URL validation.**  Every resolver-returned string
+  is checked against the `http(s)://` (case-insensitive) or
+  root-relative `/path` accept set.  Throws `TypeError` for
+  `javascript:`, `data:`, `file:`, `vbscript:`, protocol-
+  relative `//`, bare relative, empty string, non-string.
+  This is defence-in-depth: even if a buggy resolver returns
+  an XSS payload for an innocent slug, the rewriter refuses
+  to splice it into the AST.
+- **Unresolved-link policy.**  Three options:
+    - `"keep"` (default) — preserve original `/slug`.  Most
+      forgiving for incremental authoring.
+    - `"strip"` — replace the `LinkNode` with its inline
+      children (drop the wrapper).
+    - `"throw"` — throw `Error` with slug in message.  For
+      pre-publish validation pipelines.
+- **Walks nested containers.**  Headings, blockquotes, lists,
+  task items, table cells, emphasis / strong / strikethrough
+  wrappers — internal links inside any of these are rewritten.
+- **Pass-through nodes.**  `ImageNode.destination` (image
+  rewrite is a separate transform), `AutolinkNode.destination`
+  (user's explicit external URL), `CodeBlock` / `CodeSpan` /
+  `RawBlock` / `RawInline` values (would corrupt source /
+  output if rewritten).
+- **Fresh tree per call.**  Even passthrough nodes are
+  re-allocated, so the output guarantee "no shared references
+  with input" holds uniformly.
+- **Resolver called exactly once per internal LinkNode.**  No
+  quadratic re-lookups; cost is O(N) in document size.
+
+### Security posture
+
+Four concerns explicitly addressed (pre-push review):
+
+- **Hostile resolver output.**  Validation of resolver return
+  values against the http(s)-or-root-relative accept-list is
+  the security chokepoint.  Tests pin every forbidden form
+  (javascript:, data:, file:, vbscript:, protocol-relative,
+  bare relative, empty, non-string).  An XSS payload returned
+  by a buggy resolver never reaches the rendered HTML.
+- **No AST mutation.**  Input `DocumentNode` never modified.
+  Fresh-tree tests confirm output `!== input` at every level.
+- **Deterministic.**  Single forward walk, no Map/Set iteration
+  affecting output, no randomness.  Same input + pure resolver
+  → byte-identical output.
+- **Bounded computation.**  O(N) walk; resolver called once
+  per internal LinkNode.  No regex used (URL detection is
+  character-class checks via `string[i]` indexing) — zero
+  ReDoS surface.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, network, fs, shell, env.
+
+### Tests
+
+72 tests across 2 files:
+
+- `url.test.ts` (31) — `isInternalSlug` accept set (root-
+  relative paths, bare `/`) and reject set (absolute http(s),
+  protocol-relative, bare relative, `./about`, `mailto:`,
+  `javascript:`, empty, non-string, fragment-only);
+  `assertResolvedUrl` accept set (http://, https://,
+  case-insensitive scheme, port + query + fragment, root-
+  relative) and reject set (javascript:, data:, file:,
+  vbscript:, protocol-relative, bare relative, mailto:,
+  empty / null / undefined / number with descriptive error
+  messages, long URL truncation in error).
+- `walk.test.ts` (41) — internal link resolution (basic,
+  title preservation, bare /), external pass-through,
+  resolver-NOT-called for external links, unresolved policy
+  matrix (keep default + explicit, strip with single + multi-
+  child expansion, throw with slug in message, undefined =
+  null), resolver-returned-URL validation rejecting each
+  forbidden form, walks every nested container (blockquote,
+  list / list_item, task_item, heading, table cells with
+  header + body, emphasis / strong / strikethrough, nested
+  DocumentNode), pass-through (image, autolink, code_block,
+  code_span, raw_block, raw_inline, thematic_break, breaks),
+  defensive non-tree BlockNode variants as direct siblings,
+  purity (no input mutation, fresh tree, byte-identical
+  output across calls, resolver-called-once-per-link).
+
+Coverage: **97.1% line / 97.89% branch** across all source
+files with logic.  Uncovered lines are TypeScript `never`
+exhaustiveness guards (`walk.ts` 138-141, 210-213) that cannot
+fire at runtime.
+
+### v0 simplifications (documented)
+
+- **No image-src rewriting.**  Image destinations pass through;
+  `transform-image-rewrite` is a separate spec transform.
+- **No internal-link predicate customisation.**  "Internal"
+  hardcoded to "starts with `/` but not `//`".  Custom
+  predicates deferred to v1.
+- **No async resolver support.**  Resolvers are synchronous.
+  Manifest lookup is in-memory anyway.
+- **No batch / multi-document optimisation.**  Each call
+  re-walks the document.  Pipelines share the resolver but
+  not the walk.

--- a/code/packages/typescript/forme-transform-internal-links/README.md
+++ b/code/packages/typescript/forme-transform-internal-links/README.md
@@ -1,0 +1,229 @@
+# @coding-adventures/forme-transform-internal-links
+
+Resolve root-relative `/slug` references in `LinkNode`
+destinations to caller-supplied canonical URLs.  FM00 v0 §5.3
+transform.
+
+Pure transform: walks a `DocumentNode`, calls
+`(slug: string) => string | null` on every internal link,
+**validates the resolved URL against an `http(s)://` accept-list**
+to defend against a malicious or buggy resolver, returns a
+transformed `DocumentNode` copy.
+
+Eighth FM00 v0 stage package — joins
+[`forme-feeds`](../forme-feeds),
+[`forme-opengraph`](../forme-opengraph),
+[`forme-index-renderer`](../forme-index-renderer),
+[`forme-transforms`](../forme-transforms),
+[`forme-transform-autolink-headings`](../forme-transform-autolink-headings),
+[`forme-transform-toc`](../forme-transform-toc),
+[`forme-transform-typography`](../forme-transform-typography).
+
+## Quick start
+
+```ts
+import { rewriteInternalLinks } from "@coding-adventures/forme-transform-internal-links";
+
+function resolve(slug: string): string | null {
+  const entry = manifest.byPath.get(slug);
+  return entry ? entry.canonicalUrl : null;
+}
+
+const linked = rewriteInternalLinks(doc, resolve);
+
+// Stricter: treat unresolved links as content bugs.
+const validated = rewriteInternalLinks(doc, resolve, { unresolved: "throw" });
+
+// Drop unresolved links from the rendered output entirely.
+const stripped = rewriteInternalLinks(doc, resolve, { unresolved: "strip" });
+```
+
+## What counts as an internal link?
+
+`isInternalSlug(url)` accepts:
+
+- `/about`
+- `/blog/2026/post`
+- `/` (bare site root)
+
+…and rejects everything else:
+
+- `http://example.com/x`, `https://...` (already absolute — no
+  rewrite needed)
+- `//host/path` (protocol-relative — ambiguous scheme)
+- `relative/path`, `./about` (bare relative — author should
+  normalise to `/about` first)
+- `mailto:`, `tel:`, `javascript:`, `data:` (not internal)
+- `#fragment-only` (handled by
+  [`forme-transform-autolink-headings`](../forme-transform-autolink-headings))
+- Empty string, non-string
+
+## Resolver contract
+
+```ts
+type SlugResolver = (slug: string) => string | null;
+```
+
+Resolvers must be:
+
+- **Pure.**  Same slug → same result every call (else
+  reproducibility breaks).
+- **Synchronous.**  No I/O — manifest lookups are in-memory.
+
+The resolver's return value is validated by `assertResolvedUrl`:
+
+- Accepted: `http(s)://...` (case-insensitive scheme),
+  root-relative `/path`.
+- Rejected (throws `TypeError`): `javascript:`, `data:`,
+  `file:`, `vbscript:`, protocol-relative `//host`, bare
+  relative, empty string, non-string.
+
+This guards against a buggy or hostile resolver returning a
+URL that would break out of `<a href="...">` into XSS territory.
+
+## API
+
+### `rewriteInternalLinks(doc, resolver, options?): DocumentNode`
+
+Walks the document, returns a fresh copy with every internal
+`LinkNode.destination` rewritten.
+
+### `isInternalSlug(url): boolean`
+
+Exposed sub-helper.
+
+### `assertResolvedUrl(url): asserts url is string`
+
+Exposed sub-helper.  Throws `TypeError` on unsafe URL.
+
+### Types
+
+```ts
+type SlugResolver = (slug: string) => string | null;
+
+type UnresolvedPolicy = "keep" | "strip" | "throw";
+
+interface InternalLinksOptions {
+  readonly unresolved?: UnresolvedPolicy;  // default "keep"
+}
+```
+
+## Unresolved-link policy
+
+When the resolver returns `null` (or `undefined`) for an
+internal slug:
+
+| Policy   | Behaviour                                                  |
+|----------|------------------------------------------------------------|
+| `"keep"` (default) | Preserve the original `/slug` in `LinkNode.destination`.  Browsers will follow it as a site-relative path. |
+| `"strip"`| Replace the `LinkNode` with its inline children (drop the link wrapper).  Useful when the renderer refuses to emit broken `<a href>`s. |
+| `"throw"`| Throw `Error` immediately.  Useful in pre-publish validation: an unresolvable link is a content bug. |
+
+## Pass-through nodes (NOT rewritten)
+
+| Node                  | Reason                                        |
+|-----------------------|-----------------------------------------------|
+| `ImageNode.destination` | Image rewrite is a separate spec transform |
+| `AutolinkNode.destination` | User's explicit external URL            |
+| `CodeBlockNode.value` | Verbatim source                               |
+| `CodeSpanNode.value`  | Verbatim inline code                          |
+| `RawBlockNode.value`  | Back-end-specific markup                      |
+| `RawInlineNode.value` | Same                                          |
+
+## Behavioural contract
+
+| Aspect                          | Behaviour                              |
+|---------------------------------|----------------------------------------|
+| Input document                  | Never mutated                          |
+| Output                          | Fresh tree (no shared refs with input) |
+| Internal link, resolved         | New URL spliced into LinkNode          |
+| Internal link, unresolved (keep)| Original `/slug` preserved             |
+| Internal link, unresolved (strip)| `LinkNode` replaced by children       |
+| Internal link, unresolved (throw)| Throws `Error` with slug in message   |
+| Resolver returns unsafe URL     | Throws `TypeError`                     |
+| External / non-link nodes       | Pass-through                           |
+| Resolver call count             | Once per internal `LinkNode`           |
+
+## Reproducibility (FM03)
+
+Same input `DocumentNode` + same resolver → byte-identical
+output.  Safe to use as cache key input given a pure resolver.
+
+## Security posture
+
+Four concerns explicitly addressed (pre-push review):
+
+- **Hostile resolver output.**  The resolver is caller-supplied
+  code we can't audit.  Every returned URL is validated against
+  `^https?://` or root-relative `/path` before being spliced
+  back into the AST.  `javascript:`, `data:`, `file:`,
+  `vbscript:`, protocol-relative, bare-relative all rejected
+  with `TypeError`.  Defence-in-depth: even if the renderer
+  forgets to escape, the AST cannot contain a JS-URL link.
+- **No AST mutation.**  Input `DocumentNode` never modified;
+  every returned node is freshly constructed.  Fresh-tree
+  guarantee holds even for passthrough sub-trees.
+- **Deterministic.**  Single forward walk, no `Map`/`Set`
+  iteration affecting output, no randomness.  Same input +
+  pure resolver → byte-identical output.
+- **Bounded computation.**  O(N) walk; resolver called exactly
+  once per internal LinkNode (no quadratic re-lookups).  No
+  regex backtracking surface — URL detection is character-class
+  checks.
+
+## Capabilities — `[]`
+
+Pure transform.  No I/O, no network, no shell, no env, no fs.
+
+## Tests
+
+72 tests across 2 files:
+
+- `url.test.ts` (31) — `isInternalSlug` accept set (root-relative
+  paths, bare /) and reject set (absolute http(s), protocol-
+  relative, bare relative, ./about, mailto:, javascript:, empty,
+  non-string, fragment-only); `assertResolvedUrl` accept set
+  (http://, https://, case-insensitive scheme, port + query +
+  fragment, root-relative) and reject set (javascript:, data:,
+  file:, vbscript:, protocol-relative, bare relative, mailto:,
+  empty / null / undefined / number with descriptive error
+  messages, long URL truncation).
+- `walk.test.ts` (41) — internal link resolution, title
+  preservation, bare /, external pass-through, resolver-NOT-
+  called for external, unresolved policy matrix (keep default
+  + explicit, strip with single + multi-child, throw with
+  slug in message, undefined treated same as null), validation
+  rejecting each forbidden resolver output, walks every nested
+  container (blockquote, list, task_item, heading, table cells,
+  emphasis / strong / strikethrough, nested DocumentNode),
+  pass-through (image, autolink, code_block, code_span,
+  raw_block, raw_inline, breaks), defensive non-tree BlockNode
+  variants, purity (no input mutation, fresh tree, byte-
+  identical output, resolver-called-once-per-link).
+
+Coverage: **97.1% line / 97.89% branch** across all source
+files with logic.  Uncovered lines are TypeScript `never`
+exhaustiveness guards (`walk.ts` 138-141, 210-213) that cannot
+fire at runtime.
+
+## Spec adherence
+
+Implements FM00 v0 §5.3 `transform-internal-links`.  No spec
+divergences.
+
+## v0 simplifications
+
+- **No image-src rewriting.**  Image destinations pass through
+  unchanged — `transform-image-rewrite` is a separate spec
+  transform deferred to its own package.
+- **No internal-link predicate customisation.**  "Internal"
+  hardcoded to "starts with `/` but not `//`".  Custom
+  predicates (e.g. matching a specific origin like
+  `https://example.com/...`) could be added as an option in v1.
+- **No async resolver support.**  Resolvers are synchronous.
+  Manifest lookup is in-memory anyway.  Async resolution
+  (e.g. database lookup) would change the transform's purity
+  contract significantly; v1 may add `rewriteInternalLinksAsync`.
+- **No batch / multi-document optimisation.**  Each call
+  re-walks the document.  Pipelines processing many docs share
+  the resolver but not the walk state.

--- a/code/packages/typescript/forme-transform-internal-links/package-lock.json
+++ b/code/packages/typescript/forme-transform-internal-links/package-lock.json
@@ -1,0 +1,2317 @@
+{
+  "name": "@coding-adventures/forme-transform-internal-links",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-transform-internal-links",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../document-ast": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/document-ast": {
+      "resolved": "../document-ast",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-transform-internal-links/package.json
+++ b/code/packages/typescript/forme-transform-internal-links/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@coding-adventures/forme-transform-internal-links",
+  "version": "0.1.0",
+  "description": "Resolve root-relative `/slug` references in LinkNode destinations to caller-supplied canonical URLs.  Pure transform: walks a DocumentNode, calls `(slug) => string | null` resolver on every internal link, validates the resolved URL against an http(s) accept-list, returns a transformed Document copy.  FM00 v0 §5.3 transform.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/document-ast": "file:../document-ast"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-transform-internal-links/required_capabilities.json
+++ b/code/packages/typescript/forme-transform-internal-links/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-transform-internal-links",
+  "capabilities": [],
+  "justification": "Pure transform: DocumentNode + (slug) => string|null resolver → DocumentNode with internal LinkNode destinations rewritten.  No I/O, no network, no env, no shell, no fs.  Same posture as the rest of the FM00 v0 stage cluster."
+}

--- a/code/packages/typescript/forme-transform-internal-links/src/index.ts
+++ b/code/packages/typescript/forme-transform-internal-links/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @coding-adventures/forme-transform-internal-links
+ *
+ * FM00 v0 §5.3 transform — resolve root-relative `/slug`
+ * references in `LinkNode` destinations to caller-supplied
+ * canonical URLs.
+ *
+ * Pure transform: walks the input document, calls
+ * `(slug) => string | null` on every internal link, validates
+ * the resolved URL against an http(s) accept-list, returns a
+ * transformed `DocumentNode` copy.
+ *
+ * ```ts
+ * import { rewriteInternalLinks } from "@coding-adventures/forme-transform-internal-links";
+ *
+ * function resolve(slug: string): string | null {
+ *   const entry = manifest.byPath.get(slug);
+ *   return entry ? entry.canonicalUrl : null;
+ * }
+ *
+ * const linked = rewriteInternalLinks(doc, resolve);
+ *
+ * // Stricter: treat unresolved links as content bugs.
+ * const validated = rewriteInternalLinks(doc, resolve, { unresolved: "throw" });
+ * ```
+ *
+ * Eighth FM00 v0 stage package — joins `forme-feeds`,
+ * `forme-opengraph`, `forme-index-renderer`, `forme-transforms`,
+ * `forme-transform-autolink-headings`, `forme-transform-toc`,
+ * `forme-transform-typography`.
+ *
+ * @module index
+ */
+
+export { rewriteInternalLinks } from "./walk.js";
+export { isInternalSlug, assertResolvedUrl } from "./url.js";
+export type {
+  SlugResolver,
+  UnresolvedPolicy,
+  InternalLinksOptions,
+} from "./types.js";

--- a/code/packages/typescript/forme-transform-internal-links/src/types.ts
+++ b/code/packages/typescript/forme-transform-internal-links/src/types.ts
@@ -1,0 +1,77 @@
+/**
+ * types.ts — resolver signature and option bag.
+ *
+ * The resolver is the caller-supplied bridge between an internal
+ * slug (the path-style reference an author wrote in Markdown) and
+ * the canonical URL the renderer should emit.  Resolvers
+ * typically consult the site's manifest:
+ *
+ * ```ts
+ * function resolve(slug: string): string | null {
+ *   const entry = manifest.byPath.get(slug);
+ *   return entry ? entry.canonicalUrl : null;
+ * }
+ * ```
+ *
+ * Returning `null` signals "I don't know about this slug" — the
+ * `unresolved` option decides what happens next.
+ *
+ * @module types
+ */
+
+/**
+ * Caller-supplied function mapping an internal slug
+ * (`/about`, `/blog/post`) to its canonical URL or `null` if
+ * unresolved.  The resolver is invoked once per internal
+ * `LinkNode` in the document.
+ *
+ * Contract:
+ *   - **Pure.**  Must return the same result for the same slug
+ *     every call (or reproducibility breaks).
+ *   - **Synchronous.**  No I/O — manifest lookups are in-memory.
+ *   - **Validated downstream.**  Resolved URLs must match
+ *     `^https?://` once the transform emits them — anything else
+ *     is rejected (defence against a malicious or buggy
+ *     resolver).
+ */
+export type SlugResolver = (slug: string) => string | null;
+
+/**
+ * What to do with an internal link whose slug the resolver
+ * returns `null` for.
+ *
+ *   - `"keep"` (default) — leave the original `/slug` in
+ *     `LinkNode.destination`.  Browsers will follow it as a
+ *     site-relative path; works on most static hosts.
+ *   - `"strip"` — replace the `LinkNode` with its inline
+ *     children (drop the link wrapper).  Useful when the renderer
+ *     refuses to emit broken `<a href>`s.
+ *   - `"throw"` — throw `Error` immediately.  Useful in
+ *     pre-publish validation: an unresolvable link is a content
+ *     bug.
+ *
+ * Note: `"strip"` only applies to inline `LinkNode`s, not to the
+ * other URL-bearing inline shapes (image destinations, autolink
+ * destinations).  Those are passed through unchanged regardless
+ * of this option.
+ */
+export type UnresolvedPolicy = "keep" | "strip" | "throw";
+
+/**
+ * Options for the link rewriter.
+ *
+ *   - `unresolved` — see `UnresolvedPolicy`.  Defaults to
+ *     `"keep"` (least surprising for callers wiring up a
+ *     resolver mid-development).
+ *
+ * Future v1 options that v0 explicitly defers:
+ *
+ *   - `internalPredicate` — caller-defined "is this an internal
+ *     link" check (currently hardcoded to "starts with `/` but
+ *     not `//`").
+ *   - `transformImageSrc` — extend rewriting to `ImageNode`
+ *     destinations (image rewrite is a separate spec transform).
+ */
+export interface InternalLinksOptions {
+  readonly unresolved?: UnresolvedPolicy;
+}

--- a/code/packages/typescript/forme-transform-internal-links/src/url.ts
+++ b/code/packages/typescript/forme-transform-internal-links/src/url.ts
@@ -1,0 +1,107 @@
+/**
+ * url.ts — internal-link detection and resolved-URL validation.
+ *
+ * Two small but security-critical helpers:
+ *
+ *   - `isInternalSlug(url)` — true if the LinkNode destination
+ *     is "internal" (an absolute path like `/about` or
+ *     `/blog/post`) and so a candidate for rewriting.
+ *   - `assertResolvedUrl(url)` — verifies the URL the resolver
+ *     returned is safe to emit into an `href` attribute.
+ *
+ * The resolver is caller-supplied code we can't audit.  A buggy
+ * (or hostile) resolver could return `javascript:alert(1)` for
+ * an innocent-looking slug.  Validating the output before
+ * splicing it back into the AST gives us a chokepoint that
+ * downstream renderers can rely on.
+ *
+ * @module url
+ */
+
+/**
+ * True if `url` is a root-relative internal slug.
+ *
+ * Accept set:
+ *   - Starts with `/` (single slash — site-root).
+ *   - Does NOT start with `//` (protocol-relative).
+ *   - Does NOT start with `/\` (some browsers normalise `\` to
+ *     `/`, turning `/\evil.com` into `//evil.com` — same
+ *     ambiguous-scheme attack surface).
+ *   - Is a non-empty string.
+ *
+ * Reject set:
+ *   - `http://...`, `https://...` (already absolute — no rewrite).
+ *   - `mailto:`, `tel:`, `javascript:`, `data:` (not internal).
+ *   - `//example.com/x` (protocol-relative — ambiguous scheme).
+ *   - `/\example.com/x` (backslash variant — same risk).
+ *   - `relative/path`, `./about` (bare relative — author should
+ *     normalise to `/about` first).
+ *   - Empty string.
+ *
+ * Why no fragment-only links (`#section`)?  Those are intra-
+ * document references handled by `autolinkHeadings`; this
+ * package leaves them alone.
+ */
+export function isInternalSlug(url: string): boolean {
+  if (typeof url !== "string" || url.length === 0) return false;
+  if (url.length >= 2 && url[0] === "/" && (url[1] === "/" || url[1] === "\\")) {
+    return false;
+  }
+  return url[0] === "/";
+}
+
+/**
+ * Assert that a resolver-returned URL is safe to emit into an
+ * `href` attribute.  Throws `TypeError` if not.
+ *
+ * Accept set (mirrors the rest of the Forme stage cluster):
+ *   - `http://...` / `https://...`  (case-insensitive scheme)
+ *   - Root-relative paths (`/about`) — the resolver chose not to
+ *     fully resolve; keep as relative.
+ *
+ * Reject set:
+ *   - `javascript:`, `data:`, `file:`, `vbscript:`, `mailto:`,
+ *     `tel:`, etc.
+ *   - Protocol-relative (`//host/path`).
+ *   - Bare relative (`about`, `./about`).
+ *   - Empty string.
+ *   - Non-string.
+ *
+ * The error message includes the offending URL so resolver
+ * authors can debug.  Truncates long URLs to 200 chars to keep
+ * the error readable.
+ */
+export function assertResolvedUrl(url: unknown): asserts url is string {
+  if (typeof url !== "string" || url.length === 0) {
+    throw new TypeError(
+      `forme-transform-internal-links: resolver returned ${
+        url === null ? "null" : typeof url === "string" ? "empty string" : typeof url
+      }; expected http(s):// or root-relative /path`,
+    );
+  }
+  if (isHttpUrl(url) || isRootRelative(url)) return;
+  const shown = url.length > 200 ? `${url.slice(0, 200)}…` : url;
+  throw new TypeError(
+    `forme-transform-internal-links: resolver returned unsafe URL ${
+      JSON.stringify(shown)
+    }; expected http(s):// or root-relative /path`,
+  );
+}
+
+function isHttpUrl(url: string): boolean {
+  // Case-insensitive `http://` / `https://` prefix check — match
+  // by lowering only the first 8 chars to avoid a full-string
+  // `toLowerCase()` allocation in the hot path.
+  const head = url.slice(0, 8).toLowerCase();
+  return head.startsWith("http://") || head.startsWith("https://");
+}
+
+function isRootRelative(url: string): boolean {
+  // Must start with exactly one slash and NOT have a second
+  // `/` or `\` (some browsers normalise `\` to `/`, so
+  // `/\evil.com` round-trips to `//evil.com` — same
+  // ambiguous-scheme attack as protocol-relative).
+  if (url === "/") return true;
+  if (url.length < 2 || url[0] !== "/") return false;
+  return url[1] !== "/" && url[1] !== "\\";
+}

--- a/code/packages/typescript/forme-transform-internal-links/src/walk.ts
+++ b/code/packages/typescript/forme-transform-internal-links/src/walk.ts
@@ -1,0 +1,349 @@
+/**
+ * walk.ts — AST walker that rewrites internal `LinkNode`
+ * destinations to resolved URLs.
+ *
+ * Per-`LinkNode` algorithm:
+ *
+ *   1. If destination is NOT an internal slug → pass-through
+ *      (return a fresh LinkNode copy with the original URL).
+ *   2. Else call `resolver(slug)`.
+ *   3. If resolver returned a string:
+ *        - `assertResolvedUrl(...)` (throws on `javascript:` etc.).
+ *        - Return a new LinkNode with the resolved URL.
+ *   4. If resolver returned `null` (or `undefined`):
+ *        - Apply `unresolved` policy:
+ *            - `"keep"`: return LinkNode with original `/slug`.
+ *            - `"strip"`: return the LinkNode's children (drops
+ *              the wrapper; caller's inline list expands inline).
+ *            - `"throw"`: throw `Error` with slug in message.
+ *
+ * The "strip" return type is unusual — a single `LinkNode` input
+ * becomes multiple `InlineNode` outputs.  Handled by the
+ * `inline-list-rewrite` helper which flat-maps over inline
+ * children.
+ *
+ * Image, autolink, raw_inline are pass-through — they may carry
+ * URLs but `image-rewrite` is a separate spec transform and
+ * `autolink` is the user's explicit external URL.  Same for
+ * `RawBlockNode` / `RawInlineNode` values.
+ *
+ * The walker descends every block / inline container so
+ * `LinkNode`s nested inside `BlockquoteNode` / list items / table
+ * cells get rewritten.
+ *
+ * @module walk
+ */
+
+import type {
+  BlockNode,
+  CodeBlockNode,
+  CodeSpanNode,
+  DocumentNode,
+  ImageNode,
+  InlineNode,
+  LinkNode,
+  ListChildNode,
+  RawBlockNode,
+  RawInlineNode,
+  TableNode,
+  TableRowNode,
+  TableCellNode,
+  ThematicBreakNode,
+} from "@coding-adventures/document-ast";
+import { assertResolvedUrl, isInternalSlug } from "./url.js";
+import type { InternalLinksOptions, SlugResolver, UnresolvedPolicy } from "./types.js";
+
+/**
+ * Rewrite internal links throughout `doc`.  Returns a fresh
+ * `DocumentNode`; `doc` is never mutated.
+ *
+ * Defaults: `unresolved: "keep"`.
+ *
+ * Throws `TypeError` if the resolver ever returns a string
+ * outside the `http(s)://` / root-relative accept-list.
+ * Throws `Error` if `unresolved: "throw"` and the resolver
+ * returns `null` for any internal link.
+ */
+export function rewriteInternalLinks(
+  doc: DocumentNode,
+  resolver: SlugResolver,
+  options: InternalLinksOptions = {},
+): DocumentNode {
+  const unresolved: UnresolvedPolicy = options.unresolved ?? "keep";
+  return {
+    type: "document",
+    children: doc.children.map((b) => transformBlock(b, resolver, unresolved)),
+  };
+}
+
+function transformBlock(
+  b: BlockNode,
+  resolver: SlugResolver,
+  unresolved: UnresolvedPolicy,
+): BlockNode {
+  switch (b.type) {
+    case "document":
+      return {
+        type: "document",
+        children: b.children.map((c) => transformBlock(c, resolver, unresolved)),
+      };
+    case "heading":
+      return {
+        type: "heading",
+        level: b.level,
+        children: transformInlines(b.children, resolver, unresolved),
+      };
+    case "paragraph":
+      return {
+        type: "paragraph",
+        children: transformInlines(b.children, resolver, unresolved),
+      };
+    case "blockquote":
+      return {
+        type: "blockquote",
+        children: b.children.map((c) => transformBlock(c, resolver, unresolved)),
+      };
+    case "list":
+      return {
+        type: "list",
+        ordered: b.ordered,
+        start: b.start,
+        tight: b.tight,
+        children: b.children.map((c) => transformListChild(c, resolver, unresolved)),
+      };
+    case "list_item":
+      return {
+        type: "list_item",
+        children: b.children.map((c) => transformBlock(c, resolver, unresolved)),
+      };
+    case "task_item":
+      return {
+        type: "task_item",
+        checked: b.checked,
+        children: b.children.map((c) => transformBlock(c, resolver, unresolved)),
+      };
+    case "table":
+      return transformTable(b, resolver, unresolved);
+    case "table_row":
+      return transformTableRow(b, resolver, unresolved);
+    case "table_cell":
+      return transformTableCell(b, resolver, unresolved);
+    case "code_block":
+      return passthroughCodeBlock(b);
+    case "thematic_break":
+      return passthroughThematicBreak(b);
+    case "raw_block":
+      return passthroughRawBlock(b);
+    default: {
+      const _exhaustive: never = b;
+      void _exhaustive;
+      return b;
+    }
+  }
+}
+
+/**
+ * Walk an `InlineNode[]`, flat-mapping each one through the
+ * single-node transform.  Flat-map is needed because the "strip"
+ * policy turns one `LinkNode` into N children.
+ */
+function transformInlines(
+  inlines: readonly InlineNode[],
+  resolver: SlugResolver,
+  unresolved: UnresolvedPolicy,
+): InlineNode[] {
+  const out: InlineNode[] = [];
+  for (let i = 0; i < inlines.length; i++) {
+    const result = transformInline(inlines[i]!, resolver, unresolved);
+    if (Array.isArray(result)) {
+      for (let j = 0; j < result.length; j++) out.push(result[j]!);
+    } else {
+      out.push(result);
+    }
+  }
+  return out;
+}
+
+/**
+ * Per-inline transform.  Returns one `InlineNode` for most
+ * cases; returns `InlineNode[]` when an internal link is
+ * stripped (the link's children replace the wrapper).
+ */
+function transformInline(
+  n: InlineNode,
+  resolver: SlugResolver,
+  unresolved: UnresolvedPolicy,
+): InlineNode | InlineNode[] {
+  switch (n.type) {
+    case "link":
+      return transformLink(n, resolver, unresolved);
+    case "emphasis":
+      return {
+        type: "emphasis",
+        children: transformInlines(n.children, resolver, unresolved),
+      };
+    case "strong":
+      return {
+        type: "strong",
+        children: transformInlines(n.children, resolver, unresolved),
+      };
+    case "strikethrough":
+      return {
+        type: "strikethrough",
+        children: transformInlines(n.children, resolver, unresolved),
+      };
+    case "text":
+      return { type: "text", value: n.value };
+    case "code_span":
+      return passthroughCodeSpan(n);
+    case "image":
+      return passthroughImage(n);
+    case "autolink":
+      return { type: "autolink", destination: n.destination, isEmail: n.isEmail };
+    case "raw_inline":
+      return passthroughRawInline(n);
+    case "hard_break":
+      return { type: "hard_break" };
+    case "soft_break":
+      return { type: "soft_break" };
+    default: {
+      const _exhaustive: never = n;
+      void _exhaustive;
+      return n;
+    }
+  }
+}
+
+function transformLink(
+  link: LinkNode,
+  resolver: SlugResolver,
+  unresolved: UnresolvedPolicy,
+): InlineNode | InlineNode[] {
+  // Always recursively rewrite the link's children — they might
+  // contain nested formatting (no nested links, but emphasis /
+  // strong / text are legal).
+  const children = transformInlines(link.children, resolver, unresolved);
+
+  if (!isInternalSlug(link.destination)) {
+    // External link → pass-through with children rewritten in
+    // case they contained internal content (unlikely for links,
+    // but defensive).
+    return {
+      type: "link",
+      destination: link.destination,
+      title: link.title,
+      children,
+    };
+  }
+
+  // Internal link → resolve.
+  const resolved = resolver(link.destination);
+  if (resolved !== null && resolved !== undefined) {
+    assertResolvedUrl(resolved);
+    return {
+      type: "link",
+      destination: resolved,
+      title: link.title,
+      children,
+    };
+  }
+
+  // Unresolved.
+  if (unresolved === "throw") {
+    throw new Error(
+      `forme-transform-internal-links: unresolved internal slug ${
+        JSON.stringify(link.destination)
+      }`,
+    );
+  }
+  if (unresolved === "strip") {
+    // Return the children flat; the wrapper disappears.
+    return children;
+  }
+  // "keep" — preserve the original destination.
+  return {
+    type: "link",
+    destination: link.destination,
+    title: link.title,
+    children,
+  };
+}
+
+function transformListChild(
+  c: ListChildNode,
+  resolver: SlugResolver,
+  unresolved: UnresolvedPolicy,
+): ListChildNode {
+  if (c.type === "task_item") {
+    return {
+      type: "task_item",
+      checked: c.checked,
+      children: c.children.map((b) => transformBlock(b, resolver, unresolved)),
+    };
+  }
+  return {
+    type: "list_item",
+    children: c.children.map((b) => transformBlock(b, resolver, unresolved)),
+  };
+}
+
+function transformTable(
+  t: TableNode,
+  resolver: SlugResolver,
+  unresolved: UnresolvedPolicy,
+): TableNode {
+  return {
+    type: "table",
+    align: t.align,
+    children: t.children.map((r) => transformTableRow(r, resolver, unresolved)),
+  };
+}
+
+function transformTableRow(
+  r: TableRowNode,
+  resolver: SlugResolver,
+  unresolved: UnresolvedPolicy,
+): TableRowNode {
+  return {
+    type: "table_row",
+    isHeader: r.isHeader,
+    children: r.children.map((c) => transformTableCell(c, resolver, unresolved)),
+  };
+}
+
+function transformTableCell(
+  c: TableCellNode,
+  resolver: SlugResolver,
+  unresolved: UnresolvedPolicy,
+): TableCellNode {
+  return {
+    type: "table_cell",
+    children: transformInlines(c.children, resolver, unresolved),
+  };
+}
+
+// ─── Pass-through node copies ──────────────────────────────────────
+
+function passthroughCodeBlock(b: CodeBlockNode): CodeBlockNode {
+  return { type: "code_block", language: b.language, value: b.value };
+}
+
+function passthroughThematicBreak(_b: ThematicBreakNode): ThematicBreakNode {
+  return { type: "thematic_break" };
+}
+
+function passthroughRawBlock(b: RawBlockNode): RawBlockNode {
+  return { type: "raw_block", format: b.format, value: b.value };
+}
+
+function passthroughImage(n: ImageNode): ImageNode {
+  return { type: "image", destination: n.destination, title: n.title, alt: n.alt };
+}
+
+function passthroughCodeSpan(n: CodeSpanNode): CodeSpanNode {
+  return { type: "code_span", value: n.value };
+}
+
+function passthroughRawInline(n: RawInlineNode): RawInlineNode {
+  return { type: "raw_inline", format: n.format, value: n.value };
+}

--- a/code/packages/typescript/forme-transform-internal-links/tests/url.test.ts
+++ b/code/packages/typescript/forme-transform-internal-links/tests/url.test.ts
@@ -1,0 +1,158 @@
+/**
+ * url.test.ts — isInternalSlug + assertResolvedUrl.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isInternalSlug, assertResolvedUrl } from "../src/index.js";
+
+describe("isInternalSlug — accepts", () => {
+  it("root-relative path", () => {
+    expect(isInternalSlug("/about")).toBe(true);
+  });
+
+  it("multi-segment root-relative", () => {
+    expect(isInternalSlug("/blog/2026/post")).toBe(true);
+  });
+
+  it("bare /", () => {
+    expect(isInternalSlug("/")).toBe(true);
+  });
+});
+
+describe("isInternalSlug — rejects", () => {
+  it("absolute http", () => {
+    expect(isInternalSlug("http://example.com/x")).toBe(false);
+  });
+
+  it("absolute https", () => {
+    expect(isInternalSlug("https://example.com/x")).toBe(false);
+  });
+
+  it("protocol-relative //host", () => {
+    expect(isInternalSlug("//example.com/x")).toBe(false);
+  });
+
+  it("bare relative", () => {
+    expect(isInternalSlug("about")).toBe(false);
+  });
+
+  it("./about", () => {
+    expect(isInternalSlug("./about")).toBe(false);
+  });
+
+  it("mailto:", () => {
+    expect(isInternalSlug("mailto:x@y.com")).toBe(false);
+  });
+
+  it("javascript:", () => {
+    expect(isInternalSlug("javascript:alert(1)")).toBe(false);
+  });
+
+  it("empty string", () => {
+    expect(isInternalSlug("")).toBe(false);
+  });
+
+  it("non-string", () => {
+    // @ts-expect-error — defensive runtime check
+    expect(isInternalSlug(42)).toBe(false);
+  });
+
+  it("fragment only", () => {
+    expect(isInternalSlug("#anchor")).toBe(false);
+  });
+
+  it("rejects /\\evil.com (browser may normalise \\ to / producing //evil.com)", () => {
+    expect(isInternalSlug("/\\evil.com")).toBe(false);
+  });
+});
+
+describe("assertResolvedUrl — accepts", () => {
+  it("http://...", () => {
+    expect(() => assertResolvedUrl("http://example.com/x")).not.toThrow();
+  });
+
+  it("https://...", () => {
+    expect(() => assertResolvedUrl("https://example.com/x")).not.toThrow();
+  });
+
+  it("HTTP scheme case-insensitive", () => {
+    expect(() => assertResolvedUrl("HTTPS://example.com")).not.toThrow();
+    expect(() => assertResolvedUrl("Http://example.com")).not.toThrow();
+  });
+
+  it("https with port + query + fragment", () => {
+    expect(() => assertResolvedUrl("https://example.com:8443/x?a=1#y")).not.toThrow();
+  });
+
+  it("root-relative path", () => {
+    expect(() => assertResolvedUrl("/about")).not.toThrow();
+  });
+
+  it("bare /", () => {
+    expect(() => assertResolvedUrl("/")).not.toThrow();
+  });
+});
+
+describe("assertResolvedUrl — rejects", () => {
+  it("javascript:", () => {
+    expect(() => assertResolvedUrl("javascript:alert(1)")).toThrow(/unsafe URL/);
+  });
+
+  it("data:", () => {
+    expect(() => assertResolvedUrl("data:text/html,<script>")).toThrow(/unsafe URL/);
+  });
+
+  it("file:", () => {
+    expect(() => assertResolvedUrl("file:///etc/passwd")).toThrow(/unsafe URL/);
+  });
+
+  it("vbscript:", () => {
+    expect(() => assertResolvedUrl("vbscript:msgbox(1)")).toThrow(/unsafe URL/);
+  });
+
+  it("protocol-relative //host", () => {
+    expect(() => assertResolvedUrl("//evil.com")).toThrow(/unsafe URL/);
+  });
+
+  it("backslash variant /\\evil.com (browser \\-to-/ normalisation)", () => {
+    expect(() => assertResolvedUrl("/\\evil.com")).toThrow(/unsafe URL/);
+  });
+
+  it("bare relative", () => {
+    expect(() => assertResolvedUrl("about")).toThrow(/unsafe URL/);
+  });
+
+  it("mailto:", () => {
+    expect(() => assertResolvedUrl("mailto:x@y.com")).toThrow(/unsafe URL/);
+  });
+
+  it("empty string mentions empty in message", () => {
+    expect(() => assertResolvedUrl("")).toThrow(/empty string/);
+  });
+
+  it("null mentions null in message", () => {
+    expect(() => assertResolvedUrl(null)).toThrow(/null/);
+  });
+
+  it("undefined mentions undefined in message", () => {
+    expect(() => assertResolvedUrl(undefined)).toThrow(/undefined/);
+  });
+
+  it("number mentions number in message", () => {
+    expect(() => assertResolvedUrl(42)).toThrow(/number/);
+  });
+
+  it("long URL truncates to ~200 chars + ellipsis in message", () => {
+    const long = "javascript:" + "a".repeat(500);
+    try {
+      assertResolvedUrl(long);
+      expect.fail("expected throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      // Should contain truncated URL with `…`
+      expect(msg).toMatch(/…/);
+      // And the message itself shouldn't be enormous.
+      expect(msg.length).toBeLessThan(400);
+    }
+  });
+});

--- a/code/packages/typescript/forme-transform-internal-links/tests/walk.test.ts
+++ b/code/packages/typescript/forme-transform-internal-links/tests/walk.test.ts
@@ -1,0 +1,471 @@
+/**
+ * walk.test.ts — rewriteInternalLinks end-to-end.
+ */
+
+import { describe, it, expect } from "vitest";
+import type {
+  BlockNode,
+  DocumentNode,
+  InlineNode,
+  LinkNode,
+} from "@coding-adventures/document-ast";
+import { rewriteInternalLinks } from "../src/index.js";
+
+function txt(value: string): InlineNode { return { type: "text", value }; }
+function link(destination: string, ...children: InlineNode[]): InlineNode {
+  return { type: "link", destination, title: null, children };
+}
+function p(...children: InlineNode[]): BlockNode {
+  return { type: "paragraph", children };
+}
+function doc(...children: BlockNode[]): DocumentNode {
+  return { type: "document", children };
+}
+
+// Common resolver fixtures.
+const knownResolver = (slug: string): string | null => {
+  const map: Record<string, string> = {
+    "/about": "https://example.com/about",
+    "/blog/post": "https://example.com/blog/post",
+    "/": "https://example.com/",
+  };
+  return map[slug] ?? null;
+};
+const nullResolver = (): null => null;
+
+describe("rewriteInternalLinks — internal link resolution", () => {
+  it("rewrites a known internal slug", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("/about", txt("About")))),
+      knownResolver,
+    );
+    const para = out.children[0] as { children: InlineNode[] };
+    expect(para.children[0]).toEqual({
+      type: "link",
+      destination: "https://example.com/about",
+      title: null,
+      children: [txt("About")],
+    });
+  });
+
+  it("preserves link title", () => {
+    const out = rewriteInternalLinks(
+      doc(p({
+        type: "link",
+        destination: "/about",
+        title: "About us",
+        children: [txt("About")],
+      })),
+      knownResolver,
+    );
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.title).toBe("About us");
+    expect(para.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("rewrites bare /", () => {
+    const out = rewriteInternalLinks(doc(p(link("/", txt("Home")))), knownResolver);
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("https://example.com/");
+  });
+});
+
+describe("rewriteInternalLinks — external links pass through", () => {
+  it("absolute https unchanged", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("https://github.com", txt("GH")))),
+      knownResolver,
+    );
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("https://github.com");
+  });
+
+  it("mailto unchanged", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("mailto:x@y.com", txt("Mail")))),
+      knownResolver,
+    );
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("mailto:x@y.com");
+  });
+
+  it("resolver is NOT called for external links", () => {
+    let called = false;
+    rewriteInternalLinks(
+      doc(p(link("https://x.com", txt("X")))),
+      () => { called = true; return null; },
+    );
+    expect(called).toBe(false);
+  });
+});
+
+describe("rewriteInternalLinks — unresolved policy", () => {
+  it("default 'keep' preserves original /slug", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("/missing", txt("M")))),
+      nullResolver,
+    );
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("/missing");
+  });
+
+  it("'keep' explicit option also preserves", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("/missing", txt("M")))),
+      nullResolver,
+      { unresolved: "keep" },
+    );
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("/missing");
+  });
+
+  it("'strip' drops the link wrapper but keeps children", () => {
+    const out = rewriteInternalLinks(
+      doc(p(
+        txt("before "),
+        link("/missing", txt("M")),
+        txt(" after"),
+      )),
+      nullResolver,
+      { unresolved: "strip" },
+    );
+    const para = out.children[0] as { children: InlineNode[] };
+    // Original 3 inlines; link expanded inline to one text node
+    // → still 3 total.
+    expect(para.children.length).toBe(3);
+    expect(para.children[1]).toEqual(txt("M"));
+  });
+
+  it("'strip' on a link with multiple children expands them all", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("/missing", txt("hello "), {
+        type: "strong", children: [txt("world")],
+      }))),
+      nullResolver,
+      { unresolved: "strip" },
+    );
+    const para = out.children[0] as { children: InlineNode[] };
+    expect(para.children.length).toBe(2);
+    expect(para.children[0]).toEqual(txt("hello "));
+    expect(para.children[1]!.type).toBe("strong");
+  });
+
+  it("'throw' throws on first unresolved slug", () => {
+    expect(() => rewriteInternalLinks(
+      doc(p(link("/missing", txt("M")))),
+      nullResolver,
+      { unresolved: "throw" },
+    )).toThrow(/unresolved internal slug.*\/missing/);
+  });
+
+  it("resolver returning undefined treated same as null", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("/x", txt("X")))),
+      (() => undefined) as unknown as (s: string) => string | null,
+      { unresolved: "keep" },
+    );
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("/x");
+  });
+});
+
+describe("rewriteInternalLinks — resolver-returned-URL validation", () => {
+  it("throws if resolver returns javascript: URL", () => {
+    expect(() => rewriteInternalLinks(
+      doc(p(link("/about", txt("X")))),
+      () => "javascript:alert(1)",
+    )).toThrow(/unsafe URL/);
+  });
+
+  it("throws if resolver returns data: URL", () => {
+    expect(() => rewriteInternalLinks(
+      doc(p(link("/about", txt("X")))),
+      () => "data:text/html,<script>",
+    )).toThrow(/unsafe URL/);
+  });
+
+  it("throws if resolver returns protocol-relative URL", () => {
+    expect(() => rewriteInternalLinks(
+      doc(p(link("/about", txt("X")))),
+      () => "//evil.com",
+    )).toThrow(/unsafe URL/);
+  });
+
+  it("throws if resolver returns a non-URL string (bare relative)", () => {
+    expect(() => rewriteInternalLinks(
+      doc(p(link("/about", txt("X")))),
+      () => "about",
+    )).toThrow(/unsafe URL/);
+  });
+
+  it("accepts http://", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("/about", txt("X")))),
+      () => "http://example.com/about",
+    );
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("http://example.com/about");
+  });
+
+  it("accepts root-relative (resolver chose not to fully resolve)", () => {
+    const out = rewriteInternalLinks(
+      doc(p(link("/about", txt("X")))),
+      () => "/canonical/about",
+    );
+    const para = out.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("/canonical/about");
+  });
+});
+
+describe("rewriteInternalLinks — walks nested containers", () => {
+  it("inside blockquote", () => {
+    const out = rewriteInternalLinks(
+      doc({ type: "blockquote", children: [p(link("/about", txt("A")))] }),
+      knownResolver,
+    );
+    const bq = out.children[0] as { children: BlockNode[] };
+    const para = bq.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("inside list_item", () => {
+    const out = rewriteInternalLinks(
+      doc({
+        type: "list", ordered: false, start: null, tight: true,
+        children: [{ type: "list_item", children: [p(link("/about", txt("A")))] }],
+      }),
+      knownResolver,
+    );
+    const list = out.children[0] as { children: { children: BlockNode[] }[] };
+    const item = list.children[0]!;
+    const para = item.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("inside task_item", () => {
+    const out = rewriteInternalLinks(
+      doc({
+        type: "list", ordered: false, start: null, tight: true,
+        children: [{ type: "task_item", checked: true, children: [p(link("/about", txt("A")))] }],
+      }),
+      knownResolver,
+    );
+    const list = out.children[0] as { children: { children: BlockNode[] }[] };
+    const item = list.children[0]!;
+    const para = item.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("inside heading", () => {
+    const out = rewriteInternalLinks(
+      doc({ type: "heading", level: 2, children: [link("/about", txt("A"))] }),
+      knownResolver,
+    );
+    const h = out.children[0] as { children: LinkNode[] };
+    expect(h.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("inside table cells", () => {
+    const out = rewriteInternalLinks(
+      doc({
+        type: "table", align: [null],
+        children: [
+          { type: "table_row", isHeader: true, children: [
+            { type: "table_cell", children: [link("/about", txt("Header"))] },
+          ]},
+          { type: "table_row", isHeader: false, children: [
+            { type: "table_cell", children: [link("/blog/post", txt("Body"))] },
+          ]},
+        ],
+      }),
+      knownResolver,
+    );
+    const table = out.children[0] as { children: { children: { children: LinkNode[] }[] }[] };
+    expect(table.children[0]!.children[0]!.children[0]!.destination).toBe("https://example.com/about");
+    expect(table.children[1]!.children[0]!.children[0]!.destination).toBe("https://example.com/blog/post");
+  });
+
+  it("inside emphasis", () => {
+    const out = rewriteInternalLinks(
+      doc(p({ type: "emphasis", children: [link("/about", txt("A"))] })),
+      knownResolver,
+    );
+    const para = out.children[0] as { children: InlineNode[] };
+    const em = para.children[0] as { type: string; children: LinkNode[] };
+    expect(em.type).toBe("emphasis");
+    expect(em.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("inside strong", () => {
+    const out = rewriteInternalLinks(
+      doc(p({ type: "strong", children: [link("/about", txt("A"))] })),
+      knownResolver,
+    );
+    const para = out.children[0] as { children: InlineNode[] };
+    const strong = para.children[0] as { type: string; children: LinkNode[] };
+    expect(strong.type).toBe("strong");
+    expect(strong.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("inside strikethrough", () => {
+    const out = rewriteInternalLinks(
+      doc(p({ type: "strikethrough", children: [link("/about", txt("A"))] })),
+      knownResolver,
+    );
+    const para = out.children[0] as { children: InlineNode[] };
+    const strike = para.children[0] as { type: string; children: LinkNode[] };
+    expect(strike.type).toBe("strikethrough");
+    expect(strike.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("nested DocumentNode in children", () => {
+    const out = rewriteInternalLinks(
+      doc({ type: "document", children: [p(link("/about", txt("A")))] } as BlockNode),
+      knownResolver,
+    );
+    const inner = out.children[0] as { type: string; children: BlockNode[] };
+    expect(inner.type).toBe("document");
+    const para = inner.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("https://example.com/about");
+  });
+});
+
+describe("rewriteInternalLinks — pass-through nodes", () => {
+  it("ImageNode.destination unchanged even if internal-looking", () => {
+    const img: InlineNode = {
+      type: "image", destination: "/cat.png", title: null, alt: "cat",
+    };
+    const out = rewriteInternalLinks(doc(p(img)), knownResolver);
+    const para = out.children[0] as { children: InlineNode[] };
+    expect((para.children[0] as { destination: string }).destination).toBe("/cat.png");
+  });
+
+  it("AutolinkNode unchanged", () => {
+    const out = rewriteInternalLinks(doc(p({
+      type: "autolink", destination: "https://example.com", isEmail: false,
+    })), knownResolver);
+    const para = out.children[0] as { children: InlineNode[] };
+    expect(para.children[0]).toEqual({
+      type: "autolink", destination: "https://example.com", isEmail: false,
+    });
+  });
+
+  it("CodeBlockNode unchanged", () => {
+    const out = rewriteInternalLinks(doc({
+      type: "code_block", language: "md", value: "[link](/about)\n",
+    }), knownResolver);
+    expect(out.children[0]).toEqual({
+      type: "code_block", language: "md", value: "[link](/about)\n",
+    });
+  });
+
+  it("CodeSpanNode unchanged", () => {
+    const out = rewriteInternalLinks(doc(p(
+      { type: "code_span", value: "[link](/about)" },
+    )), knownResolver);
+    const para = out.children[0] as { children: InlineNode[] };
+    expect(para.children[0]).toEqual({ type: "code_span", value: "[link](/about)" });
+  });
+
+  it("RawBlockNode unchanged", () => {
+    const out = rewriteInternalLinks(doc({
+      type: "raw_block", format: "html", value: `<a href="/about">x</a>`,
+    }), knownResolver);
+    expect(out.children[0]).toEqual({
+      type: "raw_block", format: "html", value: `<a href="/about">x</a>`,
+    });
+  });
+
+  it("RawInlineNode unchanged", () => {
+    const out = rewriteInternalLinks(doc(p({
+      type: "raw_inline", format: "html", value: `<a href="/about">x</a>`,
+    })), knownResolver);
+    const para = out.children[0] as { children: InlineNode[] };
+    expect(para.children[0]).toEqual({
+      type: "raw_inline", format: "html", value: `<a href="/about">x</a>`,
+    });
+  });
+
+  it("thematic_break / hard_break / soft_break unchanged", () => {
+    const out = rewriteInternalLinks(doc(
+      { type: "thematic_break" },
+      p(txt("a"), { type: "hard_break" }, txt("b"), { type: "soft_break" }, txt("c")),
+    ), knownResolver);
+    expect(out.children[0]).toEqual({ type: "thematic_break" });
+    const para = out.children[1] as { children: InlineNode[] };
+    expect(para.children[1]).toEqual({ type: "hard_break" });
+    expect(para.children[3]).toEqual({ type: "soft_break" });
+  });
+});
+
+describe("rewriteInternalLinks — defensive non-tree BlockNode variants", () => {
+  it("list_item as direct block child rewrites internal links", () => {
+    const out = rewriteInternalLinks(
+      doc({ type: "list_item", children: [p(link("/about", txt("A")))] } as BlockNode),
+      knownResolver,
+    );
+    const li = out.children[0] as { children: BlockNode[] };
+    const para = li.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("task_item as direct block child", () => {
+    const out = rewriteInternalLinks(
+      doc({ type: "task_item", checked: false, children: [p(link("/about", txt("A")))] } as BlockNode),
+      knownResolver,
+    );
+    const ti = out.children[0] as { type: string; checked: boolean; children: BlockNode[] };
+    expect(ti.type).toBe("task_item");
+    const para = ti.children[0] as { children: LinkNode[] };
+    expect(para.children[0]!.destination).toBe("https://example.com/about");
+  });
+
+  it("table_row / table_cell as direct block child", () => {
+    const out = rewriteInternalLinks(
+      doc(
+        { type: "table_row", isHeader: false, children: [
+          { type: "table_cell", children: [link("/about", txt("A"))] },
+        ]} as BlockNode,
+        { type: "table_cell", children: [link("/blog/post", txt("B"))] } as BlockNode,
+      ),
+      knownResolver,
+    );
+    const row = out.children[0] as { children: { children: LinkNode[] }[] };
+    expect(row.children[0]!.children[0]!.destination).toBe("https://example.com/about");
+    const cell = out.children[1] as { children: LinkNode[] };
+    expect(cell.children[0]!.destination).toBe("https://example.com/blog/post");
+  });
+});
+
+describe("rewriteInternalLinks — purity / determinism", () => {
+  it("does not mutate input document", () => {
+    const d = doc(p(link("/about", txt("A"))));
+    const before = JSON.stringify(d);
+    rewriteInternalLinks(d, knownResolver);
+    expect(JSON.stringify(d)).toBe(before);
+  });
+
+  it("returns a fresh tree (no shared references)", () => {
+    const d = doc(p(link("/about", txt("A"))));
+    const out = rewriteInternalLinks(d, knownResolver);
+    expect(out).not.toBe(d);
+    expect(out.children).not.toBe(d.children);
+    expect(out.children[0]).not.toBe(d.children[0]);
+  });
+
+  it("same input + resolver → byte-identical output", () => {
+    const d = doc(p(link("/about", txt("A")), link("/blog/post", txt("B"))));
+    expect(JSON.stringify(rewriteInternalLinks(d, knownResolver)))
+      .toBe(JSON.stringify(rewriteInternalLinks(d, knownResolver)));
+  });
+
+  it("resolver invoked once per internal link (not per call)", () => {
+    let calls = 0;
+    rewriteInternalLinks(
+      doc(p(link("/about", txt("A"))), p(link("/about", txt("B")))),
+      (slug) => { calls++; return slug === "/about" ? "https://x/" : null; },
+    );
+    // Two internal links → resolver called twice.
+    expect(calls).toBe(2);
+  });
+});

--- a/code/packages/typescript/forme-transform-internal-links/tsconfig.json
+++ b/code/packages/typescript/forme-transform-internal-links/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-transform-internal-links/vitest.config.ts
+++ b/code/packages/typescript/forme-transform-internal-links/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Eighth FM00 v0 stage package — fourth concrete §5.3 transform. Walks a `DocumentNode` and rewrites every internal `LinkNode.destination` (root-relative `/slug` references) to caller-supplied canonical URLs, with strict validation of the resolver's output to defend against malicious or buggy resolvers.

```ts
import { rewriteInternalLinks } from "@coding-adventures/forme-transform-internal-links";

function resolve(slug: string): string | null {
  const entry = manifest.byPath.get(slug);
  return entry ? entry.canonicalUrl : null;
}

const linked = rewriteInternalLinks(doc, resolve);
// Strict pre-publish: throw on unresolved.
const validated = rewriteInternalLinks(doc, resolve, { unresolved: "throw" });
```

Joins the FM00 v0 cluster: [`forme-feeds`](../forme-feeds), [`forme-opengraph`](../forme-opengraph), [`forme-index-renderer`](../forme-index-renderer), [`forme-transforms`](../forme-transforms), [`forme-transform-autolink-headings`](../forme-transform-autolink-headings), [`forme-transform-toc`](../forme-transform-toc), [`forme-transform-typography`](../forme-transform-typography).

## What counts as internal?

`isInternalSlug` accepts root-relative `/path`, `/`, `/blog/post`. Rejects:
- absolute `http(s)://`
- protocol-relative `//host`
- `/\host` (browser `\`→`/` normalisation defence)
- bare relative (`about`, `./about`)
- `mailto:`, `javascript:`, `data:`, etc.
- fragment-only (`#section` — handled by `forme-transform-autolink-headings`)

## Security chokepoint: resolver-returned URL validation

The resolver is caller-supplied code we can't audit. Every returned string must pass `assertResolvedUrl` before being spliced back into the AST. Accept set: `http(s)://` (case-insensitive) or root-relative `/path`. Reject set: `javascript:`, `data:`, `file:`, `vbscript:`, protocol-relative, `/\backslash-variant`, bare relative, empty, non-string.

**Even if a buggy resolver returns `javascript:alert(1)` for an innocent slug, the rewriter throws `TypeError` and refuses to splice it into the AST.**

## Unresolved-link policy

| Policy   | Behaviour                                                  |
|----------|------------------------------------------------------------|
| `"keep"` (default) | Preserve original `/slug` (browsers follow as site-relative) |
| `"strip"`| Replace LinkNode with its inline children (drop wrapper)   |
| `"throw"`| Throw `Error` immediately (for pre-publish validation)     |

## Pass-through nodes

`ImageNode.destination` (image-rewrite is a separate transform), `AutolinkNode.destination` (user's explicit external URL), `CodeBlock` / `CodeSpan` / `RawBlock` / `RawInline` values.

## Security

Four concerns addressed pre-push (security review LOW finding for `/\backslash-variant` addressed before push):

- Hostile resolver output rejected by `assertResolvedUrl` with TypeError before reaching output AST
- `/\backslash-variant` defended (browsers normalise `\`→`/`, turning `/\evil.com` into `//evil.com`)
- No AST mutation — fresh tree per call, fresh-tree guarantee even for passthrough sub-trees
- Deterministic, bounded O(N) computation, zero regex (URL detection via character-class index checks)

Security review (general-purpose sub-agent): **no exploitable issues found** after L1 fix.

## Capabilities

`[]` — pure transform.

## Tests

**74 tests across 2 files**, **97.13% line / 97.95% branch** coverage:

- `url.test.ts` (33) — full accept/reject matrix for `isInternalSlug` and `assertResolvedUrl`, including the `/\backslash-variant` defence
- `walk.test.ts` (41) — internal/external dispatch, unresolved-policy matrix (keep/strip/throw, undefined=null), resolver-returned-URL validation, walks all nested containers, pass-through nodes, defensive non-tree BlockNode variants, purity / determinism / resolver-call-count

## Spec adherence

Implements FM00 v0 §5.3 `transform-internal-links`. No spec divergences.

## v0 simplifications

- No image-src rewriting (separate transform)
- No internal-link predicate customisation (hardcoded "starts with `/` but not `//` or `/\`")
- No async resolver support (synchronous only)
- No batch multi-document optimisation

## Test plan

- [x] All 74 tests pass locally
- [x] 97.13% line / 97.95% branch coverage
- [x] TypeScript build clean
- [x] Zero regex in `src/` (verified by grep)
- [x] Security review clean (LOW finding addressed pre-push)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)