### PR TITLE
refactor(matrix): MX08 Phase 1 — split CpuMatrixBackend into sibling module (zero behaviour change)

### DIFF
--- a/code/packages/typescript/matrix/src/backends/cpu-pure-ts.ts
+++ b/code/packages/typescript/matrix/src/backends/cpu-pure-ts.ts
@@ -1,0 +1,56 @@
+/**
+ * # `cpu-pure-ts` — the original pure-TypeScript `CpuMatrixBackend`
+ *
+ * **MX08 Phase 1.**  Moved verbatim from `src/matrix.ts:51-73`.  Zero
+ * behaviour change.  This sibling module exists so MX08 Phase 2 can
+ * land a Node-only sibling (`cpu-rust-napi.ts`) that delegates to
+ * the `@coding-adventures/matrix-rust-napi` addon, while the browser
+ * keeps the pure-TS implementation via the conditional-exports
+ * pattern in `package.json`.
+ *
+ * The class implementation here is **identical** to what previously
+ * lived inline in `matrix.ts`:
+ *
+ * * `name = "cpu"` for backward-compatible identification (consumer
+ *   tests assert on this string).
+ * * Each method delegates straight to the corresponding `Matrix`
+ *   instance method (`left.add(right)`, etc.) — no fusion, no
+ *   buffer marshalling, no GPU lift.  Pure triple-loop arithmetic
+ *   on the `number[][]` storage that `Matrix` uses today.
+ *
+ * Re-exported from `matrix.ts` so existing imports
+ * (`import { CpuMatrixBackend } from "@coding-adventures/matrix"`)
+ * continue to resolve without source change.
+ */
+
+import type { Matrix, MatrixBackend } from "../matrix";
+
+/**
+ * Pure-TypeScript `CpuMatrixBackend`.  Identical to the
+ * implementation that previously lived inline in `matrix.ts:51-73`;
+ * the move is purely organisational so MX08 Phase 2 can introduce a
+ * Node-only sibling alongside.
+ */
+export class CpuMatrixBackend implements MatrixBackend {
+  readonly name = "cpu";
+
+  add(left: Matrix, right: Matrix): Matrix {
+    return left.add(right);
+  }
+
+  subtract(left: Matrix, right: Matrix): Matrix {
+    return left.subtract(right);
+  }
+
+  scale(matrix: Matrix, scalar: number): Matrix {
+    return matrix.scale(scalar);
+  }
+
+  transpose(matrix: Matrix): Matrix {
+    return matrix.transpose();
+  }
+
+  dot(left: Matrix, right: Matrix): Matrix {
+    return left.dot(right);
+  }
+}

--- a/code/packages/typescript/matrix/src/matrix.ts
+++ b/code/packages/typescript/matrix/src/matrix.ts
@@ -48,31 +48,18 @@ export interface MatrixBackend {
   dot(left: Matrix, right: Matrix): Matrix;
 }
 
-export class CpuMatrixBackend implements MatrixBackend {
-  readonly name = "cpu";
+// MX08 Phase 1 — `CpuMatrixBackend` has been moved verbatim into the
+// `./backends/cpu-pure-ts.ts` sibling module.  Re-exported here so
+// existing `import { CpuMatrixBackend } from "@coding-adventures/matrix"`
+// callers continue to work without source change.  MX08 Phase 2 will
+// add a Node-side sibling (`./backends/cpu-rust-napi.ts`) and a
+// package.json `exports` conditional that routes the right one per
+// environment.
+export { CpuMatrixBackend } from "./backends/cpu-pure-ts";
 
-  add(left: Matrix, right: Matrix): Matrix {
-    return left.add(right);
-  }
+import { CpuMatrixBackend as CpuMatrixBackendImpl } from "./backends/cpu-pure-ts";
 
-  subtract(left: Matrix, right: Matrix): Matrix {
-    return left.subtract(right);
-  }
-
-  scale(matrix: Matrix, scalar: number): Matrix {
-    return matrix.scale(scalar);
-  }
-
-  transpose(matrix: Matrix): Matrix {
-    return matrix.transpose();
-  }
-
-  dot(left: Matrix, right: Matrix): Matrix {
-    return left.dot(right);
-  }
-}
-
-const CPU_MATRIX_BACKEND = new CpuMatrixBackend();
+const CPU_MATRIX_BACKEND = new CpuMatrixBackendImpl();
 let activeMatrixBackend: MatrixBackend = CPU_MATRIX_BACKEND;
 
 export function getMatrixBackend(): MatrixBackend {


### PR DESCRIPTION
## Summary

- **MX08 Phase 1**: pure refactor. Moves the existing `CpuMatrixBackend` class verbatim from `src/matrix.ts:51-73` into a new `src/backends/cpu-pure-ts.ts` sibling module. Re-exports it from `matrix.ts` so existing `import { CpuMatrixBackend } from "@coding-adventures/matrix"` calls keep working without source change.
- **Zero behaviour change**: all 49 existing jest tests pass unchanged.
- **Why now**: MX08 Phase 2 (next PR in the chain) adds a Node-only sibling at `src/backends/cpu-rust-napi.ts` that delegates each `MatrixBackend` op into the `@coding-adventures/matrix-rust-napi` addon (landed across MX07 Phases 1-4). Splitting Phase 1 from that landing keeps each PR mechanical and reviewable.

## Test plan

- [x] `npx jest` — **49/49 pass** in `tests/matrix.test.ts` (unchanged from main)
- [x] No method signature changes
- [x] No timing / behaviour changes (`CpuMatrixBackend` is character-for-character identical, just in a new file)
- [x] No new dependencies
- [ ] CI: workspace build, 6 downstream package builds (cas-matrix, neural-graph-vm, single-layer-network, two-layer-network, blas-library, network-stack) should all keep passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)