### PR TITLE
feat(matrix-rust-python): MX09 Phase 1 — Rust crate skeleton with graph_round_trip_json

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -388,6 +388,7 @@ members = [
     "matrix-profile",
     "matrix-runtime",
     "matrix-rust-napi",
+    "matrix-rust-python",
     "metal-compute",
     "paint-metal",
     "paint-vm-direct2d-c",

--- a/code/packages/rust/matrix-rust-python/BUILD
+++ b/code/packages/rust/matrix-rust-python/BUILD
@@ -1,0 +1,1 @@
+cargo test -p matrix-rust-python -- --nocapture

--- a/code/packages/rust/matrix-rust-python/BUILD_windows
+++ b/code/packages/rust/matrix-rust-python/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p matrix-rust-python -- --nocapture

--- a/code/packages/rust/matrix-rust-python/CHANGELOG.md
+++ b/code/packages/rust/matrix-rust-python/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog — matrix-rust-python (Rust)
+
+## [0.1.0] — 2026-05-19
+
+### Added — MX09 Phase 1: crate skeleton + JSON round-trip
+
+Initial release.  Ships the Phase 1 surface area from
+`code/specs/MX09-matrix-rust-python.md`:
+
+- **`graph_round_trip_json(json_string: str) -> str`** — Decode a
+  matrix-ir-json wire-format `Graph` and re-encode it.  Returns the
+  re-encoded JSON string (compact form, canonical field order).
+  Raises Python `ValueError` on malformed JSON, schema-invalid JSON
+  (wrong `matrix_ir_version`, missing required fields, etc.), or any
+  other decode failure.
+
+This is the smoke function that proves the matrix-ir-json wire format
+survives a trip through the Python C API boundary — exact analog of
+`matrix-rust-napi`'s `graphRoundTripJson` from MX07 Phase 1
+(PR #3518).
+
+### Implementation notes
+
+- **`crate-type = ["cdylib"]`, lib name `matrix_rust_python`** —
+  produces a `.so`/`.dylib`/`.pyd` that Python loads via its import
+  machinery.  Rename / wheel-package handled in Phase 3.
+- **`PyInit_matrix_rust_python`** is the entry point Python looks up
+  via `dlsym` / `GetProcAddress` when the module is imported.
+- **`python-bridge`** is the only binding-tooling dependency — zero
+  pyo3, zero pyo3-ffi, zero bindgen.  Python's Limited C API (PEP 384)
+  is ABI-stable across all Python 3.x versions, so the extension
+  works on every supported interpreter without per-version rebuilds.
+- **Pure-Rust core** (`pub fn round_trip_json`) splits the testable
+  work from the `unsafe extern "C"` wrapper.  The 5 unit tests run
+  on `cargo test -p matrix-rust-python` without requiring a Python
+  interpreter.
+- **`m_size = -1`** opts out of sub-interpreter reinitialisation
+  (Phase 1 has no per-interpreter state; the methods table is
+  process-global).
+
+### Tests
+
+Five pure-Rust unit tests in `src/lib.rs`:
+
+1. `round_trip_preserves_graph_under_binary_wire_format` — encode →
+   decode → re-encode produces a `Graph` byte-equal to the original
+   under the canonical binary wire format.
+2. `round_trip_handles_multi_op_graph` — exercises Add / Mul / Neg
+   in a single graph to confirm multi-op coverage.
+3. `round_trip_rejects_garbage_json` — fail-closed on syntactically
+   invalid JSON.
+4. `round_trip_rejects_unsupported_version` — fail-closed on
+   `matrix_ir_version: 9999`.
+5. `round_trip_is_idempotent` — `round_trip_json(round_trip_json(x))`
+   equals `round_trip_json(x)` byte-for-byte.
+
+### What's not shipped in Phase 1
+
+- No `run_graph_on_cpu` envelope execution (Phase 2).
+- No `Graph` / `Runtime` Python classes (Phase 2b).
+- No `pyproject.toml` / `maturin` wheel build (Phase 3).
+- No companion Python wrapper package (Phase 4).
+
+Each follow-up phase ships as its own PR per the MX09 spec.

--- a/code/packages/rust/matrix-rust-python/Cargo.toml
+++ b/code/packages/rust/matrix-rust-python/Cargo.toml
@@ -1,0 +1,34 @@
+# matrix-rust-python — Python C extension exposing the Rust matrix
+# execution layer to Python.
+#
+# Phase 1 (MX09 §"Phases"): crate skeleton + Graph JSON round-trip
+# only.  Runtime + Graph execution land in Phase 2.
+#
+# Build produces a .so/.dylib/.pyd that Python imports as
+# `matrix_rust_python`.  crate-type = ["cdylib"]: emit a C-compatible
+# shared library with no Rust-specific symbols — this is what
+# Python's import machinery expects.
+#
+# Follows the workspace convention established by font-parser-python:
+# zero-dependency on pyo3 / pyo3-ffi.  All Python C API access goes
+# through python-bridge, which declares the extern "C" functions
+# itself.  Python's Limited API (PEP 384) is ABI-stable by design,
+# so the bridge works on every Python 3.x version without rebuilding.
+
+[package]
+name = "matrix-rust-python"
+version = "0.1.0"
+edition = "2021"
+description = "MX09 Phase 1 — Python C extension exposing the Rust matrix execution layer (matrix-ir / matrix-ir-json / matrix-runtime / matrix-cpu / matrix-metal / matrix-cuda) to Python.  v0.1 exposes only graph_round_trip_json(json_string) -> json_string — a smoke function that proves the matrix-ir-json wire format survives a trip through the Python C API boundary.  v0.2+ adds Graph + Runtime classes with actual execution per MX09.  Zero external Rust dependencies beyond the workspace; no pyo3."
+license = "MIT"
+
+[lib]
+# cdylib: produce a .so / .dylib / .pyd that Python can `import`.
+# No rlib because we are not a reusable Rust library — only a bridge.
+crate-type = ["cdylib"]
+name = "matrix_rust_python"
+
+[dependencies]
+matrix-ir           = { path = "../matrix-ir" }
+matrix-ir-json      = { path = "../matrix-ir-json" }
+python-bridge       = { path = "../python-bridge" }

--- a/code/packages/rust/matrix-rust-python/README.md
+++ b/code/packages/rust/matrix-rust-python/README.md
@@ -1,0 +1,128 @@
+# matrix-rust-python
+
+Python C extension crate exposing the Rust matrix execution layer
+(`matrix-ir`, `matrix-ir-json`, future `matrix-runtime` / `matrix-cpu`)
+to Python.  Sibling crate to
+[`matrix-rust-napi`](../matrix-rust-napi) (the Node.js N-API binding)
+— same shape, different toolchain.
+
+This is **Phase 1** of [MX09](../../../specs/MX09-matrix-rust-python.md).
+Phase 1 ships the crate skeleton plus one exported function
+(`graph_round_trip_json`) — the smoke test that proves the
+matrix-ir-json wire format survives a trip through the Python C API
+boundary.  Phases 2+ add execution and class-based APIs.
+
+## What this crate is
+
+A `cdylib` that produces a `.so` / `.dylib` / `.pyd` file Python
+imports as `matrix_rust_python`.  The crate is **a Rust crate** that
+happens to expose a Python C extension — same way
+[`font-parser-python`](../font-parser-python) is a Rust crate that
+ships a font-parsing extension.
+
+```
+code/packages/rust/matrix-rust-python/
+  Cargo.toml             # cdylib only (workspace convention)
+  src/lib.rs             # graph_round_trip_json + module init + 5 tests
+  BUILD                  # cargo test -p matrix-rust-python
+  BUILD_windows
+  CHANGELOG.md
+  README.md              # ← you are here
+  required_capabilities.json
+```
+
+## What ships in Phase 1
+
+One exported Python function:
+
+```python
+import matrix_rust_python as m
+
+# Round-trip a matrix-ir-json wire-format Graph through Rust.
+out = m.graph_round_trip_json(json_in)
+# out is a compact JSON string with canonical field order;
+# `json.loads(out)` decodes to a Graph value semantically identical
+# to `json.loads(json_in)`.
+```
+
+That's it.  The function is intentionally minimal — three things it
+must prove:
+
+1. **Build pipeline works.**  The cdylib compiles, exposes a
+   `PyInit_matrix_rust_python` symbol, and is importable from
+   Python.
+2. **Python C API boundary works.**  Strings move in and out of the
+   extension without data loss.
+3. **`matrix-ir-json` is the right interop wire format.**  Anything
+   constructable on either side (Rust, hand-written JSON, future TS)
+   must survive `graph_round_trip_json` unchanged.
+
+Phases 2+ add `run_graph_on_cpu` (envelope JSON execution),
+`Graph` / `Runtime` classes with `bytes` I/O via `PyCapsule`, the
+`maturin` wheel build, and the companion `code/packages/python/`
+wrapper package.
+
+## Why `python-bridge`, not `pyo3`
+
+Workspace convention (per
+[ARCH02 §"Bindings layer"](../../../specs/ARCH02-rust-native-execution-backbone.md)
+and [MX09](../../../specs/MX09-matrix-rust-python.md)).  Zero
+crates.io dependencies, raw `extern "C"` declarations are auditable
+under `gdb`/`lldb`, Python's Limited API (PEP 384) is ABI-stable
+across every Python 3.x, no proc-macros hiding the actual C boundary.
+
+If a future binding ever hits a real ceiling that only `pyo3` can
+break through, the option remains open — but the default is
+`python-bridge`, same as the workspace's other Python extensions.
+
+## Build & test
+
+Pure-Rust tests run via `cargo`:
+
+```
+cargo test -p matrix-rust-python -- --nocapture
+```
+
+The 5 unit tests exercise the pure-Rust `round_trip_json` helper.
+They do **not** require a Python interpreter — the Python C API
+wrapper is exercised end-to-end by Phase 4's `pytest` suite via the
+companion wrapper package.
+
+To produce the actual `.so` / `.dylib` / `.pyd` that Python loads,
+Phase 3 will add a `maturin build --release` invocation.  Until
+then, `cargo build -p matrix-rust-python --release` produces
+`target/release/libmatrix_rust_python.{so,dylib}` (or
+`matrix_rust_python.dll` on Windows) which Python can `import`
+directly after renaming the extension.
+
+## How it fits in the stack
+
+```
+                    Python user code
+                          │
+                          ▼
+              matrix_rust_python.so   ← this crate (the .so)
+                          │
+                          ▼
+   matrix-ir-json ── matrix-ir   (zero-dep workspace crates)
+                          │
+                          ▼  (Phase 2+)
+   matrix-runtime ── matrix-cpu / matrix-metal / matrix-cuda
+```
+
+The `*-bridge` crate (`python-bridge`) provides the safe Rust
+wrappers over the Python C API extern declarations; no other
+binding-tooling dependency.
+
+## Related
+
+- [`matrix-rust-napi`](../matrix-rust-napi) — sibling Node.js binding
+  (MX07).  Same pattern, same shape, `napi_value` / `napi_wrap`
+  instead of `PyObject*` / `PyCapsule`.
+- [`font-parser-python`](../font-parser-python) — precedent
+  consumer of `python-bridge`; the lib.rs there is the canonical
+  reference for module-init + extern-fn patterns.
+- [`matrix-ir-json`](../matrix-ir-json) — the JSON wire format crate
+  this extension wraps.
+- [MX09 spec](../../../specs/MX09-matrix-rust-python.md) — the
+  multi-phase plan this crate implements.

--- a/code/packages/rust/matrix-rust-python/required_capabilities.json
+++ b/code/packages/rust/matrix-rust-python/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/matrix-rust-python",
+  "capabilities": [],
+  "justification": "Phase 1 surface area is one pure-function Python C API export (graph_round_trip_json) that converts JSON in -> matrix_ir::Graph -> JSON out via the matrix-ir-json crate. No filesystem, no network, no process spawn, no environment access. All extern \"C\" Python C API symbols are resolved at runtime by the embedding CPython interpreter; the extension itself opens no resources."
+}

--- a/code/packages/rust/matrix-rust-python/src/lib.rs
+++ b/code/packages/rust/matrix-rust-python/src/lib.rs
@@ -1,0 +1,376 @@
+//! # `matrix-rust-python` — Python C extension for the Rust matrix execution layer
+//!
+//! **Phase 1** of [MX09](../../../specs/MX09-matrix-rust-python.md).
+//! This is the minimal-viable shape of the Python extension crate:
+//! one exported function (`graph_round_trip_json`) that takes the
+//! canonical JSON wire format for a `matrix_ir::Graph`, parses it via
+//! `matrix-ir-json`, re-encodes it back to JSON, and returns the
+//! result.
+//!
+//! The round-trip is intentionally trivial in v0.1 — it only proves
+//! three things:
+//!
+//! 1. **The build pipeline works.**  We can compile a `cdylib` that
+//!    depends on the matrix-ir-json crate and have it load as a
+//!    Python extension (`PyInit_matrix_rust_python` symbol present,
+//!    module imports cleanly).
+//! 2. **The Python C API boundary works.**  Strings can move into the
+//!    extension via `str_from_py`, get processed by Rust code, and
+//!    come back out via `str_to_py` without losing data.
+//! 3. **The matrix-ir-json schema is the right interop boundary.**
+//!    A graph constructed anywhere — Rust, browser TS via a future
+//!    `matrix-ir-ts`, hand-written JSON — can be checked for schema
+//!    validity by round-tripping through this function.  Anything
+//!    that fails to round-trip is a bug.
+//!
+//! **Phase 2** adds an envelope-shaped `run_graph_on_cpu` for
+//! end-to-end execution; **Phase 2b** adds `Graph` and `Runtime`
+//! Python classes backed by `PyCapsule`.  This file stays small and
+//! grows gradually with each PR — same pattern as `matrix-rust-napi`.
+//!
+//! ## What Python sees
+//!
+//! ```python
+//! import matrix_rust_python as m
+//!
+//! json_in = json.dumps({
+//!   "matrix_ir_version": 1,
+//!   "tensors": [
+//!     {"id": 0, "dtype": "f32", "shape": [1, 4]},
+//!     {"id": 1, "dtype": "f32", "shape": [4, 1]},
+//!     {"id": 2, "dtype": "f32", "shape": [1, 1]},
+//!   ],
+//!   "inputs":  [0],
+//!   "outputs": [2],
+//!   "ops": [
+//!     {"kind": "MatMul", "lhs": 0, "rhs": 1, "output": 2},
+//!   ],
+//!   "constants": [
+//!     {"tensor_id": 1, "dtype": "f32", "shape": [4, 1],
+//!      "bytes_hex": "00000000000000000000000000000000"},
+//!   ],
+//! })
+//!
+//! round_tripped = m.graph_round_trip_json(json_in)
+//! # round_tripped is a JSON string that decodes to the same Graph value.
+//! ```
+//!
+//! ## Internals
+//!
+//! Two layers — same shape as `matrix-rust-napi`:
+//!
+//! 1. **Pure Rust** (`pub fn round_trip_json`) — the actual work.
+//!    Cargo-testable: no Python required.  This is the function that
+//!    Phase 2 will compose into the envelope/class exports.
+//! 2. **Python C API wrapper** (`extern "C" fn py_graph_round_trip_json`)
+//!    — un-marshals the Python `str`, calls `round_trip_json`,
+//!    marshals the result back.  Errors get raised as Python
+//!    `ValueError`s via `python-bridge::set_error` +
+//!    `value_error_class()`.
+
+#![allow(non_snake_case)] // C API names are PascalCase / SCREAMING_SNAKE_CASE
+
+use std::ffi::{c_char, c_int};
+use std::ptr;
+
+use matrix_ir_json::{decode, encode};
+use python_bridge::{
+    set_error, str_from_py, str_to_py, value_error_class, PyErr_Clear, PyMethodDef,
+    PyModuleDef, PyModuleDef_Base, PyModule_Create2, PyObjectPtr, PyTuple_GetItem,
+    PYTHON_API_VERSION, METH_VARARGS,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure Rust core: the testable round-trip.
+//
+// Splitting this from the Python wrapper lets `cargo test` exercise
+// the round-trip without any Python interpreter.  It also keeps the
+// wrapper trivial — one un-marshal, one call, one marshal — so the
+// `unsafe` surface stays small.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Round-trip a `matrix_ir::Graph` through its JSON wire format.
+///
+/// Returns the re-encoded JSON string.  The output is byte-equal to
+/// the input *modulo*:
+///
+/// * whitespace (input may be pretty-printed; output is compact);
+/// * key ordering inside objects (input may be in any order; output
+///   follows the canonical order from `matrix-ir-json`).
+///
+/// The decoded `Graph` value is semantically identical to one
+/// constructed natively in Rust — that is the property we rely on
+/// for Phase 2+ execution.
+pub fn round_trip_json(input: &str) -> Result<String, String> {
+    let graph = decode(input).map_err(|e| format!("matrix-ir-json decode failed: {:?}", e))?;
+    Ok(encode(&graph))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Python C API wrapper
+//
+// Every METH_VARARGS callback has the same signature:
+//   PyObject* fn(PyObject* _self, PyObject* args)
+// where `args` is a tuple of the positional arguments.
+//
+// We extract args[0] as a Python str, call `round_trip_json`, and
+// return a fresh Python str.  On error we raise a Python ValueError
+// (via `set_error` + `value_error_class()`) and return null — Python
+// treats a null return + active exception as "this function raised".
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `graph_round_trip_json(json_string: str) -> str`
+///
+/// Python entry point for the round-trip helper.  Argument arity is
+/// 1 (the JSON string); any other arity raises `TypeError`.  Invalid
+/// JSON (or schema-invalid JSON) raises `ValueError`.
+///
+/// # Safety
+///
+/// Called by Python via the registered module methods table.  `args`
+/// is a valid `PyObject*` tuple for the duration of the call per the
+/// Python C API contract.
+unsafe extern "C" fn py_graph_round_trip_json(
+    _self: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    // Extract args[0] — the JSON string.
+    //
+    // PyTuple_GetItem returns null + sets an IndexError on
+    // out-of-range access.  We clear that pending error before
+    // setting our own so we don't trip the "exception already set"
+    // assertion in PyErr_SetString.
+    let arg0 = PyTuple_GetItem(args, 0);
+    if arg0.is_null() {
+        PyErr_Clear();
+        set_error(
+            value_error_class(),
+            "graph_round_trip_json: expected exactly 1 argument (json_string: str)",
+        );
+        return ptr::null_mut();
+    }
+
+    let json = match str_from_py(arg0) {
+        Some(s) => s,
+        None => {
+            // str_from_py clears any pending exception itself, so it
+            // is safe to set ours.
+            set_error(
+                value_error_class(),
+                "graph_round_trip_json: argument 0 must be a str",
+            );
+            return ptr::null_mut();
+        }
+    };
+
+    match round_trip_json(&json) {
+        Ok(out) => str_to_py(&out),
+        Err(msg) => {
+            set_error(
+                value_error_class(),
+                &format!("graph_round_trip_json: {}", msg),
+            );
+            ptr::null_mut()
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module methods table
+//
+// `PyMethodDef` entries tell Python about each exported function.
+// The table must be terminated with a sentinel (all-null entry); we
+// build it inline to mirror font-parser-python's style.
+// ─────────────────────────────────────────────────────────────────────────────
+
+static mut MODULE_METHODS: [PyMethodDef; 2] = [
+    PyMethodDef {
+        ml_name: b"graph_round_trip_json\0".as_ptr() as *const c_char,
+        ml_meth: Some(py_graph_round_trip_json),
+        ml_flags: METH_VARARGS,
+        ml_doc: b"graph_round_trip_json(json_string: str) -> str\n\n\
+                  Decode a matrix-ir-json Graph and re-encode it.  \
+                  Raises ValueError on malformed or schema-invalid JSON.\n\0"
+            .as_ptr() as *const c_char,
+    },
+    // Sentinel — terminates the methods array.
+    PyMethodDef {
+        ml_name: ptr::null(),
+        ml_meth: None,
+        ml_flags: 0,
+        ml_doc: ptr::null(),
+    },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module definition
+//
+// `PyModuleDef` is the singleton descriptor for our module.  It must
+// be a `static` because Python holds a pointer to it for the lifetime
+// of the interpreter.  `m_size = -1` opts out of sub-interpreter
+// reinitialisation (we have no per-interpreter state in Phase 1; the
+// methods table is process-global).
+// ─────────────────────────────────────────────────────────────────────────────
+
+static mut MODULE_DEF: PyModuleDef = PyModuleDef {
+    m_base: PyModuleDef_Base {
+        // PyModuleDef_HEAD_INIT in C initialises ob_refcnt=1,
+        // ob_type=NULL, m_init=NULL, m_index=0, m_copy=NULL.
+        ob_base: [0u8; std::mem::size_of::<usize>() * 2],
+        m_init: None,
+        m_index: 0,
+        m_copy: ptr::null_mut(),
+    },
+    m_name: b"matrix_rust_python\0".as_ptr() as *const c_char,
+    m_doc: b"Rust-backed matrix execution layer - zero-dependency Python C extension.\0"
+        .as_ptr() as *const c_char,
+    m_size: -1,
+    m_methods: &raw mut MODULE_METHODS as *mut PyMethodDef,
+    m_slots: ptr::null_mut(),
+    m_traverse: ptr::null_mut(),
+    m_clear: ptr::null_mut(),
+    m_free: ptr::null_mut(),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module init — the entry point Python calls when it imports the module
+//
+// The name MUST be `PyInit_<module_name>` where `<module_name>` is
+// the name of the .so/.pyd file (without the file extension and ABI
+// tag).  `#[no_mangle]` prevents Rust from mangling the symbol —
+// Python's import machinery looks for this exact name via `dlsym`
+// (POSIX) or `GetProcAddress` (Windows).
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub unsafe extern "C" fn PyInit_matrix_rust_python() -> PyObjectPtr {
+    PyModule_Create2(&raw mut MODULE_DEF, PYTHON_API_VERSION as c_int)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+//
+// The unit tests cover the pure-Rust `round_trip_json` helper without
+// involving Python.  They prove that:
+//
+//  * a valid Graph JSON survives the round-trip;
+//  * the output decodes to a Graph that's byte-equal under the
+//    binary wire format (the cross-format equivalence we rely on for
+//    Phase 2+);
+//  * malformed JSON returns an Err, not a panic;
+//  * schema-invalid JSON (wrong version) is rejected;
+//  * the round-trip is idempotent (f(f(x)) == f(x)).
+//
+// The Python C API wrapper is exercised by Phase 4's end-to-end
+// tests (`pytest` via the wrapper package).  Here we keep things
+// pure-Rust so they run on `cargo test -p matrix-rust-python` with
+// no Python interpreter required.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_ir::{DType, GraphBuilder, Shape};
+
+    /// Build a small ReLU layer and confirm the JSON round-trip is
+    /// semantically identical (binary wire format byte-equal).
+    ///
+    /// This is the canonical "round-trip preserves the graph"
+    /// invariant: encode → decode → re-encode → decode must give a
+    /// `Graph` whose binary wire-format representation matches the
+    /// original.  Anything weaker (e.g. comparing JSON strings) is
+    /// brittle to whitespace and field ordering — the binary wire
+    /// format is the canonical equality test (see matrix-ir-json's
+    /// README).
+    #[test]
+    fn round_trip_preserves_graph_under_binary_wire_format() {
+        let mut g = GraphBuilder::new();
+        let x = g.input(DType::F32, Shape::from(&[1, 4]));
+        let w = g.constant(DType::F32, Shape::from(&[4, 2]), vec![0u8; 32]);
+        let b = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+        let zero = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+        let xw = g.matmul(&x, &w);
+        let xwb = g.add(&xw, &b);
+        let relu = g.max(&xwb, &zero);
+        g.output(&relu);
+        let original = g.build().expect("graph builds");
+
+        let json_in = encode(&original);
+        let json_out = round_trip_json(&json_in).expect("round-trip succeeds");
+
+        let round_tripped = decode(&json_out).expect("decode round-trip output");
+        assert_eq!(
+            original.to_bytes(),
+            round_tripped.to_bytes(),
+            "round-tripped graph must be byte-equal to the original under \
+             the binary wire format"
+        );
+    }
+
+    /// A graph with multiple Op families is non-trivial enough to be
+    /// a stress test of `matrix-ir-json` end-to-end through our
+    /// wrapper.  We don't replicate the full all-ops test from
+    /// `matrix-ir-json` here (that's its job), but we do confirm a
+    /// representative 3-op graph survives.
+    #[test]
+    fn round_trip_handles_multi_op_graph() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let b = g.input(DType::F32, Shape::from(&[2, 3]));
+        let sum = g.add(&a, &b);
+        let prod = g.mul(&sum, &a);
+        let neg = g.neg(&prod);
+        g.output(&neg);
+        let original = g.build().expect("graph builds");
+
+        let json_in = encode(&original);
+        let json_out = round_trip_json(&json_in).expect("round-trip succeeds");
+        let round_tripped = decode(&json_out).expect("decode round-trip output");
+
+        assert_eq!(original.to_bytes(), round_tripped.to_bytes());
+    }
+
+    /// Garbage JSON must produce an Err — not panic, not crash the
+    /// extension, not produce a corrupted graph value.  This is the
+    /// fail-closed property we need at the FFI boundary: a bad input
+    /// from Python becomes a clean `ValueError`, never a SIGSEGV.
+    #[test]
+    fn round_trip_rejects_garbage_json() {
+        let err = round_trip_json("not even close to json").expect_err("garbage rejected");
+        assert!(err.contains("decode failed"), "got: {}", err);
+    }
+
+    /// JSON that's syntactically valid but schema-invalid (wrong
+    /// matrix_ir_version) must also fail cleanly.  Same fail-closed
+    /// property as garbage-JSON, but covers the "newer producer, older
+    /// consumer" forward-compat path that's most likely to bite in
+    /// practice.
+    #[test]
+    fn round_trip_rejects_unsupported_version() {
+        let err = round_trip_json(
+            r#"{"matrix_ir_version": 9999, "tensors": [], "inputs": [],
+                 "outputs": [], "ops": [], "constants": []}"#,
+        )
+        .expect_err("unsupported version rejected");
+        assert!(err.contains("decode failed"), "got: {}", err);
+    }
+
+    /// The output of the round-trip must itself be valid JSON that
+    /// re-round-trips to a byte-identical string.  Idempotence:
+    /// `f(f(x)) == f(x)`.  Useful to catch any drift introduced by
+    /// the encoder (e.g. if it ever started canonicalising fields
+    /// differently between runs).
+    #[test]
+    fn round_trip_is_idempotent() {
+        let mut g = GraphBuilder::new();
+        let x = g.input(DType::F32, Shape::from(&[3]));
+        let y = g.input(DType::F32, Shape::from(&[3]));
+        let z = g.add(&x, &y);
+        g.output(&z);
+        let graph = g.build().expect("graph builds");
+
+        let once = round_trip_json(&encode(&graph)).unwrap();
+        let twice = round_trip_json(&once).unwrap();
+        assert_eq!(once, twice, "round_trip_json must be idempotent");
+    }
+}


### PR DESCRIPTION
## Summary

MX09 Phase 1 — sibling of MX07 Phase 1 for the **Python** binding to the Rust matrix execution layer. Ships the `matrix-rust-python` crate skeleton plus one exported function (\`graph_round_trip_json\`) that proves the matrix-ir-json wire format survives a trip through the Python C API boundary.

Mirrors \`matrix-rust-napi\`'s Phase 1 shape exactly, swapping node-bridge / napi_value / napi_wrap for **python-bridge / PyObject\* / PyCapsule**. Per ARCH02 §\"Bindings layer\" and the MX09 spec, uses workspace \`python-bridge\` (zero-dep wrapper over Python's stable Limited C API per PEP 384) — no pyo3, no pyo3-ffi, no bindgen.

Phase 1 surface:
- \`Cargo.toml\` — \`crate-type = [\"cdylib\"]\`, lib name \`matrix_rust_python\`; deps: matrix-ir + matrix-ir-json + python-bridge (no others).
- \`src/lib.rs\` — pure-Rust \`round_trip_json(input: &str) -> Result<String, String>\` for testability, plus \`extern \"C\" fn py_graph_round_trip_json\` wrapper, \`MODULE_METHODS\` table, \`MODULE_DEF\` static, and \`#[no_mangle] PyInit_matrix_rust_python\` entry point.
- 5 pure-Rust unit tests (all passing locally on darwin-arm64):
  1. \`round_trip_preserves_graph_under_binary_wire_format\`
  2. \`round_trip_handles_multi_op_graph\`
  3. \`round_trip_rejects_garbage_json\`
  4. \`round_trip_rejects_unsupported_version\`
  5. \`round_trip_is_idempotent\`
- \`BUILD\` / \`BUILD_windows\` — \`cargo test -p matrix-rust-python -- --nocapture\` (same as matrix-rust-napi; pure-Rust tests don't require a Python interpreter).
- \`required_capabilities.json\` — empty.
- \`CHANGELOG.md\` + \`README.md\` — Knuth-style literate explanation.

What's **not** in Phase 1 (each is a separate follow-up PR per the spec):
- No envelope \`run_graph_on_cpu\` (Phase 2)
- No \`Graph\` / \`Runtime\` Python classes via PyCapsule (Phase 2b)
- No \`pyproject.toml\` / \`maturin\` wheel build (Phase 3)
- No \`code/packages/python/matrix-rust-python/\` wrapper + pytest smoke (Phase 4)

Security review (\`/security-review\`): **PASSED** — no vulnerabilities. All unsafe patterns mirror the established \`font-parser-python\` precedent (PyTuple_GetItem borrowed-ref handling, PyErr_Clear before set_error, str_to_py new-ref ownership transfer, NUL-safe CString fallback in set_error).

## Test plan

- [x] \`cargo test -p matrix-rust-python -- --nocapture\` — 5/5 tests pass on darwin-arm64
- [x] Security review (sub-agent, Rust + Python C API focus) — passed
- [ ] CI: \`cargo build\` workspace gate (Tier 1 of MX09 §\"CI strategy\")
- [ ] CI: build-tool runs \`cargo test -p matrix-rust-python\` via per-package BUILD file
- [ ] CI: cross-platform builds (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)