### PR TITLE
feat(sql-vm): datetime timezone-offset modifiers + 'auto' modifier + %P specifier

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [1.49.0] - 2026-05-19
+
+### Added
+
+Datetime modifier and strftime improvements surfaced end-to-end via
+``sql-vm 1.33.0``:
+
+- **Timezone offset modifiers** — ``+HH:MM``, ``-HH:MM``, ``+HH:MM:SS``
+  shift the underlying datetime by the given offset.  Common pattern
+  for converting UTC to a fixed display timezone::
+
+      SELECT datetime('2024-03-15 14:30:00', '+02:00');
+      -- → '2024-03-15 16:30:00'
+
+- **``auto`` modifier** is now accepted as a no-op (SQLite 3.46+).
+  Previously caused NULL propagation as an unrecognised modifier.
+
+### Fixed
+
+- **``%P`` strftime specifier** now returns ``'am'``/``'pm'`` on macOS.
+  Python's macOS libc returns the literal ``'P'`` for ``%P``, which
+  caused mini-sqlite to diverge from real ``sqlite3`` on macOS CI
+  runners.  Pre-processing ``%P`` in ``sql-vm`` fixes the divergence.
+
+17 new oracle tests in ``test_tier3_datetime_modifier_additions.py``
+pin all three behaviours byte-for-byte against ``sqlite3``.
+
 ## [1.48.0] - 2026-05-19
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.48.0"
+version = "1.49.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_datetime_modifier_additions.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_datetime_modifier_additions.py
@@ -1,0 +1,122 @@
+"""Oracle tests for newly added datetime modifiers and strftime specifiers.
+
+This file pins behaviour for additions to ``sql_vm.scalar_functions``
+against real ``sqlite3`` so we know we match SQLite's exact semantics:
+
+1. **Timezone offset modifiers** — ``+HH:MM``, ``-HH:MM``,
+   ``+HH:MM:SS`` shift the datetime by the given offset.
+
+2. **``auto`` modifier no-op** — previously caused NULL propagation
+   (unrecognised modifier).  Mini-sqlite dispatches numeric time values
+   by Python type, so ``auto`` is a semantic no-op here; accepting it
+   prevents NULL for SQL written against SQLite 3.46+.
+
+3. **``%P`` strftime specifier** — lowercase ``am``/``pm``.  Python's
+   macOS libc returns the literal ``'P'`` for ``strftime('%P')``, so we
+   pre-process it ourselves.  Without that fix mini-sqlite would diverge
+   from real SQLite on macOS CI runners.
+
+All assertions compare against the real ``sqlite3`` module directly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _one(sql: str):
+    return mini_sqlite.connect(":memory:").execute(sql).fetchone()[0]
+
+
+def _ref(sql: str):
+    return sqlite3.connect(":memory:").execute(sql).fetchone()[0]
+
+
+def _check(sql: str) -> None:
+    m, r = _one(sql), _ref(sql)
+    assert m == r, f"SQL: {sql!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# Timezone offset modifiers
+# ---------------------------------------------------------------------------
+
+
+class TestTimezoneOffsetModifier:
+    def test_positive_hours(self) -> None:
+        _check("SELECT datetime('2024-03-15 14:30:00', '+02:00')")
+
+    def test_negative_hours_minutes(self) -> None:
+        _check("SELECT datetime('2024-03-15 14:30:00', '-05:30')")
+
+    def test_with_seconds(self) -> None:
+        _check("SELECT datetime('2024-03-15 14:30:00', '+02:30:45')")
+
+    def test_zero_offset(self) -> None:
+        _check("SELECT datetime('2024-03-15 14:30:00', '+00:00')")
+
+    def test_day_rollback(self) -> None:
+        _check("SELECT datetime('2024-03-15 02:00:00', '-05:00')")
+
+    def test_day_rollforward(self) -> None:
+        _check("SELECT datetime('2024-03-15 22:00:00', '+04:00')")
+
+    def test_with_date_function(self) -> None:
+        # Applying a timezone offset to a midnight time should not shift
+        # the date (since 00:00 + 12:00 stays on the same day).
+        _check("SELECT date('2024-03-15', '+12:00')")
+
+    def test_chained_with_day_offset(self) -> None:
+        _check("SELECT datetime('2024-03-15 14:30:00', '+02:00', '+1 day')")
+
+
+# ---------------------------------------------------------------------------
+# auto / julianday no-op modifiers
+# ---------------------------------------------------------------------------
+
+
+class TestAutoModifier:
+    def test_auto_does_not_null(self) -> None:
+        _check("SELECT datetime('2024-03-15 14:30:00', 'auto')")
+
+    def test_auto_chained_with_offset(self) -> None:
+        _check("SELECT datetime('2024-03-15 14:30:00', 'auto', '+1 day')")
+
+    def test_unrecognised_modifier_still_null(self) -> None:
+        # Make sure we didn't accidentally accept arbitrary garbage.
+        # SQLite returns NULL for unknown modifiers.
+        assert _one("SELECT datetime('2024-03-15 14:30:00', 'totally_bogus_x')") is None
+        assert _ref("SELECT datetime('2024-03-15 14:30:00', 'totally_bogus_x')") is None
+
+
+# ---------------------------------------------------------------------------
+# strftime %P (lowercase am/pm)
+# ---------------------------------------------------------------------------
+
+
+class TestStrftimeLowerCaseAmPm:
+    def test_pm_afternoon(self) -> None:
+        _check("SELECT strftime('%P', '2024-03-15 14:30:00')")
+
+    def test_am_morning(self) -> None:
+        _check("SELECT strftime('%P', '2024-03-15 06:30:00')")
+
+    def test_am_midnight(self) -> None:
+        _check("SELECT strftime('%P', '2024-03-15 00:00:00')")
+
+    def test_pm_noon(self) -> None:
+        _check("SELECT strftime('%P', '2024-03-15 12:00:00')")
+
+    def test_combined_format(self) -> None:
+        _check("SELECT strftime('%I:%M %P', '2024-03-15 14:30:00')")
+
+    def test_distinct_from_uppercase(self) -> None:
+        # %P is am/pm; %p is AM/PM
+        mini_lower = _one("SELECT strftime('%P', '2024-03-15 14:30:00')")
+        mini_upper = _one("SELECT strftime('%p', '2024-03-15 14:30:00')")
+        ref_lower = _ref("SELECT strftime('%P', '2024-03-15 14:30:00')")
+        ref_upper = _ref("SELECT strftime('%p', '2024-03-15 14:30:00')")
+        assert mini_lower == ref_lower == "pm"
+        assert mini_upper == ref_upper == "PM"

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.33.0 — 2026-05-19
+
+### Added
+
+- **Datetime timezone-offset modifiers** in ``_apply_modifier``: the
+  ``±HH:MM``, ``±HH:MM:SS``, and ``±HH:MM:SS.SSS`` forms now shift the
+  underlying datetime by the given offset, matching SQLite::
+
+      datetime('2024-03-15 14:30:00', '+02:00')    → '2024-03-15 16:30:00'
+      datetime('2024-03-15 14:30:00', '-05:30')    → '2024-03-15 09:00:00'
+      datetime('2024-03-15 14:30:00', '+02:30:45') → '2024-03-15 17:00:45'
+
+  Out-of-range components (e.g. ``+99:00``) return NULL.
+- **``auto`` modifier** is now accepted as a no-op (SQLite 3.46+
+  introduced it for forward-compat with future numeric encodings).
+  Mini-sqlite's per-Python-type dispatch in ``_parse_timevalue`` already
+  achieves what ``auto`` documents, so the modifier becomes a pass-
+  through here; this matches real SQLite's behaviour on string inputs.
+
+### Fixed
+
+- **``%P`` strftime specifier** now returns ``'am'``/``'pm'`` on every
+  platform.  Python's macOS libc returns the literal ``'P'`` for
+  ``strftime('%P')``; we pre-process the specifier ourselves so output
+  matches SQLite on Linux, macOS, and Windows CI runners.
+
 ## 1.32.0 — 2026-05-19
 
 ### Added

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.32.0"
+version = "1.33.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -1773,6 +1773,54 @@ def _apply_modifier(dt: datetime, modifier: str) -> datetime | None:
     if m_lower == "unixepoch":
         return dt
 
+    # auto (SQLite 3.46+) — auto-detect whether a numeric time argument was a
+    # Unix epoch or a Julian day, based on its magnitude.  In mini-sqlite the
+    # parser at :func:`_parse_timevalue` already discriminates by Python type
+    # (``int`` → Unix epoch, ``float`` → Julian day), so this modifier is a
+    # semantic no-op for us: by the time we reach ``_apply_modifier`` the
+    # value is already a ``datetime``.  Accepting ``auto`` prevents NULL
+    # propagation for application SQL written against SQLite 3.46+ that uses
+    # it defensively (e.g. for forward-compatibility with future numeric
+    # encodings).  Real SQLite also accepts ``auto`` on string inputs and
+    # treats it as a pass-through, matching our behaviour here.
+    if m_lower == "auto":
+        return dt
+
+    # Note: we do not accept ``julianday`` as a modifier.  In real SQLite
+    # that modifier *requires* the time value to be a float and returns NULL
+    # otherwise; we can't reliably reproduce that without restructuring
+    # ``_resolve_datetime`` to keep the original value type alongside the
+    # parsed datetime.  For ``float`` inputs mini-sqlite already interprets
+    # them as Julian days via ``_parse_timevalue``, so omitting the modifier
+    # is harmless in the common case.
+
+    # Timezone offset: ±HH:MM, ±HH:MM:SS, ±HH:MM:SS.SSS
+    #
+    # SQLite treats the offset as a *shift* of the underlying datetime: a
+    # positive value moves the wall-clock forward (UTC + offset), a negative
+    # value moves it backward.  Application code typically uses this to
+    # convert from UTC to a fixed timezone for display::
+    #
+    #     datetime('2024-03-15 14:30:00', '+02:00') → '2024-03-15 16:30:00'
+    #     datetime('2024-03-15 14:30:00', '-05:30') → '2024-03-15 09:00:00'
+    #
+    # The seconds/fractional-seconds portions are optional and rarely used
+    # but accepted for completeness with SQLite.
+    tz_match = re.match(
+        r"^([+-])(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?$",
+        m_lower,
+    )
+    if tz_match:
+        sign = 1 if tz_match.group(1) == "+" else -1
+        h = int(tz_match.group(2))
+        m = int(tz_match.group(3))
+        s = int(tz_match.group(4)) if tz_match.group(4) else 0
+        # Reject out-of-range components (e.g. '+99:99') — match SQLite.
+        if h > 23 or m > 59 or s > 59:
+            return None
+        total_seconds = sign * (h * 3600 + m * 60 + s)
+        return dt + timedelta(seconds=total_seconds)
+
     # Numeric offset: [+-]N unit
     pat = re.match(
         r"^([+-]?\d+(?:\.\d+)?)\s+"
@@ -1951,11 +1999,19 @@ def _unixepoch(*args: SqlValue) -> SqlValue:
 
 # Pre-compiled substitution map for STRFTIME's SQLite-specific specifiers.
 # Python's strftime does not support %f (SQLite = SS.SSS) or %s (epoch) or %J.
-_STRFTIME_PREPROCESS = re.compile(r"%[fJjsW]")
+_STRFTIME_PREPROCESS = re.compile(r"%[fJjsWP]")
 
 
 def _sqlite_strftime(fmt: str, dt: datetime) -> str:
-    """Format *dt* using SQLite's strftime specifiers, delegating to Python."""
+    """Format *dt* using SQLite's strftime specifiers, delegating to Python.
+
+    Cross-platform note on ``%P``
+    -----------------------------
+    SQLite's ``%P`` is lowercase ``am``/``pm`` (the GNU extension).  Python's
+    own ``strftime`` honours this on Linux libc but not on macOS libc — on
+    macOS ``dt.strftime('%P')`` returns the literal ``'P'``.  We pre-process
+    ``%P`` ourselves so output is identical on every platform.
+    """
     def _replace(m: re.Match) -> str:  # type: ignore[type-arg]
         spec = m.group(0)
         if spec == "%f":
@@ -1971,6 +2027,10 @@ def _sqlite_strftime(fmt: str, dt: datetime) -> str:
         if spec == "%W":
             # Week number (Monday as first day, 00–53)
             return f"{dt.isocalendar()[1] - 1:02d}"
+        if spec == "%P":
+            # Lowercase am/pm — Python's macOS libc doesn't support %P so we
+            # synthesise it from %p (uppercase) and lowercase the result.
+            return "am" if dt.hour < 12 else "pm"
         return spec
 
     processed = _STRFTIME_PREPROCESS.sub(_replace, fmt)

--- a/code/packages/python/sql-vm/tests/test_scalar_functions.py
+++ b/code/packages/python/sql-vm/tests/test_scalar_functions.py
@@ -1620,3 +1620,110 @@ class TestSqliteCompileOptions:
         # Any index returns NULL — no options exist.
         assert fn("sqlite_compileoption_get", 0) is None
         assert fn("sqlite_compileoption_get", 100) is None
+
+
+# ---------------------------------------------------------------------------
+# Datetime modifier — timezone offsets, auto, julianday-no-op
+# ---------------------------------------------------------------------------
+
+
+class TestTimezoneOffsetModifier:
+    """``+HH:MM`` / ``-HH:MM`` / ``+HH:MM:SS`` shift the datetime by that offset."""
+
+    def test_positive_hours(self) -> None:
+        # Adding +02:00 moves UTC clock forward by 2 hours.
+        assert fn("datetime", "2024-03-15 14:30:00", "+02:00") == "2024-03-15 16:30:00"
+
+    def test_negative_hours_minutes(self) -> None:
+        # -05:30 moves clock back 5h30m.
+        assert fn("datetime", "2024-03-15 14:30:00", "-05:30") == "2024-03-15 09:00:00"
+
+    def test_with_seconds(self) -> None:
+        # +02:30:45 → +2h30m45s
+        assert fn("datetime", "2024-03-15 14:30:00", "+02:30:45") == "2024-03-15 17:00:45"
+
+    def test_zero_offset(self) -> None:
+        # +00:00 is a no-op.
+        assert fn("datetime", "2024-03-15 14:30:00", "+00:00") == "2024-03-15 14:30:00"
+
+    def test_offset_at_day_boundary(self) -> None:
+        # -05:00 from 02:00 should roll back to previous day.
+        assert fn("datetime", "2024-03-15 02:00:00", "-05:00") == "2024-03-14 21:00:00"
+
+    def test_hour_out_of_range_returns_null(self) -> None:
+        # SQLite returns NULL for invalid offsets like +99:00.
+        assert fn("datetime", "2024-03-15 14:30:00", "+99:00") is None
+
+    def test_minute_out_of_range_returns_null(self) -> None:
+        assert fn("datetime", "2024-03-15 14:30:00", "+02:99") is None
+
+    def test_with_date_only(self) -> None:
+        # Applying timezone to date() crops back to date — verify via date().
+        # date('2024-03-15', '+12:00') → still 2024-03-15 (midnight + 12h)
+        assert fn("date", "2024-03-15", "+12:00") == "2024-03-15"
+
+    def test_offset_chained_with_other_modifier(self) -> None:
+        # Modifiers compose left-to-right.
+        result = fn(
+            "datetime", "2024-03-15 14:30:00", "+02:00", "+1 day"
+        )
+        assert result == "2024-03-16 16:30:00"
+
+
+class TestAutoModifier:
+    """The ``auto`` modifier no longer triggers NULL propagation.
+
+    Mini-sqlite's :func:`_parse_timevalue` dispatches numeric time values
+    by Python type (``int`` → Unix epoch, ``float`` → Julian day), so
+    ``auto`` is a semantic no-op here.  Accepting it matches SQLite's
+    behaviour on string inputs (pass-through).
+    """
+
+    def test_auto_modifier_no_op_on_string(self) -> None:
+        # 'auto' should not cause NULL propagation; passes the datetime through.
+        assert fn("datetime", "2024-03-15 14:30:00", "auto") == "2024-03-15 14:30:00"
+
+    def test_auto_modifier_with_chained_offset(self) -> None:
+        # 'auto' composes with subsequent modifiers.
+        assert (
+            fn("datetime", "2024-03-15 14:30:00", "auto", "+1 day")
+            == "2024-03-16 14:30:00"
+        )
+
+    def test_unrecognised_modifier_still_returns_null(self) -> None:
+        # Confirm that we didn't accidentally swallow unknown modifiers.
+        assert fn("datetime", "2024-03-15 14:30:00", "totally_made_up") is None
+
+
+# ---------------------------------------------------------------------------
+# strftime %P (lowercase am/pm) cross-platform
+# ---------------------------------------------------------------------------
+
+
+class TestStrftimeLowerCaseAmPm:
+    """``%P`` produces ``am``/``pm`` on every platform.
+
+    Python's macOS libc returns the literal ``'P'`` for ``strftime('%P')``
+    rather than ``'pm'``.  We pre-process ``%P`` ourselves so output is
+    identical on Linux, macOS, and Windows CI.
+    """
+
+    def test_pm_at_afternoon(self) -> None:
+        assert fn("strftime", "%P", "2024-03-15 14:30:00") == "pm"
+
+    def test_am_at_morning(self) -> None:
+        assert fn("strftime", "%P", "2024-03-15 06:30:00") == "am"
+
+    def test_am_at_midnight(self) -> None:
+        # 00:00 — should be 'am' (12 AM convention).
+        assert fn("strftime", "%P", "2024-03-15 00:00:00") == "am"
+
+    def test_pm_at_noon(self) -> None:
+        # 12:00 — should be 'pm' (12 PM convention).
+        assert fn("strftime", "%P", "2024-03-15 12:00:00") == "pm"
+
+    def test_combined_format(self) -> None:
+        # %P composes with other specifiers.
+        assert (
+            fn("strftime", "%I:%M %P", "2024-03-15 14:30:00") == "02:30 pm"
+        )


### PR DESCRIPTION
## Summary

Three real-world datetime gaps closed, all oracle-verified against `sqlite3`:

1. **Timezone offset modifiers** — `±HH:MM`, `±HH:MM:SS`, `±HH:MM:SS.SSS` now shift the underlying datetime. Out-of-range components return NULL.
2. **`auto` modifier** (SQLite 3.46+) is now accepted as a no-op (previously caused NULL propagation as an unrecognised modifier).
3. **`%P` strftime specifier** (lowercase `am`/`pm`) is now correct on macOS — Python's macOS libc returns the literal `'P'` for `strftime('%P')`, so we pre-process the specifier ourselves to keep CI consistent across platforms.

## Behaviour matrix

| Modifier | Input | Output |
|----------|-------|--------|
| `+02:00` | `'2024-03-15 14:30:00'` | `'2024-03-15 16:30:00'` |
| `-05:30` | `'2024-03-15 14:30:00'` | `'2024-03-15 09:00:00'` |
| `+02:30:45` | `'2024-03-15 14:30:00'` | `'2024-03-15 17:00:45'` |
| `+99:00` (invalid) | any | `NULL` |
| `auto` | `'2024-03-15 14:30:00'` | `'2024-03-15 14:30:00'` |
| `%P` | `14:30:00` | `'pm'` |
| `%P` | `06:30:00` | `'am'` |

## Version bumps

- `sql-vm`: 1.32.0 → 1.33.0
- `mini-sqlite`: 1.48.0 → 1.49.0

## Test plan

- [x] `pytest code/packages/python/sql-vm/tests/` — 714 pass (17 new), coverage 80.45%
- [x] `pytest code/packages/python/mini-sqlite/tests/` — 1464 pass (17 new), coverage 91.23%
- [x] All oracle tests compare byte-for-byte against `sqlite3`
- [x] Manual security review: no I/O, no eval, bounded regex, fixed string output

🤖 Generated with [Claude Code](https://claude.com/claude-code)