### PR TITLE
feat(forme-aot-sitemap-emitter): FM00 v0 sitemap.xml emitter

### DIFF
--- a/code/packages/typescript/forme-aot-sitemap-emitter/BUILD
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-sitemap-emitter/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/CHANGELOG.md
@@ -1,0 +1,146 @@
+# Changelog — @coding-adventures/forme-aot-sitemap-emitter
+
+## 0.1.0 — 2026-05-19
+
+Initial release.  Eleventh FM00 v0 stage package — sitemap.xml
+emitter per https://www.sitemaps.org/protocol.html.
+
+Pure transform: `SitemapEntry[]` + `baseUrl` → XML string.
+Validation pass runs BEFORE emission so callers never see a
+partial sitemap on error.
+
+### Added
+
+- `generateSitemap(entries, baseUrl): string` — main entry.
+  Returns the complete XML document.  Throws `TypeError`
+  synchronously if `baseUrl` isn't `http(s)://`, any entry
+  `url` isn't `http(s)://` / root-relative, or any entry
+  `changefreq` isn't in the allowlist.
+- `escapeXml(s)` / `stripInvalidXml(s)` — XML 1.0 entity
+  escape + C0 control strip, same single-pass character-class
+  pattern as `forme-feeds`.
+- `normaliseBaseUrl(baseUrl)` — validates http(s)://, trims
+  trailing slash.
+- `resolveEntryUrl(url, normalisedBase)` — per-entry URL
+  validator + joiner.
+- `validateChangefreq(value)` — allowlist check; returns
+  lowercased value.
+- `clampPriority(value)` — clamps to `[0.0, 1.0]`, formats
+  with one decimal place.  NaN → `"0.5"` (spec default).
+- `SitemapEntry`, `ChangeFreq` types.
+
+### Spec adherence
+
+Implements the sitemaps.org XML protocol.  No spec
+divergences.
+
+### Behavioural notes
+
+- **URL accept set.**  `http(s)://...` (case-insensitive) OR
+  `/path` (root-relative, NOT `//host` and NOT `/\host`).
+  Everything else throws.
+- **`changefreq` allowlist.**  `always | hourly | daily |
+  weekly | monthly | yearly | never`.  Case-insensitive
+  comparison; output lowercased.
+- **`priority` clamping.**  `[0.0, 1.0]`.  Above 1 → 1.0;
+  below 0 → 0.0; NaN → 0.5 (spec-documented default for
+  unspecified); non-number → 0.5.  Formatted with
+  `toFixed(1)` for byte-deterministic output.
+- **Validation BEFORE emission.**  All entries validated
+  in a single pass; if any throws, no XML reaches the caller.
+- **Child order per `<url>`.**  loc → lastmod → changefreq →
+  priority.  Matches the spec's documented presentation order.
+- **Entry order preserved.**  Caller decides the sort; the
+  emitter doesn't re-order.
+- **Reproducibility.**  Same input + same baseUrl →
+  byte-identical XML.
+
+### Security posture
+
+Five concerns explicitly addressed (pre-push review):
+
+- **URL scheme injection.**  `javascript:`, `data:`, `file:`,
+  `vbscript:`, protocol-relative `//host`,
+  `/\backslash-variant` all rejected with `TypeError`.
+  Crawlers blindly follow `<loc>` URLs; the emitter is the
+  line of defence.  Tests pin every forbidden form.
+- **XML entity injection.**  Every interpolated value routes
+  through `escapeXml`.  Single-pass character-class replace
+  covers all five XML 1.0 entities (`& < > " '`) — CodeQL-
+  friendly form (no incomplete-string-escape warning).
+- **Control-byte stripping.**  XML 1.0 §2.2 forbids C0
+  controls except `\t \n \r`.  `stripInvalidXml` removes
+  them before escape so callers can't smuggle NUL / DEL /
+  ESC through into the document.
+- **`changefreq` allowlist.**  Caller-supplied values match
+  the spec-defined set or throw.  Defends downstream parsers
+  against surprise values.
+- **Fail-fast.**  Validation completes for every entry BEFORE
+  any XML is emitted.  An exception means the caller has
+  nothing to write — no risk of a half-formed sitemap
+  reaching disk.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, no network, no shell, no env,
+no fs.
+
+### Tests
+
+112 tests across 4 files:
+
+- `escape.test.ts` (22) — every XML 1.0 entity individually +
+  composite, ampersand-first ordering, unicode passthrough,
+  C0 control stripping (NUL, backspace, vertical tab, form
+  feed, SO, ESC each parameterised), preservation of
+  `\t \n \r`, combined control + entity, non-string
+  defensive coercion.
+- `url.test.ts` (30) — `normaliseBaseUrl` accept (https,
+  http, with / without trailing slash, port, case-insensitive
+  scheme, preserves path) + reject (non-string, null, empty,
+  javascript:, file:, protocol-relative, bare relative, long
+  URL truncation in error message); `resolveEntryUrl`
+  absolute pass-through (https, http, case-insensitive
+  scheme), root-relative join (`/about`, `/`, multi-segment),
+  full reject matrix (javascript:, data:, file:, protocol-
+  relative, `/\backslash-variant`, bare relative, mailto:,
+  empty, non-string, null, long URL truncation).
+- `validate.test.ts` (30) — `validateChangefreq` allowlist
+  (all seven values individually parametrised, case-
+  insensitive), reject (not-in-allowlist, empty, non-string,
+  null, error contains bad value); `clampPriority` clamps to
+  `[0.0, 1.0]`, single-decimal rounding (0/0.5/0.75/0.25/0.01),
+  out-of-range (negative, very negative, above 1, very large,
+  ±Infinity), NaN → `"0.5"`, non-number → `"0.5"`, output
+  regex `/^[0-1]\.\d$/`.
+- `generate.test.ts` (30) — XML envelope (prelude, urlset
+  namespace, empty entries), entry rendering (minimal full,
+  child order loc→lastmod→changefreq→priority, absolute
+  pass-through, mixed absolute + relative, baseUrl trailing
+  slash normalisation), URL validation throws before any
+  emit (every forbidden scheme, protocol-relative, bad
+  baseUrl), changefreq validation (reject, allowlist
+  parametrised), priority clamping (verbatim, above-1,
+  negative, NaN), XML escaping (ampersand, quotes, control
+  bytes), purity / determinism (no input mutation,
+  byte-identical output, preserves caller's entry order),
+  fail-fast (no partial XML on mid-array validation error),
+  100-entry stress test.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only declarations).
+
+### v0 simplifications (documented)
+
+- **No sitemap index file.**  Single `<urlset>` only; sites
+  exceeding 50,000-URL / 50 MB-per-file protocol limits
+  split externally.  Sitemap-index support deferred.
+- **No image / video / news extensions.**  Core URL set
+  only; optional namespaces deferred.
+- **No gzip output.**  Caller compresses the returned string
+  before writing if desired.
+- **No URL deduplication.**  Caller dedupes before passing
+  entries.
+- **No locale-aware `lastmod` validation.**  Pass through
+  verbatim (after XML escape); ISO-8601 format validation
+  deferred.

--- a/code/packages/typescript/forme-aot-sitemap-emitter/README.md
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/README.md
@@ -1,0 +1,246 @@
+# @coding-adventures/forme-aot-sitemap-emitter
+
+Emit `sitemap.xml` from a `SitemapEntry[]` + `baseUrl` per
+[sitemaps.org/protocol.html](https://www.sitemaps.org/protocol.html).
+
+Pure transform — returns the XML string; caller decides where
+to write it (filesystem, CDN upload, in-memory test).
+Validation runs BEFORE emission, so callers never see a
+partial sitemap.
+
+Eleventh FM00 v0 stage package — joins the FM00 v0 cluster.
+
+## Quick start
+
+```ts
+import { generateSitemap } from "@coding-adventures/forme-aot-sitemap-emitter";
+
+const xml = generateSitemap([
+  { url: "/",      lastmod: "2026-05-19", changefreq: "daily",   priority: 1.0 },
+  { url: "/about", lastmod: "2026-05-15", changefreq: "monthly", priority: 0.8 },
+  { url: "https://other.example/x" },  // absolute URL passes through verbatim
+], "https://example.com");
+
+fs.writeFileSync("dist/sitemap.xml", xml);
+```
+
+Output:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url>
+  <loc>https://example.com/</loc>
+  <lastmod>2026-05-19</lastmod>
+  <changefreq>daily</changefreq>
+  <priority>1.0</priority>
+</url>
+<url>
+  <loc>https://example.com/about</loc>
+  <lastmod>2026-05-15</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+</url>
+<url>
+  <loc>https://other.example/x</loc>
+</url>
+</urlset>
+```
+
+## API
+
+### `generateSitemap(entries, baseUrl): string`
+
+Main entry.  Returns the complete XML document as a string.
+
+```ts
+interface SitemapEntry {
+  readonly url: string;                // http(s):// OR /root-relative
+  readonly lastmod?: string;           // ISO-8601 date or datetime
+  readonly changefreq?: ChangeFreq;    // allowlisted
+  readonly priority?: number;          // clamped to [0.0, 1.0]
+}
+
+type ChangeFreq =
+  | "always" | "hourly" | "daily" | "weekly"
+  | "monthly" | "yearly" | "never";
+```
+
+Throws `TypeError` synchronously BEFORE any output is emitted
+if:
+
+- `baseUrl` is not `http(s)://`.
+- Any entry `url` is not `http(s)://` or root-relative `/path`.
+- Any entry `changefreq` is not in the allowlist.
+
+Priority values outside `[0.0, 1.0]` are silently clamped
+(they're a hint, and the spec allows the convention).
+
+### Sub-helpers (exposed)
+
+- `escapeXml(s)` / `stripInvalidXml(s)` — same single-pass
+  entity-replacement pattern as
+  [`forme-feeds`](../forme-feeds).
+- `normaliseBaseUrl(baseUrl)` — validates http(s):// and strips
+  trailing slash.
+- `resolveEntryUrl(url, normalisedBase)` — validates and
+  resolves a single entry URL.
+- `validateChangefreq(value)` — allowlist check; returns
+  lowercased value.
+- `clampPriority(value)` — clamps to `[0.0, 1.0]`, formats with
+  one decimal.
+
+## URL validation (security-critical)
+
+`entry.url` accept set:
+
+- `http(s)://...` (case-insensitive scheme) — emitted verbatim.
+- `/path` (root-relative) — emitted as `baseUrl + path`.
+- `/` exactly — emitted as `baseUrl + "/"`.
+
+Reject set (throws `TypeError`):
+
+- `javascript:`, `data:`, `file:`, `vbscript:`, `mailto:`,
+  `tel:`, etc.
+- `//host/path` (protocol-relative — ambiguous scheme).
+- `/\host` (backslash variant — some browsers normalise `\`
+  to `/`).
+- Bare relative (`about`, `./about`).
+- Empty string, non-string.
+
+Error message includes the offending URL (truncated to 200
+chars) so debugging is straightforward.
+
+## `changefreq` allowlist
+
+Per [protocol §4](https://www.sitemaps.org/protocol.html#changefreqdef):
+
+`always | hourly | daily | weekly | monthly | yearly | never`
+
+Case-insensitive: `"Daily"` and `"DAILY"` both accepted and
+normalised to `"daily"`.  Anything else throws.
+
+## `priority` clamping
+
+Per [protocol §4](https://www.sitemaps.org/protocol.html#prioritydef):
+valid range is `[0.0, 1.0]`.  Out-of-range values clamp:
+
+- `5 → 1.0`
+- `-1 → 0.0`
+- `NaN → 0.5` (the spec's documented default for unspecified)
+- `0.75 → 0.8` (rounded to one decimal)
+
+Output always matches `/^[0-1]\.\d$/` for byte-deterministic
+diff-friendly sitemaps.
+
+## Behavioural contract
+
+| Aspect                          | Behaviour                              |
+|---------------------------------|----------------------------------------|
+| Input entries array             | Never mutated                          |
+| Entry order                     | Preserved (caller decides sort)        |
+| Validation                      | All entries validated BEFORE emit      |
+| Bad URL / changefreq            | Throws `TypeError`; no partial output  |
+| Bad baseUrl                     | Throws BEFORE any entry validation     |
+| Same input + baseUrl            | Byte-identical output                  |
+| XML escape                      | All five entities + C0 control strip   |
+
+## Reproducibility (FM03)
+
+Same `entries` + same `baseUrl` → byte-identical XML.  Safe to
+feed into cache key derivation.
+
+## Security posture
+
+Five concerns explicitly addressed (pre-push review):
+
+- **URL scheme injection.**  `javascript:`, `data:`, `file:`,
+  `vbscript:`, protocol-relative `//host`, `/\backslash-variant`
+  all rejected with `TypeError`.  Search-engine crawlers
+  blindly follow `<loc>` URLs; the emitter is the line of
+  defence.
+- **XML attribute / text injection.**  Every interpolated
+  value (`loc`, `lastmod`, `changefreq`, `priority`) routes
+  through `escapeXml`.  Single-pass character-class
+  replacement covers all five XML 1.0 entities (CodeQL-friendly
+  pattern — no incomplete-string-escape warning).
+- **Control-byte stripping.**  XML 1.0 §2.2 forbids C0
+  controls except `\t \n \r`.  `stripInvalidXml` removes
+  them before escape so callers can't smuggle NUL / DEL /
+  ESC into the document.
+- **changefreq allowlist.**  Caller-supplied values match the
+  spec-defined set or throw.  Prevents downstream parsers from
+  encountering surprise values.
+- **Fail-fast (no partial output).**  Validation pass completes
+  for every entry BEFORE any XML is emitted.  An exception
+  means the caller has nothing to write — no risk of a half-
+  formed sitemap reaching disk.
+
+## Capabilities — `[]`
+
+Pure transform.  No I/O, no network, no shell, no env, no fs.
+
+## Tests
+
+112 tests across 4 files:
+
+- `escape.test.ts` (22) — every XML entity individually +
+  composite, ampersand-first ordering (no double-escape),
+  unicode passthrough, C0 control stripping (each
+  individually) + preservation of `\t \n \r`, combined
+  control + entity, non-string defensive coercion.
+- `url.test.ts` (30) — `normaliseBaseUrl` accept (with/without
+  trailing slash, http, https, port, case-insensitive scheme)
+  + reject (non-string, null, empty, javascript:, file:,
+  protocol-relative, bare relative, long URL truncation in
+  message); `resolveEntryUrl` absolute pass-through, root-
+  relative join, `/` join, full reject matrix (every forbidden
+  scheme, protocol-relative, `/\backslash-variant`, bare
+  relative, mailto:, empty, non-string, null, long URL
+  truncation).
+- `validate.test.ts` (30) — `validateChangefreq` allowlist
+  (all seven values parametrised, case-insensitive), reject
+  (not-in-allowlist, empty, non-string, null, error message
+  contains bad value); `clampPriority` clamps to `[0.0, 1.0]`,
+  rounds to single decimal, NaN → `"0.5"`, non-number → `"0.5"`,
+  output matches `/^[0-1]\.\d$/`.
+- `generate.test.ts` (30) — XML envelope (prelude, urlset
+  namespace, empty entries), entry rendering (minimal,
+  full, child order loc→lastmod→changefreq→priority, absolute
+  pass-through, mixed, trailing-slash baseUrl normalisation),
+  URL validation throws before emit (every forbidden scheme,
+  protocol-relative, bad baseUrl), changefreq validation
+  (reject + allowlist parametrised), priority clamping (verbatim
+  / above-1 / negative / NaN), XML escaping (ampersand,
+  quotes, control bytes), purity / determinism (no input
+  mutation, byte-identical output, preserves input order),
+  fail-fast (no partial XML on validation error in mid-array),
+  100-entry stress test.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only).
+
+## Spec adherence
+
+Implements the sitemaps.org protocol (XML schema at
+https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd).
+No spec divergences.
+
+## v0 simplifications
+
+- **No sitemap index file.**  A single `<urlset>` is emitted;
+  sites that exceed the 50,000-URL or 50 MB-per-file protocol
+  limits should split externally.  Sitemap-index support is a
+  future v1 feature.
+- **No image / video / news extensions.**  Core URL set only;
+  the protocol's optional namespaces are deferred.
+- **No gzip output.**  Caller compresses the returned string
+  before writing if desired (`gzip(xml)` in their pipeline).
+- **No URL deduplication.**  Caller deduplicates before
+  passing entries.  Different `<loc>` values share the same
+  `<url>` block in the spec's strict reading, but we emit
+  whatever the caller supplies.
+- **No locale-aware `lastmod` validation.**  The spec mandates
+  W3C Datetime; we pass through whatever string the caller
+  supplies (after XML escape).  Validating ISO-8601 format is
+  a future v1 feature.

--- a/code/packages/typescript/forme-aot-sitemap-emitter/package-lock.json
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-aot-sitemap-emitter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-sitemap-emitter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/package.json
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-aot-sitemap-emitter",
+  "version": "0.1.0",
+  "description": "Emit sitemap.xml from a SitemapEntry[] + baseUrl, per https://www.sitemaps.org/protocol.html.  Pure transform: validates URLs (http(s)://-or-root-relative), changefreq (allowlist), priority (clamp [0.0, 1.0]); XML-escapes every interpolated value via single-pass entity replacement (CodeQL-friendly).  FM00 v0 emitter.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-sitemap-emitter",
+  "capabilities": [],
+  "justification": "Pure transform: SitemapEntry[] + baseUrl → sitemap.xml string.  No I/O, no network, no env, no shell, no fs.  Caller writes the resulting string wherever it wants.  Same posture as forme-feeds / forme-opengraph."
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/src/escape.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/src/escape.ts
@@ -1,0 +1,53 @@
+/**
+ * escape.ts — XML escaping + invalid-character stripping.
+ *
+ * Same pattern as `forme-feeds` — escape all five XML 1.0
+ * predefined entities (`& < > " '`) in element text and
+ * attribute values via a single-pass character-class
+ * replacement (CodeQL-friendly form, no
+ * "incomplete-string-escape" warning).  Strip C0 control bytes
+ * that XML 1.0 §2.2 forbids (everything in `0x00-0x1F` except
+ * `\t \n \r`).
+ *
+ * Why the duplicate copy in this package rather than depending
+ * on `forme-feeds`?  Sitemap emission is conceptually
+ * downstream of feeds — both produce XML, but sitemap callers
+ * don't need an RSS/Atom dependency.  The 30-line escape
+ * helper is small enough that duplication is cheaper than a
+ * cross-package import.
+ *
+ * @module escape
+ */
+
+const XML_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;",
+  "'": "&apos;",
+});
+
+// All five XML predefined entities — single-pass replacement.
+const XML_SPECIAL_RE = /[&<>"']/g;
+
+// XML 1.0 §2.2 forbidden C0 controls except \t \n \r.
+// Pattern: NUL to backspace, vertical-tab + form-feed, SO onwards.
+// eslint-disable-next-line no-control-regex
+const INVALID_XML_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F]/g;
+
+/**
+ * Strip XML 1.0-illegal C0 control characters.  Returns a fresh
+ * string with the forbidden bytes removed; `\t \n \r` preserved.
+ */
+export function stripInvalidXml(s: string): string {
+  return String(s).replace(INVALID_XML_RE, "");
+}
+
+/**
+ * Escape XML special characters for use in element text or
+ * attribute value.  Strips invalid XML chars first so the
+ * output is always well-formed XML 1.0.
+ */
+export function escapeXml(s: string): string {
+  return stripInvalidXml(s).replace(XML_SPECIAL_RE, (ch) => XML_ESCAPE_MAP[ch]!);
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/src/generate.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/src/generate.ts
@@ -1,0 +1,101 @@
+/**
+ * generate.ts — main `generateSitemap` entry.
+ *
+ * Algorithm:
+ *
+ *   1. Normalise `baseUrl` (validates http(s)://, trims
+ *      trailing slash).
+ *   2. **VALIDATION PASS** (no XML emitted yet): for every
+ *      entry, validate `url` (resolve relative to baseUrl,
+ *      reject bad schemes), validate `changefreq` (allowlist),
+ *      clamp `priority` (range).  Collect resolved entries
+ *      into a fresh array.  If anything throws, the caller
+ *      gets the error WITHOUT a partial sitemap.
+ *   3. **EMIT PASS**: build the XML string from the resolved
+ *      entries.  Every interpolated value passes through
+ *      `escapeXml`.
+ *
+ * Output is deterministic — same input → byte-identical XML.
+ * Entries are emitted in input order; the caller decides the
+ * sort.
+ *
+ * @module generate
+ */
+
+import { escapeXml } from "./escape.js";
+import { normaliseBaseUrl, resolveEntryUrl } from "./url.js";
+import type { SitemapEntry } from "./types.js";
+import { clampPriority, validateChangefreq } from "./validate.js";
+
+interface ResolvedEntry {
+  readonly loc: string;
+  readonly lastmod: string | undefined;
+  readonly changefreq: string | undefined;
+  readonly priority: string | undefined;
+}
+
+/**
+ * Generate the sitemap.xml string for an ordered list of
+ * entries.  Returns the XML; caller writes it wherever.
+ *
+ * Throws `TypeError` on any validation failure (bad URL
+ * scheme, bad changefreq, bad baseUrl).  Throws BEFORE any
+ * XML is emitted so callers never see a partial document.
+ *
+ * Reproducibility: same `entries` + same `baseUrl` →
+ * byte-identical output.
+ *
+ * Input arrays are never mutated.
+ */
+export function generateSitemap(
+  entries: readonly SitemapEntry[],
+  baseUrl: string,
+): string {
+  const base = normaliseBaseUrl(baseUrl);
+
+  // Validation pass — fail fast, no partial output.
+  const resolved: ResolvedEntry[] = new Array(entries.length);
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i]!;
+    resolved[i] = {
+      loc: resolveEntryUrl(e.url, base),
+      lastmod: e.lastmod,
+      changefreq: e.changefreq === undefined ? undefined : validateChangefreq(e.changefreq),
+      priority: e.priority === undefined ? undefined : clampPriority(e.priority),
+    };
+  }
+
+  // Emit pass.
+  const parts: string[] = [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`,
+  ];
+  for (let i = 0; i < resolved.length; i++) {
+    parts.push(renderUrl(resolved[i]!));
+  }
+  parts.push(`</urlset>`);
+  return parts.join("\n");
+}
+
+/**
+ * Render one `<url>` block.  Order of children matches the
+ * sitemap protocol's documented presentation order: loc →
+ * lastmod → changefreq → priority.
+ */
+function renderUrl(e: ResolvedEntry): string {
+  const children: string[] = [`  <loc>${escapeXml(e.loc)}</loc>`];
+  if (e.lastmod !== undefined) {
+    children.push(`  <lastmod>${escapeXml(e.lastmod)}</lastmod>`);
+  }
+  if (e.changefreq !== undefined) {
+    // changefreq is already allowlist-validated, so escape is
+    // belt-and-braces (no `&` / `<` could survive validation).
+    children.push(`  <changefreq>${escapeXml(e.changefreq)}</changefreq>`);
+  }
+  if (e.priority !== undefined) {
+    // priority is `clampPriority`-formatted (literal "0.0"-"1.0"),
+    // so escape is also belt-and-braces.
+    children.push(`  <priority>${escapeXml(e.priority)}</priority>`);
+  }
+  return `<url>\n${children.join("\n")}\n</url>`;
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/src/index.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @coding-adventures/forme-aot-sitemap-emitter
+ *
+ * Emit `sitemap.xml` from a `SitemapEntry[]` + `baseUrl` per
+ * https://www.sitemaps.org/protocol.html.  Pure transform —
+ * returns the XML string; caller decides where to write it.
+ *
+ * ```ts
+ * import { generateSitemap } from "@coding-adventures/forme-aot-sitemap-emitter";
+ *
+ * const xml = generateSitemap([
+ *   { url: "/",              lastmod: "2026-05-19", changefreq: "daily",   priority: 1.0 },
+ *   { url: "/about",         lastmod: "2026-05-15", changefreq: "monthly", priority: 0.8 },
+ *   { url: "https://other.example/x"                                                       },
+ * ], "https://example.com");
+ *
+ * fs.writeFileSync("dist/sitemap.xml", xml);
+ * ```
+ *
+ * Validation runs BEFORE emission — bad URL schemes, bad
+ * changefreq values, bad baseUrl all throw `TypeError`
+ * synchronously and no partial output reaches the caller.
+ *
+ * Eleventh FM00 v0 stage package — joins the FM00 v0 cluster.
+ *
+ * @module index
+ */
+
+export { generateSitemap } from "./generate.js";
+export { escapeXml, stripInvalidXml } from "./escape.js";
+export { normaliseBaseUrl, resolveEntryUrl } from "./url.js";
+export { validateChangefreq, clampPriority } from "./validate.js";
+export type { ChangeFreq, SitemapEntry } from "./types.js";

--- a/code/packages/typescript/forme-aot-sitemap-emitter/src/types.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/src/types.ts
@@ -1,0 +1,50 @@
+/**
+ * types.ts — sitemap entry and option types.
+ *
+ * Mirrors the sitemap.xml protocol per https://www.sitemaps.org/protocol.html
+ * §4 (Optional and required tags).  The required tag is `<loc>`
+ * — everything else is optional.
+ *
+ * @module types
+ */
+
+/**
+ * Allowed values for the `<changefreq>` element per
+ * https://www.sitemaps.org/protocol.html §4.
+ *
+ * Search engines treat this as a hint — they may or may not
+ * crawl with the suggested frequency.  Validated via allowlist
+ * before emission; anything else throws `TypeError`.
+ */
+export type ChangeFreq =
+  | "always"
+  | "hourly"
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "yearly"
+  | "never";
+
+/**
+ * One entry in the sitemap.
+ *
+ *   - `url` (required) — http(s):// absolute OR root-relative
+ *     `/path`.  Root-relative URLs are joined with `baseUrl`
+ *     supplied to `generateSitemap`.  All other forms throw
+ *     `TypeError` synchronously before any output is emitted.
+ *   - `lastmod` (optional) — ISO-8601 date or date-time
+ *     (`"2026-05-19"` or `"2026-05-19T14:00:00Z"`).  Passed
+ *     through verbatim after XML-escaping; the spec doesn't
+ *     require us to validate the format.
+ *   - `changefreq` (optional) — see `ChangeFreq`.  Validated
+ *     against allowlist.
+ *   - `priority` (optional) — number in `[0.0, 1.0]`.  Values
+ *     outside the range are clamped.  Emitted with one decimal
+ *     place for byte-deterministic output.
+ */
+export interface SitemapEntry {
+  readonly url: string;
+  readonly lastmod?: string;
+  readonly changefreq?: ChangeFreq | string;  // string for ergonomic input; validated downstream
+  readonly priority?: number;
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/src/url.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/src/url.ts
@@ -1,0 +1,105 @@
+/**
+ * url.ts — URL resolution and validation.
+ *
+ * Sitemap entries reach the emitter as one of two shapes:
+ *
+ *   1. Absolute `http(s)://...` — used verbatim.
+ *   2. Root-relative `/path` — joined with the caller's
+ *      `baseUrl` (which must itself be `http(s)://`).
+ *
+ * Anything else — `javascript:`, `data:`, `file:`,
+ * protocol-relative `//host`, bare relative `about`, empty
+ * string, non-string — throws `TypeError` synchronously BEFORE
+ * any XML is emitted.  This is the security chokepoint:
+ * downstream renderers / crawlers blindly trust whatever URL
+ * we put in `<loc>`, so the emitter is the line of defence.
+ *
+ * @module url
+ */
+
+/**
+ * Trim a trailing slash from `baseUrl` so we can splice in
+ * root-relative paths without doubling slashes.  Validates that
+ * `baseUrl` itself is `http(s)://`-shaped — anything else
+ * throws.
+ */
+export function normaliseBaseUrl(baseUrl: string): string {
+  if (typeof baseUrl !== "string" || baseUrl.length === 0) {
+    throw new TypeError(
+      `forme-aot-sitemap-emitter: baseUrl must be a non-empty string; got ${
+        baseUrl === null ? "null" : typeof baseUrl
+      }`,
+    );
+  }
+  if (!isHttpUrl(baseUrl)) {
+    throw new TypeError(
+      `forme-aot-sitemap-emitter: baseUrl must be http(s)://; got ${
+        JSON.stringify(baseUrl.length > 100 ? baseUrl.slice(0, 100) + "…" : baseUrl)
+      }`,
+    );
+  }
+  // Strip exactly one trailing slash if present so "/about" +
+  // "https://x.com/" doesn't become "https://x.com//about".
+  return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+/**
+ * Resolve a single entry URL against `baseUrl`.
+ *
+ * Accept set:
+ *   - http(s):// — returned as-is.
+ *   - `/path` (root-relative, NOT `//host`) — returned as
+ *     `baseUrl + path`.
+ *   - `/` exactly — returned as `baseUrl + "/"`.
+ *
+ * Reject set (throws `TypeError`):
+ *   - `javascript:`, `data:`, `file:`, `mailto:`, etc.
+ *   - `//host/path` (protocol-relative — ambiguous scheme).
+ *   - `/\host` (backslash-variant; some browsers normalise
+ *     `\` → `/`).
+ *   - bare relative (`about`, `./about`).
+ *   - empty string, non-string.
+ *
+ * Error message includes the offending URL (truncated to 200
+ * chars) so debugging is straightforward.
+ */
+export function resolveEntryUrl(url: unknown, normalisedBaseUrl: string): string {
+  if (typeof url !== "string" || url.length === 0) {
+    throw new TypeError(
+      `forme-aot-sitemap-emitter: entry url must be a non-empty string; got ${
+        url === null ? "null" : typeof url
+      }`,
+    );
+  }
+  if (isHttpUrl(url)) return url;
+  if (isRootRelative(url)) {
+    return url === "/" ? normalisedBaseUrl + "/" : normalisedBaseUrl + url;
+  }
+  const shown = url.length > 200 ? `${url.slice(0, 200)}…` : url;
+  throw new TypeError(
+    `forme-aot-sitemap-emitter: entry url must be http(s):// or root-relative /path; got ${
+      JSON.stringify(shown)
+    }`,
+  );
+}
+
+/**
+ * Case-insensitive `http://` / `https://` prefix check.  Only
+ * lower-cases the first 8 chars to avoid a full-string
+ * `toLowerCase()` allocation in the hot path.
+ */
+function isHttpUrl(url: string): boolean {
+  const head = url.slice(0, 8).toLowerCase();
+  return head.startsWith("http://") || head.startsWith("https://");
+}
+
+/**
+ * Root-relative iff starts with exactly one `/` and NOT `//`
+ * or `/\`.  Same `/\backslash-variant` defence as the
+ * internal-links package.
+ */
+function isRootRelative(url: string): boolean {
+  if (url === "/") return true;
+  if (url.length < 2 || url[0] !== "/") return false;
+  return url[1] !== "/" && url[1] !== "\\";
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/src/validate.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/src/validate.ts
@@ -1,0 +1,70 @@
+/**
+ * validate.ts — changefreq allowlist + priority clamping.
+ *
+ * Two small validators that turn caller-supplied scalar fields
+ * into emit-safe values.  Both run BEFORE any XML interpolation
+ * so the emitted document always conforms to the sitemap
+ * protocol.
+ *
+ * @module validate
+ */
+
+import type { ChangeFreq } from "./types.js";
+
+const CHANGEFREQ_ALLOWLIST: ReadonlySet<string> = new Set([
+  "always",
+  "hourly",
+  "daily",
+  "weekly",
+  "monthly",
+  "yearly",
+  "never",
+]);
+
+/**
+ * Validate `changefreq` against the sitemap protocol allowlist.
+ * Returns the lowercased value on success; throws `TypeError`
+ * otherwise.
+ *
+ * Lowercase comparison so callers can pass `"Daily"` or
+ * `"DAILY"` without surprises.
+ */
+export function validateChangefreq(value: string): ChangeFreq {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-sitemap-emitter: changefreq must be a string; got ${typeof value}`,
+    );
+  }
+  const lower = value.toLowerCase();
+  if (!CHANGEFREQ_ALLOWLIST.has(lower)) {
+    throw new TypeError(
+      `forme-aot-sitemap-emitter: changefreq must be one of [${
+        [...CHANGEFREQ_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return lower as ChangeFreq;
+}
+
+/**
+ * Clamp `priority` to the sitemap-protocol range `[0.0, 1.0]`
+ * and format with exactly one decimal place for byte-
+ * deterministic output.
+ *
+ *   priority 0    → "0.0"
+ *   priority 0.75 → "0.8"  (toFixed(1) rounds half-to-even)
+ *   priority 1    → "1.0"
+ *   priority 5    → "1.0"  (clamped)
+ *   priority -1   → "0.0"  (clamped)
+ *   priority NaN  → "0.5"  (sentinel — spec default is 0.5)
+ *
+ * NaN treated as 0.5 (the protocol's documented default for
+ * "no priority specified" — keeps the slot non-empty rather
+ * than synthesising an opinion).
+ */
+export function clampPriority(value: number): string {
+  if (typeof value !== "number" || Number.isNaN(value)) return "0.5";
+  if (value <= 0) return "0.0";
+  if (value >= 1) return "1.0";
+  return value.toFixed(1);
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/tests/escape.test.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/tests/escape.test.ts
@@ -1,0 +1,56 @@
+/**
+ * escape.test.ts — XML escape + invalid-character strip.
+ */
+
+import { describe, it, expect } from "vitest";
+import { escapeXml, stripInvalidXml } from "../src/index.js";
+
+describe("escapeXml — all five entities", () => {
+  it("ampersand", () => expect(escapeXml("a&b")).toBe("a&amp;b"));
+  it("less-than", () => expect(escapeXml("a<b")).toBe("a&lt;b"));
+  it("greater-than", () => expect(escapeXml("a>b")).toBe("a&gt;b"));
+  it("double quote", () => expect(escapeXml(`a"b`)).toBe("a&quot;b"));
+  it("single quote", () => expect(escapeXml(`a'b`)).toBe("a&apos;b"));
+
+  it("composite", () => {
+    expect(escapeXml(`<a href="x?a=1&b=2">'y'</a>`))
+      .toBe(`&lt;a href=&quot;x?a=1&amp;b=2&quot;&gt;&apos;y&apos;&lt;/a&gt;`);
+  });
+
+  it("ampersand-first ordering (no double-escape)", () => {
+    expect(escapeXml("&lt;")).toBe("&amp;lt;");
+  });
+});
+
+describe("escapeXml — passthrough", () => {
+  it("empty string", () => expect(escapeXml("")).toBe(""));
+  it("plain ASCII unchanged", () => expect(escapeXml("hello world")).toBe("hello world"));
+  it("digits unchanged", () => expect(escapeXml("123")).toBe("123"));
+  it("unicode > U+007F passes through", () => expect(escapeXml("日本語")).toBe("日本語"));
+});
+
+describe("stripInvalidXml — XML 1.0 forbidden C0", () => {
+  it("strips NUL", () => expect(stripInvalidXml("a\x00b")).toBe("ab"));
+  it("strips backspace", () => expect(stripInvalidXml("a\x08b")).toBe("ab"));
+  it("strips vertical tab", () => expect(stripInvalidXml("a\x0Bb")).toBe("ab"));
+  it("strips form feed", () => expect(stripInvalidXml("a\x0Cb")).toBe("ab"));
+  it("strips SO (shift out)", () => expect(stripInvalidXml("a\x0Eb")).toBe("ab"));
+  it("strips ESC", () => expect(stripInvalidXml("a\x1Bb")).toBe("ab"));
+
+  it("preserves tab (\\t)", () => expect(stripInvalidXml("a\tb")).toBe("a\tb"));
+  it("preserves newline (\\n)", () => expect(stripInvalidXml("a\nb")).toBe("a\nb"));
+  it("preserves carriage return (\\r)", () => expect(stripInvalidXml("a\rb")).toBe("a\rb"));
+});
+
+describe("escapeXml — strips control AND escapes entities", () => {
+  it("'<x>\\x00y' → '&lt;x&gt;y'", () => {
+    expect(escapeXml("<x>\x00y")).toBe("&lt;x&gt;y");
+  });
+});
+
+describe("escapeXml — defensive coercion", () => {
+  it("non-string coerces via String(...)", () => {
+    // @ts-expect-error — runtime coercion
+    expect(escapeXml(42)).toBe("42");
+  });
+});

--- a/code/packages/typescript/forme-aot-sitemap-emitter/tests/generate.test.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/tests/generate.test.ts
@@ -1,0 +1,248 @@
+/**
+ * generate.test.ts — end-to-end generateSitemap.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateSitemap, type SitemapEntry } from "../src/index.js";
+
+describe("generateSitemap — XML envelope", () => {
+  it("starts with <?xml version=...?>", () => {
+    const xml = generateSitemap([{ url: "/" }], "https://example.com");
+    expect(xml.startsWith(`<?xml version="1.0" encoding="UTF-8"?>`)).toBe(true);
+  });
+
+  it("contains urlset with sitemap.org namespace", () => {
+    const xml = generateSitemap([{ url: "/" }], "https://example.com");
+    expect(xml).toContain(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`);
+    expect(xml).toContain(`</urlset>`);
+  });
+
+  it("empty entries → valid empty sitemap", () => {
+    const xml = generateSitemap([], "https://example.com");
+    expect(xml).toContain(`<urlset`);
+    expect(xml).toContain(`</urlset>`);
+    expect(xml).not.toContain(`<url>`);
+  });
+});
+
+describe("generateSitemap — entry rendering", () => {
+  it("minimal entry: only <loc>", () => {
+    const xml = generateSitemap([{ url: "/" }], "https://example.com");
+    expect(xml).toContain(`<loc>https://example.com/</loc>`);
+    expect(xml).not.toContain(`<lastmod>`);
+    expect(xml).not.toContain(`<changefreq>`);
+    expect(xml).not.toContain(`<priority>`);
+  });
+
+  it("full entry with all optional fields", () => {
+    const xml = generateSitemap([{
+      url: "/about", lastmod: "2026-05-19", changefreq: "monthly", priority: 0.8,
+    }], "https://example.com");
+    expect(xml).toContain(`<loc>https://example.com/about</loc>`);
+    expect(xml).toContain(`<lastmod>2026-05-19</lastmod>`);
+    expect(xml).toContain(`<changefreq>monthly</changefreq>`);
+    expect(xml).toContain(`<priority>0.8</priority>`);
+  });
+
+  it("child order: loc → lastmod → changefreq → priority", () => {
+    const xml = generateSitemap([{
+      url: "/", lastmod: "2026-05-19", changefreq: "daily", priority: 1.0,
+    }], "https://example.com");
+    const locIdx = xml.indexOf("<loc>");
+    const modIdx = xml.indexOf("<lastmod>");
+    const freqIdx = xml.indexOf("<changefreq>");
+    const priIdx = xml.indexOf("<priority>");
+    expect(locIdx).toBeLessThan(modIdx);
+    expect(modIdx).toBeLessThan(freqIdx);
+    expect(freqIdx).toBeLessThan(priIdx);
+  });
+
+  it("absolute http(s) URL passes through verbatim", () => {
+    const xml = generateSitemap([
+      { url: "https://other.example/x" },
+    ], "https://base.example");
+    expect(xml).toContain(`<loc>https://other.example/x</loc>`);
+    expect(xml).not.toContain(`<loc>https://base.example/https`);
+  });
+
+  it("mixed absolute + relative entries", () => {
+    const xml = generateSitemap([
+      { url: "/" },
+      { url: "https://other.example/x" },
+      { url: "/about" },
+    ], "https://base.example");
+    expect(xml).toContain(`<loc>https://base.example/</loc>`);
+    expect(xml).toContain(`<loc>https://other.example/x</loc>`);
+    expect(xml).toContain(`<loc>https://base.example/about</loc>`);
+  });
+
+  it("baseUrl with trailing slash is normalised (no //path)", () => {
+    const xml = generateSitemap([{ url: "/about" }], "https://example.com/");
+    expect(xml).toContain(`<loc>https://example.com/about</loc>`);
+    expect(xml).not.toContain(`<loc>https://example.com//about</loc>`);
+  });
+});
+
+describe("generateSitemap — URL validation throws BEFORE emitting", () => {
+  it("javascript: in any entry throws TypeError", () => {
+    expect(() => generateSitemap([
+      { url: "/" },
+      { url: "javascript:alert(1)" },
+      { url: "/about" },
+    ], "https://b")).toThrow(/must be http\(s\)/);
+  });
+
+  it("data:", () => {
+    expect(() => generateSitemap([{ url: "data:text/html,x" }], "https://b"))
+      .toThrow(/http\(s\)/);
+  });
+
+  it("file:", () => {
+    expect(() => generateSitemap([{ url: "file:///etc" }], "https://b"))
+      .toThrow(/http\(s\)/);
+  });
+
+  it("protocol-relative //host", () => {
+    expect(() => generateSitemap([{ url: "//evil.com" }], "https://b"))
+      .toThrow(/http\(s\)/);
+  });
+
+  it("bad baseUrl rejected first", () => {
+    expect(() => generateSitemap([{ url: "/" }], "javascript:alert(1)"))
+      .toThrow(/baseUrl must be http\(s\)/);
+  });
+});
+
+describe("generateSitemap — changefreq validation", () => {
+  it("rejects 'often'", () => {
+    expect(() => generateSitemap([
+      { url: "/", changefreq: "often" },
+    ], "https://b")).toThrow(/one of/);
+  });
+
+  it("rejects 'never-ever'", () => {
+    expect(() => generateSitemap([
+      { url: "/", changefreq: "never-ever" },
+    ], "https://b")).toThrow(/one of/);
+  });
+
+  it("accepts every allowlist value (parametrised)", () => {
+    const values = ["always", "hourly", "daily", "weekly", "monthly", "yearly", "never"];
+    for (const v of values) {
+      const xml = generateSitemap([{ url: "/", changefreq: v }], "https://b");
+      expect(xml).toContain(`<changefreq>${v}</changefreq>`);
+    }
+  });
+});
+
+describe("generateSitemap — priority clamping", () => {
+  it("0.8 emitted verbatim", () => {
+    const xml = generateSitemap([{ url: "/", priority: 0.8 }], "https://b");
+    expect(xml).toContain(`<priority>0.8</priority>`);
+  });
+
+  it("above 1 clamps to 1.0", () => {
+    const xml = generateSitemap([{ url: "/", priority: 5 }], "https://b");
+    expect(xml).toContain(`<priority>1.0</priority>`);
+  });
+
+  it("negative clamps to 0.0", () => {
+    const xml = generateSitemap([{ url: "/", priority: -1 }], "https://b");
+    expect(xml).toContain(`<priority>0.0</priority>`);
+  });
+
+  it("NaN → 0.5 (spec default)", () => {
+    const xml = generateSitemap([{ url: "/", priority: NaN }], "https://b");
+    expect(xml).toContain(`<priority>0.5</priority>`);
+  });
+});
+
+describe("generateSitemap — XML escaping", () => {
+  it("escapes ampersand in lastmod (defensive — real ISO has none)", () => {
+    const xml = generateSitemap([
+      { url: "/", lastmod: "2026-05-19&extra" },
+    ], "https://b");
+    expect(xml).toContain(`<lastmod>2026-05-19&amp;extra</lastmod>`);
+  });
+
+  it("escapes URL with ampersand + quotes in absolute entry", () => {
+    const xml = generateSitemap([
+      { url: `https://other.example/?a=1&b=2"` },
+    ], "https://b");
+    // Note: this URL is structurally weird (quotes in URL); we
+    // pass it through but XML-escape the special chars.
+    expect(xml).toContain(`<loc>https://other.example/?a=1&amp;b=2&quot;</loc>`);
+  });
+
+  it("strips XML 1.0 invalid C0 chars from lastmod", () => {
+    const xml = generateSitemap([
+      { url: "/", lastmod: "2026\x00-05-19" },
+    ], "https://b");
+    expect(xml).toContain(`<lastmod>2026-05-19</lastmod>`);
+  });
+});
+
+describe("generateSitemap — purity / determinism", () => {
+  it("does not mutate input entries", () => {
+    const entries: SitemapEntry[] = [{ url: "/", priority: 0.8 }];
+    const before = JSON.stringify(entries);
+    generateSitemap(entries, "https://b");
+    expect(JSON.stringify(entries)).toBe(before);
+  });
+
+  it("same input → byte-identical output", () => {
+    const entries: SitemapEntry[] = [
+      { url: "/", priority: 1.0 },
+      { url: "/about", changefreq: "monthly" },
+    ];
+    expect(generateSitemap(entries, "https://b")).toBe(generateSitemap(entries, "https://b"));
+  });
+
+  it("preserves caller's entry order", () => {
+    const xml = generateSitemap([
+      { url: "/c" }, { url: "/a" }, { url: "/b" },
+    ], "https://b");
+    const cIdx = xml.indexOf(`<loc>https://b/c</loc>`);
+    const aIdx = xml.indexOf(`<loc>https://b/a</loc>`);
+    const bIdx = xml.indexOf(`<loc>https://b/b</loc>`);
+    expect(cIdx).toBeLessThan(aIdx);
+    expect(aIdx).toBeLessThan(bIdx);
+  });
+});
+
+describe("generateSitemap — fail-fast (no partial output)", () => {
+  it("if entry N is invalid, NO XML is emitted at all", () => {
+    try {
+      generateSitemap([
+        { url: "/" },
+        { url: "/about" },
+        { url: "javascript:bad" },
+      ], "https://b");
+      expect.fail("expected throw");
+    } catch (e) {
+      // No way to assert "nothing was emitted" since generateSitemap
+      // returns a string, but the throw is what proves it.
+      expect((e as Error).message).toMatch(/javascript/);
+    }
+  });
+
+  it("if changefreq is invalid, NO XML emitted", () => {
+    try {
+      generateSitemap([{ url: "/", changefreq: "often" }], "https://b");
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toMatch(/one of/);
+    }
+  });
+});
+
+describe("generateSitemap — stress test", () => {
+  it("100 entries emitted without error", () => {
+    const entries: SitemapEntry[] = [];
+    for (let i = 0; i < 100; i++) {
+      entries.push({ url: `/post-${i}`, changefreq: "weekly", priority: 0.5 });
+    }
+    const xml = generateSitemap(entries, "https://example.com");
+    expect((xml.match(/<url>/g) ?? []).length).toBe(100);
+  });
+});

--- a/code/packages/typescript/forme-aot-sitemap-emitter/tests/url.test.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/tests/url.test.ts
@@ -1,0 +1,172 @@
+/**
+ * url.test.ts — normaliseBaseUrl + resolveEntryUrl.
+ */
+
+import { describe, it, expect } from "vitest";
+import { normaliseBaseUrl, resolveEntryUrl } from "../src/index.js";
+
+describe("normaliseBaseUrl — accepts", () => {
+  it("https://example.com", () => {
+    expect(normaliseBaseUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("strips single trailing slash", () => {
+    expect(normaliseBaseUrl("https://example.com/")).toBe("https://example.com");
+  });
+
+  it("http://", () => {
+    expect(normaliseBaseUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  it("preserves path and port", () => {
+    expect(normaliseBaseUrl("https://example.com:8443/sub")).toBe("https://example.com:8443/sub");
+  });
+
+  it("scheme case-insensitive", () => {
+    expect(normaliseBaseUrl("HTTPS://example.com")).toBe("HTTPS://example.com");
+  });
+});
+
+describe("normaliseBaseUrl — rejects", () => {
+  it("non-string", () => {
+    // @ts-expect-error
+    expect(() => normaliseBaseUrl(42)).toThrow(/non-empty string/);
+  });
+
+  it("null", () => {
+    // @ts-expect-error
+    expect(() => normaliseBaseUrl(null)).toThrow(/null/);
+  });
+
+  it("empty string", () => {
+    expect(() => normaliseBaseUrl("")).toThrow(/non-empty string/);
+  });
+
+  it("javascript:", () => {
+    expect(() => normaliseBaseUrl("javascript:alert(1)")).toThrow(/http\(s\)/);
+  });
+
+  it("file:", () => {
+    expect(() => normaliseBaseUrl("file:///etc/passwd")).toThrow(/http\(s\)/);
+  });
+
+  it("protocol-relative", () => {
+    expect(() => normaliseBaseUrl("//example.com")).toThrow(/http\(s\)/);
+  });
+
+  it("bare relative", () => {
+    expect(() => normaliseBaseUrl("example.com")).toThrow(/http\(s\)/);
+  });
+
+  it("very long invalid URL truncated in error message", () => {
+    const long = "ftp://" + "x".repeat(500);
+    try {
+      normaliseBaseUrl(long);
+      expect.fail("expected throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toMatch(/…/);
+      expect(msg.length).toBeLessThan(400);
+    }
+  });
+});
+
+describe("resolveEntryUrl — absolute http(s)", () => {
+  it("https://other.example/x returned verbatim", () => {
+    expect(resolveEntryUrl("https://other.example/x", "https://base.example"))
+      .toBe("https://other.example/x");
+  });
+
+  it("http://", () => {
+    expect(resolveEntryUrl("http://other.example", "https://base.example"))
+      .toBe("http://other.example");
+  });
+
+  it("case-insensitive scheme", () => {
+    expect(resolveEntryUrl("HTTPS://other.example", "https://base.example"))
+      .toBe("HTTPS://other.example");
+  });
+});
+
+describe("resolveEntryUrl — root-relative", () => {
+  it("/about joined with base", () => {
+    expect(resolveEntryUrl("/about", "https://base.example"))
+      .toBe("https://base.example/about");
+  });
+
+  it("/ joined with base", () => {
+    expect(resolveEntryUrl("/", "https://base.example"))
+      .toBe("https://base.example/");
+  });
+
+  it("multi-segment path joined", () => {
+    expect(resolveEntryUrl("/blog/2026/post", "https://base.example"))
+      .toBe("https://base.example/blog/2026/post");
+  });
+});
+
+describe("resolveEntryUrl — rejects", () => {
+  it("javascript:", () => {
+    expect(() => resolveEntryUrl("javascript:alert(1)", "https://b"))
+      .toThrow(/must be http\(s\)/);
+  });
+
+  it("data:", () => {
+    expect(() => resolveEntryUrl("data:text/html,<script>", "https://b"))
+      .toThrow(/must be http\(s\)/);
+  });
+
+  it("file:", () => {
+    expect(() => resolveEntryUrl("file:///etc/passwd", "https://b"))
+      .toThrow(/must be http\(s\)/);
+  });
+
+  it("protocol-relative //host", () => {
+    expect(() => resolveEntryUrl("//evil.com", "https://b"))
+      .toThrow(/must be http\(s\)/);
+  });
+
+  it("/\\host (backslash variant)", () => {
+    expect(() => resolveEntryUrl("/\\evil.com", "https://b"))
+      .toThrow(/must be http\(s\)/);
+  });
+
+  it("bare relative", () => {
+    expect(() => resolveEntryUrl("about", "https://b"))
+      .toThrow(/must be http\(s\)/);
+  });
+
+  it("mailto:", () => {
+    expect(() => resolveEntryUrl("mailto:x@y.com", "https://b"))
+      .toThrow(/must be http\(s\)/);
+  });
+
+  it("empty string", () => {
+    expect(() => resolveEntryUrl("", "https://b"))
+      .toThrow(/non-empty/);
+  });
+
+  it("non-string", () => {
+    // @ts-expect-error
+    expect(() => resolveEntryUrl(42, "https://b"))
+      .toThrow(/non-empty/);
+  });
+
+  it("null", () => {
+    // @ts-expect-error
+    expect(() => resolveEntryUrl(null, "https://b"))
+      .toThrow(/null/);
+  });
+
+  it("long unsafe URL truncated in error", () => {
+    const long = "javascript:" + "a".repeat(500);
+    try {
+      resolveEntryUrl(long, "https://b");
+      expect.fail("expected throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toMatch(/…/);
+      expect(msg.length).toBeLessThan(400);
+    }
+  });
+});

--- a/code/packages/typescript/forme-aot-sitemap-emitter/tests/validate.test.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/tests/validate.test.ts
@@ -1,0 +1,91 @@
+/**
+ * validate.test.ts — changefreq allowlist + priority clamping.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateChangefreq, clampPriority } from "../src/index.js";
+
+describe("validateChangefreq — accepts allowlist", () => {
+  const allowed = ["always", "hourly", "daily", "weekly", "monthly", "yearly", "never"];
+  for (const v of allowed) {
+    it(`'${v}' accepted`, () => {
+      expect(validateChangefreq(v)).toBe(v);
+    });
+  }
+
+  it("case-insensitive: 'Daily' → 'daily'", () => {
+    expect(validateChangefreq("Daily")).toBe("daily");
+  });
+
+  it("case-insensitive: 'DAILY' → 'daily'", () => {
+    expect(validateChangefreq("DAILY")).toBe("daily");
+  });
+});
+
+describe("validateChangefreq — rejects", () => {
+  it("rejects 'often' (not in allowlist)", () => {
+    expect(() => validateChangefreq("often"))
+      .toThrow(/one of \[always, hourly, daily, weekly, monthly, yearly, never\]/);
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateChangefreq("")).toThrow(/one of/);
+  });
+
+  it("rejects non-string", () => {
+    // @ts-expect-error
+    expect(() => validateChangefreq(42)).toThrow(/string/);
+  });
+
+  it("rejects null", () => {
+    // @ts-expect-error
+    expect(() => validateChangefreq(null)).toThrow(/string/);
+  });
+
+  it("error message includes the bad value", () => {
+    try {
+      validateChangefreq("often");
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toContain('"often"');
+    }
+  });
+});
+
+describe("clampPriority — clamps to [0.0, 1.0]", () => {
+  it("0 → '0.0'", () => expect(clampPriority(0)).toBe("0.0"));
+  it("0.5 → '0.5'", () => expect(clampPriority(0.5)).toBe("0.5"));
+  it("1 → '1.0'", () => expect(clampPriority(1)).toBe("1.0"));
+  it("0.75 → '0.8' (rounded)", () => expect(clampPriority(0.75)).toBe("0.8"));
+  it("0.25 → '0.3' (rounded)", () => expect(clampPriority(0.25)).toBe("0.3"));
+  it("0.01 → '0.0'", () => expect(clampPriority(0.01)).toBe("0.0"));
+});
+
+describe("clampPriority — out-of-range clamps", () => {
+  it("negative clamps to '0.0'", () => expect(clampPriority(-0.5)).toBe("0.0"));
+  it("very negative clamps to '0.0'", () => expect(clampPriority(-100)).toBe("0.0"));
+  it("above 1 clamps to '1.0'", () => expect(clampPriority(1.5)).toBe("1.0"));
+  it("very large clamps to '1.0'", () => expect(clampPriority(1e9)).toBe("1.0"));
+  it("-Infinity → '0.0'", () => expect(clampPriority(-Infinity)).toBe("0.0"));
+  it("+Infinity → '1.0'", () => expect(clampPriority(Infinity)).toBe("1.0"));
+});
+
+describe("clampPriority — defensive defaults", () => {
+  it("NaN → '0.5' (spec default)", () => expect(clampPriority(NaN)).toBe("0.5"));
+  it("non-number → '0.5'", () => {
+    // @ts-expect-error
+    expect(clampPriority("nope")).toBe("0.5");
+  });
+});
+
+describe("clampPriority — output always single-decimal", () => {
+  it("integer 0 still emits '0.0'", () => {
+    expect(clampPriority(0)).toMatch(/^[0-1]\.\d$/);
+  });
+
+  it("output always matches /^[0-1]\\.\\d$/", () => {
+    for (const v of [0, 0.1, 0.5, 0.9, 1, -1, 2, NaN]) {
+      expect(clampPriority(v)).toMatch(/^[0-1]\.\d$/);
+    }
+  });
+});

--- a/code/packages/typescript/forme-aot-sitemap-emitter/tsconfig.json
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-sitemap-emitter/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-sitemap-emitter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Eleventh FM00 v0 stage package — emits `sitemap.xml` per [sitemaps.org/protocol.html](https://www.sitemaps.org/protocol.html) from `SitemapEntry[]` + `baseUrl`. Pure transform: returns XML string; caller decides where to write.

```ts
import { generateSitemap } from "@coding-adventures/forme-aot-sitemap-emitter";

const xml = generateSitemap([
  { url: "/",      lastmod: "2026-05-19", changefreq: "daily",   priority: 1.0 },
  { url: "/about", lastmod: "2026-05-15", changefreq: "monthly", priority: 0.8 },
  { url: "https://other.example/x" },  // absolute URL passes through verbatim
], "https://example.com");

fs.writeFileSync("dist/sitemap.xml", xml);
```

Joins the FM00 v0 cluster.

## Validation rules

- **URL accept set**: `http(s)://` (case-insensitive) OR root-relative `/path`. Anything else throws `TypeError`.
- **URL reject set**: `javascript:`, `data:`, `file:`, `vbscript:`, `mailto:`, protocol-relative `//host`, `/\backslash-variant`, bare relative, empty, non-string.
- **changefreq allowlist**: `always | hourly | daily | weekly | monthly | yearly | never` (case-insensitive).
- **priority clamping**: `[0.0, 1.0]` with single-decimal format. NaN/non-number → 0.5 (spec default).
- **baseUrl** must be `http(s)://`; trailing slash trimmed.

## Fail-fast (no partial output)

Validation pass runs over EVERY entry BEFORE any XML is emitted. If anything fails, the caller never sees a partial sitemap.

## Output structure

- `<?xml ?>` prologue
- `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`
- per-entry `<url>` blocks with children in spec order: `loc → lastmod → changefreq → priority`
- `</urlset>`

Entries emitted in caller-supplied order. Same input + baseUrl → byte-identical output.

## Security

Five concerns addressed pre-push:

- **URL scheme injection** — crawlers blindly follow `<loc>` URLs; the emitter is the line of defence. Every forbidden scheme rejected synchronously.
- **XML entity injection** — every interpolated value through `escapeXml`. Single-pass character-class replacement covering all five XML 1.0 entities. CodeQL-friendly form.
- **C0 control byte smuggling** — `stripInvalidXml` removes XML 1.0-forbidden bytes (`0x00-0x1F` except `\t \n \r`) before escape.
- **changefreq allowlist** — defends downstream parsers against surprise values.
- **Fail-fast** — no partial XML on validation error.

Security review (general-purpose sub-agent): **no exploitable findings**.

## Capabilities

`[]` — pure transform.

## Tests

**112 tests across 4 files**, **100% line / 100% branch** coverage:

- `escape.test.ts` (22) — all five XML entities, composite, ampersand-first ordering, unicode passthrough, C0 control strip (individually), `\t\n\r` preservation, defensive coercion
- `url.test.ts` (30) — `normaliseBaseUrl` full accept/reject matrix; `resolveEntryUrl` absolute pass-through, root-relative join, full reject set including `/\backslash-variant`, long-URL truncation
- `validate.test.ts` (30) — every allowlist value parametrised, case-insensitive, reject with error containing bad value; clamping (boundary, rounding, NaN, non-number, ±Infinity)
- `generate.test.ts` (30) — XML envelope, entry rendering (minimal/full/child-order/mixed/trailing-slash baseUrl), URL validation throws before emit, changefreq + priority validation, XML escaping (ampersand/quotes/control bytes), purity/determinism, fail-fast on mid-array validation error, 100-entry stress test

## Spec adherence

Implements sitemaps.org protocol. No spec divergences.

## v0 simplifications

- No sitemap-index file (single urlset only; sites exceeding 50k URLs / 50MB split externally)
- No image/video/news extensions (optional namespaces deferred)
- No gzip output (caller compresses)
- No URL deduplication (caller dedupes)
- No locale-aware lastmod validation

## Test plan

- [x] All 112 tests pass locally
- [x] 100% line / 100% branch coverage
- [x] TypeScript build clean
- [x] Security review clean (all 5 focus areas pass)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)