### PR TITLE
feat(visicalc): wire WA4 row stripes + WA5 sticky header (WA6)

### DIFF
--- a/demo/visicalc/mosaic/Grid.dark.msl
+++ b/demo/visicalc/mosaic/Grid.dark.msl
@@ -69,10 +69,19 @@ style Grid {
     height: 24px ;
   }
 
-  // Body data rows share the cell height. Once row-stripe styling
-  // arrives (UI27 §5 `data-row:even`), alternating backgrounds will
-  // also live here.
+  // Body data rows share the cell height and alternate between two
+  // backgrounds for readability. The Grid emitter (WA4) reads
+  // `state even` / `state odd` blocks under `sheet/data-row` and emits
+  // a conditional spread per `<tr>`, picking the background based on
+  // `r % 2 === 0`.
   part sheet/data-row {
     height: 22px ;
+
+    state even {
+      background: #1e1e1e ;
+    }
+    state odd {
+      background: #252526 ;
+    }
   }
 }

--- a/demo/visicalc/mosaic/Grid.desktop.mll
+++ b/demo/visicalc/mosaic/Grid.desktop.mll
@@ -13,6 +13,8 @@ layout Grid {
     selected-col:  slot: selected-col,
     edit-row:      slot: edit-row,
     edit-col:      slot: edit-col,
+    sticky-header: true,
+    total-height:  slot: total-height,
     onNavigate:    emit: onNavigate
   )
 }

--- a/demo/visicalc/mosaic/Grid.mil
+++ b/demo/visicalc/mosaic/Grid.mil
@@ -21,6 +21,12 @@ component Grid {
   // regardless of its content. UI26 §2.1.
   slot column-widths  : list<number> ;
 
+  // Total pixel height of the grid's scroll viewport. The Grid emitter
+  // wires this into the `maxHeight` of the scroll wrapper it emits
+  // when `sticky-header: true` is set in the layout (WA5, UI27 §6).
+  // Without sticky-header, this slot is unused.
+  slot total-height   : number ;
+
   // Selection (host owns, pushes in).
   slot selected-row : number ;
   slot selected-col : number ;

--- a/demo/visicalc/src/app/App.tsx
+++ b/demo/visicalc/src/app/App.tsx
@@ -116,6 +116,11 @@ export function App() {
         columnHeaders={state.columnHeaders}
         viewportRows={viewportRows}
         columnWidths={state.columnWidths}
+        // viewport scroll bound. With sticky-header: true in the .mll
+        // (WA5, UI27 §6), the Grid wraps its `<table>` in a scroll div
+        // and pins the `<thead>`. 600px keeps roughly 26 visible rows
+        // at the 22px row height declared in Grid.dark.msl.
+        totalHeight={600}
         selectedRow={state.selectedRow - state.viewportOffset}
         selectedCol={state.selectedCol}
         editRow={state.editRow - state.viewportOffset}


### PR DESCRIPTION
## Summary
WA6 — closes out the Grid v2 demo work. Consumes the WA4 (#3542) and WA5 (#3563) features now landed in main.

## Author-side changes

### Grid.mil
New `total-height : number` slot — scroll viewport bound for the Grid wrapper.

### Grid.desktop.mll
```
sticky-header: true,
total-height:  slot: total-height,
```

### Grid.dark.msl
```mosstyle
part sheet/data-row {
  height: 22px ;
  state even { background: #1e1e1e ; }
  state odd  { background: #252526 ; }
}
```

### App.tsx
Passes `totalHeight={600}`.

## What the visicalc demo now looks like
- Visible cell borders (already in WA2)
- Header row pinned during body scroll (WA5)
- Alternating row backgrounds for readability (WA4)
- Selection / editing highlights (PR #3467)
- Fixed column widths via `<colgroup>` (PR #3439-ish)
- Full keyboard navigation + edit cycle (UI26)

## Files
- `demo/visicalc/mosaic/Grid.mil` (+1 slot)
- `demo/visicalc/mosaic/Grid.desktop.mll` (+2 bindings)
- `demo/visicalc/mosaic/Grid.dark.msl` (+2 state blocks)
- `demo/visicalc/src/app/App.tsx` (+1 prop)

## Test plan
- [x] scripts/build.sh regenerates Grid.tsx with expected scroll wrapper + sticky thead + stripes
- [x] TypeScript clean
- [x] All previous styling intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)