### PR TITLE
feat(forme-aot-robots-emitter): FM00 v0 robots.txt emitter

### DIFF
--- a/code/packages/typescript/forme-aot-robots-emitter/BUILD
+++ b/code/packages/typescript/forme-aot-robots-emitter/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-robots-emitter/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-robots-emitter/CHANGELOG.md
@@ -1,0 +1,130 @@
+# Changelog — @coding-adventures/forme-aot-robots-emitter
+
+## 0.1.0 — 2026-05-19
+
+Initial release.  Twelfth FM00 v0 stage package — robots.txt
+emitter per https://www.robotstxt.org/orig.html + Google /
+Yandex extensions (Crawl-delay, Sitemap, Host).
+
+Pure transform: `RobotsConfig` → plain-text string.  Validation
+runs in a fail-fast pre-pass BEFORE emission so callers never
+see a partial robots.txt.
+
+### Added
+
+- `generateRobots(config): string` — main entry.  Returns the
+  complete robots.txt content.  Throws `TypeError`
+  synchronously on any validation failure.
+- `validateDirectiveValue(value, field)` — guards User-agent /
+  Allow / Disallow values against line-format injection.
+- `validateCrawlDelay(value)` — non-negative finite integer
+  check.
+- `validateSitemapUrl(url)` — http(s):// accept-list (same as
+  forme-aot-sitemap-emitter).
+- `validateHost(host)` — bare hostname check (no scheme, no
+  path).
+- `RobotsConfig`, `RobotsRule` types.
+
+### Spec adherence
+
+Implements the de-facto robots.txt protocol plus widely-
+recognised extensions.  No spec divergences.
+
+### Behavioural notes
+
+- **Rule order preserved.**  Caller decides the order of rule
+  blocks; emitter never reorders.
+- **Within-rule line order.**  `User-agent:` → `Allow:` →
+  `Disallow:` → `Crawl-delay:`.  Allow before Disallow because
+  the most-specific-rule-wins convention makes Allow
+  exceptions easier to read when listed first.
+- **Multiple userAgents per rule.**  Array input emits one
+  `User-agent:` line per element; the subsequent Allow /
+  Disallow / Crawl-delay lines apply to the union.
+- **Sitemap / Host after all rules.**  Convention; defers
+  these to the end of the file separated from the last rule
+  block by a blank line.
+- **Output trailing newline.**  Single `\n` at the end per
+  Unix convention.
+- **Empty config (`rules: []`, no sitemap, no host)** →
+  empty string (no trailing newline).
+
+### Security posture
+
+Five concerns explicitly addressed (pre-push review):
+
+- **Line-format header injection.**  Newlines (LF / CR / CRLF),
+  NUL, DEL, and all C0 controls EXCEPT TAB rejected in any
+  directive value.  Robots.txt is line-oriented; an unescaped
+  newline would split into extra (attacker-controlled)
+  directives.  This is the line-format analogue of HTTP
+  response splitting.  Pinned by tests for every vector.
+- **URL scheme injection on sitemap.**  Same accept-list as
+  the sitemap emitter — `javascript:`, `data:`, `file:`,
+  `vbscript:`, protocol-relative, root-relative all rejected
+  with `TypeError`.
+- **Host scheme confusion.**  `host: "https://x.com"`
+  rejected; the directive takes a bare hostname per Yandex's
+  documentation.  Path / query / fragment / space also
+  rejected.
+- **Crawl-delay type / range confusion.**  Negative values,
+  NaN, ±Infinity, non-numbers, non-integers all rejected with
+  `TypeError`.  Zero is permitted (means "no throttling").
+- **Fail-fast.**  Validation pass completes for every field
+  BEFORE any output is built.  An exception means the caller
+  has nothing to write — no risk of a half-formed robots.txt
+  reaching disk.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, no network, no shell, no env,
+no fs.
+
+### Tests
+
+93 tests across 2 files:
+
+- `validate.test.ts` (52) — `validateDirectiveValue` accept
+  (plain string, path, wildcard, `$` end-of-URL marker,
+  %-encoded path, embedded TAB) + reject (LF, CR, CRLF, NUL,
+  DEL, ESC, parameterised loop over every C0 except TAB,
+  empty, non-string, null, error contains field name);
+  `validateCrawlDelay` accept (zero, positive integer, large)
+  + reject (negative, NaN, ±Infinity, fractional, non-number);
+  `validateSitemapUrl` accept (https, http, case-insensitive,
+  port + query) + reject (root-relative, javascript:, file:,
+  data:, protocol-relative, empty, non-string, LF injection,
+  long-URL truncation in error); `validateHost` accept (bare,
+  hostname:port, subdomain, IP) + reject (URL with scheme,
+  path, query, fragment, space, LF injection, empty,
+  non-string, null).
+- `generate.test.ts` (41) — minimal (empty config, single
+  allow / disallow); multiple rule blocks (separated by blank
+  line, preserved order); userAgent array (one line per
+  element, empty array throws, non-string/array throws);
+  Allow before Disallow ordering, multiple paths each get
+  line; crawlDelay (after disallow, zero permitted, undefined
+  omits, negative/fractional/NaN reject); sitemap (single,
+  array, after rules, javascript:/root-relative/LF/non-string
+  rejects); host (after sitemap, scheme/path reject); header-
+  injection defence (userAgent / disallow / allow newline /
+  CR / NUL all reject, error identifies bad field); fail-
+  fast (bad rule in mid-array, bad sitemap with valid rules);
+  input shape validation (null rule, non-array allow/disallow);
+  purity / determinism (no input mutation, byte-identical
+  output, trailing newline); full real-world example
+  (verbatim line check).
+
+Coverage: **100% line / 98.11% branch** across all source
+files with logic (`types.ts` is type-only declarations).
+
+### v0 simplifications (documented)
+
+- **No comments.**  `#`-prefixed syntax part of robots.txt but
+  rarely used in machine-generated output.  v1 may add an
+  optional `comment` field on rules.
+- **No `Request-rate` extension.**  Less widely-supported than
+  `Crawl-delay`; deferred.
+- **No `Clean-param` extension.**  Yandex-specific; deferred.
+- **No wildcard validation.**  `*` and `$` accepted as path
+  characters but their meaning isn't checked.

--- a/code/packages/typescript/forme-aot-robots-emitter/README.md
+++ b/code/packages/typescript/forme-aot-robots-emitter/README.md
@@ -1,0 +1,234 @@
+# @coding-adventures/forme-aot-robots-emitter
+
+Emit `robots.txt` from a structured `RobotsConfig` per
+[robotstxt.org/orig.html](https://www.robotstxt.org/orig.html)
++ widely-recognised Google / Yandex extensions.
+
+Pure transform — returns the plain-text string; caller writes
+it wherever.  Validation runs BEFORE emission, so callers never
+see a partial robots.txt.
+
+Twelfth FM00 v0 stage package — joins the FM00 v0 cluster.
+
+## Quick start
+
+```ts
+import { generateRobots } from "@coding-adventures/forme-aot-robots-emitter";
+
+const txt = generateRobots({
+  rules: [
+    { userAgent: "*",         disallow: ["/admin", "/private"], crawlDelay: 10 },
+    { userAgent: "Googlebot", allow: ["/"]                                     },
+    { userAgent: ["Bingbot", "Slurp"], crawlDelay: 5 },
+  ],
+  sitemap: "https://example.com/sitemap.xml",
+  host: "example.com",
+});
+
+fs.writeFileSync("dist/robots.txt", txt);
+```
+
+Output:
+
+```
+User-agent: *
+Disallow: /admin
+Disallow: /private
+Crawl-delay: 10
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+User-agent: Slurp
+Crawl-delay: 5
+
+Sitemap: https://example.com/sitemap.xml
+Host: example.com
+```
+
+## API
+
+### `generateRobots(config): string`
+
+Main entry.  Returns the complete robots.txt content as a string.
+
+```ts
+interface RobotsConfig {
+  readonly rules: readonly RobotsRule[];
+  readonly sitemap?: string | readonly string[];
+  readonly host?: string;
+}
+
+interface RobotsRule {
+  readonly userAgent: string | readonly string[];
+  readonly allow?: readonly string[];
+  readonly disallow?: readonly string[];
+  readonly crawlDelay?: number;
+}
+```
+
+Throws `TypeError` synchronously BEFORE any output if:
+
+- Any directive value contains CR / LF / NUL / DEL / other C0
+  control byte (line-format injection risk — see Security).
+- `crawlDelay` isn't a non-negative finite integer.
+- `sitemap` URL isn't `http(s)://`.
+- `host` looks like a URL (scheme / path / query / fragment).
+- Required fields missing or wrong type.
+
+### Sub-helpers (exposed)
+
+- `validateDirectiveValue(value, field)` — guards a User-agent /
+  Allow / Disallow value against injection.
+- `validateCrawlDelay(value)` — non-negative finite integer.
+- `validateSitemapUrl(url)` — http(s):// accept-list.
+- `validateHost(host)` — bare hostname.
+
+## Header-injection defence
+
+The robots.txt protocol is line-oriented: any unescaped newline
+or CR in a value would split into extra (possibly attacker-
+controlled) directive lines:
+
+```
+User-agent: Goodbot
+Disallow: /admin    ← intended
+
+User-agent: Goodbot
+Disallow: /admin
+User-agent: *       ← injected by hostile data!
+Allow: /admin       ← injected by hostile data!
+```
+
+This is the line-format analogue of HTTP response splitting.
+We **reject** (not strip) such inputs so the caller knows about
+the bad data rather than silently shipping a half-formed
+directive.
+
+Forbidden characters in any directive value:
+
+- CR (`\x0D`), LF (`\x0A`) — the injection vectors themselves
+- NUL (`\x00`), DEL (`\x7F`) — parser confusion vectors
+- Other C0 controls (`\x01-\x1F`) EXCEPT TAB (`\x09`) — kept for
+  the rare case of multi-word user-agent strings
+
+## URL validation (sitemap)
+
+Sitemap URLs use the same accept-list as
+[`forme-aot-sitemap-emitter`](../forme-aot-sitemap-emitter):
+
+- Accept: `http(s)://...` (case-insensitive scheme).
+- Reject: `javascript:`, `data:`, `file:`, `vbscript:`,
+  protocol-relative `//host`, root-relative `/path` (absolute
+  required for `Sitemap:` directive per the spec), empty,
+  non-string.
+
+## Host validation
+
+The `Host:` directive (Yandex extension; widely-ignored but
+harmless) takes a bare hostname.  We reject:
+
+- URLs with scheme (`https://example.com`)
+- URLs with path / query / fragment
+- Strings containing spaces
+- Strings with injection characters
+
+## Behavioural contract
+
+| Aspect                          | Behaviour                              |
+|---------------------------------|----------------------------------------|
+| Input config                    | Never mutated                          |
+| Rule order                      | Preserved (caller decides order)       |
+| Per-rule line order             | UA → Allow → Disallow → Crawl-delay    |
+| Multiple UA per rule            | One `User-agent:` line per element     |
+| Validation                      | All fields validated BEFORE emit       |
+| Bad value                       | Throws `TypeError`; no partial output  |
+| Same input                      | Byte-identical output                  |
+| Empty config (`rules: []`)      | Empty string output                    |
+| Output trailing newline         | Yes (single `\n`)                      |
+
+## Reproducibility (FM03)
+
+Same `config` → byte-identical robots.txt.
+
+## Security posture
+
+Five concerns explicitly addressed (pre-push review):
+
+- **Line-format header injection.**  Newlines / CRs / NULs /
+  DELs / other C0 in any directive value rejected via
+  `validateDirectiveValue`.  Defends against an attacker
+  passing `userAgent: "Goodbot\nUser-agent: Evilbot"` to
+  inject sibling rules.
+- **URL scheme injection on sitemap.**  Same accept-list as
+  the sitemap emitter — `javascript:` / `data:` / etc.
+  rejected with `TypeError`.
+- **Host scheme confusion.**  `host: "https://x.com"` rejected
+  before emission so attackers can't piggy-back a full URL.
+- **Crawl-delay range / type confusion.**  Negative values,
+  NaN, Infinity, non-numbers, non-integers all rejected.
+- **Fail-fast.**  Validation pass completes for every field
+  BEFORE any output is built.  An exception means the caller
+  has nothing to write — no risk of a half-formed robots.txt
+  reaching disk.
+
+## Capabilities — `[]`
+
+Pure transform.  No I/O, no network, no shell, no env, no fs.
+
+## Tests
+
+93 tests across 2 files:
+
+- `validate.test.ts` (52) — `validateDirectiveValue` accept
+  (plain string, path, wildcard, `$` end-of-URL marker,
+  %-encoded path, embedded TAB) + reject (LF, CR, CRLF, NUL,
+  DEL, ESC, parameterised loop over every C0 except TAB,
+  empty, non-string, null, error contains field name);
+  `validateCrawlDelay` accept (zero, positive integer, large)
+  + reject (negative, NaN, ±Infinity, fractional, non-number);
+  `validateSitemapUrl` accept (https, http, case-insensitive,
+  port + query) + reject (root-relative, javascript:, file:,
+  data:, protocol-relative, empty, non-string, LF injection,
+  long-URL truncation); `validateHost` accept (bare,
+  hostname:port, subdomain, IP) + reject (URL with scheme,
+  path, query, fragment, space, LF injection, empty,
+  non-string, null).
+- `generate.test.ts` (41) — minimal (empty config, single
+  allow / disallow); multiple rule blocks (separated by blank
+  line, preserved order); userAgent array (one line per
+  element, empty array throws, non-string/array throws);
+  Allow before Disallow ordering, multiple paths each get
+  line; crawlDelay (after disallow, zero permitted, undefined
+  omits, negative/fractional/NaN reject); sitemap (single,
+  array, after rules, javascript: reject, root-relative
+  reject, LF reject, non-string reject); host (after sitemap,
+  scheme reject, path reject); header-injection defence
+  (userAgent / disallow / allow with newline/CR/NUL all
+  reject, error identifies bad field); fail-fast (bad rule in
+  mid-array, bad sitemap with valid rules); input shape
+  (null rule, non-array allow/disallow); purity / determinism
+  (no input mutation, byte-identical output, trailing
+  newline); full real-world example (verbatim line check).
+
+Coverage: **100% line / 98.11% branch** across all source
+files with logic (`types.ts` is type-only).
+
+## Spec adherence
+
+Implements robotstxt.org protocol (`User-agent`, `Allow`,
+`Disallow`) + Google / Bing / Yandex extensions
+(`Crawl-delay`, `Sitemap`, `Host`).  No spec divergences.
+
+## v0 simplifications
+
+- **No comments.**  The `#`-prefixed comment syntax is part of
+  robots.txt but rarely used in machine-generated output.  v1
+  may add an optional `comment` field on rules.
+- **No `Request-rate` extension.**  Less widely-supported than
+  `Crawl-delay`; deferred.
+- **No `Clean-param` extension.**  Yandex-specific; deferred.
+- **No wildcard validation.**  `*` and `$` are accepted as path
+  characters but their meaning isn't checked — the spec
+  permits arbitrary text.

--- a/code/packages/typescript/forme-aot-robots-emitter/package-lock.json
+++ b/code/packages/typescript/forme-aot-robots-emitter/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-aot-robots-emitter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-robots-emitter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-robots-emitter/package.json
+++ b/code/packages/typescript/forme-aot-robots-emitter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-aot-robots-emitter",
+  "version": "0.1.0",
+  "description": "Emit robots.txt from a structured RobotsConfig per https://www.robotstxt.org/orig.html + Google extensions.  Pure transform: validates URLs on sitemap/host, sanitises user-agent/path fields against header-injection (newlines / CRs rejected), validates crawlDelay range; returns plain-text string.  FM00 v0 emitter.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-robots-emitter/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-robots-emitter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-robots-emitter",
+  "capabilities": [],
+  "justification": "Pure transform: RobotsConfig → robots.txt string.  No I/O, no network, no env, no shell, no fs.  Same posture as forme-aot-sitemap-emitter."
+}

--- a/code/packages/typescript/forme-aot-robots-emitter/src/generate.ts
+++ b/code/packages/typescript/forme-aot-robots-emitter/src/generate.ts
@@ -1,0 +1,196 @@
+/**
+ * generate.ts — main `generateRobots` entry.
+ *
+ * Two-pass: validate every directive value first, then emit.
+ * If anything throws, the caller never sees a partial
+ * robots.txt.  Same fail-fast posture as
+ * `forme-aot-sitemap-emitter`.
+ *
+ * Output line format (per https://www.robotstxt.org/orig.html
+ * + Google extensions):
+ *
+ *   User-agent: <ua>
+ *   Allow: <path>
+ *   Disallow: <path>
+ *   Crawl-delay: <n>
+ *
+ *   [blank line]
+ *
+ *   [next rule block...]
+ *
+ *   Sitemap: <url>
+ *   Host: <host>
+ *
+ * Rule blocks separated by exactly one blank line.  Sitemap
+ * and Host directives appear after all rule blocks (a single
+ * blank line separates them from the last rule).
+ *
+ * @module generate
+ */
+
+import type { RobotsConfig, RobotsRule } from "./types.js";
+import {
+  validateCrawlDelay,
+  validateDirectiveValue,
+  validateHost,
+  validateSitemapUrl,
+} from "./validate.js";
+
+/**
+ * Generate the robots.txt content as a plain-text string.
+ *
+ * Throws `TypeError` synchronously on any validation failure
+ * BEFORE any output is built.
+ *
+ * Reproducibility: same `config` → byte-identical output.
+ * Input objects are never mutated.
+ *
+ * ```ts
+ * generateRobots({
+ *   rules: [
+ *     { userAgent: "*",         disallow: ["/admin", "/private"] },
+ *     { userAgent: "Googlebot", allow: ["/"]                    },
+ *   ],
+ *   sitemap: "https://example.com/sitemap.xml",
+ *   host: "example.com",
+ * });
+ * ```
+ */
+export function generateRobots(config: RobotsConfig): string {
+  // ─── Validation pass ────────────────────────────────────
+  const rules: RobotsRule[] = Array.isArray(config.rules) ? [...config.rules] : [];
+  const validatedRules = rules.map((rule, i) => validateRule(rule, i));
+  const validatedSitemaps = normaliseSitemap(config.sitemap).map(validateSitemapUrl);
+  const validatedHost = config.host === undefined ? undefined : validateHost(config.host);
+
+  // ─── Emit pass ──────────────────────────────────────────
+  const blocks: string[] = [];
+
+  for (let i = 0; i < validatedRules.length; i++) {
+    blocks.push(emitRuleBlock(validatedRules[i]!));
+  }
+
+  if (validatedSitemaps.length > 0 || validatedHost !== undefined) {
+    const tail: string[] = [];
+    for (let i = 0; i < validatedSitemaps.length; i++) {
+      tail.push(`Sitemap: ${validatedSitemaps[i]}`);
+    }
+    if (validatedHost !== undefined) {
+      tail.push(`Host: ${validatedHost}`);
+    }
+    blocks.push(tail.join("\n"));
+  }
+
+  // Rule blocks (and the trailing sitemap/host block) joined
+  // by exactly one blank line.  Trailing newline included so
+  // the file ends cleanly per Unix convention.
+  return blocks.length === 0 ? "" : blocks.join("\n\n") + "\n";
+}
+
+/**
+ * Internal scratch shape for a fully-validated rule.  We
+ * normalise `userAgent` to always-an-array so the emit pass
+ * has one shape to deal with.
+ */
+interface ValidatedRule {
+  readonly userAgents: readonly string[];
+  readonly allow: readonly string[];
+  readonly disallow: readonly string[];
+  readonly crawlDelay: number | undefined;
+}
+
+function validateRule(rule: RobotsRule, index: number): ValidatedRule {
+  if (rule === null || typeof rule !== "object") {
+    throw new TypeError(
+      `forme-aot-robots-emitter: rules[${index}] must be a non-null object; got ${typeof rule}`,
+    );
+  }
+
+  const uaList = normaliseUserAgent(rule.userAgent, index);
+  if (uaList.length === 0) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: rules[${index}].userAgent must yield at least one value`,
+    );
+  }
+  const validatedUAs = uaList.map((ua) =>
+    validateDirectiveValue(ua, `rules[${index}].userAgent`)
+  );
+
+  const allowList = rule.allow ?? [];
+  if (!Array.isArray(allowList)) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: rules[${index}].allow must be an array; got ${typeof allowList}`,
+    );
+  }
+  const validatedAllow = allowList.map((p, j) =>
+    validateDirectiveValue(p, `rules[${index}].allow[${j}]`)
+  );
+
+  const disallowList = rule.disallow ?? [];
+  if (!Array.isArray(disallowList)) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: rules[${index}].disallow must be an array; got ${typeof disallowList}`,
+    );
+  }
+  const validatedDisallow = disallowList.map((p, j) =>
+    validateDirectiveValue(p, `rules[${index}].disallow[${j}]`)
+  );
+
+  const validatedCrawlDelay = rule.crawlDelay === undefined
+    ? undefined
+    : validateCrawlDelay(rule.crawlDelay);
+
+  return {
+    userAgents: validatedUAs,
+    allow: validatedAllow,
+    disallow: validatedDisallow,
+    crawlDelay: validatedCrawlDelay,
+  };
+}
+
+function normaliseUserAgent(value: string | readonly string[], index: number): readonly string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value;
+  throw new TypeError(
+    `forme-aot-robots-emitter: rules[${index}].userAgent must be a string or string[]; got ${typeof value}`,
+  );
+}
+
+function normaliseSitemap(value: string | readonly string[] | undefined): readonly string[] {
+  if (value === undefined) return [];
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value;
+  throw new TypeError(
+    `forme-aot-robots-emitter: sitemap must be a string, string[], or undefined; got ${typeof value}`,
+  );
+}
+
+/**
+ * Emit one rule block.  Order of lines:
+ *   1. All `User-agent:` lines (one per UA).
+ *   2. All `Allow:` lines.
+ *   3. All `Disallow:` lines.
+ *   4. `Crawl-delay:` line if present.
+ *
+ * Why allow before disallow?  The most-specific-rule-wins
+ * convention used by major crawlers makes `Allow` exceptions
+ * to `Disallow` rules more readable when emitted first.  The
+ * spec itself doesn't mandate an order; we pick one for
+ * determinism.
+ */
+function emitRuleBlock(rule: ValidatedRule): string {
+  const lines: string[] = [];
+  for (const ua of rule.userAgents) {
+    lines.push(`User-agent: ${ua}`);
+  }
+  for (const path of rule.allow) {
+    lines.push(`Allow: ${path}`);
+  }
+  for (const path of rule.disallow) {
+    lines.push(`Disallow: ${path}`);
+  }
+  if (rule.crawlDelay !== undefined) {
+    lines.push(`Crawl-delay: ${rule.crawlDelay}`);
+  }
+  return lines.join("\n");
+}

--- a/code/packages/typescript/forme-aot-robots-emitter/src/index.ts
+++ b/code/packages/typescript/forme-aot-robots-emitter/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * @coding-adventures/forme-aot-robots-emitter
+ *
+ * Emit `robots.txt` from a structured `RobotsConfig` per
+ * https://www.robotstxt.org/orig.html + Google extensions.
+ * Pure transform — returns plain-text string; caller writes
+ * it wherever.
+ *
+ * ```ts
+ * import { generateRobots } from "@coding-adventures/forme-aot-robots-emitter";
+ *
+ * const txt = generateRobots({
+ *   rules: [
+ *     { userAgent: "*",         disallow: ["/admin", "/private"] },
+ *     { userAgent: "Googlebot", allow: ["/"]                    },
+ *   ],
+ *   sitemap: "https://example.com/sitemap.xml",
+ *   host: "example.com",
+ * });
+ *
+ * fs.writeFileSync("dist/robots.txt", txt);
+ * ```
+ *
+ * Validation runs BEFORE emission.  Any error throws
+ * `TypeError` synchronously and no partial output reaches the
+ * caller.  Header-injection chars (CR / LF / NUL / DEL / other
+ * C0) in any value are rejected — this is the line-format
+ * analogue of HTTP header injection.
+ *
+ * Twelfth FM00 v0 stage package — joins the FM00 v0 cluster.
+ *
+ * @module index
+ */
+
+export { generateRobots } from "./generate.js";
+export {
+  validateDirectiveValue,
+  validateCrawlDelay,
+  validateSitemapUrl,
+  validateHost,
+} from "./validate.js";
+export type { RobotsConfig, RobotsRule } from "./types.js";

--- a/code/packages/typescript/forme-aot-robots-emitter/src/types.ts
+++ b/code/packages/typescript/forme-aot-robots-emitter/src/types.ts
@@ -1,0 +1,54 @@
+/**
+ * types.ts — RobotsConfig and rule shapes.
+ *
+ * The robots.txt protocol is line-oriented: a sequence of
+ * `Key: Value` pairs grouped into rules.  This type set is the
+ * structured JS shape that maps onto that line format.
+ *
+ * @module types
+ */
+
+/**
+ * One robots.txt rule block (`User-agent:` + zero or more
+ * `Allow:` / `Disallow:` lines, plus optional `Crawl-delay:`).
+ *
+ *   - `userAgent` (required) — either a single string
+ *     (`"Googlebot"`) or an array (one `User-agent:` line per
+ *     element).  `"*"` matches all crawlers.
+ *   - `allow` (optional) — paths that ARE permitted.  Each path
+ *     emitted as its own `Allow:` line.
+ *   - `disallow` (optional) — paths that are NOT permitted.
+ *     Each path emitted as its own `Disallow:` line.
+ *   - `crawlDelay` (optional) — seconds between requests.  Must
+ *     be a non-negative finite integer; non-integers throw.
+ *     Google ignores this directive; most other crawlers respect
+ *     it.  Emitted as `Crawl-delay: N`.
+ */
+export interface RobotsRule {
+  readonly userAgent: string | readonly string[];
+  readonly allow?: readonly string[];
+  readonly disallow?: readonly string[];
+  readonly crawlDelay?: number;
+}
+
+/**
+ * Top-level robots.txt configuration.
+ *
+ *   - `rules` (required, may be empty) — ordered rule blocks.
+ *   - `sitemap` (optional) — one or more sitemap URLs.  Each
+ *     URL emitted as a `Sitemap:` line.  Validated against
+ *     http(s):// before emission.
+ *   - `host` (optional) — preferred host directive (Yandex
+ *     extension, widely-ignored but harmless).  Validated as
+ *     a hostname (no scheme; no path).
+ *
+ * Emit order (matches widely-recognised convention):
+ *   1. Rule blocks in input order, separated by blank lines.
+ *   2. `Sitemap:` lines (one per URL).
+ *   3. `Host:` line (if supplied).
+ */
+export interface RobotsConfig {
+  readonly rules: readonly RobotsRule[];
+  readonly sitemap?: string | readonly string[];
+  readonly host?: string;
+}

--- a/code/packages/typescript/forme-aot-robots-emitter/src/validate.ts
+++ b/code/packages/typescript/forme-aot-robots-emitter/src/validate.ts
@@ -1,0 +1,168 @@
+/**
+ * validate.ts — field-level validators for robots.txt values.
+ *
+ * The robots.txt protocol is line-oriented; any unescaped
+ * newline or carriage return in a `Value` would split into
+ * extra (possibly attacker-controlled) directive lines.  This
+ * is the analogue of HTTP header injection for the line-based
+ * robots format.  We REJECT (not strip) such inputs so the
+ * caller knows about the bad data instead of silently shipping
+ * a half-formed directive.
+ *
+ * Other validators here:
+ *   - `validateHost` — DNS hostname-ish (no scheme, no path).
+ *   - `validateSitemapUrl` — http(s)://, same accept-list as
+ *     `forme-aot-sitemap-emitter`.
+ *   - `validateCrawlDelay` — non-negative finite integer.
+ *
+ * @module validate
+ */
+
+/**
+ * Forbidden control bytes in a robots.txt directive value:
+ * CR, LF, NUL, and U+007F.  Any of these in user-supplied
+ * input would either break the line-oriented parser or — for
+ * CR/LF — inject a new directive line.
+ *
+ * Used as a guard, not a stripper: a single bad byte is enough
+ * to throw.
+ */
+function hasInjectionChars(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c === 0x0A || c === 0x0D || c === 0x00 || c === 0x7F) return true;
+    // Also reject the rest of the C0 controls — none have a
+    // legitimate place in robots.txt and accepting them just
+    // gives attackers a wider surface.
+    if (c < 0x20 && c !== 0x09) return true;  // allow TAB; reject other C0
+  }
+  return false;
+}
+
+/**
+ * Validate a single User-agent / Allow / Disallow value.
+ * Throws `TypeError` if the value contains injection
+ * characters or isn't a non-empty string.
+ *
+ * Returns the input unchanged on success — the caller emits it
+ * verbatim into a line.
+ */
+export function validateDirectiveValue(value: string, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: ${field} must be a non-empty string; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
+  }
+  if (hasInjectionChars(value)) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: ${field} contains forbidden control character (CR/LF/NUL/DEL or other C0); refusing to emit (injection risk)`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate `crawlDelay` per the de-facto convention used by
+ * Bing, Yandex, etc.: non-negative finite integer (seconds).
+ * Zero is permitted (means "no throttling").
+ *
+ * Throws `TypeError` if not a number, NaN, infinite, negative,
+ * or non-integer.
+ *
+ * Returns the integer as-is.
+ */
+export function validateCrawlDelay(value: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: crawlDelay must be a finite number; got ${typeof value === "number" ? value : typeof value}`,
+    );
+  }
+  if (!Number.isInteger(value)) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: crawlDelay must be an integer; got ${value}`,
+    );
+  }
+  if (value < 0) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: crawlDelay must be non-negative; got ${value}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate a sitemap URL.  Same accept-list as
+ * `forme-aot-sitemap-emitter`'s `assertResolvedUrl`:
+ * `http(s)://...` only (case-insensitive scheme).  Anything
+ * else throws.
+ *
+ * Why no root-relative support?  The `Sitemap:` directive in
+ * robots.txt is documented as taking an absolute URL.
+ * Root-relative paths are ambiguous (relative to which host?)
+ * and rejected by most crawlers.
+ */
+export function validateSitemapUrl(url: string): string {
+  if (typeof url !== "string" || url.length === 0) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: sitemap URL must be a non-empty string; got ${
+        url === null ? "null" : typeof url
+      }`,
+    );
+  }
+  if (hasInjectionChars(url)) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: sitemap URL contains forbidden control character; refusing to emit`,
+    );
+  }
+  const head = url.slice(0, 8).toLowerCase();
+  if (!(head.startsWith("http://") || head.startsWith("https://"))) {
+    const shown = url.length > 200 ? url.slice(0, 200) + "…" : url;
+    throw new TypeError(
+      `forme-aot-robots-emitter: sitemap URL must be http(s)://; got ${JSON.stringify(shown)}`,
+    );
+  }
+  return url;
+}
+
+/**
+ * Validate a `host:` value.  Per Yandex's documentation this
+ * is a host (and optional port), NOT a URL.  We accept
+ * anything that:
+ *
+ *   - is a non-empty string,
+ *   - has no injection characters,
+ *   - has no scheme (rejected: anything containing `://`),
+ *   - has no path / query / fragment (rejected: `/`, `?`, `#`).
+ *
+ * The character set isn't strictly DNS-validated (RFC 1123)
+ * because the directive is widely-ignored anyway — we just
+ * guard against the obvious injection / scheme-confusion
+ * attacks.
+ */
+export function validateHost(host: string): string {
+  if (typeof host !== "string" || host.length === 0) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: host must be a non-empty string; got ${
+        host === null ? "null" : typeof host
+      }`,
+    );
+  }
+  if (hasInjectionChars(host)) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: host contains forbidden control character; refusing to emit`,
+    );
+  }
+  if (host.includes("://")) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: host must be a bare hostname, not a URL; got ${JSON.stringify(host)}`,
+    );
+  }
+  if (host.includes("/") || host.includes("?") || host.includes("#") || host.includes(" ")) {
+    throw new TypeError(
+      `forme-aot-robots-emitter: host must be a bare hostname (no path / query / fragment / spaces); got ${JSON.stringify(host)}`,
+    );
+  }
+  return host;
+}

--- a/code/packages/typescript/forme-aot-robots-emitter/tests/generate.test.ts
+++ b/code/packages/typescript/forme-aot-robots-emitter/tests/generate.test.ts
@@ -1,0 +1,391 @@
+/**
+ * generate.test.ts — end-to-end generateRobots.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateRobots } from "../src/index.js";
+
+describe("generateRobots — minimal", () => {
+  it("empty config → empty string", () => {
+    expect(generateRobots({ rules: [] })).toBe("");
+  });
+
+  it("single allow-all rule", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*", allow: ["/"] }],
+    });
+    expect(txt).toContain("User-agent: *");
+    expect(txt).toContain("Allow: /");
+    expect(txt.endsWith("\n")).toBe(true);
+  });
+
+  it("single disallow rule", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*", disallow: ["/admin"] }],
+    });
+    expect(txt).toContain("User-agent: *");
+    expect(txt).toContain("Disallow: /admin");
+  });
+});
+
+describe("generateRobots — multiple rule blocks", () => {
+  it("two blocks separated by blank line", () => {
+    const txt = generateRobots({
+      rules: [
+        { userAgent: "*", disallow: ["/admin"] },
+        { userAgent: "Googlebot", allow: ["/"] },
+      ],
+    });
+    expect(txt).toContain("User-agent: *\nDisallow: /admin\n\nUser-agent: Googlebot\nAllow: /");
+  });
+
+  it("preserves caller's rule order", () => {
+    const txt = generateRobots({
+      rules: [
+        { userAgent: "C" },
+        { userAgent: "A" },
+        { userAgent: "B" },
+      ],
+    });
+    const cIdx = txt.indexOf("User-agent: C");
+    const aIdx = txt.indexOf("User-agent: A");
+    const bIdx = txt.indexOf("User-agent: B");
+    expect(cIdx).toBeLessThan(aIdx);
+    expect(aIdx).toBeLessThan(bIdx);
+  });
+});
+
+describe("generateRobots — userAgent array", () => {
+  it("array of UAs emits one User-agent line per element", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: ["Googlebot", "Bingbot"], disallow: ["/private"] }],
+    });
+    expect(txt).toContain("User-agent: Googlebot\nUser-agent: Bingbot\nDisallow: /private");
+  });
+
+  it("empty userAgent array throws", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: [], disallow: ["/x"] }],
+    })).toThrow(/at least one value/);
+  });
+
+  it("userAgent not string or array throws", () => {
+    expect(() => generateRobots({
+      // @ts-expect-error
+      rules: [{ userAgent: 42, disallow: ["/x"] }],
+    })).toThrow(/string or string\[\]/);
+  });
+});
+
+describe("generateRobots — allow + disallow ordering", () => {
+  it("Allow lines emitted before Disallow lines", () => {
+    const txt = generateRobots({
+      rules: [{
+        userAgent: "*",
+        allow: ["/public"],
+        disallow: ["/private"],
+      }],
+    });
+    const allowIdx = txt.indexOf("Allow: /public");
+    const disallowIdx = txt.indexOf("Disallow: /private");
+    expect(allowIdx).toBeLessThan(disallowIdx);
+  });
+
+  it("multiple paths each get their own line", () => {
+    const txt = generateRobots({
+      rules: [{
+        userAgent: "*",
+        disallow: ["/a", "/b", "/c"],
+      }],
+    });
+    expect(txt).toContain("Disallow: /a\nDisallow: /b\nDisallow: /c");
+  });
+});
+
+describe("generateRobots — crawlDelay", () => {
+  it("emitted after disallow lines", () => {
+    const txt = generateRobots({
+      rules: [{
+        userAgent: "Slurp",
+        disallow: ["/heavy"],
+        crawlDelay: 10,
+      }],
+    });
+    expect(txt).toContain("Disallow: /heavy\nCrawl-delay: 10");
+  });
+
+  it("zero crawlDelay permitted", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*", crawlDelay: 0 }],
+    });
+    expect(txt).toContain("Crawl-delay: 0");
+  });
+
+  it("undefined crawlDelay omits line", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*" }],
+    });
+    expect(txt).not.toContain("Crawl-delay");
+  });
+
+  it("negative crawlDelay throws", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*", crawlDelay: -1 }],
+    })).toThrow(/non-negative/);
+  });
+
+  it("fractional crawlDelay throws", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*", crawlDelay: 1.5 }],
+    })).toThrow(/integer/);
+  });
+
+  it("NaN crawlDelay throws", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*", crawlDelay: NaN }],
+    })).toThrow(/finite/);
+  });
+});
+
+describe("generateRobots — sitemap", () => {
+  it("single sitemap URL", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*", allow: ["/"] }],
+      sitemap: "https://example.com/sitemap.xml",
+    });
+    expect(txt).toContain("Sitemap: https://example.com/sitemap.xml");
+  });
+
+  it("array of sitemaps", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*" }],
+      sitemap: [
+        "https://example.com/sitemap-1.xml",
+        "https://example.com/sitemap-2.xml",
+      ],
+    });
+    expect(txt).toContain("Sitemap: https://example.com/sitemap-1.xml");
+    expect(txt).toContain("Sitemap: https://example.com/sitemap-2.xml");
+  });
+
+  it("sitemap appears AFTER rule blocks", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*", disallow: ["/admin"] }],
+      sitemap: "https://example.com/sitemap.xml",
+    });
+    const ruleIdx = txt.indexOf("Disallow: /admin");
+    const smIdx = txt.indexOf("Sitemap:");
+    expect(ruleIdx).toBeLessThan(smIdx);
+  });
+
+  it("rejects javascript: sitemap", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*" }],
+      sitemap: "javascript:alert(1)",
+    })).toThrow(/http\(s\)/);
+  });
+
+  it("rejects root-relative sitemap (absolute required)", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*" }],
+      sitemap: "/sitemap.xml",
+    })).toThrow(/http\(s\)/);
+  });
+
+  it("sitemap with newline rejected", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*" }],
+      sitemap: "https://example.com/x\nDisallow: /evil",
+    })).toThrow(/forbidden control character/);
+  });
+
+  it("non-string sitemap throws", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*" }],
+      // @ts-expect-error
+      sitemap: 42,
+    })).toThrow(/string, string\[\], or undefined/);
+  });
+});
+
+describe("generateRobots — host", () => {
+  it("host emitted at end", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*" }],
+      host: "example.com",
+    });
+    expect(txt).toContain("Host: example.com");
+  });
+
+  it("host appears AFTER sitemap when both supplied", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*" }],
+      sitemap: "https://example.com/sitemap.xml",
+      host: "example.com",
+    });
+    const smIdx = txt.indexOf("Sitemap:");
+    const hostIdx = txt.indexOf("Host:");
+    expect(smIdx).toBeLessThan(hostIdx);
+  });
+
+  it("rejects host containing scheme", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*" }],
+      host: "https://example.com",
+    })).toThrow(/not a URL/);
+  });
+
+  it("rejects host with path", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*" }],
+      host: "example.com/path",
+    })).toThrow(/no path/);
+  });
+});
+
+describe("generateRobots — header-injection defence", () => {
+  it("userAgent with newline rejected", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "Goodbot\nUser-agent: Evilbot", disallow: ["/"] }],
+    })).toThrow(/forbidden control character/);
+  });
+
+  it("disallow path with CR rejected", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*", disallow: ["/admin\rAllow: /admin"] }],
+    })).toThrow(/forbidden control character/);
+  });
+
+  it("allow path with CRLF rejected", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*", allow: ["/good\r\nDisallow: /good"] }],
+    })).toThrow(/forbidden control character/);
+  });
+
+  it("userAgent with NUL rejected", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "Bot\x00name" }],
+    })).toThrow(/forbidden control character/);
+  });
+
+  it("error message identifies the bad field", () => {
+    try {
+      generateRobots({
+        rules: [
+          { userAgent: "*" },
+          { userAgent: "*", disallow: ["/a", "/b\nbad"] },
+        ],
+      });
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toContain("rules[1].disallow[1]");
+    }
+  });
+});
+
+describe("generateRobots — fail-fast (no partial output)", () => {
+  it("bad rule in mid-array throws without partial emission", () => {
+    expect(() => generateRobots({
+      rules: [
+        { userAgent: "*", allow: ["/"] },
+        { userAgent: "Bot\nInjection" },
+        { userAgent: "Googlebot" },
+      ],
+    })).toThrow(/forbidden control character/);
+  });
+
+  it("bad sitemap throws even when rules are valid", () => {
+    expect(() => generateRobots({
+      rules: [{ userAgent: "*" }],
+      sitemap: "javascript:bad",
+    })).toThrow(/http\(s\)/);
+  });
+});
+
+describe("generateRobots — input shape validation", () => {
+  it("null rule throws", () => {
+    expect(() => generateRobots({
+      // @ts-expect-error
+      rules: [null],
+    })).toThrow(/non-null object/);
+  });
+
+  it("non-array allow throws", () => {
+    expect(() => generateRobots({
+      // @ts-expect-error
+      rules: [{ userAgent: "*", allow: "not an array" }],
+    })).toThrow(/must be an array/);
+  });
+
+  it("non-array disallow throws", () => {
+    expect(() => generateRobots({
+      // @ts-expect-error
+      rules: [{ userAgent: "*", disallow: "not an array" }],
+    })).toThrow(/must be an array/);
+  });
+});
+
+describe("generateRobots — purity / determinism", () => {
+  it("does not mutate input rules array", () => {
+    const config = {
+      rules: [{ userAgent: "*", disallow: ["/admin"] }],
+    };
+    const before = JSON.stringify(config);
+    generateRobots(config);
+    expect(JSON.stringify(config)).toBe(before);
+  });
+
+  it("same input → byte-identical output", () => {
+    const config = {
+      rules: [
+        { userAgent: "*", allow: ["/"], disallow: ["/admin"], crawlDelay: 5 },
+        { userAgent: "Googlebot", allow: ["/"] },
+      ],
+      sitemap: "https://example.com/sitemap.xml",
+      host: "example.com",
+    };
+    expect(generateRobots(config)).toBe(generateRobots(config));
+  });
+
+  it("output ends with single newline", () => {
+    const txt = generateRobots({
+      rules: [{ userAgent: "*" }],
+    });
+    expect(txt.endsWith("\n")).toBe(true);
+    expect(txt.endsWith("\n\n")).toBe(false);
+  });
+});
+
+describe("generateRobots — full real-world example", () => {
+  it("blog with admin block + googlebot exception + sitemap", () => {
+    const txt = generateRobots({
+      rules: [
+        { userAgent: "*", disallow: ["/admin", "/private"], crawlDelay: 10 },
+        { userAgent: "Googlebot", allow: ["/"] },
+        { userAgent: ["Bingbot", "Slurp"], crawlDelay: 5 },
+      ],
+      sitemap: [
+        "https://example.com/sitemap.xml",
+        "https://example.com/sitemap-news.xml",
+      ],
+      host: "example.com",
+    });
+    expect(txt).toBe([
+      "User-agent: *",
+      "Disallow: /admin",
+      "Disallow: /private",
+      "Crawl-delay: 10",
+      "",
+      "User-agent: Googlebot",
+      "Allow: /",
+      "",
+      "User-agent: Bingbot",
+      "User-agent: Slurp",
+      "Crawl-delay: 5",
+      "",
+      "Sitemap: https://example.com/sitemap.xml",
+      "Sitemap: https://example.com/sitemap-news.xml",
+      "Host: example.com",
+    ].join("\n") + "\n");
+  });
+});

--- a/code/packages/typescript/forme-aot-robots-emitter/tests/validate.test.ts
+++ b/code/packages/typescript/forme-aot-robots-emitter/tests/validate.test.ts
@@ -1,0 +1,237 @@
+/**
+ * validate.test.ts — field-level validators.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateCrawlDelay,
+  validateDirectiveValue,
+  validateHost,
+  validateSitemapUrl,
+} from "../src/index.js";
+
+describe("validateDirectiveValue — accepts", () => {
+  it("plain string", () => {
+    expect(validateDirectiveValue("Googlebot", "ua")).toBe("Googlebot");
+  });
+
+  it("path with /", () => {
+    expect(validateDirectiveValue("/admin", "p")).toBe("/admin");
+  });
+
+  it("wildcard *", () => {
+    expect(validateDirectiveValue("*", "ua")).toBe("*");
+  });
+
+  it("path with $", () => {
+    expect(validateDirectiveValue("/*.pdf$", "p")).toBe("/*.pdf$");
+  });
+
+  it("path with %-encoding", () => {
+    expect(validateDirectiveValue("/path%20with%20spaces", "p")).toBe("/path%20with%20spaces");
+  });
+
+  it("path containing tab (TAB allowed per code comment)", () => {
+    // TAB is a C0 char but it's commonly used as whitespace in
+    // some user-agent strings; we permit it.
+    expect(validateDirectiveValue("Foo\tBar", "ua")).toBe("Foo\tBar");
+  });
+});
+
+describe("validateDirectiveValue — rejects (header injection)", () => {
+  it("rejects LF (\\n) — line splitting attack", () => {
+    expect(() => validateDirectiveValue("good\nDisallow: /evil", "ua"))
+      .toThrow(/forbidden control character/);
+  });
+
+  it("rejects CR (\\r)", () => {
+    expect(() => validateDirectiveValue("good\rbad", "ua"))
+      .toThrow(/forbidden control character/);
+  });
+
+  it("rejects CR+LF (\\r\\n)", () => {
+    expect(() => validateDirectiveValue("good\r\nbad", "ua"))
+      .toThrow(/forbidden control character/);
+  });
+
+  it("rejects NUL (\\x00)", () => {
+    expect(() => validateDirectiveValue("a\x00b", "ua"))
+      .toThrow(/forbidden control character/);
+  });
+
+  it("rejects DEL (\\x7F)", () => {
+    expect(() => validateDirectiveValue("a\x7Fb", "ua"))
+      .toThrow(/forbidden control character/);
+  });
+
+  it("rejects ESC (\\x1B)", () => {
+    expect(() => validateDirectiveValue("a\x1Bb", "ua"))
+      .toThrow(/forbidden control character/);
+  });
+
+  it("rejects all other C0 controls", () => {
+    for (let c = 0; c < 32; c++) {
+      if (c === 9) continue;  // TAB allowed
+      expect(() => validateDirectiveValue(`a${String.fromCharCode(c)}b`, "ua"))
+        .toThrow(/forbidden control character/);
+    }
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateDirectiveValue("", "ua")).toThrow(/non-empty string/);
+  });
+
+  it("rejects non-string", () => {
+    // @ts-expect-error
+    expect(() => validateDirectiveValue(42, "ua")).toThrow(/non-empty string/);
+  });
+
+  it("rejects null", () => {
+    // @ts-expect-error
+    expect(() => validateDirectiveValue(null, "ua")).toThrow(/null/);
+  });
+
+  it("error message contains field name", () => {
+    try {
+      validateDirectiveValue("", "my-special-field");
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toContain("my-special-field");
+    }
+  });
+});
+
+describe("validateCrawlDelay — accepts", () => {
+  it("zero", () => expect(validateCrawlDelay(0)).toBe(0));
+  it("positive integer", () => expect(validateCrawlDelay(5)).toBe(5));
+  it("large integer", () => expect(validateCrawlDelay(86400)).toBe(86400));
+});
+
+describe("validateCrawlDelay — rejects", () => {
+  it("negative", () => expect(() => validateCrawlDelay(-1)).toThrow(/non-negative/));
+  it("NaN", () => expect(() => validateCrawlDelay(NaN)).toThrow(/finite/));
+  it("Infinity", () => expect(() => validateCrawlDelay(Infinity)).toThrow(/finite/));
+  it("-Infinity", () => expect(() => validateCrawlDelay(-Infinity)).toThrow(/finite/));
+  it("fractional", () => expect(() => validateCrawlDelay(1.5)).toThrow(/integer/));
+  it("non-number", () => {
+    // @ts-expect-error
+    expect(() => validateCrawlDelay("5")).toThrow(/finite/);
+  });
+});
+
+describe("validateSitemapUrl — accepts", () => {
+  it("https://", () => {
+    expect(validateSitemapUrl("https://example.com/sitemap.xml"))
+      .toBe("https://example.com/sitemap.xml");
+  });
+
+  it("http://", () => {
+    expect(validateSitemapUrl("http://example.com/sitemap.xml"))
+      .toBe("http://example.com/sitemap.xml");
+  });
+
+  it("case-insensitive scheme", () => {
+    expect(validateSitemapUrl("HTTPS://example.com/x")).toBe("HTTPS://example.com/x");
+  });
+
+  it("with port + query", () => {
+    expect(validateSitemapUrl("https://example.com:8443/sitemap.xml?v=1"))
+      .toBe("https://example.com:8443/sitemap.xml?v=1");
+  });
+});
+
+describe("validateSitemapUrl — rejects", () => {
+  it("root-relative (must be absolute)", () => {
+    expect(() => validateSitemapUrl("/sitemap.xml")).toThrow(/http\(s\)/);
+  });
+
+  it("javascript:", () => {
+    expect(() => validateSitemapUrl("javascript:alert(1)")).toThrow(/http\(s\)/);
+  });
+
+  it("file:", () => {
+    expect(() => validateSitemapUrl("file:///etc")).toThrow(/http\(s\)/);
+  });
+
+  it("data:", () => {
+    expect(() => validateSitemapUrl("data:text/html,x")).toThrow(/http\(s\)/);
+  });
+
+  it("protocol-relative", () => {
+    expect(() => validateSitemapUrl("//example.com")).toThrow(/http\(s\)/);
+  });
+
+  it("empty string", () => {
+    expect(() => validateSitemapUrl("")).toThrow(/non-empty/);
+  });
+
+  it("non-string", () => {
+    // @ts-expect-error
+    expect(() => validateSitemapUrl(42)).toThrow(/non-empty/);
+  });
+
+  it("LF injection in URL", () => {
+    expect(() => validateSitemapUrl("https://good.com/\nDisallow: /evil"))
+      .toThrow(/forbidden control character/);
+  });
+
+  it("long unsafe URL truncated in error", () => {
+    const long = "ftp://" + "x".repeat(500);
+    try {
+      validateSitemapUrl(long);
+      expect.fail("expected throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toMatch(/…/);
+      expect(msg.length).toBeLessThan(400);
+    }
+  });
+});
+
+describe("validateHost — accepts", () => {
+  it("bare hostname", () => expect(validateHost("example.com")).toBe("example.com"));
+  it("hostname with port", () => expect(validateHost("example.com:8080")).toBe("example.com:8080"));
+  it("subdomain", () => expect(validateHost("www.example.co.uk")).toBe("www.example.co.uk"));
+  it("IP address", () => expect(validateHost("192.168.1.1")).toBe("192.168.1.1"));
+});
+
+describe("validateHost — rejects", () => {
+  it("URL with scheme", () => {
+    expect(() => validateHost("https://example.com")).toThrow(/not a URL/);
+  });
+
+  it("URL without scheme but with path", () => {
+    expect(() => validateHost("example.com/path")).toThrow(/no path/);
+  });
+
+  it("URL with query", () => {
+    expect(() => validateHost("example.com?a=1")).toThrow(/no path/);
+  });
+
+  it("URL with fragment", () => {
+    expect(() => validateHost("example.com#frag")).toThrow(/no path/);
+  });
+
+  it("contains space", () => {
+    expect(() => validateHost("example .com")).toThrow(/no path.*spaces/);
+  });
+
+  it("LF injection", () => {
+    expect(() => validateHost("good.com\nDisallow: /evil"))
+      .toThrow(/forbidden control character/);
+  });
+
+  it("empty string", () => {
+    expect(() => validateHost("")).toThrow(/non-empty/);
+  });
+
+  it("non-string", () => {
+    // @ts-expect-error
+    expect(() => validateHost(42)).toThrow(/non-empty/);
+  });
+
+  it("null", () => {
+    // @ts-expect-error
+    expect(() => validateHost(null)).toThrow(/null/);
+  });
+});

--- a/code/packages/typescript/forme-aot-robots-emitter/tsconfig.json
+++ b/code/packages/typescript/forme-aot-robots-emitter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-robots-emitter/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-robots-emitter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Twelfth FM00 v0 stage package — emits `robots.txt` per [robotstxt.org/orig.html](https://www.robotstxt.org/orig.html) + Google / Yandex extensions (`Crawl-delay`, `Sitemap`, `Host`) from a structured `RobotsConfig`. Pure transform: returns plain-text string; caller writes wherever.

```ts
import { generateRobots } from "@coding-adventures/forme-aot-robots-emitter";

const txt = generateRobots({
  rules: [
    { userAgent: "*",         disallow: ["/admin", "/private"], crawlDelay: 10 },
    { userAgent: "Googlebot", allow: ["/"] },
    { userAgent: ["Bingbot", "Slurp"], crawlDelay: 5 },
  ],
  sitemap: "https://example.com/sitemap.xml",
  host: "example.com",
});

fs.writeFileSync("dist/robots.txt", txt);
```

Joins the FM00 v0 cluster.

## Validation rules

- **Directive values** (userAgent, allow, disallow): no CR / LF / NUL / DEL / other C0 controls (TAB allowed)
- **Sitemap URLs**: `http(s)://` only (case-insensitive)
- **Host**: bare hostname only (no scheme, path, query, fragment, spaces)
- **Crawl-delay**: non-negative finite integer (zero permitted)
- **Required fields**: rules array required; userAgent required per rule

## Line-format header-injection defence

Robots.txt is line-oriented. An unescaped newline in a value would split into extra (attacker-controlled) directive lines — the line-format analogue of HTTP response splitting:

```
User-agent: Goodbot          ← intended
Disallow: /admin             ← intended
User-agent: *                ← INJECTED if "Goodbot\nUser-agent: *" passed in!
Allow: /admin                ← INJECTED!
```

The validator **rejects** (not strips) any value containing CR / LF / NUL / DEL / other C0 controls so the caller knows about the bad data rather than silently shipping a half-formed directive.

## Emit order (deterministic)

- Per-rule line order: `User-agent: → Allow: → Disallow: → Crawl-delay:` (Allow before Disallow because most-specific-wins makes exceptions readable first)
- Rule blocks separated by blank line
- `Sitemap:` lines after all rule blocks
- `Host:` line last (Yandex convention)
- Single trailing `\n`

## Security

Five concerns addressed pre-push:

- **Line-format header injection** — newlines / CR / NUL / DEL / other C0 rejected in any value
- **URL scheme injection** on sitemap — `javascript:` / `data:` / etc. rejected
- **Host scheme confusion** — URLs with scheme / path rejected
- **Crawl-delay type confusion** — negative / NaN / Infinity / fractional / non-number rejected
- **Fail-fast** — validation completes for every field before emission

Security review (general-purpose sub-agent): **no exploitable findings**.

## Capabilities

`[]` — pure transform.

## Tests

**93 tests across 2 files**, **100% line / 98.11% branch** coverage:

- `validate.test.ts` (52) — every C0 control byte parameterised (CR/LF/CRLF/NUL/DEL/ESC + 32-loop), accept/reject matrix for all four validators, error messages contain field names, long-URL truncation
- `generate.test.ts` (41) — minimal config, multiple blocks, userAgent array, allow-before-disallow ordering, crawlDelay placement + range, sitemap (single/array/after-rules/injection rejects), host (after-sitemap/scheme-reject/path-reject), header-injection defence (every vector), fail-fast on mid-array bad value, input shape validation, purity/determinism, full real-world example with verbatim line check

## Spec adherence

Implements robotstxt.org protocol + Google / Bing / Yandex extensions. No spec divergences.

## v0 simplifications

- No `#`-prefixed comments (rarely used in machine-generated output; v1 may add)
- No `Request-rate` extension (less widely-supported than `Crawl-delay`)
- No `Clean-param` extension (Yandex-specific)
- No wildcard validation (`*` and `$` accepted as path chars; meaning not checked)

## Test plan

- [x] All 93 tests pass locally
- [x] 100% line / 98.11% branch coverage
- [x] TypeScript build clean
- [x] Security review clean (all 9 focus areas pass)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)