### PR TITLE
Check html5lib normalizer fixture output

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -19,6 +19,8 @@ documented in this file.
   runtime tokens stay aligned.
 - Shared JSON fixture IO helpers keep generated WHATWG fixture writers on the
   same stable `--check` path.
+- The html5lib tokenizer normalizer shares the same checked fixture IO path,
+  including `--check` stale detection for `html5lib-smoke.json`.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -463,6 +463,15 @@ python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures
   code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
 ```
 
+To check whether the normalized corpus is stale:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py \
+  code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test \
+  code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json \
+  --check
+```
+
 Planned flow:
 
 1. Import or mirror selected upstream tokenizer cases into a generator script.

--- a/code/packages/rust/html-lexer/tests/fixtures/generated_fixture_io.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/generated_fixture_io.py
@@ -13,13 +13,14 @@ def write_fixture_json(
     *,
     check: bool,
     ensure_ascii: bool = False,
+    sort_keys: bool = True,
     stale_hint: str | None = None,
 ) -> int:
     text = json.dumps(
         fixture,
         indent=2,
         ensure_ascii=ensure_ascii,
-        sort_keys=True,
+        sort_keys=sort_keys,
     ) + "\n"
 
     if check:

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -10,6 +10,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from generated_fixture_io import write_fixture_json
+
 
 SUPPORTED_INITIAL_STATES = {
     "CDATA section bracket state",
@@ -263,6 +265,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "output", type=Path, help="Path to write normalized venture-html-lexer fixture JSON"
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the checked-in normalized fixture is stale.",
+    )
     return parser.parse_args()
 
 
@@ -306,8 +313,19 @@ def main() -> int:
         "skipped": skipped,
     }
 
-    args.output.write_text(json.dumps(normalized, indent=2) + "\n")
-    return 0
+    return write_fixture_json(
+        args.output,
+        normalized,
+        check=args.check,
+        ensure_ascii=True,
+        sort_keys=False,
+        stale_hint=(
+            "with `python3 code/packages/rust/html-lexer/tests/fixtures/"
+            "normalize_html5lib_fixtures.py "
+            "code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test "
+            "code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json`."
+        ),
+    )
 
 
 def is_supported(test: dict[str, Any]) -> tuple[bool, str]:


### PR DESCRIPTION
## Summary
- route the html5lib tokenizer normalizer through the shared generated fixture IO helper
- add a normalizer --check mode that fails on stale html5lib-smoke.json output
- preserve the normalizer's existing ASCII-escaped, insertion-ordered JSON format while documenting the new stale check

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check

Note: Cargo generated code/packages/rust/Cargo.lock during local testing; it was removed before commit.