### PR TITLE
fix(sql-codegen): SELECT * across cross-join sources (drops columns from later tables)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [1.53.0] - 2026-05-19
+
+### Fixed
+
+- **``SELECT *`` now returns columns from every FROM source**, not
+  just the first one (via ``sql-codegen 1.31.0``).  The bug was in
+  the Wildcard branch of ``_compile_project_body``, which called
+  ``_primary_cursor`` and emitted ``ScanAllColumns`` for only the
+  first opened cursor.  Cross-join queries silently dropped columns
+  from later sources.
+
+  Example::
+
+      mini-sqlite (before): [(1,)]      -- only first table's columns
+      mini-sqlite (now):    [(1, 2)]    -- matches real SQLite
+      real SQLite:          [(1, 2)]
+
+  Affected forms (all now correct):
+
+      SELECT * FROM a, b
+      SELECT * FROM (SELECT 1 AS x) t1, (SELECT 2 AS y) t2
+      WITH x AS (...), y AS (...) SELECT * FROM x, y
+      SELECT * FROM orders, customers WHERE ...
+
+  11 new oracle tests in ``test_tier3_select_star_cross_join.py``
+  cover the cross-join cases for plain tables, derived tables, CTEs,
+  and the explicit JOIN-ON forms (regression guard).
+
+  Known follow-up (separate PR): the LEFT JOIN unmatched-row case
+  still needs NULL-padding work in the VM.  Matched rows are now
+  fully correct; unmatched left rows return fewer columns than
+  expected.
+
 ## [1.52.0] - 2026-05-19
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.52.0"
+version = "1.53.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_select_star_cross_join.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_select_star_cross_join.py
@@ -1,0 +1,196 @@
+"""Oracle tests for ``SELECT *`` spanning multiple FROM sources.
+
+This file pins a latent codegen bug fix where ``SELECT *`` only emitted
+columns from the *first* opened cursor, causing cross-join queries
+across N sources to return only the first table's columns instead of
+all of them concatenated.
+
+The fix is in ``sql_codegen/compiler.py`` — the Wildcard branch in
+``_compile_project_body`` now iterates over every entry in
+``ctx.alias_to_cursor`` (in insertion order) instead of taking only the
+primary cursor via ``_primary_cursor``.
+
+Why this matters: a lot of real-world SQLite SQL uses comma-separated
+FROM clauses for joins, and assumes ``SELECT *`` returns all columns:
+
+    SELECT * FROM orders, customers WHERE orders.customer_id = customers.id
+
+Before the fix mini-sqlite returned only ``orders``' columns, silently
+diverging from SQLite — confusing application bugs result.
+
+All assertions compare against real ``sqlite3`` row-for-row.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both(setup: list[str], query: str):
+    """Apply *setup* statements then run *query* on both engines."""
+    conn_m = mini_sqlite.connect(":memory:")
+    conn_r = sqlite3.connect(":memory:")
+    for s in setup:
+        conn_m.execute(s)
+        conn_r.execute(s)
+    m = conn_m.execute(query).fetchall()
+    r = conn_r.execute(query).fetchall()
+    return m, r
+
+
+def _check(setup: list[str], query: str) -> None:
+    m, r = _both(setup, query)
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+def _check_no_setup(query: str) -> None:
+    """Variant for queries that need no CREATE/INSERT setup."""
+    _check([], query)
+
+
+# ---------------------------------------------------------------------------
+# Single source — sanity check (no behaviour change expected)
+# ---------------------------------------------------------------------------
+
+
+class TestSelectStarSingleSource:
+    def test_single_table(self) -> None:
+        _check(
+            [
+                "CREATE TABLE t (a INTEGER, b INTEGER)",
+                "INSERT INTO t VALUES (1, 2), (3, 4)",
+            ],
+            "SELECT * FROM t ORDER BY a",
+        )
+
+    def test_single_derived_table(self) -> None:
+        _check_no_setup("SELECT * FROM (SELECT 1 AS x, 2 AS y) t")
+
+
+# ---------------------------------------------------------------------------
+# Comma cross-join with plain tables
+# ---------------------------------------------------------------------------
+
+
+class TestSelectStarCommaCrossJoinTables:
+    def test_two_tables(self) -> None:
+        _check(
+            [
+                "CREATE TABLE a (x INTEGER)",
+                "CREATE TABLE b (y INTEGER)",
+                "INSERT INTO a VALUES (1)",
+                "INSERT INTO b VALUES (2)",
+            ],
+            "SELECT * FROM a, b",
+        )
+
+    def test_three_tables(self) -> None:
+        _check(
+            [
+                "CREATE TABLE a (x INTEGER)",
+                "CREATE TABLE b (y INTEGER)",
+                "CREATE TABLE c (z INTEGER)",
+                "INSERT INTO a VALUES (1), (2)",
+                "INSERT INTO b VALUES (10)",
+                "INSERT INTO c VALUES (100)",
+            ],
+            "SELECT * FROM a, b, c ORDER BY a.x",
+        )
+
+    def test_with_where_predicate(self) -> None:
+        _check(
+            [
+                "CREATE TABLE orders (id INTEGER, cust_id INTEGER, amount INTEGER)",
+                "CREATE TABLE customers (id INTEGER, name TEXT)",
+                "INSERT INTO orders VALUES (1, 100, 50), (2, 200, 75)",
+                "INSERT INTO customers VALUES (100, 'Alice'), (200, 'Bob')",
+            ],
+            "SELECT * FROM orders, customers "
+            "WHERE orders.cust_id = customers.id ORDER BY orders.id",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Comma cross-join with derived tables
+# ---------------------------------------------------------------------------
+
+
+class TestSelectStarCommaCrossJoinDerived:
+    def test_two_derived_tables(self) -> None:
+        _check_no_setup(
+            "SELECT * FROM (SELECT 1 AS x) t1, (SELECT 2 AS y) t2"
+        )
+
+    def test_derived_table_and_real_table(self) -> None:
+        _check(
+            [
+                "CREATE TABLE t (a INTEGER)",
+                "INSERT INTO t VALUES (1)",
+            ],
+            "SELECT * FROM t, (SELECT 99 AS marker) m",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Comma cross-join with CTEs
+# ---------------------------------------------------------------------------
+
+
+class TestSelectStarCrossJoinCte:
+    def test_two_ctes(self) -> None:
+        _check_no_setup(
+            "WITH x AS (SELECT 1 AS p), y AS (SELECT 2 AS q) "
+            "SELECT * FROM x, y"
+        )
+
+    def test_three_ctes_mixed_with_real_table(self) -> None:
+        _check(
+            [
+                "CREATE TABLE r (rr INTEGER)",
+                "INSERT INTO r VALUES (99)",
+            ],
+            "WITH a AS (SELECT 1 AS aa), b AS (SELECT 2 AS bb) "
+            "SELECT * FROM a, b, r",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Explicit JOIN ... ON (regression check — must still work)
+# ---------------------------------------------------------------------------
+
+
+class TestSelectStarExplicitJoinNoRegression:
+    """The fix must not break SELECT * with explicit ``JOIN ON`` syntax."""
+
+    def test_inner_join_on(self) -> None:
+        _check(
+            [
+                "CREATE TABLE a (id INTEGER, name TEXT)",
+                "CREATE TABLE b (id INTEGER, val INTEGER)",
+                "INSERT INTO a VALUES (1, 'x'), (2, 'y')",
+                "INSERT INTO b VALUES (1, 100), (2, 200)",
+            ],
+            "SELECT * FROM a JOIN b ON a.id = b.id ORDER BY a.id",
+        )
+
+    def test_left_join_on_matched_rows(self) -> None:
+        """LEFT JOIN where every left row finds a right match — fully fixed.
+
+        The remaining ``LEFT JOIN + SELECT * + unmatched left row`` case is
+        a deeper latent bug: the VM's ``_do_scan_all_columns`` opcode
+        bails out when the right cursor has no current row, instead of
+        NULL-padding for every column the cursor *would have* produced.
+        Fixing that requires threading the cursor's schema into VM state
+        at OpenScan time — left as a follow-up PR.
+        """
+        _check(
+            [
+                "CREATE TABLE a (id INTEGER, name TEXT)",
+                "CREATE TABLE b (id INTEGER, val INTEGER)",
+                "INSERT INTO a VALUES (1, 'x'), (2, 'y')",
+                "INSERT INTO b VALUES (1, 100), (2, 200)",  # every a has a match
+            ],
+            "SELECT * FROM a LEFT JOIN b ON a.id = b.id ORDER BY a.id",
+        )

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.31.0] - 2026-05-19
+
+### Fixed
+
+- **``SELECT *`` now emits columns from every open cursor** in
+  ``_compile_project_body``.  The Wildcard branch previously called
+  ``_primary_cursor`` and emitted ``ScanAllColumns`` for *only* the
+  first scan opened, silently dropping columns from any additional
+  cross-join sources.  Now iterates ``ctx.alias_to_cursor.values()``
+  in insertion order, emitting one ``ScanAllColumns`` per cursor.
+
+  Affected queries:
+
+      SELECT * FROM a, b                         -- two plain tables
+      SELECT * FROM (SELECT 1 AS x) t1, (SELECT 2) t2  -- derived tables
+      WITH a AS (...), b AS (...) SELECT * FROM a, b   -- CTEs
+      SELECT * FROM orders, customers WHERE ...        -- ANSI cross-join
+
+  Known follow-up: ``SELECT * FROM a LEFT JOIN b ON ...`` with
+  *unmatched* left rows still under-counts columns because the VM's
+  ``_do_scan_all_columns`` opcode bails out when the right cursor has
+  no current row instead of NULL-padding.  Matched rows are now
+  correct.  Threading the cursor schema into VM state at OpenScan
+  time will close that gap in a separate PR.
+
 ## [1.30.0] - 2026-05-19
 
 ### Added

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.30.0"
+version = "1.31.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -709,9 +709,14 @@ def _compile_select(p: LogicalPlan, ctx: _Ctx) -> list[Instruction]:
         else:
             for it in project_items:
                 if isinstance(it.expr, Wildcard):
-                    primary = _primary_cursor(c)
-                    if primary is not None:
-                        out.append(ScanAllColumns(cursor_id=primary))
+                    # SELECT * — emit columns from EVERY open cursor in the
+                    # order they were opened, not just the primary one.  For
+                    # a single-source query this is a no-op change (one
+                    # cursor in alias_to_cursor); for a cross-join across
+                    # N sources this fixes a long-standing bug where only
+                    # the first table's columns appeared in the output.
+                    for cursor_id in c.alias_to_cursor.values():
+                        out.append(ScanAllColumns(cursor_id=cursor_id))
                 else:
                     out.extend(_compile_expr(it.expr, c))
                     out.append(EmitColumn(name=_projection_name(it)))


### PR DESCRIPTION
## Summary

Fixes a silent-divergence bug where `SELECT *` returned only the first FROM source's columns:

```sql
SELECT * FROM a, b
-- mini-sqlite (before): [(1,)]       <- WRONG, only a's columns
-- real SQLite:          [(1, 2)]
-- mini-sqlite (now):    [(1, 2)]     <- matches
```

## Root cause

The Wildcard branch in `_compile_project_body` (sql-codegen/compiler.py) called `_primary_cursor()` which returns "the cursor id of the first scan opened", then emitted a single `ScanAllColumns` for that cursor.  For cross-joins across N sources, only the first source's columns were emitted.

## Fix

Iterate `ctx.alias_to_cursor.values()` in insertion order, emitting one `ScanAllColumns` per cursor:

```python
# Before
primary = _primary_cursor(c)
if primary is not None:
    out.append(ScanAllColumns(cursor_id=primary))

# After
for cursor_id in c.alias_to_cursor.values():
    out.append(ScanAllColumns(cursor_id=cursor_id))
```

For a single-source query this is a no-op change.

## Affected forms (all now correct)

| SQL | Before | Now |
|-----|--------|-----|
| `SELECT * FROM a, b` | `[(1,)]` | `[(1, 2)]` |
| `SELECT * FROM (SELECT 1) t1, (SELECT 2) t2` | `[(1,)]` | `[(1, 2)]` |
| `WITH a AS (..), b AS (..) SELECT * FROM a, b` | `[(1,)]` | `[(1, 2)]` |
| `SELECT * FROM orders, customers WHERE ...` | missing cols | full row |

## Known follow-up (deferred)

`LEFT JOIN` with **unmatched** left rows still loses the right side's columns because `_do_scan_all_columns` in sql-vm bails out when the cursor has no current row instead of NULL-padding. **Matched rows are now fully correct.** Fixing the unmatched-row case requires threading the cursor's schema into VM state at `OpenScan` time — separate PR.

## Version bumps

- `sql-codegen`: 1.30.0 → 1.31.0
- `mini-sqlite`: 1.52.0 → 1.53.0

## Test plan

- [x] `pytest code/packages/python/sql-codegen/tests/` — 82 pass, coverage 81.48%
- [x] `pytest code/packages/python/mini-sqlite/tests/` — 1510 pass (11 new), coverage 91.29%
- [x] All oracle tests compare against `sqlite3`
- [x] Manual security review: single structural change, no new attack surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)