### PR TITLE
spice: add PSS branch residuals

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- **PSS branch-current residuals** — `pss_residual` now includes one-period
+  branch-current closure alongside node-voltage closure.
+
 - **PSS residual convergence flag** — `pss_residual` now accepts a residual
   tolerance and reports whether one-period node closure is within tolerance.
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -294,6 +294,7 @@ class CornerSweepResult:
 class TransientPoint:
     time: float
     node_voltages: dict[str, float]
+    branch_currents: dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -326,6 +327,8 @@ class PssResidualResult:
     period: float
     time_step: float
     node_residuals: dict[str, float]
+    branch_residuals: dict[str, float]
+    max_abs_branch_residual: float
     max_abs_residual: float
     residual_tol: float
     within_tolerance: bool
@@ -2163,7 +2166,11 @@ def transient(
         return TransientResult(points=[], converged=False, method=method)
 
     points: list[TransientPoint] = [
-        TransientPoint(time=0.0, node_voltages=dict(op.node_voltages))
+        TransientPoint(
+            time=0.0,
+            node_voltages=dict(op.node_voltages),
+            branch_currents=dict(op.branch_currents),
+        )
     ]
 
     # ---- Reactive element history ------------------------------------------
@@ -2252,8 +2259,11 @@ def transient(
                 cap_voltages, cap_currents, ind_currents, ind_voltages,
             )
             cap_voltages_prev = dict(cap_voltages)
-            points.append(TransientPoint(time=t_actual,
-                                         node_voltages=dict(op.node_voltages)))
+            points.append(TransientPoint(
+                time=t_actual,
+                node_voltages=dict(op.node_voltages),
+                branch_currents=dict(op.branch_currents),
+            ))
 
             if lte < tol_lte / 8.0:
                 h = min(h * 2.0, _max_step)
@@ -2264,8 +2274,11 @@ def transient(
                 cap_voltages, cap_currents, ind_currents, ind_voltages,
             )
             cap_voltages_prev = dict(cap_voltages)
-            points.append(TransientPoint(time=t,
-                                         node_voltages=dict(op.node_voltages)))
+            points.append(TransientPoint(
+                time=t,
+                node_voltages=dict(op.node_voltages),
+                branch_currents=dict(op.branch_currents),
+            ))
 
         t += h
 
@@ -2309,24 +2322,37 @@ def pss_residual(
             period=period,
             time_step=time_step,
             node_residuals={},
+            branch_residuals={},
+            max_abs_branch_residual=0.0,
             max_abs_residual=0.0,
             residual_tol=residual_tol,
             within_tolerance=False,
             converged=False,
         )
 
-    start = result.points[0].node_voltages
-    end = result.points[-1].node_voltages
-    nodes = set(start) | set(end)
-    residuals = {
-        node: end.get(node, 0.0) - start.get(node, 0.0)
+    start_nodes = result.points[0].node_voltages
+    end_nodes = result.points[-1].node_voltages
+    nodes = set(start_nodes) | set(end_nodes)
+    node_residuals = {
+        node: end_nodes.get(node, 0.0) - start_nodes.get(node, 0.0)
         for node in sorted(nodes)
     }
-    max_abs = max((abs(value) for value in residuals.values()), default=0.0)
+    start_branches = result.points[0].branch_currents
+    end_branches = result.points[-1].branch_currents
+    branches = set(start_branches) | set(end_branches)
+    branch_residuals = {
+        branch: end_branches.get(branch, 0.0) - start_branches.get(branch, 0.0)
+        for branch in sorted(branches)
+    }
+    max_abs_node = max((abs(value) for value in node_residuals.values()), default=0.0)
+    max_abs_branch = max((abs(value) for value in branch_residuals.values()), default=0.0)
+    max_abs = max(max_abs_node, max_abs_branch)
     return PssResidualResult(
         period=period,
         time_step=time_step,
-        node_residuals=residuals,
+        node_residuals=node_residuals,
+        branch_residuals=branch_residuals,
+        max_abs_branch_residual=max_abs_branch,
         max_abs_residual=max_abs,
         residual_tol=residual_tol,
         within_tolerance=result.converged and max_abs <= residual_tol,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -224,6 +224,8 @@ def test_pss_residual_reports_one_period_node_closure() -> None:
     assert result.residual_tol == pytest.approx(1.0e-6)
     assert result.within_tolerance is True
     assert result.node_residuals["in"] == pytest.approx(0.0, abs=1.0e-12)
+    assert result.branch_residuals["I(V1)"] == pytest.approx(0.0, abs=1.0e-12)
+    assert result.max_abs_branch_residual == pytest.approx(0.0, abs=1.0e-12)
     assert result.max_abs_residual == pytest.approx(0.0, abs=1.0e-12)
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add branch-current closure residuals to `PssResidualResult` alongside
+  node-voltage residuals.
 - Add tolerance-aware PSS residual convergence reporting through
   `pss_residual_with_tolerance`, including `residual_tolerance` and
   `within_tolerance` on `PssResidualResult`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1671,6 +1671,8 @@ pub struct PssResidualResult {
     pub period_seconds: f64,
     pub time_step_seconds: f64,
     pub node_residuals: BTreeMap<String, f64>,
+    pub branch_residuals: BTreeMap<String, f64>,
+    pub max_abs_branch_residual: f64,
     pub max_abs_residual: f64,
     pub residual_tolerance: f64,
     pub within_tolerance: bool,
@@ -2687,6 +2689,8 @@ pub fn pss_residual_with_tolerance(
             period_seconds: period,
             time_step_seconds: time_step,
             node_residuals: BTreeMap::new(),
+            branch_residuals: BTreeMap::new(),
+            max_abs_branch_residual: 0.0,
             max_abs_residual: 0.0,
             residual_tolerance,
             within_tolerance: false,
@@ -2717,10 +2721,39 @@ pub fn pss_residual_with_tolerance(
         node_residuals.insert(node, residual);
     }
 
+    let mut branches: Vec<String> = initial_solution
+        .branch_currents
+        .keys()
+        .chain(last.branch_currents.keys())
+        .cloned()
+        .collect();
+    branches.sort();
+    branches.dedup();
+
+    let mut branch_residuals = BTreeMap::new();
+    let mut max_abs_branch_residual = 0.0;
+    for branch in branches {
+        let residual = last.branch_currents.get(&branch).copied().unwrap_or(0.0)
+            - initial_solution
+                .branch_currents
+                .get(&branch)
+                .copied()
+                .unwrap_or(0.0);
+        if residual.abs() > max_abs_branch_residual {
+            max_abs_branch_residual = residual.abs();
+        }
+        branch_residuals.insert(branch, residual);
+    }
+    if max_abs_branch_residual > max_abs_residual {
+        max_abs_residual = max_abs_branch_residual;
+    }
+
     Ok(Some(PssResidualResult {
         period_seconds: period,
         time_step_seconds: time_step,
         node_residuals,
+        branch_residuals,
+        max_abs_branch_residual,
         max_abs_residual,
         residual_tolerance,
         within_tolerance: max_abs_residual <= residual_tolerance,

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -121,6 +121,8 @@ fn pss_residual_reports_one_period_node_closure() {
     assert_close(result.residual_tolerance, 1.0e-6);
     assert!(result.within_tolerance);
     assert_close(*result.node_residuals.get("in").unwrap(), 0.0);
+    assert_close(*result.branch_residuals.get("I(V1)").unwrap(), 0.0);
+    assert_close(result.max_abs_branch_residual, 0.0);
     assert_close(result.max_abs_residual, 0.0);
 }
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add branch-current closure residuals to `pssResidual` results alongside
+  node-voltage residuals.
 - Add tolerance-aware PSS residual convergence reporting through
   `pssResidual`, including `residualTolerance` and `withinTolerance`.
 - Add PSS period-closure residual reporting with `pssResidual`, which runs one

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -596,6 +596,8 @@ export interface PssResidualResult {
   readonly periodSeconds: number;
   readonly timeStepSeconds: number;
   readonly nodeResiduals: ReadonlyMap<string, number>;
+  readonly branchResiduals: ReadonlyMap<string, number>;
+  readonly maxAbsBranchResidual: number;
   readonly maxAbsResidual: number;
   readonly residualTolerance: number;
   readonly withinTolerance: boolean;
@@ -1716,6 +1718,8 @@ export function pssResidual(
       periodSeconds: period,
       timeStepSeconds: timeStep,
       nodeResiduals: new Map(),
+      branchResiduals: new Map(),
+      maxAbsBranchResidual: 0.0,
       maxAbsResidual: 0.0,
       residualTolerance,
       withinTolerance: false,
@@ -1736,10 +1740,26 @@ export function pssResidual(
     nodeResiduals.set(node, residual);
     maxAbsResidual = Math.max(maxAbsResidual, Math.abs(residual));
   }
+  const branches = new Set<string>([
+    ...initialSolution.branchCurrents.keys(),
+    ...last.branchCurrents.keys(),
+  ]);
+  const branchResiduals = new Map<string, number>();
+  let maxAbsBranchResidual = 0.0;
+  for (const branch of [...branches].sort()) {
+    const residual =
+      (last.branchCurrents.get(branch) ?? 0.0) -
+      (initialSolution.branchCurrents.get(branch) ?? 0.0);
+    branchResiduals.set(branch, residual);
+    maxAbsBranchResidual = Math.max(maxAbsBranchResidual, Math.abs(residual));
+  }
+  maxAbsResidual = Math.max(maxAbsResidual, maxAbsBranchResidual);
   return {
     periodSeconds: period,
     timeStepSeconds: timeStep,
     nodeResiduals,
+    branchResiduals,
+    maxAbsBranchResidual,
     maxAbsResidual,
     residualTolerance,
     withinTolerance: maxAbsResidual <= residualTolerance,

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -118,6 +118,8 @@ describe("transient", () => {
     expectClose(result!.residualTolerance, 1.0e-6);
     expect(result!.withinTolerance).toBe(true);
     expectClose(result!.nodeResiduals.get("in"), 0.0);
+    expectClose(result!.branchResiduals.get("I(V1)"), 0.0);
+    expectClose(result!.maxAbsBranchResidual, 0.0);
     expectClose(result!.maxAbsResidual, 0.0);
   });
 

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -106,9 +106,9 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- PSS residual convergence checks across Python, TypeScript, and Rust SPICE
-  engines: one-period node-closure residuals now carry a tolerance and an
-  explicit in/out-of-tolerance decision as the next reusable stop condition for
+- PSS branch-current closure residuals across Python, TypeScript, and Rust
+  SPICE engines: one-period residuals now include branch-current closure
+  alongside node-voltage closure as the next residual-vector foothold for
   shooting-Newton periodic steady-state analysis.
 
 ---
@@ -131,7 +131,7 @@ and the sparse real solver path landed in PR #3391.
 | Feature | Design notes |
 |---|---|
 | **S-parameter extraction** | Two-port network characterisation. Run AC sweep, compute Y-parameters from node voltages and port currents, convert to S-parameters. Shipped in PR #3490. |
-| **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Source-period estimation for periodic `SIN` / `PULSE` waveforms shipped in PR #3524; one-period node-closure residual helpers shipped in PR #3534; tolerance-aware residual closure is in flight as the next stop-condition foothold. |
+| **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Source-period estimation for periodic `SIN` / `PULSE` waveforms shipped in PR #3524; one-period node-closure residual helpers shipped in PR #3534; tolerance-aware residual closure shipped in PR #3540; branch-current residual closure is in flight as the next residual-vector foothold. |
 | **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners shipped in PR #3516. |
 | **Mixed-signal coupling with `hardware-vm`** | AMS simulation — digital events feed into analog SPICE nodes and vice versa. Long-range project; `hardware-vm.md` spec describes the interface. |
 | **Verilog-A compact models** | Custom device models. Requires a Verilog-A parser (`code/specs/verilog-a-parser.md` is referenced but not written). |


### PR DESCRIPTION
## Summary
- Add one-period branch-current closure residuals to PSS residual results across Python, TypeScript, and Rust.
- Carry branch-current residuals into the max residual / tolerance decision alongside node-voltage residuals.
- Refresh the SPICE/MACSYMA pending-work notes now that PSS residual convergence landed in #3540.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pss-branch-residual sh BUILD` in `code/packages/python/spice-engine`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pss-branch-residual sh BUILD` in `code/packages/typescript/spice-engine`
- isolated `cargo test` copy of `code/packages/rust/spice-engine` because the sparse checkout intentionally omits unrelated workspace members
- `rustfmt code/packages/rust/spice-engine/src/lib.rs code/packages/rust/spice-engine/tests/transient_tests.rs`
- `git diff --check`
