### PR TITLE
Finish HTML fixture generator IO sharing

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -17,8 +17,8 @@ documented in this file.
   the crate links static source instead of loading TOML at runtime.
 - Fixture-backed tests proving the generated lexer definition and emitted
   runtime tokens stay aligned.
-- Shared JSON fixture IO helpers keep generated WHATWG boundary and recovery
-  fixture writers on the same stable `--check` path.
+- Shared JSON fixture IO helpers keep generated WHATWG fixture writers on the
+  same stable `--check` path.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -107,7 +107,7 @@ The same helper module centralizes generated suite metadata guards for format,
 description, case-count floor, and sentinel case IDs.
 The fixture generator scripts also share JSON fixture IO helpers, so `--check`
 mode, stale-file diagnostics, sorted output, and UTF-8 preservation stay
-consistent across generated WHATWG boundary and recovery fixtures.
+consistent across generated WHATWG fixtures.
 The generated text-mode boundary suite drills into parser-seeded RCDATA,
 RAWTEXT, and PLAINTEXT state boundaries: less-than recovery, end-tag-open/name
 continuations, NULL replacement, EOF literal recovery, and PLAINTEXT markup

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py
@@ -12,8 +12,9 @@ unexpected solidus recovery, and recoverable end-tag attributes.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-attribute-edges.json")
@@ -23,16 +24,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_chunk_boundaries_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_chunk_boundaries_fixture.py
@@ -11,8 +11,9 @@ across representative tokenizer states and recovery paths.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-chunk-boundaries.json")
@@ -229,16 +230,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py
@@ -19,6 +19,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from generated_fixture_io import write_fixture_json
+
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-entities.json")
 SOURCE_URL = "https://html.spec.whatwg.org/entities.json"
@@ -31,16 +33,12 @@ def main() -> int:
 
     entities = json.loads(source.read_text())
     fixture = build_fixture(entities)
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it from {source}")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(
+        output,
+        fixture,
+        check=args.check,
+        stale_hint=f"from {source}",
+    )
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py
@@ -10,8 +10,9 @@ doctypes, character references, text modes, and seeded continuation states.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-eof-recovery.json")
@@ -339,16 +340,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py
@@ -11,8 +11,9 @@ RCDATA, script data, and seeded continuation states.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-input-stream.json")
@@ -225,16 +226,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py
@@ -11,8 +11,9 @@ html5lib-style adapters can resume through the typed Rust context API.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-markup-declarations.json")
@@ -22,16 +23,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py
@@ -13,8 +13,9 @@ hand.
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
+
+from generated_fixture_io import write_fixture_json
 
 
 DEFAULT_OUTPUT = Path(__file__).with_name("whatwg-numeric-references.json")
@@ -54,16 +55,7 @@ def main() -> int:
     args = parse_args()
     output = Path(args.output).expanduser().resolve()
     fixture = build_fixture()
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output.read_text()
-        if existing != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
-        return 0
-
-    output.write_text(text)
-    return 0
+    return write_fixture_json(output, fixture, check=args.check)
 
 
 def parse_args() -> argparse.Namespace:

--- a/code/packages/rust/html-lexer/tests/fixtures/generated_fixture_io.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generated_fixture_io.py
@@ -7,12 +7,25 @@ from pathlib import Path
 from typing import Any
 
 
-def write_fixture_json(output: Path, fixture: dict[str, Any], *, check: bool) -> int:
-    text = json.dumps(fixture, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+def write_fixture_json(
+    output: Path,
+    fixture: dict[str, Any],
+    *,
+    check: bool,
+    ensure_ascii: bool = False,
+    stale_hint: str | None = None,
+) -> int:
+    text = json.dumps(
+        fixture,
+        indent=2,
+        ensure_ascii=ensure_ascii,
+        sort_keys=True,
+    ) + "\n"
 
     if check:
         if output.read_text() != text:
-            raise SystemExit(f"{output} is stale; regenerate it")
+            hint = f" {stale_hint}" if stale_hint is not None else ""
+            raise SystemExit(f"{output} is stale; regenerate it{hint}")
         return 0
 
     output.write_text(text)

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py
@@ -12,12 +12,17 @@ the catch-all smoke test.
 from __future__ import annotations
 
 import argparse
-import json
 import re
+import sys
 from pathlib import Path
 
 
 FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
 DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
 DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-tree-insertion-audit.json"
 
@@ -57,16 +62,7 @@ def main() -> int:
 
     sources = parse_sources(input_path)
     fixture = build_fixture(sources)
-    text = json.dumps(fixture, indent=2, sort_keys=True) + "\n"
-
-    if args.check:
-        existing = output_path.read_text()
-        if existing != text:
-            raise SystemExit(f"{output_path} is stale; regenerate it")
-        return 0
-
-    output_path.write_text(text)
-    return 0
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- extend the shared generated fixture JSON writer with stale hints and ASCII-preserving output
- route the remaining WHATWG lexer fixture generators and parser tree-insertion generator through the shared IO path
- tighten html-lexer docs/changelog wording now all generated WHATWG fixture writers share the helper

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_chunk_boundaries_fixture.py --check
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/generated_fixture_io.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_entities_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_numeric_references_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_edges_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_markup_declarations_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_eof_recovery_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_input_stream_fixture.py code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_chunk_boundaries_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py