### PR TITLE
Add Chief of Staff drain label parsing

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -24,9 +24,11 @@ All notable changes to this package will be documented in this file.
   actual bounded drain result.
 - Scheduler-facing supervisor drain outcomes for idle, caught-up,
   continuation, follow-up, and plan-divergence states.
-- Stable supervisor drain outcome labels and action flags for host schedulers.
+- Stable, parseable supervisor drain outcome labels and action flags for host
+  schedulers.
 - Flattened supervisor drain run summaries for host logs and scheduler loops.
-- Stable supervisor drain scheduler action recommendations for host loops.
+- Stable, parseable supervisor drain scheduler action recommendations for host
+  loops.
 - Batch audit write summaries for host flush loops.
 - Replay helpers for loading queried audit rows into any `ToolAuditSink`.
 - `StorageToolAuditSink` for runtime audit emission through D18A storage with

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -33,12 +33,13 @@ The crate keeps the boundary narrow:
   drain result, letting schedulers compare expected and delivered audit work
 - supervisor drain reports classify scheduler outcomes as idle, caught up,
   needing continuation, needing follow-up, or diverged from preflight
-- supervisor drain outcomes expose stable snake_case labels and action flags
-  for host logs and scheduling decisions
+- supervisor drain outcomes expose stable, parseable snake_case labels and
+  action flags for host logs and scheduling decisions
 - supervisor drain reports can emit flattened payload-free run summaries for
   host logs, schedulers, and continuation decisions
-- supervisor drain summaries expose stable scheduler action recommendations
-  for continuation, follow-up routing, and plan-drift investigation
+- supervisor drain summaries expose stable, parseable scheduler action
+  recommendations for continuation, follow-up routing, and plan-drift
+  investigation
 
 ## Development
 

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1059,6 +1059,18 @@ impl ToolAuditSupervisorDrainRunOutcome {
         }
     }
 
+    /// Parse a stable snake_case outcome label.
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "idle" => Some(Self::Idle),
+            "caught_up" => Some(Self::CaughtUp),
+            "needs_continuation" => Some(Self::NeedsContinuation),
+            "needs_follow_up" => Some(Self::NeedsFollowUp),
+            "plan_diverged" => Some(Self::PlanDiverged),
+            _ => None,
+        }
+    }
+
     /// Return whether the scheduler should take action for this outcome.
     pub fn requires_scheduler_action(self) -> bool {
         self.scheduler_action().requires_scheduler_action()
@@ -1104,6 +1116,17 @@ impl ToolAuditSupervisorDrainSchedulerAction {
             Self::ScheduleContinuation => "schedule_continuation",
             Self::RouteFollowUp => "route_follow_up",
             Self::InvestigatePlanDrift => "investigate_plan_drift",
+        }
+    }
+
+    /// Parse a stable snake_case scheduler action label.
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "no_action" => Some(Self::NoAction),
+            "schedule_continuation" => Some(Self::ScheduleContinuation),
+            "route_follow_up" => Some(Self::RouteFollowUp),
+            "investigate_plan_drift" => Some(Self::InvestigatePlanDrift),
+            _ => None,
         }
     }
 
@@ -2702,9 +2725,17 @@ mod tests {
         for (outcome, label, scheduler_action, requires_action) in cases {
             assert_eq!(outcome.as_str(), label);
             assert_eq!(outcome.to_string(), label);
+            assert_eq!(
+                ToolAuditSupervisorDrainRunOutcome::from_label(label),
+                Some(outcome)
+            );
             assert_eq!(outcome.scheduler_action(), scheduler_action);
             assert_eq!(outcome.requires_scheduler_action(), requires_action);
         }
+        assert_eq!(
+            ToolAuditSupervisorDrainRunOutcome::from_label("needs_attention"),
+            None
+        );
     }
 
     #[test]
@@ -2735,8 +2766,16 @@ mod tests {
         for (action, label, requires_action) in cases {
             assert_eq!(action.as_str(), label);
             assert_eq!(action.to_string(), label);
+            assert_eq!(
+                ToolAuditSupervisorDrainSchedulerAction::from_label(label),
+                Some(action)
+            );
             assert_eq!(action.requires_scheduler_action(), requires_action);
         }
+        assert_eq!(
+            ToolAuditSupervisorDrainSchedulerAction::from_label("rerun_everything"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add reverse parsing for stable supervisor drain outcome labels
- add reverse parsing for stable scheduler action labels
- document that the host-facing labels are parseable as well as stable

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD