### PR TITLE
feat(forme-collect-by-author): FM00 v0 §5.4 author collector

### DIFF
--- a/code/packages/typescript/forme-collect-by-author/BUILD
+++ b/code/packages/typescript/forme-collect-by-author/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-collect-by-author/CHANGELOG.md
+++ b/code/packages/typescript/forme-collect-by-author/CHANGELOG.md
@@ -1,0 +1,126 @@
+# Changelog — @coding-adventures/forme-collect-by-author
+
+## 0.1.0 — 2026-05-19
+
+Initial release.  Tenth FM00 v0 stage package — third concrete
+§5.4 collector (joins `forme-collect-chronological` and
+`forme-collect-by-tag`).  Groups documents by author for author
+archive pages.
+
+Mirrors `forme-collect-by-tag`'s shape but the `authorOf`
+accessor accepts `string | string[]` so co-author posts cleanly
+land in every contributor's bucket.
+
+### Added
+
+- `collectByAuthor<T>(items, options): { byAuthor, authorNames }`
+  — main entry.  Generic over the item type; only constraint is
+  caller-supplied `authorOf` accessor.
+- `normaliseAuthor(name): string` — exposed sub-helper.
+- `CollectByAuthorOptions<T>`, `CollectByAuthorResult<T>`,
+  `AuthorOf<T>` types.
+
+### Spec adherence
+
+Implements FM00 v0 §5.4 `collect-by-author`.  No spec
+divergences.
+
+### Behavioural notes
+
+- **`authorOf` shape.**  Returns `string | string[] | null |
+  undefined`.  `null` / `undefined` / `""` / `[]` are all
+  treated as anonymous.
+- **Co-author splitting.**  A post with
+  `authors: ["Ada", "Charles"]` appears in BOTH the `ada` and
+  `charles` buckets.  Same-author posts across single-author
+  and co-author shapes collide into one bucket via
+  normalisation.
+- **Per-item dedup.**  `["Ada", "ada", "ADA"]` inserts the
+  item into the `ada` bucket exactly once.  Done via a per-
+  item `Set<string>` of normalised keys.
+- **Hostile array elements defensively dropped.**  Non-string
+  entries (numbers, `null`, `undefined`, objects) and empty
+  strings in a co-author array are silently dropped — never
+  reach `normaliseAuthor`, never become bucket keys.
+- **Normalisation.**  Same single-pass `charCodeAt` slugifier
+  as `forme-collect-by-tag` and
+  `forme-transform-autolink-headings`.  Lowercase + strip
+  `[^a-z0-9 -]` + collapse runs + trim.  Output matches
+  `/^[a-z0-9-]*$/`.
+- **Anonymous policy.**  Default `includeAnonymous: false`.
+  Opt-in routes anonymous items to a bucket whose name
+  defaults to `"anonymous"` (overridable via
+  `anonymousBucketName`).
+- **Two output orderings.**  `byAuthor` Map iterates in
+  first-seen-bucket order; `authorNames` is alphabetically
+  sorted.  Both exposed because either alone forces callers to
+  redo work.
+
+### Security posture
+
+Four concerns explicitly addressed (pre-push review):
+
+- **Prototype pollution.**  `Map` / `Set` used throughout —
+  never plain-Object property assignment.  Tag `__proto__`
+  becomes bucket key `"proto"` (underscores stripped); even an
+  attacker bypassing the normaliser cannot pollute
+  `Object.prototype` because `Map` keys live in an internal
+  slot.  Two test cases pin this.
+- **HTML metacharacter injection.**  `normaliseAuthor` strips
+  everything except `[a-z0-9 -]`; bucket keys are safe to
+  interpolate into archive URLs / HTML attributes without
+  escaping.
+- **Hostile co-author array entries.**  Non-string entries
+  (`null`, `undefined`, numbers, objects) dropped before
+  normalisation — they never become bucket keys.  Test pinned.
+- **No regex / ReDoS.**  Single-pass `charCodeAt` loop —
+  zero backtracking surface.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, network, fs, shell, env.
+
+### Tests
+
+56 tests across 2 files:
+
+- `normalise.test.ts` (22) — basic shape (lowercase, hyphen
+  replacement, run collapse, trim, digit preservation,
+  idempotence); security (angle brackets, quotes, ampersand,
+  control bytes, underscores → `__proto__` becomes `proto`,
+  non-ASCII CJK / emoji → empty, path-traversal sequences);
+  output always matches `/^[a-z0-9-]*$/`; empty / whitespace /
+  punctuation-only / non-ASCII-only fallback; defensive
+  non-string coercion; deterministic.
+- `collect.test.ts` (34) — basic grouping (Map by normalised
+  key, case variants merge, anonymous dropped by default,
+  co-author items in every bucket); string vs array accessor
+  (single-string author handled, single-element array, co-
+  author split into multiple buckets, non-string array
+  elements dropped defensively including `null`/`undefined`/
+  numbers, empty strings dropped); sorted `authorNames` parity;
+  within-bucket sort (default input-order, sortBy newest-first,
+  applied to every bucket); anonymous policy (off by default,
+  opt-in via `null`/`undefined`/all-stripped, custom name,
+  explicit off); per-item dedup (same-key inserts once,
+  different-key separate buckets); prototype-pollution defence
+  (`__proto__` tag AND synthetic bypass, `constructor`);
+  purity / determinism (no input mutation, no co-author array
+  mutation, byte-identical output, fresh buckets, `byAuthor`
+  first-seen vs `authorNames` alphabetical, empty input);
+  authors-normalising-to-empty drop policy.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only declarations).
+
+### v0 simplifications (documented)
+
+- **No author identity reconciliation.**  `Ada Lovelace` and
+  `Ada Augusta King, Countess of Lovelace` are unrelated
+  buckets.  Reconciliation belongs at the manifest layer.
+- **No primary-vs-secondary author distinction.**  Co-authors
+  are equal; the item appears in every bucket equally.
+- **No author-count summaries / popular-authors cap.**  Caller
+  computes / slices themselves.
+- **No locale-aware case folding.**  Always
+  `String.prototype.toLowerCase()`.

--- a/code/packages/typescript/forme-collect-by-author/README.md
+++ b/code/packages/typescript/forme-collect-by-author/README.md
@@ -1,0 +1,194 @@
+# @coding-adventures/forme-collect-by-author
+
+Group an array of documents by author for author archive pages.
+FM00 v0 §5.4 collector.
+
+Pure transform: items + `authorOf` accessor (returns
+`string | string[] | null | undefined`) → `Map<normalisedAuthor,
+items[]>` plus a sorted `authorNames` list.  Mirrors
+[`forme-collect-by-tag`](../forme-collect-by-tag)'s shape but
+accepts co-author arrays so posts with multiple contributors
+land in every author's bucket.
+
+Tenth FM00 v0 stage package — joins the FM00 v0 cluster.
+
+## Quick start
+
+```ts
+import { collectByAuthor } from "@coding-adventures/forme-collect-by-author";
+
+const { byAuthor, authorNames } = collectByAuthor(posts, {
+  authorOf: (p) => p.author ?? p.authors,
+  sortBy: (a, b) => b.pubDate.localeCompare(a.pubDate),  // newest first
+  includeAnonymous: true,
+});
+
+for (const author of authorNames) {
+  const items = byAuthor.get(author)!;
+  renderAuthorArchive(author, items);
+}
+```
+
+## Single author vs co-authors
+
+The `authorOf` accessor returns either form:
+
+```ts
+authorOf: (p) => p.author              // "Ada Lovelace"
+authorOf: (p) => p.authors             // ["Ada", "Charles"]
+authorOf: (p) => p.author ?? p.authors // mix of both shapes in your data
+```
+
+A post with `authors: ["Ada", "Charles"]` appears in BOTH the
+`ada` and `charles` buckets.  Same author across co-author and
+single-author posts collide into one bucket — same case /
+punctuation normalisation as
+[`forme-collect-by-tag`](../forme-collect-by-tag).
+
+## Why a separate collector?
+
+Same reason `forme-collect-by-tag` exists separately from
+`forme-transforms.groupBy`: author archive pages are a common
+enough site feature that they deserve a typed, validated,
+security-hardened helper.  Splitting authors from tags avoids
+forcing one shape onto callers — many posts have one author but
+many tags; treating them with the same accessor would make the
+API noisy.
+
+## API
+
+### `collectByAuthor(items, options): { byAuthor, authorNames }`
+
+Generic over `T`.  Options:
+
+```ts
+interface CollectByAuthorOptions<T> {
+  readonly authorOf: (item: T) => string | readonly string[] | null | undefined;
+  readonly sortBy?: (a: T, b: T) => number;
+  readonly includeAnonymous?: boolean;        // default false
+  readonly anonymousBucketName?: string;      // default "anonymous"
+}
+```
+
+Returns:
+
+```ts
+interface CollectByAuthorResult<T> {
+  readonly byAuthor: ReadonlyMap<string, readonly T[]>;
+  readonly authorNames: readonly string[];    // alphabetically sorted
+}
+```
+
+### `normaliseAuthor(name): string`
+
+Exposed sub-helper.  Same single-pass character-loop slugifier
+used in `forme-collect-by-tag` and
+`forme-transform-autolink-headings`.
+
+- Lowercase
+- Strip ASCII control bytes
+- Drop everything outside `[a-z0-9 -]`
+- Collapse whitespace + hyphen runs
+- Trim leading/trailing hyphens
+- Empty input or all-stripped → empty string
+
+Output guarantees: matches `/^[a-z0-9-]*$/`; safe to
+interpolate into HTML attributes / URL slugs without escaping.
+
+## Behavioural contract
+
+| Aspect                          | Behaviour                              |
+|---------------------------------|----------------------------------------|
+| Input items array               | Never mutated                          |
+| Co-author arrays                | Never mutated                          |
+| Output buckets                  | Fresh arrays per call                  |
+| Output map storage              | `Map` (not plain `Object`)             |
+| Single-string author            | Single bucket                          |
+| Co-author array                 | One bucket per author; item in each    |
+| Non-string array elements       | Dropped defensively                    |
+| Empty string in array           | Dropped                                |
+| Per-item dedup                  | Same normalised key inserts item once  |
+| Authors normalising to empty    | Silently dropped                       |
+| `null` / `undefined` / `""` / `[]` author | Treated as anonymous       |
+| Anonymous items                 | Drop by default; opt-in via `includeAnonymous` |
+| Within-bucket order             | Input order; `sortBy` overrides        |
+| `byAuthor` iteration order      | First-seen-bucket order                |
+| `authorNames` order             | Alphabetically sorted                  |
+
+## Reproducibility (FM03)
+
+Same `items` + same `authorOf` + same `sortBy` → byte-identical
+output.
+
+## Security posture
+
+Four concerns explicitly addressed (pre-push review):
+
+- **Prototype pollution via attacker author names.**  `Map` /
+  `Set` used throughout — never plain-Object property
+  assignment.  `__proto__` becomes `"proto"` (underscores
+  stripped); even an attacker bypassing the normaliser cannot
+  pollute `Object.prototype` because `Map` keys live in an
+  internal slot.  Test pins both vectors.
+- **HTML metacharacter injection.**  `normaliseAuthor` strips
+  everything except `[a-z0-9 -]`; bucket keys are safe to
+  interpolate into archive URLs / HTML attributes without
+  escaping.
+- **Co-author array hostile inputs.**  Non-string entries
+  (`null`, `undefined`, numbers, objects) and empty strings in
+  a co-author array are silently dropped — they never reach
+  `normaliseAuthor`, never become bucket keys.  Pinned by the
+  "non-string array elements" test.
+- **No regex / ReDoS.**  Single-pass `charCodeAt` loop —
+  trivially passes CodeQL polynomial-regex analysis.
+
+## Capabilities — `[]`
+
+Pure transform.  No I/O, no network, no shell, no env, no fs.
+
+## Tests
+
+56 tests across 2 files:
+
+- `normalise.test.ts` (22) — basic shape, security (angle
+  brackets, quotes, ampersand, control bytes, underscores
+  including `__proto__`, non-ASCII CJK/emoji, path-traversal),
+  output regex guarantee, empty/whitespace/punctuation-only
+  fallback, defensive non-string coercion, deterministic.
+- `collect.test.ts` (34) — basic grouping (Map by normalised
+  key, case variants merge, anonymous dropped by default,
+  co-author items in every bucket), string vs array accessor
+  (single-string, single-element array, co-author split,
+  non-string array elements dropped, empty strings dropped),
+  sorted `authorNames`, within-bucket sort, anonymous bucket
+  policy (off by default, opt-in via `null`/`undefined`/empty/
+  all-stripped, custom name, explicit off), per-item dedup
+  (same-key inserts once, different-key separate buckets),
+  prototype-pollution defence (normalised + bypass paths,
+  `constructor`), purity / determinism (no input mutation, no
+  co-author array mutation, byte-identical output, fresh
+  buckets, first-seen vs alphabetical, empty input),
+  authors-normalising-to-empty drop policy.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only).
+
+## Spec adherence
+
+Implements FM00 v0 §5.4 `collect-by-author`.  No spec
+divergences.
+
+## v0 simplifications
+
+- **No author identity reconciliation.**  Different spellings
+  of the same author (`Ada Lovelace` vs `Ada Augusta King,
+  Countess of Lovelace`) get separate buckets.  Reconciliation
+  is a manifest-level concern, not a collector concern.
+- **No primary-vs-secondary author distinction.**  Co-authors
+  are equal; the item appears in every bucket equally.  A
+  future v1 might expose a `primaryAuthor` field separately.
+- **No author-count summaries / popular-authors cap.**  Caller
+  computes `byAuthor.get(author)!.length` and slices
+  `authorNames` themselves.
+- **No locale-aware case folding.**  Always `String.prototype.
+  toLowerCase()`.  Matches the rest of the FM00 v0 cluster.

--- a/code/packages/typescript/forme-collect-by-author/package-lock.json
+++ b/code/packages/typescript/forme-collect-by-author/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-collect-by-author",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-collect-by-author",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-collect-by-author/package.json
+++ b/code/packages/typescript/forme-collect-by-author/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-collect-by-author",
+  "version": "0.1.0",
+  "description": "Group an array of documents by author for author archive pages.  Pure transform: items + authorOf accessor (string | string[]) → Map<normalisedAuthor, items[]> + sorted authorNames list.  Supports co-author arrays (item appears in each author's bucket).  Same normalisation as forme-collect-by-tag.  FM00 v0 §5.4 collector.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-collect-by-author/required_capabilities.json
+++ b/code/packages/typescript/forme-collect-by-author/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-collect-by-author",
+  "capabilities": [],
+  "justification": "Pure transform: items + authorOf accessor → Map<normalisedAuthor, items[]>.  Caller-supplied author accessor; pure data grouping with normalisation.  No I/O, no network, no env, no shell, no fs.  Same posture as the rest of the FM00 v0 stage cluster."
+}

--- a/code/packages/typescript/forme-collect-by-author/src/collect.ts
+++ b/code/packages/typescript/forme-collect-by-author/src/collect.ts
@@ -1,0 +1,144 @@
+/**
+ * collect.ts — the main `collectByAuthor` entry point.
+ *
+ * Mirrors `collectByTag` from `forme-collect-by-tag` but
+ * accepts an `authorOf` accessor that may return either a
+ * single string OR a string array (co-authors).  The string
+ * case is treated as a single-element array internally.
+ *
+ * Algorithm:
+ *
+ *   1. For each input item:
+ *        a. Call `authorOf(item)`.
+ *        b. Normalise to an array of raw author strings.
+ *           - `null` / `undefined` → `[]`
+ *           - `"name"` → `["name"]`
+ *           - `["name1", "name2"]` → as-is
+ *        c. For each raw name: normalise to bucket key.
+ *           Skip empty results.
+ *        d. Push the item into each (deduped per-item) bucket.
+ *        e. If the item is anonymous AND `includeAnonymous` is
+ *           true, push into the synthetic anonymous bucket.
+ *   2. After all items are bucketed:
+ *        a. Sort items within each bucket via `sortBy` if
+ *           supplied.
+ *        b. Compute `authorNames`: alphabetically-sorted array
+ *           of all bucket keys.
+ *
+ * Per-item dedup is critical for co-authors who appear under
+ * multiple spellings: `["Ada Lovelace", "ada lovelace"]` both
+ * normalise to `"ada-lovelace"`, but the item should appear in
+ * that bucket only once.
+ *
+ * @module collect
+ */
+
+import { normaliseAuthor } from "./normalise.js";
+import type { CollectByAuthorOptions, CollectByAuthorResult } from "./types.js";
+
+/**
+ * Group `items` by author.
+ *
+ * ```ts
+ * const result = collectByAuthor(posts, {
+ *   authorOf: (p) => p.author ?? p.authors,
+ *   sortBy: (a, b) => b.pubDate.localeCompare(a.pubDate),
+ *   includeAnonymous: true,
+ * });
+ *
+ * for (const author of result.authorNames) {
+ *   const items = result.byAuthor.get(author)!;
+ *   // render author archive page...
+ * }
+ * ```
+ *
+ * Reproducibility: same `items` + same `authorOf` + same
+ * `sortBy` → byte-identical output.
+ *
+ * Input `items` array is never mutated.  Output buckets are
+ * fresh arrays.
+ */
+export function collectByAuthor<T>(
+  items: readonly T[],
+  options: CollectByAuthorOptions<T>,
+): CollectByAuthorResult<T> {
+  const includeAnonymous = options.includeAnonymous === true;
+  const anonymousName = options.anonymousBucketName ?? "anonymous";
+
+  // Map<bucketKey, items[]> — uses Map (not Object) so attacker
+  // author names like `__proto__` cannot pollute Object.prototype.
+  const byAuthor = new Map<string, T[]>();
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]!;
+    const raw = options.authorOf(item);
+    const rawList = normaliseToList(raw);
+
+    // Compute the set of normalised bucket keys for THIS item.
+    // Set deduplicates within-item collisions like
+    // `["Ada", "ada"]` (both → "ada").
+    const seen = new Set<string>();
+    for (let j = 0; j < rawList.length; j++) {
+      const key = normaliseAuthor(rawList[j]!);
+      if (key === "") continue;  // unrenderable author — drop silently
+      seen.add(key);
+    }
+
+    if (seen.size === 0) {
+      // Anonymous: null / undefined / [] / "" / all-stripped.
+      if (includeAnonymous) {
+        addToBucket(byAuthor, anonymousName, item);
+      }
+      continue;
+    }
+
+    for (const key of seen) {
+      addToBucket(byAuthor, key, item);
+    }
+  }
+
+  // Sort within each bucket if a comparator was supplied.
+  if (options.sortBy) {
+    const cmp = options.sortBy;
+    for (const bucket of byAuthor.values()) {
+      bucket.sort(cmp);
+    }
+  }
+
+  // Deterministic alphabetical author-name list.
+  const authorNames = [...byAuthor.keys()].sort();
+
+  return { byAuthor, authorNames };
+}
+
+/**
+ * Internal: coerce the accessor's return value to a uniform
+ * `readonly string[]`.  Single string becomes a one-element
+ * array; null/undefined become an empty array.  Non-string
+ * array elements are dropped defensively (someone passing
+ * `[null, "Ada"]` shouldn't crash the collector).
+ */
+function normaliseToList(value: string | readonly string[] | null | undefined): readonly string[] {
+  if (value === null || value === undefined) return [];
+  if (typeof value === "string") return value === "" ? [] : [value];
+  // Array case — filter non-strings defensively.
+  const out: string[] = [];
+  for (let i = 0; i < value.length; i++) {
+    const v = value[i];
+    if (typeof v === "string" && v !== "") out.push(v);
+  }
+  return out;
+}
+
+/**
+ * Internal helper: append `item` to `byAuthor[key]`, creating
+ * the bucket if absent.
+ */
+function addToBucket<T>(byAuthor: Map<string, T[]>, key: string, item: T): void {
+  const existing = byAuthor.get(key);
+  if (existing) {
+    existing.push(item);
+  } else {
+    byAuthor.set(key, [item]);
+  }
+}

--- a/code/packages/typescript/forme-collect-by-author/src/index.ts
+++ b/code/packages/typescript/forme-collect-by-author/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @coding-adventures/forme-collect-by-author
+ *
+ * FM00 v0 §5.4 collector — group documents by author.
+ *
+ * Pure transform: items array + `authorOf` accessor → Map
+ * keyed by normalised author bucket → items sorted within each
+ * bucket.  Mirrors `forme-collect-by-tag` but the accessor
+ * accepts `string | string[]` so co-author posts cleanly land
+ * in every contributor's bucket.
+ *
+ * ```ts
+ * import { collectByAuthor } from "@coding-adventures/forme-collect-by-author";
+ *
+ * const { byAuthor, authorNames } = collectByAuthor(posts, {
+ *   authorOf: (p) => p.author ?? p.authors,
+ *   sortBy: (a, b) => b.pubDate.localeCompare(a.pubDate),
+ *   includeAnonymous: true,
+ * });
+ *
+ * for (const author of authorNames) {
+ *   const archivePage = renderAuthorArchive(author, byAuthor.get(author)!);
+ * }
+ * ```
+ *
+ * Tenth FM00 v0 stage package — joins `forme-feeds`,
+ * `forme-opengraph`, `forme-index-renderer`, `forme-transforms`,
+ * `forme-transform-autolink-headings`, `forme-transform-toc`,
+ * `forme-transform-typography`,
+ * `forme-transform-internal-links`, `forme-collect-by-tag`.
+ *
+ * @module index
+ */
+
+export { collectByAuthor } from "./collect.js";
+export { normaliseAuthor } from "./normalise.js";
+export type {
+  CollectByAuthorOptions,
+  CollectByAuthorResult,
+  AuthorOf,
+} from "./types.js";

--- a/code/packages/typescript/forme-collect-by-author/src/normalise.ts
+++ b/code/packages/typescript/forme-collect-by-author/src/normalise.ts
@@ -1,0 +1,86 @@
+/**
+ * normalise.ts — author-string normalisation.
+ *
+ * Identical algorithm to `forme-collect-by-tag`'s `normaliseTag`
+ * — lowercase + slug-strip via a single-pass `charCodeAt` loop.
+ * Why the duplicate copy here instead of a shared sub-package?
+ * The collector packages are intentionally standalone so a
+ * caller can pull `forme-collect-by-author` without dragging
+ * `forme-collect-by-tag` into their dependency graph.  The
+ * 50-line normaliser is small enough that the duplication is
+ * cheaper than a third "forme-slug" package.
+ *
+ * If both packages ever need to coordinate on tweaks to the
+ * normalisation rules, factor out a shared `forme-slug` package
+ * at that point.
+ *
+ * Substitutions:
+ *
+ *   1. Lowercase.
+ *   2. Strip ASCII control bytes (`\x00-\x1F`, `\x7F`).
+ *   3. Walk char-by-char:
+ *        - Keep `[a-z0-9]`.
+ *        - Collapse `[\t\n\r -]` runs to single `-`.
+ *        - Drop everything else (punctuation, underscores,
+ *          non-ASCII, quotes, angle brackets, ampersand).
+ *   4. Trim trailing `-`.
+ *   5. Empty → empty.  Caller-empty input signals "anonymous".
+ *
+ * Output guarantee: `/^[a-z0-9-]*$/`; safe to interpolate into
+ * HTML attributes / URL slugs without escaping.
+ *
+ * @module normalise
+ */
+
+// Character codes (named for readability).
+const CC_DIGIT_0 = 48;
+const CC_DIGIT_9 = 57;
+const CC_LOWER_A = 97;
+const CC_LOWER_Z = 122;
+const CC_SPACE = 32;
+const CC_HYPHEN = 45;
+const CC_TAB = 9;
+const CC_LF = 10;
+const CC_CR = 13;
+
+/**
+ * Normalise one author name to its canonical bucket key.
+ *
+ * ```
+ * normaliseAuthor("Ada Lovelace")     → "ada-lovelace"
+ * normaliseAuthor("AdaLovelace")      → "adalovelace"
+ * normaliseAuthor("ada lovelace")     → "ada-lovelace"
+ * normaliseAuthor("  Ada  ")          → "ada"
+ * normaliseAuthor("<script>")         → "script"
+ * normaliseAuthor("日本語")           → ""
+ * normaliseAuthor("")                 → ""
+ * ```
+ *
+ * Complexity: O(n) in input length.  No regex, no backtracking.
+ */
+export function normaliseAuthor(name: string): string {
+  const s = String(name).toLowerCase();
+  const out: string[] = [];
+  let lastHyphen = true;  // suppress leading hyphen
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (
+      (c >= CC_LOWER_A && c <= CC_LOWER_Z) ||
+      (c >= CC_DIGIT_0 && c <= CC_DIGIT_9)
+    ) {
+      out.push(s[i]!);
+      lastHyphen = false;
+    } else if (
+      c === CC_SPACE || c === CC_HYPHEN ||
+      c === CC_TAB || c === CC_LF || c === CC_CR
+    ) {
+      if (!lastHyphen) {
+        out.push("-");
+        lastHyphen = true;
+      }
+    }
+    // Everything else dropped.
+  }
+  if (out.length > 0 && out[out.length - 1] === "-") out.pop();
+  return out.join("");
+}

--- a/code/packages/typescript/forme-collect-by-author/src/types.ts
+++ b/code/packages/typescript/forme-collect-by-author/src/types.ts
@@ -1,0 +1,69 @@
+/**
+ * types.ts — public signatures for the author collector.
+ *
+ * Mirrors `forme-collect-by-tag` but the accessor surface is
+ * subtly different: an item commonly has a single primary author
+ * (`author: "Ada Lovelace"`) but may also have co-authors
+ * (`authors: ["Ada", "Charles"]`).  The `authorOf` accessor
+ * returns either form so the collector can handle both without
+ * forcing callers to normalise upstream.
+ *
+ * @module types
+ */
+
+/**
+ * Accessor used by `collectByAuthor` to pull the author name(s)
+ * off an item.  Should be pure (same item → same authors every
+ * call) for the collector's output to be deterministic.
+ *
+ * Return shape:
+ *   - `string` — single author (most common case).
+ *   - `readonly string[]` — co-authors (each gets its own
+ *     bucket; the item appears in every author's bucket).
+ *   - `null` / `undefined` — anonymous (no author).
+ *   - empty `""` or `[]` — also anonymous (no meaningful name).
+ *
+ * The collector treats `null` / `undefined` / `""` / `[]`
+ * identically: the item is anonymous.  Whether anonymous items
+ * appear in the output depends on
+ * `CollectByAuthorOptions.includeAnonymous`.
+ */
+export type AuthorOf<T> = (item: T) => string | readonly string[] | null | undefined;
+
+/**
+ * Options controlling the grouping behaviour.
+ *
+ *   - `authorOf` (required) — see `AuthorOf`.
+ *   - `sortBy` (optional) — comparator used to sort items WITHIN
+ *     each bucket.  Defaults to "preserve input order".  Common
+ *     choice: newest-first by publication date.
+ *   - `includeAnonymous` (optional, default `false`) — when
+ *     `true`, items with no author land in a special bucket
+ *     whose key is `anonymousBucketName`.
+ *   - `anonymousBucketName` (optional, default `"anonymous"`) —
+ *     the synthetic bucket name for items with no author.
+ */
+export interface CollectByAuthorOptions<T> {
+  readonly authorOf: AuthorOf<T>;
+  readonly sortBy?: (a: T, b: T) => number;
+  readonly includeAnonymous?: boolean;
+  readonly anonymousBucketName?: string;
+}
+
+/**
+ * Result of `collectByAuthor`.
+ *
+ *   - `byAuthor` — `Map<normalisedAuthor, items[]>`.  Iteration
+ *     order is first-seen-author order (matches input traversal).
+ *   - `authorNames` — alphabetically-sorted array of all bucket
+ *     names.  Useful for "browse all authors" navigation
+ *     widgets.
+ *
+ * Why both?  `byAuthor` preserves input-traversal ordering;
+ * `authorNames` is the deterministic-alphabetical view.  Either
+ * alone would force callers to redo work.
+ */
+export interface CollectByAuthorResult<T> {
+  readonly byAuthor: ReadonlyMap<string, readonly T[]>;
+  readonly authorNames: readonly string[];
+}

--- a/code/packages/typescript/forme-collect-by-author/tests/collect.test.ts
+++ b/code/packages/typescript/forme-collect-by-author/tests/collect.test.ts
@@ -1,0 +1,291 @@
+/**
+ * collect.test.ts — collectByAuthor end-to-end behaviour.
+ */
+
+import { describe, it, expect } from "vitest";
+import { collectByAuthor } from "../src/index.js";
+
+interface Post {
+  id: string;
+  title: string;
+  author?: string;
+  authors?: readonly string[];
+  pubDate?: string;
+}
+
+const POSTS: Post[] = [
+  { id: "a", title: "A", author: "Ada Lovelace", pubDate: "2026-01-15" },
+  { id: "b", title: "B", author: "ada lovelace", pubDate: "2026-02-20" },
+  { id: "c", title: "C", authors: ["Ada Lovelace", "Charles Babbage"], pubDate: "2025-12-01" },
+  { id: "d", title: "D" },                       // no author
+  { id: "e", title: "E", author: "" },           // empty author
+  { id: "f", title: "F", authors: [] },          // empty co-author array
+];
+
+const authorOf = (p: Post): string | readonly string[] | null | undefined =>
+  p.author ?? p.authors;
+
+describe("collectByAuthor — basic grouping", () => {
+  it("groups by normalised author", () => {
+    const { byAuthor } = collectByAuthor(POSTS, { authorOf });
+    expect(byAuthor.has("ada-lovelace")).toBe(true);
+    expect(byAuthor.has("charles-babbage")).toBe(true);
+  });
+
+  it("merges case/punctuation variants into one bucket", () => {
+    const { byAuthor } = collectByAuthor(POSTS, { authorOf });
+    const ada = byAuthor.get("ada-lovelace")!;
+    expect(ada.map((p) => p.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("anonymous items dropped by default", () => {
+    const { byAuthor, authorNames } = collectByAuthor(POSTS, { authorOf });
+    expect(authorNames.includes("anonymous")).toBe(false);
+    expect(byAuthor.has("anonymous")).toBe(false);
+  });
+
+  it("co-authored item appears in every co-author's bucket", () => {
+    const { byAuthor } = collectByAuthor(POSTS, { authorOf });
+    // Post 'c' has Ada + Charles → in both buckets.
+    expect(byAuthor.get("ada-lovelace")!.some((p) => p.id === "c")).toBe(true);
+    expect(byAuthor.get("charles-babbage")!.some((p) => p.id === "c")).toBe(true);
+  });
+});
+
+describe("collectByAuthor — string vs array accessor", () => {
+  it("single-string author handled", () => {
+    const items = [{ id: "x", title: "X", author: "Solo" }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.author });
+    expect(byAuthor.get("solo")!.length).toBe(1);
+  });
+
+  it("array author handled (single element)", () => {
+    const items = [{ id: "x", title: "X", authors: ["Solo"] }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.authors });
+    expect(byAuthor.get("solo")!.length).toBe(1);
+  });
+
+  it("co-author array splits into multiple buckets", () => {
+    const items = [{ id: "x", title: "X", authors: ["A", "B", "C"] }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.authors });
+    expect(byAuthor.size).toBe(3);
+    expect(byAuthor.get("a")!.length).toBe(1);
+    expect(byAuthor.get("b")!.length).toBe(1);
+    expect(byAuthor.get("c")!.length).toBe(1);
+  });
+
+  it("non-string array elements dropped defensively", () => {
+    // Some loose-typed manifest might mix in nulls; we shouldn't
+    // crash and we shouldn't normalise them to "null".
+    const items = [{ id: "x", title: "X" }];
+    const { byAuthor } = collectByAuthor(items, {
+      authorOf: () => ["Ada", null, undefined, 42, "Charles"] as unknown as string[],
+    });
+    expect(byAuthor.size).toBe(2);
+    expect(byAuthor.has("ada")).toBe(true);
+    expect(byAuthor.has("charles")).toBe(true);
+    expect(byAuthor.has("null")).toBe(false);
+    expect(byAuthor.has("undefined")).toBe(false);
+    expect(byAuthor.has("42")).toBe(false);
+  });
+
+  it("empty string in array dropped", () => {
+    const items = [{ id: "x", title: "X" }];
+    const { byAuthor } = collectByAuthor(items, {
+      authorOf: () => ["", "Ada"],
+    });
+    expect(byAuthor.size).toBe(1);
+    expect(byAuthor.has("ada")).toBe(true);
+  });
+});
+
+describe("collectByAuthor — sorted authorNames", () => {
+  it("authorNames is alphabetically sorted", () => {
+    const { authorNames } = collectByAuthor(POSTS, { authorOf });
+    expect(authorNames).toEqual([...authorNames].sort());
+  });
+
+  it("authorNames length matches byAuthor.size", () => {
+    const { byAuthor, authorNames } = collectByAuthor(POSTS, { authorOf });
+    expect(authorNames.length).toBe(byAuthor.size);
+  });
+});
+
+describe("collectByAuthor — within-bucket sort", () => {
+  it("default: preserve input order", () => {
+    const { byAuthor } = collectByAuthor(POSTS, { authorOf });
+    // ada-lovelace bucket: a (input idx 0) → b (idx 1) → c (idx 2)
+    expect(byAuthor.get("ada-lovelace")!.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("sortBy comparator sorts within each bucket", () => {
+    const { byAuthor } = collectByAuthor(POSTS, {
+      authorOf,
+      sortBy: (a, b) => (b.pubDate ?? "").localeCompare(a.pubDate ?? ""),
+    });
+    // newest-first within ada-lovelace: b (2026-02) → a (2026-01) → c (2025-12)
+    expect(byAuthor.get("ada-lovelace")!.map((p) => p.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("sortBy applied to every bucket", () => {
+    const { byAuthor } = collectByAuthor(POSTS, {
+      authorOf,
+      sortBy: (a, b) => a.id.localeCompare(b.id),
+    });
+    for (const bucket of byAuthor.values()) {
+      const ids = bucket.map((p) => p.id);
+      expect(ids).toEqual([...ids].sort());
+    }
+  });
+});
+
+describe("collectByAuthor — anonymous bucket", () => {
+  it("includeAnonymous: true creates the bucket", () => {
+    const { byAuthor, authorNames } = collectByAuthor(POSTS, { authorOf, includeAnonymous: true });
+    expect(byAuthor.has("anonymous")).toBe(true);
+    expect(authorNames).toContain("anonymous");
+  });
+
+  it("anonymous bucket contains items with no author field", () => {
+    const { byAuthor } = collectByAuthor(POSTS, { authorOf, includeAnonymous: true });
+    const anon = byAuthor.get("anonymous")!;
+    expect(anon.map((p) => p.id).sort()).toEqual(["d", "e", "f"]);
+  });
+
+  it("anonymousBucketName option overrides", () => {
+    const { byAuthor } = collectByAuthor(POSTS, {
+      authorOf,
+      includeAnonymous: true,
+      anonymousBucketName: "no-byline",
+    });
+    expect(byAuthor.has("anonymous")).toBe(false);
+    expect(byAuthor.has("no-byline")).toBe(true);
+  });
+
+  it("authorOf returning null treated as anonymous", () => {
+    const items = [{ id: "x" }];
+    const { byAuthor } = collectByAuthor(items, {
+      authorOf: () => null,
+      includeAnonymous: true,
+    });
+    expect(byAuthor.get("anonymous")!.length).toBe(1);
+  });
+
+  it("authorOf returning undefined treated as anonymous", () => {
+    const items = [{ id: "x" }];
+    const { byAuthor } = collectByAuthor(items, {
+      authorOf: () => undefined,
+      includeAnonymous: true,
+    });
+    expect(byAuthor.get("anonymous")!.length).toBe(1);
+  });
+
+  it("includeAnonymous: false explicit also drops", () => {
+    const { byAuthor } = collectByAuthor(POSTS, { authorOf, includeAnonymous: false });
+    expect(byAuthor.has("anonymous")).toBe(false);
+  });
+
+  it("all-stripped names treated as anonymous when includeAnonymous=true", () => {
+    const items = [{ id: "x", title: "X", author: "夏目漱石" }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.author, includeAnonymous: true });
+    expect(byAuthor.get("anonymous")!.length).toBe(1);
+  });
+});
+
+describe("collectByAuthor — per-item dedup", () => {
+  it("same author multiple times in co-author array dedups", () => {
+    const items = [{ id: "x", title: "X", authors: ["Ada", "ada", "ADA"] }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.authors });
+    expect(byAuthor.get("ada")!.length).toBe(1);
+  });
+
+  it("different-normalised co-authors get separate buckets", () => {
+    const items = [{ id: "x", title: "X", authors: ["Ada Lovelace", "Charles Babbage"] }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.authors });
+    expect(byAuthor.get("ada-lovelace")!.length).toBe(1);
+    expect(byAuthor.get("charles-babbage")!.length).toBe(1);
+  });
+});
+
+describe("collectByAuthor — prototype pollution defence", () => {
+  it("'__proto__' author normalises to 'proto' and lands in its own bucket", () => {
+    const items = [{ id: "x", title: "X", author: "__proto__" }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.author });
+    expect(byAuthor.has("proto")).toBe(true);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("attacker-key bypass also safe (Map storage)", () => {
+    const items = [{ id: "x", title: "X" }];
+    const { byAuthor } = collectByAuthor(items, {
+      authorOf: () => "__proto__-literally",
+    });
+    expect(byAuthor.has("proto-literally")).toBe(true);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("'constructor' author normalised + Map-stored", () => {
+    const items = [{ id: "x", title: "X", author: "constructor" }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.author });
+    expect(byAuthor.has("constructor")).toBe(true);
+  });
+});
+
+describe("collectByAuthor — purity / determinism", () => {
+  it("does not mutate input items array", () => {
+    const before = JSON.stringify(POSTS);
+    collectByAuthor(POSTS, { authorOf, sortBy: (a, b) => a.id.localeCompare(b.id) });
+    expect(JSON.stringify(POSTS)).toBe(before);
+  });
+
+  it("does not mutate co-author arrays", () => {
+    const item: Post = { id: "x", title: "X", authors: ["B", "A"] };
+    collectByAuthor([item], { authorOf: (p) => p.authors });
+    expect(item.authors).toEqual(["B", "A"]);  // unchanged order
+  });
+
+  it("same input → byte-identical output", () => {
+    const a = collectByAuthor(POSTS, { authorOf });
+    const b = collectByAuthor(POSTS, { authorOf });
+    expect(JSON.stringify([...a.byAuthor.entries()])).toBe(JSON.stringify([...b.byAuthor.entries()]));
+    expect(a.authorNames).toEqual(b.authorNames);
+  });
+
+  it("output buckets are fresh arrays", () => {
+    const a = collectByAuthor(POSTS, { authorOf });
+    const b = collectByAuthor(POSTS, { authorOf });
+    expect(a.byAuthor.get("ada-lovelace")).not.toBe(b.byAuthor.get("ada-lovelace"));
+  });
+
+  it("byAuthor Map iteration order matches first-seen-bucket order", () => {
+    const items: Post[] = [
+      { id: "1", title: "1", author: "Zelda" },
+      { id: "2", title: "2", author: "Apollo" },
+      { id: "3", title: "3", author: "Mercury" },
+    ];
+    const { byAuthor, authorNames } = collectByAuthor(items, { authorOf });
+    expect([...byAuthor.keys()]).toEqual(["zelda", "apollo", "mercury"]);
+    expect(authorNames).toEqual(["apollo", "mercury", "zelda"]);
+  });
+
+  it("empty input → empty result", () => {
+    const { byAuthor, authorNames } = collectByAuthor([], { authorOf });
+    expect(byAuthor.size).toBe(0);
+    expect(authorNames).toEqual([]);
+  });
+});
+
+describe("collectByAuthor — authors that normalise to empty are dropped", () => {
+  it("author of '@@@' doesn't create a bucket", () => {
+    const items = [{ id: "x", title: "X", author: "@@@" }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.author });
+    expect(byAuthor.size).toBe(0);
+  });
+
+  it("mix of valid + empty author names: only valid one creates bucket", () => {
+    const items = [{ id: "x", title: "X", authors: ["@@@", "Ada"] }];
+    const { byAuthor } = collectByAuthor(items, { authorOf: (p) => p.authors });
+    expect(byAuthor.size).toBe(1);
+    expect(byAuthor.get("ada")!.length).toBe(1);
+  });
+});

--- a/code/packages/typescript/forme-collect-by-author/tests/normalise.test.ts
+++ b/code/packages/typescript/forme-collect-by-author/tests/normalise.test.ts
@@ -1,0 +1,113 @@
+/**
+ * normalise.test.ts — author-string normalisation rules.
+ */
+
+import { describe, it, expect } from "vitest";
+import { normaliseAuthor } from "../src/index.js";
+
+describe("normaliseAuthor — basic", () => {
+  it("lowercases", () => {
+    expect(normaliseAuthor("Ada Lovelace")).toBe("ada-lovelace");
+  });
+
+  it("collapses multi-space", () => {
+    expect(normaliseAuthor("Ada   Lovelace")).toBe("ada-lovelace");
+  });
+
+  it("keeps digits (e.g. 'John Doe III' loses III to numerals)", () => {
+    expect(normaliseAuthor("John 2nd")).toBe("john-2nd");
+  });
+
+  it("trims leading/trailing hyphens", () => {
+    expect(normaliseAuthor("-Ada-")).toBe("ada");
+  });
+
+  it("trims leading/trailing whitespace", () => {
+    expect(normaliseAuthor("  Ada  ")).toBe("ada");
+  });
+
+  it("collapses adjacent hyphens", () => {
+    expect(normaliseAuthor("Ada---Lovelace")).toBe("ada-lovelace");
+  });
+
+  it("idempotent: normaliseAuthor(normaliseAuthor(x)) === normaliseAuthor(x)", () => {
+    for (const input of ["Ada Lovelace", "Foo!!Bar", "  x  "]) {
+      const once = normaliseAuthor(input);
+      expect(normaliseAuthor(once)).toBe(once);
+    }
+  });
+});
+
+describe("normaliseAuthor — security hardening", () => {
+  it("strips angle brackets", () => {
+    expect(normaliseAuthor("<script>")).toBe("script");
+  });
+
+  it("strips quotes", () => {
+    expect(normaliseAuthor(`Ada "Bytes" Lovelace`)).toBe("ada-bytes-lovelace");
+  });
+
+  it("strips ampersand", () => {
+    expect(normaliseAuthor("Ada & Charles")).toBe("ada-charles");
+  });
+
+  it("strips control bytes", () => {
+    expect(normaliseAuthor("Ada\x00\x1b\x7fLovelace")).toBe("adalovelace");
+  });
+
+  it("strips underscores (so '__proto__' becomes 'proto')", () => {
+    expect(normaliseAuthor("__proto__")).toBe("proto");
+  });
+
+  it("strips non-ASCII (CJK / emoji)", () => {
+    expect(normaliseAuthor("夏目漱石")).toBe("");
+    expect(normaliseAuthor("🎉")).toBe("");
+  });
+
+  it("strips path-traversal sequences", () => {
+    expect(normaliseAuthor("../../etc")).toBe("etc");
+  });
+
+  it("output always matches /^[a-z0-9-]*$/", () => {
+    const cases = ["<x>", "Ada & Charles", `"q"`, "../x", "\x00\x01", "夏目漱石"];
+    for (const c of cases) {
+      expect(normaliseAuthor(c)).toMatch(/^[a-z0-9-]*$/);
+    }
+  });
+});
+
+describe("normaliseAuthor — empty / collapsed input", () => {
+  it("empty string → empty", () => {
+    expect(normaliseAuthor("")).toBe("");
+  });
+
+  it("whitespace-only → empty", () => {
+    expect(normaliseAuthor("   ")).toBe("");
+  });
+
+  it("punctuation-only → empty", () => {
+    expect(normaliseAuthor("!!!")).toBe("");
+  });
+
+  it("non-ASCII-only → empty", () => {
+    expect(normaliseAuthor("夏目漱石")).toBe("");
+  });
+});
+
+describe("normaliseAuthor — defensive coercion", () => {
+  it("non-string coerces via String(...)", () => {
+    // @ts-expect-error — runtime coercion
+    expect(normaliseAuthor(42)).toBe("42");
+  });
+
+  it("null → 'null'", () => {
+    // @ts-expect-error — runtime coercion
+    expect(normaliseAuthor(null)).toBe("null");
+  });
+});
+
+describe("normaliseAuthor — deterministic", () => {
+  it("same input → same output", () => {
+    expect(normaliseAuthor("Ada Lovelace")).toBe(normaliseAuthor("Ada Lovelace"));
+  });
+});

--- a/code/packages/typescript/forme-collect-by-author/tsconfig.json
+++ b/code/packages/typescript/forme-collect-by-author/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-collect-by-author/vitest.config.ts
+++ b/code/packages/typescript/forme-collect-by-author/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Tenth FM00 v0 stage package — third concrete §5.4 collector (joins [`forme-collect-chronological`](../forme-collect-chronological) and [`forme-collect-by-tag`](../forme-collect-by-tag)). Pure transform: items + `authorOf` accessor → `Map<normalisedAuthor, items[]>` plus sorted `authorNames`.

Mirrors `forme-collect-by-tag`'s shape but the accessor accepts `string | string[] | null | undefined` so co-author posts cleanly land in every contributor's bucket.

```ts
import { collectByAuthor } from "@coding-adventures/forme-collect-by-author";

const { byAuthor, authorNames } = collectByAuthor(posts, {
  authorOf: (p) => p.author ?? p.authors,            // string OR string[]
  sortBy: (a, b) => b.pubDate.localeCompare(a.pubDate),
  includeAnonymous: true,
});
```

Joins the FM00 v0 cluster.

## Single vs co-author

`authorOf` returns either form. Post with `authors: ["Ada", "Charles"]` appears in BOTH the `ada` and `charles` buckets. Same author across single + co-author shapes collide via normalisation.

## Hostile-input handling

Co-author arrays in real-world manifests can be sloppy. The collector defensively drops:
- Non-string entries (`null`, `undefined`, numbers, objects) — never reach `normaliseAuthor`
- Empty strings
- Authors that normalise to empty (e.g. `"@@@"` or `"日本語"`)

Items whose authors ALL normalise to empty are treated as anonymous.

## Security

Four concerns addressed pre-push:

- **Prototype pollution** — `Map<string, T[]>` storage. Attacker author `__proto__` cannot pollute `Object.prototype`. Tests pin both normalised path (`__proto__` → `proto`) and synthetic bypass.
- **HTML metacharacter stripping** — whitelist `[a-z0-9-]` only.
- **Hostile co-author array entries** — `normaliseToList` requires `typeof v === "string" && v !== ""` before passing to normaliser. Pinned test feeds `[null, undefined, 42, "Ada"]` and asserts only `ada` bucket exists.
- **Zero regex / ReDoS** — single-pass `charCodeAt` loop.

Security review (general-purpose sub-agent): **no exploitable findings**.

## Capabilities

`[]` — pure transform.

## Tests

**56 tests across 2 files**, **100% line / 100% branch** coverage:

- `normalise.test.ts` (22) — basic shape, security (angle brackets, quotes, ampersand, control bytes, underscores including `__proto__`, non-ASCII, path-traversal), output regex guarantee, empty fallback, defensive non-string coercion
- `collect.test.ts` (34) — basic grouping with case-variant merging, string vs array accessor (single, single-elem array, co-author split, non-string elements dropped, empty strings dropped), sorted `authorNames` parity, within-bucket sort, anonymous policy matrix (off default / `null` / `undefined` / `[]` / all-stripped / custom name / explicit off), per-item dedup, prototype-pollution defence (normalised + bypass + `constructor`), purity / determinism / fresh buckets / first-seen vs alphabetical / empty input, authors-normalising-to-empty drop policy

## Spec adherence

Implements FM00 v0 §5.4 `collect-by-author`. No spec divergences.

## v0 simplifications

- No author identity reconciliation
- No primary-vs-secondary author distinction (co-authors equal)
- No author-count summaries / popular caps
- No locale-aware case folding

## Test plan

- [x] All 56 tests pass locally
- [x] 100% line / 100% branch coverage
- [x] TypeScript build clean
- [x] Zero regex in `src/`
- [x] Security review clean
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)