### PR TITLE
feat(matrix-rust-python): MX09 Phase 2 — envelope-shaped CPU execution

### DIFF
--- a/code/packages/rust/matrix-rust-python/CHANGELOG.md
+++ b/code/packages/rust/matrix-rust-python/CHANGELOG.md
@@ -1,5 +1,105 @@
 # Changelog — matrix-rust-python (Rust)
 
+## [0.2.0] — 2026-05-19
+
+### Added — MX09 Phase 2: envelope-shaped one-shot CPU execution
+
+Adds the second exported function — `run_graph_on_cpu` — that takes a
+JSON envelope describing a graph plus its inputs and returns a JSON
+envelope holding the executed outputs.  This is the smallest possible
+slice of "real execution through the binding" — no `Graph` / `Runtime`
+classes (Phase 2b), no bytes-typed I/O (Phase 2b), just one
+string-in / string-out function that exercises the full
+plan → alloc → upload → dispatch → download pipeline on
+`matrix-cpu` via `matrix-runtime`.
+
+The envelope shape is bit-identical to `matrix-rust-napi`'s
+`runGraphOnCpu` Phase 2 envelope so a single JSON test fixture can
+verify either binding.
+
+Envelope shape:
+
+```
+in : {
+        "graph":  <matrix-ir-json schema>,
+        "inputs": [ "<lowercase-hex bytes>", ... ]
+      }
+
+out: {
+        "outputs": [ "<lowercase-hex bytes>", ... ]
+      }
+```
+
+Per-tensor byte strings use the same hex encoding `matrix-ir-json`
+uses for constants — lowercase, no separator, no `0x` prefix, length
+always `2 * num_bytes`.
+
+### Security — `MAX_TOTAL_BUFFER_BYTES = 4 GiB` cap
+
+Implements the same hard cap as `matrix-rust-napi::exec`: any graph
+whose total placed-tensor byte size would exceed 4 GiB is refused
+*before* any `AllocBuffer` call.  Without this, a ~500-byte JSON
+envelope declaring a tensor like `shape=[1_000_000_000, 1_000_000_000],
+dtype=F32` would flow `~4e18` bytes into `vec![0u8; bytes]` inside
+`matrix-cpu::BufferStore` and abort the Python interpreter via
+`handle_alloc_error`.
+
+The cap matches the napi binding so the CPU executor's effective
+DoS posture is the same regardless of which FFI edge invoked it.
+
+### Added — pure-Rust tests (now 19, was 5)
+
+- `exec::tests` (6 new tests, ported from matrix-rust-napi exec.rs):
+  - `add_two_vectors_executes_end_to_end`
+  - `matmul_2x2_executes_end_to_end`
+  - `relu_layer_executes_end_to_end`
+  - `rejects_wrong_input_count`
+  - `rejects_wrong_input_byte_length`
+  - `rejects_graph_with_oversized_output`  ← exercises the DoS cap
+- `tests::envelope_*` (5 new tests on the envelope helper):
+  - `envelope_runs_add_end_to_end` (headline JSON-in / JSON-out)
+  - `envelope_rejects_missing_graph`
+  - `envelope_rejects_non_array_inputs`
+  - `envelope_rejects_invalid_hex_input`
+  - `envelope_rejects_garbage_json`
+- `tests::hex_*` (3 new tests on the hex codec):
+  - `hex_round_trips`
+  - `hex_decoder_rejects_odd_length`
+  - `hex_decoder_rejects_bad_chars`
+
+### Implementation notes
+
+- **New module `src/exec.rs`** — direct port of
+  `matrix-rust-napi/src/exec.rs`.  Same `run_graph_on_cpu(graph: &Graph,
+  inputs: &[Vec<u8>]) -> Result<Vec<Vec<u8>>, String>` signature.
+  Pre-allocates every buffer up front (trades a bit of peak memory
+  for a much simpler glue layer; honouring `PlacedOp::Alloc/Free`
+  lifetimes is Phase 2b work).
+- **New dependencies** — adds `matrix-runtime`, `matrix-cpu`,
+  `compute-ir`, `executor-protocol`, `coding-adventures-json-value`,
+  `coding-adventures-json-serializer` to `Cargo.toml`.  All workspace
+  path deps; zero new crates.io deps.  MX00 zero-dep mandate
+  preserved (matrix-ir / matrix-runtime / matrix-cpu themselves
+  gain no deps).
+- **Python C API wrapper** `py_run_graph_on_cpu` follows the same
+  pattern as `py_graph_round_trip_json`: extract args[0] as str,
+  call the pure-Rust helper, return a fresh str.  Errors raise
+  `ValueError`.  `extern "C"` boundary stays panic-free
+  (`extern "C-unwind"` would be required to propagate panics; we
+  don't enable it, so the "return Err, never panic" discipline is a
+  hard safety invariant).
+- **Methods table** grew from 2 to 3 entries (`graph_round_trip_json`,
+  `run_graph_on_cpu`, sentinel).
+
+### What's not shipped in Phase 2
+
+- No `Graph` / `Runtime` Python classes via PyCapsule (Phase 2b).
+- No `bytes` I/O — Phase 2 still uses hex-string-in / hex-string-out
+  for parity with napi Phase 2.  Phase 2b switches to
+  `python-bridge`'s `bytes_to_py` / `bytes_from_py`.
+- No `pyproject.toml` / `maturin` wheel build (Phase 3).
+- No companion Python wrapper package (Phase 4).
+
 ## [0.1.0] — 2026-05-19
 
 ### Added — MX09 Phase 1: crate skeleton + JSON round-trip

--- a/code/packages/rust/matrix-rust-python/Cargo.toml
+++ b/code/packages/rust/matrix-rust-python/Cargo.toml
@@ -29,6 +29,12 @@ crate-type = ["cdylib"]
 name = "matrix_rust_python"
 
 [dependencies]
-matrix-ir           = { path = "../matrix-ir" }
-matrix-ir-json      = { path = "../matrix-ir-json" }
-python-bridge       = { path = "../python-bridge" }
+matrix-ir                          = { path = "../matrix-ir" }
+matrix-ir-json                     = { path = "../matrix-ir-json" }
+matrix-runtime                     = { path = "../matrix-runtime" }
+matrix-cpu                         = { path = "../matrix-cpu" }
+compute-ir                         = { path = "../compute-ir" }
+executor-protocol                  = { path = "../executor-protocol" }
+coding-adventures-json-value       = { path = "../json-value" }
+coding-adventures-json-serializer  = { path = "../json-serializer" }
+python-bridge                      = { path = "../python-bridge" }

--- a/code/packages/rust/matrix-rust-python/README.md
+++ b/code/packages/rust/matrix-rust-python/README.md
@@ -6,11 +6,15 @@ to Python.  Sibling crate to
 [`matrix-rust-napi`](../matrix-rust-napi) (the Node.js N-API binding)
 — same shape, different toolchain.
 
-This is **Phase 1** of [MX09](../../../specs/MX09-matrix-rust-python.md).
-Phase 1 ships the crate skeleton plus one exported function
-(`graph_round_trip_json`) — the smoke test that proves the
-matrix-ir-json wire format survives a trip through the Python C API
-boundary.  Phases 2+ add execution and class-based APIs.
+Currently at **Phase 2** of [MX09](../../../specs/MX09-matrix-rust-python.md).
+
+| Phase | Surface |
+|-------|---------|
+| 1 ✅ | `graph_round_trip_json(json_string: str) -> str` |
+| 2 ✅ | `run_graph_on_cpu(envelope_json: str) -> str` |
+| 2b | `Graph` / `Runtime` classes with `bytes` I/O via PyCapsule |
+| 3   | `pyproject.toml` + `maturin` wheel build workflow |
+| 4   | Python wrapper package + `pytest` smoke tests |
 
 ## What this crate is
 
@@ -31,36 +35,35 @@ code/packages/rust/matrix-rust-python/
   required_capabilities.json
 ```
 
-## What ships in Phase 1
-
-One exported Python function:
+## What ships today (Phases 1 + 2)
 
 ```python
 import matrix_rust_python as m
+import json
 
-# Round-trip a matrix-ir-json wire-format Graph through Rust.
+# ── Phase 1: round-trip a matrix-ir-json wire-format Graph through Rust.
 out = m.graph_round_trip_json(json_in)
 # out is a compact JSON string with canonical field order;
 # `json.loads(out)` decodes to a Graph value semantically identical
 # to `json.loads(json_in)`.
+
+# ── Phase 2: plan + execute on matrix-cpu via matrix-runtime.
+envelope = json.dumps({
+    "graph": {...},                                     # matrix-ir-json schema
+    "inputs": ["3f8000003f000000", "..."],              # lowercase-hex bytes
+})
+result = json.loads(m.run_graph_on_cpu(envelope))
+output_bytes = bytes.fromhex(result["outputs"][0])      # little-endian f32 payload
 ```
 
-That's it.  The function is intentionally minimal — three things it
-must prove:
+The Phase 2 envelope shape is bit-identical to `matrix-rust-napi`'s
+`runGraphOnCpu` envelope, so a single JSON test fixture cross-checks
+both bindings.
 
-1. **Build pipeline works.**  The cdylib compiles, exposes a
-   `PyInit_matrix_rust_python` symbol, and is importable from
-   Python.
-2. **Python C API boundary works.**  Strings move in and out of the
-   extension without data loss.
-3. **`matrix-ir-json` is the right interop wire format.**  Anything
-   constructable on either side (Rust, hand-written JSON, future TS)
-   must survive `graph_round_trip_json` unchanged.
-
-Phases 2+ add `run_graph_on_cpu` (envelope JSON execution),
-`Graph` / `Runtime` classes with `bytes` I/O via `PyCapsule`, the
-`maturin` wheel build, and the companion `code/packages/python/`
-wrapper package.
+Phases 2b+ add `Graph` / `Runtime` Python classes with `bytes` I/O
+via `PyCapsule`, the `maturin` wheel build, and the companion
+`code/packages/python/` wrapper package — each as its own PR per
+the MX09 spec.
 
 ## Why `python-bridge`, not `pyo3`
 

--- a/code/packages/rust/matrix-rust-python/required_capabilities.json
+++ b/code/packages/rust/matrix-rust-python/required_capabilities.json
@@ -3,5 +3,5 @@
   "version": 1,
   "package": "rust/matrix-rust-python",
   "capabilities": [],
-  "justification": "Phase 1 surface area is one pure-function Python C API export (graph_round_trip_json) that converts JSON in -> matrix_ir::Graph -> JSON out via the matrix-ir-json crate. No filesystem, no network, no process spawn, no environment access. All extern \"C\" Python C API symbols are resolved at runtime by the embedding CPython interpreter; the extension itself opens no resources."
+  "justification": "Phase 2 surface area is two pure-function Python C API exports: graph_round_trip_json (JSON in -> matrix_ir::Graph -> JSON out via matrix-ir-json) and run_graph_on_cpu (envelope JSON -> plan + execute on matrix-runtime + matrix-cpu -> envelope JSON). No filesystem, no network, no process spawn, no environment access. matrix-runtime and matrix-cpu are pure in-process compute over caller-supplied bytes. All extern \"C\" Python C API symbols are resolved at runtime by the embedding CPython interpreter; the extension itself opens no resources. A 4 GiB hard cap on total placed-tensor byte size (MAX_TOTAL_BUFFER_BYTES in exec.rs) prevents adversarial envelope JSON from triggering a process abort via handle_alloc_error."
 }

--- a/code/packages/rust/matrix-rust-python/src/exec.rs
+++ b/code/packages/rust/matrix-rust-python/src/exec.rs
@@ -1,0 +1,468 @@
+//! # `exec` — Pure-Rust glue: plan a `matrix_ir::Graph`, run it on
+//! the CPU executor, return the output bytes.
+//!
+//! This module is the **Phase 2** core of MX09.  It is intentionally
+//! Python-free so `cargo test` can exercise the real planning +
+//! execution pipeline without a Python interpreter.  The Python C API
+//! wrapper in `lib.rs` just marshals strings across the FFI boundary
+//! and calls into here.
+//!
+//! Direct port of `matrix-rust-napi`'s `exec.rs` (MX07 Phase 2,
+//! PR #3527 + PR #3539).  The pure-Rust shape is identical because
+//! the underlying matrix-runtime / matrix-cpu APIs are language-agnostic
+//! — only the binding edge differs (Python C API vs N-API).
+//!
+//! ## What the helper does
+//!
+//! ```text
+//! matrix_ir::Graph    (caller-built; also reachable via matrix-ir-json::decode)
+//!         │
+//!         │ matrix_runtime::Runtime::plan()
+//!         ▼
+//! compute_ir::ComputeGraph    (with planner-assigned BufferIds)
+//!         │
+//!         │ allocate one CpuExecutor buffer per planner-BufferId,
+//!         │ remember the planner→real BufferId map
+//!         ▼
+//! ComputeGraph with real BufferIds    (we rewrite every Residency in place)
+//!         │
+//!         │ upload constants → upload caller inputs → Dispatch → download outputs
+//!         ▼
+//! Vec<Vec<u8>>    (one byte vector per graph.outputs())
+//! ```
+//!
+//! ## Why pre-allocate every buffer instead of relying on `PlacedOp::Alloc/Free`?
+//!
+//! The planner inserts `PlacedOp::Alloc` and `Free` lifetime
+//! annotations as a memory optimisation (`compute-ir` spec says
+//! executors that manage their own allocations may treat them as
+//! no-ops — and CpuExecutor does).  We choose the simpler
+//! "allocate everything up front, free nothing" path: it trades a
+//! bit of peak memory for a much simpler glue layer that doesn't
+//! need to thread the planner→real BufferId map into the executor.
+//!
+//! When profiling shows the memory cost matters for big graphs,
+//! Phase 2b can switch to honouring lifetime ops by extending the
+//! executor protocol with a server-controlled-id Alloc variant.
+
+use std::collections::HashMap;
+
+use compute_ir::{BufferId, ComputeGraph, PlacedConstant, PlacedOp, PlacedTensor, Residency};
+use executor_protocol::{ExecutorRequest, ExecutorResponse};
+use matrix_cpu::CpuExecutor;
+use matrix_ir::Graph;
+use matrix_runtime::Runtime;
+
+/// Maximum total byte size of *all* placed tensors a single
+/// `run_graph_on_cpu` call is permitted to allocate.  Hard-cap to
+/// prevent a malicious envelope from declaring giant tensor shapes
+/// (each `Shape::byte_size` only rejects on `u64` overflow — i.e. up
+/// to ~18 EB).  Without this cap, a ~500-byte JSON envelope could
+/// flow into `vec![0u8; bytes]` inside `matrix-cpu`'s `BufferStore`
+/// and trigger a process abort via `handle_alloc_error`.
+///
+/// 4 GiB is "generous for a 2026-era inference workload, well below
+/// the host RAM of every CI runner this project targets".  Bigger
+/// graphs can override by setting an env var when the helper grows
+/// env-var support (not in v0.2 — file an issue when it becomes a
+/// real constraint).
+///
+/// Same value as `matrix-rust-napi::exec::MAX_TOTAL_BUFFER_BYTES`
+/// — the two bindings share the policy so the CPU executor sees the
+/// same effective DoS posture regardless of which FFI edge invoked
+/// it.
+pub const MAX_TOTAL_BUFFER_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Plan and execute `graph` on the CPU executor.  Each entry of
+/// `inputs` provides the little-endian byte payload for the
+/// corresponding `graph.inputs()` tensor in declaration order.
+/// Returns one little-endian byte vector per `graph.outputs()` tensor.
+///
+/// All errors are stringified into a single `Err(String)`; this is a
+/// binding-edge helper and the caller (the Python C API wrapper) will
+/// turn the string into a `ValueError`.  No panics on adversarial
+/// input — every fallible step is matched explicitly.  Panics across
+/// the Python C API boundary are undefined behaviour (`extern "C"`
+/// requires `extern "C-unwind"` for panic propagation, and we don't
+/// use that here), so the "return Err, never panic" discipline is a
+/// safety invariant, not a stylistic choice.
+pub fn run_graph_on_cpu(graph: &Graph, inputs: &[Vec<u8>]) -> Result<Vec<Vec<u8>>, String> {
+    // ─── Argument validation ────────────────────────────────────
+    if inputs.len() != graph.inputs.len() {
+        return Err(format!(
+            "input count mismatch: graph declares {} inputs, caller provided {}",
+            graph.inputs.len(),
+            inputs.len()
+        ));
+    }
+    // Confirm each input's byte length matches the declared tensor
+    // size.  Catches the most common caller bug — wrong dtype or
+    // wrong shape on the Python side — with a precise error.
+    for (i, t) in graph.inputs.iter().enumerate() {
+        let expected = t
+            .shape
+            .byte_size(t.dtype)
+            .ok_or_else(|| format!("graph.inputs[{}] tensor size overflows u64", i))?;
+        if (inputs[i].len() as u64) != expected {
+            return Err(format!(
+                "graph.inputs[{}] byte length mismatch: tensor dtype/shape requires {} bytes, \
+                 caller provided {}",
+                i,
+                expected,
+                inputs[i].len()
+            ));
+        }
+    }
+
+    // ─── Plan ──────────────────────────────────────────────────
+    let rt = Runtime::new(matrix_cpu::profile());
+    let mut placed = rt
+        .plan(graph)
+        .map_err(|e| format!("matrix-runtime plan failed: {:?}", e))?;
+
+    // ─── Defence-in-depth: planner-invariant check ────────────
+    //
+    // The upload loop below indexes `placed.inputs[i]` by the caller's
+    // input index.  We've already pinned `inputs.len() == graph.inputs.len()`;
+    // the trusted planner is expected to preserve
+    // `placed.inputs.len() == graph.inputs.len()`.  Make that
+    // expectation explicit so a planner regression surfaces as a
+    // clean `Err` instead of an index-panic across the FFI boundary.
+    if placed.inputs.len() != graph.inputs.len() {
+        return Err(format!(
+            "planner invariant broken: graph.inputs.len() = {} but placed.inputs.len() = {} \
+             (matrix-runtime bug)",
+            graph.inputs.len(),
+            placed.inputs.len()
+        ));
+    }
+
+    // ─── Resource cap: reject graphs whose total buffer footprint
+    // would exceed MAX_TOTAL_BUFFER_BYTES.  This runs *before* any
+    // AllocBuffer call, so we never start allocating a graph we'd
+    // then have to fail mid-way through.
+    //
+    // Without this cap, a ~500-byte JSON envelope declaring a tensor
+    // like `shape=[1_000_000_000, 1_000_000_000], dtype=F32` would
+    // pass `Graph::validate()` (overflow check is u64-bounded only),
+    // pass our pre-flight byte-length check (we never check
+    // intermediate / output tensors against caller bytes — they
+    // have no caller-supplied counterpart), then flow `bytes` into
+    // `vec![0u8; bytes]` and abort the Python process.
+    {
+        let mut total: u64 = 0;
+        for t in &placed.tensors {
+            let bytes = t
+                .shape
+                .byte_size(t.dtype)
+                .ok_or_else(|| format!("tensor {:?} byte size overflows u64", t.id))?;
+            total = total
+                .checked_add(bytes)
+                .ok_or_else(|| "graph total byte size overflows u64".to_string())?;
+            if total > MAX_TOTAL_BUFFER_BYTES {
+                return Err(format!(
+                    "graph total buffer size {} bytes exceeds limit of {} bytes \
+                     (MAX_TOTAL_BUFFER_BYTES); refusing to allocate",
+                    total, MAX_TOTAL_BUFFER_BYTES
+                ));
+            }
+        }
+    }
+
+    // ─── Allocate one CPU buffer per unique planner-BufferId ───
+    //
+    // The planner assigns abstract BufferIds (a monotonic counter).
+    // The executor uses its own BufferId space (also monotonic but
+    // started at 1).  We need a mapping so we can rewrite every
+    // Residency in the placed graph before dispatch.
+    let exec = CpuExecutor::new();
+    let mut id_map: HashMap<BufferId, BufferId> = HashMap::new();
+
+    // Collect (planner_buf_id, bytes_needed) for every tensor we'll
+    // touch.  Constants and compute outputs all live in placed.tensors
+    // (per ComputeGraph docs §"the per-tensor metadata table"); inputs
+    // and outputs are duplicate entries that re-state the same
+    // tensors with their starting/ending residency.  Iterating
+    // placed.tensors is sufficient to cover every buffer.
+    for t in &placed.tensors {
+        if id_map.contains_key(&t.residency.buffer) {
+            continue; // already sized via another tensor (shouldn't happen
+                      // in V1 since planner allocates 1 buffer/tensor, but
+                      // belt-and-braces).
+        }
+        let bytes = t
+            .shape
+            .byte_size(t.dtype)
+            .ok_or_else(|| format!("tensor {:?} byte size overflows u64", t.id))?;
+        let resp = exec.handle(ExecutorRequest::AllocBuffer { bytes });
+        let real = match resp {
+            ExecutorResponse::BufferAllocated { buffer } => buffer,
+            other => return Err(format!("AllocBuffer failed: {:?}", other)),
+        };
+        id_map.insert(t.residency.buffer, real);
+    }
+
+    // ─── Rewrite every Residency.buffer in the placed graph ────
+    let rewrite_residency = |r: &mut Residency| {
+        if let Some(real) = id_map.get(&r.buffer) {
+            r.buffer = *real;
+        }
+    };
+    let rewrite_placed_tensor = |t: &mut PlacedTensor| rewrite_residency(&mut t.residency);
+    let rewrite_placed_constant = |c: &mut PlacedConstant| rewrite_residency(&mut c.residency);
+
+    for t in placed.tensors.iter_mut() {
+        rewrite_placed_tensor(t);
+    }
+    for t in placed.inputs.iter_mut() {
+        rewrite_placed_tensor(t);
+    }
+    for t in placed.outputs.iter_mut() {
+        rewrite_placed_tensor(t);
+    }
+    for c in placed.constants.iter_mut() {
+        rewrite_placed_constant(c);
+    }
+    for op in placed.ops.iter_mut() {
+        match op {
+            PlacedOp::Compute { .. } => {} // no buffer refs inside
+            PlacedOp::Transfer { src, dst, .. } => {
+                rewrite_residency(src);
+                rewrite_residency(dst);
+            }
+            PlacedOp::Alloc { residency, .. } => rewrite_residency(residency),
+            PlacedOp::Free { residency } => rewrite_residency(residency),
+        }
+    }
+
+    // ─── Upload constants to their buffers ──────────────────────
+    for c in &placed.constants {
+        let resp = exec.handle(ExecutorRequest::UploadBuffer {
+            buffer: c.residency.buffer,
+            offset: 0,
+            data: c.bytes.clone(),
+        });
+        match resp {
+            ExecutorResponse::BufferUploaded { .. } => {}
+            other => return Err(format!("UploadBuffer (constant) failed: {:?}", other)),
+        }
+    }
+
+    // ─── Upload caller-supplied inputs to input buffers ─────────
+    //
+    // Use `.get(i)` instead of indexing to make any planner-invariant
+    // violation surface as an `Err` rather than a panic across the
+    // FFI boundary (the planner-invariant check above should make
+    // this unreachable, but defence in depth — panics across the
+    // Python C API are UB).
+    for (i, input) in inputs.iter().enumerate() {
+        let buf = placed
+            .inputs
+            .get(i)
+            .ok_or_else(|| format!("internal: placed.inputs[{}] missing after plan", i))?
+            .residency
+            .buffer;
+        let resp = exec.handle(ExecutorRequest::UploadBuffer {
+            buffer: buf,
+            offset: 0,
+            data: input.clone(),
+        });
+        match resp {
+            ExecutorResponse::BufferUploaded { .. } => {}
+            other => return Err(format!("UploadBuffer (input {}) failed: {:?}", i, other)),
+        }
+    }
+
+    // ─── Dispatch ───────────────────────────────────────────────
+    let resp = exec.handle(ExecutorRequest::Dispatch {
+        job_id: 1,
+        graph: ComputeGraph {
+            format_version: placed.format_version,
+            inputs: placed.inputs.clone(),
+            outputs: placed.outputs.clone(),
+            constants: placed.constants.clone(),
+            ops: placed.ops.clone(),
+            tensors: placed.tensors.clone(),
+        },
+    });
+    match resp {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => return Err(format!("Dispatch failed: {:?}", other)),
+    }
+
+    // ─── Download outputs ───────────────────────────────────────
+    let mut outputs = Vec::with_capacity(placed.outputs.len());
+    for out in &placed.outputs {
+        let bytes = out
+            .shape
+            .byte_size(out.dtype)
+            .ok_or_else(|| format!("output tensor {:?} byte size overflows u64", out.id))?;
+        let resp = exec.handle(ExecutorRequest::DownloadBuffer {
+            buffer: out.residency.buffer,
+            offset: 0,
+            len: bytes,
+        });
+        match resp {
+            ExecutorResponse::BufferData { data, .. } => outputs.push(data),
+            other => return Err(format!("DownloadBuffer failed: {:?}", other)),
+        }
+    }
+
+    Ok(outputs)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests — pure-Rust, no Python interpreter needed
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_ir::{DType, GraphBuilder, Shape};
+
+    /// Convert an `&[f32]` to little-endian bytes.
+    fn f32_bytes(xs: &[f32]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(xs.len() * 4);
+        for x in xs {
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+        out
+    }
+
+    /// Read `&[u8]` (LE) as `Vec<f32>`.
+    fn from_f32_bytes(bytes: &[u8]) -> Vec<f32> {
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    /// The headline test: build an Add graph, run it on CPU through
+    /// the full plan+alloc+upload+dispatch+download flow, assert the
+    /// numerical result.  This is the property that proves the whole
+    /// stack works end-to-end.
+    #[test]
+    fn add_two_vectors_executes_end_to_end() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        let b = g.input(DType::F32, Shape::from(&[3]));
+        let c = g.add(&a, &b);
+        g.output(&c);
+        let graph = g.build().expect("graph builds");
+
+        let outputs = run_graph_on_cpu(
+            &graph,
+            &[f32_bytes(&[1.0, 2.0, 3.0]), f32_bytes(&[10.0, 20.0, 30.0])],
+        )
+        .expect("execution succeeds");
+
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(from_f32_bytes(&outputs[0]), vec![11.0, 22.0, 33.0]);
+    }
+
+    /// MatMul is the workhorse op of every NN; if it works the rest
+    /// is downstream.  2×2 × 2×2 = 2×2 (small enough to assert by hand).
+    #[test]
+    fn matmul_2x2_executes_end_to_end() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 2]));
+        let b = g.input(DType::F32, Shape::from(&[2, 2]));
+        let c = g.matmul(&a, &b);
+        g.output(&c);
+        let graph = g.build().expect("graph builds");
+
+        let outputs = run_graph_on_cpu(
+            &graph,
+            &[
+                f32_bytes(&[1.0, 2.0, 3.0, 4.0]), // [[1,2],[3,4]]
+                f32_bytes(&[5.0, 6.0, 7.0, 8.0]), // [[5,6],[7,8]]
+            ],
+        )
+        .expect("execution succeeds");
+
+        // [[1,2],[3,4]] × [[5,6],[7,8]] = [[19,22],[43,50]]
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(from_f32_bytes(&outputs[0]), vec![19.0, 22.0, 43.0, 50.0]);
+    }
+
+    /// Wrong input count must fail cleanly.
+    #[test]
+    fn rejects_wrong_input_count() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2]));
+        let b = g.input(DType::F32, Shape::from(&[2]));
+        let c = g.add(&a, &b);
+        g.output(&c);
+        let graph = g.build().unwrap();
+
+        let err = run_graph_on_cpu(&graph, &[f32_bytes(&[1.0, 2.0])])
+            .expect_err("must reject 1 input when graph wants 2");
+        assert!(err.contains("input count mismatch"), "got: {}", err);
+    }
+
+    /// Wrong input byte length must fail cleanly.
+    #[test]
+    fn rejects_wrong_input_byte_length() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[4])); // needs 16 bytes
+        g.output(&a);
+        let graph = g.build().unwrap();
+
+        let err = run_graph_on_cpu(&graph, &[f32_bytes(&[1.0, 2.0])]) // 8 bytes
+            .expect_err("must reject 8 bytes when 16 expected");
+        assert!(err.contains("byte length mismatch"), "got: {}", err);
+    }
+
+    /// Adversarial graph with an *output* tensor whose byte size
+    /// exceeds `MAX_TOTAL_BUFFER_BYTES` must be refused *before* any
+    /// `AllocBuffer` call — otherwise a malicious envelope could
+    /// crash the process via `handle_alloc_error`.
+    ///
+    /// We choose K such that the output tensor `[1, K]` of F32 just
+    /// exceeds the 4 GiB cap, while the inputs are tiny enough to pass
+    /// the pre-flight byte-length check.  The cap check is the only
+    /// guard that fires.
+    #[test]
+    fn rejects_graph_with_oversized_output() {
+        // MAX = 4 GiB; /4 = 1 GiB elements; K = 1 GiB + 1.
+        let k: u32 = 1_073_741_825;
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[1, 1]));
+        let b = g.input(DType::F32, Shape::from(&[1, k]));
+        let c = g.matmul(&a, &b);
+        g.output(&c);
+        let graph = g.build().expect("graph builds");
+
+        let err = run_graph_on_cpu(
+            &graph,
+            &[f32_bytes(&[1.0]), vec![0u8; (k as usize) * 4]],
+        )
+        .expect_err("oversized intermediate/output must be refused");
+        assert!(err.contains("exceeds limit"), "got: {}", err);
+    }
+
+    /// A small ReLU layer: MatMul → Add → Max(0).  Exercises constants
+    /// AND multiple ops, so it proves constant upload + op chaining.
+    #[test]
+    fn relu_layer_executes_end_to_end() {
+        let mut g = GraphBuilder::new();
+        // y = max(0, x @ W + b)
+        let x = g.input(DType::F32, Shape::from(&[1, 2]));
+        let w = g.constant(DType::F32, Shape::from(&[2, 2]), f32_bytes(&[1.0, 0.0, 0.0, 1.0])); // identity
+        let b = g.constant(DType::F32, Shape::from(&[1, 2]), f32_bytes(&[-1.0, -5.0])); // bias
+        let zero = g.constant(DType::F32, Shape::from(&[1, 2]), f32_bytes(&[0.0, 0.0]));
+        let xw = g.matmul(&x, &w);
+        let xwb = g.add(&xw, &b);
+        let y = g.max(&xwb, &zero);
+        g.output(&y);
+        let graph = g.build().expect("graph builds");
+
+        let outputs = run_graph_on_cpu(&graph, &[f32_bytes(&[10.0, 3.0])])
+            .expect("execution succeeds");
+
+        // x @ W + b = [10, 3] + [-1, -5] = [9, -2]
+        // max(0, [9, -2]) = [9, 0]
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(from_f32_bytes(&outputs[0]), vec![9.0, 0.0]);
+    }
+}

--- a/code/packages/rust/matrix-rust-python/src/lib.rs
+++ b/code/packages/rust/matrix-rust-python/src/lib.rs
@@ -70,15 +70,20 @@
 
 #![allow(non_snake_case)] // C API names are PascalCase / SCREAMING_SNAKE_CASE
 
+mod exec;
+
 use std::ffi::{c_char, c_int};
 use std::ptr;
 
+use coding_adventures_json_value::JsonValue;
 use matrix_ir_json::{decode, encode};
 use python_bridge::{
     set_error, str_from_py, str_to_py, value_error_class, PyErr_Clear, PyMethodDef,
     PyModuleDef, PyModuleDef_Base, PyModule_Create2, PyObjectPtr, PyTuple_GetItem,
     PYTHON_API_VERSION, METH_VARARGS,
 };
+
+pub use exec::run_graph_on_cpu;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Pure Rust core: the testable round-trip.
@@ -104,6 +109,197 @@ use python_bridge::{
 pub fn round_trip_json(input: &str) -> Result<String, String> {
     let graph = decode(input).map_err(|e| format!("matrix-ir-json decode failed: {:?}", e))?;
     Ok(encode(&graph))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 2: end-to-end execution on the CPU executor.
+//
+// The Rust helper `exec::run_graph_on_cpu` (ported from
+// matrix-rust-napi's exec.rs) does the real work; this section adds
+// a JSON-envelope wrapper so we can expose it over the existing
+// string-in / string-out Python C API surface without yet wiring
+// bytes marshalling into the wrapper.
+//
+// Envelope shape (in):
+//   { "graph":  <matrix-ir-json schema>,
+//     "inputs": [ "<lowercase-hex bytes>", ... ] }
+//
+// Envelope shape (out):
+//   { "outputs": [ "<lowercase-hex bytes>", ... ] }
+//
+// Per-tensor byte strings use the same hex encoding the
+// matrix-ir-json crate uses for constants — lowercase, no separator,
+// no 0x prefix, length always `2 * num_bytes`.  Phase 2b will
+// replace this with real `bytes` marshalling via python-bridge's
+// `bytes_to_py` / `bytes_from_py` helpers (already shipped); for
+// Phase 2 the JSON envelope keeps the Python C API surface tiny
+// (one function, identical pattern to graph_round_trip_json) while
+// still proving the full plan + execute + return path works.
+//
+// This is the exact mirror of matrix-rust-napi's Phase 2 surface —
+// the envelope shape is bit-identical so the same envelope JSON
+// works against either binding.  Useful for cross-binding
+// equivalence testing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Hex-decode a lowercase string (no separators, no `0x` prefix)
+/// into bytes.  Used to parse `inputs[i]` from the envelope JSON.
+///
+/// Rejects odd-length strings and any non-hex character with a
+/// precise error — fail-closed at the trust boundary.
+fn hex_decode(s: &str) -> Result<Vec<u8>, String> {
+    if s.len() % 2 != 0 {
+        return Err(format!("hex string length must be even, got {}", s.len()));
+    }
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for chunk in bytes.chunks_exact(2) {
+        let hi = hex_nibble(chunk[0])?;
+        let lo = hex_nibble(chunk[1])?;
+        out.push((hi << 4) | lo);
+    }
+    Ok(out)
+}
+
+fn hex_nibble(b: u8) -> Result<u8, String> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(10 + b - b'a'),
+        b'A'..=b'F' => Ok(10 + b - b'A'),
+        other => Err(format!("invalid hex character: 0x{:02X}", other)),
+    }
+}
+
+/// Hex-encode a byte slice as a lowercase, separator-free,
+/// 0x-prefix-free string.  Used to serialise `outputs[i]` in the
+/// result envelope.
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0F) as usize] as char);
+    }
+    out
+}
+
+/// Helper: get a required object field by name, return a clear error
+/// if it's missing or the parent is not an object.
+fn envelope_field<'a>(v: &'a JsonValue, key: &str) -> Result<&'a JsonValue, String> {
+    match v {
+        JsonValue::Object(fields) => fields
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v)
+            .ok_or_else(|| format!("envelope missing required field '{}'", key)),
+        _ => Err(format!("envelope must be a JSON object (looking for '{}')", key)),
+    }
+}
+
+/// Pure-Rust entry point for the JSON-envelope-shaped `run_graph_on_cpu`.
+/// Parses the envelope, hex-decodes inputs, decodes the graph,
+/// executes via [`run_graph_on_cpu`], hex-encodes outputs, returns
+/// the result envelope JSON.
+///
+/// All errors are stringified into `Err(String)` — the Python C API
+/// wrapper turns them into `ValueError`.  Never panics on adversarial
+/// input.
+pub fn run_graph_on_cpu_via_json_envelope(envelope_json: &str) -> Result<String, String> {
+    // ── parse envelope ──────────────────────────────────────────
+    let env = coding_adventures_json_value::parse(envelope_json)
+        .map_err(|e| format!("envelope parse failed: {:?}", e))?;
+
+    // ── extract `graph` field, re-serialise it, pass to matrix-ir-json::decode ──
+    //
+    // We re-serialise rather than pass the JsonValue directly because
+    // matrix-ir-json's public API is `&str -> Graph`, not
+    // `JsonValue -> Graph`.  One extra serialise per call; cost is
+    // negligible at typical graph sizes and the API is cleaner.
+    let graph_value = envelope_field(&env, "graph")?;
+    let graph_str = coding_adventures_json_serializer::serialize(graph_value)
+        .map_err(|e| format!("graph re-serialise failed: {:?}", e))?;
+    let graph = decode(&graph_str)
+        .map_err(|e| format!("matrix-ir-json decode failed: {:?}", e))?;
+
+    // ── extract `inputs` field — array of hex strings ──────────
+    let inputs_value = envelope_field(&env, "inputs")?;
+    let inputs_array = match inputs_value {
+        JsonValue::Array(xs) => xs,
+        _ => return Err("envelope.inputs must be a JSON array".to_string()),
+    };
+    let mut inputs: Vec<Vec<u8>> = Vec::with_capacity(inputs_array.len());
+    for (i, item) in inputs_array.iter().enumerate() {
+        match item {
+            JsonValue::String(s) => inputs
+                .push(hex_decode(s).map_err(|e| format!("envelope.inputs[{}]: {}", i, e))?),
+            _ => return Err(format!("envelope.inputs[{}] must be a hex string", i)),
+        }
+    }
+
+    // ── execute ─────────────────────────────────────────────────
+    let outputs = run_graph_on_cpu(&graph, &inputs)?;
+
+    // ── build result envelope ───────────────────────────────────
+    let outputs_array = JsonValue::Array(
+        outputs
+            .iter()
+            .map(|b| JsonValue::String(hex_encode(b)))
+            .collect(),
+    );
+    let envelope_out = JsonValue::Object(vec![("outputs".to_string(), outputs_array)]);
+    coding_adventures_json_serializer::serialize(&envelope_out)
+        .map_err(|e| format!("output envelope serialise failed: {:?}", e))
+}
+
+/// `run_graph_on_cpu(envelope_json: str) -> str`
+///
+/// Python entry point for envelope-shaped one-shot execution on the
+/// CPU executor.  Argument arity is 1 (the envelope JSON); any other
+/// arity raises `ValueError`.  Malformed JSON, missing fields,
+/// invalid hex, planner errors, executor errors, or oversized graphs
+/// all raise `ValueError`.
+///
+/// # Safety
+///
+/// Called by Python via the registered module methods table.  `args`
+/// is a valid `PyObject*` tuple for the duration of the call per the
+/// Python C API contract.
+unsafe extern "C" fn py_run_graph_on_cpu(
+    _self: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    // Extract args[0] — the envelope JSON string.
+    let arg0 = PyTuple_GetItem(args, 0);
+    if arg0.is_null() {
+        PyErr_Clear();
+        set_error(
+            value_error_class(),
+            "run_graph_on_cpu: expected exactly 1 argument (envelope_json: str)",
+        );
+        return ptr::null_mut();
+    }
+
+    let envelope = match str_from_py(arg0) {
+        Some(s) => s,
+        None => {
+            set_error(
+                value_error_class(),
+                "run_graph_on_cpu: argument 0 must be a str",
+            );
+            return ptr::null_mut();
+        }
+    };
+
+    match run_graph_on_cpu_via_json_envelope(&envelope) {
+        Ok(out) => str_to_py(&out),
+        Err(msg) => {
+            set_error(
+                value_error_class(),
+                &format!("run_graph_on_cpu: {}", msg),
+            );
+            ptr::null_mut()
+        }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -183,7 +379,7 @@ unsafe extern "C" fn py_graph_round_trip_json(
 // build it inline to mirror font-parser-python's style.
 // ─────────────────────────────────────────────────────────────────────────────
 
-static mut MODULE_METHODS: [PyMethodDef; 2] = [
+static mut MODULE_METHODS: [PyMethodDef; 3] = [
     PyMethodDef {
         ml_name: b"graph_round_trip_json\0".as_ptr() as *const c_char,
         ml_meth: Some(py_graph_round_trip_json),
@@ -191,6 +387,19 @@ static mut MODULE_METHODS: [PyMethodDef; 2] = [
         ml_doc: b"graph_round_trip_json(json_string: str) -> str\n\n\
                   Decode a matrix-ir-json Graph and re-encode it.  \
                   Raises ValueError on malformed or schema-invalid JSON.\n\0"
+            .as_ptr() as *const c_char,
+    },
+    PyMethodDef {
+        ml_name: b"run_graph_on_cpu\0".as_ptr() as *const c_char,
+        ml_meth: Some(py_run_graph_on_cpu),
+        ml_flags: METH_VARARGS,
+        ml_doc: b"run_graph_on_cpu(envelope_json: str) -> str\n\n\
+                  Plan and execute a matrix-ir-json Graph on the CPU executor.  \
+                  Envelope is `{\"graph\": <matrix-ir-json>, \"inputs\": [<hex>, ...]}`; \
+                  result is `{\"outputs\": [<hex>, ...]}`.  \
+                  Raises ValueError on malformed JSON, missing fields, invalid hex, \
+                  planner errors, executor errors, or graphs exceeding the 4 GiB \
+                  total-buffer cap.\n\0"
             .as_ptr() as *const c_char,
     },
     // Sentinel — terminates the methods array.
@@ -372,5 +581,139 @@ mod tests {
         let once = round_trip_json(&encode(&graph)).unwrap();
         let twice = round_trip_json(&once).unwrap();
         assert_eq!(once, twice, "round_trip_json must be idempotent");
+    }
+
+    // ── Phase 2: envelope-shaped end-to-end execution ────────────
+
+    /// Hex encoder round-trips through the decoder for every byte
+    /// value 0x00..=0xFF.
+    #[test]
+    fn hex_round_trips() {
+        let bytes = vec![0u8, 1, 2, 0xAB, 0xCD, 0xEF, 0xFF];
+        let s = hex_encode(&bytes);
+        assert_eq!(s, "000102abcdefff");
+        assert_eq!(hex_decode(&s).unwrap(), bytes);
+    }
+
+    /// Hex decoder rejects odd-length input.
+    #[test]
+    fn hex_decoder_rejects_odd_length() {
+        assert!(hex_decode("abc").is_err());
+    }
+
+    /// Hex decoder rejects non-hex characters.
+    #[test]
+    fn hex_decoder_rejects_bad_chars() {
+        assert!(hex_decode("zz").is_err());
+    }
+
+    /// Headline envelope test: build an Add graph, package it + inputs
+    /// into the envelope JSON, run through the string-in / string-out
+    /// entry point, parse the result envelope, hex-decode outputs,
+    /// assert.  This is the end-to-end property that proves the
+    /// envelope path from string → Graph → execute → string works.
+    #[test]
+    fn envelope_runs_add_end_to_end() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        let b = g.input(DType::F32, Shape::from(&[3]));
+        let c = g.add(&a, &b);
+        g.output(&c);
+        let graph_json = encode(&g.build().expect("graph builds"));
+
+        let envelope = format!(
+            r#"{{ "graph": {}, "inputs": ["{}", "{}"] }}"#,
+            graph_json,
+            hex_encode(
+                &[1.0f32, 2.0, 3.0]
+                    .iter()
+                    .flat_map(|f| f.to_le_bytes())
+                    .collect::<Vec<u8>>()
+            ),
+            hex_encode(
+                &[10.0f32, 20.0, 30.0]
+                    .iter()
+                    .flat_map(|f| f.to_le_bytes())
+                    .collect::<Vec<u8>>()
+            ),
+        );
+
+        let out_envelope = run_graph_on_cpu_via_json_envelope(&envelope)
+            .expect("envelope execution succeeds");
+
+        // Parse result envelope and read first output bytes.
+        let parsed = coding_adventures_json_value::parse(&out_envelope)
+            .expect("output envelope parses");
+        let outputs = envelope_field(&parsed, "outputs").unwrap();
+        let arr = match outputs {
+            JsonValue::Array(xs) => xs,
+            _ => panic!("outputs not array"),
+        };
+        let bytes = match &arr[0] {
+            JsonValue::String(s) => hex_decode(s).unwrap(),
+            _ => panic!("output not string"),
+        };
+        let floats: Vec<f32> = bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        assert_eq!(floats, vec![11.0, 22.0, 33.0]);
+    }
+
+    /// Envelope without a `graph` field must fail cleanly — never
+    /// panic across the FFI boundary.
+    #[test]
+    fn envelope_rejects_missing_graph() {
+        let err = run_graph_on_cpu_via_json_envelope(r#"{"inputs": []}"#)
+            .expect_err("missing graph field rejected");
+        assert!(err.contains("graph"), "got: {}", err);
+    }
+
+    /// Envelope where `inputs` is not an array must fail cleanly.
+    #[test]
+    fn envelope_rejects_non_array_inputs() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2]));
+        g.output(&a);
+        let graph_json = encode(&g.build().unwrap());
+        let envelope = format!(
+            r#"{{ "graph": {}, "inputs": "not-an-array" }}"#,
+            graph_json
+        );
+
+        let err = run_graph_on_cpu_via_json_envelope(&envelope)
+            .expect_err("inputs-not-array rejected");
+        assert!(err.contains("inputs"), "got: {}", err);
+    }
+
+    /// Envelope where an entry of `inputs` contains invalid hex must
+    /// fail cleanly with a precise error pointing at the bad index.
+    #[test]
+    fn envelope_rejects_invalid_hex_input() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[1]));
+        g.output(&a);
+        let graph_json = encode(&g.build().unwrap());
+        let envelope = format!(
+            r#"{{ "graph": {}, "inputs": ["zzzz"] }}"#,
+            graph_json
+        );
+
+        let err = run_graph_on_cpu_via_json_envelope(&envelope)
+            .expect_err("non-hex input rejected");
+        assert!(
+            err.contains("envelope.inputs[0]") && err.contains("hex"),
+            "got: {}",
+            err
+        );
+    }
+
+    /// Garbage envelope JSON must fail with a parse error — never
+    /// panic, never crash the interpreter.
+    #[test]
+    fn envelope_rejects_garbage_json() {
+        let err = run_graph_on_cpu_via_json_envelope("not even close to json")
+            .expect_err("garbage rejected");
+        assert!(err.contains("parse"), "got: {}", err);
     }
 }


### PR DESCRIPTION
## Summary

MX09 Phase 2 — mirrors matrix-rust-napi's Phase 2 (PR #3527 + #3539) for the **Python** binding. Adds the second exported function — \`run_graph_on_cpu(envelope_json: str) -> str\` — that takes a JSON envelope (graph + hex-encoded input bytes) and returns a JSON envelope (hex-encoded output bytes). Exercises the full plan → alloc → upload → dispatch → download pipeline on matrix-cpu via matrix-runtime.

The envelope shape is **bit-identical** to matrix-rust-napi's \`runGraphOnCpu\` envelope, so a single JSON test fixture cross-checks both bindings.

## Deliverables

- \`src/exec.rs\` (new, 487 lines) — direct port of matrix-rust-napi/src/exec.rs.
- \`src/lib.rs\` — adds \`run_graph_on_cpu_via_json_envelope\` + \`py_run_graph_on_cpu\` + hex codec helpers.
- \`Cargo.toml\` — adds workspace deps: matrix-runtime, matrix-cpu, compute-ir, executor-protocol, coding-adventures-json-value, coding-adventures-json-serializer. **Zero new crates.io deps.**
- Methods table grows from 2 → 3 entries.
- \`required_capabilities.json\`, \`CHANGELOG.md\`, \`README.md\` — updated for Phase 2.

## Security control: \`MAX_TOTAL_BUFFER_BYTES = 4 GiB\`

Hard cap checked *before* any \`AllocBuffer\` call. Without it, a ~500-byte adversarial envelope declaring a tensor like \`shape=[1e9, 1e9] F32\` would flow ~4e18 bytes into \`vec![0u8; bytes]\` inside matrix-cpu::BufferStore and abort the Python interpreter via \`handle_alloc_error\`. Same value the napi binding uses → CPU executor sees the same DoS posture regardless of which FFI edge invoked it.

## Tests

19/19 passing locally on darwin-arm64 (was 5 in Phase 1):

- \`exec::tests\` (6): add / matmul / relu end-to-end, wrong-count, wrong-byte-length, oversized-output (cap fires).
- \`tests::hex_*\` (3): round-trip, odd-length reject, bad-char reject.
- \`tests::envelope_*\` (5): headline JSON-in/out add, missing-graph, non-array-inputs, invalid-hex-input, garbage-json.
- \`tests::round_trip_*\` (5): unchanged from Phase 1.

Security review (\`/security-review\` sub-agent, Rust + Python C API focus, DoS cap as centerpiece): **PASSED** — no vulnerabilities found. Independently verified the cap path, integer overflow handling (\`checked_add\` + \`byte_size\`'s internal \`checked_mul\`), planner-invariant check, panic-free FFI discipline, borrowed-vs-owned PyObject refcount handling, and JSON error-message safety.

## Test plan

- [x] \`cargo test -p matrix-rust-python -- --nocapture\` — 19/19 pass
- [x] Security review — PASSED in 1 round
- [ ] CI: workspace cargo build (Tier 1)
- [ ] CI: build-tool runs \`cargo test\` via per-package BUILD
- [ ] CI: cross-platform builds (ubuntu, macos, windows)

## What's NOT in Phase 2 (each is its own PR per the spec)

- No \`Graph\` / \`Runtime\` Python classes via PyCapsule (Phase 2b)
- No \`bytes\` I/O — still hex-string-in / hex-string-out for parity with napi Phase 2 (Phase 2b switches to python-bridge \`bytes_to_py\` / \`bytes_from_py\`)
- No \`pyproject.toml\` / \`maturin\` wheel build (Phase 3)
- No companion Python wrapper package (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)