### PR TITLE
Share HTML lexer fixture case helpers

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -112,6 +112,8 @@ documented in this file.
 - Generated WHATWG lexer fixture runners now share test-only assertion helpers
   for token, attribute, DOCTYPE, adjacent-text, and diagnostic-code
   normalization.
+- Generated WHATWG boundary and recovery fixture runners now share case
+  description and push/finish boilerplate through the same helper module.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -100,6 +100,9 @@ constructors instead of test-local context field assembly.
 The generated WHATWG lexer runners share the same test-only assertion helpers,
 so boundary fixtures compare token text, attributes, doctypes, coalesced text
 recovery, and diagnostic codes through one normalization path.
+Those helpers also own the repeated case description, push, and finish checks
+for generated boundary and recovery fixtures, keeping each runner focused on
+the lexer context it seeds.
 The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup

--- a/code/packages/rust/html-lexer/tests/common/mod.rs
+++ b/code/packages/rust/html-lexer/tests/common/mod.rs
@@ -1,4 +1,46 @@
-use coding_adventures_html_lexer::{Attribute, Diagnostic, Token};
+use coding_adventures_html_lexer::{create_html_lexer, Attribute, Diagnostic, HtmlLexer, Token};
+
+pub fn assert_case_description(case_id: &str, description: &str, label: &str) {
+    assert!(
+        !description.is_empty(),
+        "case `{case_id}` should describe its {label}"
+    );
+}
+
+#[allow(dead_code)]
+pub fn assert_default_lexer_case(
+    case_id: &str,
+    input: &str,
+    expected_tokens: &[String],
+    expected_diagnostics: &[String],
+) {
+    let mut lexer = create_html_lexer().expect("HTML lexer should build");
+    assert_lexer_case(
+        case_id,
+        &mut lexer,
+        input,
+        expected_tokens,
+        expected_diagnostics,
+    );
+}
+
+pub fn assert_lexer_case(
+    case_id: &str,
+    lexer: &mut HtmlLexer,
+    input: &str,
+    expected_tokens: &[String],
+    expected_diagnostics: &[String],
+) {
+    lexer
+        .push(input)
+        .unwrap_or_else(|error| panic!("case `{case_id}` push failed: {error:?}"));
+    lexer
+        .finish()
+        .unwrap_or_else(|error| panic!("case `{case_id}` finish failed: {error:?}"));
+
+    assert_token_summaries(case_id, lexer.drain_tokens(), expected_tokens);
+    assert_diagnostic_codes(case_id, lexer.diagnostics(), expected_diagnostics);
+}
 
 pub fn assert_token_summaries(
     case_id: &str,

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
@@ -72,11 +72,7 @@ fn whatwg_attribute_boundaries_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its attribute boundary",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "attribute boundary");
         let initial_state = HtmlTokenizerState::from_machine_state(&case.initial_state)
             .unwrap_or_else(|| panic!("case `{}` unknown initial state", case.id));
         let context =
@@ -89,15 +85,13 @@ fn whatwg_attribute_boundaries_cases_match_default_lexer() {
                 });
         let mut lexer =
             create_html_lexer_with_context(&context).expect("HTML lexer should build with context");
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
@@ -1,4 +1,3 @@
-use coding_adventures_html_lexer::create_html_lexer;
 use serde::Deserialize;
 
 mod common;
@@ -48,21 +47,8 @@ fn whatwg_attribute_edge_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its attribute edge",
-            case.id
-        );
-        let mut lexer = create_html_lexer().expect("HTML lexer should build");
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_case_description(&case.id, &case.description, "attribute edge");
+        common::assert_default_lexer_case(&case.id, &case.input, &case.tokens, &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
@@ -52,21 +52,15 @@ fn whatwg_cdata_boundaries_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its CDATA boundary",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "CDATA boundary");
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
@@ -62,21 +62,19 @@ fn whatwg_character_reference_boundaries_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its character-reference boundary",
-            case.id
+        common::assert_case_description(
+            &case.id,
+            &case.description,
+            "character-reference boundary",
         );
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
@@ -54,21 +54,15 @@ fn whatwg_comment_boundaries_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its comment boundary",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "comment boundary");
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
@@ -66,21 +66,15 @@ fn whatwg_doctype_boundaries_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its DOCTYPE boundary",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "DOCTYPE boundary");
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
@@ -69,21 +69,15 @@ fn whatwg_eof_recovery_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its EOF edge",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "EOF edge");
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
@@ -76,21 +76,15 @@ fn whatwg_markup_declaration_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its markup declaration edge",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "markup declaration edge");
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
@@ -58,21 +58,15 @@ fn whatwg_script_escape_boundaries_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its script escape boundary",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "script escape boundary");
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
@@ -1,4 +1,3 @@
-use coding_adventures_html_lexer::create_html_lexer;
 use serde::Deserialize;
 
 mod common;
@@ -48,21 +47,8 @@ fn whatwg_tag_open_recovery_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its tag-open edge",
-            case.id
-        );
-        let mut lexer = create_html_lexer().expect("HTML lexer should build");
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_case_description(&case.id, &case.description, "tag-open edge");
+        common::assert_default_lexer_case(&case.id, &case.input, &case.tokens, &case.diagnostics);
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
@@ -60,21 +60,15 @@ fn whatwg_text_mode_boundaries_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its text-mode boundary",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "text-mode boundary");
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
@@ -75,21 +75,15 @@ fn whatwg_text_mode_delimiter_cases_match_default_lexer() {
     let suite = load_suite();
 
     for case in &suite.cases {
-        assert!(
-            !case.description.is_empty(),
-            "case `{}` should describe its delimiter edge",
-            case.id
-        );
+        common::assert_case_description(&case.id, &case.description, "delimiter edge");
         let mut lexer = configured_lexer(case);
-        lexer
-            .push(&case.input)
-            .unwrap_or_else(|error| panic!("case `{}` push failed: {error:?}", case.id));
-        lexer
-            .finish()
-            .unwrap_or_else(|error| panic!("case `{}` finish failed: {error:?}", case.id));
-
-        common::assert_token_summaries(&case.id, lexer.drain_tokens(), &case.tokens);
-        common::assert_diagnostic_codes(&case.id, lexer.diagnostics(), &case.diagnostics);
+        common::assert_lexer_case(
+            &case.id,
+            &mut lexer,
+            &case.input,
+            &case.tokens,
+            &case.diagnostics,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- extend the shared WHATWG lexer test helper to own case description checks and push/finish flow
- migrate generated boundary/recovery runner tests to use common case helpers
- document the shared case helper normalization path

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- git diff --check