### PR TITLE
Add checked html5lib audit counts

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -101,6 +101,10 @@ binary while production code continues to link only static Rust source.
   exercise the normalization path toward broader upstream corpora
 - `normalize_html5lib_fixtures.py`: importer that lowers supported raw
   html5lib-style tokenizer cases into Venture's portable fixture schema
+- the parser fixture audit can pin the current html5lib tokenizer counts with
+  `--expect-tokenizer-upstream-cases 6806`,
+  `--expect-tokenizer-local-raw-cases 7015`,
+  `--expect-normalized-cases 7242`, and `--expect-normalized-skipped 0`
 - `generate_whatwg_entities_fixture.py`: importer that lowers the HTML
   Standard's `entities.json` table into the checked-in `whatwg-entities.json`
   fixture

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -80,6 +80,20 @@ The audit fails if an upstream tree-construction case is missing, if an
 upstream tokenizer case is missing from the raw mirrored tokenizer corpus, or
 if the normalized tokenizer corpus records skipped cases.
 
+For CI jobs that need to catch accidental fixture drift as well as missing
+coverage, the audit can pin the current corpus counts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
+  /path/to/html5lib-tests \
+  --expect-tree-upstream-cases 1778 \
+  --expect-tree-local-cases 2485 \
+  --expect-tokenizer-upstream-cases 6806 \
+  --expect-tokenizer-local-raw-cases 7015 \
+  --expect-normalized-cases 7242 \
+  --expect-normalized-skipped 0
+```
+
 For sharper parser regression reporting, the generated
 `tests/fixtures/whatwg-tree-insertion-audit.json` fixture indexes the
 adoption-agency, table/foster-parenting, template, foreign-content fragment,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -22,6 +22,20 @@ The command exits nonzero if any upstream tree-construction or tokenizer source
 case is missing, or if the normalized tokenizer fixture still has skipped
 runtime gaps.
 
+Use the expectation flags when the audit should also pin the exact upstream and
+checked-in corpus sizes used by the current compliance snapshot:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
+  /path/to/html5lib-tests \
+  --expect-tree-upstream-cases 1778 \
+  --expect-tree-local-cases 2485 \
+  --expect-tokenizer-upstream-cases 6806 \
+  --expect-tokenizer-local-raw-cases 7015 \
+  --expect-normalized-cases 7242 \
+  --expect-normalized-skipped 0
+```
+
 `whatwg-tree-insertion-audit.json` is a generated index over the high-signal
 tree-construction families inside `html5lib-tree-construction-smoke.dat`:
 adoption-agency formatting recovery, table insertion and foster parenting,

--- a/code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
+++ b/code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -107,7 +108,17 @@ def main() -> int:
     else:
         print_report(report, upstream_root)
 
-    if missing_tree or missing_tokenizer or normalized_skipped:
+    sys.stdout.flush()
+    expectation_mismatches = collect_expectation_mismatches(report, args)
+    for mismatch in expectation_mismatches:
+        print(f"expectation mismatch: {mismatch}", file=sys.stderr)
+
+    if (
+        missing_tree
+        or missing_tokenizer
+        or normalized_skipped
+        or expectation_mismatches
+    ):
         return 1
     return 0
 
@@ -135,6 +146,36 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=20,
         help="Maximum missing case sources to include in the report.",
+    )
+    parser.add_argument(
+        "--expect-tree-upstream-cases",
+        type=int,
+        help="Require the upstream tree-construction case count to match.",
+    )
+    parser.add_argument(
+        "--expect-tree-local-cases",
+        type=int,
+        help="Require the checked-in tree-construction case count to match.",
+    )
+    parser.add_argument(
+        "--expect-tokenizer-upstream-cases",
+        type=int,
+        help="Require the upstream tokenizer case count to match.",
+    )
+    parser.add_argument(
+        "--expect-tokenizer-local-raw-cases",
+        type=int,
+        help="Require the checked-in raw tokenizer case count to match.",
+    )
+    parser.add_argument(
+        "--expect-normalized-cases",
+        type=int,
+        help="Require the normalized tokenizer case count to match.",
+    )
+    parser.add_argument(
+        "--expect-normalized-skipped",
+        type=int,
+        help="Require the normalized tokenizer skipped-case count to match.",
     )
     return parser.parse_args()
 
@@ -290,6 +331,51 @@ def missing_cases(
 
 def stable_signature(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def collect_expectation_mismatches(
+    report: dict[str, Any], args: argparse.Namespace
+) -> list[str]:
+    tree = report["tree_construction"]
+    tokenizer = report["tokenizer"]
+    checks = [
+        (
+            "tree-construction upstream cases",
+            tree["upstream_cases"],
+            args.expect_tree_upstream_cases,
+        ),
+        (
+            "tree-construction local cases",
+            tree["local_cases"],
+            args.expect_tree_local_cases,
+        ),
+        (
+            "tokenizer upstream cases",
+            tokenizer["upstream_cases"],
+            args.expect_tokenizer_upstream_cases,
+        ),
+        (
+            "tokenizer local raw cases",
+            tokenizer["local_raw_cases"],
+            args.expect_tokenizer_local_raw_cases,
+        ),
+        (
+            "tokenizer normalized cases",
+            tokenizer["normalized_cases"],
+            args.expect_normalized_cases,
+        ),
+        (
+            "tokenizer normalized skipped",
+            tokenizer["normalized_skipped"],
+            args.expect_normalized_skipped,
+        ),
+    ]
+
+    mismatches = []
+    for label, actual, expected in checks:
+        if expected is not None and actual != expected:
+            mismatches.append(f"{label}: expected {expected}, got {actual}")
+    return mismatches
 
 
 def print_report(report: dict[str, Any], upstream_root: Path) -> None:


### PR DESCRIPTION
## Summary
- add expectation flags to the html5lib fixture coverage audit so CI can pin upstream/local corpus counts
- document the current parser and tokenizer audit counts for the compliance snapshot

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
- intentional mismatch: python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1 exits nonzero
