### PR TITLE
feat(forme-aot-meta-link-tags): FM00 v0 generic <meta>/<link> head tag emitter

### DIFF
--- a/code/packages/typescript/forme-aot-meta-link-tags/BUILD
+++ b/code/packages/typescript/forme-aot-meta-link-tags/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-meta-link-tags/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-meta-link-tags/CHANGELOG.md
@@ -1,0 +1,129 @@
+# Changelog — @coding-adventures/forme-aot-meta-link-tags
+
+## 0.1.0 — 2026-05-19
+
+Initial release.  Fifteenth FM00 v0 stage package — generic
+`<meta>` + `<link>` head-tag emitter.  Pure transform:
+`MetaLinkConfig` → HTML string.  Validation runs in a fail-fast
+pre-pass BEFORE emission so callers never see partial output.
+
+### Added
+
+- `generateMetaLinkTags(config): string` — main entry.  Accepts
+  the structured `MetaLinkConfig` shape; returns the concatenated
+  tag string (one tag per line, no trailing newline).
+- `validateUrl(url, field)` — http(s)://-or-root-relative
+  accept-list; `field` parameter threads through error messages
+  so callers can pinpoint which entry failed.
+- `validateIconRel`, `validateHintRel`, `validateHintAs`,
+  `validateCrossOrigin` — allowlist checks for the four
+  attribute-allowlisted fields.
+- `validateOptionalString` — generic optional-string check
+  (returns `undefined` for `undefined`, throws for any other
+  non-string).
+- `escapeHtmlAttr` / `stripAsciiControl` — same single-pass
+  character-class HTML-entity escape + control-byte strip as the
+  sibling FM00 emitters.
+- Types: `MetaLinkConfig`, `IconLink`, `IconRel`, `ResourceHint`,
+  `ResourceHintRel`, `ResourceHintAs`, `CrossOrigin`, `MetaTag`.
+
+### Spec adherence
+
+Implements the de-facto HTML head-tag conventions per the HTML
+Living Standard + Resource Hints + Preload specs.  No formal
+divergence from upstream specs.
+
+### Behavioural notes
+
+- **Output order**: `meta → canonical → prev → next → icons →
+  hints`.  Fixed across runs.
+- **Attribute order** is fixed per tag (see source).
+- **`<meta>` shape**: exactly one of `name` / `httpEquiv` is
+  required.  Empty values throw.
+- **`as` is required for `preload` and `modulepreload`**;
+  silently dropped on other hint rels (where it's invalid HTML).
+- **Empty config** → empty string output.
+- **Same input → byte-identical output.**
+
+### Security posture
+
+Five concerns explicitly addressed (pre-push review):
+
+- **HTML attribute injection.**  Every interpolated value
+  passes through `escapeHtmlAttr`.  Single-pass character-
+  class replacement covers all five HTML entities + strips
+  ASCII control bytes.  Attacker-controlled `content` like
+  `<script>alert(1)</script>` becomes inert text.
+- **URL scheme injection.**  Every `href` field (canonical /
+  prev / next / icons / hints) runs through `validateUrl`.
+  `javascript:`, `data:`, `file:`, `vbscript:`,
+  protocol-relative `//`, backslash-variant `/\`, bare relative,
+  empty, non-string all rejected with `TypeError`.  Crawlers and
+  link prefetchers follow these URLs aggressively — emitter is
+  the last line of defence.
+- **rel allowlist (icons + hints).**  Different categories
+  restrict to the spec-defined `rel` set for that category
+  (icons: 4 values; hints: 5 values).  Prevents caller from
+  injecting arbitrary rel values that downstream parsers might
+  treat permissively.
+- **as allowlist.**  Defends against `as="iframe"`-style fetch-
+  destination confusion attacks.
+- **Fail-fast.**  Validation completes for every field BEFORE
+  any tag is emitted.  An exception means the caller has nothing
+  to write — no risk of a half-formed `<head>` reaching disk.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, network, fs, shell, env.
+
+### Tests
+
+132 tests across 2 files:
+
+- `validate.test.ts` (73) — `validateUrl` full accept (https,
+  http, scheme case-insensitive, root-relative, bare /,
+  multi-segment) and reject matrix (javascript:, data:, file:,
+  vbscript:, protocol-relative, backslash-variant, bare
+  relative, empty, non-string, null, undefined, long URL
+  truncation, error field-path threading); `validateIconRel`
+  (4 accept + case-sensitive reject + non-string + null);
+  `validateHintRel` (all 5 values parametrised + reject +
+  case-sensitive + non-string); `validateHintAs` (all 10 values
+  parametrised + reject + non-string); `validateCrossOrigin`
+  (2 accept + reject true / empty / non-string);
+  `validateOptionalString` (undefined / string / empty / non-
+  string / null / error path); `escapeHtmlAttr` (5 HTML entities
+  individually + composite + ampersand-first + control bytes +
+  non-string coercion); `stripAsciiControl` (control byte
+  matrix + printable preservation + tab/lf/cr handling).
+- `generate.test.ts` (59) — empty / null / non-object config;
+  canonical / prev / next individually and in fixed order;
+  multiple meta tags with name + http-equiv; meta validation
+  (both / neither name+httpEquiv, empty values, null entry,
+  non-string content / name / httpEquiv, non-array meta, XSS in
+  content + name); icons (default rel, type + sizes, apple-
+  touch-icon variant, multi-icon order, bad rel, javascript:
+  href, null entry, non-array, escape in sizes); resource hints
+  (preload requires as, modulepreload requires as, preload
+  script, preload font with type + crossorigin, preconnect (no
+  as), preconnect with as gets dropped, dns-prefetch, prefetch,
+  modulepreload, preconnect with use-credentials, bad rel, bad
+  as, bad crossorigin, javascript: href, null entry, non-array,
+  non-string type); output order (meta → canonical → prev →
+  next → icons → hints); fail-fast (bad icon URL mid-array,
+  bad meta before canonical); HTML escaping (ampersand, quotes,
+  control bytes); purity / determinism (byte-identical, no
+  input mutation); full real-world example with verbatim line
+  check.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only).
+
+### v0 simplifications (documented)
+
+- **No `media="..."`** attribute (deferred).
+- **No `integrity`** / SRI (lives in `forme-aot-script-tag-emitter`).
+- **No `referrerpolicy`** attribute (v1 may add).
+- **No HTTP Link header emission** — HTML only.
+- **No `charset` support** — emit `<meta charset="utf-8">` via a
+  separate head builder.

--- a/code/packages/typescript/forme-aot-meta-link-tags/README.md
+++ b/code/packages/typescript/forme-aot-meta-link-tags/README.md
@@ -1,0 +1,197 @@
+# @coding-adventures/forme-aot-meta-link-tags
+
+> FM00 v0 emitter — structured-config → HTML `<meta>` + `<link>`
+> `<head>` tags, with URL accept-list + rel/as allowlists.
+
+Fifteenth FM00 v0 stage package. Pure transform — no I/O, no fs,
+no network, no env, no shell.
+
+## What it does
+
+`generateMetaLinkTags(config) → string` takes a structured
+`MetaLinkConfig` and emits a deterministic string of one tag per
+line. Returns the empty string for an empty config.
+
+Five categories of tag are supported:
+
+| Field          | Output                                                     |
+| -------------- | ---------------------------------------------------------- |
+| `meta`         | `<meta name|http-equiv="..." content="...">`               |
+| `canonical`    | `<link rel="canonical" href="...">`                        |
+| `prev`, `next` | `<link rel="prev|next" href="...">` pagination             |
+| `icons`        | `<link rel="icon|apple-touch-icon|..." href="...">` icons  |
+| `preload`      | `<link rel="preload|prefetch|preconnect|..." href="...">`  |
+
+Output order is fixed: `meta → canonical → prev → next → icons →
+hints`. Inside each array, the caller's order is preserved.
+
+## Quick start
+
+```ts
+import { generateMetaLinkTags } from "@coding-adventures/forme-aot-meta-link-tags";
+
+const head = generateMetaLinkTags({
+  canonical: "https://example.com/blog/post-1",
+  prev: "/blog/page/0",
+  next: "/blog/page/2",
+  meta: [
+    { name: "viewport", content: "width=device-width, initial-scale=1" },
+    { name: "description", content: "A blog post about feeds." },
+    { httpEquiv: "x-ua-compatible", content: "IE=edge" },
+  ],
+  icons: [
+    { href: "/favicon.svg", type: "image/svg+xml" },
+    { href: "/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180" },
+  ],
+  preload: [
+    { href: "/main.js", rel: "preload", as: "script" },
+    { href: "/inter.woff2", rel: "preload", as: "font", type: "font/woff2", crossorigin: "anonymous" },
+    { href: "https://fonts.example.com", rel: "preconnect", crossorigin: "anonymous" },
+  ],
+});
+```
+
+Produces (verbatim):
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="A blog post about feeds.">
+<meta http-equiv="x-ua-compatible" content="IE=edge">
+<link rel="canonical" href="https://example.com/blog/post-1">
+<link rel="prev" href="/blog/page/0">
+<link rel="next" href="/blog/page/2">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="preload" as="script" href="/main.js">
+<link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href="/inter.woff2">
+<link rel="preconnect" crossorigin="anonymous" href="https://fonts.example.com">
+```
+
+## Validation
+
+Two-pass fail-fast. The validator walks the entire config first;
+if anything throws, the caller gets a `TypeError` with the field
+path (`icons[2].href`, `preload[0].crossorigin`, …) and **no
+output is ever produced** — there's no risk of a half-formed
+`<head>` reaching disk.
+
+### URL accept-list
+
+Every `href` field — `canonical`, `prev`, `next`, `icons[].href`,
+`preload[].href` — must be either:
+
+- `http://...` or `https://...` (scheme case-insensitive), **or**
+- root-relative `/path` (NOT `//host`, NOT `/\host`).
+
+Everything else throws: `javascript:`, `data:`, `file:`,
+`vbscript:`, protocol-relative `//`, backslash-variant `/\`, bare
+relative (`about`), empty string, non-string.
+
+### `rel` allowlist (icons)
+
+`icon` | `shortcut icon` | `apple-touch-icon` | `mask-icon`.
+Case-sensitive.
+
+### `rel` allowlist (resource hints)
+
+`preload` | `prefetch` | `preconnect` | `dns-prefetch` |
+`modulepreload`. Case-sensitive.
+
+### `as` allowlist (resource hints)
+
+`script` | `style` | `image` | `font` | `fetch` | `document` |
+`audio` | `video` | `track` | `worker`.
+
+- Required when `rel="preload"` or `rel="modulepreload"`.
+- Validated but dropped on `prefetch` / `preconnect` /
+  `dns-prefetch` — including `as` there is invalid HTML.
+
+### `crossorigin` allowlist
+
+`anonymous` | `use-credentials`.
+
+### `<meta>` shape
+
+Exactly one of `name` / `httpEquiv` must be provided; `content`
+is required. Empty `name` / `httpEquiv` throws.
+
+## Security posture
+
+Five concerns explicitly addressed:
+
+1. **HTML attribute injection.** Every interpolated value passes
+   through `escapeHtmlAttr` — single-pass character-class
+   replacement covering all five HTML entities (`& < > " '`) plus
+   ASCII control-byte stripping. Attacker-controlled `content`
+   like `<script>alert(1)</script>` becomes inert text.
+2. **URL scheme injection.** `javascript:`, `data:`, `file:`,
+   `vbscript:`, protocol-relative, backslash-variant, bare
+   relative all rejected with `TypeError`. Crawlers and link
+   prefetchers follow these URLs aggressively — the emitter is
+   the last line of defence.
+3. **rel allowlist.** `rel` controls how browsers treat the
+   linked resource (preload runs it immediately, icon is
+   downloaded eagerly, preconnect opens a socket). Caller-
+   supplied `rel` values are constrained to the spec-defined set
+   per category.
+4. **as allowlist.** Defends against `as="iframe"`-style
+   confusion attacks where a preload might be mis-classified as a
+   different fetch destination.
+5. **Fail-fast.** Validation completes for every field before
+   any tag is emitted. An exception means the caller has nothing
+   to write — no partial `<head>` can reach the output buffer.
+
+## Behavioural notes
+
+- **Empty config** → empty string.
+- **Output order** is fixed: `meta → canonical → prev → next →
+  icons → hints`. The caller controls only the array order
+  inside each category.
+- **Attribute order** is fixed per tag (see source).
+- **Reproducibility.** Same input → byte-identical output. No
+  hidden randomness, no environment reads, no input mutation.
+- **`charset` is intentionally NOT supported here.** Emit
+  `<meta charset="utf-8">` via a separate head builder; this
+  emitter focuses on `name` / `http-equiv` pairs.
+
+## v0 simplifications (documented)
+
+- **No `media`** attribute on `<link>` (cold-load optimisation;
+  deferred).
+- **No `integrity`** / SRI on hints (out of scope — that lives
+  in `forme-aot-script-tag-emitter`).
+- **No `referrerpolicy`** attribute (rarely set on head tags;
+  v1 may add).
+- **No HTTP Link header emission.** This package emits HTML
+  only; server-side push hints handled elsewhere.
+
+## Tests
+
+132 tests across two files: `validate.test.ts` (URL accept /
+reject matrix; rel / as / crossorigin allowlists; optional-string
+helper; HTML escape + control-byte strip), `generate.test.ts`
+(empty / null / wrong-type configs; canonical / prev / next
+order; multiple meta tags with name + http-equiv; meta validation
+edge cases; icons with defaults + multiple variants; resource
+hints across all five rel values; preload-requires-as enforcement;
+as-dropped-on-preconnect; output order across all categories;
+fail-fast; HTML escaping; purity / determinism; full real-world
+example with verbatim line check).
+
+Coverage: **100% line / 100% branch** across all source files
+with logic.
+
+## Capabilities
+
+`[]` — pure transform.
+
+## How it fits in the stack
+
+This is the generic `<head>` tag emitter, complementary to:
+
+- `forme-aot-rss-discovery-link` — feed `<link rel="alternate">` tags.
+- `forme-aot-sitemap-emitter` — sitemap.xml.
+- `forme-aot-manifest-emitter` — Web App Manifest JSON.
+
+Higher-level FM00 head builders compose all of the above to
+produce the final `<head>` for each page.

--- a/code/packages/typescript/forme-aot-meta-link-tags/package-lock.json
+++ b/code/packages/typescript/forme-aot-meta-link-tags/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-aot-meta-link-tags",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-meta-link-tags",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-meta-link-tags/package.json
+++ b/code/packages/typescript/forme-aot-meta-link-tags/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-aot-meta-link-tags",
+  "version": "0.1.0",
+  "description": "Emit HTML <meta> + <link> head tags from a structured config — canonical, prev/next, icons, preload/prefetch/preconnect, arbitrary <meta name|http-equiv>.  Pure transform: URL accept-list (http(s):// OR root-relative), rel/as allowlists, HTML-attribute-escapes every value.  FM00 v0 emitter.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-meta-link-tags/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-meta-link-tags/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-meta-link-tags",
+  "capabilities": [],
+  "justification": "Pure transform: MetaLinkConfig → HTML <meta>/<link> tag string.  No I/O, no network, no env, no shell, no fs."
+}

--- a/code/packages/typescript/forme-aot-meta-link-tags/src/escape.ts
+++ b/code/packages/typescript/forme-aot-meta-link-tags/src/escape.ts
@@ -1,0 +1,41 @@
+/**
+ * escape.ts — HTML attribute escaping.
+ *
+ * Same single-pass character-class replacement pattern as the
+ * sibling emitters (`forme-aot-rss-discovery-link`,
+ * `forme-aot-sitemap-emitter`, `forme-opengraph`,
+ * `forme-feeds`).  Covers all five HTML entities; strips ASCII
+ * control bytes first so attribute values are guaranteed safe
+ * to interpolate.
+ *
+ * @module escape
+ */
+
+const HTML_ATTR_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;",
+  "'": "&#39;",
+});
+
+const HTML_ATTR_SPECIAL_RE = /[&<>"']/g;
+// eslint-disable-next-line no-control-regex
+const ASCII_CONTROL_RE = /[\x00-\x1F\x7F]/g;
+
+/**
+ * Strip ASCII control bytes (`\x00-\x1F`, `\x7F`).  Returns a
+ * fresh string.  Defensive coercion: non-string inputs go
+ * through `String(...)` first.
+ */
+export function stripAsciiControl(s: string): string {
+  return String(s).replace(ASCII_CONTROL_RE, "");
+}
+
+/**
+ * Escape HTML attribute special chars + strip control bytes.
+ * Single-pass character-class replace.
+ */
+export function escapeHtmlAttr(s: string): string {
+  return stripAsciiControl(s).replace(HTML_ATTR_SPECIAL_RE, (ch) => HTML_ATTR_ESCAPE_MAP[ch]!);
+}

--- a/code/packages/typescript/forme-aot-meta-link-tags/src/generate.ts
+++ b/code/packages/typescript/forme-aot-meta-link-tags/src/generate.ts
@@ -1,0 +1,276 @@
+/**
+ * generate.ts — main `generateMetaLinkTags` entry.
+ *
+ * Two-pass fail-fast design:
+ *
+ *   1. Walk the entire config validating every field.  Build a
+ *      flat "resolved" list of tag descriptors in deterministic
+ *      output order.  Any validation error throws BEFORE step 2.
+ *   2. Render each descriptor to its tag string.  Join with
+ *      newlines.  No trailing newline.
+ *
+ * Output order (matches the documented `MetaLinkConfig` order):
+ *
+ *     <meta>* → canonical → prev → next → icons* → hints*
+ *
+ * Attribute order within each tag is fixed (see `renderXxx`
+ * below).  Same input → byte-identical output.
+ *
+ * @module generate
+ */
+
+import { escapeHtmlAttr } from "./escape.js";
+import type {
+  IconLink,
+  MetaLinkConfig,
+  MetaTag,
+  ResourceHint,
+} from "./types.js";
+import {
+  validateCrossOrigin,
+  validateHintAs,
+  validateHintRel,
+  validateIconRel,
+  validateOptionalString,
+  validateUrl,
+} from "./validate.js";
+
+// Internal resolved (post-validation) descriptors.  These are
+// what the render pass consumes; building them up-front means
+// the render pass can't fail.
+interface ResolvedMeta {
+  readonly kind: "meta";
+  readonly nameAttr: "name" | "http-equiv";
+  readonly nameValue: string;
+  readonly content: string;
+}
+interface ResolvedSimpleLink {
+  readonly kind: "simple-link";
+  readonly rel: "canonical" | "prev" | "next";
+  readonly href: string;
+}
+interface ResolvedIcon {
+  readonly kind: "icon";
+  readonly rel: string;
+  readonly href: string;
+  readonly type?: string;
+  readonly sizes?: string;
+}
+interface ResolvedHint {
+  readonly kind: "hint";
+  readonly rel: string;
+  readonly href: string;
+  readonly as?: string;
+  readonly type?: string;
+  readonly crossorigin?: string;
+}
+type Resolved = ResolvedMeta | ResolvedSimpleLink | ResolvedIcon | ResolvedHint;
+
+/**
+ * Generate the concatenated `<head>` tag string from a
+ * structured config.  Returns the empty string for an empty
+ * config (no fields set).  Throws `TypeError` synchronously
+ * for any validation failure before emitting anything.
+ *
+ * ```ts
+ * generateMetaLinkTags({
+ *   canonical: "https://example.com/post",
+ *   meta: [
+ *     { name: "viewport", content: "width=device-width" },
+ *     { name: "description", content: "Hello" },
+ *   ],
+ *   icons: [{ href: "/favicon.png", type: "image/png", sizes: "32x32" }],
+ *   preload: [{ href: "/main.js", rel: "preload", as: "script" }],
+ * });
+ * ```
+ */
+export function generateMetaLinkTags(config: MetaLinkConfig): string {
+  if (config === null || typeof config !== "object") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: config must be a non-null object; got ${typeof config}`,
+    );
+  }
+
+  const resolved: Resolved[] = [];
+
+  // 1. <meta> tags (in caller's array order, first).
+  if (config.meta !== undefined) {
+    if (!Array.isArray(config.meta)) {
+      throw new TypeError(
+        `forme-aot-meta-link-tags: meta must be an array; got ${typeof config.meta}`,
+      );
+    }
+    for (let i = 0; i < config.meta.length; i++) {
+      resolved.push(validateMeta(config.meta[i]!, i));
+    }
+  }
+
+  // 2. canonical.
+  if (config.canonical !== undefined) {
+    resolved.push({
+      kind: "simple-link",
+      rel: "canonical",
+      href: validateUrl(config.canonical, "canonical"),
+    });
+  }
+
+  // 3. prev.
+  if (config.prev !== undefined) {
+    resolved.push({
+      kind: "simple-link",
+      rel: "prev",
+      href: validateUrl(config.prev, "prev"),
+    });
+  }
+
+  // 4. next.
+  if (config.next !== undefined) {
+    resolved.push({
+      kind: "simple-link",
+      rel: "next",
+      href: validateUrl(config.next, "next"),
+    });
+  }
+
+  // 5. icons.
+  if (config.icons !== undefined) {
+    if (!Array.isArray(config.icons)) {
+      throw new TypeError(
+        `forme-aot-meta-link-tags: icons must be an array; got ${typeof config.icons}`,
+      );
+    }
+    for (let i = 0; i < config.icons.length; i++) {
+      resolved.push(validateIcon(config.icons[i]!, i));
+    }
+  }
+
+  // 6. preload / hints.
+  if (config.preload !== undefined) {
+    if (!Array.isArray(config.preload)) {
+      throw new TypeError(
+        `forme-aot-meta-link-tags: preload must be an array; got ${typeof config.preload}`,
+      );
+    }
+    for (let i = 0; i < config.preload.length; i++) {
+      resolved.push(validateHint(config.preload[i]!, i));
+    }
+  }
+
+  // Render pass — no validation failures possible past this point.
+  const lines: string[] = new Array(resolved.length);
+  for (let i = 0; i < resolved.length; i++) {
+    lines[i] = renderResolved(resolved[i]!);
+  }
+  return lines.join("\n");
+}
+
+function validateMeta(m: MetaTag, i: number): ResolvedMeta {
+  if (m === null || typeof m !== "object") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: meta[${i}] must be a non-null object; got ${typeof m}`,
+    );
+  }
+  const hasName = m.name !== undefined;
+  const hasHttpEquiv = m.httpEquiv !== undefined;
+  if (hasName === hasHttpEquiv) {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: meta[${i}] must have exactly one of name/httpEquiv; got name=${
+        hasName ? JSON.stringify(m.name) : "undefined"
+      } httpEquiv=${hasHttpEquiv ? JSON.stringify(m.httpEquiv) : "undefined"}`,
+    );
+  }
+  const nameValue = hasName ? validateOptionalString(m.name, `meta[${i}].name`)!
+                             : validateOptionalString(m.httpEquiv, `meta[${i}].httpEquiv`)!;
+  if (nameValue.length === 0) {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: meta[${i}].${hasName ? "name" : "httpEquiv"} must be non-empty`,
+    );
+  }
+  if (typeof m.content !== "string") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: meta[${i}].content must be a string; got ${typeof m.content}`,
+    );
+  }
+  return {
+    kind: "meta",
+    nameAttr: hasName ? "name" : "http-equiv",
+    nameValue,
+    content: m.content,
+  };
+}
+
+function validateIcon(icon: IconLink, i: number): ResolvedIcon {
+  if (icon === null || typeof icon !== "object") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: icons[${i}] must be a non-null object; got ${typeof icon}`,
+    );
+  }
+  const href = validateUrl(icon.href, `icons[${i}].href`);
+  const rel = icon.rel === undefined ? "icon" : validateIconRel(icon.rel, `icons[${i}].rel`);
+  const type = validateOptionalString(icon.type, `icons[${i}].type`);
+  const sizes = validateOptionalString(icon.sizes, `icons[${i}].sizes`);
+  return { kind: "icon", rel, href, type, sizes };
+}
+
+function validateHint(hint: ResourceHint, i: number): ResolvedHint {
+  if (hint === null || typeof hint !== "object") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: preload[${i}] must be a non-null object; got ${typeof hint}`,
+    );
+  }
+  const href = validateUrl(hint.href, `preload[${i}].href`);
+  const rel = validateHintRel(hint.rel, `preload[${i}].rel`);
+  // `as` required for preload / modulepreload; rejected as an error
+  // if MISSING (helps callers — preload without `as` is broken in
+  // most browsers).  For prefetch / preconnect / dns-prefetch it's
+  // ignored if present (we still validate the value to catch typos).
+  let asValue: string | undefined;
+  if (hint.as !== undefined) {
+    asValue = validateHintAs(hint.as, `preload[${i}].as`);
+  } else if (rel === "preload" || rel === "modulepreload") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: preload[${i}].as is required when rel="${rel}"`,
+    );
+  }
+  // Suppress `as` on non-preload variants — it's invalid HTML there.
+  const asOut = (rel === "preload" || rel === "modulepreload") ? asValue : undefined;
+  const type = validateOptionalString(hint.type, `preload[${i}].type`);
+  const crossorigin = hint.crossorigin === undefined
+    ? undefined
+    : validateCrossOrigin(hint.crossorigin, `preload[${i}].crossorigin`);
+  return { kind: "hint", rel, href, as: asOut, type, crossorigin };
+}
+
+function renderResolved(r: Resolved): string {
+  switch (r.kind) {
+    case "meta":      return renderMeta(r);
+    case "simple-link": return renderSimpleLink(r);
+    case "icon":      return renderIcon(r);
+    case "hint":      return renderHint(r);
+  }
+}
+
+function renderMeta(r: ResolvedMeta): string {
+  return `<meta ${r.nameAttr}="${escapeHtmlAttr(r.nameValue)}" content="${escapeHtmlAttr(r.content)}">`;
+}
+
+function renderSimpleLink(r: ResolvedSimpleLink): string {
+  return `<link rel="${r.rel}" href="${escapeHtmlAttr(r.href)}">`;
+}
+
+function renderIcon(r: ResolvedIcon): string {
+  const parts: string[] = [`<link rel="${escapeHtmlAttr(r.rel)}"`];
+  if (r.type !== undefined)  parts.push(`type="${escapeHtmlAttr(r.type)}"`);
+  if (r.sizes !== undefined) parts.push(`sizes="${escapeHtmlAttr(r.sizes)}"`);
+  parts.push(`href="${escapeHtmlAttr(r.href)}">`);
+  return parts.join(" ");
+}
+
+function renderHint(r: ResolvedHint): string {
+  const parts: string[] = [`<link rel="${escapeHtmlAttr(r.rel)}"`];
+  if (r.as !== undefined)          parts.push(`as="${escapeHtmlAttr(r.as)}"`);
+  if (r.type !== undefined)        parts.push(`type="${escapeHtmlAttr(r.type)}"`);
+  if (r.crossorigin !== undefined) parts.push(`crossorigin="${escapeHtmlAttr(r.crossorigin)}"`);
+  parts.push(`href="${escapeHtmlAttr(r.href)}">`);
+  return parts.join(" ");
+}

--- a/code/packages/typescript/forme-aot-meta-link-tags/src/index.ts
+++ b/code/packages/typescript/forme-aot-meta-link-tags/src/index.ts
@@ -1,0 +1,70 @@
+/**
+ * @coding-adventures/forme-aot-meta-link-tags
+ *
+ * Emit HTML `<head>` tags from a structured config — canonical,
+ * pagination (prev/next), favicons (icons), resource hints
+ * (preload/prefetch/preconnect/dns-prefetch/modulepreload),
+ * and arbitrary `<meta name|http-equiv>` pairs.
+ *
+ * Pure transform.  Validates URLs (http(s):// or
+ * root-relative), allowlists rel / as / crossorigin,
+ * HTML-attribute-escapes every value.  Two-pass fail-fast:
+ * any validation failure throws `TypeError` BEFORE any tag
+ * string is emitted.
+ *
+ * ```ts
+ * import { generateMetaLinkTags } from "@coding-adventures/forme-aot-meta-link-tags";
+ *
+ * const head = generateMetaLinkTags({
+ *   canonical: "https://example.com/post-1",
+ *   prev: "/post-0",
+ *   next: "/post-2",
+ *   meta: [
+ *     { name: "viewport", content: "width=device-width, initial-scale=1" },
+ *     { name: "description", content: "A blog post." },
+ *   ],
+ *   icons: [
+ *     { href: "/favicon.svg", type: "image/svg+xml" },
+ *     { href: "/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180" },
+ *   ],
+ *   preload: [
+ *     { href: "/main.js", rel: "preload", as: "script" },
+ *     { href: "https://fonts.example.com", rel: "preconnect", crossorigin: "anonymous" },
+ *   ],
+ * });
+ * // <meta name="viewport" content="...">
+ * // <meta name="description" content="A blog post.">
+ * // <link rel="canonical" href="https://example.com/post-1">
+ * // <link rel="prev" href="/post-0">
+ * // <link rel="next" href="/post-2">
+ * // <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+ * // <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+ * // <link rel="preload" as="script" href="/main.js">
+ * // <link rel="preconnect" crossorigin="anonymous" href="https://fonts.example.com">
+ * ```
+ *
+ * Fifteenth FM00 v0 stage package.
+ *
+ * @module index
+ */
+
+export { generateMetaLinkTags } from "./generate.js";
+export { escapeHtmlAttr, stripAsciiControl } from "./escape.js";
+export {
+  validateUrl,
+  validateIconRel,
+  validateHintRel,
+  validateHintAs,
+  validateCrossOrigin,
+  validateOptionalString,
+} from "./validate.js";
+export type {
+  MetaLinkConfig,
+  IconLink,
+  IconRel,
+  ResourceHint,
+  ResourceHintRel,
+  ResourceHintAs,
+  CrossOrigin,
+  MetaTag,
+} from "./types.js";

--- a/code/packages/typescript/forme-aot-meta-link-tags/src/types.ts
+++ b/code/packages/typescript/forme-aot-meta-link-tags/src/types.ts
@@ -1,0 +1,140 @@
+/**
+ * types.ts — public signatures for the meta/link tag emitter.
+ *
+ * The emitter handles five distinct categories of `<head>` tag:
+ *
+ *   - `canonical`  — `<link rel="canonical">`.  At most one.
+ *   - `prev` / `next` — pagination `<link>` tags.  At most one each.
+ *   - `icons`      — favicons (`<link rel="icon">`), array.
+ *   - `preload`    — resource hints (`<link rel="preload|prefetch|preconnect|dns-prefetch">`), array.
+ *   - `meta`       — arbitrary `<meta name|http-equiv ...>` pairs, array.
+ *
+ * Every field is optional; an empty config emits the empty string.
+ * The shape is intentionally flat — no nesting beyond one level —
+ * so callers can build it by spreading individual feature modules
+ * (an SEO helper sets `canonical`, a favicon helper sets `icons`,
+ * etc.) and the emitter merges them at the call site.
+ *
+ * @module types
+ */
+
+/**
+ * Favicon `<link rel="icon">` entry.
+ *
+ *   - `href`  — required.  http(s):// or root-relative `/path`.
+ *   - `type`  — optional MIME (`image/png`, `image/svg+xml`, etc).
+ *               Pure pass-through string; no allowlist (browsers
+ *               accept many image MIMEs; we don't gatekeep here).
+ *   - `sizes` — optional sizes attribute, e.g. `"32x32"` or
+ *               `"any"` for SVG.
+ *   - `rel`   — optional `rel` override.  Defaults to `"icon"`.
+ *               Allowlist: `icon` | `shortcut icon` |
+ *               `apple-touch-icon` | `mask-icon`.
+ */
+export interface IconLink {
+  readonly href: string;
+  readonly type?: string;
+  readonly sizes?: string;
+  readonly rel?: IconRel;
+}
+
+export type IconRel = "icon" | "shortcut icon" | "apple-touch-icon" | "mask-icon";
+
+/**
+ * Resource-hint `<link>` entry.  Covers preload / prefetch /
+ * preconnect / dns-prefetch via the `rel` field.
+ *
+ *   - `href`        — required.  Same URL accept-list.
+ *   - `rel`         — required.  `preload` | `prefetch` |
+ *                     `preconnect` | `dns-prefetch` | `modulepreload`.
+ *   - `as`          — required for `preload` / `modulepreload`;
+ *                     ignored otherwise.  Allowlist of the
+ *                     standard fetch destinations the platform
+ *                     accepts here (`script`, `style`, `image`,
+ *                     `font`, `fetch`, `document`, `audio`,
+ *                     `video`, `track`, `worker`).
+ *   - `type`        — optional MIME (e.g. `font/woff2`).
+ *   - `crossorigin` — optional.  `anonymous` | `use-credentials`.
+ *                     Bare boolean coercion: when `crossorigin`
+ *                     is provided without value, emit
+ *                     `crossorigin="anonymous"` (per HTML spec
+ *                     default).  We require explicit string here
+ *                     for clarity.
+ */
+export interface ResourceHint {
+  readonly href: string;
+  readonly rel: ResourceHintRel;
+  readonly as?: ResourceHintAs;
+  readonly type?: string;
+  readonly crossorigin?: CrossOrigin;
+}
+
+export type ResourceHintRel =
+  | "preload"
+  | "prefetch"
+  | "preconnect"
+  | "dns-prefetch"
+  | "modulepreload";
+
+export type ResourceHintAs =
+  | "script"
+  | "style"
+  | "image"
+  | "font"
+  | "fetch"
+  | "document"
+  | "audio"
+  | "video"
+  | "track"
+  | "worker";
+
+export type CrossOrigin = "anonymous" | "use-credentials";
+
+/**
+ * Arbitrary `<meta>` tag.  Exactly one of `name` / `httpEquiv`
+ * must be provided.  `content` is required.
+ *
+ * Examples:
+ *   - `{ name: "description", content: "..." }`
+ *   - `{ name: "viewport", content: "width=device-width" }`
+ *   - `{ httpEquiv: "content-security-policy", content: "..." }`
+ *
+ * `charset` is intentionally NOT supported here — emit
+ * `<meta charset="utf-8">` via a higher-level head builder, or
+ * pass `{ name: "charset", content: "utf-8" }` (which emits
+ * `<meta name="charset" content="utf-8">` — not the canonical
+ * form).  Charset-as-attribute is special-cased by HTML; we
+ * keep this emitter narrowly focused on name/http-equiv pairs.
+ */
+export interface MetaTag {
+  readonly name?: string;
+  readonly httpEquiv?: string;
+  readonly content: string;
+}
+
+/**
+ * Top-level config consumed by `generateMetaLinkTags`.
+ *
+ * All fields optional.  Output order is deterministic and
+ * matches the field order documented in {@link MetaLinkConfig}:
+ *
+ *   1. `<meta>` (in caller's array order)
+ *   2. `<link rel="canonical">`
+ *   3. `<link rel="prev">`
+ *   4. `<link rel="next">`
+ *   5. `<link rel="icon">` / variants (in caller's array order)
+ *   6. resource hints (in caller's array order)
+ *
+ * Rationale: `<meta>` (charset, viewport, description) tends to
+ * appear first in real `<head>` templates; canonical / pagination
+ * are SEO signals (logically a unit); favicons follow; resource
+ * hints last (they're performance hints, not document metadata).
+ */
+export interface MetaLinkConfig {
+  readonly canonical?: string;
+  readonly prev?: string;
+  readonly next?: string;
+  readonly icons?: readonly IconLink[];
+  readonly preload?: readonly ResourceHint[];
+  readonly meta?: readonly MetaTag[];
+}

--- a/code/packages/typescript/forme-aot-meta-link-tags/src/validate.ts
+++ b/code/packages/typescript/forme-aot-meta-link-tags/src/validate.ts
@@ -1,0 +1,185 @@
+/**
+ * validate.ts — URL accept-list, rel/as/crossorigin allowlists.
+ *
+ * The URL validator is the security-critical piece: every
+ * tag attribute that browsers may auto-fetch (`href`, `src`)
+ * must pass through it.  `javascript:` / `data:` / `file:` /
+ * protocol-relative are rejected with `TypeError` and never
+ * reach the output buffer.
+ *
+ * @module validate
+ */
+
+import type {
+  CrossOrigin,
+  IconRel,
+  ResourceHintAs,
+  ResourceHintRel,
+} from "./types.js";
+
+const ICON_REL_ALLOWLIST: ReadonlySet<string> = new Set([
+  "icon",
+  "shortcut icon",
+  "apple-touch-icon",
+  "mask-icon",
+]);
+
+const HINT_REL_ALLOWLIST: ReadonlySet<string> = new Set([
+  "preload",
+  "prefetch",
+  "preconnect",
+  "dns-prefetch",
+  "modulepreload",
+]);
+
+const HINT_AS_ALLOWLIST: ReadonlySet<string> = new Set([
+  "script",
+  "style",
+  "image",
+  "font",
+  "fetch",
+  "document",
+  "audio",
+  "video",
+  "track",
+  "worker",
+]);
+
+const CROSSORIGIN_ALLOWLIST: ReadonlySet<string> = new Set([
+  "anonymous",
+  "use-credentials",
+]);
+
+/**
+ * Validate a URL against http(s)://-or-root-relative.
+ *
+ * Same logic as `forme-aot-rss-discovery-link` / sitemap /
+ * manifest.  Rejects `javascript:`, `data:`, `file:`,
+ * `vbscript:`, protocol-relative `//host`, backslash-variant
+ * `/\host`, bare relative `about`, empty string, non-string.
+ *
+ * `field` is the dotted field path (`"canonical"`,
+ * `"icons[2].href"`, ...) used in the error message so callers
+ * can pinpoint the offending input.
+ */
+export function validateUrl(url: unknown, field: string): string {
+  if (typeof url !== "string" || url.length === 0) {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be a non-empty string; got ${
+        url === null ? "null" : typeof url
+      }`,
+    );
+  }
+  if (isHttpUrl(url)) return url;
+  if (isRootRelative(url)) return url;
+  const shown = url.length > 200 ? `${url.slice(0, 200)}…` : url;
+  throw new TypeError(
+    `forme-aot-meta-link-tags: ${field} must be http(s):// or root-relative /path; got ${JSON.stringify(shown)}`,
+  );
+}
+
+/**
+ * Allowlist check for `<link rel="icon">` rel variants.
+ * Comparison is case-sensitive — HTML spec uses lowercase
+ * canonical forms.
+ */
+export function validateIconRel(value: unknown, field: string): IconRel {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be a string; got ${typeof value}`,
+    );
+  }
+  if (!ICON_REL_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be one of [${
+        [...ICON_REL_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as IconRel;
+}
+
+/**
+ * Allowlist check for resource-hint `rel`.
+ */
+export function validateHintRel(value: unknown, field: string): ResourceHintRel {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be a string; got ${typeof value}`,
+    );
+  }
+  if (!HINT_REL_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be one of [${
+        [...HINT_REL_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as ResourceHintRel;
+}
+
+/**
+ * Allowlist check for `<link rel="preload" as="...">`.
+ * Required when `rel === "preload"` / `"modulepreload"`,
+ * ignored otherwise.
+ */
+export function validateHintAs(value: unknown, field: string): ResourceHintAs {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be a string; got ${typeof value}`,
+    );
+  }
+  if (!HINT_AS_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be one of [${
+        [...HINT_AS_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as ResourceHintAs;
+}
+
+/**
+ * Allowlist check for `crossorigin` attribute value.
+ */
+export function validateCrossOrigin(value: unknown, field: string): CrossOrigin {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be a string; got ${typeof value}`,
+    );
+  }
+  if (!CROSSORIGIN_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be one of [${
+        [...CROSSORIGIN_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as CrossOrigin;
+}
+
+/**
+ * Generic optional-string field check.  Returns the validated
+ * string, or `undefined` if the input is `undefined`.  Throws
+ * for any other non-string.
+ */
+export function validateOptionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-meta-link-tags: ${field} must be a string; got ${typeof value}`,
+    );
+  }
+  return value;
+}
+
+function isHttpUrl(url: string): boolean {
+  const head = url.slice(0, 8).toLowerCase();
+  return head.startsWith("http://") || head.startsWith("https://");
+}
+
+function isRootRelative(url: string): boolean {
+  if (url === "/") return true;
+  if (url.length < 2 || url[0] !== "/") return false;
+  return url[1] !== "/" && url[1] !== "\\";
+}

--- a/code/packages/typescript/forme-aot-meta-link-tags/tests/generate.test.ts
+++ b/code/packages/typescript/forme-aot-meta-link-tags/tests/generate.test.ts
@@ -1,0 +1,407 @@
+/**
+ * generate.test.ts — end-to-end generateMetaLinkTags.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateMetaLinkTags } from "../src/index.js";
+
+describe("generateMetaLinkTags — empty / shape", () => {
+  it("empty config → empty string", () => {
+    expect(generateMetaLinkTags({})).toBe("");
+  });
+  it("null config throws", () => {
+    expect(() => generateMetaLinkTags(null as unknown as never))
+      .toThrow(/config must be a non-null object/);
+  });
+  it("string config throws", () => {
+    expect(() => generateMetaLinkTags("nope" as unknown as never))
+      .toThrow(/config must be a non-null object/);
+  });
+});
+
+describe("generateMetaLinkTags — canonical / prev / next", () => {
+  it("canonical only", () => {
+    expect(generateMetaLinkTags({ canonical: "https://example.com/x" }))
+      .toBe(`<link rel="canonical" href="https://example.com/x">`);
+  });
+  it("prev only", () => {
+    expect(generateMetaLinkTags({ prev: "/page/1" }))
+      .toBe(`<link rel="prev" href="/page/1">`);
+  });
+  it("next only", () => {
+    expect(generateMetaLinkTags({ next: "/page/3" }))
+      .toBe(`<link rel="next" href="/page/3">`);
+  });
+  it("all three in canonical → prev → next order", () => {
+    const out = generateMetaLinkTags({
+      next: "/page/3",     // intentionally reversed input order
+      prev: "/page/1",
+      canonical: "https://example.com/page/2",
+    });
+    expect(out).toBe([
+      `<link rel="canonical" href="https://example.com/page/2">`,
+      `<link rel="prev" href="/page/1">`,
+      `<link rel="next" href="/page/3">`,
+    ].join("\n"));
+  });
+  it("canonical rejects javascript:", () => {
+    expect(() => generateMetaLinkTags({ canonical: "javascript:x" }))
+      .toThrow(/canonical must be http\(s\)/);
+  });
+  it("prev rejects bad URL", () => {
+    expect(() => generateMetaLinkTags({ prev: "//evil" }))
+      .toThrow(/prev must be http\(s\)/);
+  });
+  it("next rejects bad URL", () => {
+    expect(() => generateMetaLinkTags({ next: "data:bad" }))
+      .toThrow(/next must be http\(s\)/);
+  });
+});
+
+describe("generateMetaLinkTags — meta tags", () => {
+  it("name + content", () => {
+    expect(generateMetaLinkTags({ meta: [{ name: "description", content: "Hi" }] }))
+      .toBe(`<meta name="description" content="Hi">`);
+  });
+  it("http-equiv + content", () => {
+    expect(generateMetaLinkTags({ meta: [{ httpEquiv: "content-security-policy", content: "default-src 'self'" }] }))
+      .toBe(`<meta http-equiv="content-security-policy" content="default-src &#39;self&#39;">`);
+  });
+  it("multiple meta tags in caller's order", () => {
+    const out = generateMetaLinkTags({
+      meta: [
+        { name: "viewport", content: "width=device-width" },
+        { name: "description", content: "Hello" },
+        { name: "robots", content: "index,follow" },
+      ],
+    });
+    expect(out).toBe([
+      `<meta name="viewport" content="width=device-width">`,
+      `<meta name="description" content="Hello">`,
+      `<meta name="robots" content="index,follow">`,
+    ].join("\n"));
+  });
+  it("rejects entry with both name AND httpEquiv", () => {
+    expect(() => generateMetaLinkTags({
+      meta: [{ name: "x", httpEquiv: "y", content: "z" }],
+    })).toThrow(/exactly one of name\/httpEquiv/);
+  });
+  it("rejects entry with NEITHER name nor httpEquiv", () => {
+    expect(() => generateMetaLinkTags({
+      meta: [{ content: "z" } as unknown as never],
+    })).toThrow(/exactly one of name\/httpEquiv/);
+  });
+  it("rejects empty name", () => {
+    expect(() => generateMetaLinkTags({ meta: [{ name: "", content: "x" }] }))
+      .toThrow(/must be non-empty/);
+  });
+  it("rejects empty httpEquiv", () => {
+    expect(() => generateMetaLinkTags({ meta: [{ httpEquiv: "", content: "x" }] }))
+      .toThrow(/must be non-empty/);
+  });
+  it("rejects null meta entry", () => {
+    expect(() => generateMetaLinkTags({ meta: [null as unknown as never] }))
+      .toThrow(/meta\[0\] must be a non-null object/);
+  });
+  it("rejects non-string content", () => {
+    expect(() => generateMetaLinkTags({
+      meta: [{ name: "x", content: 42 as unknown as string }],
+    })).toThrow(/content must be a string/);
+  });
+  it("rejects non-string name", () => {
+    expect(() => generateMetaLinkTags({
+      meta: [{ name: 42 as unknown as string, content: "x" }],
+    })).toThrow(/name must be a string/);
+  });
+  it("rejects non-string httpEquiv", () => {
+    expect(() => generateMetaLinkTags({
+      meta: [{ httpEquiv: true as unknown as string, content: "x" }],
+    })).toThrow(/httpEquiv must be a string/);
+  });
+  it("rejects non-array meta", () => {
+    expect(() => generateMetaLinkTags({ meta: "x" as unknown as never }))
+      .toThrow(/meta must be an array/);
+  });
+  it("escapes XSS attempt in content", () => {
+    const out = generateMetaLinkTags({
+      meta: [{ name: "description", content: `<script>alert("x")</script>` }],
+    });
+    expect(out).toContain(`content="&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;"`);
+    expect(out).not.toContain("<script>alert");
+  });
+  it("escapes special chars in name", () => {
+    const out = generateMetaLinkTags({
+      meta: [{ name: `evil"x`, content: "y" }],
+    });
+    expect(out).toContain(`name="evil&quot;x"`);
+  });
+});
+
+describe("generateMetaLinkTags — icons", () => {
+  it("single icon defaults rel to 'icon'", () => {
+    expect(generateMetaLinkTags({ icons: [{ href: "/favicon.png" }] }))
+      .toBe(`<link rel="icon" href="/favicon.png">`);
+  });
+  it("icon with type + sizes", () => {
+    expect(generateMetaLinkTags({
+      icons: [{ href: "/favicon.png", type: "image/png", sizes: "32x32" }],
+    }))
+      .toBe(`<link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">`);
+  });
+  it("apple-touch-icon rel", () => {
+    expect(generateMetaLinkTags({
+      icons: [{ href: "/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180" }],
+    }))
+      .toBe(`<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">`);
+  });
+  it("multiple icons in caller's order", () => {
+    const out = generateMetaLinkTags({
+      icons: [
+        { href: "/favicon-32.png", type: "image/png", sizes: "32x32" },
+        { href: "/favicon-16.png", type: "image/png", sizes: "16x16" },
+      ],
+    });
+    expect(out).toBe([
+      `<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">`,
+      `<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">`,
+    ].join("\n"));
+  });
+  it("rejects bad icon rel", () => {
+    expect(() => generateMetaLinkTags({
+      icons: [{ href: "/f.png", rel: "manifest" as unknown as never }],
+    })).toThrow(/icons\[0\]\.rel must be one of/);
+  });
+  it("rejects javascript: href", () => {
+    expect(() => generateMetaLinkTags({
+      icons: [{ href: "javascript:x" }],
+    })).toThrow(/icons\[0\]\.href must be http\(s\)/);
+  });
+  it("rejects null icon", () => {
+    expect(() => generateMetaLinkTags({ icons: [null as unknown as never] }))
+      .toThrow(/icons\[0\] must be a non-null object/);
+  });
+  it("rejects non-array icons", () => {
+    expect(() => generateMetaLinkTags({ icons: "x" as unknown as never }))
+      .toThrow(/icons must be an array/);
+  });
+  it("escapes special chars in sizes", () => {
+    const out = generateMetaLinkTags({
+      icons: [{ href: "/f.png", sizes: `32x32"` }],
+    });
+    expect(out).toContain(`sizes="32x32&quot;"`);
+  });
+});
+
+describe("generateMetaLinkTags — resource hints", () => {
+  it("preload requires as", () => {
+    expect(() => generateMetaLinkTags({
+      preload: [{ href: "/main.js", rel: "preload" }],
+    })).toThrow(/preload\[0\]\.as is required when rel="preload"/);
+  });
+  it("modulepreload requires as", () => {
+    expect(() => generateMetaLinkTags({
+      preload: [{ href: "/m.js", rel: "modulepreload" }],
+    })).toThrow(/required when rel="modulepreload"/);
+  });
+  it("preload script", () => {
+    expect(generateMetaLinkTags({
+      preload: [{ href: "/main.js", rel: "preload", as: "script" }],
+    }))
+      .toBe(`<link rel="preload" as="script" href="/main.js">`);
+  });
+  it("preload font with type + crossorigin", () => {
+    expect(generateMetaLinkTags({
+      preload: [{ href: "/inter.woff2", rel: "preload", as: "font", type: "font/woff2", crossorigin: "anonymous" }],
+    }))
+      .toBe(`<link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href="/inter.woff2">`);
+  });
+  it("preconnect (no as)", () => {
+    expect(generateMetaLinkTags({
+      preload: [{ href: "https://fonts.example.com", rel: "preconnect" }],
+    }))
+      .toBe(`<link rel="preconnect" href="https://fonts.example.com">`);
+  });
+  it("preconnect with as gets `as` dropped (not valid HTML)", () => {
+    const out = generateMetaLinkTags({
+      preload: [{ href: "https://fonts.example.com", rel: "preconnect", as: "font" }],
+    });
+    expect(out).toBe(`<link rel="preconnect" href="https://fonts.example.com">`);
+    expect(out).not.toContain("as=");
+  });
+  it("dns-prefetch", () => {
+    expect(generateMetaLinkTags({
+      preload: [{ href: "https://cdn.example.com", rel: "dns-prefetch" }],
+    }))
+      .toBe(`<link rel="dns-prefetch" href="https://cdn.example.com">`);
+  });
+  it("prefetch", () => {
+    expect(generateMetaLinkTags({
+      preload: [{ href: "/next-page.html", rel: "prefetch" }],
+    }))
+      .toBe(`<link rel="prefetch" href="/next-page.html">`);
+  });
+  it("modulepreload with as=script", () => {
+    expect(generateMetaLinkTags({
+      preload: [{ href: "/m.js", rel: "modulepreload", as: "script" }],
+    }))
+      .toBe(`<link rel="modulepreload" as="script" href="/m.js">`);
+  });
+  it("preconnect with crossorigin use-credentials", () => {
+    expect(generateMetaLinkTags({
+      preload: [{ href: "https://api.example.com", rel: "preconnect", crossorigin: "use-credentials" }],
+    }))
+      .toBe(`<link rel="preconnect" crossorigin="use-credentials" href="https://api.example.com">`);
+  });
+  it("rejects bad rel", () => {
+    expect(() => generateMetaLinkTags({
+      preload: [{ href: "/x", rel: "yolo" as unknown as never }],
+    })).toThrow(/preload\[0\]\.rel must be one of/);
+  });
+  it("rejects bad as on preload", () => {
+    expect(() => generateMetaLinkTags({
+      preload: [{ href: "/x", rel: "preload", as: "iframe" as unknown as never }],
+    })).toThrow(/preload\[0\]\.as must be one of/);
+  });
+  it("rejects bad crossorigin", () => {
+    expect(() => generateMetaLinkTags({
+      preload: [{ href: "/x", rel: "preconnect", crossorigin: "true" as unknown as never }],
+    })).toThrow(/preload\[0\]\.crossorigin must be one of/);
+  });
+  it("rejects javascript: href", () => {
+    expect(() => generateMetaLinkTags({
+      preload: [{ href: "javascript:x", rel: "preload", as: "script" }],
+    })).toThrow(/preload\[0\]\.href must be http\(s\)/);
+  });
+  it("rejects null hint", () => {
+    expect(() => generateMetaLinkTags({ preload: [null as unknown as never] }))
+      .toThrow(/preload\[0\] must be a non-null object/);
+  });
+  it("rejects non-array preload", () => {
+    expect(() => generateMetaLinkTags({ preload: "x" as unknown as never }))
+      .toThrow(/preload must be an array/);
+  });
+  it("rejects non-string type", () => {
+    expect(() => generateMetaLinkTags({
+      preload: [{ href: "/x", rel: "preload", as: "font", type: 1 as unknown as string }],
+    })).toThrow(/preload\[0\]\.type must be a string/);
+  });
+});
+
+describe("generateMetaLinkTags — output order", () => {
+  it("meta → canonical → prev → next → icons → hints", () => {
+    const out = generateMetaLinkTags({
+      preload:    [{ href: "/main.js", rel: "preload", as: "script" }],
+      icons:      [{ href: "/favicon.png" }],
+      next:       "/next",
+      prev:       "/prev",
+      canonical:  "https://example.com",
+      meta:       [{ name: "viewport", content: "width=device-width" }],
+    });
+    const lines = out.split("\n");
+    expect(lines).toEqual([
+      `<meta name="viewport" content="width=device-width">`,
+      `<link rel="canonical" href="https://example.com">`,
+      `<link rel="prev" href="/prev">`,
+      `<link rel="next" href="/next">`,
+      `<link rel="icon" href="/favicon.png">`,
+      `<link rel="preload" as="script" href="/main.js">`,
+    ]);
+  });
+});
+
+describe("generateMetaLinkTags — fail-fast (no partial output)", () => {
+  it("bad icon URL in mid-array throws — no XML emitted", () => {
+    try {
+      generateMetaLinkTags({
+        icons: [
+          { href: "/ok.png" },
+          { href: "javascript:bad" },
+          { href: "/also-ok.png" },
+        ],
+      });
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toMatch(/icons\[1\]\.href must be http\(s\)/);
+    }
+  });
+  it("bad meta entry throws before canonical is emitted", () => {
+    expect(() => generateMetaLinkTags({
+      meta: [{ name: "x", content: "y" }, { content: "z" } as unknown as never],
+      canonical: "https://example.com",
+    })).toThrow(/meta\[1\] must have exactly one/);
+  });
+});
+
+describe("generateMetaLinkTags — HTML escaping security", () => {
+  it("escapes ampersand in canonical URL", () => {
+    expect(generateMetaLinkTags({ canonical: "https://example.com/?a=1&b=2" }))
+      .toBe(`<link rel="canonical" href="https://example.com/?a=1&amp;b=2">`);
+  });
+  it("escapes quotes in meta content", () => {
+    expect(generateMetaLinkTags({ meta: [{ name: "x", content: `say "hi"` }] }))
+      .toContain(`content="say &quot;hi&quot;"`);
+  });
+  it("strips control bytes from meta content", () => {
+    expect(generateMetaLinkTags({ meta: [{ name: "x", content: "ab\x00cd" }] }))
+      .toContain(`content="abcd"`);
+  });
+});
+
+describe("generateMetaLinkTags — purity / determinism", () => {
+  it("same input → byte-identical output", () => {
+    const cfg = {
+      canonical: "https://example.com",
+      meta: [{ name: "viewport", content: "x" }],
+      icons: [{ href: "/f.png", sizes: "32x32" }],
+    };
+    expect(generateMetaLinkTags(cfg)).toBe(generateMetaLinkTags(cfg));
+  });
+  it("does not mutate input", () => {
+    const cfg = {
+      canonical: "https://example.com",
+      icons: [{ href: "/f.png" }],
+      preload: [{ href: "/m.js", rel: "preload" as const, as: "script" as const }],
+      meta: [{ name: "viewport", content: "x" }],
+    };
+    const before = JSON.stringify(cfg);
+    generateMetaLinkTags(cfg);
+    expect(JSON.stringify(cfg)).toBe(before);
+  });
+});
+
+describe("generateMetaLinkTags — full real-world example", () => {
+  it("blog-post head with everything", () => {
+    const out = generateMetaLinkTags({
+      meta: [
+        { name: "viewport", content: "width=device-width, initial-scale=1" },
+        { name: "description", content: "A blog post about feeds." },
+        { httpEquiv: "x-ua-compatible", content: "IE=edge" },
+      ],
+      canonical: "https://example.com/blog/post-1",
+      prev: "/blog/page/0",
+      next: "/blog/page/2",
+      icons: [
+        { href: "/favicon.svg", type: "image/svg+xml" },
+        { href: "/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180" },
+      ],
+      preload: [
+        { href: "/main.js", rel: "preload", as: "script" },
+        { href: "/inter.woff2", rel: "preload", as: "font", type: "font/woff2", crossorigin: "anonymous" },
+        { href: "https://fonts.example.com", rel: "preconnect", crossorigin: "anonymous" },
+      ],
+    });
+    expect(out).toBe([
+      `<meta name="viewport" content="width=device-width, initial-scale=1">`,
+      `<meta name="description" content="A blog post about feeds.">`,
+      `<meta http-equiv="x-ua-compatible" content="IE=edge">`,
+      `<link rel="canonical" href="https://example.com/blog/post-1">`,
+      `<link rel="prev" href="/blog/page/0">`,
+      `<link rel="next" href="/blog/page/2">`,
+      `<link rel="icon" type="image/svg+xml" href="/favicon.svg">`,
+      `<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">`,
+      `<link rel="preload" as="script" href="/main.js">`,
+      `<link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href="/inter.woff2">`,
+      `<link rel="preconnect" crossorigin="anonymous" href="https://fonts.example.com">`,
+    ].join("\n"));
+  });
+});

--- a/code/packages/typescript/forme-aot-meta-link-tags/tests/validate.test.ts
+++ b/code/packages/typescript/forme-aot-meta-link-tags/tests/validate.test.ts
@@ -1,0 +1,181 @@
+/**
+ * validate.test.ts — URL, rel/as/crossorigin allowlists, escape helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  escapeHtmlAttr,
+  stripAsciiControl,
+  validateCrossOrigin,
+  validateHintAs,
+  validateHintRel,
+  validateIconRel,
+  validateOptionalString,
+  validateUrl,
+} from "../src/index.js";
+
+describe("validateUrl — accept", () => {
+  it("https URL", () => {
+    expect(validateUrl("https://example.com/page", "f")).toBe("https://example.com/page");
+  });
+  it("http URL", () => {
+    expect(validateUrl("http://example.com", "f")).toBe("http://example.com");
+  });
+  it("scheme is case-insensitive", () => {
+    expect(validateUrl("HTTPS://example.com", "f")).toBe("HTTPS://example.com");
+    expect(validateUrl("HtTp://example.com", "f")).toBe("HtTp://example.com");
+  });
+  it("root-relative /path", () => {
+    expect(validateUrl("/about", "f")).toBe("/about");
+  });
+  it("bare /", () => {
+    expect(validateUrl("/", "f")).toBe("/");
+  });
+  it("multi-segment root-relative", () => {
+    expect(validateUrl("/posts/2026/may", "f")).toBe("/posts/2026/may");
+  });
+});
+
+describe("validateUrl — reject", () => {
+  it("javascript:", () => {
+    expect(() => validateUrl("javascript:alert(1)", "canonical"))
+      .toThrow(/canonical must be http\(s\)/);
+  });
+  it("data:", () => {
+    expect(() => validateUrl("data:text/html,x", "f")).toThrow(/http\(s\)/);
+  });
+  it("file:", () => {
+    expect(() => validateUrl("file:///etc/passwd", "f")).toThrow(/http\(s\)/);
+  });
+  it("vbscript:", () => {
+    expect(() => validateUrl("vbscript:msgbox", "f")).toThrow(/http\(s\)/);
+  });
+  it("protocol-relative //host", () => {
+    expect(() => validateUrl("//evil.com", "f")).toThrow(/http\(s\)/);
+  });
+  it("backslash-variant /\\host", () => {
+    expect(() => validateUrl("/\\evil.com", "f")).toThrow(/http\(s\)/);
+  });
+  it("bare relative", () => {
+    expect(() => validateUrl("about", "f")).toThrow(/http\(s\)/);
+  });
+  it("empty string", () => {
+    expect(() => validateUrl("", "f")).toThrow(/non-empty string/);
+  });
+  it("non-string number", () => {
+    expect(() => validateUrl(42 as unknown as string, "f")).toThrow(/non-empty string/);
+  });
+  it("null", () => {
+    expect(() => validateUrl(null, "f")).toThrow(/got null/);
+  });
+  it("undefined", () => {
+    expect(() => validateUrl(undefined, "f")).toThrow(/got undefined/);
+  });
+  it("long URL truncated in error message", () => {
+    const longUrl = "bad://" + "a".repeat(500);
+    try {
+      validateUrl(longUrl, "f");
+      expect.fail("expected throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("…");
+      expect(msg.length).toBeLessThan(longUrl.length + 100);
+    }
+  });
+  it("error includes the field path", () => {
+    expect(() => validateUrl("javascript:x", "icons[3].href")).toThrow(/icons\[3\]\.href/);
+  });
+});
+
+describe("validateIconRel", () => {
+  it("accepts 'icon'", () => { expect(validateIconRel("icon", "f")).toBe("icon"); });
+  it("accepts 'shortcut icon'", () => { expect(validateIconRel("shortcut icon", "f")).toBe("shortcut icon"); });
+  it("accepts 'apple-touch-icon'", () => { expect(validateIconRel("apple-touch-icon", "f")).toBe("apple-touch-icon"); });
+  it("accepts 'mask-icon'", () => { expect(validateIconRel("mask-icon", "f")).toBe("mask-icon"); });
+  it("rejects 'manifest'", () => { expect(() => validateIconRel("manifest", "f")).toThrow(/one of/); });
+  it("case-sensitive: 'ICON' rejected", () => { expect(() => validateIconRel("ICON", "f")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateIconRel(123 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("rejects null", () => { expect(() => validateIconRel(null, "f")).toThrow(/must be a string/); });
+});
+
+describe("validateHintRel", () => {
+  for (const v of ["preload", "prefetch", "preconnect", "dns-prefetch", "modulepreload"]) {
+    it(`accepts '${v}'`, () => { expect(validateHintRel(v, "f")).toBe(v); });
+  }
+  it("rejects 'fetch'", () => { expect(() => validateHintRel("fetch", "f")).toThrow(/one of/); });
+  it("rejects 'PRELOAD' (case-sensitive)", () => { expect(() => validateHintRel("PRELOAD", "f")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateHintRel(0 as unknown as string, "f")).toThrow(/must be a string/); });
+});
+
+describe("validateHintAs", () => {
+  for (const v of ["script", "style", "image", "font", "fetch", "document", "audio", "video", "track", "worker"]) {
+    it(`accepts '${v}'`, () => { expect(validateHintAs(v, "f")).toBe(v); });
+  }
+  it("rejects 'iframe'", () => { expect(() => validateHintAs("iframe", "f")).toThrow(/one of/); });
+  it("rejects 'object'", () => { expect(() => validateHintAs("object", "f")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateHintAs(true as unknown as string, "f")).toThrow(/must be a string/); });
+});
+
+describe("validateCrossOrigin", () => {
+  it("accepts 'anonymous'", () => { expect(validateCrossOrigin("anonymous", "f")).toBe("anonymous"); });
+  it("accepts 'use-credentials'", () => { expect(validateCrossOrigin("use-credentials", "f")).toBe("use-credentials"); });
+  it("rejects 'true'", () => { expect(() => validateCrossOrigin("true", "f")).toThrow(/one of/); });
+  it("rejects empty", () => { expect(() => validateCrossOrigin("", "f")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateCrossOrigin(1 as unknown as string, "f")).toThrow(/must be a string/); });
+});
+
+describe("validateOptionalString", () => {
+  it("undefined passes through as undefined", () => {
+    expect(validateOptionalString(undefined, "f")).toBeUndefined();
+  });
+  it("string passes through", () => {
+    expect(validateOptionalString("hello", "f")).toBe("hello");
+  });
+  it("empty string allowed", () => {
+    expect(validateOptionalString("", "f")).toBe("");
+  });
+  it("non-string number rejected", () => {
+    expect(() => validateOptionalString(7 as unknown as string, "f")).toThrow(/must be a string/);
+  });
+  it("null rejected", () => {
+    expect(() => validateOptionalString(null, "f")).toThrow(/must be a string/);
+  });
+  it("error includes field name", () => {
+    expect(() => validateOptionalString(7 as unknown as string, "myField"))
+      .toThrow(/myField must be a string/);
+  });
+});
+
+describe("escapeHtmlAttr", () => {
+  it("ampersand", () => { expect(escapeHtmlAttr("a&b")).toBe("a&amp;b"); });
+  it("less-than", () => { expect(escapeHtmlAttr("a<b")).toBe("a&lt;b"); });
+  it("greater-than", () => { expect(escapeHtmlAttr("a>b")).toBe("a&gt;b"); });
+  it("double quote", () => { expect(escapeHtmlAttr(`a"b`)).toBe("a&quot;b"); });
+  it("single quote", () => { expect(escapeHtmlAttr(`a'b`)).toBe("a&#39;b"); });
+  it("composite", () => {
+    expect(escapeHtmlAttr(`<a href="?x&y='z'">`))
+      .toBe("&lt;a href=&quot;?x&amp;y=&#39;z&#39;&quot;&gt;");
+  });
+  it("ampersand ordered first (no double-escape)", () => {
+    expect(escapeHtmlAttr("&amp;")).toBe("&amp;amp;");
+  });
+  it("strips NUL", () => { expect(escapeHtmlAttr("a\x00b")).toBe("ab"); });
+  it("strips DEL", () => { expect(escapeHtmlAttr("a\x7Fb")).toBe("ab"); });
+  it("strips ESC", () => { expect(escapeHtmlAttr("a\x1Bb")).toBe("ab"); });
+  it("non-string coerced via String()", () => {
+    expect(escapeHtmlAttr(42 as unknown as string)).toBe("42");
+  });
+});
+
+describe("stripAsciiControl", () => {
+  it("removes NUL/DEL/ESC", () => {
+    expect(stripAsciiControl("a\x00b\x1Bc\x7Fd")).toBe("abcd");
+  });
+  it("preserves printable ASCII", () => {
+    expect(stripAsciiControl("Hello, World!")).toBe("Hello, World!");
+  });
+  it("strips tab/newline/cr (these are <0x20)", () => {
+    // tab=0x09, lf=0x0A, cr=0x0D — all in [0x00..0x1F] so they're stripped.
+    expect(stripAsciiControl("a\tb\nc\rd")).toBe("abcd");
+  });
+});

--- a/code/packages/typescript/forme-aot-meta-link-tags/tsconfig.json
+++ b/code/packages/typescript/forme-aot-meta-link-tags/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-meta-link-tags/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-meta-link-tags/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Fifteenth FM00 v0 stage package — pure-transform `<head>` tag emitter.
- Takes a structured `MetaLinkConfig` and emits `<meta>` + `<link>` tags as a single newline-joined string.
- Covers canonical / prev / next / icons (favicons) / resource hints (preload/prefetch/preconnect/dns-prefetch/modulepreload) / arbitrary `<meta name|http-equiv content=...>` pairs.
- Two-pass fail-fast: validates the entire config (URL accept-list + rel/as/crossorigin allowlists + HTML-attr escape) before emitting a single tag — callers never see partial output.
- 132 tests, **100% line / 100% branch** coverage.
- `required_capabilities.json` → `[]` (pure transform, no I/O / fs / network / env / shell).

## Security posture

Five concerns explicitly addressed (pre-push agent review found nothing material):

- **HTML attribute injection.** Every interpolated value passes through `escapeHtmlAttr` (single-pass char-class replace covering all 5 HTML entities + ASCII control-byte strip).
- **URL scheme injection.** Every `href` runs through `validateUrl` — `javascript:` / `data:` / `file:` / `vbscript:` / `//host` / `/\host` / bare relative / empty / non-string all rejected with `TypeError`.
- **rel allowlists.** Icons restrict to `icon | shortcut icon | apple-touch-icon | mask-icon`; hints restrict to `preload | prefetch | preconnect | dns-prefetch | modulepreload`. Case-sensitive.
- **as allowlist.** Defends against `as="iframe"` fetch-destination confusion.
- **Fail-fast.** Validation completes before any tag is emitted; an exception means the caller has nothing to write.

## Behavioural notes

- Output order is fixed: `meta → canonical → prev → next → icons → hints`. Caller controls only array order within each category.
- `as` is required for `preload` / `modulepreload`; silently dropped on the other hint rels (where it's invalid HTML).
- `<meta>` shape: exactly one of `name` / `httpEquiv` required; empty values throw.
- Same input → byte-identical output. No input mutation.

## v0 simplifications (documented)

- No `media="..."` on `<link>` (deferred).
- No `integrity` / SRI (lives in `forme-aot-script-tag-emitter`).
- No `referrerpolicy` (v1 may add).
- No HTTP Link header emission — HTML only.
- No `charset` support — emit `<meta charset="utf-8">` via a separate head builder.

## Test plan

- [x] All 132 vitest tests pass locally
- [x] Coverage report shows 100% line / 100% branch on source files with logic
- [x] Security review via Agent skill — clean
- [x] CHANGELOG + README written with usage examples + behavioural notes
- [x] `required_capabilities.json` set to `[]` with justification
- [ ] CI green on ubuntu / macos / windows
- [ ] CodeQL JS/TS analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)