### PR TITLE
Test html5lib coverage audit report

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -16,6 +16,9 @@ documented in this file.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.
+- A parser integration test verifies that the checked coverage-audit report
+  still matches the checked tree-construction, raw tokenizer, and normalized
+  tokenizer fixture corpora.
 - Stack-of-open-elements tree construction seed with void element handling,
   adjacent text merging, simple implied end tags, and unmatched end-tag
   diagnostics.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -96,7 +96,9 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
 
 The audit also owns a checked `tests/fixtures/html5lib-coverage-audit.json`
 summary. Regenerate or verify that exact report with `--write-report` or
-`--check-report`.
+`--check-report`. The Rust integration tests also parse that report and compare
+its local corpus counts against the checked tree-construction and tokenizer
+fixtures.
 
 For sharper parser regression reporting, the generated
 `tests/fixtures/whatwg-tree-insertion-audit.json` fixture indexes the

--- a/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
@@ -1,0 +1,90 @@
+#[allow(dead_code)]
+mod common;
+
+use common::parse_tree_construction_cases;
+use serde::Deserialize;
+
+const HTML5LIB_COVERAGE_AUDIT: &str = include_str!("fixtures/html5lib-coverage-audit.json");
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const HTML5LIB_RAW_FIXTURES: &str =
+    include_str!("../../html-lexer/tests/fixtures/upstream-html5lib-smoke.test");
+const HTML5LIB_NORMALIZED_FIXTURES: &str =
+    include_str!("../../html-lexer/tests/fixtures/html5lib-smoke.json");
+
+#[derive(Debug, Deserialize)]
+struct CoverageAudit {
+    tree_construction: TreeConstructionAudit,
+    tokenizer: TokenizerAudit,
+}
+
+#[derive(Debug, Deserialize)]
+struct TreeConstructionAudit {
+    upstream_cases: usize,
+    local_cases: usize,
+    missing: usize,
+    missing_sources: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenizerAudit {
+    upstream_cases: usize,
+    local_raw_cases: usize,
+    missing: usize,
+    missing_sources: Vec<String>,
+    normalized_cases: usize,
+    normalized_skipped: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTokenizerFixtures {
+    tests: Vec<RawTokenizerCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTokenizerCase {}
+
+#[derive(Debug, Deserialize)]
+struct NormalizedTokenizerFixtures {
+    cases: Vec<NormalizedTokenizerCase>,
+    skipped: Vec<SkippedTokenizerCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NormalizedTokenizerCase {}
+
+#[derive(Debug, Deserialize)]
+struct SkippedTokenizerCase {}
+
+#[test]
+fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
+    let audit: CoverageAudit = serde_json::from_str(HTML5LIB_COVERAGE_AUDIT)
+        .expect("html5lib coverage audit report should parse");
+    let tree_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE);
+    let raw_tokenizer: RawTokenizerFixtures =
+        serde_json::from_str(HTML5LIB_RAW_FIXTURES).expect("raw html5lib fixture should parse");
+    let normalized_tokenizer: NormalizedTokenizerFixtures =
+        serde_json::from_str(HTML5LIB_NORMALIZED_FIXTURES)
+            .expect("normalized html5lib fixture should parse");
+
+    assert_eq!(audit.tree_construction.upstream_cases, 1778);
+    assert_eq!(audit.tree_construction.local_cases, tree_cases.len());
+    assert_eq!(audit.tree_construction.local_cases, 2485);
+    assert_eq!(audit.tree_construction.missing, 0);
+    assert!(audit.tree_construction.missing_sources.is_empty());
+
+    assert_eq!(audit.tokenizer.upstream_cases, 6806);
+    assert_eq!(audit.tokenizer.local_raw_cases, raw_tokenizer.tests.len());
+    assert_eq!(audit.tokenizer.local_raw_cases, 7015);
+    assert_eq!(
+        audit.tokenizer.normalized_cases,
+        normalized_tokenizer.cases.len()
+    );
+    assert_eq!(audit.tokenizer.normalized_cases, 7242);
+    assert_eq!(
+        audit.tokenizer.normalized_skipped,
+        normalized_tokenizer.skipped.len()
+    );
+    assert_eq!(audit.tokenizer.normalized_skipped, 0);
+    assert_eq!(audit.tokenizer.missing, 0);
+    assert!(audit.tokenizer.missing_sources.is_empty());
+}


### PR DESCRIPTION
## Summary
- add a parser integration test for the checked html5lib coverage audit report
- compare the report local counts against the checked tree-construction, raw tokenizer, and normalized tokenizer fixtures
- document that the Rust test surface now validates the checked report

## Validation
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_attribute_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_cdata_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_script_escape_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_character_reference_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_tag_open_recovery_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_doctype_boundaries_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/generate_whatwg_comment_boundaries_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py --check
