### PR TITLE
feat(forme-aot-script-tag-emitter): FM00 v0 <script src> tag emitter w/ SRI

### DIFF
--- a/code/packages/typescript/forme-aot-script-tag-emitter/BUILD
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-script-tag-emitter/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/CHANGELOG.md
@@ -1,0 +1,159 @@
+# Changelog — @coding-adventures/forme-aot-script-tag-emitter
+
+## 0.1.0 — 2026-05-19
+
+Initial release.  Sixteenth FM00 v0 stage package — HTML
+`<script src="...">` tag emitter with Subresource Integrity (SRI)
+format validation and crossorigin / referrerpolicy / async /
+defer / nomodule support.
+
+Pure transform: `ScriptTag | ScriptTag[]` → HTML string.
+Two-pass validate-then-emit so callers never see partial output.
+
+### Added
+
+- `generateScriptTags(input): string` — main entry.  Accepts a
+  single `ScriptTag` or array; returns one tag per line.
+- `validateScriptSrc(url)` — http(s)://-or-root-relative URL
+  accept-list (same pattern as the sibling FM00 emitters).
+- `validateIntegrity(value)` — SRI string format validator.
+  Accepts one or more whitespace-separated `<algo>-<base64>`
+  tokens with algo ∈ `{sha256, sha384, sha512}` and base64
+  matching the algo's expected digest length (44 / 64 / 88
+  chars).  Standard base64 only (no URL-safe `- _` variants).
+- `validateScriptType(value)` — allowlist of
+  `{module, importmap}`.
+- `validateCrossOrigin(value)` — `{anonymous, use-credentials}`.
+- `validateReferrerPolicy(value)` — all eight spec-defined
+  Referrer Policy values.
+- `escapeHtmlAttr` / `stripAsciiControl` — single-pass HTML
+  attribute escape + C0 control strip.
+- Types: `ScriptTag`, `ScriptType`, `CrossOrigin`,
+  `ReferrerPolicy`.
+
+### Spec adherence
+
+Implements HTML Living Standard `<script>` element semantics +
+Subresource Integrity (W3C SRI) + Referrer Policy enum.  No
+divergence.
+
+### Behavioural notes
+
+- **Attribute order**: `type → src → integrity → crossorigin →
+  referrerpolicy → async → defer → nomodule`.
+- **Boolean attributes** emit as bare attribute names
+  (`async`, `defer`, `nomodule`), spec-canonical form.
+- **`async` + `defer`** simultaneously → throws (spec says
+  `defer` is silently ignored; we treat the combination as a
+  caller bug rather than hide it).
+- **Empty array input** → empty string output.
+- **Single object** treated as a one-element array (same output
+  as `[{...}]`).
+- **Reproducibility.**  Same input → byte-identical output.
+  No input mutation.
+
+### Security posture
+
+Eight concerns explicitly addressed (pre-push review found
+three issues and they're fixed below):
+
+- **URL scheme injection.**  Every `src` runs through
+  `validateScriptSrc`.  `javascript:`, `data:`, `file:`,
+  `vbscript:`, protocol-relative `//host`, backslash-variant
+  `/\host`, bare relative, empty, non-string all rejected.
+- **HTML attribute injection.**  Every interpolated value
+  passes through `escapeHtmlAttr`.  Single-pass character-
+  class replacement covers all five HTML entities + strips
+  ASCII control bytes.
+- **SRI integrity format validation.**  Malformed `integrity=`
+  silently disables SRI in some browsers and allows MITM
+  substitution.  The validator pins algo prefix, base64
+  charset (standard only — not URL-safe), length, AND per-algo
+  padding count.  Per-algo padding is the subtle one — a sha256
+  string with `==` instead of `=` is the right total length
+  (44 chars) but decodes to 31 bytes, not 32, and browsers
+  silently disable SRI rather than throw.  Fixed: pad count
+  must be exactly `(3 - bytes % 3) % 3` for each algo.
+- **Object-prototype walk defence.**  `SRI_ALGOS` is a `Map`
+  (not a plain object) so attacker-supplied algo names like
+  `"__proto__"`, `"toString"`, `"hasOwnProperty"` can't return
+  truthy values from `Object.prototype` and bypass the
+  "unknown algo" branch.
+- **ASCII control bytes in `src` are rejected** at the
+  validator (not silently stripped by `escapeHtmlAttr`).
+  Otherwise `/\tevil` would pass the root-relative check
+  (`url[1]` is tab, not `/` or `\`) and then become `/evil`
+  after escape — a different file than the caller asked for.
+- **`type` / `crossorigin` / `referrerpolicy` allowlists.**
+  Defend against typo-driven bugs.  `type` deliberately
+  excludes legacy `text/javascript` etc. (equivalent to
+  omission in modern browsers; including them adds typo
+  surface).
+- **`async` + `defer` conflict** rejected as caller bug rather
+  than silently ignored.
+- **Fail-fast.**  Validation completes for every entry BEFORE
+  any tag is emitted.  An exception means the caller has
+  nothing to write.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, network, fs, shell, env.
+
+### Tests
+
+139 tests across 2 files:
+
+- `validate.test.ts` (93) — `validateScriptSrc` accept (https,
+  http, case-insensitive scheme, root-relative, bare /, multi-
+  segment) + reject matrix (javascript:, data:, file:,
+  vbscript:, protocol-relative, backslash-variant, bare
+  relative, empty, non-string, null, undefined, long-URL
+  truncation in error, NUL / tab / newline / DEL / ESC control
+  bytes); `validateIntegrity` accept (sha256 / sha384 / sha512
+  single + multi-algo, whitespace collapsing, trimming, base64
+  with +//, mixed alphabet) + reject (non-string, null, empty,
+  whitespace-only, md5/sha1, no dash, dash at start / end,
+  wrong length for sha256 / 384 / 512, invalid base64 chars
+  including URL-safe `_` and triple padding, bad second token,
+  wrong padding per algo (sha256 `==`, sha384 with padding,
+  sha512 `=` instead of `==`), `__proto__` / `toString` /
+  `hasOwnProperty` algo names (Object.prototype walk defence),
+  error-contains-bad-algo); `validateScriptType`
+  (2 accept + reject legacy MIMEs + case-sensitive + empty +
+  non-string); `validateCrossOrigin` (2 accept + reject 'true'
+  / empty / non-string); `validateReferrerPolicy` (all 8 values
+  parametrised + case-sensitive + deprecated 'never' + empty +
+  non-string); `escapeHtmlAttr` (5 entities + composite +
+  control bytes + non-string coercion); `stripAsciiControl`
+  (control-byte matrix + printable preservation).
+- `generate.test.ts` (46) — single tag (minimal / module /
+  importmap / SRI+crossorigin / each boolean attr /
+  referrerpolicy / absolute URL / false-booleans-omitted);
+  attribute order (full 7-attr order, defer before nomodule);
+  array (multi-tag newline-joined, empty, single same as
+  object, order preserved); URL validation (each forbidden
+  scheme); SRI integrity (sha384 verbatim, two-algo verbatim,
+  md5 rejected, wrong length rejected); allowlist validation
+  (type / crossorigin / referrerpolicy each); async+defer
+  conflict (both rejected, async-only ok, defer-only ok);
+  boolean type-checking (non-bool async / defer / nomodule
+  rejected); input shape (null entry, non-object, bad-entry-
+  index-in-error); HTML escaping (ampersand in src);
+  control bytes in src REJECTED (NUL + tab); fail-fast (mid-array bad integrity, no
+  output); purity / determinism (byte-identical, no input
+  mutation including arrays); full real-world example with
+  verbatim line check.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only).
+
+### v0 simplifications (documented)
+
+- **No inline `<script>...code...</script>`** — external `src`
+  only.  Inline has a fundamentally different trust boundary
+  and needs a dedicated emitter.
+- **No `blocking="render"`** attribute (low adoption; v1 may
+  add).
+- **No `fetchpriority`** attribute (deferred).
+- **No SRI hash computation** — caller supplies the integrity
+  string; this package validates format only.

--- a/code/packages/typescript/forme-aot-script-tag-emitter/README.md
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/README.md
@@ -1,0 +1,185 @@
+# @coding-adventures/forme-aot-script-tag-emitter
+
+> FM00 v0 emitter — `ScriptTag` config → HTML `<script src="...">`
+> tag string, with SRI integrity validation + crossorigin /
+> referrerpolicy / async / defer / nomodule support.
+
+Sixteenth FM00 v0 stage package. Pure transform — no I/O, no fs,
+no network, no env, no shell.
+
+## What it does
+
+`generateScriptTags(input) → string` takes either a single
+`ScriptTag` descriptor or an array of them and emits one
+`<script>` tag per entry, joined by newlines (no trailing
+newline). Empty array → empty string.
+
+| Field            | Output behaviour                                          |
+| ---------------- | --------------------------------------------------------- |
+| `src`            | required. `http(s)://` or root-relative `/path`           |
+| `type`           | `module` \| `importmap`                                   |
+| `integrity`      | SRI `sha256-...` / `sha384-...` / `sha512-...` (space-separated for multiple) |
+| `crossorigin`    | `anonymous` \| `use-credentials`                          |
+| `async`          | boolean attr                                              |
+| `defer`          | boolean attr                                              |
+| `nomodule`       | boolean attr                                              |
+| `referrerpolicy` | spec-defined enum                                         |
+
+Attribute order in output is fixed:
+`type → src → integrity → crossorigin → referrerpolicy → async → defer → nomodule`.
+
+## Quick start
+
+```ts
+import { generateScriptTags } from "@coding-adventures/forme-aot-script-tag-emitter";
+
+// Single module script with SRI:
+generateScriptTags({
+  src: "https://cdn.example.com/app.js",
+  type: "module",
+  integrity: "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC",
+  crossorigin: "anonymous",
+});
+// <script type="module" src="https://cdn.example.com/app.js" integrity="sha384-..." crossorigin="anonymous"></script>
+
+// App + analytics + legacy fallback:
+generateScriptTags([
+  { src: "/main.js",   type: "module", integrity: "sha384-...", crossorigin: "anonymous" },
+  { src: "/legacy.js", nomodule: true, defer: true },
+  { src: "https://analytics.example.com/a.js", async: true, referrerpolicy: "no-referrer" },
+]);
+```
+
+## Validation
+
+Two-pass fail-fast. The validator walks the entire input array
+first; if anything throws, the caller gets a `TypeError` and
+**no output is ever produced** — there's no risk of a half-formed
+`<script>` reaching the page.
+
+### URL accept-list (`src`)
+
+`http://...` or `https://...` (scheme case-insensitive), or
+root-relative `/path` (NOT `//host`, NOT `/\host`). Everything
+else throws.
+
+ASCII control bytes (`\x00-\x1F`, `\x7F`) are also rejected
+up-front — otherwise `/\tevil` would pass the root-relative
+check (`url[1]` is tab, not `/` or `\`) and become `/evil`
+after HTML-attribute escape, silently redirecting to a
+different file.
+
+### SRI integrity
+
+Format: one or more whitespace-separated `<algo>-<base64>`
+tokens. Algo ∈ `{sha256, sha384, sha512}`. Base64 charset
+restricted to `[A-Za-z0-9+/]` plus padding (NO URL-safe
+`-` `_` variants — the SRI spec uses standard base64). Base64
+length must match the algo's expected digest size (44 / 64 / 88
+chars respectively) **with exactly the right number of `=`
+padding characters** for that algo (1 / 0 / 2 respectively).
+The per-algo padding check is essential — a sha256 string with
+`==` instead of `=` decodes to 31 bytes (not 32) and browsers
+silently disable SRI rather than throwing. We catch this at the
+emitter.
+
+Multiple hashes in one `integrity` are allowed and emitted
+verbatim; the browser picks the strongest it supports.
+
+### `type` allowlist
+
+`module` | `importmap`. Classic scripts (no `type=`) come from
+omitting the field. Legacy MIMEs (`text/javascript`,
+`application/javascript`) are intentionally NOT in the allowlist
+— they're equivalent to omission in modern browsers, and
+accepting them widens the surface for typo-driven bugs.
+
+### `crossorigin` allowlist
+
+`anonymous` | `use-credentials`.
+
+### `referrerpolicy` allowlist
+
+The eight values defined by the Referrer Policy spec:
+`no-referrer`, `no-referrer-when-downgrade`, `origin`,
+`origin-when-cross-origin`, `same-origin`, `strict-origin`,
+`strict-origin-when-cross-origin`, `unsafe-url`.
+
+### `async` + `defer` conflict
+
+The HTML spec says when both are set on a classic script, `defer`
+is silently ignored. We treat setting both as a caller bug and
+throw — emitting both bytes hides the bug downstream.
+
+## Security posture
+
+Eight concerns explicitly addressed (pre-push review found
+three issues — all fixed in this initial release):
+
+1. **URL scheme injection.** Every `src` runs through
+   `validateScriptSrc`. `javascript:`, `data:`, `file:`,
+   `vbscript:`, protocol-relative, backslash-variant, bare
+   relative, empty, non-string all rejected with `TypeError`.
+2. **HTML attribute injection.** Every interpolated value
+   passes through `escapeHtmlAttr` (single-pass char-class
+   replacement + ASCII control-byte strip). Attacker-controlled
+   strings can't break out of the attribute quote.
+3. **SRI integrity format validation.** Caller can't accidentally
+   ship a malformed `integrity=` attribute (which would silently
+   disable SRI in some browsers and allow MITM substitution).
+   Wrong algo → throw; wrong base64 length → throw; non-base64
+   chars → throw; **wrong per-algo padding** → throw (a sha256
+   string with `==` is the right total length but decodes to
+   31 bytes; browsers silently disable SRI rather than reject).
+4. **Object-prototype walk defence.** Internal algo table is a
+   `Map`, not a plain object — so `"__proto__"` / `"toString"`
+   / `"hasOwnProperty"` as algo names don't return truthy
+   values from `Object.prototype` and bypass the unknown-algo
+   branch.
+5. **Allowlists.** `type`, `crossorigin`, `referrerpolicy` all
+   restrict to spec-defined sets. Defends against typo-driven
+   bugs that browsers might treat permissively.
+6. **ASCII control bytes in `src` rejected at the validator** —
+   prevents `escapeHtmlAttr` from silently stripping them and
+   redirecting to a different URL.
+7. **`async` + `defer` conflict** rejected as caller bug.
+8. **Fail-fast.** Validation completes for every entry BEFORE
+   any tag is emitted.
+
+## Behavioural notes
+
+- **Empty array** → empty string.
+- **Single object** is treated as a one-element array.
+- **Boolean attributes** (`async`, `defer`, `nomodule`) emit as
+  bare attribute names (`async`) — the HTML spec canonical form.
+  `false` / `undefined` omits them entirely.
+- **Reproducibility.** Same input → byte-identical output. No
+  hidden randomness, no input mutation.
+
+## v0 simplifications (documented)
+
+- **No inline `<script>...code...</script>`.** External `src`
+  only — inline has a fundamentally different trust boundary
+  (caller-supplied code executes verbatim) and belongs in a
+  separate emitter.
+- **No `blocking="render"`** attribute (recently-shipped, low
+  adoption; v1 may add).
+- **No `fetchpriority`** attribute (deferred).
+- **No SRI hash computation** — caller supplies the integrity
+  string. This package only validates format.
+
+## Tests
+
+139 tests across two files. **100% line / 100% branch** coverage
+on all source files with logic.
+
+## Capabilities
+
+`[]` — pure transform.
+
+## How it fits in the stack
+
+Sibling of `forme-aot-meta-link-tags` (head `<meta>`/`<link>` tags)
+and `forme-aot-rss-discovery-link` (`<link rel="alternate">` feed
+tags). Higher-level FM00 head builders compose these to produce
+the final `<head>`.

--- a/code/packages/typescript/forme-aot-script-tag-emitter/package-lock.json
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-aot-script-tag-emitter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-script-tag-emitter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-script-tag-emitter/package.json
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-aot-script-tag-emitter",
+  "version": "0.1.0",
+  "description": "Emit HTML <script src=\"...\"> tags with optional SRI integrity, crossorigin, async/defer, nomodule, referrerpolicy.  Pure transform: URL accept-list (http(s):// OR root-relative), SRI integrity sha256/384/512 base64 syntax check, type/crossorigin/referrerpolicy allowlists, HTML-attribute-escapes every value, async+defer rule.  FM00 v0 emitter.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-script-tag-emitter/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-script-tag-emitter",
+  "capabilities": [],
+  "justification": "Pure transform: ScriptTag config → HTML <script> tag string.  No I/O, no network, no env, no shell, no fs."
+}

--- a/code/packages/typescript/forme-aot-script-tag-emitter/src/escape.ts
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/src/escape.ts
@@ -1,0 +1,38 @@
+/**
+ * escape.ts — HTML attribute escaping.
+ *
+ * Same single-pass character-class replacement pattern as the
+ * sibling FM00 emitters (rss-discovery-link, sitemap-emitter,
+ * meta-link-tags).  Covers all five HTML entities; strips ASCII
+ * control bytes first so attribute values are guaranteed safe
+ * to interpolate.
+ *
+ * @module escape
+ */
+
+const HTML_ATTR_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;",
+  "'": "&#39;",
+});
+
+const HTML_ATTR_SPECIAL_RE = /[&<>"']/g;
+// eslint-disable-next-line no-control-regex
+const ASCII_CONTROL_RE = /[\x00-\x1F\x7F]/g;
+
+/**
+ * Strip ASCII control bytes (`\x00-\x1F`, `\x7F`).
+ */
+export function stripAsciiControl(s: string): string {
+  return String(s).replace(ASCII_CONTROL_RE, "");
+}
+
+/**
+ * Escape HTML attribute special chars + strip control bytes.
+ * Single-pass character-class replace.
+ */
+export function escapeHtmlAttr(s: string): string {
+  return stripAsciiControl(s).replace(HTML_ATTR_SPECIAL_RE, (ch) => HTML_ATTR_ESCAPE_MAP[ch]!);
+}

--- a/code/packages/typescript/forme-aot-script-tag-emitter/src/generate.ts
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/src/generate.ts
@@ -1,0 +1,137 @@
+/**
+ * generate.ts — main `generateScriptTags` entry.
+ *
+ * Two-pass fail-fast: validate every entry into a fresh resolved
+ * array, then render each to a `<script>` tag string joined by
+ * newlines.  No trailing newline.
+ *
+ * Attribute order (deterministic, matches WHATWG conventions):
+ *
+ *     type → src → integrity → crossorigin → referrerpolicy →
+ *     async → defer → nomodule
+ *
+ * Boolean attributes (`async`, `defer`, `nomodule`) are emitted
+ * as bare attribute names with no value — this is the
+ * spec-canonical form and what every modern HTML formatter
+ * produces.
+ *
+ * @module generate
+ */
+
+import { escapeHtmlAttr } from "./escape.js";
+import type { ScriptTag } from "./types.js";
+import {
+  validateCrossOrigin,
+  validateIntegrity,
+  validateReferrerPolicy,
+  validateScriptSrc,
+  validateScriptType,
+} from "./validate.js";
+
+interface ResolvedScript {
+  readonly type: string | undefined;
+  readonly src: string;
+  readonly integrity: string | undefined;
+  readonly crossorigin: string | undefined;
+  readonly referrerpolicy: string | undefined;
+  readonly async: boolean;
+  readonly defer: boolean;
+  readonly nomodule: boolean;
+}
+
+/**
+ * Generate one or more `<script src="...">` tags from one or
+ * many `ScriptTag` descriptors.
+ *
+ * Accepts a single object or an array.  Returns the
+ * concatenated HTML string (one tag per line; no trailing
+ * newline).  Empty array → empty string.
+ *
+ * Throws `TypeError` synchronously on validation failure BEFORE
+ * any output is built.  An exception means the caller has
+ * nothing to write — there's no risk of partial `<script>`
+ * tags reaching the page.
+ *
+ * ```ts
+ * generateScriptTags({
+ *   src: "/main.js",
+ *   type: "module",
+ *   integrity: "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC",
+ *   crossorigin: "anonymous",
+ * });
+ * // <script type="module" src="/main.js" integrity="sha384-..." crossorigin="anonymous"></script>
+ *
+ * generateScriptTags([
+ *   { src: "/app.js", async: true },
+ *   { src: "/analytics.js", defer: true, referrerpolicy: "no-referrer" },
+ * ]);
+ * ```
+ *
+ * **`async` + `defer` rule.**  The HTML spec says when both are
+ * present on a classic script, `defer` is ignored.  We treat
+ * setting both as a caller bug and throw — emitting both bytes
+ * masks the bug downstream.
+ */
+export function generateScriptTags(
+  input: ScriptTag | readonly ScriptTag[],
+): string {
+  const tags = Array.isArray(input) ? input : [input];
+
+  const resolved: ResolvedScript[] = new Array(tags.length);
+  for (let i = 0; i < tags.length; i++) {
+    resolved[i] = validateOne(tags[i]!, i);
+  }
+
+  const lines: string[] = new Array(resolved.length);
+  for (let i = 0; i < resolved.length; i++) {
+    lines[i] = renderTag(resolved[i]!);
+  }
+  return lines.join("\n");
+}
+
+function validateOne(tag: ScriptTag, i: number): ResolvedScript {
+  if (tag === null || typeof tag !== "object") {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: input[${i}] must be a non-null object; got ${typeof tag}`,
+    );
+  }
+  const src = validateScriptSrc(tag.src);
+  const type = tag.type === undefined ? undefined : validateScriptType(tag.type);
+  const integrity = tag.integrity === undefined ? undefined : validateIntegrity(tag.integrity);
+  const crossorigin = tag.crossorigin === undefined ? undefined : validateCrossOrigin(tag.crossorigin);
+  const referrerpolicy = tag.referrerpolicy === undefined
+    ? undefined
+    : validateReferrerPolicy(tag.referrerpolicy);
+  const async_ = validateBool(tag.async, `input[${i}].async`);
+  const defer = validateBool(tag.defer, `input[${i}].defer`);
+  const nomodule = validateBool(tag.nomodule, `input[${i}].nomodule`);
+
+  if (async_ && defer) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: input[${i}] cannot set both async and defer (spec: defer is ignored when async is present; reject as caller bug)`,
+    );
+  }
+
+  return { type, src, integrity, crossorigin, referrerpolicy, async: async_, defer, nomodule };
+}
+
+function validateBool(value: unknown, field: string): boolean {
+  if (value === undefined || value === false) return false;
+  if (value === true) return true;
+  throw new TypeError(
+    `forme-aot-script-tag-emitter: ${field} must be a boolean; got ${typeof value}`,
+  );
+}
+
+function renderTag(s: ResolvedScript): string {
+  const parts: string[] = ["<script"];
+  if (s.type !== undefined)           parts.push(`type="${escapeHtmlAttr(s.type)}"`);
+  parts.push(`src="${escapeHtmlAttr(s.src)}"`);
+  if (s.integrity !== undefined)      parts.push(`integrity="${escapeHtmlAttr(s.integrity)}"`);
+  if (s.crossorigin !== undefined)    parts.push(`crossorigin="${escapeHtmlAttr(s.crossorigin)}"`);
+  if (s.referrerpolicy !== undefined) parts.push(`referrerpolicy="${escapeHtmlAttr(s.referrerpolicy)}"`);
+  if (s.async)    parts.push("async");
+  if (s.defer)    parts.push("defer");
+  if (s.nomodule) parts.push("nomodule");
+  return `${parts.join(" ")}></script>`;
+}

--- a/code/packages/typescript/forme-aot-script-tag-emitter/src/index.ts
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @coding-adventures/forme-aot-script-tag-emitter
+ *
+ * Emit HTML `<script src="...">` tags with optional Subresource
+ * Integrity (SRI), crossorigin, async/defer/nomodule, type
+ * (module / importmap), and referrerpolicy.  Pure transform —
+ * returns the tag string(s); caller drops it into the page.
+ *
+ * ```ts
+ * import { generateScriptTags } from "@coding-adventures/forme-aot-script-tag-emitter";
+ *
+ * // Single module script with SRI:
+ * generateScriptTags({
+ *   src: "https://cdn.example.com/app.js",
+ *   type: "module",
+ *   integrity: "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC",
+ *   crossorigin: "anonymous",
+ * });
+ *
+ * // Multiple scripts:
+ * generateScriptTags([
+ *   { src: "/main.js",      type: "module", async: true },
+ *   { src: "/legacy.js",    nomodule: true, defer: true },
+ *   { src: "/analytics.js", defer: true, referrerpolicy: "no-referrer" },
+ * ]);
+ * ```
+ *
+ * Validation runs BEFORE emission — bad URLs, bad SRI strings,
+ * bad allowlist values, async+defer conflicts all throw
+ * `TypeError` synchronously.
+ *
+ * Sixteenth FM00 v0 stage package.
+ *
+ * @module index
+ */
+
+export { generateScriptTags } from "./generate.js";
+export { escapeHtmlAttr, stripAsciiControl } from "./escape.js";
+export {
+  validateScriptSrc,
+  validateIntegrity,
+  validateScriptType,
+  validateCrossOrigin,
+  validateReferrerPolicy,
+} from "./validate.js";
+export type {
+  ScriptTag,
+  ScriptType,
+  CrossOrigin,
+  ReferrerPolicy,
+} from "./types.js";

--- a/code/packages/typescript/forme-aot-script-tag-emitter/src/types.ts
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/src/types.ts
@@ -1,0 +1,85 @@
+/**
+ * types.ts — public signatures for the script tag emitter.
+ *
+ * Emits a single HTML `<script src="...">` tag string per
+ * `ScriptTag` entry.  Inline scripts (`<script>...code...</script>`)
+ * are out of scope here — that's a separate path (security
+ * posture is fundamentally different: external `src` runs after
+ * URL validation + SRI; inline executes whatever the caller
+ * passes verbatim, so it needs a dedicated trust boundary).
+ *
+ * @module types
+ */
+
+/**
+ * `<script>` `type` attribute.
+ *
+ *   - `"module"`     — ES module script.  Implicitly `defer`-like
+ *                      semantics in browsers.
+ *   - `"importmap"`  — JSON import map.  No `src` semantics
+ *                      typically (importmaps are inline) but
+ *                      modern browsers accept `<script
+ *                      type="importmap" src="...">` for external
+ *                      maps; we permit it.
+ *
+ * Classic scripts (no `type=`) are emitted by omitting the
+ * `type` field.  Other MIME types (legacy `text/javascript`,
+ * `application/javascript`) are intentionally NOT in the
+ * allowlist — they're equivalent to omission in modern browsers
+ * and accepting them widens the surface for typo-driven bugs.
+ */
+export type ScriptType = "module" | "importmap";
+
+/**
+ * `crossorigin` attribute value.  Same allowlist as
+ * `forme-aot-meta-link-tags`.
+ */
+export type CrossOrigin = "anonymous" | "use-credentials";
+
+/**
+ * `referrerpolicy` attribute value.  Spec-defined enum from the
+ * Referrer Policy Living Standard.
+ */
+export type ReferrerPolicy =
+  | "no-referrer"
+  | "no-referrer-when-downgrade"
+  | "origin"
+  | "origin-when-cross-origin"
+  | "same-origin"
+  | "strict-origin"
+  | "strict-origin-when-cross-origin"
+  | "unsafe-url";
+
+/**
+ * One `<script>` tag descriptor.
+ *
+ *   - `src`            — required.  http(s):// or root-relative.
+ *   - `type`           — optional.  `"module"` | `"importmap"`.
+ *                        Omit for classic script.
+ *   - `integrity`      — optional SRI string.  Must be of the
+ *                        form `sha256-<base64>`,
+ *                        `sha384-<base64>`, or `sha512-<base64>`,
+ *                        possibly space-separated for multiple
+ *                        hashes.
+ *   - `crossorigin`    — optional.  `"anonymous"` | `"use-credentials"`.
+ *                        Required by browsers when `integrity`
+ *                        is set on a cross-origin resource; we
+ *                        emit it verbatim, leaving the policy
+ *                        choice to the caller.
+ *   - `async`          — optional.  Emit `async` boolean attr.
+ *   - `defer`          — optional.  Emit `defer` boolean attr.
+ *   - `nomodule`       — optional.  Emit `nomodule` boolean attr.
+ *                        Useful for ES-module-aware browsers to
+ *                        skip a legacy fallback bundle.
+ *   - `referrerpolicy` — optional.  Spec-allowlist value.
+ */
+export interface ScriptTag {
+  readonly src: string;
+  readonly type?: ScriptType;
+  readonly integrity?: string;
+  readonly crossorigin?: CrossOrigin;
+  readonly async?: boolean;
+  readonly defer?: boolean;
+  readonly nomodule?: boolean;
+  readonly referrerpolicy?: ReferrerPolicy;
+}

--- a/code/packages/typescript/forme-aot-script-tag-emitter/src/validate.ts
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/src/validate.ts
@@ -1,0 +1,238 @@
+/**
+ * validate.ts — URL, SRI integrity, type / crossorigin /
+ * referrerpolicy allowlist validators.
+ *
+ * SRI integrity is the most subtle bit — `<script integrity>` is
+ * the W3C Subresource Integrity spec, format
+ * `<algo>-<base64>[ <algo>-<base64> ...]`.  We accept only the
+ * three browser-implemented algos (sha256 / sha384 / sha512) and
+ * validate the base64 length matches the expected digest size
+ * (32 / 48 / 64 bytes respectively).  Multiple hashes in one
+ * `integrity` string are allowed (the spec lets browsers pick
+ * the strongest one they support).
+ *
+ * @module validate
+ */
+
+import type { CrossOrigin, ReferrerPolicy, ScriptType } from "./types.js";
+
+const SCRIPT_TYPE_ALLOWLIST: ReadonlySet<string> = new Set([
+  "module",
+  "importmap",
+]);
+
+const CROSSORIGIN_ALLOWLIST: ReadonlySet<string> = new Set([
+  "anonymous",
+  "use-credentials",
+]);
+
+const REFERRER_POLICY_ALLOWLIST: ReadonlySet<string> = new Set([
+  "no-referrer",
+  "no-referrer-when-downgrade",
+  "origin",
+  "origin-when-cross-origin",
+  "same-origin",
+  "strict-origin",
+  "strict-origin-when-cross-origin",
+  "unsafe-url",
+]);
+
+// Each algo prefix → expected raw digest byte length.  Base64
+// representation length, including any trailing `=` padding, is
+// derived from the byte length.
+//
+// Backed by a `Map` (not a plain object) so attacker-supplied
+// keys like `"__proto__"`, `"constructor"`, `"toString"` can't
+// walk Object.prototype and accidentally satisfy the
+// "is-known-algo" check with a function value.
+const SRI_ALGOS: ReadonlyMap<string, number> = new Map([
+  ["sha256", 32],
+  ["sha384", 48],
+  ["sha512", 64],
+]);
+
+// Base64 alphabet, case-sensitive.  We accept standard (A-Z a-z 0-9 + /)
+// + `=` padding.  SRI does NOT permit URL-safe (- _) variants.
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+// Disallow ASCII control bytes (`\x00-\x1F`, `\x7F`) anywhere in
+// a URL — `escapeHtmlAttr` would silently strip them downstream
+// and change the URL's meaning (e.g. `/path\x00.js` → `/path.js`,
+// a different file).  Rejecting up-front means the caller always
+// gets the URL they asked for or a TypeError.
+// eslint-disable-next-line no-control-regex
+const URL_CONTROL_RE = /[\x00-\x1F\x7F]/;
+
+/**
+ * Validate the `src` URL against http(s)://-or-root-relative
+ * accept-list.  Same logic as the sibling emitters.
+ */
+export function validateScriptSrc(url: unknown): string {
+  if (typeof url !== "string" || url.length === 0) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: src must be a non-empty string; got ${
+        url === null ? "null" : typeof url
+      }`,
+    );
+  }
+  if (URL_CONTROL_RE.test(url)) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: src must not contain ASCII control bytes (\\x00-\\x1F, \\x7F)`,
+    );
+  }
+  if (isHttpUrl(url)) return url;
+  if (isRootRelative(url)) return url;
+  const shown = url.length > 200 ? `${url.slice(0, 200)}…` : url;
+  throw new TypeError(
+    `forme-aot-script-tag-emitter: src must be http(s):// or root-relative /path; got ${JSON.stringify(shown)}`,
+  );
+}
+
+/**
+ * Validate an SRI `integrity` string.
+ *
+ * Accepts: one or more whitespace-separated `<algo>-<base64>`
+ * tokens, where algo ∈ {sha256, sha384, sha512} and the base64
+ * decodes to the algo's digest byte length.
+ *
+ * Trims surrounding whitespace; collapses internal runs of
+ * whitespace into single spaces in the returned canonical form
+ * for deterministic output.
+ *
+ * Throws `TypeError` on:
+ *   - non-string or empty
+ *   - unknown algo prefix (e.g. `md5-...`)
+ *   - missing or malformed base64 portion (wrong charset, wrong
+ *     length for the named algo)
+ */
+export function validateIntegrity(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: integrity must be a string; got ${typeof value}`,
+    );
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: integrity must be non-empty`,
+    );
+  }
+  const tokens = trimmed.split(/\s+/);
+  for (const tok of tokens) {
+    validateSriToken(tok);
+  }
+  return tokens.join(" ");
+}
+
+function validateSriToken(token: string): void {
+  const dashIdx = token.indexOf("-");
+  if (dashIdx <= 0 || dashIdx >= token.length - 1) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: integrity token must be "<algo>-<base64>"; got ${JSON.stringify(token)}`,
+    );
+  }
+  const algo = token.slice(0, dashIdx);
+  const b64 = token.slice(dashIdx + 1);
+  const expectedBytes = SRI_ALGOS.get(algo);
+  if (expectedBytes === undefined) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: integrity algo must be one of [${
+        [...SRI_ALGOS.keys()].join(", ")
+      }]; got ${JSON.stringify(algo)}`,
+    );
+  }
+  if (!BASE64_RE.test(b64)) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: integrity base64 has invalid characters; got ${JSON.stringify(b64)}`,
+    );
+  }
+  // Expected base64 length: ceil(bytes / 3) * 4.
+  const expectedB64Len = Math.ceil(expectedBytes / 3) * 4;
+  if (b64.length !== expectedB64Len) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: integrity ${algo} expects ${expectedB64Len}-char base64; got ${b64.length}`,
+    );
+  }
+  // Per-algo padding check.  Without this, a sha256 string with
+  // `==` instead of `=` would still pass the length check but
+  // decode to 31 bytes, and browsers would silently disable SRI.
+  //   bytes % 3 == 0 → 0 pad chars (e.g. sha384)
+  //   bytes % 3 == 1 → 2 pad chars (e.g. sha512)
+  //   bytes % 3 == 2 → 1 pad char  (e.g. sha256)
+  const expectedPad = (3 - (expectedBytes % 3)) % 3;
+  const actualPad = b64.length - b64.replace(/=+$/, "").length;
+  if (actualPad !== expectedPad) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: integrity ${algo} requires ${expectedPad} '=' padding char${expectedPad === 1 ? "" : "s"}; got ${actualPad}`,
+    );
+  }
+}
+
+/**
+ * Validate `type` against `{module, importmap}` allowlist.
+ */
+export function validateScriptType(value: unknown): ScriptType {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: type must be a string; got ${typeof value}`,
+    );
+  }
+  if (!SCRIPT_TYPE_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: type must be one of [${
+        [...SCRIPT_TYPE_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as ScriptType;
+}
+
+/**
+ * Validate `crossorigin` against `{anonymous, use-credentials}`.
+ */
+export function validateCrossOrigin(value: unknown): CrossOrigin {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: crossorigin must be a string; got ${typeof value}`,
+    );
+  }
+  if (!CROSSORIGIN_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: crossorigin must be one of [${
+        [...CROSSORIGIN_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as CrossOrigin;
+}
+
+/**
+ * Validate `referrerpolicy` against the Referrer Policy spec
+ * enum.
+ */
+export function validateReferrerPolicy(value: unknown): ReferrerPolicy {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: referrerpolicy must be a string; got ${typeof value}`,
+    );
+  }
+  if (!REFERRER_POLICY_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-script-tag-emitter: referrerpolicy must be one of [${
+        [...REFERRER_POLICY_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as ReferrerPolicy;
+}
+
+function isHttpUrl(url: string): boolean {
+  const head = url.slice(0, 8).toLowerCase();
+  return head.startsWith("http://") || head.startsWith("https://");
+}
+
+function isRootRelative(url: string): boolean {
+  if (url === "/") return true;
+  if (url.length < 2 || url[0] !== "/") return false;
+  return url[1] !== "/" && url[1] !== "\\";
+}

--- a/code/packages/typescript/forme-aot-script-tag-emitter/tests/generate.test.ts
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/tests/generate.test.ts
@@ -1,0 +1,280 @@
+/**
+ * generate.test.ts — end-to-end generateScriptTags.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateScriptTags } from "../src/index.js";
+
+const SHA256_B64 = "A".repeat(43) + "=";
+const SHA384_B64 = "A".repeat(64);
+
+describe("generateScriptTags — single tag", () => {
+  it("minimal src-only emits classic script", () => {
+    expect(generateScriptTags({ src: "/main.js" }))
+      .toBe(`<script src="/main.js"></script>`);
+  });
+  it("type module", () => {
+    expect(generateScriptTags({ src: "/main.js", type: "module" }))
+      .toBe(`<script type="module" src="/main.js"></script>`);
+  });
+  it("type importmap", () => {
+    expect(generateScriptTags({ src: "/im.json", type: "importmap" }))
+      .toBe(`<script type="importmap" src="/im.json"></script>`);
+  });
+  it("with SRI sha384 + crossorigin", () => {
+    const out = generateScriptTags({
+      src: "https://cdn.example.com/x.js",
+      integrity: `sha384-${SHA384_B64}`,
+      crossorigin: "anonymous",
+    });
+    expect(out).toBe(
+      `<script src="https://cdn.example.com/x.js" integrity="sha384-${SHA384_B64}" crossorigin="anonymous"></script>`,
+    );
+  });
+  it("async boolean", () => {
+    expect(generateScriptTags({ src: "/app.js", async: true }))
+      .toBe(`<script src="/app.js" async></script>`);
+  });
+  it("defer boolean", () => {
+    expect(generateScriptTags({ src: "/app.js", defer: true }))
+      .toBe(`<script src="/app.js" defer></script>`);
+  });
+  it("nomodule boolean", () => {
+    expect(generateScriptTags({ src: "/legacy.js", nomodule: true }))
+      .toBe(`<script src="/legacy.js" nomodule></script>`);
+  });
+  it("referrerpolicy", () => {
+    expect(generateScriptTags({ src: "/x.js", referrerpolicy: "no-referrer" }))
+      .toBe(`<script src="/x.js" referrerpolicy="no-referrer"></script>`);
+  });
+  it("absolute https URL passes through", () => {
+    expect(generateScriptTags({ src: "https://example.com/x.js" }))
+      .toBe(`<script src="https://example.com/x.js"></script>`);
+  });
+  it("false booleans are not emitted", () => {
+    expect(generateScriptTags({ src: "/a.js", async: false, defer: false, nomodule: false }))
+      .toBe(`<script src="/a.js"></script>`);
+  });
+});
+
+describe("generateScriptTags — attribute order", () => {
+  it("type → src → integrity → crossorigin → referrerpolicy → async → defer → nomodule", () => {
+    const out = generateScriptTags({
+      nomodule: true,
+      async: true,
+      referrerpolicy: "no-referrer",
+      crossorigin: "anonymous",
+      integrity: `sha384-${SHA384_B64}`,
+      src: "https://cdn.example.com/x.js",
+      type: "module",
+    });
+    // async + defer can't coexist, so defer omitted from this test.
+    expect(out).toBe(
+      `<script type="module" src="https://cdn.example.com/x.js" integrity="sha384-${SHA384_B64}" crossorigin="anonymous" referrerpolicy="no-referrer" async nomodule></script>`,
+    );
+  });
+  it("defer ordered before nomodule", () => {
+    const out = generateScriptTags({ src: "/x.js", defer: true, nomodule: true });
+    expect(out).toBe(`<script src="/x.js" defer nomodule></script>`);
+  });
+});
+
+describe("generateScriptTags — array of tags", () => {
+  it("multiple tags joined by newline", () => {
+    const out = generateScriptTags([
+      { src: "/a.js" },
+      { src: "/b.js", type: "module" },
+      { src: "/c.js", defer: true },
+    ]);
+    expect(out).toBe([
+      `<script src="/a.js"></script>`,
+      `<script type="module" src="/b.js"></script>`,
+      `<script src="/c.js" defer></script>`,
+    ].join("\n"));
+  });
+  it("empty array → empty string", () => {
+    expect(generateScriptTags([])).toBe("");
+  });
+  it("single-element array same as single object", () => {
+    const single = generateScriptTags({ src: "/x.js" });
+    const arr    = generateScriptTags([{ src: "/x.js" }]);
+    expect(arr).toBe(single);
+  });
+  it("preserves caller's order", () => {
+    const out = generateScriptTags([
+      { src: "/c.js" }, { src: "/a.js" }, { src: "/b.js" },
+    ]);
+    const cIdx = out.indexOf("/c.js");
+    const aIdx = out.indexOf("/a.js");
+    const bIdx = out.indexOf("/b.js");
+    expect(cIdx).toBeLessThan(aIdx);
+    expect(aIdx).toBeLessThan(bIdx);
+  });
+});
+
+describe("generateScriptTags — URL validation", () => {
+  it("javascript: throws", () => {
+    expect(() => generateScriptTags({ src: "javascript:alert(1)" })).toThrow(/src must be http\(s\)/);
+  });
+  it("data: throws", () => {
+    expect(() => generateScriptTags({ src: "data:text/x,1" })).toThrow(/http\(s\)/);
+  });
+  it("file: throws", () => {
+    expect(() => generateScriptTags({ src: "file:///etc/passwd" })).toThrow(/http\(s\)/);
+  });
+  it("protocol-relative throws", () => {
+    expect(() => generateScriptTags({ src: "//evil.com/x.js" })).toThrow(/http\(s\)/);
+  });
+  it("backslash-variant throws", () => {
+    expect(() => generateScriptTags({ src: "/\\evil.com/x.js" })).toThrow(/http\(s\)/);
+  });
+  it("bare relative throws", () => {
+    expect(() => generateScriptTags({ src: "x.js" })).toThrow(/http\(s\)/);
+  });
+});
+
+describe("generateScriptTags — SRI integrity", () => {
+  it("valid sha384 emitted verbatim", () => {
+    expect(generateScriptTags({ src: "/x.js", integrity: `sha384-${SHA384_B64}` }))
+      .toContain(`integrity="sha384-${SHA384_B64}"`);
+  });
+  it("two-algo SRI emitted verbatim", () => {
+    const sri = `sha256-${SHA256_B64} sha384-${SHA384_B64}`;
+    expect(generateScriptTags({ src: "/x.js", integrity: sri }))
+      .toContain(`integrity="${sri}"`);
+  });
+  it("md5 algo rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", integrity: "md5-abc" }))
+      .toThrow(/algo must be one of/);
+  });
+  it("wrong-length base64 rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", integrity: "sha256-abc" }))
+      .toThrow(/sha256 expects 44/);
+  });
+});
+
+describe("generateScriptTags — allowlist validation", () => {
+  it("type 'text/javascript' rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", type: "text/javascript" as unknown as never }))
+      .toThrow(/type must be one of/);
+  });
+  it("crossorigin 'true' rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", crossorigin: "true" as unknown as never }))
+      .toThrow(/crossorigin must be one of/);
+  });
+  it("referrerpolicy 'never' rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", referrerpolicy: "never" as unknown as never }))
+      .toThrow(/referrerpolicy must be one of/);
+  });
+});
+
+describe("generateScriptTags — async + defer conflict", () => {
+  it("both true rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", async: true, defer: true }))
+      .toThrow(/cannot set both async and defer/);
+  });
+  it("async true + defer false ok", () => {
+    expect(generateScriptTags({ src: "/x.js", async: true, defer: false }))
+      .toBe(`<script src="/x.js" async></script>`);
+  });
+  it("async false + defer true ok", () => {
+    expect(generateScriptTags({ src: "/x.js", async: false, defer: true }))
+      .toBe(`<script src="/x.js" defer></script>`);
+  });
+});
+
+describe("generateScriptTags — boolean type-checking", () => {
+  it("non-boolean async rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", async: 1 as unknown as boolean }))
+      .toThrow(/async must be a boolean/);
+  });
+  it("non-boolean defer rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", defer: "yes" as unknown as boolean }))
+      .toThrow(/defer must be a boolean/);
+  });
+  it("non-boolean nomodule rejected", () => {
+    expect(() => generateScriptTags({ src: "/x.js", nomodule: null as unknown as boolean }))
+      .toThrow(/nomodule must be a boolean/);
+  });
+});
+
+describe("generateScriptTags — input shape validation", () => {
+  it("null entry in array throws with index", () => {
+    expect(() => generateScriptTags([null as unknown as never]))
+      .toThrow(/input\[0\] must be a non-null object/);
+  });
+  it("non-object entry throws", () => {
+    expect(() => generateScriptTags(["x" as unknown as never]))
+      .toThrow(/input\[0\] must be a non-null object/);
+  });
+  it("error in second entry shows index 1", () => {
+    expect(() => generateScriptTags([
+      { src: "/ok.js" },
+      { src: "javascript:bad" },
+    ])).toThrow(/src must be http\(s\)/);
+  });
+});
+
+describe("generateScriptTags — HTML escaping", () => {
+  it("escapes ampersand in src", () => {
+    expect(generateScriptTags({ src: "https://example.com/?a=1&b=2" }))
+      .toContain(`src="https://example.com/?a=1&amp;b=2"`);
+  });
+  it("rejects control byte in src (security: silent strip would redirect to different URL)", () => {
+    expect(() => generateScriptTags({ src: "/main.js\x00" }))
+      .toThrow(/must not contain ASCII control bytes/);
+  });
+  it("rejects tab in src (otherwise /\\tevil would become /evil after escape)", () => {
+    expect(() => generateScriptTags({ src: "/\tevil" }))
+      .toThrow(/must not contain ASCII control bytes/);
+  });
+});
+
+describe("generateScriptTags — fail-fast (no partial output)", () => {
+  it("bad entry mid-array throws — no output", () => {
+    try {
+      generateScriptTags([
+        { src: "/a.js" },
+        { src: "/b.js", integrity: "bad-format" },
+        { src: "/c.js" },
+      ]);
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toMatch(/algo must be one of/);
+    }
+  });
+});
+
+describe("generateScriptTags — purity / determinism", () => {
+  it("same input → byte-identical output", () => {
+    const cfg = { src: "/main.js", type: "module" as const, defer: true };
+    expect(generateScriptTags(cfg)).toBe(generateScriptTags(cfg));
+  });
+  it("does not mutate input", () => {
+    const cfg = { src: "/x.js", integrity: `sha384-${SHA384_B64}`, async: true };
+    const before = JSON.stringify(cfg);
+    generateScriptTags(cfg);
+    expect(JSON.stringify(cfg)).toBe(before);
+  });
+  it("does not mutate array input", () => {
+    const arr = [{ src: "/a.js" }, { src: "/b.js" }];
+    const before = JSON.stringify(arr);
+    generateScriptTags(arr);
+    expect(JSON.stringify(arr)).toBe(before);
+  });
+});
+
+describe("generateScriptTags — full real-world example", () => {
+  it("app + analytics + legacy fallback", () => {
+    const out = generateScriptTags([
+      { src: "/main.js", type: "module", integrity: `sha384-${SHA384_B64}`, crossorigin: "anonymous" },
+      { src: "/legacy.js", nomodule: true, defer: true },
+      { src: "https://analytics.example.com/a.js", async: true, referrerpolicy: "no-referrer" },
+    ]);
+    expect(out).toBe([
+      `<script type="module" src="/main.js" integrity="sha384-${SHA384_B64}" crossorigin="anonymous"></script>`,
+      `<script src="/legacy.js" defer nomodule></script>`,
+      `<script src="https://analytics.example.com/a.js" referrerpolicy="no-referrer" async></script>`,
+    ].join("\n"));
+  });
+});

--- a/code/packages/typescript/forme-aot-script-tag-emitter/tests/validate.test.ts
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/tests/validate.test.ts
@@ -1,0 +1,314 @@
+/**
+ * validate.test.ts — URL, SRI integrity, type / crossorigin /
+ * referrerpolicy allowlists, escape helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  escapeHtmlAttr,
+  stripAsciiControl,
+  validateCrossOrigin,
+  validateIntegrity,
+  validateReferrerPolicy,
+  validateScriptSrc,
+  validateScriptType,
+} from "../src/index.js";
+
+// Pre-computed valid base64 of exact length for each algo.
+// 32 bytes (sha256) → 44 chars (43 'A' + '=')
+const SHA256_B64 = "A".repeat(43) + "=";
+// 48 bytes (sha384) → 64 chars (no padding needed since 48 % 3 == 0)
+const SHA384_B64 = "A".repeat(64);
+// 64 bytes (sha512) → 88 chars (86 'A' + '==')
+const SHA512_B64 = "A".repeat(86) + "==";
+
+describe("validateScriptSrc — accept", () => {
+  it("https URL", () => {
+    expect(validateScriptSrc("https://example.com/app.js")).toBe("https://example.com/app.js");
+  });
+  it("http URL", () => {
+    expect(validateScriptSrc("http://example.com/x.js")).toBe("http://example.com/x.js");
+  });
+  it("scheme case-insensitive", () => {
+    expect(validateScriptSrc("HTTPS://example.com/x.js")).toBe("HTTPS://example.com/x.js");
+    expect(validateScriptSrc("HtTp://example.com/x.js")).toBe("HtTp://example.com/x.js");
+  });
+  it("root-relative /path", () => {
+    expect(validateScriptSrc("/main.js")).toBe("/main.js");
+  });
+  it("bare /", () => {
+    expect(validateScriptSrc("/")).toBe("/");
+  });
+  it("multi-segment root-relative", () => {
+    expect(validateScriptSrc("/assets/js/main.js")).toBe("/assets/js/main.js");
+  });
+});
+
+describe("validateScriptSrc — reject", () => {
+  it("javascript:", () => {
+    expect(() => validateScriptSrc("javascript:alert(1)")).toThrow(/src must be http\(s\)/);
+  });
+  it("data:", () => {
+    expect(() => validateScriptSrc("data:application/javascript,alert(1)")).toThrow(/http\(s\)/);
+  });
+  it("file:", () => {
+    expect(() => validateScriptSrc("file:///etc/passwd")).toThrow(/http\(s\)/);
+  });
+  it("vbscript:", () => {
+    expect(() => validateScriptSrc("vbscript:msgbox")).toThrow(/http\(s\)/);
+  });
+  it("protocol-relative //host", () => {
+    expect(() => validateScriptSrc("//evil.com/x.js")).toThrow(/http\(s\)/);
+  });
+  it("backslash-variant /\\host", () => {
+    expect(() => validateScriptSrc("/\\evil.com/x.js")).toThrow(/http\(s\)/);
+  });
+  it("bare relative", () => {
+    expect(() => validateScriptSrc("about.js")).toThrow(/http\(s\)/);
+  });
+  it("empty", () => {
+    expect(() => validateScriptSrc("")).toThrow(/non-empty string/);
+  });
+  it("non-string number", () => {
+    expect(() => validateScriptSrc(42 as unknown as string)).toThrow(/non-empty string/);
+  });
+  it("null", () => {
+    expect(() => validateScriptSrc(null)).toThrow(/got null/);
+  });
+  it("undefined", () => {
+    expect(() => validateScriptSrc(undefined)).toThrow(/got undefined/);
+  });
+  it("long URL truncated in error", () => {
+    const longUrl = "bad://" + "a".repeat(500);
+    try {
+      validateScriptSrc(longUrl);
+      expect.fail("expected throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("…");
+      expect(msg.length).toBeLessThan(longUrl.length + 100);
+    }
+  });
+  it("NUL byte in src rejected", () => {
+    expect(() => validateScriptSrc("/main.js\x00"))
+      .toThrow(/must not contain ASCII control bytes/);
+  });
+  it("tab in src rejected (defends against /\\tevil bypass)", () => {
+    expect(() => validateScriptSrc("/\tevil")).toThrow(/control bytes/);
+  });
+  it("newline in src rejected", () => {
+    expect(() => validateScriptSrc("/x\nevil")).toThrow(/control bytes/);
+  });
+  it("DEL byte in src rejected", () => {
+    expect(() => validateScriptSrc("/x\x7Fy")).toThrow(/control bytes/);
+  });
+  it("ESC byte in src rejected", () => {
+    expect(() => validateScriptSrc("/x\x1By")).toThrow(/control bytes/);
+  });
+});
+
+describe("validateIntegrity — accept", () => {
+  it("sha256 single hash", () => {
+    expect(validateIntegrity(`sha256-${SHA256_B64}`)).toBe(`sha256-${SHA256_B64}`);
+  });
+  it("sha384 single hash", () => {
+    expect(validateIntegrity(`sha384-${SHA384_B64}`)).toBe(`sha384-${SHA384_B64}`);
+  });
+  it("sha512 single hash", () => {
+    expect(validateIntegrity(`sha512-${SHA512_B64}`)).toBe(`sha512-${SHA512_B64}`);
+  });
+  it("two algos space-separated", () => {
+    const in_ = `sha256-${SHA256_B64} sha384-${SHA384_B64}`;
+    expect(validateIntegrity(in_)).toBe(in_);
+  });
+  it("three algos", () => {
+    const in_ = `sha256-${SHA256_B64} sha384-${SHA384_B64} sha512-${SHA512_B64}`;
+    expect(validateIntegrity(in_)).toBe(in_);
+  });
+  it("collapses multiple whitespace between tokens", () => {
+    const in_ = `sha256-${SHA256_B64}   sha384-${SHA384_B64}`;
+    expect(validateIntegrity(in_)).toBe(`sha256-${SHA256_B64} sha384-${SHA384_B64}`);
+  });
+  it("collapses tab/newline whitespace", () => {
+    const in_ = `sha256-${SHA256_B64}\tsha384-${SHA384_B64}`;
+    expect(validateIntegrity(in_)).toBe(`sha256-${SHA256_B64} sha384-${SHA384_B64}`);
+  });
+  it("trims surrounding whitespace", () => {
+    expect(validateIntegrity(`  sha256-${SHA256_B64}  `)).toBe(`sha256-${SHA256_B64}`);
+  });
+  it("base64 with + and /", () => {
+    // Valid 44-char base64 with + and /
+    const b64 = "+".repeat(20) + "/".repeat(23) + "=";
+    expect(validateIntegrity(`sha256-${b64}`)).toBe(`sha256-${b64}`);
+  });
+  it("base64 with all alphabet classes", () => {
+    // 44 chars mixing alpha/num/+//
+    const b64 = "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUu0=";
+    expect(b64.length).toBe(44);
+    expect(validateIntegrity(`sha256-${b64}`)).toBe(`sha256-${b64}`);
+  });
+});
+
+describe("validateIntegrity — reject", () => {
+  it("non-string", () => {
+    expect(() => validateIntegrity(42 as unknown as string)).toThrow(/must be a string/);
+  });
+  it("null", () => {
+    expect(() => validateIntegrity(null)).toThrow(/must be a string/);
+  });
+  it("empty", () => {
+    expect(() => validateIntegrity("")).toThrow(/non-empty/);
+  });
+  it("whitespace-only", () => {
+    expect(() => validateIntegrity("   ")).toThrow(/non-empty/);
+  });
+  it("unknown algo md5", () => {
+    expect(() => validateIntegrity("md5-abc")).toThrow(/algo must be one of/);
+  });
+  it("unknown algo sha1", () => {
+    expect(() => validateIntegrity("sha1-abc")).toThrow(/algo must be one of/);
+  });
+  it("no dash at all", () => {
+    expect(() => validateIntegrity("sha256abc")).toThrow(/"<algo>-<base64>"/);
+  });
+  it("dash at start (empty algo)", () => {
+    expect(() => validateIntegrity("-abc")).toThrow(/"<algo>-<base64>"/);
+  });
+  it("dash at end (empty b64)", () => {
+    expect(() => validateIntegrity("sha256-")).toThrow(/"<algo>-<base64>"/);
+  });
+  it("sha256 wrong length (too short)", () => {
+    expect(() => validateIntegrity(`sha256-${"A".repeat(20)}=`))
+      .toThrow(/sha256 expects 44-char base64; got 21/);
+  });
+  it("sha256 wrong length (too long)", () => {
+    expect(() => validateIntegrity(`sha256-${"A".repeat(60)}`))
+      .toThrow(/sha256 expects 44-char base64; got 60/);
+  });
+  it("sha384 wrong length", () => {
+    expect(() => validateIntegrity(`sha384-${"A".repeat(60)}`))
+      .toThrow(/sha384 expects 64-char base64; got 60/);
+  });
+  it("sha512 wrong length", () => {
+    expect(() => validateIntegrity(`sha512-${"A".repeat(80)}==`))
+      .toThrow(/sha512 expects 88-char base64; got 82/);
+  });
+  it("base64 with invalid char (space inside)", () => {
+    const bad = "A".repeat(20) + " " + "A".repeat(22) + "=";
+    // After split by /\s+/ this becomes two tokens; the second will fail "<algo>-<base64>".
+    expect(() => validateIntegrity(`sha256-${bad}`)).toThrow();
+  });
+  it("base64 with invalid char (@)", () => {
+    const bad = "A".repeat(42) + "@" + "=";
+    expect(() => validateIntegrity(`sha256-${bad}`)).toThrow(/invalid characters/);
+  });
+  it("base64 with URL-safe chars (- _) rejected", () => {
+    // sha256 b64 with `_` replacing `/` (not allowed by SRI spec).
+    const bad = "A".repeat(42) + "_" + "=";
+    expect(() => validateIntegrity(`sha256-${bad}`)).toThrow(/invalid characters/);
+  });
+  it("base64 with three padding =", () => {
+    // 41 A + '===' = 44, but BASE64_RE allows {0,2} = padding.
+    const bad = "A".repeat(41) + "===";
+    expect(() => validateIntegrity(`sha256-${bad}`)).toThrow(/invalid characters/);
+  });
+  it("sha256 with wrong padding (== instead of =) rejected", () => {
+    // 42 A + '==' = 44 chars, passes length check but decodes to 31 bytes not 32.
+    const bad = "A".repeat(42) + "==";
+    expect(() => validateIntegrity(`sha256-${bad}`))
+      .toThrow(/sha256 requires 1 '=' padding/);
+  });
+  it("sha384 with extra padding rejected", () => {
+    // 62 A + '==' = 64 chars, passes length but pad expected = 0
+    const bad = "A".repeat(62) + "==";
+    expect(() => validateIntegrity(`sha384-${bad}`))
+      .toThrow(/sha384 requires 0 '=' padding chars/);
+  });
+  it("sha512 with wrong padding rejected", () => {
+    // 87 A + '=' = 88 chars, passes length but pad expected = 2
+    const bad = "A".repeat(87) + "=";
+    expect(() => validateIntegrity(`sha512-${bad}`))
+      .toThrow(/sha512 requires 2 '=' padding chars/);
+  });
+  it("__proto__ algo rejected (Object.prototype walk defence)", () => {
+    expect(() => validateIntegrity("__proto__-AAAA"))
+      .toThrow(/algo must be one of/);
+  });
+  it("toString algo rejected (Object.prototype walk defence)", () => {
+    expect(() => validateIntegrity("toString-AAAA"))
+      .toThrow(/algo must be one of/);
+  });
+  it("hasOwnProperty algo rejected", () => {
+    expect(() => validateIntegrity("hasOwnProperty-AAAA"))
+      .toThrow(/algo must be one of/);
+  });
+  it("second-in-pair token bad", () => {
+    expect(() => validateIntegrity(`sha256-${SHA256_B64} md5-xxx`))
+      .toThrow(/algo must be one of/);
+  });
+  it("error message contains the bad algo", () => {
+    try {
+      validateIntegrity("md5-aaaa");
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toContain("md5");
+    }
+  });
+});
+
+describe("validateScriptType", () => {
+  it("accepts module", () => { expect(validateScriptType("module")).toBe("module"); });
+  it("accepts importmap", () => { expect(validateScriptType("importmap")).toBe("importmap"); });
+  it("rejects text/javascript", () => { expect(() => validateScriptType("text/javascript")).toThrow(/one of/); });
+  it("rejects application/javascript", () => { expect(() => validateScriptType("application/javascript")).toThrow(/one of/); });
+  it("rejects 'MODULE' (case-sensitive)", () => { expect(() => validateScriptType("MODULE")).toThrow(/one of/); });
+  it("rejects empty", () => { expect(() => validateScriptType("")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateScriptType(true as unknown as string)).toThrow(/must be a string/); });
+});
+
+describe("validateCrossOrigin", () => {
+  it("accepts anonymous", () => { expect(validateCrossOrigin("anonymous")).toBe("anonymous"); });
+  it("accepts use-credentials", () => { expect(validateCrossOrigin("use-credentials")).toBe("use-credentials"); });
+  it("rejects 'true'", () => { expect(() => validateCrossOrigin("true")).toThrow(/one of/); });
+  it("rejects empty", () => { expect(() => validateCrossOrigin("")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateCrossOrigin(1 as unknown as string)).toThrow(/must be a string/); });
+});
+
+describe("validateReferrerPolicy", () => {
+  const values = [
+    "no-referrer", "no-referrer-when-downgrade", "origin",
+    "origin-when-cross-origin", "same-origin", "strict-origin",
+    "strict-origin-when-cross-origin", "unsafe-url",
+  ];
+  for (const v of values) {
+    it(`accepts '${v}'`, () => { expect(validateReferrerPolicy(v)).toBe(v); });
+  }
+  it("rejects 'NO-REFERRER' (case-sensitive)", () => { expect(() => validateReferrerPolicy("NO-REFERRER")).toThrow(/one of/); });
+  it("rejects 'never' (deprecated value)", () => { expect(() => validateReferrerPolicy("never")).toThrow(/one of/); });
+  it("rejects empty", () => { expect(() => validateReferrerPolicy("")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateReferrerPolicy(0 as unknown as string)).toThrow(/must be a string/); });
+});
+
+describe("escapeHtmlAttr", () => {
+  it("ampersand", () => { expect(escapeHtmlAttr("a&b")).toBe("a&amp;b"); });
+  it("less-than", () => { expect(escapeHtmlAttr("a<b")).toBe("a&lt;b"); });
+  it("greater-than", () => { expect(escapeHtmlAttr("a>b")).toBe("a&gt;b"); });
+  it("double quote", () => { expect(escapeHtmlAttr(`a"b`)).toBe("a&quot;b"); });
+  it("single quote", () => { expect(escapeHtmlAttr(`a'b`)).toBe("a&#39;b"); });
+  it("composite", () => {
+    expect(escapeHtmlAttr(`<a href="?x&y='z'">`))
+      .toBe("&lt;a href=&quot;?x&amp;y=&#39;z&#39;&quot;&gt;");
+  });
+  it("strips NUL", () => { expect(escapeHtmlAttr("a\x00b")).toBe("ab"); });
+  it("strips DEL", () => { expect(escapeHtmlAttr("a\x7Fb")).toBe("ab"); });
+  it("non-string coerced", () => { expect(escapeHtmlAttr(7 as unknown as string)).toBe("7"); });
+});
+
+describe("stripAsciiControl", () => {
+  it("removes NUL/DEL/ESC", () => {
+    expect(stripAsciiControl("a\x00b\x1Bc\x7Fd")).toBe("abcd");
+  });
+  it("preserves printable ASCII", () => {
+    expect(stripAsciiControl("Hello, World!")).toBe("Hello, World!");
+  });
+});

--- a/code/packages/typescript/forme-aot-script-tag-emitter/tsconfig.json
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-script-tag-emitter/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-script-tag-emitter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Sixteenth FM00 v0 stage package — pure-transform `<script src="...">` tag emitter.
- Takes a `ScriptTag` config (single or array) and emits `<script>` tags joined by newlines.
- Supports SRI integrity (sha256/384/512 with per-algo length + padding validation), crossorigin, async/defer/nomodule, type (module/importmap), referrerpolicy.
- Two-pass fail-fast: validates the entire input (URL accept-list, SRI format, allowlists, async+defer conflict) before emitting any tag.
- 139 tests, **100% line / 100% branch** coverage.
- `required_capabilities.json` → `[]` (pure transform).

## Security posture

Eight concerns explicitly addressed. Pre-push security review (general-purpose agent) found three issues, **all fixed before push**:

1. **MEDIUM — SRI per-algo padding** wasn't validated (only total length). A sha256 string with `==` (instead of `=`) is the right total length (44 chars) but decodes to 31 bytes; browsers silently disable SRI rather than throwing. Fix: enforce `(3 - bytes % 3) % 3` pad count per algo (`1 / 0 / 2` for sha256/384/512).
2. **LOW — Object.prototype walk.** `SRI_ALGOS[algo]` on a plain frozen object would return truthy values for `"__proto__"` / `"toString"` / `"hasOwnProperty"`, bypassing the unknown-algo branch (downstream `Math.ceil(fn/3)` → NaN, throws with confusing message). Fix: switched to `ReadonlyMap`.
3. **LOW — Control bytes in `src` silently stripped.** `escapeHtmlAttr` strips `\x00-\x1F` / `\x7F`, which turns `/\tevil` (passes the root-relative check since `url[1]` is tab) into `/evil` after escape — silent redirection. Fix: reject control bytes at `validateScriptSrc`.

Tests added covering all three fixes (12 new tests).

Plus the standard FM00 concerns:
- URL scheme injection (every `src` runs through `validateScriptSrc`).
- HTML attribute injection (every interpolated value through `escapeHtmlAttr`).
- type/crossorigin/referrerpolicy allowlists (case-sensitive `Set.has`).
- async + defer rejected (spec says defer is silently ignored; surface the bug instead).
- Fail-fast (validation completes before any tag emitted).

## Behavioural notes

- Attribute order: `type → src → integrity → crossorigin → referrerpolicy → async → defer → nomodule`.
- Booleans emit as bare attribute names (`async`, `defer`, `nomodule`) — spec-canonical form.
- Empty array → empty string. Single object treated as one-element array.
- Same input → byte-identical output. No input mutation.

## v0 simplifications (documented)

- No inline `<script>...code...</script>` (different trust boundary; separate emitter).
- No `blocking="render"` (low adoption).
- No `fetchpriority` (deferred).
- No SRI hash computation (caller supplies; this validates format only).

## Test plan

- [x] All 139 vitest tests pass locally
- [x] Coverage 100% line / 100% branch on source files with logic
- [x] Security review via Agent — 3 findings, all fixed before push
- [x] CHANGELOG + README written with usage examples + the three security fixes documented
- [x] `required_capabilities.json` set to `[]` with justification
- [ ] CI green on ubuntu / macos / windows
- [ ] CodeQL JS/TS analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)