### PR TITLE
Check html5lib coverage audit report

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -277,6 +277,10 @@ The command exits nonzero if any upstream tokenizer case is missing from
 missing from the parser fixture, or if `html5lib-smoke.json` still records
 skipped runtime gaps.
 
+The same audit can verify the checked
+`html-parser/tests/fixtures/html5lib-coverage-audit.json` report with
+`--check-report`, so fixture-count and missing-source drift stays visible in CI.
+
 ## WPT Path
 
 The next layer normalizes WHATWG/WPT or html5lib-style tokenizer coverage into

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -13,6 +13,9 @@ documented in this file.
   and HTML fragment-shell families, with a dedicated parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion audit checks on the same parser and DOM dump path.
+- The html5lib source-coverage audit now has a checked JSON report plus
+  `--write-report` and `--check-report` modes for parser/tokenizer fixture
+  drift detection.
 - Stack-of-open-elements tree construction seed with void element handling,
   adjacent text merging, simple implied end tags, and unmatched end-tag
   diagnostics.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -94,6 +94,10 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
   --expect-normalized-skipped 0
 ```
 
+The audit also owns a checked `tests/fixtures/html5lib-coverage-audit.json`
+summary. Regenerate or verify that exact report with `--write-report` or
+`--check-report`.
+
 For sharper parser regression reporting, the generated
 `tests/fixtures/whatwg-tree-insertion-audit.json` fixture indexes the
 adoption-agency, table/foster-parenting, template, foreign-content fragment,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -36,6 +36,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
   --expect-normalized-skipped 0
 ```
 
+The stable JSON report is checked in as `html5lib-coverage-audit.json`.
+Regenerate or check it with:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
+  /path/to/html5lib-tests --write-report
+python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
+  /path/to/html5lib-tests --check-report
+```
+
 `whatwg-tree-insertion-audit.json` is a generated index over the high-signal
 tree-construction families inside `html5lib-tree-construction-smoke.dat`:
 adoption-agency formatting recovery, table insertion and foster parenting,

--- a/code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
+++ b/code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
@@ -32,6 +32,8 @@ TOKENIZER_SIGNATURE_KEYS = (
     "errors",
 )
 
+DEFAULT_REPORT_PATH = Path(__file__).with_name("html5lib-coverage-audit.json")
+
 
 @dataclass(frozen=True)
 class TreeCase:
@@ -108,6 +110,15 @@ def main() -> int:
     else:
         print_report(report, upstream_root)
 
+    report_mismatch = None
+    if args.write_report:
+        write_report(args.report_path, report)
+    if args.check_report:
+        report_mismatch = check_report(args.report_path, report)
+        if report_mismatch:
+            sys.stdout.flush()
+            print(report_mismatch, file=sys.stderr)
+
     sys.stdout.flush()
     expectation_mismatches = collect_expectation_mismatches(report, args)
     for mismatch in expectation_mismatches:
@@ -117,6 +128,7 @@ def main() -> int:
         missing_tree
         or missing_tokenizer
         or normalized_skipped
+        or report_mismatch
         or expectation_mismatches
     ):
         return 1
@@ -146,6 +158,22 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=20,
         help="Maximum missing case sources to include in the report.",
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        default=DEFAULT_REPORT_PATH,
+        help="Path for --write-report or --check-report.",
+    )
+    parser.add_argument(
+        "--write-report",
+        action="store_true",
+        help="Write the stable machine-readable audit report.",
+    )
+    parser.add_argument(
+        "--check-report",
+        action="store_true",
+        help="Exit non-zero if the stable audit report differs from --report-path.",
     )
     parser.add_argument(
         "--expect-tree-upstream-cases",
@@ -331,6 +359,25 @@ def missing_cases(
 
 def stable_signature(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def stable_report_json(report: dict[str, Any]) -> str:
+    return json.dumps(report, indent=2, sort_keys=True) + "\n"
+
+
+def write_report(path: Path, report: dict[str, Any]) -> None:
+    path.write_text(stable_report_json(report))
+
+
+def check_report(path: Path, report: dict[str, Any]) -> str | None:
+    actual = stable_report_json(report)
+    if not path.exists():
+        return f"report mismatch: {path} does not exist"
+
+    expected = path.read_text()
+    if actual == expected:
+        return None
+    return f"report mismatch: regenerate {path} with --write-report"
 
 
 def collect_expectation_mismatches(

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -1,0 +1,16 @@
+{
+  "tokenizer": {
+    "local_raw_cases": 7015,
+    "missing": 0,
+    "missing_sources": [],
+    "normalized_cases": 7242,
+    "normalized_skipped": 0,
+    "upstream_cases": 6806
+  },
+  "tree_construction": {
+    "local_cases": 2485,
+    "missing": 0,
+    "missing_sources": [],
+    "upstream_cases": 1778
+  }
+}


### PR DESCRIPTION
## Summary
- add a checked html5lib coverage audit JSON report for parser/tree and lexer/tokenizer fixture coverage
- add --write-report and --check-report modes to the coverage audit
- document the report check in parser and lexer fixture docs

## Validation
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
- intentional missing report: python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report --report-path /tmp/missing-html5lib-coverage-audit.json exits nonzero
