### PR TITLE
Add Chief of Staff audit supervisor drain outcomes

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this package will be documented in this file.
   tick-budget exhaustion.
 - Supervisor drain run reports that keep read-only preflight plans beside the
   actual bounded drain result.
+- Scheduler-facing supervisor drain outcomes for idle, caught-up,
+  continuation, follow-up, and plan-divergence states.
 - Batch audit write summaries for host flush loops.
 - Replay helpers for loading queried audit rows into any `ToolAuditSink`.
 - `StorageToolAuditSink` for runtime audit emission through D18A storage with

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -31,6 +31,8 @@ The crate keeps the boundary narrow:
   tick-budget exhaustion for the next scheduler pass
 - supervisors can capture a preflight drain plan beside the actual bounded
   drain result, letting schedulers compare expected and delivered audit work
+- supervisor drain reports classify scheduler outcomes as idle, caught up,
+  needing continuation, needing follow-up, or diverged from preflight
 
 ## Development
 

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -870,6 +870,23 @@ pub struct ToolAuditSupervisorDrainRunReport {
 }
 
 impl ToolAuditSupervisorDrainRunReport {
+    /// Classify the drain run for scheduler decisions.
+    pub fn outcome(&self) -> ToolAuditSupervisorDrainRunOutcome {
+        if !self.matches_planned_record_count() {
+            return ToolAuditSupervisorDrainRunOutcome::PlanDiverged;
+        }
+        if self.requires_follow_up() {
+            return ToolAuditSupervisorDrainRunOutcome::NeedsFollowUp;
+        }
+        if self.should_continue() {
+            return ToolAuditSupervisorDrainRunOutcome::NeedsContinuation;
+        }
+        if self.made_progress() {
+            return ToolAuditSupervisorDrainRunOutcome::CaughtUp;
+        }
+        ToolAuditSupervisorDrainRunOutcome::Idle
+    }
+
     /// Return whether the actual run delivered the planned number of rows.
     pub fn matches_planned_record_count(&self) -> bool {
         self.plan.planned_records == self.drain.drained_records
@@ -909,6 +926,21 @@ impl ToolAuditSupervisorDrainRunReport {
     pub fn last_checkpoint(&self) -> Option<&ToolAuditReadCheckpoint> {
         self.drain.last_checkpoint()
     }
+}
+
+/// Scheduler-facing classification for a bounded supervisor drain run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolAuditSupervisorDrainRunOutcome {
+    /// No rows were waiting and the checkpoint stayed untouched.
+    Idle,
+    /// Rows were replayed and the drain reached the current end of the log.
+    CaughtUp,
+    /// The tick budget was exhausted before reaching the end of the log.
+    NeedsContinuation,
+    /// Planned or replayed rows contain follow-up pressure.
+    NeedsFollowUp,
+    /// The preflight plan and actual drain delivered different row counts.
+    PlanDiverged,
 }
 
 /// Payload-free summary for a batch audit write.
@@ -2331,6 +2363,10 @@ mod tests {
         assert!(report.should_continue());
         assert!(!report.reached_end_of_log());
         assert_eq!(
+            report.outcome(),
+            ToolAuditSupervisorDrainRunOutcome::NeedsContinuation
+        );
+        assert_eq!(
             report.last_checkpoint(),
             Some(&ToolAuditReadCheckpoint::new(120, "call_4"))
         );
@@ -2369,6 +2405,10 @@ mod tests {
         assert!(!report.exhausted_tick_budget());
         assert!(!report.should_continue());
         assert_eq!(
+            report.outcome(),
+            ToolAuditSupervisorDrainRunOutcome::NeedsFollowUp
+        );
+        assert_eq!(
             report.last_checkpoint(),
             Some(&ToolAuditReadCheckpoint::new(151, "call_3"))
         );
@@ -2399,9 +2439,53 @@ mod tests {
         assert!(!report.advanced_checkpoint());
         assert!(report.reached_end_of_log());
         assert!(!report.should_continue());
+        assert_eq!(report.outcome(), ToolAuditSupervisorDrainRunOutcome::Idle);
         assert!(report.last_checkpoint().is_some());
         assert!(sink.records().is_empty());
         assert!(store.fetch_checkpoint("supervisor").unwrap().is_none());
+    }
+
+    #[test]
+    fn supervisor_drain_report_outcome_reports_caught_up_progress() {
+        let store = ToolAuditStore::new(InMemoryStorageBackend::new());
+        assert!(store
+            .record_audit_batch(vec![sample_record("call_1"), sample_record("call_2")])
+            .completed_without_failures());
+
+        let mut sink = InMemoryToolAuditSink::new();
+        let report = store
+            .drain_supervisor_checkpoint_loop_with_plan("supervisor", 10, 2, &mut sink)
+            .unwrap();
+
+        assert!(report.matches_planned_record_count());
+        assert!(report.made_progress());
+        assert!(report.reached_end_of_log());
+        assert!(!report.requires_follow_up());
+        assert!(!report.should_continue());
+        assert_eq!(
+            report.outcome(),
+            ToolAuditSupervisorDrainRunOutcome::CaughtUp
+        );
+    }
+
+    #[test]
+    fn supervisor_drain_report_outcome_detects_plan_drift() {
+        let store = ToolAuditStore::new(InMemoryStorageBackend::new());
+        assert!(store
+            .record_audit_batch(vec![sample_record("call_1"), sample_record("call_2")])
+            .completed_without_failures());
+
+        let mut sink = InMemoryToolAuditSink::new();
+        let mut report = store
+            .drain_supervisor_checkpoint_loop_with_plan("supervisor", 10, 2, &mut sink)
+            .unwrap();
+        report.drain.drained_records += 1;
+
+        assert!(!report.matches_planned_record_count());
+        assert_eq!(
+            report.outcome(),
+            ToolAuditSupervisorDrainRunOutcome::PlanDiverged
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a scheduler-facing supervisor drain run outcome enum
- classify drain reports as idle, caught up, needing continuation, needing follow-up, or diverged from preflight
- document the outcome path and cover caught-up, continuation, follow-up, idle, and plan-drift cases

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD
- git diff --check