### PR TITLE
Share HTML lexer fixture generator IO

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -17,6 +17,8 @@ documented in this file.
   the crate links static source instead of loading TOML at runtime.
 - Fixture-backed tests proving the generated lexer definition and emitted
   runtime tokens stay aligned.
+- Shared JSON fixture IO helpers keep generated WHATWG boundary and recovery
+  fixture writers on the same stable `--check` path.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -105,6 +105,9 @@ for generated boundary and recovery fixtures, keeping each runner focused on
 the lexer context it seeds.
 The same helper module centralizes generated suite metadata guards for format,
 description, case-count floor, and sentinel case IDs.
+The fixture generator scripts also share JSON fixture IO helpers, so `--check`
+mode, stale-file diagnostics, sorted output, and UTF-8 preservation stay
+consistent across generated WHATWG boundary and recovery fixtures.
 The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-attribute-boundaries.json")
@@ -15,15 +16,7 @@ DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-attribute-boundaries.json")
 def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
-    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        if output.read_text() != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, build_fixture(), check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-cdata-boundaries.json")
@@ -15,15 +16,7 @@ DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-cdata-boundaries.json")
 def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
-    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        if output.read_text() != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, build_fixture(), check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name(
@@ -17,15 +18,7 @@ DEFAULT_OUTPUT = Path(__file__).with_name(
 def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
-    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        if output.read_text() != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, build_fixture(), check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py
@@ -12,8 +12,9 @@ seeded parser continuation contexts.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-comment-boundaries.json")
@@ -23,16 +24,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py
@@ -11,8 +11,9 @@ NULL replacement, force-quirks handling, and seeded continuation contexts.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-doctype-boundaries.json")
@@ -22,16 +23,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-script-escape-boundaries.json")
@@ -15,15 +16,7 @@ DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-script-escape-boundaries.json"
 def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
-    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        if output.read_text() != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, build_fixture(), check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py
@@ -11,8 +11,9 @@ NULL replacement in tag names, and EOF recovery for partial tag tokens.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-tag-open-recovery.json")
@@ -22,16 +23,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-text-mode-boundaries.json")
@@ -15,15 +16,7 @@ DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-text-mode-boundaries.json")
 def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
-    text = json.dumps(build_fixture(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        if output.read_text() != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, build_fixture(), check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py
@@ -12,8 +12,9 @@ seeded end-tag continuation states.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-text-mode-delimiters.json")
@@ -127,16 +128,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generated_fixture_io.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generated_fixture_io.py
@@ -1,0 +1,19 @@
+"""Shared JSON IO helpers for checked-in HTML lexer fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_fixture_json(output: Path, fixture: dict[str, Any], *, check: bool) -> int:
+    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+    if check:
+        if output.read_text() != text:
+            raise SystemExit(f"{output} is stale; regenerate it")
+        return 0
+
+    output.write_text(text)
+    return 0


### PR DESCRIPTION
## Summary
- add a shared JSON fixture IO helper for generated HTML lexer WHATWG fixtures
- route the active boundary and recovery generator scripts through the shared `--check`/write path
- document the generator helper in the html-lexer README and changelog

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/generated_fixture_io.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py