### PR TITLE
spice: add PSS residual vector norms

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **PSS residual vector norms** — `pss_residual` now reports L2 and RMS
+  norms over the ordered node-then-branch residual vector for future
+  shooting-Newton convergence checks.
+
 - **PSS ordered residual vector** — `pss_residual` now exposes a stable
   node-then-branch residual vector for future shooting-Newton solves.
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -340,6 +340,8 @@ class PssResidualResult:
     residual_vector: list[PssResidualEntry]
     max_abs_branch_residual: float
     max_abs_residual: float
+    residual_l2_norm: float
+    residual_rms_norm: float
     residual_tol: float
     within_tolerance: bool
     converged: bool
@@ -2336,6 +2338,8 @@ def pss_residual(
             residual_vector=[],
             max_abs_branch_residual=0.0,
             max_abs_residual=0.0,
+            residual_l2_norm=0.0,
+            residual_rms_norm=0.0,
             residual_tol=residual_tol,
             within_tolerance=False,
             converged=False,
@@ -2369,6 +2373,14 @@ def pss_residual(
     max_abs_node = max((abs(value) for value in node_residuals.values()), default=0.0)
     max_abs_branch = max((abs(value) for value in branch_residuals.values()), default=0.0)
     max_abs = max(max_abs_node, max_abs_branch)
+    residual_l2_norm = math.sqrt(
+        sum(entry.value * entry.value for entry in residual_vector)
+    )
+    residual_rms_norm = (
+        residual_l2_norm / math.sqrt(len(residual_vector))
+        if residual_vector
+        else 0.0
+    )
     return PssResidualResult(
         period=period,
         time_step=time_step,
@@ -2377,6 +2389,8 @@ def pss_residual(
         residual_vector=residual_vector,
         max_abs_branch_residual=max_abs_branch,
         max_abs_residual=max_abs,
+        residual_l2_norm=residual_l2_norm,
+        residual_rms_norm=residual_rms_norm,
         residual_tol=residual_tol,
         within_tolerance=result.converged and max_abs <= residual_tol,
         converged=result.converged,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -235,6 +235,14 @@ def test_pss_residual_reports_one_period_node_closure() -> None:
     )
     assert result.max_abs_branch_residual == pytest.approx(0.0, abs=1.0e-12)
     assert result.max_abs_residual == pytest.approx(0.0, abs=1.0e-12)
+    expected_l2_norm = math.sqrt(
+        sum(entry.value * entry.value for entry in result.residual_vector)
+    )
+    assert result.residual_l2_norm == pytest.approx(expected_l2_norm, abs=1.0e-12)
+    assert result.residual_rms_norm == pytest.approx(
+        expected_l2_norm / math.sqrt(len(result.residual_vector)),
+        abs=1.0e-12,
+    )
 
 
 def test_pss_residual_requires_periodic_sources() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add L2 and RMS norms over the ordered PSS residual vector for future
+  shooting-Newton convergence checks.
 - Add a stable node-then-branch residual vector to `PssResidualResult` as the
   next state-vector foothold for shooting-Newton PSS solves.
 - Add branch-current closure residuals to `PssResidualResult` alongside

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1682,6 +1682,8 @@ pub struct PssResidualResult {
     pub residual_vector: Vec<PssResidualEntry>,
     pub max_abs_branch_residual: f64,
     pub max_abs_residual: f64,
+    pub residual_l2_norm: f64,
+    pub residual_rms_norm: f64,
     pub residual_tolerance: f64,
     pub within_tolerance: bool,
 }
@@ -2701,6 +2703,8 @@ pub fn pss_residual_with_tolerance(
             residual_vector: Vec::new(),
             max_abs_branch_residual: 0.0,
             max_abs_residual: 0.0,
+            residual_l2_norm: 0.0,
+            residual_rms_norm: 0.0,
             residual_tolerance,
             within_tolerance: false,
         }));
@@ -2767,6 +2771,16 @@ pub fn pss_residual_with_tolerance(
     if max_abs_branch_residual > max_abs_residual {
         max_abs_residual = max_abs_branch_residual;
     }
+    let residual_l2_norm = residual_vector
+        .iter()
+        .map(|entry| entry.value * entry.value)
+        .sum::<f64>()
+        .sqrt();
+    let residual_rms_norm = if residual_vector.is_empty() {
+        0.0
+    } else {
+        residual_l2_norm / (residual_vector.len() as f64).sqrt()
+    };
 
     Ok(Some(PssResidualResult {
         period_seconds: period,
@@ -2776,6 +2790,8 @@ pub fn pss_residual_with_tolerance(
         residual_vector,
         max_abs_branch_residual,
         max_abs_residual,
+        residual_l2_norm,
+        residual_rms_norm,
         residual_tolerance,
         within_tolerance: max_abs_residual <= residual_tolerance,
     }))

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -130,6 +130,17 @@ fn pss_residual_reports_one_period_node_closure() {
     assert_close(result.residual_vector[1].value, 0.0);
     assert_close(result.max_abs_branch_residual, 0.0);
     assert_close(result.max_abs_residual, 0.0);
+    let expected_l2_norm = result
+        .residual_vector
+        .iter()
+        .map(|entry| entry.value * entry.value)
+        .sum::<f64>()
+        .sqrt();
+    assert_close(result.residual_l2_norm, expected_l2_norm);
+    assert_close(
+        result.residual_rms_norm,
+        expected_l2_norm / (result.residual_vector.len() as f64).sqrt(),
+    );
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add L2 and RMS norms over the ordered PSS residual vector for future
+  shooting-Newton convergence checks.
 - Add a stable node-then-branch residual vector to `pssResidual` as the next
   state-vector foothold for shooting-Newton PSS solves.
 - Add branch-current closure residuals to `pssResidual` results alongside

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -606,6 +606,8 @@ export interface PssResidualResult {
   readonly residualVector: readonly PssResidualEntry[];
   readonly maxAbsBranchResidual: number;
   readonly maxAbsResidual: number;
+  readonly residualL2Norm: number;
+  readonly residualRmsNorm: number;
   readonly residualTolerance: number;
   readonly withinTolerance: boolean;
 }
@@ -1729,6 +1731,8 @@ export function pssResidual(
       residualVector: [],
       maxAbsBranchResidual: 0.0,
       maxAbsResidual: 0.0,
+      residualL2Norm: 0.0,
+      residualRmsNorm: 0.0,
       residualTolerance,
       withinTolerance: false,
     };
@@ -1769,6 +1773,13 @@ export function pssResidual(
     maxAbsBranchResidual = Math.max(maxAbsBranchResidual, Math.abs(residual));
   }
   maxAbsResidual = Math.max(maxAbsResidual, maxAbsBranchResidual);
+  const residualL2Norm = Math.sqrt(
+    residualVector.reduce((sum, entry) => sum + entry.value * entry.value, 0.0),
+  );
+  const residualRmsNorm =
+    residualVector.length > 0
+      ? residualL2Norm / Math.sqrt(residualVector.length)
+      : 0.0;
   return {
     periodSeconds: period,
     timeStepSeconds: timeStep,
@@ -1777,6 +1788,8 @@ export function pssResidual(
     residualVector,
     maxAbsBranchResidual,
     maxAbsResidual,
+    residualL2Norm,
+    residualRmsNorm,
     residualTolerance,
     withinTolerance: maxAbsResidual <= residualTolerance,
   };

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -127,6 +127,11 @@ describe("transient", () => {
     expectClose(result!.residualVector[1].value, 0.0);
     expectClose(result!.maxAbsBranchResidual, 0.0);
     expectClose(result!.maxAbsResidual, 0.0);
+    const expectedL2Norm = Math.sqrt(
+      result!.residualVector.reduce((sum, entry) => sum + entry.value * entry.value, 0.0),
+    );
+    expectClose(result!.residualL2Norm, expectedL2Norm);
+    expectClose(result!.residualRmsNorm, expectedL2Norm / Math.sqrt(result!.residualVector.length));
   });
 
   it("does not report a PSS residual without a periodic source period", () => {

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -106,10 +106,9 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- PSS ordered residual vectors across Python, TypeScript, and Rust SPICE
-  engines: one-period node and branch-current residuals are now exposed in a
-  stable state-vector order as the next foothold for shooting-Newton periodic
-  steady-state analysis.
+- PSS residual vector norms across Python, TypeScript, and Rust SPICE engines:
+  ordered residual vectors have landed, and this follow-up exposes L2 and RMS
+  norms as solver-facing convergence metrics.
 
 ---
 
@@ -131,7 +130,7 @@ and the sparse real solver path landed in PR #3391.
 | Feature | Design notes |
 |---|---|
 | **S-parameter extraction** | Two-port network characterisation. Run AC sweep, compute Y-parameters from node voltages and port currents, convert to S-parameters. Shipped in PR #3490. |
-| **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Source-period estimation for periodic `SIN` / `PULSE` waveforms shipped in PR #3524; one-period node-closure residual helpers shipped in PR #3534; tolerance-aware residual closure shipped in PR #3540; branch-current residual closure shipped in PR #3553; ordered residual vectors are in flight as the next state-vector foothold. |
+| **Periodic steady-state (PSS)** | RF / oscillator analysis. Shooting-Newton method: find the initial condition `x(0)` such that `x(T) = x(0)`. Source-period estimation for periodic `SIN` / `PULSE` waveforms shipped in PR #3524; one-period node-closure residual helpers shipped in PR #3534; tolerance-aware residual closure shipped in PR #3540; branch-current residual closure shipped in PR #3553; ordered residual vectors shipped in PR #3560; residual vector norms are in flight as the next convergence-metric foothold. |
 | **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners shipped in PR #3516. |
 | **Mixed-signal coupling with `hardware-vm`** | AMS simulation — digital events feed into analog SPICE nodes and vice versa. Long-range project; `hardware-vm.md` spec describes the interface. |
 | **Verilog-A compact models** | Custom device models. Requires a Verilog-A parser (`code/specs/verilog-a-parser.md` is referenced but not written). |


### PR DESCRIPTION
## Summary
- Add L2 and RMS norms over the ordered PSS residual vector in Python, TypeScript, and Rust.
- Keep the existing max-norm tolerance behavior intact while exposing solver-facing convergence metrics for future shooting-Newton work.
- Refresh the SPICE/MACSYMA pending-work notes now that #3560 landed and residual vector norms are the active PSS foothold.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pss-residual-norm sh BUILD` in `code/packages/python/spice-engine`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pss-residual-norm sh BUILD` in `code/packages/typescript/spice-engine`
- isolated `cargo test` copy of `code/packages/rust/spice-engine` because this slice only needs the package-local Rust crate
- `rustfmt code/packages/rust/spice-engine/src/lib.rs code/packages/rust/spice-engine/tests/transient_tests.rs`
- `git diff --check`