### PR TITLE
Share HTML lexer fixture suite helpers

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -114,6 +114,8 @@ documented in this file.
   normalization.
 - Generated WHATWG boundary and recovery fixture runners now share case
   description and push/finish boilerplate through the same helper module.
+- Generated WHATWG boundary and recovery fixture runners now share suite
+  metadata assertions for format, description, case-count, and sentinel IDs.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -103,6 +103,8 @@ recovery, and diagnostic codes through one normalization path.
 Those helpers also own the repeated case description, push, and finish checks
 for generated boundary and recovery fixtures, keeping each runner focused on
 the lexer context it seeds.
+The same helper module centralizes generated suite metadata guards for format,
+description, case-count floor, and sentinel case IDs.
 The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup

--- a/code/packages/rust/html-lexer/tests/common/mod.rs
+++ b/code/packages/rust/html-lexer/tests/common/mod.rs
@@ -1,5 +1,31 @@
 use coding_adventures_html_lexer::{create_html_lexer, Attribute, Diagnostic, HtmlLexer, Token};
 
+pub fn assert_suite_metadata<'a, I>(
+    actual_format: &str,
+    description: &str,
+    case_ids: I,
+    expected_format: &str,
+    minimum_cases: usize,
+    required_case_ids: &[&str],
+) where
+    I: IntoIterator<Item = &'a str>,
+{
+    let case_ids = case_ids.into_iter().collect::<Vec<_>>();
+
+    assert_eq!(actual_format, expected_format);
+    assert!(!description.is_empty());
+    assert!(
+        case_ids.len() >= minimum_cases,
+        "fixture should include at least {minimum_cases} cases"
+    );
+    for required_case_id in required_case_ids {
+        assert!(
+            case_ids.contains(required_case_id),
+            "fixture should include case `{required_case_id}`"
+        );
+    }
+}
+
 pub fn assert_case_description(case_id: &str, description: &str, label: &str) {
     assert!(
         !description.is_empty(),

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_boundaries_test.rs
@@ -47,24 +47,18 @@ struct FixtureAttribute {
 fn whatwg_attribute_boundaries_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(
-        suite.format,
-        "whatwg-html-tokenizer-attribute-boundaries/v1"
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-attribute-boundaries/v1",
+        18,
+        &[
+            "attribute-name-null-replacement",
+            "after-attribute-value-quoted-missing-whitespace",
+            "self-closing-start-tag-reconsumes-attribute",
+        ],
     );
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 18);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "attribute-name-null-replacement"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "after-attribute-value-quoted-missing-whitespace"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "self-closing-start-tag-reconsumes-attribute"));
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_attribute_edges_test.rs
@@ -25,21 +25,18 @@ struct AttributeEdgeCase {
 fn whatwg_attribute_edge_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(suite.format, "whatwg-html-tokenizer-attribute-edges/v1");
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 25);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "duplicate-attributes-drop-later-name"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "unexpected-solidus-before-attribute"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "end-tag-with-attributes-and-trailing-solidus"));
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-attribute-edges/v1",
+        25,
+        &[
+            "duplicate-attributes-drop-later-name",
+            "unexpected-solidus-before-attribute",
+            "end-tag-with-attributes-and-trailing-solidus",
+        ],
+    );
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_cdata_boundaries_test.rs
@@ -30,21 +30,18 @@ struct CdataBoundaryCase {
 fn whatwg_cdata_boundaries_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(suite.format, "whatwg-html-tokenizer-cdata-boundaries/v1");
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 25);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "cdata-markup-stays-text"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "html-cdata-looking-declaration"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "seeded-cdata-end-eof"));
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-cdata-boundaries/v1",
+        25,
+        &[
+            "cdata-markup-stays-text",
+            "html-cdata-looking-declaration",
+            "seeded-cdata-end-eof",
+        ],
+    );
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_character_reference_boundaries_test.rs
@@ -37,24 +37,18 @@ struct CharacterReferenceBoundaryCase {
 fn whatwg_character_reference_boundaries_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(
-        suite.format,
-        "whatwg-html-tokenizer-character-reference-boundaries/v1"
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-character-reference-boundaries/v1",
+        40,
+        &[
+            "data-ambiguous-name-text",
+            "attribute-ambiguous-preserved",
+            "seeded-decimal-reference-rcdata",
+        ],
     );
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 40);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "data-ambiguous-name-text"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "attribute-ambiguous-preserved"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "seeded-decimal-reference-rcdata"));
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_comment_boundaries_test.rs
@@ -32,21 +32,18 @@ struct CommentBoundaryCase {
 fn whatwg_comment_boundaries_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(suite.format, "whatwg-html-tokenizer-comment-boundaries/v1");
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 45);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "comment-nested-looking-opener"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "comment-eof-end-bang"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "seeded-bogus-comment-eof"));
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-comment-boundaries/v1",
+        45,
+        &[
+            "comment-nested-looking-opener",
+            "comment-eof-end-bang",
+            "seeded-bogus-comment-eof",
+        ],
+    );
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_doctype_boundaries_test.rs
@@ -44,21 +44,18 @@ struct FixtureDoctypeSeed {
 fn whatwg_doctype_boundaries_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(suite.format, "whatwg-html-tokenizer-doctype-boundaries/v1");
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 40);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "doctype-public-system-missing-whitespace"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "doctype-bogus-null-discard"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "seeded-after-system-keyword-missing-whitespace"));
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-doctype-boundaries/v1",
+        40,
+        &[
+            "doctype-public-system-missing-whitespace",
+            "doctype-bogus-null-discard",
+            "seeded-after-system-keyword-missing-whitespace",
+        ],
+    );
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_eof_recovery_test.rs
@@ -54,14 +54,14 @@ struct FixtureDoctypeSeed {
 fn whatwg_eof_recovery_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(suite.format, "whatwg-html-tokenizer-eof-recovery/v1");
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 40);
-    assert!(suite.cases.iter().any(|case| case.id == "doctype-name"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "seeded-character-reference-rcdata"));
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-eof-recovery/v1",
+        40,
+        &["doctype-name", "seeded-character-reference-rcdata"],
+    );
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_markup_declarations_test.rs
@@ -54,21 +54,18 @@ struct FixtureDoctypeSeed {
 fn whatwg_markup_declaration_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(suite.format, "whatwg-html-tokenizer-markup-declarations/v1");
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 40);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "comment-nested-looking-opener"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "doctype-public-and-system-identifiers"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "seeded-bogus-doctype-close"));
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-markup-declarations/v1",
+        40,
+        &[
+            "comment-nested-looking-opener",
+            "doctype-public-and-system-identifiers",
+            "seeded-bogus-doctype-close",
+        ],
+    );
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_script_escape_boundaries_test.rs
@@ -33,24 +33,18 @@ struct ScriptEscapeBoundaryCase {
 fn whatwg_script_escape_boundaries_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(
-        suite.format,
-        "whatwg-html-tokenizer-script-escape-boundaries/v1"
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-script-escape-boundaries/v1",
+        40,
+        &[
+            "script-data-comment-eof",
+            "script-escaped-less-than-uppercase-script",
+            "script-double-escape-end-script",
+        ],
     );
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 40);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "script-data-comment-eof"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "script-escaped-less-than-uppercase-script"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "script-double-escape-end-script"));
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_tag_open_recovery_test.rs
@@ -25,21 +25,18 @@ struct TagOpenRecoveryCase {
 fn whatwg_tag_open_recovery_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(suite.format, "whatwg-html-tokenizer-tag-open-recovery/v1");
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 20);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "less-than-null-reconsumes-as-text"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "invalid-end-tag-digit-bogus-comment"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "eof-in-end-tag-attributes"));
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-tag-open-recovery/v1",
+        20,
+        &[
+            "less-than-null-reconsumes-as-text",
+            "invalid-end-tag-digit-bogus-comment",
+            "eof-in-end-tag-attributes",
+        ],
+    );
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_boundaries_test.rs
@@ -35,24 +35,18 @@ struct TextModeBoundaryCase {
 fn whatwg_text_mode_boundaries_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(
-        suite.format,
-        "whatwg-html-tokenizer-text-mode-boundaries/v1"
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-text-mode-boundaries/v1",
+        25,
+        &[
+            "rcdata-less-than-end-tag",
+            "rawtext-end-tag-name-self-closing-recovery",
+            "plaintext-markup-stays-text",
+        ],
     );
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 25);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "rcdata-less-than-end-tag"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "rawtext-end-tag-name-self-closing-recovery"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "plaintext-markup-stays-text"));
 }
 
 #[test]

--- a/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
+++ b/code/packages/rust/html-lexer/tests/whatwg_text_mode_delimiters_test.rs
@@ -54,20 +54,17 @@ struct FixtureDoctypeSeed {
 fn whatwg_text_mode_delimiter_fixture_parses() {
     let suite = load_suite();
 
-    assert_eq!(
-        suite.format,
-        "whatwg-html-tokenizer-text-mode-delimiters/v1"
+    common::assert_suite_metadata(
+        &suite.format,
+        &suite.description,
+        suite.cases.iter().map(|case| case.id.as_str()),
+        "whatwg-html-tokenizer-text-mode-delimiters/v1",
+        50,
+        &[
+            "rcdata-matching-end-tag",
+            "script-escaped-double-escape-start",
+        ],
     );
-    assert!(!suite.description.is_empty());
-    assert!(suite.cases.len() >= 50);
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "rcdata-matching-end-tag"));
-    assert!(suite
-        .cases
-        .iter()
-        .any(|case| case.id == "script-escaped-double-escape-start"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a shared HTML lexer fixture suite metadata assertion helper for generated WHATWG runners
- migrate boundary/recovery fixture parse tests to use one helper for format, description, case-count floors, and sentinel case IDs
- document the shared suite metadata guard alongside the existing generated fixture case helpers

## Validation
- rustfmt on touched html-lexer test files
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser (from code/packages/rust)
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
