### PR TITLE
feat(mini-sqlite): six additional PRAGMAs (reverse_unordered_selects, cell_size_check, fullfsync, wal_autocheckpoint, journal_size_limit, threads)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.50.0] - 2026-05-19
+
+### Added
+
+Six additional PRAGMAs that application code commonly probes when
+running against real SQLite — all are oracle-verified round-trip
+storage with no semantic effect on execution (mini-sqlite has no
+on-disk file, no WAL, no thread pool):
+
+- **`reverse_unordered_selects`** — bool, default 0
+- **`cell_size_check`** — bool, default 0
+- **`fullfsync`** — bool, default 0
+- **`wal_autocheckpoint`** — int, default 1000
+- **`journal_size_limit`** — int, default -1 (no limit)
+- **`threads`** — int, default 0
+
+The three integer-valued PRAGMAs (`wal_autocheckpoint`,
+`journal_size_limit`, `threads`) echo their new value back on set —
+a SQLite quirk where most `PRAGMA name = X` forms return an empty
+result but these three return a one-row scalar.  Mini-sqlite now
+matches that distinction byte-for-byte.
+
+18 oracle tests in `test_tier3_pragma_audit_additions.py` pin both
+default values and round-trip behaviour against `sqlite3`.
+
 ## [1.49.0] - 2026-05-19
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.49.0"
+version = "1.50.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -530,6 +530,17 @@ _PRAGMA_DEFAULTS: dict[str, tuple[object, str]] = {
     "encoding":         ("UTF-8",          "text"),
     "journal_mode":     ("memory",         "text"),     # mini-sqlite is in-memory
     "locking_mode":     ("normal",         "text"),
+    # Additional PRAGMAs that applications written for real SQLite often probe
+    # defensively.  Mini-sqlite has no on-disk file, no WAL log, and no
+    # thread pool, so most of these are accept-and-store cosmetic state — the
+    # value round-trips but otherwise has no effect on execution.  Defaults
+    # mirror SQLite's documented defaults so a fresh read matches the oracle.
+    "reverse_unordered_selects": (0,       "integer"),  # bool; off by default
+    "cell_size_check":  (0,                "integer"),  # bool; off by default
+    "fullfsync":        (0,                "integer"),  # bool; off by default
+    "wal_autocheckpoint": (1000,           "integer"),  # pages between autocheckpoints
+    "journal_size_limit": (-1,             "integer"),  # bytes; -1 = no limit
+    "threads":          (0,                "integer"),  # worker threads in sort/index
 }
 
 # Per-connection PRAGMA state.  Keyed by the backend object's id() so each
@@ -779,6 +790,10 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
         "legacy_alter_table",
         "defer_foreign_keys",
         "secure_delete",
+        # Accept-and-store cosmetic flags (no semantic effect in mini-sqlite):
+        "reverse_unordered_selects",  # planner hint, no scrambling implemented
+        "cell_size_check",            # btree integrity flag, no btree in mini
+        "fullfsync",                  # fsync mode, no disk I/O in mini
     }
     _INT_PRAGMAS = {
         "temp_store",
@@ -789,6 +804,10 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
         "page_size",
         "page_count",
         "freelist_count",
+        # Accept-and-store integer-valued flags (no semantic effect):
+        "wal_autocheckpoint",  # WAL autocheckpoint threshold (no WAL in mini)
+        "journal_size_limit",  # journal size cap in bytes (no journal in mini)
+        "threads",             # worker-thread pool size (no threading in mini)
     }
     _TEXT_PRAGMAS = {
         "encoding",
@@ -819,6 +838,14 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
             # We mirror that: silently swallow the assignment.
             if name not in ("page_size", "page_count", "freelist_count"):
                 _pragma_set(backend, name, iv)
+            # Most ``PRAGMA name = value`` forms return an empty result, but
+            # a few echo the new value back as a one-row scalar.  This is a
+            # SQLite quirk documented per-PRAGMA: ``wal_autocheckpoint``,
+            # ``journal_size_limit``, and ``threads`` all echo on set;
+            # ``application_id``, ``user_version``, and the cache/temp/
+            # synchronous family stay silent.
+            if name in {"wal_autocheckpoint", "journal_size_limit", "threads"}:
+                return QueryResult(columns=(name,), rows=((iv,),))
             return QueryResult(rows_affected=0)
         v = _pragma_get(backend, name)
         return QueryResult(columns=(name,), rows=((v,),))

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_audit_additions.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_audit_additions.py
@@ -1,0 +1,188 @@
+"""Oracle tests for newly added PRAGMAs (gap audit batch 3).
+
+This file pins behaviour for six additional PRAGMAs that real-world
+SQLite applications probe defensively:
+
+- ``reverse_unordered_selects`` (bool, default 0)
+- ``cell_size_check`` (bool, default 0)
+- ``fullfsync`` (bool, default 0)
+- ``wal_autocheckpoint`` (int, default 1000) — *echoes value on set*
+- ``journal_size_limit`` (int, default -1) — *echoes value on set*
+- ``threads`` (int, default 0) — *echoes value on set*
+
+Mini-sqlite has no on-disk file, no WAL, and no thread pool, so all six
+are accept-and-store cosmetic state: the value round-trips through
+``PRAGMA name = X; PRAGMA name;`` but has no semantic effect on
+execution.  Defaults mirror SQLite so a fresh read matches the oracle.
+
+The trio of "echo-on-set" int PRAGMAs is a SQLite quirk — most
+``PRAGMA name = X`` forms return an empty result, but these three
+return a one-row scalar of the new value.  Tests pin that distinction.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both(sql: str):
+    """Run the same PRAGMA on both engines (fresh connection each)."""
+    m = mini_sqlite.connect(":memory:").execute(sql).fetchone()
+    r = sqlite3.connect(":memory:").execute(sql).fetchone()
+    return m, r
+
+
+def _round_trip(sql_set: str, sql_get: str, value):
+    """Set + get on a single connection (each engine independently)."""
+    conn_m = mini_sqlite.connect(":memory:")
+    conn_r = sqlite3.connect(":memory:")
+    m_set = conn_m.execute(sql_set).fetchone()
+    r_set = conn_r.execute(sql_set).fetchone()
+    m_get = conn_m.execute(sql_get).fetchone()
+    r_get = conn_r.execute(sql_get).fetchone()
+    return (m_set, r_set), (m_get, r_get)
+
+
+# ---------------------------------------------------------------------------
+# Bool-valued PRAGMAs: reverse_unordered_selects, cell_size_check, fullfsync
+# ---------------------------------------------------------------------------
+
+
+class TestReverseUnorderedSelects:
+    def test_default_is_zero(self) -> None:
+        m, r = _both("PRAGMA reverse_unordered_selects")
+        assert m == r == (0,)
+
+    def test_set_to_one(self) -> None:
+        (m_set, r_set), (m_get, r_get) = _round_trip(
+            "PRAGMA reverse_unordered_selects = 1",
+            "PRAGMA reverse_unordered_selects",
+            1,
+        )
+        assert m_set == r_set  # both engines return None on set
+        assert m_get == r_get == (1,)
+
+    def test_set_then_unset(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        conn_m.execute("PRAGMA reverse_unordered_selects = 1")
+        conn_r.execute("PRAGMA reverse_unordered_selects = 1")
+        conn_m.execute("PRAGMA reverse_unordered_selects = 0")
+        conn_r.execute("PRAGMA reverse_unordered_selects = 0")
+        m = conn_m.execute("PRAGMA reverse_unordered_selects").fetchone()
+        r = conn_r.execute("PRAGMA reverse_unordered_selects").fetchone()
+        assert m == r == (0,)
+
+
+class TestCellSizeCheck:
+    def test_default_is_zero(self) -> None:
+        m, r = _both("PRAGMA cell_size_check")
+        assert m == r == (0,)
+
+    def test_set_to_one(self) -> None:
+        (m_set, r_set), (m_get, r_get) = _round_trip(
+            "PRAGMA cell_size_check = 1",
+            "PRAGMA cell_size_check",
+            1,
+        )
+        assert m_set == r_set
+        assert m_get == r_get == (1,)
+
+
+class TestFullfsync:
+    def test_default_is_zero(self) -> None:
+        m, r = _both("PRAGMA fullfsync")
+        assert m == r == (0,)
+
+    def test_set_to_one(self) -> None:
+        (m_set, r_set), (m_get, r_get) = _round_trip(
+            "PRAGMA fullfsync = 1",
+            "PRAGMA fullfsync",
+            1,
+        )
+        assert m_set == r_set
+        assert m_get == r_get == (1,)
+
+
+# ---------------------------------------------------------------------------
+# Int-valued PRAGMAs: wal_autocheckpoint, journal_size_limit, threads
+# Note: these THREE echo the new value back on set (SQLite quirk).
+# ---------------------------------------------------------------------------
+
+
+class TestWalAutocheckpoint:
+    def test_default_is_1000(self) -> None:
+        m, r = _both("PRAGMA wal_autocheckpoint")
+        assert m == r == (1000,)
+
+    def test_set_echoes_value(self) -> None:
+        # Unlike most int PRAGMAs, the set form returns the new value.
+        m_set, r_set = _both("PRAGMA wal_autocheckpoint = 500")
+        assert m_set == r_set == (500,)
+
+    def test_round_trip_500(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        conn_m.execute("PRAGMA wal_autocheckpoint = 500")
+        conn_r.execute("PRAGMA wal_autocheckpoint = 500")
+        m = conn_m.execute("PRAGMA wal_autocheckpoint").fetchone()
+        r = conn_r.execute("PRAGMA wal_autocheckpoint").fetchone()
+        assert m == r == (500,)
+
+
+class TestJournalSizeLimit:
+    def test_default_is_negative_one(self) -> None:
+        m, r = _both("PRAGMA journal_size_limit")
+        assert m == r == (-1,)
+
+    def test_set_echoes_value(self) -> None:
+        m_set, r_set = _both("PRAGMA journal_size_limit = 1048576")
+        assert m_set == r_set == (1048576,)
+
+    def test_round_trip_1mb(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        conn_m.execute("PRAGMA journal_size_limit = 1048576")
+        conn_r.execute("PRAGMA journal_size_limit = 1048576")
+        m = conn_m.execute("PRAGMA journal_size_limit").fetchone()
+        r = conn_r.execute("PRAGMA journal_size_limit").fetchone()
+        assert m == r == (1048576,)
+
+
+class TestThreads:
+    def test_default_is_zero(self) -> None:
+        m, r = _both("PRAGMA threads")
+        assert m == r == (0,)
+
+    def test_set_echoes_value(self) -> None:
+        m_set, r_set = _both("PRAGMA threads = 4")
+        assert m_set == r_set == (4,)
+
+    def test_round_trip_four(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        conn_m.execute("PRAGMA threads = 4")
+        conn_r.execute("PRAGMA threads = 4")
+        m = conn_m.execute("PRAGMA threads").fetchone()
+        r = conn_r.execute("PRAGMA threads").fetchone()
+        assert m == r == (4,)
+
+
+# ---------------------------------------------------------------------------
+# Make sure we didn't accidentally turn ``application_id`` into echoing.
+# ---------------------------------------------------------------------------
+
+
+class TestSilentSetPragmasUnchanged:
+    """Pre-existing silent-set int PRAGMAs must still return None on set."""
+
+    def test_application_id_set_stays_silent(self) -> None:
+        m, r = _both("PRAGMA application_id = 12345")
+        # Both engines return None for the SET form of application_id.
+        assert m == r is None
+
+    def test_cache_size_set_stays_silent(self) -> None:
+        m, r = _both("PRAGMA cache_size = 1000")
+        assert m == r is None


### PR DESCRIPTION
## Summary

Closes a common application-portability gap where SQL written for real SQLite probes PRAGMAs that mini-sqlite returned `NULL` for as unrecognised.

## What's added

All six PRAGMAs are accept-and-store with no semantic effect (mini-sqlite has no on-disk file, no WAL log, no thread pool):

| PRAGMA | Type | Default | Echoes on set? |
|--------|------|---------|----------------|
| `reverse_unordered_selects` | bool | 0 | no |
| `cell_size_check` | bool | 0 | no |
| `fullfsync` | bool | 0 | no |
| `wal_autocheckpoint` | int | 1000 | **yes** |
| `journal_size_limit` | int | -1 | **yes** |
| `threads` | int | 0 | **yes** |

The three echo-on-set PRAGMAs are a SQLite quirk — most `PRAGMA name = X` forms return an empty result, but these three return a one-row scalar of the new value. Mini-sqlite now matches that distinction byte-for-byte.

## Version bump

`mini-sqlite`: 1.49.0 → 1.50.0

## Test plan

- [x] `pytest code/packages/python/mini-sqlite/tests/` — 1482 pass (18 new), coverage 91.24%
- [x] 18 oracle tests in `test_tier3_pragma_audit_additions.py` against `sqlite3`
- [x] Manual security review: no I/O, no eval, all input goes through existing `int()` / `_parse_bool_pragma()` validators

🤖 Generated with [Claude Code](https://claude.com/claude-code)